### PR TITLE
Miniconda

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,15 +13,13 @@ environment:
 
 init:
   - "ECHO %PYTHON%"
-  - cmd: C:\Miniconda.exe /S /D=C:\Miniconda
-  - ps: ls C:\Miniconda/Scripts
-  - C:\Miniconda\Scripts\conda config --set always_yes yes
+  - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
-  - C:\Miniconda\Scripts\conda update conda
-  - C:\Miniconda\Scripts\conda install numpy scipy nose hdf5 --quiet
+  - conda update conda
+  - conda install numpy scipy nose hdf5 --quiet
 
 install:
-  - C:\Miniconda\Scripts\pip install .
+  - pip install .
 
 test_script:
-  - C:\Miniconda\Scripts\nosetests
+  - nosetests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,6 @@ environment:
 
 init:
   - "ECHO %PYTHON%"
-  - ps: if($env:PYTHON -eq "2.7" -and $env:Platform -eq "x64"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"}
-  - ps: if($env:PYTHON -eq "2.7" -and $env:Platform -eq "x86"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda-latest-Windows-x86.exe' C:\Miniconda.exe; echo "Done"}
-  - ps: if($env:PYTHON -eq "3.4" -and $env:Platform -eq "x64"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86_64.exe' C:\Miniconda.exe; echo "Done"}
-  - ps: if($env:PYTHON -eq "3.4" -and $env:Platform -eq "x86"){Start-FileDownload 'http://repo.continuum.io/miniconda/Miniconda3-latest-Windows-x86.exe' C:\Miniconda.exe; echo "Done"}
   - cmd: C:\Miniconda.exe /S /D=C:\Miniconda
   - ps: ls C:\Miniconda/Scripts
   - C:\Miniconda\Scripts\conda config --set always_yes yes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ environment:
 
 init:
   - "ECHO %PYTHON%"
+  - set PATH=C:\Miniconda3;C:\Miniconda3\Scripts;%PATH%
   - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda


### PR DESCRIPTION
Appveyor changed their default machine loadout to include Miniconda.  So I removed our manual installation of Miniconda, because it was trying to install Miniconda OVER Miniconda and hanging.  Now I just put in a line to add Miniconda to our path, and all the conda calls after that will use the conda on the path.