### PR TITLE
A couple of things for Steve.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -945,6 +945,9 @@ class Problem(System):
                             i += nk
                 j += 1
 
+        # Clean up after ourselves
+        root.clear_dparams()
+
         return J
 
     def check_partial_derivatives(self, out_stream=sys.stdout):

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -27,8 +27,8 @@ class Newton(NonLinearSolver):
                        desc='Maximum number of line searches.')
         opt.add_option('alpha', 1.0,
                        desc='Initial over-relaxation factor.')
-        opt.add_option('solve_subsystems', False,
-                       desc='Set to True to solve subsystems. You may need this for solvers nested under Newton, though it will be slower..')
+        opt.add_option('solve_subsystems', True,
+                       desc='Set to True to solve subsystems. You may need this for solvers nested under Newton.')
 
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Solves the system using a Netwon's Method.
@@ -67,7 +67,8 @@ class Newton(NonLinearSolver):
         update_local_meta(local_meta, (self.iter_count, ls_itercount))
 
         # Perform an initial run to propagate srcs to targets.
-        system.children_solve_nonlinear(local_meta)
+        if self.options['solve_subsystems'] is True:
+            system.children_solve_nonlinear(local_meta)
         system.apply_nonlinear(params, unknowns, resids)
 
         f_norm = resids.norm()

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -27,7 +27,7 @@ class Newton(NonLinearSolver):
                        desc='Maximum number of line searches.')
         opt.add_option('alpha', 1.0,
                        desc='Initial over-relaxation factor.')
-        opt.add_option('solve_subsystems', True,
+        opt.add_option('solve_subsystems', False,
                        desc='Set to True to solve subsystems. You may need this for solvers nested under Newton, though it will be slower..')
 
     def solve(self, params, unknowns, resids, system, metadata=None):

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -122,8 +122,8 @@ class Newton(NonLinearSolver):
                 update_local_meta(local_meta, (self.iter_count, ls_itercount))
 
                 # Just evaluate the model with the new points
-
-                system.children_solve_nonlinear(local_meta)
+                if self.options['solve_subsystems'] is True:
+                    system.children_solve_nonlinear(local_meta)
                 system.apply_nonlinear(params, unknowns, resids, local_meta)
 
                 for recorder in self.recorders:
@@ -132,13 +132,10 @@ class Newton(NonLinearSolver):
                 f_norm = resids.norm()
                 if self.options['iprint'] > 1:
                     self.print_norm('BK_TKG', local_meta, ls_itercount, f_norm,
-                                    f_norm/f_norm0, indent=1, solver='LS')
+                                    f_norm0, indent=1, solver='LS')
 
             # Reset backtracking
             alpha = alpha_base
-
-            for recorder in self.recorders:
-                recorder.raw_record(params, unknowns, resids, local_meta)
 
         # Need to make sure the whole workflow is executed at the final
         # point, not just evaluated.

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -27,6 +27,8 @@ class Newton(NonLinearSolver):
                        desc='Maximum number of line searches.')
         opt.add_option('alpha', 1.0,
                        desc='Initial over-relaxation factor.')
+        opt.add_option('solve_subsystems', True,
+                       desc='Set to True to solve subsystems. You may need this for solvers nested under Newton, though it will be slower..')
 
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Solves the system using a Netwon's Method.
@@ -96,7 +98,8 @@ class Newton(NonLinearSolver):
             update_local_meta(local_meta, (self.iter_count, ls_itercount))
 
             # Just evaluate the model with the new points
-            system.children_solve_nonlinear(local_meta)
+            if self.options['solve_subsystems'] is True:
+                system.children_solve_nonlinear(local_meta)
             system.apply_nonlinear(params, unknowns, resids, local_meta)
 
             for recorder in self.recorders:


### PR DESCRIPTION
1. Added an option to disable the solve_nonlinear in Newton (apply_nonlinear is still run.) Didn't have an impact on pyMission, so it is set to True, which is no change from before.

2. Clean out the dp after a gradient is calculated so that it doesn't screw up subsequent Newton subsolves.