### PR TITLE
Fixed up ExternalCode so that it supports Windows better and easier

### DIFF
--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -163,11 +163,9 @@ class ExternalCode(Component):
             raise ValueError("The command to be executed, '%s', cannot be found" % program_to_execute)
 
         command_for_shell_proc = self.options['command']
-
         if sys.platform == 'win32':
             command_for_shell_proc = ['cmd.exe', '/c' ] + command_for_shell_proc
 
-        # ShellProc(self.options['command'], self.stdin,
         self._process = \
             ShellProc(command_for_shell_proc, self.stdin,
                       self.stdout, self.stderr, self.options['env_vars'])

--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -4,7 +4,6 @@
 
 import sys
 import os
-#from distutils.spawn import find_executable
 from numpy.distutils.exec_command import find_executable
 
 from openmdao.core.component import Component

--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -4,7 +4,8 @@
 
 import sys
 import os
-from distutils.spawn import find_executable
+#from distutils.spawn import find_executable
+from numpy.distutils.exec_command import find_executable
 
 from openmdao.core.component import Component
 from openmdao.core.options import OptionsDictionary
@@ -156,13 +157,19 @@ class ExternalCode(Component):
             program_to_execute = self.options['command']
         else:
             program_to_execute = self.options['command'][0]
+        
         command_full_path = find_executable( program_to_execute )
-
         if not command_full_path:
             raise ValueError("The command to be executed, '%s', cannot be found" % program_to_execute)
 
+        command_for_shell_proc = self.options['command']
+
+        if sys.platform == 'win32':
+            command_for_shell_proc = ['cmd.exe', '/c' ] + command_for_shell_proc
+
+        # ShellProc(self.options['command'], self.stdin,
         self._process = \
-            ShellProc(self.options['command'], self.stdin,
+            ShellProc(command_for_shell_proc, self.stdin,
                       self.stdout, self.stderr, self.options['env_vars'])
         #self._logger.debug('PID = %d', self._process.pid)
 


### PR DESCRIPTION
Users don't need to prepend 'cmd.exe /c' on Windows any more. The code does it for them. 

Also the use of numpy's find_exectutable supports '.bat' and '.cmd' files now.