### PR TITLE
Updated dump_recorder to work in parallel.

### DIFF
--- a/mpitest/test_parallel_record.py
+++ b/mpitest/test_parallel_record.py
@@ -1,0 +1,56 @@
+""" Testing out recorders under MPI."""
+
+import os
+import unittest
+
+from openmdao.core import Problem
+from openmdao.core.mpi_wrap import MPI
+from openmdao.recorders import DumpRecorder
+from openmdao.test.simple_comps import FanInGrouped
+from openmdao.test.mpi_util import MPITestCase
+
+if MPI:
+    from openmdao.core.petsc_impl import PetscImpl as impl
+else:
+    from openmdao.core import BasicImpl as impl
+
+
+class TestDumpRecorder(MPITestCase):
+
+    N_PROCS = 2
+
+    def setUp(self):
+        if MPI:
+            if MPI.COMM_WORLD.rank == 0:
+                self.filename = 'data_0.dmp'
+            elif MPI.COMM_WORLD.rank == 1:
+                self.filename = 'data_1.dmp'
+        else:
+            self.filename = 'data.dmp'
+
+    def tearDown(self):
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
+
+    def test_dump_converge_diverge_par(self):
+
+        prob = Problem(impl=impl)
+        prob.root = FanInGrouped()
+
+        rec = DumpRecorder(out='data.dmp')
+        rec.options['includes'] = ['p1.x1', 'p2.x2', 'comp3.y']
+        prob.driver.add_recorder(rec)
+
+        prob.setup(check=False)
+        prob.run()
+
+        with open(self.filename, 'r') as dumpfile:
+            dump = dumpfile.readlines()
+
+        self.assertEqual(dump[3], '  comp3.y: 29.0\n')
+        self.assertEqual(dump[4], '  p1.x1: 1.0\n')
+        self.assertEqual(dump[5], '  p2.x2: 1.0\n')
+
+if __name__ == '__main__':
+    from openmdao.test.mpi_util import mpirun_tests
+    mpirun_tests()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -254,9 +254,6 @@ class pyOptSparseDriver(Driver):
             update_local_meta(metadata, (self.iter_count,))
 
             system.solve_nonlinear(metadata=metadata)
-            for recorder in self.recorders:
-                recorder.raw_record(system.params, system.unknowns,
-                                    system.resids, metadata)
 
             # Get the objective function evaluations
             for name, obj in iteritems(self.get_objectives()):
@@ -279,6 +276,12 @@ class pyOptSparseDriver(Driver):
                 #         func_dict[name] = comm.bcast(None, root=owner)
                 # else:
                 func_dict[name] = con
+
+            # Record after getting obj and constraint to assure they have
+            # been gathered in MPI.
+            for recorder in self.recorders:
+                recorder.raw_record(system.params, system.unknowns,
+                                    system.resids, metadata)
 
             # Get the double-sided constraint evaluations
             #for key, con in iteritems(self.get_2sided_constraints()):


### PR DESCRIPTION
1. Updated dump recorder to work in parallel, appending file name with rank name and printing on each rank. Note, you can only print vars that exist on each rank, or have been gathered.
2. Made some fixes to record in drivers so that they recorder after constraints and objectives are gathered.