### PR TITLE
Fix unit for degrees (deg) in unit_library.ini

### DIFF
--- a/openmdao/units/unit_library.ini
+++ b/openmdao/units/unit_library.ini
@@ -95,7 +95,7 @@ kat: mol/s, katal
 min: 60*s, minute
 h: 3600*s, hour
 d: 86400*s, day
-deg: (pi/180)*rad, degree
+deg: (180/pi)*rad, degree
 arc_minute: deg/60, arc minute
 arc_second: arc_minute/60, arc second
 ha: 1e4*m**2, hectare


### PR DESCRIPTION
deg is incorrectly defined as (pi/180) * rad instead of deg: (180/pi) * rad in unit_library.ini