### PR TITLE
Driver should support everything

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -28,10 +28,10 @@ class Driver(object):
         self.supports = OptionsDictionary(read_only=True)
         self.supports.add_option('inequality_constraints', True)
         self.supports.add_option('equality_constraints', True)
-        self.supports.add_option('linear_constraints', False)
-        self.supports.add_option('multiple_objectives', False)
-        self.supports.add_option('two_sided_constraints', False)
-        self.supports.add_option('integer_parameters', False)
+        self.supports.add_option('linear_constraints', True)
+        self.supports.add_option('multiple_objectives', True)
+        self.supports.add_option('two_sided_constraints', True)
+        self.supports.add_option('integer_parameters', True)
 
         # This driver's options
         self.options = OptionsDictionary()

--- a/openmdao/core/test/test_driver_interface.py
+++ b/openmdao/core/test/test_driver_interface.py
@@ -250,6 +250,9 @@ class TestDriver(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), "Constraint 'con1' cannot be both equality and inequality.")
 
+        # Don't try this at home, kids
+        prob.driver.supports['two_sided_constraints'] = False
+
         with self.assertRaises(RuntimeError) as cm:
             prob.driver.add_constraint('con1', lower=0.0, upper=1.1)
 


### PR DESCRIPTION
It is common practice to comment out an optimizer to test things like derivatives, so Driver needs to support everything.