### PR TITLE
New way to convert units during gradient calculation.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -747,7 +747,7 @@ class Group(System):
                 if do_apply:
 
                     # Process incoming unit conversions
-                    dparams._convert_units(iterkeys(dparams))
+                    dparams._apply_unit_derivatives(iterkeys(dparams))
 
                     if force_fd:
                         system._apply_linear_jac(system.params, system.unknowns, dparams,
@@ -793,7 +793,7 @@ class Group(System):
                                                 dparams, dunknowns, dresids, mode)
                     finally:
                         # Process incoming unit conversions
-                        dparams._convert_units(iterkeys(dparams))
+                        dparams._apply_unit_derivatives(iterkeys(dparams))
 
                 dresids.vec *= -1.0
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -430,7 +430,6 @@ class Group(System):
         dunknowns = impl.create_src_vecwrapper(sys_pathname, comm)
         dresids = impl.create_src_vecwrapper(sys_pathname, comm)
         dparams = impl.create_tgt_vecwrapper(sys_pathname, comm)
-        dparams.adj_accumulate_mode = False
 
         dunknowns.setup(unknowns_dict, relevance=self._relevance,
                         var_of_interest=var_of_interest)
@@ -747,6 +746,9 @@ class Group(System):
 
                 if do_apply:
 
+                    # Process incoming unit conversions
+                    dparams._convert_units(iterkeys(dparams))
+
                     if force_fd:
                         system._apply_linear_jac(system.params, system.unknowns, dparams,
                                                  dunknowns, dresids, mode)
@@ -782,7 +784,6 @@ class Group(System):
 
                     #if np.any(dresids.vec):
                     try:
-                        dparams.adj_accumulate_mode = True
                         if force_fd:
                             system._apply_linear_jac(system.params,
                                                      system.unknowns, dparams,
@@ -791,7 +792,8 @@ class Group(System):
                             system.apply_linear(system.params, system.unknowns,
                                                 dparams, dunknowns, dresids, mode)
                     finally:
-                        dparams.adj_accumulate_mode = False
+                        # Process incoming unit conversions
+                        dparams._convert_units(iterkeys(dparams))
 
                 dresids.vec *= -1.0
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1112,11 +1112,10 @@ class Problem(System):
 
                     dresids.flat[u_name][idx] = 1.0
                     try:
-                        dparams.adj_accumulate_mode = True
                         comp.apply_linear(params, unknowns, dparams,
                                           dunknowns, dresids, 'rev')
                     finally:
-                        dparams.adj_accumulate_mode = False
+                        pass
 
                     for p_name in chain(dparams, states):
                         if (u_name, p_name) in skip_keys:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1115,7 +1115,7 @@ class Problem(System):
                         comp.apply_linear(params, unknowns, dparams,
                                           dunknowns, dresids, 'rev')
                     finally:
-                        pass
+                        dparams._apply_unit_derivatives(iterkeys(dparams))
 
                     for p_name in chain(dparams, states):
                         if (u_name, p_name) in skip_keys:
@@ -1138,6 +1138,7 @@ class Problem(System):
                     dunknowns.vec[:] = 0.0
 
                     dinputs.flat[p_name][idx] = 1.0
+                    dparams._apply_unit_derivatives(iterkeys(dparams))
                     comp.apply_linear(params, unknowns, dparams,
                                       dunknowns, dresids, 'fwd')
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -558,7 +558,6 @@ class System(object):
         self.dumat[voi] = parent.dumat[voi].get_view(self.pathname, comm, umap)
         self.drmat[voi] = parent.drmat[voi].get_view(self.pathname, comm, umap)
         self.dpmat[voi] = parent._impl.create_tgt_vecwrapper(self.pathname, comm)
-        self.dpmat[voi].adj_accumulate_mode = False
 
         self.dpmat[voi].setup(parent.dpmat[voi], params_dict, top_unknowns,
                               my_params, self.connections,

--- a/openmdao/core/test/test_units.py
+++ b/openmdao/core/test/test_units.py
@@ -164,6 +164,13 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
         assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
+        J = prob.calc_gradient(indep_list, unknown_list, mode='fd',
+                               return_format='dict')
+
+        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+
     def test_basic_input_input(self):
 
         prob = Problem()
@@ -206,6 +213,13 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
         assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
+        J = prob.calc_gradient(indep_list, unknown_list, mode='fd',
+                               return_format='dict')
+
+        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+
     def test_basic_implicit_conn(self):
 
         prob = Problem()
@@ -238,6 +252,13 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         J = prob.calc_gradient(indep_list, unknown_list, mode='rev',
+                               return_format='dict')
+
+        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+
+        J = prob.calc_gradient(indep_list, unknown_list, mode='fd',
                                return_format='dict')
 
         assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
@@ -288,6 +309,13 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
         assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
+        J = prob.calc_gradient(indep_list, unknown_list, mode='fd',
+                               return_format='dict')
+
+        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+
     def test_basic_grouped_bug_from_pycycle(self):
 
         prob = Problem()
@@ -321,6 +349,13 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         J = prob.calc_gradient(indep_list, unknown_list, mode='rev',
+                               return_format='dict')
+
+        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+
+        J = prob.calc_gradient(indep_list, unknown_list, mode='fd',
                                return_format='dict')
 
         assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)

--- a/openmdao/core/test/test_units.py
+++ b/openmdao/core/test/test_units.py
@@ -172,6 +172,7 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
         assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
+        # Need to clean up after FD gradient call, so just rerun.
         prob.run()
 
         # Make sure check partials handles conversion

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -7,24 +7,9 @@ from six import iteritems, itervalues, iterkeys
 from six.moves import cStringIO
 
 from collections import OrderedDict
-from openmdao.util.type_util import is_differentiable, int_types
+from openmdao.util.type_util import is_differentiable
 from openmdao.util.string_util import get_common_ancestor
 
-class _NoPlusEqArray(object):
-    """
-    This is here as a hack to get around the issue of unit conversions
-    getting applied multiple times when doing a += in reverse mode.
-    """
-    def __init__(self, arr):
-        self._arr = arr
-
-    def __getattr__(self, name):
-        return getattr(self._arr, name)
-
-    def __iadd__(self, other):
-        # instead of doing +=, just do =
-        self._arr[:] = other
-        return self._arr
 
 class _ByObjWrapper(object):
     """
@@ -904,9 +889,9 @@ class TgtVecWrapper(VecWrapper):
         return [[(n, m['size']) for n, m in self._get_vecvars()
                     if m.get('owned')]]
 
-    def _convert_units(self, varnames):
-        """ Applies unit conversion factor to params sitting in vector for
-        names passed in varnames."""
+    def _apply_unit_derivatives(self, varnames):
+        """ Applies derivative of the unit conversion factor to params
+        sitting in vector for names passed in varnames."""
         if self.deriv_units:
             for name in varnames:
                 conv = self._vardict[name].get('unit_conv')

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -235,6 +235,7 @@ class pyOptSparseDriver(Driver):
         -------
         func_dict : dict
             Dictionary of all functional variables evaluated at design point.
+
         fail : int
             0 for successful function evaluation
             1 for unsuccessful function evaluation
@@ -317,6 +318,7 @@ class pyOptSparseDriver(Driver):
         ----
         dv_dict : dict
             Dictionary of design variable values.
+
         func_dict : dict
             Dictionary of all functional variables evaluated at design point.
 
@@ -324,6 +326,7 @@ class pyOptSparseDriver(Driver):
         -------
         sens_dict : dict
             Dictionary of dictionaries for gradient of each dv/func pair
+
         fail : int
             0 for successful function evaluation
             1 for unsuccessful function evaluation

--- a/openmdao/solvers/scipy_gmres.py
+++ b/openmdao/solvers/scipy_gmres.py
@@ -21,7 +21,7 @@ class ScipyGMRES(LinearSolver):
         opt = self.options
         opt.add_option('atol', 1e-12,
                        desc='Absolute convergence tolerance.')
-        opt.add_option('maxiter', 100,
+        opt.add_option('maxiter', 1000,
                        desc='Maximum number of iterations.')
         opt.add_option('mode', 'auto', values=['fwd', 'rev', 'auto'],
                        desc="Derivative calculation mode, set to 'fwd' for " +

--- a/openmdao/solvers/scipy_gmres.py
+++ b/openmdao/solvers/scipy_gmres.py
@@ -92,7 +92,7 @@ class ScipyGMRES(LinearSolver):
 
             if info > 0:
                 msg = "Solve in '{}': gmres failed to converge " \
-                -                      "after {} iterations"
+                                      "after {} iterations"
                 print(msg.format(system.name, options['maxiter']))
                 #logger.error(msg, system.name, info)
                 msg = 'FAILED to converge after max iterations'


### PR DESCRIPTION
Removed automatic unit conversion from the dparams vector because it caused problems and required non intuitive syntax for setting slices. Unit conversion is now done in the wrapper that calls apply_linear on components.