### PR TITLE
added surrogate model test & updated metamodel

### DIFF
--- a/openmdao/components/meta_model.py
+++ b/openmdao/components/meta_model.py
@@ -56,7 +56,7 @@ class MetaModel(Component):
 
         self._input_size = 0
 
-    def add_param(self, name, val=_NotSet, training_data=(), **kwargs):
+    def add_param(self, name, val=_NotSet, training_data=None, **kwargs):
         """ Add a `param` input to this component and a corresponding
         training parameter.
 
@@ -72,6 +72,9 @@ class MetaModel(Component):
             training data for this variable. Optional, can be set 
             by the problem later.
         """
+        if training_data is None:
+            training_data = list()
+
         super(MetaModel, self).add_param(name, val, **kwargs)
         super(MetaModel, self).add_param('train:'+name, val=training_data, pass_by_obj=True)
 
@@ -80,7 +83,7 @@ class MetaModel(Component):
         self._surrogate_param_names.append((name, input_size))
         self._input_size += input_size
 
-    def add_output(self, name, val=_NotSet, training_data=(), **kwargs):
+    def add_output(self, name, val=_NotSet, training_data=None, **kwargs):
         """ Add an output to this component and a corresponding
         training output.
 
@@ -97,6 +100,9 @@ class MetaModel(Component):
             training data for this variable. Optional, can be set 
             by the problem later.
         """
+        if training_data is None:
+            training_data = list()
+
         super(MetaModel, self).add_output(name, val, **kwargs)
         super(MetaModel, self).add_output('train:'+name, val=training_data, pass_by_obj=True)
 

--- a/openmdao/components/meta_model.py
+++ b/openmdao/components/meta_model.py
@@ -56,7 +56,7 @@ class MetaModel(Component):
 
         self._input_size = 0
 
-    def add_param(self, name, val=_NotSet, **kwargs):
+    def add_param(self, name, val=_NotSet, training_data=list(), **kwargs):
         """ Add a `param` input to this component and a corresponding
         training parameter.
 
@@ -67,16 +67,20 @@ class MetaModel(Component):
 
         val : float or ndarray or object
             Initial value for the input.
+
+        training_data : float or ndarray
+            training data for this variable. Optional, can be set 
+            by the problem later.
         """
         super(MetaModel, self).add_param(name, val, **kwargs)
-        super(MetaModel, self).add_param('train:'+name, val=list(), pass_by_obj=True)
+        super(MetaModel, self).add_param('train:'+name, val=training_data, pass_by_obj=True)
 
         input_size = self._params_dict[name]['size']
 
         self._surrogate_param_names.append((name, input_size))
         self._input_size += input_size
 
-    def add_output(self, name, val=_NotSet, **kwargs):
+    def add_output(self, name, val=_NotSet, training_data=list(), **kwargs):
         """ Add an output to this component and a corresponding
         training output.
 
@@ -88,9 +92,13 @@ class MetaModel(Component):
         val : float or ndarray
             Initial value for the output. While the value is overwritten during
             execution, it is useful for infering size.
+
+        training_data : float or ndarray
+            training data for this variable. Optional, can be set 
+            by the problem later.
         """
         super(MetaModel, self).add_output(name, val, **kwargs)
-        super(MetaModel, self).add_output('train:'+name, val=list(), pass_by_obj=True)
+        super(MetaModel, self).add_output('train:'+name, val=training_data, pass_by_obj=True)
 
         try:
             output_shape = self._unknowns_dict[name]['shape']

--- a/openmdao/components/meta_model.py
+++ b/openmdao/components/meta_model.py
@@ -56,7 +56,7 @@ class MetaModel(Component):
 
         self._input_size = 0
 
-    def add_param(self, name, val=_NotSet, training_data=list(), **kwargs):
+    def add_param(self, name, val=_NotSet, training_data=(), **kwargs):
         """ Add a `param` input to this component and a corresponding
         training parameter.
 
@@ -80,7 +80,7 @@ class MetaModel(Component):
         self._surrogate_param_names.append((name, input_size))
         self._input_size += input_size
 
-    def add_output(self, name, val=_NotSet, training_data=list(), **kwargs):
+    def add_output(self, name, val=_NotSet, training_data=(), **kwargs):
         """ Add an output to this component and a corresponding
         training output.
 

--- a/openmdao/surrogate_models/test/test_map.py
+++ b/openmdao/surrogate_models/test/test_map.py
@@ -7,7 +7,6 @@ from openmdao.surrogate_models import NearestNeighbor
 from openmdao.test.util import assert_rel_error
 
 import numpy as np
-
 import unittest
 
 class CompressorMap(Group):

--- a/openmdao/surrogate_models/test/test_map.py
+++ b/openmdao/surrogate_models/test/test_map.py
@@ -1,0 +1,69 @@
+from openmdao.core.group import Group
+from openmdao.core.problem import Problem
+from openmdao.core.component import Component
+from openmdao.components import MetaModel
+from openmdao.surrogate_models import NearestNeighbor
+
+from openmdao.test.util import assert_rel_error
+
+import numpy as np
+
+import unittest
+
+class CompressorMap(Group):
+
+    def __init__(self):
+        super(CompressorMap, self).__init__()
+
+        compmap = self.add('compmap', MetaModel())
+
+        compmap.add_param('Nc', val=1.0)
+        compmap.add_param('Rline', val=2.0)
+        compmap.add_param('alpha', val=0.0)
+
+        compmap.add_output('PR', val=1.0, surrogate=NearestNeighbor(interpolant_type='linear'))
+        compmap.add_output('eff', val=1.0, surrogate=NearestNeighbor(interpolant_type='linear'))
+        compmap.add_output('Wc', val=1.0, surrogate=NearestNeighbor(interpolant_type='linear'))
+
+
+class TestMap(unittest.TestCase):
+
+    def test_comp_map(self):
+        p = Problem()
+        p.root = CompressorMap()
+        p.setup(check=False)
+
+        Nc = np.array([0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1])
+        Rline = np.array([1.0, 1.2, 1.4, 1.6, 1.8, 2.0, 2.2, 2.4, 2.6, 2.8, 3.0])
+        alpha = np.array([0.0, 1.0])
+        Nc_mat, Rline_mat, alpha_mat = np.meshgrid(Nc, Rline, alpha, sparse=False)
+
+        p['compmap.train:Nc'] = Nc_mat.flatten()
+        p['compmap.train:Rline'] = Rline_mat.flatten()
+        p['compmap.train:alpha'] = alpha_mat.flatten()
+
+        p['compmap.train:PR'] = p['compmap.train:Nc']*p['compmap.train:Rline']+p['compmap.train:alpha']
+        p['compmap.train:eff'] = p['compmap.train:Nc']*p['compmap.train:Rline']**2+p['compmap.train:alpha']
+        p['compmap.train:Wc'] = p['compmap.train:Nc']**2*p['compmap.train:Rline']**2+p['compmap.train:alpha'] 
+
+        p['compmap.Nc'] = 0.9
+        p['compmap.Rline'] = 2.0
+        p['compmap.alpha'] = 0.0
+        p.run()
+
+        tol = 1e-1
+        assert_rel_error(self, p['compmap.PR'], p['compmap.Nc']*p['compmap.Rline']+p['compmap.alpha'], tol)
+        assert_rel_error(self, p['compmap.eff'], p['compmap.Nc']*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+        assert_rel_error(self, p['compmap.Wc'], p['compmap.Nc']**2*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+
+        p['compmap.Nc'] = 0.95
+        p['compmap.Rline'] = 2.1
+        p['compmap.alpha'] = 0.0
+        p.run()
+
+        assert_rel_error(self, p['compmap.PR'], p['compmap.Nc']*p['compmap.Rline']+p['compmap.alpha'], tol)
+        assert_rel_error(self, p['compmap.eff'], p['compmap.Nc']*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+        assert_rel_error(self, p['compmap.Wc'], p['compmap.Nc']**2*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This tests a use case that closely mirrors the creation of a compressor map for off-design pycycle analysis. 

This PR is just to get some CI testing, we think there may be a Windows-specific bug