### PR TITLE
setup out_stream fix

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -381,7 +381,7 @@ class Problem(System):
         side)"""
         if self._unit_diffs:
             tuples = sorted(iteritems(self._unit_diffs))
-            print("\nUnit Conversions")
+            print("\nUnit Conversions",file=out_stream)
             for (src, tgt), (sunit, tunit) in tuples:
                 print("%s -> %s : %s -> %s" % (src, tgt, sunit, tunit),
                         file=out_stream)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -381,7 +381,7 @@ class Problem(System):
         side)"""
         if self._unit_diffs:
             tuples = sorted(iteritems(self._unit_diffs))
-            print("\nUnit Conversions",file=out_stream)
+            print("\nUnit Conversions", file=out_stream)
             for (src, tgt), (sunit, tunit) in tuples:
                 print("%s -> %s : %s -> %s" % (src, tgt, sunit, tunit),
                         file=out_stream)


### PR DESCRIPTION
If there were unit conversion issues and setup was passed a specific out_stream, the header for 'Unit Conversions' was always being sent to sys.stdout.