### PR TITLE
use under_mpirun instead of try/except in api.py to avoid MPI crash

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -9,6 +9,7 @@ from openmdao.components.indep_var_comp import IndepVarComp
 from openmdao.components.param_comp import ParamComp  #deprecated
 from openmdao.components.unit_comp import UnitComp
 #core
+from openmdao.core.mpi_wrap import under_mpirun
 from openmdao.core.component import Component
 from openmdao.core.group import Group
 from openmdao.core.parallel_group import ParallelGroup
@@ -17,17 +18,15 @@ from openmdao.core.problem import Problem
 from openmdao.core.system import System
 from openmdao.core.driver import Driver
 from openmdao.core.basic_impl import BasicImpl
-try:
+if under_mpirun():
     from openmdao.core.petsc_impl import PetscImpl
-except ImportError:
-    pass
 from openmdao.core.relevance import Relevance
 #drivers
 from openmdao.drivers.scipy_optimizer import ScipyOptimizer
 try:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 except ImportError:
-    pass
+    pass 
 #recorders
 from openmdao.recorders.base_recorder import BaseRecorder
 from openmdao.recorders.dump_recorder import DumpRecorder
@@ -40,10 +39,8 @@ from openmdao.solvers.nl_gauss_seidel import NLGaussSeidel
 from openmdao.solvers.run_once import RunOnce
 from openmdao.solvers.scipy_gmres import ScipyGMRES
 from openmdao.solvers.solver_base import LinearSolver, NonLinearSolver
-try:
+if under_mpirun():
     from openmdao.solvers.petsc_ksp import PetscKSP
-except ImportError:
-    pass
 #surrogate models
 from openmdao.surrogate_models.kriging import KrigingSurrogate, FloatKrigingSurrogate
 from openmdao.surrogate_models.multifi_cokriging import MultiFiCoKrigingSurrogate, \


### PR DESCRIPTION
try/except is not sufficient and causes a crash of python when not running under MPI, so I replaced it with an if statement using under_mpirun.