### PR TITLE
better long-term fix for Miniconda/TravisCI problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,9 +47,9 @@ before_install:
 - wget "https://repo.continuum.io/miniconda/Miniconda-latest-$OS-x86_64.sh" -O miniconda.sh
 - chmod +x miniconda.sh
 - if [ "$OS" = "Linux" ]; then
-    ./miniconda.sh -b  -p /home/travis/miniconda
+    ./miniconda.sh -b  -p /home/travis/miniconda;
 - if [ "$OS" = "MacOSX" ]; then
-    ./miniconda.sh -b  -p /Users/travis/miniconda
+    ./miniconda.sh -b  -p /Users/travis/miniconda;
 - PATHPREFIX=$(if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then echo "/Users/travis/miniconda/bin"; else echo "/home/travis/miniconda/bin"; fi)
 - export PATH=$PATHPREFIX:$PATH
 - export OPENMDAO_TEST_DOCS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,8 +48,10 @@ before_install:
 - chmod +x miniconda.sh
 - if [ "$OS" = "Linux" ]; then
     ./miniconda.sh -b  -p /home/travis/miniconda;
+  fi
 - if [ "$OS" = "MacOSX" ]; then
     ./miniconda.sh -b  -p /Users/travis/miniconda;
+  fi
 - PATHPREFIX=$(if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then echo "/Users/travis/miniconda/bin"; else echo "/home/travis/miniconda/bin"; fi)
 - export PATH=$PATHPREFIX:$PATH
 - export OPENMDAO_TEST_DOCS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,9 +44,12 @@ notifications:
 before_install:
 - OS=$(if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then echo "MacOSX"; else echo "Linux"; fi)
 - if [ "$OS" = "MacOSX" ] && [ "$MPI" ]; then brew install openmpi; fi
-- wget "https://repo.continuum.io/miniconda/Miniconda-3.9.1-$OS-x86_64.sh" -O miniconda.sh
+- wget "https://repo.continuum.io/miniconda/Miniconda-latest-$OS-x86_64.sh" -O miniconda.sh
 - chmod +x miniconda.sh
-- ./miniconda.sh -b
+- if [ "$OS" = "Linux" ]; then
+    ./miniconda.sh -b  -p /home/travis/miniconda
+- if [ "$OS" = "MacOSX" ]; then
+    ./miniconda.sh -b  -p /Users/travis/miniconda
 - PATHPREFIX=$(if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then echo "/Users/travis/miniconda/bin"; else echo "/home/travis/miniconda/bin"; fi)
 - export PATH=$PATHPREFIX:$PATH
 - export OPENMDAO_TEST_DOCS=1


### PR DESCRIPTION
it turns out that the install path for Miniconda is what changed, changing it by default to /Users/travis/miniconda2.  Adding an explicit install path based on platform is a better solution, and keeps us grabbing the latest instead of being pinned to the past.