### PR TITLE
Fix for pass_by_obj=True on Driver DesignVariables

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -386,7 +386,8 @@ class Driver(object):
         val : ndarray or float
             value to set the parameter
         """
-        if self.root.unknowns.flat[name].size == 0:
+        pass_by_obj = self.root.unknowns.metadata(name).get('pass_by_obj', False)
+        if not pass_by_obj and self.root.unknowns.flat[name].size == 0:
             return
 
         scaler = self._desvars[name]['scaler']

--- a/openmdao/drivers/latinhypercube_driver.py
+++ b/openmdao/drivers/latinhypercube_driver.py
@@ -22,7 +22,7 @@ class LatinHypercubeDriver(PredeterminedRunsDriver):
         design_vars = self.get_desvar_metadata()
         design_vars_names = list(design_vars)
         self.num_design_vars = len(design_vars_names)
-        if self.seed != None:
+        if self.seed is not None:
             seed(self.seed)
             np.random.seed(self.seed)
 
@@ -43,7 +43,7 @@ class LatinHypercubeDriver(PredeterminedRunsDriver):
             yield dict(((key, np.random.uniform(bounds[i][0], bounds[i][1])) for key, bounds in iteritems(buckets)))
 
     def _get_lhc(self):
-        """Generates a Latin Hypercube based on the number of samplts and the number of design variables."""
+        """Generates a Latin Hypercube based on the number of samples and the number of design variables."""
 
         rand_lhc = _rand_latin_hypercube(self.num_samples, self.num_design_vars)
         return rand_lhc.astype(int)


### PR DESCRIPTION
This PR fixes this crash when a Component has a Parameter with pass_by_obj=True connected to a driver.

    Traceback (most recent call last):
      File "paraboloid.py", line 74, in <module>
        top.run()
      File "C:\Users\kevin\Documents\OpenMDAO\openmdao\core\problem.py", line 789, in run
        self.driver.run(self)
      File "paraboloid.py", line 16, in run
        self.set_desvar('p1.x', u'var_x')
      File "C:\Users\kevin\Documents\OpenMDAO\openmdao\core\driver.py", line 389, in set_desvar
        if self.root.unknowns.flat[name].size == 0:
    KeyError: 'p1.x'

I've created a minimal example reproducing the problem:
https://gist.github.com/ksmyth/a995066d9cd48a7c47fe

If the fix is appropriate, I can make a test out of the example.