### PR TITLE
Refactoring Line Searches

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1780,6 +1780,16 @@ class Problem(System):
 
         return connections, dangling
 
+    def print_all_convergence(self):
+        """ Sets iprint to True for all solvers and subsolvers in the model."""
+
+        root = self.root
+        root.ln_solver.print_all_convergence()
+        root.nl_solver.print_all_convergence()
+        for grp in root.subgroups(recurse=True):
+            grp.ln_solver.print_all_convergence()
+            grp.nl_solver.print_all_convergence()
+
 
 def _assign_parameters(connections):
     """Map absolute system names to the absolute names of the

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -714,10 +714,9 @@ class TestProblem(unittest.TestCase):
         top.setup(check=False)
 
         base_stdout = sys.stdout
-        from cStringIO import StringIO
 
         try:
-            ostream = StringIO()
+            ostream = cStringIO()
             sys.stdout = ostream
             top.run()
         finally:
@@ -730,7 +729,7 @@ class TestProblem(unittest.TestCase):
         top.print_all_convergence()
 
         try:
-            ostream = StringIO()
+            ostream = cStringIO()
             sys.stdout = ostream
             top.run()
         finally:

--- a/openmdao/drivers/latinhypercube_driver.py
+++ b/openmdao/drivers/latinhypercube_driver.py
@@ -109,10 +109,14 @@ class _LHC_Individual(object):
             # TODO: This norm takes up the majority of the computation time. It
             # should be converted to C or ShedSkin.
             arr = self.doe
-            for i in range(n):
-                for j in range(i + 1, n):
-                    nrm = np.linalg.norm(arr[i] - arr[j], ord=self.p)
-                    distdict[nrm] = distdict.get(nrm, 0) + 1
+            for i in range(1, n):
+                nrm = np.linalg.norm(arr[i] - arr[:i], ord=self.p, axis=1)
+                for j in range(0, i):
+                    nrmj = nrm[j]
+                    if nrmj in distdict:
+                        distdict[nrmj] += 1
+                    else:
+                        distdict[nrmj] = 1
 
             distinct_d = np.array(list(distdict))
 

--- a/openmdao/drivers/latinhypercube_driver.py
+++ b/openmdao/drivers/latinhypercube_driver.py
@@ -106,8 +106,6 @@ class _LHC_Individual(object):
             distdict = {}
 
             # Calculate the norm between each pair of points in the DOE
-            # TODO: This norm takes up the majority of the computation time. It
-            # should be converted to C or ShedSkin.
             arr = self.doe
             for i in range(1, n):
                 nrm = np.linalg.norm(arr[i] - arr[:i], ord=self.p, axis=1)

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -1,0 +1,104 @@
+""" Line search using backtracking."""
+
+from openmdao.solvers.solver_base import LineSearch
+from openmdao.util.record_util import update_local_meta, create_local_meta
+
+
+class BackTracking(LineSearch):
+    """A line search subsolver using backtracking.
+
+    Options
+    -------
+    options['iprint'] :  int(0)
+        Set to 0 to disable printing, set to 1 to print the residual to stdout
+        each iteration, set to 2 to print subiteration residuals as well.
+    options['atol'] :  float(1e-10)
+        Absolute convergence tolerancee for line search.
+    options['maxiter'] :  int(10)
+        Maximum number of line searches.
+    options['rtol'] :  float(0.9)
+        Relative convergence tolerancee for line search.
+    options['solve_subsystems'] :  bool(True)
+        Set to True to solve subsystems. You may need this for solvers nested under Newton.
+    """
+
+    def __init__(self):
+        super(BackTracking, self).__init__()
+
+        opt = self.options
+        opt.add_option('atol', 1e-10,
+                       desc='Absolute convergence tolerancee for line search.')
+        opt.add_option('rtol', 0.9,
+                       desc='Relative convergence tolerancee for line search.')
+        opt.add_option('maxiter', 10,
+                       desc='Maximum number of line searches.')
+        opt.add_option('solve_subsystems', True,
+                       desc='Set to True to solve subsystems. You may need this for solvers nested under Newton.')
+
+    def solve(self, params, unknowns, resids, system, solver, alpha, fnorm,
+              fnorm0, metadata=None):
+        """ Take the gradient calculated by the parent solver and figure out
+        how far to go.
+
+        Args
+        ----
+        params : `VecWrapper`
+            `VecWrapper` containing parameters. (p)
+
+        unknowns : `VecWrapper`
+            `VecWrapper` containing outputs and states. (u)
+
+        resids : `VecWrapper`
+            `VecWrapper` containing residuals. (r)
+
+        system : `System`
+            Parent `System` object.
+
+        metadata : dict, optional
+            Dictionary containing execution metadata (e.g. iteration coordinate).
+
+        solver : `Solver`
+            Parent solver instance.
+
+        alpha : float
+            Initial over-relaxation factor as used in parent solver.
+
+        fnorm : float
+            Initial norm of the residual for absolute tolerance check.
+
+        fnorm0 : float
+            Initial norm of the residual for relative tolerance check.
+        """
+
+        atol = self.options['atol']
+        rtol = self.options['rtol']
+        maxiter = self.options['maxiter']
+        result = system.dumat[None]
+
+        local_meta = create_local_meta(metadata, system.pathname)
+        itercount = 0
+        ls_alpha = alpha
+
+        # Backtracking Line Search
+        while itercount < maxiter and \
+              fnorm > atol and \
+              fnorm/fnorm0 > rtol:
+
+            ls_alpha *= 0.5
+            unknowns.vec[:] -= ls_alpha*result.vec
+            itercount += 1
+
+            # Metadata update
+            update_local_meta(local_meta, (solver.iter_count, itercount))
+
+            # Just evaluate the model with the new points
+            if self.options['solve_subsystems'] is True:
+                system.children_solve_nonlinear(local_meta)
+            system.apply_nonlinear(params, unknowns, resids, local_meta)
+
+            solver.recorders.record_iteration(system, local_meta)
+
+            fnorm = resids.norm()
+            if self.options['iprint'] > 0:
+                self.print_norm('BK_TKG', system.pathname, itercount, fnorm,
+                                fnorm0, indent=1, solver='LS')

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -85,7 +85,7 @@ class BackTracking(LineSearch):
               fnorm/fnorm0 > rtol:
 
             ls_alpha *= 0.5
-            unknowns.vec[:] -= ls_alpha*result.vec
+            unknowns.vec -= ls_alpha*result.vec
             itercount += 1
 
             # Metadata update

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -10,7 +10,7 @@ from openmdao.util.record_util import update_local_meta, create_local_meta
 class Newton(NonLinearSolver):
     """A python Newton solver that solves a linear system to determine the
     next direction to step. Also uses `Backtracking` as the default line
-    search algorithm, but you can choose a different on by specifying
+    search algorithm, but you can choose a different one by specifying
     `self.line_search`.
 
     Options
@@ -103,7 +103,7 @@ class Newton(NonLinearSolver):
             arg.vec[:] = resids.vec
             system.solve_linear(system.dumat, system.drmat, [None], mode='fwd')
 
-            unknowns.vec[:] += alpha*result.vec
+            unknowns.vec += alpha*result.vec
 
             # Metadata update
             self.iter_count += 1

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -68,7 +68,7 @@ class SolverBase(object):
         # Find indentation level
         level = pathname.count('.')
         # No indentation for driver; top solver is no indentation.
-        level = level + indent - 2
+        level = level + indent
 
         indent = '   ' * level
         if msg is not None:
@@ -78,6 +78,11 @@ class SolverBase(object):
 
         form = indent + '[%s] %s: %s   %d | %.9g %.9g'
         print(form % (name, solver, solver_string, iteration, res, res/res0))
+
+    def print_all_convergence(self):
+        """ Turns on iprint for this solver and all subsolvers. Override if
+        your solver has subsolvers."""
+        self.options['iprint'] = 1
 
     def generate_docstring(self):
         """
@@ -128,9 +133,8 @@ class LinearSolver(SolverBase):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
-
-
+        Set to 0 to disable printing, set to 1 to print the residual to stdout
+        each iteration, set to 2 to print subiteration residuals as well.
     """
 
     def add_recorder(self, recorder):
@@ -174,8 +178,8 @@ class NonLinearSolver(SolverBase):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
-
+        Set to 0 to disable printing, set to 1 to print the residual to stdout
+        each iteration, set to 2 to print subiteration residuals as well.
     """
 
     def add_recorder(self, recorder):
@@ -209,5 +213,54 @@ class NonLinearSolver(SolverBase):
 
         metadata : dict, optional
             Dictionary containing execution metadata (e.g. iteration coordinate).
+        """
+        pass
+
+
+class LineSearch(SolverBase):
+    """ Base class for all linesearch subsolvers. Line search is used by
+    other solvers such as the Newton solver. Inherit from this class to
+    create a new custom line search.
+
+    Options
+    -------
+    options['iprint'] :  int(0)
+        Set to 0 to disable printing, set to 1 to print the residual to stdout
+        each iteration, set to 2 to print subiteration residuals as well.
+    """
+
+    def solve(self, params, unknowns, resids, system, solver, alpha, fnorm,
+              fnorm0, metadata=None):
+        """ Take the gradient calculated by the parent solver and figure out
+        how far to go.
+
+        Args
+        ----
+        params : `VecWrapper`
+            `VecWrapper` containing parameters. (p)
+
+        unknowns : `VecWrapper`
+            `VecWrapper` containing outputs and states. (u)
+
+        resids : `VecWrapper`
+            `VecWrapper` containing residuals. (r)
+
+        system : `System`
+            Parent `System` object.
+
+        metadata : dict, optional
+            Dictionary containing execution metadata (e.g. iteration coordinate).
+
+        solver : `Solver`
+            Parent solver instance.
+
+        alpha : float
+            Initial over-relaxation factor as used in parent solver.
+
+        fnorm : float
+            Initial norm of the residual for absolute tolerance check.
+
+        fnorm0 : float
+            Initial norm of the residual for relative tolerance check.
         """
         pass

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -34,7 +34,7 @@ class FakeSolver(NonLinearSolver):
         arg.vec[:] = resids.vec*100
         system.solve_linear(system.dumat, system.drmat, [None], mode='fwd')
 
-        unknowns.vec[:] += result.vec
+        unknowns.vec += result.vec
 
         self.sub.solve(params, unknowns, resids, system, self, 1.0, 1.0, 1.0)
 

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -1,0 +1,64 @@
+""" Unit testing for the Backtracking sub-solver. """
+
+import unittest
+
+from openmdao.api import Problem, Group, NonLinearSolver, IndepVarComp
+from openmdao.solvers.backtracking import BackTracking
+from openmdao.test.paraboloid import Paraboloid
+from openmdao.test.sellar import SellarStateConnection
+from openmdao.test.util import assert_rel_error
+
+
+class FakeSolver(NonLinearSolver):
+    """ Does nothing but invoke a line search."""
+
+    def __init__(self):
+        super(FakeSolver, self).__init__()
+        self.sub = BackTracking()
+
+    def solve(self, params, unknowns, resids, system, metadata=None):
+        """ Calc deriv then do line search."""
+
+        # Perform an initial run to propagate srcs to targets.
+        system.children_solve_nonlinear(None)
+        system.apply_nonlinear(params, unknowns, resids)
+
+        # Linearize Model with partial derivatives
+        system._sys_linearize(params, unknowns, resids, total_derivs=False)
+
+        # Calculate direction to take step
+        arg = system.drmat[None]
+        result = system.dumat[None]
+
+        # Step waaaaay to far so we have to backtrack
+        arg.vec[:] = resids.vec*100
+        system.solve_linear(system.dumat, system.drmat, [None], mode='fwd')
+
+        unknowns.vec[:] += result.vec
+
+        self.sub.solve(params, unknowns, resids, system, self, 1.0, 1.0, 1.0)
+
+class TestBackTracking(unittest.TestCase):
+
+    def test_newton_with_backtracking(self):
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.root.nl_solver.line_search.options['atol'] = 1e-12
+        top.root.nl_solver.line_search.options['rtol'] = 1e-12
+        top.root.nl_solver.line_search.options['maxiter'] = 3
+
+        # This is a very contrived test, but we step 8 times farther than we
+        # should, then allow the line search to backtrack 3 steps, which
+        # takes us back to 1.0.
+        top.root.nl_solver.options['alpha'] = 8.0
+
+        top.setup(check=False)
+        top.run()
+
+        assert_rel_error(self, top['y1'], 25.58830273, .00001)
+        assert_rel_error(self, top['state_eq.y2_command'], 12.05848819, .00001)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/units/test/test_units.py
+++ b/openmdao/units/test/test_units.py
@@ -6,7 +6,7 @@ import os
 import unittest
 
 from openmdao.test.util import assert_rel_error
-from openmdao.units.units import PhysicalUnit, PhysicalQuantity, NumberDict, UnitsOnlyPQ 
+from openmdao.units.units import PhysicalUnit, PhysicalQuantity, NumberDict
 from openmdao.api import convert_units, get_conversion_tuple
 from openmdao.units.units import import_library, add_unit, add_offset_unit
 

--- a/openmdao/units/units.py
+++ b/openmdao/units/units.py
@@ -377,44 +377,6 @@ class PhysicalQuantity(object):
             raise TypeError('Argument of tan must be an angle')
 
 
-class UnitsOnlyPQ(PhysicalQuantity):
-    """When you want to determine the units of a combined expression without
-    worrying about possible problems with the actual values (divide by zero, etc.),
-    replace the variables in the expression with instances of this class, evaluate
-    the expression, and retrieve the units of the result.
-
-    .. warning:: Only the units of the resulting UnitsOnlyPQ object will be correct. The value
-       may be incorrect, so don't use it.
-    """
-    def __div__(self, other):
-        if not isinstance(other, PhysicalQuantity):
-            return self.__class__(self.value, self.unit)
-        value = self.value
-        unit = self.unit/other.unit
-        if unit.is_dimensionless():
-            return value*unit.factor
-        else:
-            return self.__class__(value, unit)
-
-    def __rdiv__(self, other):
-        if not isinstance(other, PhysicalQuantity):
-            return self.__class__(other, pow(self.unit, -1))
-        value = other.value
-        unit = other.unit/self.unit
-        if unit.is_dimensionless():
-            return value*unit.factor
-        else:
-            return self.__class__(value, unit)
-
-    def tan(self):
-        if self.unit.is_angle():
-            #return N.tan(self.value * \
-            return tan(0. * \
-                self.unit.conversion_factor_to(PhysicalQuantity('1rad').unit))
-        else:
-            raise TypeError('Argument of tan must be an angle')
-
-
 class PhysicalUnit(object):
     """
     Physical unit.


### PR DESCRIPTION
1. Created LineSearch class of subsolvers that perform line searches
2. Created a BackTracking line search
3. Removed bactracking from the Newton solver and used gave it a line_search attribute with BackTracking as the default.
4. Add a method `print_all_convergence() that is called after setup to set iprint to 1 in all subsolvers.
5. Performance improvement in OptimalLatinHypercube to vectorize a very slow norm calculation.