### PR TITLE
fix to allow pass_by_obj vars to be added to a gradient free driver.

### DIFF
--- a/openmdao/core/test/test_pbo_desvar.py
+++ b/openmdao/core/test/test_pbo_desvar.py
@@ -1,4 +1,3 @@
-""" Unit test for the Problem class. """
 
 import unittest
 from openmdao.api import Component, Problem, Group, IndepVarComp, ExecComp, Driver
@@ -49,6 +48,9 @@ class PassByObjParaboloid(Component):
         return J
 
 class TestPBODesvar(unittest.TestCase):
+    """Test for adding pass_by_obj variables to a gradient free
+    driver.
+    """
 
     def test_pbo_desvar(self):
         top = Problem()

--- a/openmdao/core/test/test_pbo_desvar.py
+++ b/openmdao/core/test/test_pbo_desvar.py
@@ -1,0 +1,77 @@
+""" Unit test for the Problem class. """
+
+import unittest
+from openmdao.api import Component, Problem, Group, IndepVarComp, ExecComp, Driver
+from openmdao.core.checks import ConnectError
+from openmdao.util.record_util import create_local_meta, update_local_meta
+
+
+class DummyDriver(Driver):
+    def __init__(self, *args, **kwargs):
+        super(DummyDriver, self).__init__(*args, **kwargs)
+
+    def run(self, problem):
+        self.set_desvar('p1.x', u'var_x')
+        self.set_desvar('p2.y', 123.0)
+        metadata = create_local_meta(None, 'Driver')
+        problem.root.solve_nonlinear(metadata=metadata)
+
+class PassByObjParaboloid(Component):
+    """ Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3 """
+
+    def __init__(self):
+        super(PassByObjParaboloid, self).__init__()
+
+        self.add_param('x', val=u'var_x', pass_by_obj=True)
+        self.add_param('y', val=0.0)
+
+        self.add_output('f_xy', val=0.0)
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        """f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+        Optimal solution (minimum): x = 6.6667; y = -7.3333
+        """
+
+        x = hash(params['x'])
+        y = params['y']
+
+        unknowns['f_xy'] = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
+
+    def linearize(self, params, unknowns, resids):
+        """ Jacobian for our paraboloid."""
+
+        x = hash(params['x'])
+        y = params['y']
+        J = {}
+
+        J['f_xy', 'x'] = 2.0*x - 6.0 + y
+        J['f_xy', 'y'] = 2.0*y + 8.0 + x
+        return J
+
+class TestPBODesvar(unittest.TestCase):
+
+    def test_pbo_desvar(self):
+        top = Problem()
+
+        root = top.root = Group()
+
+        root.add('p1', IndepVarComp('x', u'var_x', pass_by_obj=True))
+        root.add('p2', IndepVarComp('y', -4.0))
+        root.add('p', PassByObjParaboloid())
+
+        root.connect('p1.x', 'p.x')
+        root.connect('p2.y', 'p.y')
+
+        top.driver = DummyDriver()
+
+        top.driver.add_desvar('p1.x')
+        top.driver.add_desvar('p2.y')
+        top.driver.add_objective('p.f_xy')
+
+        top.setup()
+        top.run()
+        # print(root.p.unknowns['f_xy'])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/drivers/latinhypercube_driver.py
+++ b/openmdao/drivers/latinhypercube_driver.py
@@ -22,7 +22,7 @@ class LatinHypercubeDriver(PredeterminedRunsDriver):
         design_vars = self.get_desvar_metadata()
         design_vars_names = list(design_vars)
         self.num_design_vars = len(design_vars_names)
-        if self.seed != None:
+        if self.seed is not None:
             seed(self.seed)
             np.random.seed(self.seed)
 
@@ -43,7 +43,7 @@ class LatinHypercubeDriver(PredeterminedRunsDriver):
             yield dict(((key, np.random.uniform(bounds[i][0], bounds[i][1])) for key, bounds in iteritems(buckets)))
 
     def _get_lhc(self):
-        """Generates a Latin Hypercube based on the number of samplts and the number of design variables."""
+        """Generates a Latin Hypercube based on the number of samples and the number of design variables."""
 
         rand_lhc = _rand_latin_hypercube(self.num_samples, self.num_design_vars)
         return rand_lhc.astype(int)

--- a/openmdao/drivers/test/test_latin_hypercube_driver.py
+++ b/openmdao/drivers/test/test_latin_hypercube_driver.py
@@ -1,44 +1,45 @@
 """ Testing driver LatinHypercubeDriver."""
 
-from pprint import pformat
 import unittest
-from random import randint
+from random import seed
 from types import GeneratorType
 
 import numpy as np
 
-from openmdao.api import IndepVarComp, Group, Problem, ScipyOptimizer, ExecComp
+from openmdao.api import IndepVarComp, Group, Problem
 from openmdao.test.paraboloid import Paraboloid
-from openmdao.test.sellar import SellarDerivatives, SellarStateConnection
-from openmdao.test.simple_comps import SimpleArrayComp, ArrayComp2D
-from openmdao.test.util import assert_rel_error
 
 from openmdao.drivers.latinhypercube_driver import LatinHypercubeDriver, OptimizedLatinHypercubeDriver
 from openmdao.drivers.latinhypercube_driver import _is_latin_hypercube, _rand_latin_hypercube, _mmlhs, _LHC_Individual
 
+
 class TestLatinHypercubeDriver(unittest.TestCase):
 
+    def setUp(self):
+        self.seed()
+        self.hypercube_sizes = ((3, 1), (5, 5), (20, 8))
+
+    def seed(self):
+        # seedval = None
+        self.seedval = 1
+        seed(self.seedval)
+        np.random.seed(self.seedval)
+
     def test_rand_latin_hypercube(self):
+        for n, k in self.hypercube_sizes:
+            test_lhc = _rand_latin_hypercube(n, k)
 
-        n = randint(1,100)
-        k = randint(1,20)
+            self.assertTrue(_is_latin_hypercube(test_lhc))
 
-        test_lhc = _rand_latin_hypercube(n, k)
-
-        self.assertTrue(_is_latin_hypercube(test_lhc))
-
-    def test_mmlhs(self):
-
-        n = randint(1,100)
-        k = randint(1,20)
+    def _test_mmlhs_latin(self, n, k):
         p = 1
-        population = 30
+        population = 3
         generations = 6
 
         test_lhc = _rand_latin_hypercube(n, k)
         best_lhc = _LHC_Individual(test_lhc, 1, p)
         mmphi_initial = best_lhc.mmphi()
-        for q in [1,2,5,10,20,50,100]:
+        for q in (1, 2, 5, 10, 20, 50, 100):
             lhc_start = _LHC_Individual(test_lhc, q, p)
             lhc_opt = _mmlhs(lhc_start, population, generations)
             if lhc_opt.mmphi() < best_lhc.mmphi():
@@ -46,7 +47,11 @@ class TestLatinHypercubeDriver(unittest.TestCase):
 
         self.assertTrue(
                 best_lhc.mmphi() < mmphi_initial,
-                "'_mmlhs' didn't yield lower phi.")
+                "'_mmlhs' didn't yield lower phi. Seed was {}".format(self.seedval))
+
+    def test_mmlhs_latin(self):
+        for n, k in self.hypercube_sizes:
+            self._test_mmlhs_latin(n, k)
 
     def test_algorithm_coverage_lhc(self):
 
@@ -58,9 +63,10 @@ class TestLatinHypercubeDriver(unittest.TestCase):
         root.add('comp', Paraboloid(), promotes=['*'])
 
         prob.driver = LatinHypercubeDriver(100)
+
         prob.driver.add_desvar('x', lower=-50.0, upper=50.0)
         prob.driver.add_desvar('y', lower=-50.0, upper=50.0)
-        
+
         prob.driver.add_objective('f_xy')
 
         prob.setup(check=False)
@@ -103,7 +109,7 @@ class TestLatinHypercubeDriver(unittest.TestCase):
         self.assertTrue(
                 len(yDict) == 100,
                 "One of the intervals wasn't covered.")
-        
+
     def test_algorithm_coverage_olhc(self):
 
         prob = Problem()
@@ -113,10 +119,10 @@ class TestLatinHypercubeDriver(unittest.TestCase):
         root.add('p2', IndepVarComp('y', 50.0), promotes=['*'])
         root.add('comp', Paraboloid(), promotes=['*'])
 
-        prob.driver = OptimizedLatinHypercubeDriver(100)
+        prob.driver = OptimizedLatinHypercubeDriver(100, population=5)
         prob.driver.add_desvar('x', lower=-50.0, upper=50.0)
         prob.driver.add_desvar('y', lower=-50.0, upper=50.0)
-        
+
         prob.driver.add_objective('f_xy')
 
         prob.setup(check=False)
@@ -159,7 +165,7 @@ class TestLatinHypercubeDriver(unittest.TestCase):
         self.assertTrue(
                 len(yDict) == 100,
                 "One of the intervals wasn't covered.")
-        
+
     '''
     def test_seed_works(self):
 


### PR DESCRIPTION
Also contains a fix for a latin hypercube test.   This PR originally came from ksmyth but I had to resolve some merge conflicts.