### PR TITLE
fix to sqlite_recorder so only root records to db

### DIFF
--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -13,6 +13,10 @@ class RecordingManager(object):
 
         self._recorders = []
         self.__has_serial_recorders = False
+        if MPI:
+            self.rank = MPI.COMM_WORLD.rank
+        else:
+            self.rank = 0
 
     def append(self, recorder):
         self._recorders.append(recorder)
@@ -57,7 +61,7 @@ class RecordingManager(object):
         for recorder in self._recorders:
             # If the recorder does not support parallel recording
             # we need to make sure we only record on rank 0.
-            if recorder._parallel or root.comm.rank == 0:
+            if recorder._parallel or self.rank == 0:
                 metadata_option = recorder.options['record_metadata']
 
                 if metadata_option is False:
@@ -110,5 +114,5 @@ class RecordingManager(object):
         # If the recorder does not support parallel recording
         # we need to make sure we only record on rank 0.
         for recorder in self._recorders:
-            if recorder._parallel or root.comm.rank == 0:
+            if recorder._parallel or self.rank == 0:
                 recorder.record_iteration(params, unknowns, resids, metadata)

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -32,8 +32,10 @@ class SqliteRecorder(BaseRecorder):
         Args
         ----
         group : `System`
-            `System` containing vectors 
+            `System` containing vectors
         """
+
+        if not self._open_close_sqlitedict: return
 
         params = group.params.iteritems()
         resids = group.resids.iteritems()
@@ -65,13 +67,15 @@ class SqliteRecorder(BaseRecorder):
             Dictionary containing execution metadata (e.g. iteration coordinate).
         """
 
+        if not self._open_close_sqlitedict: return
+
         data = OrderedDict()
         iteration_coordinate = metadata['coord']
         timestamp = metadata['timestamp']
         params, unknowns, resids = self._filter_vectors(params, unknowns, resids, iteration_coordinate)
 
         group_name = format_iteration_coordinate(iteration_coordinate)
-        
+
         data['timestamp'] = timestamp
 
         if self.options['record_params']:

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -35,8 +35,6 @@ class SqliteRecorder(BaseRecorder):
             `System` containing vectors
         """
 
-        if not self._open_close_sqlitedict: return
-
         params = group.params.iteritems()
         resids = group.resids.iteritems()
         unknowns = group.unknowns.iteritems()
@@ -66,8 +64,6 @@ class SqliteRecorder(BaseRecorder):
         metadata : dict, optional
             Dictionary containing execution metadata (e.g. iteration coordinate).
         """
-
-        if not self._open_close_sqlitedict: return
 
         data = OrderedDict()
         iteration_coordinate = metadata['coord']


### PR DESCRIPTION
I can't run in parallel on the latest master with the changes made to SqliteRecorder. It looks like only the root proc returns from the record calls and the other procs raise this warning and cause the process to stall:

    TypeError: 'NoneType' object does not support item assignment

since they all set self.out to `None`.

adding a return statement in `record_metadata` and `record_iteration` seems to fix it so that only the root tries to record.