### PR TITLE
Namelist update

### DIFF
--- a/openmdao/util/namelist_util.py
+++ b/openmdao/util/namelist_util.py
@@ -172,8 +172,11 @@ class Namelist(object):
         varpath : string
             Variable name being added. For variable trees, include the colon
             between each level."""
-
-        value = self.comp.params[name]
+        # To support loading a model before setup so that we can interact with it.
+        if hasattr(self.comp.params, 'keys'):
+            value = self.comp.params[name]
+        else:
+            value = self.comp._init_params_dict[name]['val']
 
         self.cards[self.currentgroup].append(Card(name, value))
 
@@ -206,7 +209,7 @@ class Namelist(object):
         if not skip:
             skip = []
 
-        for name in iterkeys(self.comp._init_params_dict):
+        for name in sorted(iterkeys(self.comp._init_params_dict)):
             if name.startswith(varpath):
                 sub_name = name.lstrip(varpath + ':')
                 if sub_name not in skip:
@@ -240,29 +243,31 @@ class Namelist(object):
                 data.append("%s\n" % group_name)
 
             for card in self.cards[i]:
-
+                #avoid using entire xxx:xxx:var
+                #only use 'var' as the cardname to be printed
+                card_name = card.name.split(":")[-1]
                 if card.is_comment:
                     line = "  %s\n" % (card.value)
 
                 elif isinstance(card.value, bool):
                     fstring = "  %s = " + _boolfmt(card.value) + "\n"
-                    line = fstring % (card.name, card.value)
+                    line = fstring % (card_name, card.value)
 
                 elif isinstance(card.value, int):
                     fstring = "  %s = " + _intfmt(card.value) + "\n"
-                    line = fstring % (card.name, card.value)
+                    line = fstring % (card_name, card.value)
 
                 elif isinstance(card.value, float):
                     fstring = "  %s = " + _floatfmt(card.value) + "\n"
-                    line =  fstring % (card.name, card.value)
+                    line =  fstring % (card_name, card.value)
 
                 elif isinstance(card.value, str):
                     fstring = "  %s = " + _strfmt(card.value) + "\n"
-                    line =  fstring % (card.name, card.value)
+                    line =  fstring % (card_name, card.value)
 
                 # Lists are mainly supported for the Enum Array
                 elif isinstance(card.value, list):
-                    line = "  %s = " % (card.name)
+                    line = "  %s = " % (card_name)
                     sep = ""
                     for val in card.value:
 
@@ -299,7 +304,7 @@ class Namelist(object):
                         continue
 
                     elif len(card.value.shape) == 1:
-                        line = "  %s = " % (card.name)
+                        line = "  %s = " % (card_name)
                         sep = ""
                         for val in card.value:
                             fstring = "%s" + fmt(val)
@@ -311,7 +316,7 @@ class Namelist(object):
 
                         line = "  "
                         for row in range(0, card.value.shape[0]):
-                            line += card.name + "(1," + str(row+1) + ") ="
+                            line += card_name + "(1," + str(row+1) + ") ="
                             for col in range(0, card.value.shape[1]):
                                 val = card.value[row, col]
                                 fstring = " " + fmt(val) + "%s"
@@ -326,7 +331,7 @@ class Namelist(object):
                 else:
                     raise RuntimeError("Error generating input file. Don't"
                                        " know how to handle data in variable"
-                                       " %s in group %s." % (card.name,
+                                       " %s in group %s." % (card_name,
                                                              group_name))
 
                 data.append(line)

--- a/openmdao/util/namelist_util.py
+++ b/openmdao/util/namelist_util.py
@@ -208,10 +208,9 @@ class Namelist(object):
 
         if not skip:
             skip = []
-
         for name in sorted(iterkeys(self.comp._init_params_dict)):
-            if name.startswith(varpath):
-                sub_name = name.lstrip(varpath + ':')
+            if name.startswith(varpath+':'):
+                sub_name = name[len(varpath+':'):]
                 if sub_name not in skip:
                     self.add_var(name)
 
@@ -243,9 +242,11 @@ class Namelist(object):
                 data.append("%s\n" % group_name)
 
             for card in self.cards[i]:
-                #avoid using entire xxx:xxx:var
-                #only use 'var' as the cardname to be printed
+
+                #avoid writing 'xxx:xxx:var'
+                #write 'var' instead
                 card_name = card.name.split(":")[-1]
+
                 if card.is_comment:
                     line = "  %s\n" % (card.value)
 


### PR DESCRIPTION
Found that add_container could not handle container with similar names e.g 
container vs container_1 

lstrip does not have the desired behavior so I'm avoid the use of it.

Modified
---- def  generate(self): 
to write only the desired variables ('var') instead of the entire container ('xxxx:xxxx:var')

Added a test case in test_namelist for the variable tree