### PR TITLE
update names for OSX pyoptsparse wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,9 +68,9 @@ install:
   fi
 - if [ "$OS" = "MacOSX" ]; then
     if [ "$PY" = "2.7" ]; then
-        pip install https://openmdao.org/dists/pyoptsparsepyoptsparse-1.0.0-cp27-none-macosx_10_5_x86_64.whl;
+        pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp27-none-macosx_10_5_x86_64.whl;
     elif [ "$PY" = "3.4" ]; then
-        pip install https://openmdao.org/dists/pyoptsparsepyoptsparse-1.0.0-cp34-cp34m-macosx_10_5_x86_64.whl;
+        pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp34-none-macosx_10_5_x86_64.whl;
     fi
   fi
 - if [ "$MPI" ]; then


### PR DESCRIPTION
the OSX pyoptsparse wheels were remade to resolve an issue with naming that prevented the installed package from being recognized as satisfying the `pyoptsparse` dependency