### PR TITLE
fix bug with linear constraints in pyoptsparse, add tests

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -155,18 +155,19 @@ class pyOptSparseDriver(Driver):
             self.sparsity[name] = self.indep_list
 
         # Calculate and save gradient for any linear constraints.
-        lcons = self.get_constraints(lintype='linear').values()
+        lcons = self.get_constraints(lintype='linear').keys()
         if len(lcons) > 0:
             self.lin_jacs = problem.calc_gradient(indep_list, lcons,
                                                   return_format='dict')
-            #print("Linear Gradient")
-            #print(self.lin_jacs)
+            print("Linear Gradient")
+            print(self.lin_jacs)
 
         # Add all equality constraints
         econs = self.get_constraints(ctype='eq', lintype='nonlinear')
         con_meta = self.get_constraint_metadata()
         self.quantities += list(iterkeys(econs))
-        for name in econs:
+
+        for name in self.get_constraints(ctype='eq'):
             size = con_meta[name]['size']
             lower = upper = con_meta[name]['equals']
 
@@ -185,7 +186,8 @@ class pyOptSparseDriver(Driver):
         # Add all inequality constraints
         incons = self.get_constraints(ctype='ineq', lintype='nonlinear')
         self.quantities += list(iterkeys(incons))
-        for name in incons:
+
+        for name in self.get_constraints(ctype='ineq'):
             size = con_meta[name]['size']
 
             # Bounds - double sided is supported

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -159,8 +159,8 @@ class pyOptSparseDriver(Driver):
         if len(lcons) > 0:
             self.lin_jacs = problem.calc_gradient(indep_list, lcons,
                                                   return_format='dict')
-            print("Linear Gradient")
-            print(self.lin_jacs)
+            #print("Linear Gradient")
+            #print(self.lin_jacs)
 
         # Add all equality constraints
         econs = self.get_constraints(ctype='eq', lintype='nonlinear')

--- a/openmdao/drivers/test/test_pyoptsparse.py
+++ b/openmdao/drivers/test/test_pyoptsparse.py
@@ -130,7 +130,7 @@ class TestPyoptSparse(unittest.TestCase):
         prob.driver.add_desvar('y', lower=-50.0, upper=50.0)
 
         prob.driver.add_objective('f_xy')
-        prob.driver.add_constraint('c', equals=-15.0)
+        prob.driver.add_constraint('c', equals=-15.0, linear=True)
 
         prob.setup(check=False)
         prob.run()

--- a/openmdao/drivers/test/test_pyoptsparse.py
+++ b/openmdao/drivers/test/test_pyoptsparse.py
@@ -131,6 +131,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.driver.add_objective('f_xy')
         prob.driver.add_constraint('c', equals=-15.0, linear=True)
+        prob.driver.add_constraint('x', lower=-100.0)
 
         prob.setup(check=False)
         prob.run()

--- a/openmdao/drivers/test/test_pyoptsparse.py
+++ b/openmdao/drivers/test/test_pyoptsparse.py
@@ -111,6 +111,38 @@ class TestPyoptSparse(unittest.TestCase):
         assert_rel_error(self, prob['x'], 7.16667, 1e-6)
         assert_rel_error(self, prob['y'], -7.833334, 1e-6)
 
+    def test_simple_paraboloid_lower_linear(self):
+
+        prob = Problem()
+        root = prob.root = Group()
+
+        root.add('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        root.add('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        root.add('comp', Paraboloid(), promotes=['*'])
+        root.add('con', ExecComp('c = x - y'), promotes=['*'])
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+        prob.driver.options['print_results'] = False
+        prob.driver.add_desvar('x', lower=-50.0, upper=50.0)
+        prob.driver.add_desvar('y', lower=-50.0, upper=50.0)
+
+        prob.driver.add_objective('f_xy')
+        prob.driver.add_constraint('c', lower=15.0, linear=True)
+        if OPTIMIZER == 'SNOPT':
+            # there is currently a bug in SNOPT, it requires at least one
+            # nonlinear inequality constraint, so provide a 'fake' one
+            prob.driver.add_constraint('x', lower=-100.0)
+
+        prob.setup(check=False)
+        prob.run()
+
+        # Minimum should be at (7.166667, -7.833334)
+        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
+        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+
     def test_simple_paraboloid_equality(self):
 
         prob = Problem()
@@ -130,8 +162,39 @@ class TestPyoptSparse(unittest.TestCase):
         prob.driver.add_desvar('y', lower=-50.0, upper=50.0)
 
         prob.driver.add_objective('f_xy')
+        prob.driver.add_constraint('c', equals=-15.0)
+
+        prob.setup(check=False)
+        prob.run()
+
+        # Minimum should be at (7.166667, -7.833334)
+        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
+        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+
+    def test_simple_paraboloid_equality_linear(self):
+
+        prob = Problem()
+        root = prob.root = Group()
+
+        root.add('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        root.add('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        root.add('comp', Paraboloid(), promotes=['*'])
+        root.add('con', ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+        prob.driver.options['print_results'] = False
+        prob.driver.add_desvar('x', lower=-50.0, upper=50.0)
+        prob.driver.add_desvar('y', lower=-50.0, upper=50.0)
+
+        prob.driver.add_objective('f_xy')
         prob.driver.add_constraint('c', equals=-15.0, linear=True)
-        prob.driver.add_constraint('x', lower=-100.0)
+        if OPTIMIZER == 'SNOPT':
+            # there is currently a bug in SNOPT, it requires at least one
+            # nonlinear inequality constraint, so provide a 'fake' one
+            prob.driver.add_constraint('x', lower=-100.0)
 
         prob.setup(check=False)
         prob.run()


### PR DESCRIPTION
Note: there is an outstanding bug in pyopt/snopt that requires at least one nonlinear constraint TBR