### PR TITLE
Adressing the double-run during solver solves

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -62,6 +62,7 @@ class Component(System):
         # keep a list of nondifferentiable vars without user set 'pass_by_obj'
         # metadata for use later in check_setup
         self._pbo_warns = []
+        self._run_apply = False
 
     def _get_initial_val(self, val, shape):
         """ Determines initial value based on starting val and shape."""
@@ -176,6 +177,7 @@ class Component(System):
         args = self._add_variable(name, val, **kwargs)
         args['state'] = True
         self._init_unknowns_dict[name] = args
+        self._run_apply = True
 
     def set_var_indices(self, name, val=_NotSet, shape=None,
                         src_indices=None):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -62,6 +62,7 @@ class Group(System):
         self._order_set = False
 
         self._gs_outputs = None
+        self._run_apply = True
 
     def _subsystem(self, name):
         """
@@ -675,6 +676,14 @@ class Group(System):
 
         # transfer data to each subsystem and then apply_nonlinear to it
         for sub in itervalues(self._subsystems):
+
+            # Don't want to double if we don't have to. Only generate
+            # residuals on components that provide useful ones, namely comps
+            # that are targets of severed connections or have implicit
+            # states.
+            if not sub._run_apply:
+                continue
+
             self._transfer_data(sub.name)
             if sub.is_active():
                 if isinstance(sub, Component):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -642,7 +642,16 @@ class Problem(System):
         for s in self.root.subgroups(recurse=True, include_self=True):
             # set auto order if order not already set
             if not s._order_set:
-                s.set_order(s.list_auto_order()[0])
+                order, broken_edges = s.list_auto_order()
+                s.set_order(order)
+
+                # Mark "head" of each broken edge
+                for edge in broken_edges:
+                    cname = edge[1]
+                    head_sys = self.root
+                    for name in cname.split('.'):
+                        head_sys = getattr(head_sys, name)
+                    head_sys._run_apply = True
 
         # report any differences in units or initial values for
         # sourceless connected inputs

--- a/openmdao/solvers/test/test_newton.py
+++ b/openmdao/solvers/test/test_newton.py
@@ -60,6 +60,14 @@ class TestNewton(unittest.TestCase):
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.root.nl_solver.iter_count, 8)
 
+        # Make sure we only call apply_linear on 'heads'
+        nd1 = prob.root.d1.execution_count
+        nd2 = prob.root.d2.execution_count
+        if prob.root.d1._run_apply == True:
+            self.assertEqual(nd1, 2*nd2)
+        else:
+            self.assertEqual(2*nd1, nd2)
+
     def test_sellar_derivs_with_Lin_GS(self):
 
         prob = Problem()

--- a/openmdao/solvers/test/test_nl_gauss_seidel.py
+++ b/openmdao/solvers/test/test_nl_gauss_seidel.py
@@ -27,6 +27,14 @@ class TestNLGaussSeidel(unittest.TestCase):
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.root.nl_solver.iter_count, 8)
 
+        # Make sure we only call apply_linear on 'heads'
+        nd1 = prob.root.cycle.d1.execution_count
+        nd2 = prob.root.cycle.d2.execution_count
+        if prob.root.cycle.d1._run_apply == True:
+            self.assertEqual(nd1, 2*nd2)
+        else:
+            self.assertEqual(2*nd1, nd2)
+
     def test_sellar_group(self):
 
         prob = Problem()

--- a/openmdao/test/sellar.py
+++ b/openmdao/test/sellar.py
@@ -35,6 +35,8 @@ class SellarDis1(Component):
         # Coupling output
         self.add_output('y1', val=1.0)
 
+        self.execution_count = 0
+
     def solve_nonlinear(self, params, unknowns, resids):
         """Evaluates the equation
         y1 = z1**2 + z2 + x1 - 0.2*y2"""
@@ -45,6 +47,8 @@ class SellarDis1(Component):
         y2 = params['y2']
 
         unknowns['y1'] = z1**2 + z2 + x1 - 0.2*y2
+
+        self.execution_count += 1
 
 
 class SellarDis1withDerivatives(SellarDis1):
@@ -76,6 +80,8 @@ class SellarDis2(Component):
         # Coupling output
         self.add_output('y2', val=1.0)
 
+        self.execution_count = 0
+
     def solve_nonlinear(self, params, unknowns, resids):
         """Evaluates the equation
         y2 = y1**(.5) + z1 + z2"""
@@ -90,6 +96,8 @@ class SellarDis2(Component):
         y1 = abs(y1)
 
         unknowns['y2'] = y1**.5 + z1 + z2
+
+        self.execution_count += 1
 
 
 class SellarDis2withDerivatives(SellarDis2):


### PR DESCRIPTION
This fix is a partial performance improvement for a double-run that occurs during solves. The double run occurs in implicit components because they need to run a 2nd time in order to calculate a residual. There are other possible ways to solve this problem, but they don't fit into MAUD so well. 

With this fix, the apply_linear call is limited to the following Components:
1. Comps with implicit states, which is not a double run.
2. Components that are on the target side of a broken edge in a cycle.