### PR TITLE
removed System inheritance from Problem in order to improve error mes…

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -44,7 +44,7 @@ class _ProbData(object):
         self.top_lin_gs = False
 
 
-class Problem(System):
+class Problem(object):
     """ The Problem is always the top object for running an OpenMDAO
     model.
 
@@ -101,6 +101,8 @@ class Problem(System):
             self.driver = Driver()
         else:
             self.driver = driver
+
+        self.pathname = ''
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected
@@ -839,7 +841,7 @@ class Problem(System):
             if self.comm.rank == 0:
                 for grp in self.root.subgroups(recurse=True, include_self=True):
                     if (isinstance(grp, ParallelGroup) or
-                        isinstance(grp, ParallelFDGroup) or 
+                        isinstance(grp, ParallelFDGroup) or
                         isinstance(grp, ParallelDOEGroup)):
                         break
                 else:

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -637,6 +637,33 @@ class TestProblem(unittest.TestCase):
         prob.root.list_connections(group_by_comp=False, stream=stream)
         prob.root.G3.C3.list_connections(var='x', stream=stream)
 
+    def test_no_vecs(self):
+        prob = Problem(root=ExampleGroup())
+        prob.setup(check=False)
+
+        # test that problem has no unknowns, params, etc.
+        try:
+            prob.unknowns['G3.C4.y']
+        except AttributeError as err:
+            self.assertEqual(str(err), "'Problem' object has no attribute 'unknowns'")
+        else:
+            self.fail("AttributeError expected")
+
+        try:
+            prob.params['G3.C4.x']
+        except AttributeError as err:
+            self.assertEqual(str(err), "'Problem' object has no attribute 'params'")
+        else:
+            self.fail("AttributeError expected")
+
+        try:
+            prob.resids['G3.C4.x']
+        except AttributeError as err:
+            self.assertEqual(str(err), "'Problem' object has no attribute 'resids'")
+        else:
+            self.fail("AttributeError expected")
+
+
     def test_byobj_run(self):
         prob = Problem(root=ExampleByObjGroup())
 


### PR DESCRIPTION
…sage when user attempts to access prob.unknowns, etc.  In the future when we allow for nested problems, we'll need to put the Problem object into a 'ProblemSystem' object to specify what vars are visible to the rest of the system tree.