### PR TITLE
Exclude pbo design vars from problem's partial and total deriv checks.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1657,20 +1657,24 @@ class Problem(object):
             dparams = comp.dpmat[voi]
             dunknowns = comp.dumat[voi]
             dresids = comp.drmat[voi]
+            states = comp.states
 
             # Skip if all of our inputs are unconnected.
             if len(dparams) == 0:
                 continue
+
+            # Work with all params that are not pbo.
+            param_list = [item for item in dparams if not \
+                          dparams.metadata(item).get('pass_by_obj')]
+            param_list.extend(states)
 
             if out_stream is not None:
                 out_stream.write('-'*(len(cname)+15) + '\n')
                 out_stream.write("Component: '%s'\n" % cname)
                 out_stream.write('-'*(len(cname)+15) + '\n')
 
-            states = comp.states
-
             # Create all our keys and allocate Jacs
-            for p_name in chain(dparams, states):
+            for p_name in param_list:
 
                 dinputs = dunknowns if p_name in states else dparams
                 p_size = np.size(dinputs[p_name])
@@ -1716,13 +1720,13 @@ class Problem(object):
                     finally:
                         dparams._apply_unit_derivatives()
 
-                    for p_name in chain(dparams, states):
+                    for p_name in param_list:
 
                         dinputs = dunknowns if p_name in states else dparams
                         jac_rev[(u_name, p_name)][idx, :] = dinputs._dat[p_name].val
 
             # Forward derivatives second
-            for p_name in chain(dparams, states):
+            for p_name in param_list:
 
                 dinputs = dunknowns if p_name in states else dparams
                 p_size = np.size(dinputs[p_name])

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1789,9 +1789,11 @@ class Problem(object):
             out_stream.write('Total Derivatives Check\n\n')
 
         # Params and Unknowns that we provide at this level.
-        abs_indep_list = self.root._get_fd_params()
-        param_srcs = [self.root.connections[p] for p in abs_indep_list]
-        unknown_list = self.root._get_fd_unknowns()
+        root = self.root
+        abs_indep_list = root._get_fd_params()
+        param_srcs = [root.connections[p] for p in abs_indep_list \
+                      if not root.params.metadata(p).get('pass_by_obj')]
+        unknown_list = root._get_fd_unknowns()
 
         # Convert absolute parameter names to promoted ones because it is
         # easier for the user to read.

--- a/openmdao/core/test/test_pbo_desvar.py
+++ b/openmdao/core/test/test_pbo_desvar.py
@@ -314,5 +314,8 @@ class TestPBODesvar(unittest.TestCase):
         data = prob.check_partial_derivatives(out_stream=None)
         self.assertEqual(data['comp'][('z', 'x')]['J_fwd'][0][0], 3.0)
 
+        data = prob.check_total_derivatives(out_stream=None)
+        self.assertEqual(data[('z', 'x')]['J_fwd'][0][0], 3.0)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
For a user-reported bug