### PR TITLE
Support unit conversion on pass_by_object vars

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -997,8 +997,8 @@ class Problem(object):
         return pbos
 
     def _check_relevant_pbos(self, out_stream=sys.stdout):
-        """ Warn if any pass_by_object variables are in any relevant set.
-        Warn even more sternly if top driver requires derivatives."""
+        """ Warn if any pass_by_object variables are in any relevant set if
+        top driver requires derivatives."""
 
         # Only warn if we are taking gradients across model with a pbo
         # variable.

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -815,8 +815,16 @@ class Problem(object):
         if self._unit_diffs:
             tuples = sorted(iteritems(self._unit_diffs))
             print("\nUnit Conversions", file=out_stream)
+
+            vec = self.root.unknowns
+            pbos = [var for var in vec if vec.metadata(var).get('pass_by_obj') is True]
+
             for (src, tgt), (sunit, tunit) in tuples:
-                print("%s -> %s : %s -> %s" % (src, tgt, sunit, tunit),
+                if src in pbos:
+                    pbo_str = ' (pass_by_obj)'
+                else:
+                    pbo_str = ''
+                print("%s -> %s : %s -> %s%s" % (src, tgt, sunit, tunit, pbo_str),
                       file=out_stream)
 
             return tuples
@@ -988,6 +996,46 @@ class Problem(object):
 
         return pbos
 
+    def _check_relevant_pbos(self, out_stream=sys.stdout):
+        """ Warn if any pass_by_object variables are in any relevant set.
+        Warn even more sternly if top driver requires derivatives."""
+
+        # Only warn if we are taking gradients across model with a pbo
+        # variable.
+        if self.driver.__class__ is Driver or \
+           self.driver.supports['gradients'] is False or \
+           self.root.fd_options['force_fd'] is True:
+            return []
+
+        vec = self.root.unknowns
+        pbos = [var for var in vec if vec.metadata(var).get('pass_by_obj') is True]
+
+        rels = set()
+        for key, rel in iteritems(self._probdata.relevance.relevant):
+            rels.update(rel)
+
+        rel_pbos = rels.intersection(pbos)
+        if rel_pbos:
+            print("\nThe following relevant connections are marked as pass_by_obj:",
+                  file=out_stream)
+            for src in rel_pbos:
+                val = vec[src]
+
+                # Find target(s) and print whole relevant connection
+                for tgt, src_tuple in iteritems(self.root.connections):
+                    if src_tuple[0] == src and tgt in rels:
+                        print("%s -> %s: type %s" % (src, tgt, type(val).__name__),
+                              file=out_stream)
+
+            print("\nYour driver requires a gradient across a model with pass_by_obj "
+                  "connections. We strongly recommend either setting the root "
+                  "fd_options 'force_fd' to True, or isolating the pass_by_obj "
+                  "connection into a Group and setting its fd_options 'force_fd' "
+                  "to True.",
+                  file=out_stream)
+
+        return list(rel_pbos)
+
     def check_setup(self, out_stream=sys.stdout):
         """Write a report to the given stream indicating any potential problems
         found with the current configuration of this ``Problem``.
@@ -1012,6 +1060,7 @@ class Problem(object):
         results['ubcs'] = self._check_ubcs(out_stream)
         results['solver_issues'] = self._check_gmres_under_mpi(out_stream)
         results['unmarked_pbos'] = self._check_unmarked_pbos(out_stream)
+        results['relevant_pbos'] = self._check_relevant_pbos(out_stream)
         results['layout'] = self._check_layout(out_stream)
 
         # TODO: Incomplete optimization driver configuration

--- a/openmdao/core/test/test_units.py
+++ b/openmdao/core/test/test_units.py
@@ -605,7 +605,7 @@ class TestUnitConversionPBO(unittest.TestCase):
         prob.root.connect('x1', 'src.x1')
         prob.root.connect('src.x2', 'tgtF.x2')
 
-        top.root.fd_options['force_fd'] = True
+        prob.root.fd_options['force_fd'] = True
 
         prob.setup(check=False)
         prob.run()

--- a/openmdao/core/test/test_units.py
+++ b/openmdao/core/test/test_units.py
@@ -605,18 +605,20 @@ class TestUnitConversionPBO(unittest.TestCase):
         prob.root.connect('x1', 'src.x1')
         prob.root.connect('src.x2', 'tgtF.x2')
 
+        top.root.fd_options['force_fd'] = True
+
         prob.setup(check=False)
         prob.run()
 
         assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
         assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
 
-        #indep_list = ['x1']
-        #unknown_list = ['tgtF.x3']
-        #J = prob.calc_gradient(indep_list, unknown_list, mode='fwd',
-                               #return_format='dict')
+        indep_list = ['x1']
+        unknown_list = ['tgtF.x3']
+        J = prob.calc_gradient(indep_list, unknown_list, mode='fwd',
+                               return_format='dict')
 
-        #assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -61,11 +61,14 @@ class Accessor(object):
         if self.remote:
             return self._remote_access_error, self._remote_access_error
 
+        scale, offset = meta.get('unit_conv', (None, None))
         if self.pbo:
-            return self._get_pbo, flatfunc
+            if scale:
+                return self._get_pbo_units, flatfunc
+            else:
+                return self._get_pbo, flatfunc
 
         shape = meta['shape']
-        scale, offset = meta.get('unit_conv', (None, None))
         if vecwrapper.deriv_units:
             offset = 0.0
         is_scalar = shape == 1
@@ -114,6 +117,13 @@ class Accessor(object):
     def _get_pbo(self):
         """pass by obj"""
         return self.val.val
+
+    def _get_pbo_units(self):
+        """Special unit conversions for pass by obj"""
+        scale, offset = self.meta['unit_conv']
+        vec = self.val.val + offset
+        vec *= scale
+        return vec
 
     def _get_arr(self):
         """Array with same shape"""


### PR DESCRIPTION
1. Unit conversion support for pass_by_object variables. If they aren't floats, you'll get an error when it tries to convert them.
2. Setup check warns if there are any relevant pbo connections under a gradient driver.
3. Marked pbo conversions in the unit conversion list.