### PR TITLE
fix for a parallel bug that Rob found.

### DIFF
--- a/mpitest/test_pointer_bug.py
+++ b/mpitest/test_pointer_bug.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 
 from openmdao.api import Group, Component, IndepVarComp, ParallelGroup, \
-                         PetscImpl, Problem
+                         Problem
 from openmdao.core.mpi_wrap import MPI
 from openmdao.test.mpi_util import MPITestCase
 
@@ -181,7 +181,7 @@ class CollocationSegment(Group):
 
 def flat_earth(num_seg=3, seg_ncn=3):
 
-    prob = PointerProblem(root=Trajectory(), impl=PetscImpl)
+    prob = PointerProblem(root=Trajectory(), impl=impl)
     traj = prob.root
     rhs = FlatEarthRHS(1)
     phase0 = CollocationPhase(name='phase0', rhs=rhs, num_seg=num_seg, seg_ncn=seg_ncn,

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1234,17 +1234,17 @@ class Group(System):
                 new_indices[on_irank] = arg_idxs[on_irank] + offset
 
             src_idxs = new_indices
-            var_rank = self._owning_ranks[pname] if (rev and pacc.remote) else iproc
+            p_rank = self._owning_ranks[pname] if (rev and pacc.remote) else iproc
 
         else:
-            var_rank = self._owning_ranks[uname] if fwd else iproc
-            offset = np.sum(u_sizes[:var_rank]) + np.sum(u_sizes[var_rank, :ivar])
+            u_rank = self._owning_ranks[uname] if fwd else iproc
+            p_rank = self._owning_ranks[pname] if rev else iproc
+
+            offset = np.sum(u_sizes[:u_rank]) + np.sum(u_sizes[u_rank, :ivar])
             src_idxs = arg_idxs + offset
 
-            var_rank = self._owning_ranks[pname] if rev else iproc
-
-        tgt_start = (np.sum(p_sizes[:var_rank]) +
-                     np.sum(p_sizes[var_rank, :p_var_idxs[pname]]))
+        tgt_start = (np.sum(p_sizes[:p_rank]) +
+                     np.sum(p_sizes[p_rank, :p_var_idxs[pname]]))
         tgt_idxs = tgt_start + self.params.make_idx_array(0, len(arg_idxs))
 
         return src_idxs, tgt_idxs

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1234,7 +1234,7 @@ class Group(System):
                 new_indices[on_irank] = arg_idxs[on_irank] + offset
 
             src_idxs = new_indices
-            var_rank = iproc
+            var_rank = self._owning_ranks[pname] if (rev and pacc.remote) else iproc
 
         else:
             var_rank = self._owning_ranks[uname] if fwd else iproc


### PR DESCRIPTION
We were using the wrong rank to calculate an offset into the global params vector when there was a remote param with src_indices.