### PR TITLE
Improved Timeout behavior for ExternalCode

### DIFF
--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -43,8 +43,13 @@ class ExternalCode(Component):
         (optional) list of input file names to check the pressence of after solve_nonlinear
     options['poll_delay'] :  float(0.0)
         Delay between polling for command completion. A value of zero will use an internally computed default
-    options['timeout'] :  float(0.0)
+    options['on_timeout'] :  float(0.0)
+        Timeout behvaior, either raise an exception or terminate process and continue running OpenMDAO
+    options['timeout'] :  str('raise')
         Maximum time to wait for command completion. A value of zero implies an infinite wait
+    options['timeout'] :  str('raise')
+        Maximum time to wait for command completion. A value of zero implies an infinite wait
+
 
     """
 
@@ -70,9 +75,9 @@ class ExternalCode(Component):
         self.options.add_option( 'external_output_files', [],
             desc='(optional) list of input file names to check the pressence of after solve_nonlinear')
         self.options.add_option('on_timeout', 'raise', values=['raise', 'continue'],
-            desc='Timeout behvaior, either raise an exception or terminate and continue running OpenMDAO')
+            desc='Timeout behvaior, either raise an exception or terminate process and continue running OpenMDAO')
         self.options.add_option('on_error', 'raise', values=['raise', 'continue'],
-                                desc='Behvaior on error returned from code, either raise an exception or terminate and continue running OpenMDAO')
+                                desc='Behvaior on error returned from code, either raise an exception or terminate process and continue running OpenMDAO')
 
         # Outputs of the run of the component or items that will not work with the OptionsDictionary
         self.return_code = 0 # Return code from the command

--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -71,6 +71,8 @@ class ExternalCode(Component):
             desc='(optional) list of input file names to check the pressence of after solve_nonlinear')
         self.options.add_option('on_timeout', 'raise', values=['raise', 'continue'],
             desc='Timeout behvaior, either raise an exception or terminate and continue running OpenMDAO')
+        self.options.add_option('on_error', 'raise', values=['raise', 'continue'],
+                                desc='Behvaior on error returned from code, either raise an exception or terminate and continue running OpenMDAO')
 
         # Outputs of the run of the component or items that will not work with the OptionsDictionary
         self.return_code = 0 # Return code from the command
@@ -129,7 +131,7 @@ class ExternalCode(Component):
                 self.timed_out = True
                 raise RuntimeError('Timed out')
 
-            elif return_code:
+            elif return_code and self.options['on_error'] == 'raise':
                 if isinstance(self.stderr, str):
                     if os.path.exists(self.stderr):
                         stderrfile = open(self.stderr, 'r')

--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -69,6 +69,8 @@ class ExternalCode(Component):
             desc='(optional) list of input file names to check the pressence of before solve_nonlinear')
         self.options.add_option( 'external_output_files', [],
             desc='(optional) list of input file names to check the pressence of after solve_nonlinear')
+        self.options.add_option('on_timeout', 'raise', values=['raise', 'continue'],
+            desc='Timeout behvaior, either raise an exception or terminate and continue running OpenMDAO')
 
         # Outputs of the run of the component or items that will not work with the OptionsDictionary
         self.return_code = 0 # Return code from the command
@@ -123,10 +125,7 @@ class ExternalCode(Component):
         try:
             return_code, error_msg = self._execute_local()
 
-            if return_code is None:
-                # if self._stop:
-                #     raise RuntimeError('Run stopped')
-                # else:
+            if return_code is None and self.options['on_timeout'] == 'raise':
                 self.timed_out = True
                 raise RuntimeError('Timed out')
 
@@ -143,6 +142,7 @@ class ExternalCode(Component):
                     err_fragment = error_msg
 
                 raise RuntimeError('return_code = %d%s' % (return_code, err_fragment))
+
 
             if self.options['check_external_outputs']:
                 missing_files = self._check_for_files(input=False)

--- a/openmdao/components/external_code.py
+++ b/openmdao/components/external_code.py
@@ -43,12 +43,12 @@ class ExternalCode(Component):
         (optional) list of input file names to check the pressence of after solve_nonlinear
     options['poll_delay'] :  float(0.0)
         Delay between polling for command completion. A value of zero will use an internally computed default
-    options['on_timeout'] :  float(0.0)
-        Timeout behvaior, either raise an exception or terminate process and continue running OpenMDAO
-    options['timeout'] :  str('raise')
+    options['timeout'] :  float(0.0)
         Maximum time to wait for command completion. A value of zero implies an infinite wait
-    options['timeout'] :  str('raise')
-        Maximum time to wait for command completion. A value of zero implies an infinite wait
+    options['on_timeout'] :  str('raise')
+        Timeout behavior, either "raise" an exception or "continue" running OpenMDAO
+    options['on_error'] :  str('raise')
+        Behavior on error returned from code, either "raise" an exception or "continue" running OpenMDAO
 
 
     """
@@ -75,9 +75,9 @@ class ExternalCode(Component):
         self.options.add_option( 'external_output_files', [],
             desc='(optional) list of input file names to check the pressence of after solve_nonlinear')
         self.options.add_option('on_timeout', 'raise', values=['raise', 'continue'],
-            desc='Timeout behvaior, either raise an exception or terminate process and continue running OpenMDAO')
+            desc='Timeout behavior, either "raise" an exception or "continue" running OpenMDAO')
         self.options.add_option('on_error', 'raise', values=['raise', 'continue'],
-                                desc='Behvaior on error returned from code, either raise an exception or terminate process and continue running OpenMDAO')
+            desc='Behavior on error returned from code, either "raise" an exception or "continue" running OpenMDAO')
 
         # Outputs of the run of the component or items that will not work with the OptionsDictionary
         self.return_code = 0 # Return code from the command

--- a/openmdao/components/test/test_external_code.py
+++ b/openmdao/components/test/test_external_code.py
@@ -69,10 +69,10 @@ class TestExternalCode(unittest.TestCase):
     #         file_contents = out.read()
     #     self.assertTrue('external_code_for_testing.py' in file_contents)
 
-    def test_timeout(self):
+    def test_timeout_raise(self):
 
         self.extcode.options['command'] = ['python', 'external_code_for_testing.py',
-             'external_code_output.txt', '--delay', '5']
+             'external_code_output.txt', '--delay', '3']
         self.extcode.options['timeout'] = 1.0
 
         self.extcode.options['external_input_files'] = ['external_code_for_testing.py', ]
@@ -86,6 +86,51 @@ class TestExternalCode(unittest.TestCase):
             self.assertEqual(self.extcode.timed_out, True)
         else:
             self.fail('Expected RunInterrupted')
+
+    def test_timeout_continue(self):
+
+        self.extcode.options['command'] = ['python', 'external_code_for_testing.py',
+             'external_code_output.txt', '--delay', '3']
+        self.extcode.options['timeout'] = 1.0
+
+        self.extcode.options['external_input_files'] = ['external_code_for_testing.py', ]
+        self.extcode.options['on_timeout'] = 'continue'
+
+        dev_null = open(os.devnull, 'w')
+        self.top.setup(check=True, out_stream=dev_null)
+
+        self.top.run()
+
+    def test_error_code_raise(self):
+
+        self.extcode.options['command'] = ['python', 'external_code_for_testing.py',
+             'external_code_output.txt', '--delay', '-3']
+        self.extcode.options['timeout'] = 1.0
+
+        self.extcode.options['external_input_files'] = ['external_code_for_testing.py', ]
+
+        dev_null = open(os.devnull, 'w')
+        self.top.setup(check=True, out_stream=dev_null)
+        try:
+            self.top.run()
+        except RuntimeError as exc:
+            self.assertTrue('Traceback' in str(exc))
+            self.assertEqual(self.extcode.return_code, 1)
+        else:
+            self.fail('Expected ValueError')
+
+    def test_error_code_continue(self):
+
+        self.extcode.options['command'] = ['python', 'external_code_for_testing.py',
+             'external_code_output.txt', '--delay', '-3']
+        self.extcode.options['timeout'] = 1.0
+        self.extcode.options['on_error'] = 'continue'
+
+        self.extcode.options['external_input_files'] = ['external_code_for_testing.py', ]
+
+        dev_null = open(os.devnull, 'w')
+        self.top.setup(check=True, out_stream=dev_null)
+        self.top.run()
 
     def test_badcmd(self):
 

--- a/openmdao/components/test/test_external_code.py
+++ b/openmdao/components/test/test_external_code.py
@@ -49,6 +49,8 @@ class TestExternalCode(unittest.TestCase):
         dev_null = open(os.devnull, 'w')
         self.top.setup(check=True, out_stream=dev_null)
         self.top.run()
+        self.assertEqual(self.extcode.timed_out, False)
+        self.assertEqual(self.extcode.errored_out, False)
 
     # def test_ls_command(self):
     #     output_filename = 'ls_output.txt'
@@ -100,6 +102,7 @@ class TestExternalCode(unittest.TestCase):
         self.top.setup(check=True, out_stream=dev_null)
 
         self.top.run()
+        self.assertEqual(self.extcode.timed_out, True)
 
     def test_error_code_raise(self):
 
@@ -116,6 +119,7 @@ class TestExternalCode(unittest.TestCase):
         except RuntimeError as exc:
             self.assertTrue('Traceback' in str(exc))
             self.assertEqual(self.extcode.return_code, 1)
+            self.assertEqual(self.extcode.errored_out, True)
         else:
             self.fail('Expected ValueError')
 
@@ -131,6 +135,7 @@ class TestExternalCode(unittest.TestCase):
         dev_null = open(os.devnull, 'w')
         self.top.setup(check=True, out_stream=dev_null)
         self.top.run()
+        self.assertEqual(self.extcode.errored_out, True)
 
     def test_badcmd(self):
 

--- a/openmdao/util/shell_proc.py
+++ b/openmdao/util/shell_proc.py
@@ -74,8 +74,7 @@ class ShellProc(subprocess.Popen):
             subprocess.Popen.__init__(self, args, stdin=self._inp,
                                       stdout=self._out, stderr=self._err,
                                       shell=shell, env=environ,
-                                      universal_newlines=universal_newlines,
-                                      preexec_fn=os.setsid)
+                                      universal_newlines=universal_newlines)
         except Exception:
             self.close_files()
             raise
@@ -99,8 +98,10 @@ class ShellProc(subprocess.Popen):
             A value of zero implies an infinite maximum wait.
 
         """
-        #super(ShellProc, self).terminate()
-        os.killpg(os.getpgid(self.pid), signal.SIGTERM)
+        if sys.platform == 'win32':
+            subprocess.Popen("TASKKILL /F /PID {pid} /T".format(pid=self.pid))
+        else:
+            super(ShellProc, self).terminate()
         if timeout is not None:
             return self.wait(timeout=timeout)
 

--- a/openmdao/util/shell_proc.py
+++ b/openmdao/util/shell_proc.py
@@ -57,7 +57,7 @@ class ShellProc(subprocess.Popen):
             self._inp = open(stdin, 'r')
         else:
             self._inp = stdin
-    
+
         if isinstance(stdout, str):
             self._out = open(stdout, 'w')
         else:
@@ -74,7 +74,8 @@ class ShellProc(subprocess.Popen):
             subprocess.Popen.__init__(self, args, stdin=self._inp,
                                       stdout=self._out, stderr=self._err,
                                       shell=shell, env=environ,
-                                      universal_newlines=universal_newlines)
+                                      universal_newlines=universal_newlines,
+                                      preexec_fn=os.setsid)
         except Exception:
             self.close_files()
             raise
@@ -98,7 +99,8 @@ class ShellProc(subprocess.Popen):
             A value of zero implies an infinite maximum wait.
 
         """
-        super(ShellProc, self).terminate()
+        #super(ShellProc, self).terminate()
+        os.killpg(os.getpgid(self.pid), signal.SIGTERM)
         if timeout is not None:
             return self.wait(timeout=timeout)
 


### PR DESCRIPTION
1. Added `on_timeout` option to choose to raise exception or continue on timeout.
2. Added `on_error` option to choose to raise exception or continue on external code raised error.
3. Changed process termination in Windows so that jobs aren't left running.