### PR TITLE
Empty Jacobian allowed by linearize

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -758,7 +758,7 @@ class System(object):
         any derivative specification in any `Component` or `Group` to perform
         finite difference."""
 
-        if not self._jacobian_cache:
+        if self._jacobian_cache is None:
             msg = ("No derivatives defined for Component '{name}'")
             msg = msg.format(name=self.pathname)
             raise ValueError(msg)

--- a/openmdao/core/test/test_empty_jacobian.py
+++ b/openmdao/core/test/test_empty_jacobian.py
@@ -1,0 +1,128 @@
+""" Test to verify that components without outputs will work as expected as
+long as their linearize method returns an empty dict {}.
+"""
+
+
+__author__ = 'rfalck'
+
+import unittest
+
+from openmdao.api import Problem, Group, Component, ExecComp, IndepVarComp
+from openmdao.drivers.scipy_optimizer import ScipyOptimizer
+
+
+class InputComp(Component):
+
+    def __init__(self):
+
+        super(InputComp,self).__init__()
+
+        self.add_param(name='A',val=0.0)
+        self.add_param(name='B',val=0.0)
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        pass
+
+    def linearize(self, params, unknowns, resids):
+        return {}
+
+
+class InputComp2(Component):
+
+    def __init__(self):
+
+        super(InputComp2,self).__init__()
+
+        self.add_param(name='A',val=0.0)
+        self.add_param(name='B',val=0.0)
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        pass
+
+    def linearize(self, params, unknowns, resids):
+        return None
+
+
+
+class MyGroup(Group):
+
+    def __init__(self):
+        super(MyGroup,self).__init__()
+
+        self.add(name='input',system=InputComp())
+
+        self.add(name='exec',system=ExecComp('y=a**2+b**2',a=5.0,b=5.0))
+
+        self.connect('input.A','exec.a')
+        self.connect('input.B','exec.b')
+
+
+
+class MyGroup2(Group):
+
+    def __init__(self):
+        super(MyGroup2,self).__init__()
+
+        self.add(name='input',system=InputComp2())
+
+        self.add(name='exec',system=ExecComp('y=a**2+b**2',a=5.0,b=5.0))
+
+        self.connect('input.A','exec.a')
+        self.connect('input.B','exec.b')
+
+
+class TestEmptyJacobian(unittest.TestCase):
+
+    def test_empty_jacobian(self):
+
+        prob = Problem(root=Group())
+
+        root = prob.root
+
+        root.add(name='ivc_a',system=IndepVarComp(name='a',val=5.0),promotes=['a'])
+        root.add(name='ivc_b',system=IndepVarComp(name='b',val=10.0),promotes=['b'])
+
+        root.add(name='g',system=MyGroup())
+
+        root.connect('a','g.input.A')
+        root.connect('b','g.input.B')
+
+        prob.driver = ScipyOptimizer()
+        prob.driver.options["disp"] = False
+        prob.driver.add_objective('g.exec.y')
+        prob.driver.add_desvar(name='a')
+        prob.driver.add_desvar(name='b')
+
+        prob.setup(check=False)
+
+        try:
+            prob.run()
+        except ValueError as e:
+            self.fail("test_empty_jacobian resulted in an exception:\n    "
+                      "{0}".format(e.message))
+
+    def test_none_jacobian(self):
+
+        prob = Problem(root=Group())
+
+        root = prob.root
+
+        root.add(name='ivc_a',system=IndepVarComp(name='a',val=5.0),promotes=['a'])
+        root.add(name='ivc_b',system=IndepVarComp(name='b',val=10.0),promotes=['b'])
+
+        root.add(name='g',system=MyGroup2())
+
+        root.connect('a','g.input.A')
+        root.connect('b','g.input.B')
+
+        prob.driver = ScipyOptimizer()
+        prob.driver.options["disp"] = False
+        prob.driver.add_objective('g.exec.y')
+        prob.driver.add_desvar(name='a')
+        prob.driver.add_desvar(name='b')
+
+        prob.setup(check=False)
+
+        with self.assertRaises(ValueError):
+            prob.run()
+

--- a/openmdao/core/test/test_empty_jacobian.py
+++ b/openmdao/core/test/test_empty_jacobian.py
@@ -120,8 +120,8 @@ class TestEmptyJacobian(unittest.TestCase):
         try:
             prob.run()
         except ValueError as e:
-            self.fail("test_empty_jacobian resulted in an exception:\n    "
-                      "{0}".format(e.message))
+            if e.message == "No derivatives defined for Component 'g.input'":
+                self.fail("Raised an error for a component with an empty Jacobian")
 
     def test_none_jacobian(self):
 
@@ -147,8 +147,12 @@ class TestEmptyJacobian(unittest.TestCase):
 
         prob.setup(check=False)
 
-        with self.assertRaises(ValueError):
+        try:
             prob.run()
+        except ValueError as e:
+            assert(e.message == "No derivatives defined for Component 'g.input'")
+        else:
+            self.fail("Failed to raise an exception for a jacobian returning None")
 
     def test_undefined_jacobian(self):
 
@@ -174,8 +178,13 @@ class TestEmptyJacobian(unittest.TestCase):
 
         prob.setup(check=False)
 
-        with self.assertRaises(ValueError):
+        try:
             prob.run()
+        except ValueError as e:
+            assert(e.message == "No derivatives defined for Component 'g.input'")
+        else:
+            self.fail("Failed to raise an exception for an undefined jacobian")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/test/test_empty_jacobian.py
+++ b/openmdao/core/test/test_empty_jacobian.py
@@ -1,10 +1,6 @@
 """ Test to verify that components without outputs will work as expected as
 long as their linearize method returns an empty dict {}.
 """
-
-
-__author__ = 'rfalck'
-
 import unittest
 
 from openmdao.api import Problem, Group, Component, ExecComp, IndepVarComp
@@ -15,10 +11,10 @@ class InputComp(Component):
 
     def __init__(self):
 
-        super(InputComp,self).__init__()
+        super(InputComp, self).__init__()
 
-        self.add_param(name='A',val=0.0)
-        self.add_param(name='B',val=0.0)
+        self.add_param(name="A", val=0.0)
+        self.add_param(name="B", val=0.0)
 
     def solve_nonlinear(self, params, unknowns, resids):
         pass
@@ -31,10 +27,10 @@ class InputComp2(Component):
 
     def __init__(self):
 
-        super(InputComp2,self).__init__()
+        super(InputComp2, self).__init__()
 
-        self.add_param(name='A',val=0.0)
-        self.add_param(name='B',val=0.0)
+        self.add_param(name="A", val=0.0)
+        self.add_param(name="B", val=0.0)
 
     def solve_nonlinear(self, params, unknowns, resids):
         pass
@@ -43,32 +39,56 @@ class InputComp2(Component):
         return None
 
 
+class InputComp3(Component):
+
+    def __init__(self):
+
+        super(InputComp3, self).__init__()
+
+        self.add_param(name="A", val=0.0)
+        self.add_param(name="B", val=0.0)
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        pass
+
 
 class MyGroup(Group):
 
     def __init__(self):
-        super(MyGroup,self).__init__()
+        super(MyGroup, self).__init__()
 
-        self.add(name='input',system=InputComp())
+        self.add(name="input", system=InputComp())
 
-        self.add(name='exec',system=ExecComp('y=a**2+b**2',a=5.0,b=5.0))
+        self.add(name="exec", system=ExecComp("y=a**2+b**2", a=5.0, b=5.0))
 
-        self.connect('input.A','exec.a')
-        self.connect('input.B','exec.b')
-
+        self.connect("input.A", "exec.a")
+        self.connect("input.B", "exec.b")
 
 
 class MyGroup2(Group):
 
     def __init__(self):
-        super(MyGroup2,self).__init__()
+        super(MyGroup2, self).__init__()
 
-        self.add(name='input',system=InputComp2())
+        self.add(name="input", system=InputComp2())
 
-        self.add(name='exec',system=ExecComp('y=a**2+b**2',a=5.0,b=5.0))
+        self.add(name="exec", system=ExecComp("y=a**2+b**2", a=5.0, b=5.0))
 
-        self.connect('input.A','exec.a')
-        self.connect('input.B','exec.b')
+        self.connect("input.A", "exec.a")
+        self.connect("input.B", "exec.b")
+
+
+class MyGroup3(Group):
+
+    def __init__(self):
+        super(MyGroup3, self).__init__()
+
+        self.add(name="input", system=InputComp3())
+
+        self.add(name="exec", system=ExecComp("y=a**2+b**2", a=5.0, b=5.0))
+
+        self.connect("input.A", "exec.a")
+        self.connect("input.B", "exec.b")
 
 
 class TestEmptyJacobian(unittest.TestCase):
@@ -79,19 +99,21 @@ class TestEmptyJacobian(unittest.TestCase):
 
         root = prob.root
 
-        root.add(name='ivc_a',system=IndepVarComp(name='a',val=5.0),promotes=['a'])
-        root.add(name='ivc_b',system=IndepVarComp(name='b',val=10.0),promotes=['b'])
+        root.add(name="ivc_a", system=IndepVarComp(name="a", val=5.0),
+                 promotes=["a"])
+        root.add(name="ivc_b", system=IndepVarComp(name="b", val=10.0),
+                 promotes=["b"])
 
-        root.add(name='g',system=MyGroup())
+        root.add(name="g", system=MyGroup())
 
-        root.connect('a','g.input.A')
-        root.connect('b','g.input.B')
+        root.connect("a", "g.input.A")
+        root.connect("b", "g.input.B")
 
         prob.driver = ScipyOptimizer()
         prob.driver.options["disp"] = False
-        prob.driver.add_objective('g.exec.y')
-        prob.driver.add_desvar(name='a')
-        prob.driver.add_desvar(name='b')
+        prob.driver.add_objective("g.exec.y")
+        prob.driver.add_desvar(name="a")
+        prob.driver.add_desvar(name="b")
 
         prob.setup(check=False)
 
@@ -107,22 +129,53 @@ class TestEmptyJacobian(unittest.TestCase):
 
         root = prob.root
 
-        root.add(name='ivc_a',system=IndepVarComp(name='a',val=5.0),promotes=['a'])
-        root.add(name='ivc_b',system=IndepVarComp(name='b',val=10.0),promotes=['b'])
+        root.add(name="ivc_a", system=IndepVarComp(name="a", val=5.0),
+                 promotes=["a"])
+        root.add(name="ivc_b", system=IndepVarComp(name="b", val=10.0),
+                 promotes=["b"])
 
-        root.add(name='g',system=MyGroup2())
+        root.add(name="g", system=MyGroup2())
 
-        root.connect('a','g.input.A')
-        root.connect('b','g.input.B')
+        root.connect("a", "g.input.A")
+        root.connect("b", "g.input.B")
 
         prob.driver = ScipyOptimizer()
         prob.driver.options["disp"] = False
-        prob.driver.add_objective('g.exec.y')
-        prob.driver.add_desvar(name='a')
-        prob.driver.add_desvar(name='b')
+        prob.driver.add_objective("g.exec.y")
+        prob.driver.add_desvar(name="a")
+        prob.driver.add_desvar(name="b")
 
         prob.setup(check=False)
 
         with self.assertRaises(ValueError):
             prob.run()
 
+    def test_undefined_jacobian(self):
+
+        prob = Problem(root=Group())
+
+        root = prob.root
+
+        root.add(name="ivc_a", system=IndepVarComp(name="a", val=5.0),
+                 promotes=["a"])
+        root.add(name="ivc_b", system=IndepVarComp(name="b", val=10.0),
+                 promotes=["b"])
+
+        root.add(name="g", system=MyGroup3())
+
+        root.connect("a", "g.input.A")
+        root.connect("b", "g.input.B")
+
+        prob.driver = ScipyOptimizer()
+        prob.driver.options["disp"] = False
+        prob.driver.add_objective("g.exec.y")
+        prob.driver.add_desvar(name="a")
+        prob.driver.add_desvar(name="b")
+
+        prob.setup(check=False)
+
+        with self.assertRaises(ValueError):
+            prob.run()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/core/test/test_empty_jacobian.py
+++ b/openmdao/core/test/test_empty_jacobian.py
@@ -117,10 +117,7 @@ class TestEmptyJacobian(unittest.TestCase):
 
         prob.setup(check=False)
 
-        try:
-            prob.run()
-        except Exception:
-            self.fail("Unexpected exception encountered")
+        prob.run()
 
 
     def test_none_jacobian(self):

--- a/openmdao/core/test/test_empty_jacobian.py
+++ b/openmdao/core/test/test_empty_jacobian.py
@@ -119,9 +119,9 @@ class TestEmptyJacobian(unittest.TestCase):
 
         try:
             prob.run()
-        except ValueError as e:
-            if e.message == "No derivatives defined for Component 'g.input'":
-                self.fail("Raised an error for a component with an empty Jacobian")
+        except Exception:
+            self.fail("Unexpected exception encountered")
+
 
     def test_none_jacobian(self):
 
@@ -149,10 +149,11 @@ class TestEmptyJacobian(unittest.TestCase):
 
         try:
             prob.run()
-        except ValueError as e:
-            assert(e.message == "No derivatives defined for Component 'g.input'")
+        except ValueError as err:
+            self.assertEqual(str(err), "No derivatives defined for Component 'g.input'")
         else:
-            self.fail("Failed to raise an exception for a jacobian returning None")
+            self.fail("expecting ValueError due to linearize returning None")
+
 
     def test_undefined_jacobian(self):
 
@@ -180,10 +181,10 @@ class TestEmptyJacobian(unittest.TestCase):
 
         try:
             prob.run()
-        except ValueError as e:
-            assert(e.message == "No derivatives defined for Component 'g.input'")
+        except ValueError as err:
+            self.assertEqual(str(err), "No derivatives defined for Component 'g.input'")
         else:
-            self.fail("Failed to raise an exception for an undefined jacobian")
+            self.fail("expecting ValueError due to undefined linearize")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
[https://www.pivotaltracker.com/story/show/108645368](https://www.pivotaltracker.com/story/show/108645368)

Empty Jacobian matrices are now allowed by linearize when the component has no outputs.  Sometimes it's useful to define a component with only inputs to serve as a port to which all inputs to a group will be connected.

