### PR TITLE
Remove misleading Unit Conversions message

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -308,15 +308,6 @@ class Problem(object):
 
                 for i, u in enumerate(units):
                     if i != tgt_idx and u != units[tgt_idx]:
-                        if units[tgt_idx] is None:
-                            sname, s = connected_inputs[i], u
-                            tname, t = connected_inputs[tgt_idx], units[tgt_idx]
-                        else:
-                            sname, s = connected_inputs[tgt_idx], units[tgt_idx]
-                            tname, t = connected_inputs[i], u
-
-                        # report these in check_setup later
-                        self._unit_diffs[(sname, tname)] = (s, t)
                         diff_units.append((connected_inputs[i], u))
 
                 if isinstance(vals[tgt_idx], np.ndarray):


### PR DESCRIPTION
This simple test program:

    from __future__ import print_function

    from openmdao.api import IndepVarComp, Component, Problem, Group


    class Sink1(Component):
        def __init__(self):
            super(Sink1, self).__init__()

            self.add_param('x', val=0.0, units='m')


    class Sink2(Component):
        def __init__(self):
            super(Sink2, self).__init__()

            self.add_param('x', val=0.0, units='mm')

    if __name__ == "__main__":

        top = Problem()

        root = top.root = Group()

        root.add('src1', IndepVarComp('x', 0.0, units='m'))
        root.add('sink1', Sink1())
        root.add('sink2', Sink2())

        root.connect('src1.x', 'sink1.x')
        root.connect('src1.x', 'sink2.x')

        top.setup(check=True)

results in this output:

    ##############################################
    Setup: Checking for potential issues...

    Unit Conversions
    sink2.x -> sink1.x : mm -> m
    src1.x -> sink2.x : m -> mm
    ....

`sink2.x -> sink1.x : mm -> m` doesn't make sense to me. It seems to imply that `sink2.x` provides the value for `sink1.x`, which is not the case.

This PR removes such messages, leaving just the second message.