### PR TITLE
Give users a readable error message if they try to change the FD form after setup.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1051,7 +1051,7 @@ class Problem(object):
         for opt, saved in iteritems(self._root_options):
             current = self.root.fd_options[opt]
             if current != saved:
-                msg = "The '%s' option needs to be set before setup." % opt
+                msg = "The '%s' option cannot be changed after setup." % opt
                 raise RuntimeError(msg)
 
     def run(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -70,24 +70,6 @@ class Problem(object):
     comm : an MPI communicator (real or fake), optional
         A communicator that can be used for distributed operations when running
         under MPI. If not specified, the default "COMM_WORLD" will be used.
-
-    Options
-    -------
-    fd_options['force_fd'] :  bool(False)
-        Set to True to finite difference this system.
-    fd_options['form'] :  str('forward')
-        Finite difference mode. (forward, backward, central) You can also set to 'complex_step' to peform the complex step method if your components support it.
-    fd_options['step_size'] :  float(1e-06)
-        Default finite difference stepsize
-    fd_options['step_type'] :  str('absolute')
-        Set to absolute, relative
-    fd_options['extra_check_partials_form'] :  None or str
-        Finite difference mode: ("forward", "backward", "central", "complex_step")
-        During check_partial_derivatives, you can optionally do a
-        second finite difference with a different mode.
-    fd_options['linearize'] : bool(False)
-        Set to True if you want linearize to be called even though you are using FD.
-
     """
 
     def __init__(self, root=None, driver=None, impl=None, comm=None):
@@ -113,6 +95,9 @@ class Problem(object):
             self.driver = driver
 
         self.pathname = ''
+
+        # Used to check if user changed any of these options.
+        self._root_options = {}
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected
@@ -646,6 +631,11 @@ class Problem(object):
                 stream.write("%s\n" % err)
             raise RuntimeError(stream.getvalue())
 
+        # The user is not allowed to change these options after setup.
+        options = ['form', 'extra_check_partials_form']
+        for opt in options:
+            self._root_options[opt] = self.root.fd_options[opt]
+
         # check for any potential issues
         if check or force_check:
             return self.check_setup(out_stream)
@@ -1053,8 +1043,20 @@ class Problem(object):
 
         return results
 
+    def pre_run_check(self):
+        """ Last chance for some checks."""
+
+        # If the user changes these settings, a weird error is raised, so
+        # raise a readable error.
+        for opt, saved in iteritems(self._root_options):
+            current = self.root.fd_options[opt]
+            if current != saved:
+                msg = "The '%s' option needs to be set before setup." % opt
+                raise RuntimeError(msg)
+
     def run(self):
         """ Runs the Driver in self.driver. """
+        self.pre_run_check()
         if self.root.is_active():
             self.driver.run(self)
 
@@ -1071,6 +1073,7 @@ class Problem(object):
     def run_once(self):
         """ Execute run_once in the driver, executing the model at the
         the current design point. """
+        self.pre_run_check()
         root = self.root
         driver = self.driver
         if root.is_active():

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -871,7 +871,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "The 'form' option needs to be set before setup."
+        expected_msg = "The 'form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
         top = Problem()
@@ -884,7 +884,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "The 'extra_check_partials_form' option needs to be set before setup."
+        expected_msg = "The 'extra_check_partials_form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
 

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -859,6 +859,35 @@ class TestProblem(unittest.TestCase):
         self.assertTrue('[root] NL: NEWTON   0 | ' in printed)
         self.assertTrue('   [root.sub] LN: GMRES   0 | ' in printed)
 
+    def test_error_change_after_setup(self):
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['form'] = 'complex_step'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'form' option needs to be set before setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['extra_check_partials_form'] = 'complex_step'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'extra_check_partials_form' option needs to be set before setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+
 class TestCheckSetup(unittest.TestCase):
 
     def test_out_of_order(self):


### PR DESCRIPTION
Actually, changing the fd_form will only hurt if they set it to complex after setup, but let's keep everyone in the habit of setting these options before setup.