### PR TITLE
Give a sensible error message if the user changes certain fd_options or ln_solver.options after setup.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -98,6 +98,8 @@ class Problem(object):
 
         # Used to check if user changed any of these options.
         self._saved_options = {}
+        self.restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
+        self.restricted_ln_options = ['mode', 'single_voi_relevance_reduction']
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected
@@ -632,8 +634,8 @@ class Problem(object):
             raise RuntimeError(stream.getvalue())
 
         # The user is not allowed to change these options after setup.
-        restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
-        restricted_ln_options = ['mode', 'single_voi_relevance_reduction']
+        restricted_fd_options = self.restricted_fd_options
+        restricted_ln_options = self.restricted_ln_options
         saved_options = self._saved_options
         for sub in self.root.subsystems(recurse=True, include_self=True):
             sub_name = sub.pathname
@@ -1069,8 +1071,8 @@ class Problem(object):
 
         # If the user changes these settings, a weird error is raised, so
         # raise a readable error.
-        restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
-        restricted_ln_options = ['mode', 'single_voi_relevance_reduction']
+        restricted_fd_options = self.restricted_fd_options
+        restricted_ln_options = self.restricted_ln_options
         saved_options = self._saved_options
         for sub in self.root.subsystems(recurse=True, include_self=True):
             sub_name = sub.pathname

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1072,7 +1072,7 @@ class Problem(object):
 
         # New message if you forget to run setup first.
         if len(saved_options) == 0:
-            msg = "setup() must be called before run()."
+            msg = "setup() must be called before running the model."
             raise RuntimeError(msg)
 
         # If the user changes these settings, a weird error is raised, so

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1051,7 +1051,7 @@ class Problem(object):
         for opt, saved in iteritems(self._root_options):
             current = self.root.fd_options[opt]
             if current != saved:
-                msg = "The '%s' option needs to be set before setup." % opt
+                msg = "The '%s' option cannot be changed after setup." % opt
                 raise RuntimeError(msg)
 
     def run(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -70,24 +70,6 @@ class Problem(object):
     comm : an MPI communicator (real or fake), optional
         A communicator that can be used for distributed operations when running
         under MPI. If not specified, the default "COMM_WORLD" will be used.
-
-    Options
-    -------
-    fd_options['force_fd'] :  bool(False)
-        Set to True to finite difference this system.
-    fd_options['form'] :  str('forward')
-        Finite difference mode. (forward, backward, central) You can also set to 'complex_step' to peform the complex step method if your components support it.
-    fd_options['step_size'] :  float(1e-06)
-        Default finite difference stepsize
-    fd_options['step_type'] :  str('absolute')
-        Set to absolute, relative
-    fd_options['extra_check_partials_form'] :  None or str
-        Finite difference mode: ("forward", "backward", "central", "complex_step")
-        During check_partial_derivatives, you can optionally do a
-        second finite difference with a different mode.
-    fd_options['linearize'] : bool(False)
-        Set to True if you want linearize to be called even though you are using FD.
-
     """
 
     def __init__(self, root=None, driver=None, impl=None, comm=None):
@@ -113,6 +95,9 @@ class Problem(object):
             self.driver = driver
 
         self.pathname = ''
+
+        # Used to check if user changed any of these options.
+        self._root_options = {}
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected
@@ -646,6 +631,11 @@ class Problem(object):
                 stream.write("%s\n" % err)
             raise RuntimeError(stream.getvalue())
 
+        # The user is not allowed to change these options after setup.
+        options = ['form', 'extra_check_partials_form']
+        for opt in options:
+            self._root_options[opt] = self.root.fd_options[opt]
+
         # check for any potential issues
         if check or force_check:
             return self.check_setup(out_stream)
@@ -1053,8 +1043,20 @@ class Problem(object):
 
         return results
 
+    def pre_run_check(self):
+        """ Last chance for some checks."""
+
+        # If the user changes these settings, a weird error is raised, so
+        # raise a readable error.
+        for opt, saved in iteritems(self._root_options):
+            current = self.root.fd_options[opt]
+            if current != saved:
+                msg = "The '%s' option needs to be set before setup." % opt
+                raise RuntimeError(msg)
+
     def run(self):
         """ Runs the Driver in self.driver. """
+        self.pre_run_check()
         if self.root.is_active():
             self.driver.run(self)
 
@@ -1071,6 +1073,7 @@ class Problem(object):
     def run_once(self):
         """ Execute run_once in the driver, executing the model at the
         the current design point. """
+        self.pre_run_check()
         root = self.root
         driver = self.driver
         if root.is_active():

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -633,7 +633,9 @@ class Problem(object):
                 stream.write("%s\n" % err)
             raise RuntimeError(stream.getvalue())
 
-        # The user is not allowed to change these options after setup.
+        # The user is not allowed to change certain options after setup. In
+        # order to figure out if they get changed, we needed to save copies
+        # of them in problem.
         restricted_fd_options = self.restricted_fd_options
         restricted_ln_options = self.restricted_ln_options
         saved_options = self._saved_options
@@ -1062,9 +1064,13 @@ class Problem(object):
         return results
 
     def pre_run_check(self):
-        """ Last chance for some checks."""
+        """ Last chance for some checks. The checks that should be performed
+        here are those that would generate a cryptic error message. We can
+        raise a readable error for the user."""
+
         saved_options = self._saved_options
-        # New message if you forget to run setup.
+
+        # New message if you forget to run setup first.
         if len(saved_options) == 0:
             msg = "setup() must be called before run()."
             raise RuntimeError(msg)

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -861,11 +861,14 @@ class TestProblem(unittest.TestCase):
 
     def test_error_change_after_setup(self):
 
+        # Tests error messages for the 5 options that we should never change
+        # after setup is called.
+
         top = Problem()
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.fd_options['form'] = 'complex_step'
 
         with self.assertRaises(RuntimeError) as err:
@@ -878,7 +881,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.fd_options['extra_check_partials_form'] = 'complex_step'
 
         with self.assertRaises(RuntimeError) as err:
@@ -891,7 +894,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.fd_options['force_fd'] = True
 
         with self.assertRaises(RuntimeError) as err:
@@ -904,7 +907,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.ln_solver.options['mode'] = 'rev'
 
         with self.assertRaises(RuntimeError) as err:
@@ -917,7 +920,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.ln_solver.options['single_voi_relevance_reduction'] = True
 
         with self.assertRaises(RuntimeError) as err:

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -616,7 +616,7 @@ class TestProblem(unittest.TestCase):
         try:
             prob.run()
         except RuntimeError as err:
-            msg = "setup() must be called before run()."
+            msg = "setup() must be called before running the model."
             self.assertEqual(text_type(err), msg)
         else:
             self.fail('Exception expected')

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -615,8 +615,8 @@ class TestProblem(unittest.TestCase):
 
         try:
             prob.run()
-        except AttributeError as err:
-            msg = "'unknowns' has not been initialized, setup() must be called before 'x' can be accessed"
+        except RuntimeError as err:
+            msg = "setup() must be called before run()."
             self.assertEqual(text_type(err), msg)
         else:
             self.fail('Exception expected')
@@ -885,6 +885,45 @@ class TestProblem(unittest.TestCase):
             top.run()
 
         expected_msg = "The 'extra_check_partials_form' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['force_fd'] = True
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'force_fd' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.ln_solver.options['mode'] = 'rev'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'mode' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.ln_solver.options['single_voi_relevance_reduction'] = True
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'single_voi_relevance_reduction' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
 

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -871,7 +871,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "The 'form' option needs to be set before setup."
+        expected_msg = "The 'form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
         top = Problem()
@@ -884,7 +884,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "The 'extra_check_partials_form' option needs to be set before setup."
+        expected_msg = "The 'extra_check_partials_form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
 

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -859,6 +859,35 @@ class TestProblem(unittest.TestCase):
         self.assertTrue('[root] NL: NEWTON   0 | ' in printed)
         self.assertTrue('   [root.sub] LN: GMRES   0 | ' in printed)
 
+    def test_error_change_after_setup(self):
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['form'] = 'complex_step'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'form' option needs to be set before setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['extra_check_partials_form'] = 'complex_step'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'extra_check_partials_form' option needs to be set before setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+
 class TestCheckSetup(unittest.TestCase):
 
     def test_out_of_order(self):

--- a/openmdao/solvers/ln_direct.py
+++ b/openmdao/solvers/ln_direct.py
@@ -12,8 +12,8 @@ from openmdao.solvers.solver_base import MultLinearSolver
 
 class DirectSolver(MultLinearSolver):
     """ OpenMDAO LinearSolver that explicitly solves the linear system using
-    linalg.solve. The user can choose to have the jacobian assemblled
-    directly or throuugh matrix-vector product.
+    linalg.solve. The user can choose to have the jacobian assembled
+    directly or through matrix-vector product.
 
     Options
     -------


### PR DESCRIPTION
Changing certain options have setup results in error messages that are hard to track down. These are the ones identified as potential problem now (or after certain future stories are finished.)
        restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
        restricted_ln_options = ['mode', 'single_voi_relevance_reduction']

Also, removed some docstring from Problem that was leftover from when it used to inherit from System.