### PR TITLE
Candidate 2 - Give a sensible error message if the user changes certain fd_options or ln_solver.options after setup.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -98,6 +98,8 @@ class Problem(object):
 
         # Used to check if user changed any of these options.
         self._saved_options = {}
+        self.restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
+        self.restricted_ln_options = ['mode', 'single_voi_relevance_reduction']
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected
@@ -632,8 +634,8 @@ class Problem(object):
             raise RuntimeError(stream.getvalue())
 
         # The user is not allowed to change these options after setup.
-        restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
-        restricted_ln_options = ['mode', 'single_voi_relevance_reduction']
+        restricted_fd_options = self.restricted_fd_options
+        restricted_ln_options = self.restricted_ln_options
         saved_options = self._saved_options
         for sub in self.root.subsystems(recurse=True, include_self=True):
             sub_name = sub.pathname
@@ -1069,8 +1071,8 @@ class Problem(object):
 
         # If the user changes these settings, a weird error is raised, so
         # raise a readable error.
-        restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
-        restricted_ln_options = ['mode', 'single_voi_relevance_reduction']
+        restricted_fd_options = self.restricted_fd_options
+        restricted_ln_options = self.restricted_ln_options
         saved_options = self._saved_options
         for sub in self.root.subsystems(recurse=True, include_self=True):
             sub_name = sub.pathname

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1072,7 +1072,7 @@ class Problem(object):
 
         # New message if you forget to run setup first.
         if len(saved_options) == 0:
-            msg = "setup() must be called before run()."
+            msg = "setup() must be called before running the model."
             raise RuntimeError(msg)
 
         # If the user changes these settings, a weird error is raised, so

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1051,7 +1051,7 @@ class Problem(object):
         for opt, saved in iteritems(self._root_options):
             current = self.root.fd_options[opt]
             if current != saved:
-                msg = "The '%s' option needs to be set before setup." % opt
+                msg = "The '%s' option cannot be changed after setup." % opt
                 raise RuntimeError(msg)
 
     def run(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -70,24 +70,6 @@ class Problem(object):
     comm : an MPI communicator (real or fake), optional
         A communicator that can be used for distributed operations when running
         under MPI. If not specified, the default "COMM_WORLD" will be used.
-
-    Options
-    -------
-    fd_options['force_fd'] :  bool(False)
-        Set to True to finite difference this system.
-    fd_options['form'] :  str('forward')
-        Finite difference mode. (forward, backward, central) You can also set to 'complex_step' to peform the complex step method if your components support it.
-    fd_options['step_size'] :  float(1e-06)
-        Default finite difference stepsize
-    fd_options['step_type'] :  str('absolute')
-        Set to absolute, relative
-    fd_options['extra_check_partials_form'] :  None or str
-        Finite difference mode: ("forward", "backward", "central", "complex_step")
-        During check_partial_derivatives, you can optionally do a
-        second finite difference with a different mode.
-    fd_options['linearize'] : bool(False)
-        Set to True if you want linearize to be called even though you are using FD.
-
     """
 
     def __init__(self, root=None, driver=None, impl=None, comm=None):
@@ -113,6 +95,9 @@ class Problem(object):
             self.driver = driver
 
         self.pathname = ''
+
+        # Used to check if user changed any of these options.
+        self._root_options = {}
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected
@@ -646,6 +631,11 @@ class Problem(object):
                 stream.write("%s\n" % err)
             raise RuntimeError(stream.getvalue())
 
+        # The user is not allowed to change these options after setup.
+        options = ['form', 'extra_check_partials_form']
+        for opt in options:
+            self._root_options[opt] = self.root.fd_options[opt]
+
         # check for any potential issues
         if check or force_check:
             return self.check_setup(out_stream)
@@ -1053,8 +1043,20 @@ class Problem(object):
 
         return results
 
+    def pre_run_check(self):
+        """ Last chance for some checks."""
+
+        # If the user changes these settings, a weird error is raised, so
+        # raise a readable error.
+        for opt, saved in iteritems(self._root_options):
+            current = self.root.fd_options[opt]
+            if current != saved:
+                msg = "The '%s' option needs to be set before setup." % opt
+                raise RuntimeError(msg)
+
     def run(self):
         """ Runs the Driver in self.driver. """
+        self.pre_run_check()
         if self.root.is_active():
             self.driver.run(self)
 
@@ -1071,6 +1073,7 @@ class Problem(object):
     def run_once(self):
         """ Execute run_once in the driver, executing the model at the
         the current design point. """
+        self.pre_run_check()
         root = self.root
         driver = self.driver
         if root.is_active():

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -633,7 +633,9 @@ class Problem(object):
                 stream.write("%s\n" % err)
             raise RuntimeError(stream.getvalue())
 
-        # The user is not allowed to change these options after setup.
+        # The user is not allowed to change certain options after setup. In
+        # order to figure out if they get changed, we needed to save copies
+        # of them in problem.
         restricted_fd_options = self.restricted_fd_options
         restricted_ln_options = self.restricted_ln_options
         saved_options = self._saved_options
@@ -1062,9 +1064,13 @@ class Problem(object):
         return results
 
     def pre_run_check(self):
-        """ Last chance for some checks."""
+        """ Last chance for some checks. The checks that should be performed
+        here are those that would generate a cryptic error message. We can
+        raise a readable error for the user."""
+
         saved_options = self._saved_options
-        # New message if you forget to run setup.
+
+        # New message if you forget to run setup first.
         if len(saved_options) == 0:
             msg = "setup() must be called before run()."
             raise RuntimeError(msg)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -103,12 +103,14 @@ class System(object):
 
         opt = self.fd_options = OptionsDictionary()
         opt.add_option('force_fd', False,
-                       desc="Set to True to finite difference this system.")
+                       desc="Set to True to finite difference this system.",
+                       lock_on_setup=True)
         opt.add_option('form', 'forward',
                        values=['forward', 'backward', 'central', 'complex_step'],
                        desc="Finite difference mode. (forward, backward, central) "
                        "You can also set to 'complex_step' to peform the complex "
-                       "step method if your components support it.")
+                       "step method if your components support it.",
+                       lock_on_setup=True)
         opt.add_option("step_size", 1.0e-6, lower=0.0,
                        desc="Default finite difference stepsize")
         opt.add_option("step_type", 'absolute',
@@ -118,7 +120,8 @@ class System(object):
                        values=[None, 'forward', 'backward', 'central', 'complex_step'],
                        desc='Finite difference mode: ("forward", "backward", "central", "complex_step")'
                        " During check_partial_derivatives, you can optionally do a "
-                       "second finite difference with a different mode.")
+                       "second finite difference with a different mode.",
+                       lock_on_setup=True)
         opt.add_option('linearize', False,
                        desc='Set to True if you want linearize to be called even though you are using FD.')
 

--- a/openmdao/core/test/test_check_derivatives.py
+++ b/openmdao/core/test/test_check_derivatives.py
@@ -13,6 +13,7 @@ from openmdao.test.paraboloid import Paraboloid
 from openmdao.test.simple_comps import SimpleArrayComp, SimpleImplicitComp, \
                                       SimpleCompDerivMatVec
 from openmdao.test.util import assert_rel_error
+from openmdao.util.options import OptionsDictionary
 
 
 class TestProblemCheckPartials(unittest.TestCase):
@@ -363,10 +364,11 @@ class TestProblemFullFD(unittest.TestCase):
 
         prob = Problem()
         prob.root = ConvergeDivergeGroups()
-        prob.setup(check=False)
-        prob.run()
 
         prob.root.fd_options['force_fd'] = True
+
+        prob.setup(check=False)
+        prob.run()
 
         indep_list = ['sub1.comp1.x1']
         unknown_list = ['comp7.y1']
@@ -374,7 +376,11 @@ class TestProblemFullFD(unittest.TestCase):
         J = prob.calc_gradient(indep_list, unknown_list, mode='fwd', return_format='dict')
         assert_rel_error(self, J['comp7.y1']['sub1.comp1.x1'][0][0], -40.75, 1e-6)
 
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
+
         prob.root.fd_options['form'] = 'central'
+
         J = prob.calc_gradient(indep_list, unknown_list, mode='fwd', return_format='dict')
         assert_rel_error(self, J['comp7.y1']['sub1.comp1.x1'][0][0], -40.75, 1e-6)
 
@@ -385,10 +391,10 @@ class TestProblemFullFD(unittest.TestCase):
         par = root.add('par', ParallelGroup())
         par.add('sub', ConvergeDivergeGroups())
 
+        prob.root.fd_options['force_fd'] = True
+
         prob.setup(check=False)
         prob.run()
-
-        prob.root.fd_options['force_fd'] = True
 
         # Make sure we don't get a key error.
         data = prob.check_total_derivatives(out_stream=None)

--- a/openmdao/core/test/test_comp_fd_jacobian.py
+++ b/openmdao/core/test/test_comp_fd_jacobian.py
@@ -14,6 +14,8 @@ from openmdao.test.simple_comps import SimpleArrayComp, \
                                       SimpleImplicitComp
 from openmdao.test.paraboloid import Paraboloid
 from openmdao.test.util import assert_equal_jacobian, assert_rel_error
+from openmdao.util.options import OptionsDictionary
+
 
 class FDpropsComp(Component):
 
@@ -469,6 +471,9 @@ class CompFDinSystemTestCase(unittest.TestCase):
 
         J = prob.calc_gradient(indep_list, unknowns_list, return_format='dict')
         assert_rel_error(self, J['comp.f_xy']['p1.x'][0][0], 39.0, 1e-6)
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
 
         # Make sure it gives good result with small stepsize
         comp.fd_options['form'] = 'backward'

--- a/openmdao/core/test/test_complex_step.py
+++ b/openmdao/core/test/test_complex_step.py
@@ -13,6 +13,7 @@ from openmdao.test.converge_diverge import ConvergeDivergeGroups
 from openmdao.test.paraboloid import Paraboloid
 from openmdao.test.sellar import SellarDerivativesGrouped
 from openmdao.test.util import assert_rel_error
+from openmdao.util.options import OptionsDictionary
 
 try:
     from openmdao.solvers.petsc_ksp import PetscKSP
@@ -150,7 +151,12 @@ class ComplexStepVectorUnitTestsBasicImpl(unittest.TestCase):
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
 
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
+
         prob.root.fd_options['form'] = 'central'
+
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')
         for key1, val1 in Jbase.items():
             for key2, val2 in val1.items():
@@ -438,6 +444,9 @@ class ComplexStepVectorUnitTestsPETSCImpl(unittest.TestCase):
         for key1, val1 in Jbase.items():
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
 
         prob.root.fd_options['form'] = 'central'
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -861,11 +861,14 @@ class TestProblem(unittest.TestCase):
 
     def test_error_change_after_setup(self):
 
+        # Tests error messages for the 5 options that we should never change
+        # after setup is called.
+
         top = Problem()
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.fd_options['form'] = 'complex_step'
 
         with self.assertRaises(RuntimeError) as err:
@@ -878,7 +881,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.fd_options['extra_check_partials_form'] = 'complex_step'
 
         with self.assertRaises(RuntimeError) as err:
@@ -891,7 +894,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.fd_options['force_fd'] = True
 
         with self.assertRaises(RuntimeError) as err:
@@ -904,7 +907,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.ln_solver.options['mode'] = 'rev'
 
         with self.assertRaises(RuntimeError) as err:
@@ -917,7 +920,7 @@ class TestProblem(unittest.TestCase):
         top.root = SellarStateConnection()
         top.setup(check=False)
 
-        # Canna do this
+        # Not permitted to change this
         top.root.ln_solver.options['single_voi_relevance_reduction'] = True
 
         with self.assertRaises(RuntimeError) as err:

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -616,7 +616,7 @@ class TestProblem(unittest.TestCase):
         try:
             prob.run()
         except RuntimeError as err:
-            msg = "setup() must be called before run()."
+            msg = "setup() must be called before running the model."
             self.assertEqual(text_type(err), msg)
         else:
             self.fail('Exception expected')

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -615,8 +615,8 @@ class TestProblem(unittest.TestCase):
 
         try:
             prob.run()
-        except AttributeError as err:
-            msg = "'unknowns' has not been initialized, setup() must be called before 'x' can be accessed"
+        except RuntimeError as err:
+            msg = "setup() must be called before run()."
             self.assertEqual(text_type(err), msg)
         else:
             self.fail('Exception expected')
@@ -885,6 +885,45 @@ class TestProblem(unittest.TestCase):
             top.run()
 
         expected_msg = "The 'extra_check_partials_form' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['force_fd'] = True
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'force_fd' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.ln_solver.options['mode'] = 'rev'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'mode' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.ln_solver.options['single_voi_relevance_reduction'] = True
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'single_voi_relevance_reduction' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
 

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -871,7 +871,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "The 'form' option needs to be set before setup."
+        expected_msg = "The 'form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
         top = Problem()
@@ -884,7 +884,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "The 'extra_check_partials_form' option needs to be set before setup."
+        expected_msg = "The 'extra_check_partials_form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
 

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -859,6 +859,35 @@ class TestProblem(unittest.TestCase):
         self.assertTrue('[root] NL: NEWTON   0 | ' in printed)
         self.assertTrue('   [root.sub] LN: GMRES   0 | ' in printed)
 
+    def test_error_change_after_setup(self):
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['form'] = 'complex_step'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'form' option needs to be set before setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        # Canna do this
+        top.root.fd_options['extra_check_partials_form'] = 'complex_step'
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "The 'extra_check_partials_form' option needs to be set before setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+
 class TestCheckSetup(unittest.TestCase):
 
     def test_out_of_order(self):

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -1,12 +1,13 @@
 """ Unit test for the Problem class. """
 
-import unittest
 import sys
+import unittest
+import warnings
 
-import numpy as np
 from six import text_type, PY3
 from six.moves import cStringIO
-import warnings
+
+import numpy as np
 
 from openmdao.api import Component, Problem, Group, IndepVarComp, ExecComp, \
                          LinearGaussSeidel, ScipyGMRES, Driver
@@ -14,6 +15,7 @@ from openmdao.core.mpi_wrap import MPI
 from openmdao.test.example_groups import ExampleGroup, ExampleGroupWithPromotes, ExampleByObjGroup
 from openmdao.test.sellar import SellarStateConnection
 from openmdao.test.simple_comps import SimpleComp, SimpleImplicitComp, RosenSuzuki, FanIn
+from openmdao.util.options import OptionsDictionary
 
 if PY3:
     def py3fix(s):
@@ -21,6 +23,7 @@ if PY3:
 else:
     def py3fix(s):
         return s
+
 
 class TestProblem(unittest.TestCase):
 
@@ -766,7 +769,11 @@ class TestProblem(unittest.TestCase):
         #else:
             #self.fail('Exception expected')
 
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
+
         root.ln_solver.options['mode'] = 'fwd'
+
         mode = prob._check_for_parallel_derivs(['a', 'b'], ['x'], False, False)
         self.assertEqual(mode, 'fwd')
 
@@ -869,10 +876,8 @@ class TestProblem(unittest.TestCase):
         top.setup(check=False)
 
         # Not permitted to change this
-        top.root.fd_options['form'] = 'complex_step'
-
         with self.assertRaises(RuntimeError) as err:
-            top.run()
+            top.root.fd_options['form'] = 'complex_step'
 
         expected_msg = "The 'form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
@@ -882,10 +887,8 @@ class TestProblem(unittest.TestCase):
         top.setup(check=False)
 
         # Not permitted to change this
-        top.root.fd_options['extra_check_partials_form'] = 'complex_step'
-
         with self.assertRaises(RuntimeError) as err:
-            top.run()
+            top.root.fd_options['extra_check_partials_form'] = 'complex_step'
 
         expected_msg = "The 'extra_check_partials_form' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
@@ -895,10 +898,8 @@ class TestProblem(unittest.TestCase):
         top.setup(check=False)
 
         # Not permitted to change this
-        top.root.fd_options['force_fd'] = True
-
         with self.assertRaises(RuntimeError) as err:
-            top.run()
+            top.root.fd_options['force_fd'] = True
 
         expected_msg = "The 'force_fd' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
@@ -908,10 +909,8 @@ class TestProblem(unittest.TestCase):
         top.setup(check=False)
 
         # Not permitted to change this
-        top.root.ln_solver.options['mode'] = 'rev'
-
         with self.assertRaises(RuntimeError) as err:
-            top.run()
+            top.root.ln_solver.options['mode'] = 'rev'
 
         expected_msg = "The 'mode' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
@@ -921,10 +920,8 @@ class TestProblem(unittest.TestCase):
         top.setup(check=False)
 
         # Not permitted to change this
-        top.root.ln_solver.options['single_voi_relevance_reduction'] = True
-
         with self.assertRaises(RuntimeError) as err:
-            top.run()
+            top.root.ln_solver.options['single_voi_relevance_reduction'] = True
 
         expected_msg = "The 'single_voi_relevance_reduction' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)

--- a/openmdao/docs/usr-guide/examples/example_fd.rst
+++ b/openmdao/docs/usr-guide/examples/example_fd.rst
@@ -155,6 +155,8 @@ To activate it, you just need to set the `form` option on a Compontent to
     top.setup()
     top.run()
     self = top.root
+    from openmdao.util.options import OptionsDictionary
+    OptionsDictionary.locked = False
 
 .. testoutput:: fd_example
    :hide:

--- a/openmdao/drivers/test/test_driver_param_indices.py
+++ b/openmdao/drivers/test/test_driver_param_indices.py
@@ -10,7 +10,7 @@ from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ScipyOptimizer,
     LinearGaussSeidel
 from openmdao.test.sellar import SellarStateConnection
 from openmdao.test.util import assert_rel_error
-
+from openmdao.util.options import OptionsDictionary
 
 # check that pyoptsparse is installed
 # if it is, try to use SNOPT but fall back to SLSQP
@@ -290,6 +290,9 @@ class TestParamIndicesPyoptsparse(unittest.TestCase):
         assert_rel_error(self, J['con1.c']['p2.x'], .0, 1e-3)
         assert_rel_error(self, J['con2.c']['p1.x'], .0, 1e-3)
         assert_rel_error(self, J['con2.c']['p2.x'], -3.0, 1e-3)
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
 
         prob.root.ln_solver.options['mode'] = 'fwd'
         prob.setup(check=False)

--- a/openmdao/solvers/ln_direct.py
+++ b/openmdao/solvers/ln_direct.py
@@ -12,8 +12,8 @@ from openmdao.solvers.solver_base import MultLinearSolver
 
 class DirectSolver(MultLinearSolver):
     """ OpenMDAO LinearSolver that explicitly solves the linear system using
-    linalg.solve. The user can choose to have the jacobian assemblled
-    directly or throuugh matrix-vector product.
+    linalg.solve. The user can choose to have the jacobian assembled
+    directly or through matrix-vector product.
 
     Options
     -------

--- a/openmdao/solvers/ln_direct.py
+++ b/openmdao/solvers/ln_direct.py
@@ -40,7 +40,9 @@ class DirectSolver(MultLinearSolver):
         self.options.add_option('mode', 'auto', values=['fwd', 'rev', 'auto'],
                        desc="Derivative calculation mode, set to 'fwd' for " +
                        "forward mode, 'rev' for reverse mode, or 'auto' to " +
-                       "let OpenMDAO determine the best mode.")
+                       "let OpenMDAO determine the best mode.",
+                       lock_on_setup=True)
+
         self.options.add_option('jacobian_method', 'MVP', values=['MVP', 'assemble'],
                                 desc="Method to assemble the jacobian to solve. " +
                                 "Select 'MVP' to build the Jacobian by calling " +

--- a/openmdao/solvers/ln_gauss_seidel.py
+++ b/openmdao/solvers/ln_gauss_seidel.py
@@ -42,13 +42,15 @@ class LinearGaussSeidel(LinearSolver):
         opt.add_option('mode', 'auto', values=['fwd', 'rev', 'auto'],
                        desc="Derivative calculation mode, set to 'fwd' for " +
                        "forward mode, 'rev' for reverse mode, or 'auto' to " +
-                       "let OpenMDAO determine the best mode.")
+                       "let OpenMDAO determine the best mode.",
+                       lock_on_setup=True)
         opt.add_option('single_voi_relevance_reduction',
                         False, values=[True, False],
                         desc="If True, use relevance reduction even for"
                               " individual variables of interest. This "
                               "may increase performance but will use "
-                              "more memory.")
+                              "more memory.",
+                        lock_on_setup=True)
 
         self.print_name = 'LN_GS'
 

--- a/openmdao/solvers/petsc_ksp.py
+++ b/openmdao/solvers/petsc_ksp.py
@@ -100,7 +100,8 @@ class PetscKSP(LinearSolver):
         opt.add_option('mode', 'auto', values=['fwd', 'rev', 'auto'],
                        desc="Derivative calculation mode, set to 'fwd' for " +
                        "forward mode, 'rev' for reverse mode, or 'auto' to " +
-                       "let OpenMDAO determine the best mode.")
+                       "let OpenMDAO determine the best mode.",
+                       lock_on_setup=True)
 
         # These are defined whenever we call solve to provide info we need in
         # the callback.

--- a/openmdao/solvers/scipy_gmres.py
+++ b/openmdao/solvers/scipy_gmres.py
@@ -50,7 +50,8 @@ class ScipyGMRES(MultLinearSolver):
                        "let OpenMDAO determine the best mode.")
         opt.add_option('restart', 20, lower=0,
                        desc='Number of iterations between restarts. Larger values ' +
-                       'increase iteration cost, but may be necessary for convergence')
+                       'increase iteration cost, but may be necessary for convergence',
+                       lock_on_setup=True)
 
         # These are defined whenever we call solve to provide info we need in
         # the callback.

--- a/openmdao/solvers/test/test_ln_gauss_seidel.py
+++ b/openmdao/solvers/test/test_ln_gauss_seidel.py
@@ -13,6 +13,7 @@ from openmdao.test.sellar import SellarDerivativesGrouped, SellarDerivatives, St
 from openmdao.test.simple_comps import SimpleCompDerivMatVec, FanOut, FanIn, \
                                        FanOutGrouped, FanInGrouped, ArrayComp2D
 from openmdao.test.util import assert_rel_error
+from openmdao.util.options import OptionsDictionary
 
 
 class TestLinearGaussSeidel(unittest.TestCase):
@@ -389,6 +390,9 @@ class TestLinearGaussSeidel(unittest.TestCase):
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
 
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
+
         prob.root.fd_options['form'] = 'central'
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')
         for key1, val1 in Jbase.items():
@@ -477,6 +481,9 @@ class TestLinearGaussSeidel(unittest.TestCase):
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
 
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
+
         prob.root.fd_options['form'] = 'central'
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')
         for key1, val1 in Jbase.items():
@@ -525,6 +532,9 @@ class TestLinearGaussSeidel(unittest.TestCase):
         for key1, val1 in Jbase.items():
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
 
         prob.root.fd_options['form'] = 'central'
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')

--- a/openmdao/solvers/test/test_petsc_ksp.py
+++ b/openmdao/solvers/test/test_petsc_ksp.py
@@ -12,6 +12,7 @@ from openmdao.test.simple_comps import SimpleCompDerivMatVec, FanOut, FanIn, \
                                        FanOutGrouped, DoubleArrayComp, \
                                        FanInGrouped, ArrayComp2D, FanOutAllGrouped
 from openmdao.test.util import assert_rel_error
+from openmdao.util.options import OptionsDictionary
 
 try:
     from openmdao.solvers.petsc_ksp import PetscKSP
@@ -405,6 +406,9 @@ class TestPetscKSPSerial(unittest.TestCase):
         for key1, val1 in Jbase.items():
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
 
         prob.root.fd_options['form'] = 'central'
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')

--- a/openmdao/solvers/test/test_scipy_gmres.py
+++ b/openmdao/solvers/test/test_scipy_gmres.py
@@ -12,6 +12,7 @@ from openmdao.test.simple_comps import SimpleCompDerivMatVec, FanOut, FanIn, \
                                        FanOutGrouped, DoubleArrayComp, \
                                        FanInGrouped, ArrayComp2D, FanOutAllGrouped
 from openmdao.test.util import assert_rel_error
+from openmdao.util.options import OptionsDictionary
 
 
 class TestScipyGMRES(unittest.TestCase):
@@ -395,6 +396,9 @@ class TestScipyGMRES(unittest.TestCase):
         for key1, val1 in Jbase.items():
             for key2, val2 in val1.items():
                 assert_rel_error(self, J[key1][key2], val2, .00001)
+
+        # Cheat a bit so I can twiddle mode
+        OptionsDictionary.locked = False
 
         prob.root.fd_options['form'] = 'central'
         J = prob.calc_gradient(indep_list, unknown_list, mode='fd', return_format='dict')

--- a/openmdao/util/options.py
+++ b/openmdao/util/options.py
@@ -34,7 +34,6 @@ class OptionsDictionary(object):
         # around it.
         OptionsDictionary.locked = False
 
-
     def add_option(self, name, value, lower=None, upper=None, values=None,
                    desc='', lock_on_setup=False):
         """ Adds an option to this options dictionary.

--- a/openmdao/util/test/test_options.py
+++ b/openmdao/util/test/test_options.py
@@ -7,6 +7,7 @@ from openmdao.api import OptionsDictionary
 
 
 class TestOptions(unittest.TestCase):
+
     def test_options_dictionary(self):
         self.options = OptionsDictionary()
 
@@ -94,6 +95,30 @@ class TestOptions(unittest.TestCase):
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[0].message),
                      "Option 'max_iter' is deprecated. Use 'maxiter' instead.")
+
+    def test_locking(self):
+
+        opt1 = OptionsDictionary()
+        opt1.add_option('zzz', 10.0, lock_on_setup=True)
+        opt2 = OptionsDictionary()
+        opt2.add_option('xxx', 10.0, lock_on_setup=True)
+
+        opt1['zzz'] = 15.0
+        opt2['xxx'] = 12.0
+
+        OptionsDictionary.locked = True
+
+        with self.assertRaises(RuntimeError) as err:
+            opt1['zzz'] = 14.0
+
+        expected_msg = "The 'zzz' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
+
+        with self.assertRaises(RuntimeError) as err:
+            opt2['xxx'] = 13.0
+
+        expected_msg = "The 'xxx' option cannot be changed after setup."
+        self.assertEqual(str(err.exception), expected_msg)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This implementation allows the `lock_on_setup` to be specified for any option in an OptionDictionary so that it will lock on setup.

Changing certain options have setup results in error messages that are hard to track down. These are the ones identified as potential problem now (or after certain future stories are finished.)
restricted_fd_options = ['form', 'extra_check_partials_form', 'force_fd']
restricted_ln_options = ['mode', 'single_voi_relevance_reduction']

Also, removed some docstring from Problem that was leftover from when it used to inherit from System.