### PR TITLE
Multiple obj error

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -495,6 +495,11 @@ class Driver(object):
             is second in precedence.
         """
 
+        if len(self._objs) > 0 and not self.supports["multiple_objectives"]:
+            raise RuntimeError("Attempted to add multiple objectives to a "
+                               "driver that does not support multiple "
+                               "objectives.")
+
         if name in self._objs:
             msg = "Objective '{}' already exists."
             raise RuntimeError(msg.format(name))

--- a/openmdao/core/test/test_driver_interface.py
+++ b/openmdao/core/test/test_driver_interface.py
@@ -492,6 +492,25 @@ class TestDriver(unittest.TestCase):
         raised_error = str(cm.exception)
         self.assertEqual(msg, raised_error)
 
+    def test_unsupported_multiple_obj(self):
+        prob = Problem()
+        prob.root = SellarDerivatives()
+
+        prob.driver = MySimpleDriver()
+        prob.driver.add_desvar('z', lower=-100.0, upper=100.0)
+
+        prob.driver.add_objective('obj')
+
+        # Add duplicate objective
+        with self.assertRaises(RuntimeError) as cm:
+            prob.driver.add_objective('x')
+
+        msg = "Attempted to add multiple objectives to a driver that does not " \
+              "support multiple objectives."
+        raised_error = str(cm.exception)
+        self.assertEqual(msg, raised_error)
+
+
     def test_no_desvar_bound(self):
 
         prob = Problem()


### PR DESCRIPTION
If a driver does not support multiple objectives, an error should be raised when add_objective is issued a second time:  https://www.pivotaltracker.com/story/show/117225181