### PR TITLE
Multiple obj error

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -495,6 +495,11 @@ class Driver(object):
             is second in precedence.
         """
 
+        if len(self._objs) > 0 and not self.supports["multiple_objectives"]:
+            raise RuntimeError("Attempted to add multiple objectives to a "
+                               "driver that does not support multiple "
+                               "objectives.")
+
         if name in self._objs:
             msg = "Objective '{}' already exists."
             raise RuntimeError(msg.format(name))

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -494,7 +494,6 @@ class Driver(object):
             value to multiply the model value to get the scaled value. Scaler
             is second in precedence.
         """
-
         if len(self._objs) > 0 and not self.supports["multiple_objectives"]:
             raise RuntimeError("Attempted to add multiple objectives to a "
                                "driver that does not support multiple "

--- a/openmdao/core/test/test_driver_interface.py
+++ b/openmdao/core/test/test_driver_interface.py
@@ -463,6 +463,11 @@ class TestDriver(unittest.TestCase):
         root = prob.root = SellarDerivatives()
 
         prob.driver = MySimpleDriver()
+
+        # For this test only assume the driver supports multiple objectives
+        prob.driver.supports['multiple_objectives'] = True
+
+
         prob.driver.add_desvar('z', lower=-100.0, upper=100.0)
 
         prob.driver.add_objective('obj')
@@ -509,7 +514,6 @@ class TestDriver(unittest.TestCase):
               "support multiple objectives."
         raised_error = str(cm.exception)
         self.assertEqual(msg, raised_error)
-
 
     def test_no_desvar_bound(self):
 

--- a/openmdao/core/test/test_driver_interface.py
+++ b/openmdao/core/test/test_driver_interface.py
@@ -492,6 +492,25 @@ class TestDriver(unittest.TestCase):
         raised_error = str(cm.exception)
         self.assertEqual(msg, raised_error)
 
+    def test_unsupported_multiple_obj(self):
+        prob = Problem()
+        prob.root = SellarDerivatives()
+
+        prob.driver = MySimpleDriver()
+        prob.driver.add_desvar('z', lower=-100.0, upper=100.0)
+
+        prob.driver.add_objective('obj')
+
+        # Add duplicate objective
+        with self.assertRaises(RuntimeError) as cm:
+            prob.driver.add_objective('x')
+
+        msg = "Attempted to add multiple objectives to a driver that does not " \
+              "support multiple objectives."
+        raised_error = str(cm.exception)
+        self.assertEqual(msg, raised_error)
+
+
     def test_no_desvar_bound(self):
 
         prob = Problem()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -25,6 +25,9 @@ from collections import OrderedDict
 grad_drivers = set(['CONMIN', 'FSQP', 'IPOPT', 'NLPQLP',
                     'PSQP', 'SLSQP', 'SNOPT', 'NLPY_AUGLAG'])
 
+# names of optimizers that allow multiple objectives
+multi_obj_drivers = set(['NSGA2'])
+
 def _check_imports():
     """ Dynamically remove optimizers we don't have
     """
@@ -80,7 +83,7 @@ class pyOptSparseDriver(Driver):
         # What we support
         self.supports['inequality_constraints'] = True
         self.supports['equality_constraints'] = True
-        self.supports['multiple_objectives'] = False
+        self.supports['multiple_objectives'] = True
         self.supports['two_sided_constraints'] = True
 
         # TODO: Support these
@@ -116,6 +119,10 @@ class pyOptSparseDriver(Driver):
 
     def _setup(self):
         self.supports['gradients'] = self.options['optimizer'] in grad_drivers
+        if len(self._objs) > 1 and self.options['optimizer'] not in multi_obj_drivers:
+            raise RuntimeError('Multiple objectives have been added to pyOptSparseDriver'
+                               ' but the selected optimizer ({0}) does not support'
+                               ' multiple objectives.'.format(self.options['optimizer']))
         super(pyOptSparseDriver, self)._setup()
 
     def run(self, problem):


### PR DESCRIPTION
Been a while since I messed with this.  Rebased and submitted as new pull request.
pyOptSparseDriver now as `supports['multiple_objectives'] = True`, with more tests in `_setup` to test that the selected optimizer supports multiple objectives.

