### PR TITLE
A couple of small speedups

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -707,8 +707,7 @@ class System(object):
                 # do dparams.vec[:] = 0.0 for example.
                 for _, val in dparams.vec_val_iter():
                     val[:] = 0.0
-                for _, val in dunknowns.vec_val_iter():
-                    val[:] = 0.0
+                dunknowns.vec[:] = 0.0
 
                 for var, val in dresids.vec_val_iter():
                     # Skip all states

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -448,6 +448,7 @@ class VecWrapper(object):
         self._probdata = probdata
 
         self.scale_cache = None
+        self.units_cache = None
 
     def _flat(self, name):
         """

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -1196,7 +1196,8 @@ class TgtVecWrapper(VecWrapper):
                                                             owned=False,
                                                             imag_val=imag_val)
 
-        self._cache_units()
+        if self.deriv_units:
+            self._cache_units()
 
 
     def _setup_var_meta(self, pathname, meta, index, src_acc, store_byobjs):

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -1272,11 +1272,25 @@ class TgtVecWrapper(VecWrapper):
         """ Applies derivative of the unit conversion factor to params
         sitting in vector.
         """
+
         if self.deriv_units:
-            for name, acc in iteritems(self._dat):
-                meta = acc.meta
-                if 'unit_conv' in meta:
-                    acc.val *= meta['unit_conv'][0]
+            if self.units_cache is None:
+                self._cache_units()
+
+            for name, val in self.units_cache:
+                acc = self._dat[name]
+                acc.val *= val
+
+    def _cache_units(self):
+        """ Caches the scalers so we don't have to do a lot of looping."""
+
+        units_cache = []
+        for name, acc in iteritems(self._dat):
+            meta = acc.meta
+            if 'unit_conv' in meta:
+                units_cache.append((name, meta['unit_conv'][0]))
+
+        self.units_cache = units_cache
 
 
 class _PlaceholderVecWrapper(object):

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -1278,8 +1278,7 @@ class TgtVecWrapper(VecWrapper):
                 self._cache_units()
 
             for name, val in self.units_cache:
-                acc = self._dat[name]
-                acc.val *= val
+                self._dat[name].val *= val
 
     def _cache_units(self):
         """ Caches the scalers so we don't have to do a lot of looping."""

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -1196,6 +1196,9 @@ class TgtVecWrapper(VecWrapper):
                                                             owned=False,
                                                             imag_val=imag_val)
 
+        self._cache_units()
+
+
     def _setup_var_meta(self, pathname, meta, index, src_acc, store_byobjs):
         """
         Populate the metadata dict for the named variable.
@@ -1274,9 +1277,6 @@ class TgtVecWrapper(VecWrapper):
         """
 
         if self.deriv_units:
-            if self.units_cache is None:
-                self._cache_units()
-
             for name, val in self.units_cache:
                 self._dat[name].val *= val
 


### PR DESCRIPTION
1. Cache unit conversion factors in the vecwrappers to prevent a slow iteritems.
2. Removed one vec_val_iter where it wasn't needed (since the whole u vector can be assigned.) Note: all calls to vec_val_iter are really slow because there is an iteritems in there. We should consider some alternatives here.