### PR TITLE
Reasonable error message if user changes solver after setup, and forgets to rerun setup.

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -481,8 +481,6 @@ class Component(System):
         if not self.is_active():
             return
 
-        self._setup_prom_map()
-
         self._impl = impl
 
         # create map of relative name in parent to relative name in child

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -73,6 +73,22 @@ class Group(System):
         self._gs_outputs = None
         self._run_apply = True
 
+    @property
+    def ln_solver(self):
+        return self._ln_solver
+
+    @ln_solver.setter
+    def ln_solver(self, item):
+        self._ln_solver = item
+
+    @property
+    def nl_solver(self):
+        return self._nl_solver
+
+    @nl_solver.setter
+    def nl_solver(self, item):
+        self._nl_solver = item
+
     def _subsystem(self, name):
         """
         Returns a reference to a named subsystem that is a direct or an indirect

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -73,22 +73,6 @@ class Group(System):
         self._gs_outputs = None
         self._run_apply = True
 
-    @property
-    def ln_solver(self):
-        return self._ln_solver
-
-    @ln_solver.setter
-    def ln_solver(self, item):
-        self._ln_solver = item
-
-    @property
-    def nl_solver(self):
-        return self._nl_solver
-
-    @nl_solver.setter
-    def nl_solver(self, item):
-        self._nl_solver = item
-
     def _subsystem(self, name):
         """
         Returns a reference to a named subsystem that is a direct or an indirect
@@ -417,8 +401,6 @@ class Group(System):
 
         if not self.is_active():
             return
-
-        self._setup_prom_map()
 
         self._impl = impl
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1052,15 +1052,12 @@ class Problem(object):
         here are those that would generate a cryptic error message. We can
         raise a readable error for the user."""
 
-        # New message if you forget to run setup first.
-        if not self.root._order_set:
-            msg = "setup() must be called before running the model."
-            raise RuntimeError(msg)
-
-        # or if you assign a new ln or nl solver and forget to run setup.
-        elif not self.root.fd_options.locked:
-            msg = "Solvers have changed, so setup() must be called again " + \
-            "before running the model."
+        # New message if you forget to run setup first, or if you assign a
+        # new ln or nl solver and forget to run setup.
+        if not self.root.fd_options.locked:
+            msg = "Before running the model, setup() must be called. If " + \
+                 "the configuration has changed since it was called, then " + \
+                 "setup must be called again before running the model."
             raise RuntimeError(msg)
 
     def run(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1053,8 +1053,14 @@ class Problem(object):
         raise a readable error for the user."""
 
         # New message if you forget to run setup first.
-        if not self.root.fd_options.locked:
+        if not self.root._order_set:
             msg = "setup() must be called before running the model."
+            raise RuntimeError(msg)
+
+        # or if you assign a new ln or nl solver and forget to run setup.
+        elif not self.root.fd_options.locked:
+            msg = "Solvers have changed, so setup() must be called again " + \
+            "before running the model."
             raise RuntimeError(msg)
 
     def run(self):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1074,18 +1074,6 @@ class System(object):
 
         return max_size, offsets
 
-    def _setup_prom_map(self):
-        """
-        Sets up the internal dict that maps absolute name to promoted name.
-        """
-        to_prom_name = self._sysdata.to_prom_name
-
-        for pathname, meta in iteritems(self._unknowns_dict):
-            prom = to_prom_name[pathname]
-
-        for pathname, meta in iteritems(self._params_dict):
-            prom = to_prom_name[pathname]
-
     def list_connections(self, group_by_comp=True, unconnected=True,
                          var=None, stream=sys.stdout):
         """

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -926,6 +926,20 @@ class TestProblem(unittest.TestCase):
         expected_msg = "The 'single_voi_relevance_reduction' option cannot be changed after setup."
         self.assertEqual(str(err.exception), expected_msg)
 
+    def test_change_solver_after_setup(self):
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        top.root.ln_solver = ScipyGMRES()
+
+        with self.assertRaises(RuntimeError) as err:
+            top.run()
+
+        expected_msg = "Solvers have changed, so setup() must be called again " + \
+                       "before running the model."
+        self.assertEqual(str(err.exception), expected_msg)
 
 class TestCheckSetup(unittest.TestCase):
 

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -619,7 +619,9 @@ class TestProblem(unittest.TestCase):
         try:
             prob.run()
         except RuntimeError as err:
-            msg = "setup() must be called before running the model."
+            msg = "Before running the model, setup() must be called. If " + \
+                "the configuration has changed since it was called, then " + \
+                "setup must be called again before running the model."
             self.assertEqual(text_type(err), msg)
         else:
             self.fail('Exception expected')
@@ -937,8 +939,9 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as err:
             top.run()
 
-        expected_msg = "Solvers have changed, so setup() must be called again " + \
-                       "before running the model."
+        expected_msg = "Before running the model, setup() must be called. If " + \
+            "the configuration has changed since it was called, then " + \
+            "setup must be called again before running the model."
         self.assertEqual(str(err.exception), expected_msg)
 
 class TestCheckSetup(unittest.TestCase):


### PR DESCRIPTION
1. Better error message by realizing what causes what during setup.
2. Cleaned out an old function that didn't do anything.