### PR TITLE
Overhaul of bounds checking in the Backtracking line search

### DIFF
--- a/mpitest/test_newton_backtracking.py
+++ b/mpitest/test_newton_backtracking.py
@@ -1,6 +1,7 @@
 """ Test out newton solve with the array alpha on the backtracking linesearch."""
 
 from __future__ import print_function
+import unittest
 
 import numpy as np
 

--- a/mpitest/test_newton_backtracking.py
+++ b/mpitest/test_newton_backtracking.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, Component, ParallelGroup, \
-                         Newton, PetscKSP
+                         Newton
 from openmdao.test.mpi_util import MPITestCase
 
 try:

--- a/mpitest/test_newton_backtracking.py
+++ b/mpitest/test_newton_backtracking.py
@@ -1,0 +1,221 @@
+""" Test out newton solve with the array alpha on the backtracking linesearch."""
+
+from __future__ import print_function
+
+import numpy as np
+
+from openmdao.api import Problem, Group, IndepVarComp, Component, ParallelGroup, \
+                         Newton, PetscKSP
+from openmdao.test.mpi_util import MPITestCase
+
+try:
+    from mpi4py import MPI
+    from openmdao.core.petsc_impl import PetscImpl as impl
+    from openmdao.solvers.petsc_ksp import PetscKSP
+except ImportError:
+    impl = None
+
+
+class SimpleImplicitComp1(Component):
+    """ A Simple Implicit Component with an additional output equation.
+
+    f(x,z) = xz + z - 4
+    y = x + 2z
+
+    Sol: when x = 0.5, z = 2.666
+    Sol: when x = 2.0, z = 1.333
+
+    Coupled derivs:
+
+    y = x + 8/(x+1)
+    dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+    z = 4/(x+1)
+    dz_dx = -4/(x+1)**2 = -1.7777777777777777
+    """
+
+    def __init__(self):
+        super(SimpleImplicitComp1, self).__init__()
+
+        # Params
+        self.add_param('x', np.zeros((3, 1)))
+
+        # Unknowns
+        self.add_output('y', np.zeros((3, 1)))
+
+        # States
+        self.add_state('z', 2.0*np.ones((3, 1)), lower=1.5, upper=np.array([[2.6, 2.5, 2.65]]).T)
+
+        self.maxiter = 10
+        self.atol = 1.0e-12
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        pass
+
+    def apply_nonlinear(self, params, unknowns, resids):
+        """ Don't solve; just calculate the residual."""
+
+        x = params['x']
+        z = unknowns['z']
+        resids['z'] = x*z + z - 4.0
+
+        # Output equations need to evaluate a residual just like an explicit comp.
+        resids['y'] = x + 2.0*z - unknowns['y']
+
+    def linearize(self, params, unknowns, resids):
+        """Analytical derivatives."""
+
+        J = {}
+
+        # Output equation
+        J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
+        J[('y', 'z')] = np.diag(np.array([2.0, 2.0, 2.0]))
+
+        # State equation
+        J[('z', 'z')] = (params['x'] + 1.0) * np.eye(3)
+        J[('z', 'x')] = unknowns['z'] * np.eye(3)
+
+        return J
+
+
+class SimpleImplicitComp2(Component):
+    """ A Simple Implicit Component with an additional output equation.
+
+    f(x,z) = xz + z - 4
+    y = x + 2z
+
+    Sol: when x = 0.5, z = 2.666
+    Sol: when x = 2.0, z = 1.333
+
+    Coupled derivs:
+
+    y = x + 8/(x+1)
+    dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+    z = 4/(x+1)
+    dz_dx = -4/(x+1)**2 = -1.7777777777777777
+    """
+
+    def __init__(self):
+        super(SimpleImplicitComp2, self).__init__()
+
+        # Params
+        self.add_param('x', np.zeros((3, 1)))
+
+        # Unknowns
+        self.add_output('y', np.zeros((3, 1)))
+
+        # States
+        self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, -2.65]]).T)
+
+        self.maxiter = 10
+        self.atol = 1.0e-12
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        pass
+
+    def apply_nonlinear(self, params, unknowns, resids):
+        """ Don't solve; just calculate the residual."""
+
+        x = params['x']
+        z = unknowns['z']
+        resids['z'] = -x*z - z - 4.0
+
+        # Output equations need to evaluate a residual just like an explicit comp.
+        resids['y'] = x - 2.0*z - unknowns['y']
+
+    def linearize(self, params, unknowns, resids):
+        """Analytical derivatives."""
+
+        J = {}
+
+        # Output equation
+        J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
+        J[('y', 'z')] = -np.diag(np.array([2.0, 2.0, 2.0]))
+
+        # State equation
+        J[('z', 'z')] = -(params['x'] + 1.0) * np.eye(3)
+        J[('z', 'x')] = -unknowns['z'] * np.eye(3)
+
+        return J
+
+class TestNewtonBacktrackingMPI(MPITestCase):
+
+    N_PROCS = 2
+
+    def setUp(self):
+        if impl is None:
+            raise unittest.SkipTest("Can't run this test (even in serial) without mpi4py and petsc4py")
+
+    def test_newton_backtrack_MPI(self):
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem(impl=impl)
+        top.root = Group()
+        par = top.root.add('par', ParallelGroup())
+        par.add('comp1', SimpleImplicitComp1())
+        par.add('comp2', SimpleImplicitComp2())
+        top.root.ln_solver = PetscKSP()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.nl_solver.line_search.options['vector_alpha'] = True
+
+        top.root.connect('px.x', 'par.comp1.x')
+        top.root.connect('px.x', 'par.comp2.x')
+        top.setup(check=False)
+
+        top['px.x'] = np.array([2.0, 2.0, 2.0])
+        top.run()
+
+        if not MPI or self.comm.rank == 0:
+            self.assertEqual(top['par.comp1.z'][0], 1.5)
+            self.assertEqual(top['par.comp1.z'][1], 1.5)
+            self.assertEqual(top['par.comp1.z'][2], 1.5)
+
+        if not MPI or self.comm.rank == 1:
+            self.assertEqual(top['par.comp2.z'][0], -1.5)
+            self.assertEqual(top['par.comp2.z'][1], -1.5)
+            self.assertEqual(top['par.comp2.z'][2], -1.5)
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past upper bounds
+        #------------------------------------------------------
+
+        top = Problem(impl=impl)
+        top.root = Group()
+        par = top.root.add('par', ParallelGroup())
+        par.add('comp1', SimpleImplicitComp1())
+        par.add('comp2', SimpleImplicitComp2())
+        top.root.ln_solver = PetscKSP()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.nl_solver.line_search.options['vector_alpha'] = True
+
+        top.root.connect('px.x', 'par.comp1.x')
+        top.root.connect('px.x', 'par.comp2.x')
+        top.setup(check=False)
+
+        top['px.x'] = 0.5*np.ones((3, 1))
+        top.run()
+
+        # Each bound is observed
+        if not MPI or self.comm.rank == 0:
+            self.assertEqual(top['par.comp1.z'][0], 2.6)
+            self.assertEqual(top['par.comp1.z'][1], 2.5)
+            self.assertEqual(top['par.comp1.z'][2], 2.65)
+
+        if not MPI or self.comm.rank == 1:
+            self.assertEqual(top['par.comp2.z'][0], -2.6)
+            self.assertEqual(top['par.comp2.z'][1], -2.5)
+            self.assertEqual(top['par.comp2.z'][2], -2.65)
+
+if __name__ == '__main__':
+    from openmdao.test.mpi_util import mpirun_tests
+    mpirun_tests()

--- a/openmdao/core/petsc_impl.py
+++ b/openmdao/core/petsc_impl.py
@@ -227,30 +227,37 @@ class PetscSrcVecWrapper(SrcVecWrapper):
         if trace: debug("petsc_vec creation DONE")
         return view
 
-    def distance_along_vector_to_limit(self, alpha, duvec):
+    def distance_along_vector_to_limit(self, alpha, duvec, vector_alpha):
         """ Returns a new alpha so that new_u = current_u + alpha*duvec does
         not violate any `lower` or `upper` limits if specified.
 
 
         Args
         -----
-        alpha: float
+        alpha: float or ndarray
             Initial value for step in gradient direction.
         duvec: `Vecwrapper`
             Direction to apply step. generally the gradient.
+        vector_alpha: bool
+            If True, then alpha is a vector, so limit each vector element
+            individually.
 
         Returns
         --------
-        float
-            New step size, backtracked to prevent violation."""
+        float or ndarray
+            New step size(s), backtracked to prevent violation."""
 
         # We need an alpha that violates no variables on any process, which
         # is the min alpha over all processes.
         local_alpha = super(PetscSrcVecWrapper,
-                            self).distance_along_vector_to_limit(alpha, duvec)
+                            self).distance_along_vector_to_limit(alpha, duvec,
+                                                                 vector_alpha)
 
-        alphas = self.comm.allgather(local_alpha)
-        return min(alphas)
+        if vector_alpha:
+            return local_alpha
+        else:
+            alphas = self.comm.allgather(local_alpha)
+            return min(alphas)
 
 
 class PetscTgtVecWrapper(TgtVecWrapper):

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -943,7 +943,7 @@ class SrcVecWrapper(VecWrapper):
         return [[(n, acc.meta['size']) for n, acc in iteritems(self._dat)
                         if not acc.pbo]]
 
-    def distance_along_vector_to_limit(self, alpha, duvec, central_path):
+    def distance_along_vector_to_limit(self, alpha, duvec, vector_alpha):
         """ Returns a new alpha so that new_u = current_u + alpha*duvec does
         not violate any `lower` or `upper` limits if specified.
 
@@ -953,8 +953,9 @@ class SrcVecWrapper(VecWrapper):
             Initial value for step in gradient direction.
         duvec: `Vecwrapper`
             Direction to apply step. generally the gradient.
-        central_path: bool
-            If True, then alpha is a vector, so return a vector of alphas
+        vector_alpha: bool
+            If True, then alpha is a vector, so limit each vector element
+            individually.
 
         Returns
         --------
@@ -967,7 +968,7 @@ class SrcVecWrapper(VecWrapper):
         numpy.seterr(divide='ignore')
 
         # Alpha is a vector
-        if central_path:
+        if vector_alpha:
 
             for name, meta in iteritems(self):
 

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -972,17 +972,39 @@ class SrcVecWrapper(VecWrapper):
 
             val = self[name]
 
+            #upper = meta.get('upper')
+            #if upper is not None:
+                #alpha_bound = numpy.min((upper - val)/duvec[name])
+                #if alpha_bound >= 0.0:
+                    #new_alpha = min(new_alpha, alpha_bound)
+
+            #lower = meta.get('lower')
+            #if lower is not None:
+                #alpha_bound = numpy.min((lower - val)/duvec[name])
+                #if alpha_bound >= 0.0:
+                    #new_alpha = min(new_alpha, alpha_bound)
+
             upper = meta.get('upper')
             if upper is not None:
-                alpha_bound = numpy.min((upper - val)/duvec[name])
-                if alpha_bound >= 0.0:
-                    new_alpha = min(new_alpha, alpha_bound)
+                alpha_bound = (upper - val)/duvec[name]
+                if isinstance(alpha_bound, float):
+                    if alpha_bound >= 0.0:
+                        new_alpha = min(new_alpha, alpha_bound)
+                else:
+                    for new_val in alpha_bound:
+                        if new_val >= 0.0:
+                            new_alpha = min(new_alpha, new_val)
 
             lower = meta.get('lower')
             if lower is not None:
-                alpha_bound = numpy.min((lower - val)/duvec[name])
-                if alpha_bound >= 0.0:
-                    new_alpha = min(new_alpha, alpha_bound)
+                alpha_bound = (lower - val)/duvec[name]
+                if isinstance(alpha_bound, float):
+                    if alpha_bound >= 0.0:
+                        new_alpha = min(new_alpha, alpha_bound)
+                else:
+                    for new_val in alpha_bound:
+                        if new_val >= 0.0:
+                            new_alpha = min(new_alpha, new_val)
 
         # Return numpy warn to what it was
         numpy.seterr(divide=old_warn['divide'])

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -1013,18 +1013,6 @@ class SrcVecWrapper(VecWrapper):
 
                 val = self[name]
 
-                #upper = meta.get('upper')
-                #if upper is not None:
-                    #alpha_bound = numpy.min((upper - val)/duvec[name])
-                    #if alpha_bound >= 0.0:
-                        #alpha = min(alpha, alpha_bound)
-
-                #lower = meta.get('lower')
-                #if lower is not None:
-                    #alpha_bound = numpy.min((lower - val)/duvec[name])
-                    #if alpha_bound >= 0.0:
-                        #alpha = min(alpha, alpha_bound)
-
                 upper = meta.get('upper')
                 if upper is not None:
                     alpha_bound = (upper - val)/duvec[name]

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -943,73 +943,113 @@ class SrcVecWrapper(VecWrapper):
         return [[(n, acc.meta['size']) for n, acc in iteritems(self._dat)
                         if not acc.pbo]]
 
-    def distance_along_vector_to_limit(self, alpha, duvec):
+    def distance_along_vector_to_limit(self, alpha, duvec, central_path):
         """ Returns a new alpha so that new_u = current_u + alpha*duvec does
         not violate any `lower` or `upper` limits if specified.
 
         Args
         -----
-        alpha: float
+        alpha: float or ndarray
             Initial value for step in gradient direction.
         duvec: `Vecwrapper`
             Direction to apply step. generally the gradient.
+        central_path: bool
+            If True, then alpha is a vector, so return a vector of alphas
 
         Returns
         --------
-        float
-            New step size, backtracked to prevent violation."""
+        float or ndarray
+            New step size(s), backtracked to prevent violation."""
 
         # A single index of the gradient can be zero, so we want to suppress
         # the warnings from numpy.
         old_warn = numpy.geterr()
         numpy.seterr(divide='ignore')
 
-        new_alpha = alpha
-        for name, meta in iteritems(self):
+        # Alpha is a vector
+        if central_path:
 
-            if 'remote' in meta:
-                continue
+            for name, meta in iteritems(self):
 
-            val = self[name]
+                if 'remote' in meta:
+                    continue
 
-            #upper = meta.get('upper')
-            #if upper is not None:
-                #alpha_bound = numpy.min((upper - val)/duvec[name])
-                #if alpha_bound >= 0.0:
-                    #new_alpha = min(new_alpha, alpha_bound)
+                val = self[name]
+                idx = duvec._dat[name].slice[0]
 
-            #lower = meta.get('lower')
-            #if lower is not None:
-                #alpha_bound = numpy.min((lower - val)/duvec[name])
-                #if alpha_bound >= 0.0:
-                    #new_alpha = min(new_alpha, alpha_bound)
+                upper = meta.get('upper')
+                if upper is not None:
+                    alpha_bound = (upper - val)/duvec[name]
+                    if isinstance(alpha_bound, float):
+                        if alpha_bound >= 0.0:
+                            alpha[idx] = min(alpha[idx], alpha_bound)
+                    else:
+                        j = 0
+                        for new_val in alpha_bound:
+                            if new_val >= 0.0:
+                                alpha[idx+j] = min(alpha[idx+j], new_val)
+                            j += 1
 
-            upper = meta.get('upper')
-            if upper is not None:
-                alpha_bound = (upper - val)/duvec[name]
-                if isinstance(alpha_bound, float):
-                    if alpha_bound >= 0.0:
-                        new_alpha = min(new_alpha, alpha_bound)
-                else:
-                    for new_val in alpha_bound:
-                        if new_val >= 0.0:
-                            new_alpha = min(new_alpha, new_val)
+                lower = meta.get('lower')
+                if lower is not None:
+                    alpha_bound = (lower - val)/duvec[name]
+                    if isinstance(alpha_bound, float):
+                        if alpha_bound >= 0.0:
+                            alpha[idx] = min(alpha[idx], alpha_bound)
+                    else:
+                        j = 0
+                        for new_val in alpha_bound:
+                            if new_val >= 0.0:
+                                alpha[idx+j] = min(alpha[idx+j], new_val)
+                            j += 1
 
-            lower = meta.get('lower')
-            if lower is not None:
-                alpha_bound = (lower - val)/duvec[name]
-                if isinstance(alpha_bound, float):
-                    if alpha_bound >= 0.0:
-                        new_alpha = min(new_alpha, alpha_bound)
-                else:
-                    for new_val in alpha_bound:
-                        if new_val >= 0.0:
-                            new_alpha = min(new_alpha, new_val)
+        # Alpha is a scaler
+        else:
+            for name, meta in iteritems(self):
+
+                if 'remote' in meta:
+                    continue
+
+                val = self[name]
+
+                #upper = meta.get('upper')
+                #if upper is not None:
+                    #alpha_bound = numpy.min((upper - val)/duvec[name])
+                    #if alpha_bound >= 0.0:
+                        #alpha = min(alpha, alpha_bound)
+
+                #lower = meta.get('lower')
+                #if lower is not None:
+                    #alpha_bound = numpy.min((lower - val)/duvec[name])
+                    #if alpha_bound >= 0.0:
+                        #alpha = min(alpha, alpha_bound)
+
+                upper = meta.get('upper')
+                if upper is not None:
+                    alpha_bound = (upper - val)/duvec[name]
+                    if isinstance(alpha_bound, float):
+                        if alpha_bound >= 0.0:
+                            alpha = min(alpha, alpha_bound)
+                    else:
+                        for new_val in alpha_bound:
+                            if new_val >= 0.0:
+                                alpha = min(alpha, new_val)
+
+                lower = meta.get('lower')
+                if lower is not None:
+                    alpha_bound = (lower - val)/duvec[name]
+                    if isinstance(alpha_bound, float):
+                        if alpha_bound >= 0.0:
+                            alpha = min(alpha, alpha_bound)
+                    else:
+                        for new_val in alpha_bound:
+                            if new_val >= 0.0:
+                                alpha = min(alpha, new_val)
 
         # Return numpy warn to what it was
         numpy.seterr(divide=old_warn['divide'])
 
-        return max(0.0, new_alpha)
+        return alpha
 
     def _scale_derivatives(self):
         """ Applies derivative of the scaling factor to the contents sitting

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -39,9 +39,10 @@ class BackTracking(LineSearch):
                        desc='Maximum number of line searches.')
         opt.add_option('solve_subsystems', True,
                        desc='Set to True to solve subsystems. You may need this for solvers nested under Newton.')
-        opt.add_option('central_path', False,
-                       desc='Set to True to use Central Path method, where bounded '
-                            'directions are capped but others continue to solve.')
+        opt.add_option('vector_alpha', False,
+                       desc='If set to True, then hitting the upper or lower bounds in a '
+                       'variable only stops that variable from proceding beyond the '
+                       'bounds. Unbounded variables continue with the default alpha.')
 
         self.print_name = 'BK_TKG'
 
@@ -87,15 +88,14 @@ class BackTracking(LineSearch):
         maxiter = self.options['maxiter']
         result = system.dumat[None]
         local_meta = create_local_meta(metadata, system.pathname)
-        central_path = self.options['central_path']
+        vector_alpha = self.options['vector_alpha']
 
-        if central_path:
+        if vector_alpha:
             alpha = alpha*np.ones(len(unknowns.vec))
 
         # If our step will violate any upper or lower bounds, then reduce
         # alpha so that we only step to that boundary.
-        print('Alpha original step', alpha)
-        alpha = unknowns.distance_along_vector_to_limit(alpha, result, central_path)
+        alpha = unknowns.distance_along_vector_to_limit(alpha, result, vector_alpha)
 
         # Apply step that doesn't violate bounds
         unknowns.vec += alpha*result.vec

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -25,6 +25,11 @@ class BackTracking(LineSearch):
         Relative convergence tolerancee for line search.
     options['solve_subsystems'] :  bool(True)
         Set to True to solve subsystems. You may need this for solvers nested under Newton.
+    options['vector_alpha'] :  bool(False)
+        If set to True, then hitting the upper or lower bounds in a
+        variable only stops that variable from proceding beyond the
+        bounds. Unbounded variables continue with the default alpha.
+
     """
 
     def __init__(self):

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -199,8 +199,8 @@ class MultLinearSolver(LinearSolver):
 
         system._sys_apply_linear(mode, self.system._do_apply, vois=(voi,))
 
-        print("arg", arg)
-        print("result", rhs_vec.vec)
+        #print("arg", arg)
+        #print("result", rhs_vec.vec)
         return rhs_vec.vec
 
 

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -199,8 +199,8 @@ class MultLinearSolver(LinearSolver):
 
         system._sys_apply_linear(mode, self.system._do_apply, vois=(voi,))
 
-        #print("arg", arg)
-        #print("result", rhs_vec.vec)
+        print("arg", arg)
+        print("result", rhs_vec.vec)
         return rhs_vec.vec
 
 

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -385,7 +385,7 @@ class TestBackTracking(unittest.TestCase):
                 self.add_output('y', np.zeros((3, 1)))
 
                 # States
-                self.add_state('z', 2.0*np.ones((3, 1)), lower=1.5, upper=np.array([2.5, 2.6, 2.7]))
+                self.add_state('z', 2.0*np.ones((3, 1)), lower=1.5, upper=np.array([[2.6, 2.5, 2.7]]).T)
 
                 self.maxiter = 10
                 self.atol = 1.0e-12
@@ -462,6 +462,114 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][0], 2.5)
         self.assertEqual(top['comp.z'][1], 2.5)
         self.assertEqual(top['comp.z'][2], 2.5)
+
+    def test_bounds_backtracking_arrays_lower(self):
+
+        class SimpleImplicitComp(Component):
+            """ A Simple Implicit Component with an additional output equation.
+
+            f(x,z) = xz + z - 4
+            y = x + 2z
+
+            Sol: when x = 0.5, z = 2.666
+            Sol: when x = 2.0, z = 1.333
+
+            Coupled derivs:
+
+            y = x + 8/(x+1)
+            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+            z = 4/(x+1)
+            dz_dx = -4/(x+1)**2 = -1.7777777777777777
+            """
+
+            def __init__(self):
+                super(SimpleImplicitComp, self).__init__()
+
+                # Params
+                self.add_param('x', np.zeros((3, 1)))
+
+                # Unknowns
+                self.add_output('y', np.zeros((3, 1)))
+
+                # States
+                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, -2.7]]).T)
+
+                self.maxiter = 10
+                self.atol = 1.0e-12
+
+            def solve_nonlinear(self, params, unknowns, resids):
+                pass
+
+            def apply_nonlinear(self, params, unknowns, resids):
+                """ Don't solve; just calculate the residual."""
+
+                x = params['x']
+                z = unknowns['z']
+                resids['z'] = -x*z - z - 4.0
+
+                # Output equations need to evaluate a residual just like an explicit comp.
+                resids['y'] = x - 2.0*z - unknowns['y']
+
+            def linearize(self, params, unknowns, resids):
+                """Analytical derivatives."""
+
+                J = {}
+
+                # Output equation
+                J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
+                J[('y', 'z')] = -np.diag(np.array([2.0, 2.0, 2.0]))
+
+                # State equation
+                J[('z', 'z')] = -(params['x'] + 1.0) * np.eye(3)
+                J[('z', 'x')] = -unknowns['z'] * np.eye(3)
+
+                return J
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past upper bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = np.array([2.0, 2.0, 2.0])
+        top.run()
+
+        self.assertEqual(top['comp.z'][0], -1.5)
+        self.assertEqual(top['comp.z'][1], -1.5)
+        self.assertEqual(top['comp.z'][2], -1.5)
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = 0.5*np.ones((3, 1))
+        top.run()
+
+        # Most restrictive bound is observed
+        self.assertEqual(top['comp.z'][0], -2.5)
+        self.assertEqual(top['comp.z'][1], -2.5)
+        self.assertEqual(top['comp.z'][2], -2.5)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -463,6 +463,118 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][1], 2.5)
         self.assertEqual(top['comp.z'][2], 2.5)
 
+    def test_bounds_backtracking_arrays_vector_alpha(self):
+
+        class SimpleImplicitComp(Component):
+            """ A Simple Implicit Component with an additional output equation.
+
+            f(x,z) = xz + z - 4
+            y = x + 2z
+
+            Sol: when x = 0.5, z = 2.666
+            Sol: when x = 2.0, z = 1.333
+
+            Coupled derivs:
+
+            y = x + 8/(x+1)
+            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+            z = 4/(x+1)
+            dz_dx = -4/(x+1)**2 = -1.7777777777777777
+            """
+
+            def __init__(self):
+                super(SimpleImplicitComp, self).__init__()
+
+                # Params
+                self.add_param('x', np.zeros((3, 1)))
+
+                # Unknowns
+                self.add_output('y', np.zeros((3, 1)))
+
+                # States
+                self.add_state('z', 2.0*np.ones((3, 1)), lower=1.5, upper=np.array([[2.6, 2.5, 2.65]]).T)
+
+                self.maxiter = 10
+                self.atol = 1.0e-12
+
+            def solve_nonlinear(self, params, unknowns, resids):
+                pass
+
+            def apply_nonlinear(self, params, unknowns, resids):
+                """ Don't solve; just calculate the residual."""
+
+                x = params['x']
+                z = unknowns['z']
+                resids['z'] = x*z + z - 4.0
+
+                # Output equations need to evaluate a residual just like an explicit comp.
+                resids['y'] = x + 2.0*z - unknowns['y']
+
+            def linearize(self, params, unknowns, resids):
+                """Analytical derivatives."""
+
+                J = {}
+
+                # Output equation
+                J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
+                J[('y', 'z')] = np.diag(np.array([2.0, 2.0, 2.0]))
+
+                # State equation
+                J[('z', 'z')] = (params['x'] + 1.0) * np.eye(3)
+                J[('z', 'x')] = unknowns['z'] * np.eye(3)
+
+                return J
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.nl_solver.line_search.options['vector_alpha'] = True
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = np.array([2.0, 2.0, 2.0])
+        top.run()
+
+        self.assertEqual(top['comp.z'][0], 1.5)
+        self.assertEqual(top['comp.z'][1], 1.5)
+        self.assertEqual(top['comp.z'][2], 1.5)
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past upper bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 6
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.nl_solver.line_search.options['vector_alpha'] = True
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = 0.5*np.ones((3, 1))
+        top.run()
+
+        # Most restrictive bound is observed
+        self.assertEqual(top['comp.z'][0], 2.6)
+        self.assertEqual(top['comp.z'][1], 2.5)
+        self.assertEqual(top['comp.z'][2], 2.65)
+
     def test_bounds_backtracking_arrays_lower(self):
 
         class SimpleImplicitComp(Component):
@@ -571,7 +683,7 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][1], -2.5)
         self.assertEqual(top['comp.z'][2], -2.5)
 
-    def test_bounds_backtracking_arrays_lower_different(self):
+    def test_bounds_backtracking_arrays_lower_vector_alpha(self):
 
         class SimpleImplicitComp(Component):
             """ A Simple Implicit Component with an additional output equation.
@@ -601,7 +713,119 @@ class TestBackTracking(unittest.TestCase):
                 self.add_output('y', np.zeros((3, 1)))
 
                 # States
-                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, -2.7]]).T)
+                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, -2.65]]).T)
+
+                self.maxiter = 10
+                self.atol = 1.0e-12
+
+            def solve_nonlinear(self, params, unknowns, resids):
+                pass
+
+            def apply_nonlinear(self, params, unknowns, resids):
+                """ Don't solve; just calculate the residual."""
+
+                x = params['x']
+                z = unknowns['z']
+                resids['z'] = -x*z - z - 4.0
+
+                # Output equations need to evaluate a residual just like an explicit comp.
+                resids['y'] = x - 2.0*z - unknowns['y']
+
+            def linearize(self, params, unknowns, resids):
+                """Analytical derivatives."""
+
+                J = {}
+
+                # Output equation
+                J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
+                J[('y', 'z')] = -np.diag(np.array([2.0, 2.0, 2.0]))
+
+                # State equation
+                J[('z', 'z')] = -(params['x'] + 1.0) * np.eye(3)
+                J[('z', 'x')] = -unknowns['z'] * np.eye(3)
+
+                return J
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past upper bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.nl_solver.line_search.options['vector_alpha'] = True
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = np.array([2.0, 2.0, 2.0])
+        top.run()
+
+        self.assertEqual(top['comp.z'][0], -1.5)
+        self.assertEqual(top['comp.z'][1], -1.5)
+        self.assertEqual(top['comp.z'][2], -1.5)
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.nl_solver.line_search.options['vector_alpha'] = True
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = 0.5*np.ones((3, 1))
+        top.run()
+
+        # Most restrictive bound is observed
+        self.assertEqual(top['comp.z'][0], -2.6)
+        self.assertEqual(top['comp.z'][1], -2.5)
+        self.assertEqual(top['comp.z'][2], -2.65)
+
+    def test_bounds_backtracking_arrays_lower_bugfix(self):
+
+        class SimpleImplicitComp(Component):
+            """ A Simple Implicit Component with an additional output equation.
+
+            f(x,z) = xz + z - 4
+            y = x + 2z
+
+            Sol: when x = 0.5, z = 2.666
+            Sol: when x = 2.0, z = 1.333
+
+            Coupled derivs:
+
+            y = x + 8/(x+1)
+            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+            z = 4/(x+1)
+            dz_dx = -4/(x+1)**2 = -1.7777777777777777
+            """
+
+            def __init__(self):
+                super(SimpleImplicitComp, self).__init__()
+
+                # Params
+                self.add_param('x', np.zeros((3, 1)))
+
+                # Unknowns
+                self.add_output('y', np.zeros((3, 1)))
+
+                # States
+                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, 2.7]]).T)
 
                 self.maxiter = 10
                 self.atol = 1.0e-12

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -570,7 +570,7 @@ class TestBackTracking(unittest.TestCase):
         top['px.x'] = 0.5*np.ones((3, 1))
         top.run()
 
-        # Most restrictive bound is observed
+        # Each bound is observed
         self.assertEqual(top['comp.z'][0], 2.6)
         self.assertEqual(top['comp.z'][1], 2.5)
         self.assertEqual(top['comp.z'][2], 2.65)
@@ -790,7 +790,7 @@ class TestBackTracking(unittest.TestCase):
         top['px.x'] = 0.5*np.ones((3, 1))
         top.run()
 
-        # Most restrictive bound is observed
+        # Each bound is observed
         self.assertEqual(top['comp.z'][0], -2.6)
         self.assertEqual(top['comp.z'][1], -2.5)
         self.assertEqual(top['comp.z'][2], -2.65)

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -571,5 +571,117 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][1], -2.5)
         self.assertEqual(top['comp.z'][2], -2.5)
 
+    def test_bounds_backtracking_arrays_lower_different(self):
+
+        class SimpleImplicitComp(Component):
+            """ A Simple Implicit Component with an additional output equation.
+
+            f(x,z) = xz + z - 4
+            y = x + 2z
+
+            Sol: when x = 0.5, z = 2.666
+            Sol: when x = 2.0, z = 1.333
+
+            Coupled derivs:
+
+            y = x + 8/(x+1)
+            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+            z = 4/(x+1)
+            dz_dx = -4/(x+1)**2 = -1.7777777777777777
+            """
+
+            def __init__(self):
+                super(SimpleImplicitComp, self).__init__()
+
+                # Params
+                self.add_param('x', np.zeros((3, 1)))
+
+                # Unknowns
+                self.add_output('y', np.zeros((3, 1)))
+
+                # States
+                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, -2.7]]).T)
+
+                self.maxiter = 10
+                self.atol = 1.0e-12
+
+            def solve_nonlinear(self, params, unknowns, resids):
+                pass
+
+            def apply_nonlinear(self, params, unknowns, resids):
+                """ Don't solve; just calculate the residual."""
+
+                x = params['x']
+                z = unknowns['z']
+                resids['z'] = -x*z - z - 4.0
+
+                # Output equations need to evaluate a residual just like an explicit comp.
+                resids['y'] = x - 2.0*z - unknowns['y']
+
+            def linearize(self, params, unknowns, resids):
+                """Analytical derivatives."""
+
+                J = {}
+
+                # Output equation
+                J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
+                J[('y', 'z')] = -np.diag(np.array([2.0, 2.0, 2.0]))
+
+                # State equation
+                J[('z', 'z')] = -(params['x'] + 1.0) * np.eye(3)
+                J[('z', 'x')] = -unknowns['z'] * np.eye(3)
+
+                # Make it more interesting
+                J[('y', 'z')][0][2] = -J[('y', 'z')][0][2]
+                J[('z', 'z')][0][2] = -J[('z', 'z')][0][2]
+
+                return J
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past upper bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = np.array([2.0, 2.0, 2.0])
+        top.run()
+
+        self.assertEqual(top['comp.z'][0], -1.5)
+        self.assertEqual(top['comp.z'][1], -1.5)
+        self.assertEqual(top['comp.z'][2], -1.5)
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = 0.5*np.ones((3, 1))
+        top.run()
+
+        # Most restrictive bound is observed
+        self.assertEqual(top['comp.z'][0], -2.5)
+        self.assertEqual(top['comp.z'][1], -2.5)
+        self.assertEqual(top['comp.z'][2], -2.5)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
1. Fixed a sign bug that cropped up when checking the bound on a vector.
2. Added the `vector_alpha` option to the Backtracking line search. This option can be turned on to allow the non-capped variable to continue to progress while the capped ones stay at the bounds. In this case, a separate alpha is determined for each element in the unknowns.