### PR TITLE
Some more improvements and fixes for bounds-limiting in the line search.

### DIFF
--- a/mpitest/test_newton_backtracking.py
+++ b/mpitest/test_newton_backtracking.py
@@ -164,8 +164,6 @@ class TestNewtonBacktrackingMPI(MPITestCase):
         top.root.nl_solver.options['maxiter'] = 5
         top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
 
-        top.root.nl_solver.line_search.options['vector_alpha'] = True
-
         top.root.connect('px.x', 'par.comp1.x')
         top.root.connect('px.x', 'par.comp2.x')
         top.setup(check=False)
@@ -197,8 +195,6 @@ class TestNewtonBacktrackingMPI(MPITestCase):
         top.root.nl_solver.options['maxiter'] = 5
         top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
 
-        top.root.nl_solver.line_search.options['vector_alpha'] = True
-
         top.root.connect('px.x', 'par.comp1.x')
         top.root.connect('px.x', 'par.comp2.x')
         top.setup(check=False)
@@ -207,12 +203,12 @@ class TestNewtonBacktrackingMPI(MPITestCase):
         top.run()
 
         # Each bound is observed
-        if not MPI or self.comm.rank == 0:
+        if top.root.par.comp1.is_active():
             self.assertEqual(top['par.comp1.z'][0], 2.6)
             self.assertEqual(top['par.comp1.z'][1], 2.5)
             self.assertEqual(top['par.comp1.z'][2], 2.65)
 
-        if not MPI or self.comm.rank == 1:
+        if top.root.par.com2.is_active():
             self.assertEqual(top['par.comp2.z'][0], -2.6)
             self.assertEqual(top['par.comp2.z'][1], -2.5)
             self.assertEqual(top['par.comp2.z'][2], -2.65)

--- a/mpitest/test_newton_backtracking.py
+++ b/mpitest/test_newton_backtracking.py
@@ -208,7 +208,7 @@ class TestNewtonBacktrackingMPI(MPITestCase):
             self.assertEqual(top['par.comp1.z'][1], 2.5)
             self.assertEqual(top['par.comp1.z'][2], 2.65)
 
-        if top.root.par.com2.is_active():
+        if top.root.par.comp2.is_active():
             self.assertEqual(top['par.comp2.z'][0], -2.6)
             self.assertEqual(top['par.comp2.z'][1], -2.5)
             self.assertEqual(top['par.comp2.z'][2], -2.65)

--- a/mpitest/test_parallel_solver_bounds.py
+++ b/mpitest/test_parallel_solver_bounds.py
@@ -177,7 +177,7 @@ class TestParallelBounds(MPITestCase):
         # allgathered and used the lowest alpha.
 
         if top.root.par.comp1.is_active():
-            self.assertEqual(top['par.comp1.z'], 1.5)
+            self.assertEqual(top['par.comp1.z'], 1.4)
         if top.root.par.comp2.is_active():
             self.assertEqual(top['par.comp2.z'], 1.5)
 

--- a/openmdao/core/petsc_impl.py
+++ b/openmdao/core/petsc_impl.py
@@ -227,26 +227,6 @@ class PetscSrcVecWrapper(SrcVecWrapper):
         if trace: debug("petsc_vec creation DONE")
         return view
 
-    def distance_along_vector_to_limit(self, alpha, duvec):
-        """ Returns a new alpha so that new_u = current_u + alpha*duvec does
-        not violate any `lower` or `upper` limits if specified.
-
-        Args
-        -----
-        alpha: ndarray
-            Initial value for step in gradient direction.
-        duvec: `Vecwrapper`
-            Direction to apply step. generally the gradient.
-        Returns
-        --------
-        ndarray
-            New step size(s), backtracked to prevent violation."""
-
-        local_alpha = super(PetscSrcVecWrapper,
-                            self).distance_along_vector_to_limit(alpha, duvec)
-
-        return local_alpha
-
 
 class PetscTgtVecWrapper(TgtVecWrapper):
     idx_arr_type = PetscImpl.idx_arr_type

--- a/openmdao/core/petsc_impl.py
+++ b/openmdao/core/petsc_impl.py
@@ -227,37 +227,25 @@ class PetscSrcVecWrapper(SrcVecWrapper):
         if trace: debug("petsc_vec creation DONE")
         return view
 
-    def distance_along_vector_to_limit(self, alpha, duvec, vector_alpha):
+    def distance_along_vector_to_limit(self, alpha, duvec):
         """ Returns a new alpha so that new_u = current_u + alpha*duvec does
         not violate any `lower` or `upper` limits if specified.
 
-
         Args
         -----
-        alpha: float or ndarray
+        alpha: ndarray
             Initial value for step in gradient direction.
         duvec: `Vecwrapper`
             Direction to apply step. generally the gradient.
-        vector_alpha: bool
-            If True, then alpha is a vector, so limit each vector element
-            individually.
-
         Returns
         --------
-        float or ndarray
+        ndarray
             New step size(s), backtracked to prevent violation."""
 
-        # We need an alpha that violates no variables on any process, which
-        # is the min alpha over all processes.
         local_alpha = super(PetscSrcVecWrapper,
-                            self).distance_along_vector_to_limit(alpha, duvec,
-                                                                 vector_alpha)
+                            self).distance_along_vector_to_limit(alpha, duvec)
 
-        if vector_alpha:
-            return local_alpha
-        else:
-            alphas = self.comm.allgather(local_alpha)
-            return min(alphas)
+        return local_alpha
 
 
 class PetscTgtVecWrapper(TgtVecWrapper):

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -943,7 +943,7 @@ class SrcVecWrapper(VecWrapper):
         return [[(n, acc.meta['size']) for n, acc in iteritems(self._dat)
                         if not acc.pbo]]
 
-    def distance_along_vector_to_limit(self, alpha, duvec, vector_alpha):
+    def distance_along_vector_to_limit(self, alpha, duvec):
         """ Returns a new alpha so that new_u = current_u + alpha*duvec does
         not violate any `lower` or `upper` limits if specified.
 
@@ -953,13 +953,10 @@ class SrcVecWrapper(VecWrapper):
             Initial value for step in gradient direction.
         duvec: `Vecwrapper`
             Direction to apply step. generally the gradient.
-        vector_alpha: bool
-            If True, then alpha is a vector, so limit each vector element
-            individually.
 
         Returns
         --------
-        float or ndarray
+        ndarray
             New step size(s), backtracked to prevent violation."""
 
         # A single index of the gradient can be zero, so we want to suppress
@@ -967,80 +964,53 @@ class SrcVecWrapper(VecWrapper):
         old_warn = numpy.geterr()
         numpy.seterr(divide='ignore')
 
-        # Alpha is a vector
-        if vector_alpha:
+        for name, meta in iteritems(self):
 
-            for name, meta in iteritems(self):
+            if 'remote' in meta:
+                continue
 
-                if 'remote' in meta:
-                    continue
+            val = self[name]
+            idx = duvec._dat[name].slice[0]
 
-                val = self[name]
-                idx = duvec._dat[name].slice[0]
+            upper = meta.get('upper')
+            if upper is not None:
+                diff = upper - val
+                alpha_bound = diff/duvec[name]
+                if isinstance(alpha_bound, float):
+                    if alpha_bound >= 0.0:
+                        alpha[idx] = min(alpha[idx], alpha_bound)
+                else:
+                    j = 0
+                    for new_val in alpha_bound:
+                        if new_val >= 0.0:
+                            alpha[idx+j] = min(alpha[idx+j], new_val)
 
-                upper = meta.get('upper')
-                if upper is not None:
-                    diff = upper - val
-                    alpha_bound = diff/duvec[name]
-                    if isinstance(alpha_bound, float):
-                        if alpha_bound >= 0.0:
-                            alpha[idx] = min(alpha[idx], alpha_bound)
-                    else:
-                        j = 0
-                        for new_val in alpha_bound:
-                            if new_val >= 0.0:
-                                alpha[idx+j] = min(alpha[idx+j], new_val)
-                            elif diff[j] < 0.0:
-                                alpha[idx+j] = new_val
-                            j += 1
+                        # If we are already violated for any reason,
+                        # bring it back to the boundary.
+                        elif diff[j] < 0.0:
+                            alpha[idx+j] = new_val
 
-                lower = meta.get('lower')
-                if lower is not None:
-                    diff = lower - val
-                    alpha_bound = diff/duvec[name]
-                    if isinstance(alpha_bound, float):
-                        if alpha_bound >= 0.0:
-                            alpha[idx] = min(alpha[idx], alpha_bound)
-                    else:
-                        j = 0
-                        for new_val in alpha_bound:
-                            if new_val >= 0.0:
-                                alpha[idx+j] = min(alpha[idx+j], new_val)
-                            elif diff[j] > 0.0:
-                                alpha[idx+j] = new_val
+                        j += 1
 
-                            j += 1
+            lower = meta.get('lower')
+            if lower is not None:
+                diff = lower - val
+                alpha_bound = diff/duvec[name]
+                if isinstance(alpha_bound, float):
+                    if alpha_bound >= 0.0:
+                        alpha[idx] = min(alpha[idx], alpha_bound)
+                else:
+                    j = 0
+                    for new_val in alpha_bound:
+                        if new_val >= 0.0:
+                            alpha[idx+j] = min(alpha[idx+j], new_val)
 
-        # Alpha is a scaler
-        else:
-            for name, meta in iteritems(self):
+                        # If we are already violated for any reason,
+                        # bring it back to the boundary.
+                        elif diff[j] > 0.0:
+                            alpha[idx+j] = new_val
 
-                if 'remote' in meta:
-                    continue
-
-                val = self[name]
-
-                upper = meta.get('upper')
-                if upper is not None:
-                    alpha_bound = (upper - val)/duvec[name]
-                    if isinstance(alpha_bound, float):
-                        if alpha_bound >= 0.0:
-                            alpha = min(alpha, alpha_bound)
-                    else:
-                        for new_val in alpha_bound:
-                            if new_val >= 0.0:
-                                alpha = min(alpha, new_val)
-
-                lower = meta.get('lower')
-                if lower is not None:
-                    alpha_bound = (lower - val)/duvec[name]
-                    if isinstance(alpha_bound, float):
-                        if alpha_bound >= 0.0:
-                            alpha = min(alpha, alpha_bound)
-                    else:
-                        for new_val in alpha_bound:
-                            if new_val >= 0.0:
-                                alpha = min(alpha, new_val)
+                        j += 1
 
         # Return numpy warn to what it was
         numpy.seterr(divide=old_warn['divide'])

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -980,7 +980,8 @@ class SrcVecWrapper(VecWrapper):
 
                 upper = meta.get('upper')
                 if upper is not None:
-                    alpha_bound = (upper - val)/duvec[name]
+                    diff = upper - val
+                    alpha_bound = diff/duvec[name]
                     if isinstance(alpha_bound, float):
                         if alpha_bound >= 0.0:
                             alpha[idx] = min(alpha[idx], alpha_bound)
@@ -989,11 +990,14 @@ class SrcVecWrapper(VecWrapper):
                         for new_val in alpha_bound:
                             if new_val >= 0.0:
                                 alpha[idx+j] = min(alpha[idx+j], new_val)
+                            elif diff[j] < 0.0:
+                                alpha[idx+j] = new_val
                             j += 1
 
                 lower = meta.get('lower')
                 if lower is not None:
-                    alpha_bound = (lower - val)/duvec[name]
+                    diff = lower - val
+                    alpha_bound = diff/duvec[name]
                     if isinstance(alpha_bound, float):
                         if alpha_bound >= 0.0:
                             alpha[idx] = min(alpha[idx], alpha_bound)
@@ -1002,6 +1006,9 @@ class SrcVecWrapper(VecWrapper):
                         for new_val in alpha_bound:
                             if new_val >= 0.0:
                                 alpha[idx+j] = min(alpha[idx+j], new_val)
+                            elif diff[j] > 0.0:
+                                alpha[idx+j] = new_val
+
                             j += 1
 
         # Alpha is a scaler

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -949,7 +949,7 @@ class SrcVecWrapper(VecWrapper):
 
         Args
         -----
-        alpha: float or ndarray
+        alpha: ndarray
             Initial value for step in gradient direction.
         duvec: `Vecwrapper`
             Direction to apply step. generally the gradient.

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -984,7 +984,8 @@ class SrcVecWrapper(VecWrapper):
                         alpha[idx] = alpha_bound
 
                     elif alpha_bound >= 0.0:
-                        alpha[idx] = min(alpha[idx], alpha_bound)
+                        if alpha_bound < alpha[idx]:
+                            alpha[idx] = alpha_bound
 
                 else:
                     j = 0
@@ -996,7 +997,8 @@ class SrcVecWrapper(VecWrapper):
                             alpha[idx+j] = new_val
 
                         elif new_val >= 0.0:
-                            alpha[idx+j] = min(alpha[idx+j], new_val)
+                            if new_val < alpha[idx+j]:
+                                alpha[idx+j] = new_val
 
                         j += 1
 
@@ -1012,7 +1014,8 @@ class SrcVecWrapper(VecWrapper):
                         alpha[idx] = alpha_bound
 
                     elif alpha_bound >= 0.0:
-                        alpha[idx] = min(alpha[idx], alpha_bound)
+                        if alpha_bound < alpha[idx]:
+                            alpha[idx] = alpha_bound
 
                 else:
                     j = 0
@@ -1024,7 +1027,8 @@ class SrcVecWrapper(VecWrapper):
                             alpha[idx+j] = new_val
 
                         elif new_val >= 0.0:
-                            alpha[idx+j] = min(alpha[idx+j], new_val)
+                            if new_val < alpha[idx+j]:
+                                alpha[idx+j] = new_val
 
                         j += 1
 

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -964,76 +964,78 @@ class SrcVecWrapper(VecWrapper):
         old_warn = numpy.geterr()
         numpy.seterr(divide='ignore')
 
-        for name, meta in iteritems(self):
+        try:
+            for name, meta in iteritems(self):
 
-            if 'remote' in meta:
-                continue
+                if 'remote' in meta:
+                    continue
 
-            val = self[name]
-            idx = duvec._dat[name].slice[0]
+                val = self[name]
+                idx = duvec._dat[name].slice[0]
 
-            upper = meta.get('upper')
-            if upper is not None:
-                diff = upper - val
-                alpha_bound = diff/duvec[name]
-                if isinstance(alpha_bound, float):
-
-                    # If we are already violated for any reason,
-                    # bring it back to the boundary.
-                    if diff < 0.0:
-                        alpha[idx] = alpha_bound
-
-                    elif alpha_bound >= 0.0:
-                        if alpha_bound < alpha[idx]:
-                            alpha[idx] = alpha_bound
-
-                else:
-                    j = 0
-                    for new_val in alpha_bound:
+                upper = meta.get('upper')
+                if upper is not None:
+                    diff = upper - val
+                    alpha_bound = diff/duvec[name]
+                    if isinstance(alpha_bound, float):
 
                         # If we are already violated for any reason,
                         # bring it back to the boundary.
-                        if diff[j] < 0.0:
-                            alpha[idx+j] = new_val
-
-                        elif new_val >= 0.0:
-                            if new_val < alpha[idx+j]:
-                                alpha[idx+j] = new_val
-
-                        j += 1
-
-            lower = meta.get('lower')
-            if lower is not None:
-                diff = lower - val
-                alpha_bound = diff/duvec[name]
-                if isinstance(alpha_bound, float):
-
-                    # If we are already violated for any reason,
-                    # bring it back to the boundary.
-                    if diff > 0.0:
-                        alpha[idx] = alpha_bound
-
-                    elif alpha_bound >= 0.0:
-                        if alpha_bound < alpha[idx]:
+                        if diff < 0.0:
                             alpha[idx] = alpha_bound
 
-                else:
-                    j = 0
-                    for new_val in alpha_bound:
+                        elif alpha_bound >= 0.0:
+                            if alpha_bound < alpha[idx]:
+                                alpha[idx] = alpha_bound
+
+                    else:
+                        j = 0
+                        for new_val in alpha_bound:
+
+                            # If we are already violated for any reason,
+                            # bring it back to the boundary.
+                            if diff[j] < 0.0:
+                                alpha[idx+j] = new_val
+
+                            elif new_val >= 0.0:
+                                if new_val < alpha[idx+j]:
+                                    alpha[idx+j] = new_val
+
+                            j += 1
+
+                lower = meta.get('lower')
+                if lower is not None:
+                    diff = lower - val
+                    alpha_bound = diff/duvec[name]
+                    if isinstance(alpha_bound, float):
 
                         # If we are already violated for any reason,
                         # bring it back to the boundary.
-                        if diff[j] > 0.0:
-                            alpha[idx+j] = new_val
+                        if diff > 0.0:
+                            alpha[idx] = alpha_bound
 
-                        elif new_val >= 0.0:
-                            if new_val < alpha[idx+j]:
+                        elif alpha_bound >= 0.0:
+                            if alpha_bound < alpha[idx]:
+                                alpha[idx] = alpha_bound
+
+                    else:
+                        j = 0
+                        for new_val in alpha_bound:
+
+                            # If we are already violated for any reason,
+                            # bring it back to the boundary.
+                            if diff[j] > 0.0:
                                 alpha[idx+j] = new_val
 
-                        j += 1
+                            elif new_val >= 0.0:
+                                if new_val < alpha[idx+j]:
+                                    alpha[idx+j] = new_val
+
+                            j += 1
 
         # Return numpy warn to what it was
-        numpy.seterr(divide=old_warn['divide'])
+        finally:
+            numpy.seterr(divide=old_warn['divide'])
 
         return alpha
 

--- a/openmdao/core/vec_wrapper.py
+++ b/openmdao/core/vec_wrapper.py
@@ -977,18 +977,26 @@ class SrcVecWrapper(VecWrapper):
                 diff = upper - val
                 alpha_bound = diff/duvec[name]
                 if isinstance(alpha_bound, float):
-                    if alpha_bound >= 0.0:
+
+                    # If we are already violated for any reason,
+                    # bring it back to the boundary.
+                    if diff < 0.0:
+                        alpha[idx] = alpha_bound
+
+                    elif alpha_bound >= 0.0:
                         alpha[idx] = min(alpha[idx], alpha_bound)
+
                 else:
                     j = 0
                     for new_val in alpha_bound:
-                        if new_val >= 0.0:
-                            alpha[idx+j] = min(alpha[idx+j], new_val)
 
                         # If we are already violated for any reason,
                         # bring it back to the boundary.
-                        elif diff[j] < 0.0:
+                        if diff[j] < 0.0:
                             alpha[idx+j] = new_val
+
+                        elif new_val >= 0.0:
+                            alpha[idx+j] = min(alpha[idx+j], new_val)
 
                         j += 1
 
@@ -997,18 +1005,26 @@ class SrcVecWrapper(VecWrapper):
                 diff = lower - val
                 alpha_bound = diff/duvec[name]
                 if isinstance(alpha_bound, float):
-                    if alpha_bound >= 0.0:
+
+                    # If we are already violated for any reason,
+                    # bring it back to the boundary.
+                    if diff > 0.0:
+                        alpha[idx] = alpha_bound
+
+                    elif alpha_bound >= 0.0:
                         alpha[idx] = min(alpha[idx], alpha_bound)
+
                 else:
                     j = 0
                     for new_val in alpha_bound:
-                        if new_val >= 0.0:
-                            alpha[idx+j] = min(alpha[idx+j], new_val)
 
                         # If we are already violated for any reason,
                         # bring it back to the boundary.
-                        elif diff[j] > 0.0:
+                        if diff[j] > 0.0:
                             alpha[idx+j] = new_val
+
+                        elif new_val >= 0.0:
+                            alpha[idx+j] = min(alpha[idx+j], new_val)
 
                         j += 1
 

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -25,11 +25,6 @@ class BackTracking(LineSearch):
         Relative convergence tolerancee for line search.
     options['solve_subsystems'] :  bool(True)
         Set to True to solve subsystems. You may need this for solvers nested under Newton.
-    options['vector_alpha'] :  bool(False)
-        If set to True, then hitting the upper or lower bounds in a
-        variable only stops that variable from proceding beyond the
-        bounds. Unbounded variables continue with the default alpha.
-
     """
 
     def __init__(self):
@@ -44,10 +39,6 @@ class BackTracking(LineSearch):
                        desc='Maximum number of line searches.')
         opt.add_option('solve_subsystems', True,
                        desc='Set to True to solve subsystems. You may need this for solvers nested under Newton.')
-        opt.add_option('vector_alpha', False,
-                       desc='If set to True, then hitting the upper or lower bounds in a '
-                       'variable only stops that variable from proceding beyond the '
-                       'bounds. Unbounded variables continue with the default alpha.')
 
         self.print_name = 'BK_TKG'
 
@@ -93,14 +84,14 @@ class BackTracking(LineSearch):
         maxiter = self.options['maxiter']
         result = system.dumat[None]
         local_meta = create_local_meta(metadata, system.pathname)
-        vector_alpha = self.options['vector_alpha']
 
-        if vector_alpha:
-            alpha = alpha*np.ones(len(unknowns.vec))
+        # Allow different alphas for each value so we can keep moving when we
+        # hit a bound.
+        alpha = alpha*np.ones(len(unknowns.vec))
 
         # If our step will violate any upper or lower bounds, then reduce
         # alpha so that we only step to that boundary.
-        alpha = unknowns.distance_along_vector_to_limit(alpha, result, vector_alpha)
+        alpha = unknowns.distance_along_vector_to_limit(alpha, result)
 
         # Apply step that doesn't violate bounds
         unknowns.vec += alpha*result.vec

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -92,9 +92,11 @@ class BackTracking(LineSearch):
         # If our step will violate any upper or lower bounds, then reduce
         # alpha so that we only step to that boundary.
         alpha = unknowns.distance_along_vector_to_limit(alpha, result)
+        print("RESULT", result.vec)
 
         # Apply step that doesn't violate bounds
         unknowns.vec += alpha*result.vec
+        print("New Unknown", unknowns.vec)
 
         # Metadata update
         update_local_meta(local_meta, (solver.iter_count, 0))

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -92,11 +92,9 @@ class BackTracking(LineSearch):
         # If our step will violate any upper or lower bounds, then reduce
         # alpha so that we only step to that boundary.
         alpha = unknowns.distance_along_vector_to_limit(alpha, result)
-        print("RESULT", result.vec)
 
         # Apply step that doesn't violate bounds
         unknowns.vec += alpha*result.vec
-        print("New Unknown", unknowns.vec)
 
         # Metadata update
         update_local_meta(local_meta, (solver.iter_count, 0))

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -199,8 +199,8 @@ class MultLinearSolver(LinearSolver):
 
         system._sys_apply_linear(mode, self.system._do_apply, vois=(voi,))
 
-        print("arg", arg)
-        print("result", rhs_vec.vec)
+        #print("arg", arg)
+        #print("result", rhs_vec.vec)
         return rhs_vec.vec
 
 

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -199,8 +199,8 @@ class MultLinearSolver(LinearSolver):
 
         system._sys_apply_linear(mode, self.system._do_apply, vois=(voi,))
 
-        #print("arg", arg)
-        #print("result", rhs_vec.vec)
+        print("arg", arg)
+        print("result", rhs_vec.vec)
         return rhs_vec.vec
 
 

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -354,115 +354,6 @@ class TestBackTracking(unittest.TestCase):
 
         self.assertEqual(top['comp.z'], 2.5)
 
-
-    def test_bounds_backtracking_arrays(self):
-
-        class SimpleImplicitComp(Component):
-            """ A Simple Implicit Component with an additional output equation.
-
-            f(x,z) = xz + z - 4
-            y = x + 2z
-
-            Sol: when x = 0.5, z = 2.666
-            Sol: when x = 2.0, z = 1.333
-
-            Coupled derivs:
-
-            y = x + 8/(x+1)
-            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
-
-            z = 4/(x+1)
-            dz_dx = -4/(x+1)**2 = -1.7777777777777777
-            """
-
-            def __init__(self):
-                super(SimpleImplicitComp, self).__init__()
-
-                # Params
-                self.add_param('x', np.zeros((3, 1)))
-
-                # Unknowns
-                self.add_output('y', np.zeros((3, 1)))
-
-                # States
-                self.add_state('z', 2.0*np.ones((3, 1)), lower=1.5, upper=np.array([[2.6, 2.5, 2.7]]).T)
-
-                self.maxiter = 10
-                self.atol = 1.0e-12
-
-            def solve_nonlinear(self, params, unknowns, resids):
-                pass
-
-            def apply_nonlinear(self, params, unknowns, resids):
-                """ Don't solve; just calculate the residual."""
-
-                x = params['x']
-                z = unknowns['z']
-                resids['z'] = x*z + z - 4.0
-
-                # Output equations need to evaluate a residual just like an explicit comp.
-                resids['y'] = x + 2.0*z - unknowns['y']
-
-            def linearize(self, params, unknowns, resids):
-                """Analytical derivatives."""
-
-                J = {}
-
-                # Output equation
-                J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
-                J[('y', 'z')] = np.diag(np.array([2.0, 2.0, 2.0]))
-
-                # State equation
-                J[('z', 'z')] = (params['x'] + 1.0) * np.eye(3)
-                J[('z', 'x')] = unknowns['z'] * np.eye(3)
-
-                return J
-
-        #------------------------------------------------------
-        # Test that Newton doesn't drive it past lower bounds
-        #------------------------------------------------------
-
-        top = Problem()
-        top.root = Group()
-        top.root.add('comp', SimpleImplicitComp())
-        top.root.ln_solver = ScipyGMRES()
-        top.root.nl_solver = Newton()
-        top.root.nl_solver.options['maxiter'] = 5
-        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
-
-        top.root.connect('px.x', 'comp.x')
-        top.setup(check=False)
-
-        top['px.x'] = np.array([2.0, 2.0, 2.0])
-        top.run()
-
-        self.assertEqual(top['comp.z'][0], 1.5)
-        self.assertEqual(top['comp.z'][1], 1.5)
-        self.assertEqual(top['comp.z'][2], 1.5)
-
-        #------------------------------------------------------
-        # Test that Newton doesn't drive it past upper bounds
-        #------------------------------------------------------
-
-        top = Problem()
-        top.root = Group()
-        top.root.add('comp', SimpleImplicitComp())
-        top.root.ln_solver = ScipyGMRES()
-        top.root.nl_solver = Newton()
-        top.root.nl_solver.options['maxiter'] = 5
-        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
-
-        top.root.connect('px.x', 'comp.x')
-        top.setup(check=False)
-
-        top['px.x'] = 0.5*np.ones((3, 1))
-        top.run()
-
-        # Most restrictive bound is observed
-        self.assertEqual(top['comp.z'][0], 2.5)
-        self.assertEqual(top['comp.z'][1], 2.5)
-        self.assertEqual(top['comp.z'][2], 2.5)
-
     def test_bounds_backtracking_arrays_vector_alpha(self):
 
         class SimpleImplicitComp(Component):
@@ -538,8 +429,6 @@ class TestBackTracking(unittest.TestCase):
         top.root.nl_solver.options['maxiter'] = 5
         top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
 
-        top.root.nl_solver.line_search.options['vector_alpha'] = True
-
         top.root.connect('px.x', 'comp.x')
         top.setup(check=False)
 
@@ -562,8 +451,6 @@ class TestBackTracking(unittest.TestCase):
         top.root.nl_solver.options['maxiter'] = 6
         top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
 
-        top.root.nl_solver.line_search.options['vector_alpha'] = True
-
         top.root.connect('px.x', 'comp.x')
         top.setup(check=False)
 
@@ -574,114 +461,6 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][0], 2.6)
         self.assertEqual(top['comp.z'][1], 2.5)
         self.assertEqual(top['comp.z'][2], 2.65)
-
-    def test_bounds_backtracking_arrays_lower(self):
-
-        class SimpleImplicitComp(Component):
-            """ A Simple Implicit Component with an additional output equation.
-
-            f(x,z) = xz + z - 4
-            y = x + 2z
-
-            Sol: when x = 0.5, z = 2.666
-            Sol: when x = 2.0, z = 1.333
-
-            Coupled derivs:
-
-            y = x + 8/(x+1)
-            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
-
-            z = 4/(x+1)
-            dz_dx = -4/(x+1)**2 = -1.7777777777777777
-            """
-
-            def __init__(self):
-                super(SimpleImplicitComp, self).__init__()
-
-                # Params
-                self.add_param('x', np.zeros((3, 1)))
-
-                # Unknowns
-                self.add_output('y', np.zeros((3, 1)))
-
-                # States
-                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, -2.7]]).T)
-
-                self.maxiter = 10
-                self.atol = 1.0e-12
-
-            def solve_nonlinear(self, params, unknowns, resids):
-                pass
-
-            def apply_nonlinear(self, params, unknowns, resids):
-                """ Don't solve; just calculate the residual."""
-
-                x = params['x']
-                z = unknowns['z']
-                resids['z'] = -x*z - z - 4.0
-
-                # Output equations need to evaluate a residual just like an explicit comp.
-                resids['y'] = x - 2.0*z - unknowns['y']
-
-            def linearize(self, params, unknowns, resids):
-                """Analytical derivatives."""
-
-                J = {}
-
-                # Output equation
-                J[('y', 'x')] = np.diag(np.array([1.0, 1.0, 1.0]))
-                J[('y', 'z')] = -np.diag(np.array([2.0, 2.0, 2.0]))
-
-                # State equation
-                J[('z', 'z')] = -(params['x'] + 1.0) * np.eye(3)
-                J[('z', 'x')] = -unknowns['z'] * np.eye(3)
-
-                return J
-
-        #------------------------------------------------------
-        # Test that Newton doesn't drive it past upper bounds
-        #------------------------------------------------------
-
-        top = Problem()
-        top.root = Group()
-        top.root.add('comp', SimpleImplicitComp())
-        top.root.ln_solver = ScipyGMRES()
-        top.root.nl_solver = Newton()
-        top.root.nl_solver.options['maxiter'] = 5
-        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
-
-        top.root.connect('px.x', 'comp.x')
-        top.setup(check=False)
-
-        top['px.x'] = np.array([2.0, 2.0, 2.0])
-        top.run()
-
-        self.assertEqual(top['comp.z'][0], -1.5)
-        self.assertEqual(top['comp.z'][1], -1.5)
-        self.assertEqual(top['comp.z'][2], -1.5)
-
-        #------------------------------------------------------
-        # Test that Newton doesn't drive it past lower bounds
-        #------------------------------------------------------
-
-        top = Problem()
-        top.root = Group()
-        top.root.add('comp', SimpleImplicitComp())
-        top.root.ln_solver = ScipyGMRES()
-        top.root.nl_solver = Newton()
-        top.root.nl_solver.options['maxiter'] = 5
-        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
-
-        top.root.connect('px.x', 'comp.x')
-        top.setup(check=False)
-
-        top['px.x'] = 0.5*np.ones((3, 1))
-        top.run()
-
-        # Most restrictive bound is observed
-        self.assertEqual(top['comp.z'][0], -2.5)
-        self.assertEqual(top['comp.z'][1], -2.5)
-        self.assertEqual(top['comp.z'][2], -2.5)
 
     def test_bounds_backtracking_arrays_lower_vector_alpha(self):
 
@@ -758,8 +537,6 @@ class TestBackTracking(unittest.TestCase):
         top.root.nl_solver.options['maxiter'] = 5
         top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
 
-        top.root.nl_solver.line_search.options['vector_alpha'] = True
-
         top.root.connect('px.x', 'comp.x')
         top.setup(check=False)
 
@@ -782,8 +559,6 @@ class TestBackTracking(unittest.TestCase):
         top.root.nl_solver.options['maxiter'] = 5
         top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
 
-        top.root.nl_solver.line_search.options['vector_alpha'] = True
-
         top.root.connect('px.x', 'comp.x')
         top.setup(check=False)
 
@@ -795,7 +570,7 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][1], -2.5)
         self.assertEqual(top['comp.z'][2], -2.65)
 
-    def test_bounds_backtracking_arrays_lower_bugfix(self):
+    def test_bounds_initially_violated(self):
 
         class SimpleImplicitComp(Component):
             """ A Simple Implicit Component with an additional output equation.
@@ -825,7 +600,7 @@ class TestBackTracking(unittest.TestCase):
                 self.add_output('y', np.zeros((3, 1)))
 
                 # States
-                self.add_state('z', -2.0*np.ones((3, 1)), upper=-1.5, lower=np.array([[-2.6, -2.5, 2.7]]).T)
+                self.add_state('z', np.array([[-1.0, -2.5, -2.8]]).T, upper=-1.5, lower=np.array([[-2.6, -2.5, -2.65]]).T)
 
                 self.maxiter = 10
                 self.atol = 1.0e-12
@@ -856,10 +631,6 @@ class TestBackTracking(unittest.TestCase):
                 J[('z', 'z')] = -(params['x'] + 1.0) * np.eye(3)
                 J[('z', 'x')] = -unknowns['z'] * np.eye(3)
 
-                # Make it more interesting
-                J[('y', 'z')][0][2] = -J[('y', 'z')][0][2]
-                J[('z', 'z')][0][2] = -J[('z', 'z')][0][2]
-
                 return J
 
         #------------------------------------------------------
@@ -877,35 +648,13 @@ class TestBackTracking(unittest.TestCase):
         top.root.connect('px.x', 'comp.x')
         top.setup(check=False)
 
-        top['px.x'] = np.array([2.0, 2.0, 2.0])
+        top['px.x'] = np.array([-2.0, -2.0, -2.0])
         top.run()
 
         self.assertEqual(top['comp.z'][0], -1.5)
         self.assertEqual(top['comp.z'][1], -1.5)
         self.assertEqual(top['comp.z'][2], -1.5)
 
-        #------------------------------------------------------
-        # Test that Newton doesn't drive it past lower bounds
-        #------------------------------------------------------
-
-        top = Problem()
-        top.root = Group()
-        top.root.add('comp', SimpleImplicitComp())
-        top.root.ln_solver = ScipyGMRES()
-        top.root.nl_solver = Newton()
-        top.root.nl_solver.options['maxiter'] = 5
-        top.root.add('px', IndepVarComp('x', np.ones((3, 1))))
-
-        top.root.connect('px.x', 'comp.x')
-        top.setup(check=False)
-
-        top['px.x'] = 0.5*np.ones((3, 1))
-        top.run()
-
-        # Most restrictive bound is observed
-        self.assertEqual(top['comp.z'][0], -2.5)
-        self.assertEqual(top['comp.z'][1], -2.5)
-        self.assertEqual(top['comp.z'][2], -2.5)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -188,6 +188,172 @@ class TestBackTracking(unittest.TestCase):
 
         self.assertEqual(top['comp.z'], 2.5)
 
+    def test_bounds_backtracking_start_violated_high(self):
+
+        class SimpleImplicitComp(Component):
+            """ A Simple Implicit Component with an additional output equation.
+
+            f(x,z) = xz + z - 4
+            y = x + 2z
+
+            Sol: when x = 0.5, z = 2.666
+            Sol: when x = 2.0, z = 1.333
+
+            Coupled derivs:
+
+            y = x + 8/(x+1)
+            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+            z = 4/(x+1)
+            dz_dx = -4/(x+1)**2 = -1.7777777777777777
+            """
+
+            def __init__(self):
+                super(SimpleImplicitComp, self).__init__()
+
+                # Params
+                self.add_param('x', 0.5)
+
+                # Unknowns
+                self.add_output('y', 0.0)
+
+                # States
+                self.add_state('z', 3.0, lower=1.5, upper=2.5)
+
+                self.maxiter = 10
+                self.atol = 1.0e-12
+
+            def solve_nonlinear(self, params, unknowns, resids):
+                pass
+
+            def apply_nonlinear(self, params, unknowns, resids):
+                """ Don't solve; just calculate the residual."""
+
+                x = params['x']
+                z = unknowns['z']
+                resids['z'] = x*z + z - 4.0
+
+                # Output equations need to evaluate a residual just like an explicit comp.
+                resids['y'] = x + 2.0*z - unknowns['y']
+
+            def linearize(self, params, unknowns, resids):
+                """Analytical derivatives."""
+
+                J = {}
+
+                # Output equation
+                J[('y', 'x')] = np.array([1.0])
+                J[('y', 'z')] = np.array([2.0])
+
+                # State equation
+                J[('z', 'z')] = np.array([params['x'] + 1.0])
+                J[('z', 'x')] = np.array([unknowns['z']])
+
+                return J
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', 1.0))
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = 2.0
+        top.run()
+
+        self.assertEqual(top['comp.z'], 2.5)
+
+    def test_bounds_backtracking_start_violated_low(self):
+
+        class SimpleImplicitComp(Component):
+            """ A Simple Implicit Component with an additional output equation.
+
+            f(x,z) = xz + z - 4
+            y = x + 2z
+
+            Sol: when x = 0.5, z = 2.666
+            Sol: when x = 2.0, z = 1.333
+
+            Coupled derivs:
+
+            y = x + 8/(x+1)
+            dy_dx = 1 - 8/(x+1)**2 = -2.5555555555555554
+
+            z = 4/(x+1)
+            dz_dx = -4/(x+1)**2 = -1.7777777777777777
+            """
+
+            def __init__(self):
+                super(SimpleImplicitComp, self).__init__()
+
+                # Params
+                self.add_param('x', 0.5)
+
+                # Unknowns
+                self.add_output('y', 0.0)
+
+                # States
+                self.add_state('z', 1.2, lower=1.5, upper=2.5)
+
+                self.maxiter = 10
+                self.atol = 1.0e-12
+
+            def solve_nonlinear(self, params, unknowns, resids):
+                pass
+
+            def apply_nonlinear(self, params, unknowns, resids):
+                """ Don't solve; just calculate the residual."""
+
+                x = params['x']
+                z = unknowns['z']
+                resids['z'] = x*z + z - 4.0
+
+                # Output equations need to evaluate a residual just like an explicit comp.
+                resids['y'] = x + 2.0*z - unknowns['y']
+
+            def linearize(self, params, unknowns, resids):
+                """Analytical derivatives."""
+
+                J = {}
+
+                # Output equation
+                J[('y', 'x')] = np.array([1.0])
+                J[('y', 'z')] = np.array([2.0])
+
+                # State equation
+                J[('z', 'z')] = np.array([params['x'] + 1.0])
+                J[('z', 'x')] = np.array([unknowns['z']])
+
+                return J
+
+        #------------------------------------------------------
+        # Test that Newton doesn't drive it past lower bounds
+        #------------------------------------------------------
+
+        top = Problem()
+        top.root = Group()
+        top.root.add('comp', SimpleImplicitComp())
+        top.root.ln_solver = ScipyGMRES()
+        top.root.nl_solver = Newton()
+        top.root.nl_solver.options['maxiter'] = 5
+        top.root.add('px', IndepVarComp('x', 1.0))
+
+        top.root.connect('px.x', 'comp.x')
+        top.setup(check=False)
+
+        top['px.x'] = 2.0
+        top.run()
+
+        self.assertEqual(top['comp.z'], 1.5)
+
     def test_bounds_backtracking_lower_only(self):
 
         class SimpleImplicitComp(Component):
@@ -570,7 +736,7 @@ class TestBackTracking(unittest.TestCase):
         self.assertEqual(top['comp.z'][1], -2.5)
         self.assertEqual(top['comp.z'][2], -2.65)
 
-    def test_bounds_initially_violated(self):
+    def test_bounds_array_initially_violated(self):
 
         class SimpleImplicitComp(Component):
             """ A Simple Implicit Component with an additional output equation.
@@ -600,7 +766,7 @@ class TestBackTracking(unittest.TestCase):
                 self.add_output('y', np.zeros((3, 1)))
 
                 # States
-                self.add_state('z', np.array([[-1.0, -2.5, -2.8]]).T, upper=-1.5, lower=np.array([[-2.6, -2.5, -2.65]]).T)
+                self.add_state('z', np.array([[-1.0, -2.0, -2.8]]).T, upper=-1.5, lower=np.array([[-2.6, -2.5, -2.65]]).T)
 
                 self.maxiter = 10
                 self.atol = 1.0e-12
@@ -653,7 +819,7 @@ class TestBackTracking(unittest.TestCase):
 
         self.assertEqual(top['comp.z'][0], -1.5)
         self.assertEqual(top['comp.z'][1], -1.5)
-        self.assertEqual(top['comp.z'][2], -1.5)
+        self.assertEqual(top['comp.z'][2], -2.65)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Made the new vector-alpha method the default.
2. Got rid of the old crappy method that stopped advancing in all directions when one variable element hits a bound.
3. Modified method so that if you start violated, or if you end up violating the bounds slightly due to floating point math, then it will always try to push you all the way back to the boundary.