### PR TITLE
Overhaul of the Backtracking Line Search

### DIFF
--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -22,6 +22,10 @@ class BackTracking(LineSearch):
         Maximum number of line searches.
     options['solve_subsystems'] :  bool(True)
         Set to True to solve subsystems. You may need this for solvers nested under Newton.
+    options['rho'] : int(0.5)
+        Backtracking step.
+    options['c'] : int(0.5)
+        Slope check trigger.
     """
 
     def __init__(self):
@@ -35,7 +39,7 @@ class BackTracking(LineSearch):
         opt.add_option('rho', 0.5,
                        desc="Backtracking step.")
         opt.add_option('c', 0.5,
-                       desc="Backtracking step.")
+                       desc="Slope check trigger.")
 
         self.print_name = 'BK_TKG'
 
@@ -99,7 +103,11 @@ class BackTracking(LineSearch):
         ls_alpha = alpha_scalar
 
         # Further backtacking if needed.
-        while itercount < maxiter and fnorm > base_norm - c*ls_alpha*result.vec.dot(result.vec):
+        # The Armijo-Goldstein is basically a slope comparison --actual vs predicted.
+        # We don't have an actual gradient, but we have the Newton vector that should
+        # take us to zero, and our "runs" are the same, and we can just compare the
+        # "rise".
+        while itercount < maxiter and (base_norm - fnorm) < c*ls_alpha*base_norm:
 
             ls_alpha *= rho
 

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -2,8 +2,9 @@
 
 from math import isnan
 
+import numpy as np
+
 from openmdao.core.system import AnalysisError
-from openmdao.solvers.backtracking import BackTracking
 from openmdao.solvers.solver_base import NonLinearSolver
 from openmdao.util.record_util import update_local_meta, create_local_meta
 
@@ -55,8 +56,8 @@ class Newton(NonLinearSolver):
 
         self.print_name = 'NEWTON'
 
-        # Only one choice, but the user could write their own.
-        self.line_search = BackTracking()
+        # User can optionally specify a line search.
+        self.line_search = None
 
         # User can specify a different linear solver for Newton. Default is
         # to use the parent's solver.
@@ -99,7 +100,7 @@ class Newton(NonLinearSolver):
         atol = self.options['atol']
         rtol = self.options['rtol']
         maxiter = self.options['maxiter']
-        alpha = self.options['alpha']
+        alpha_scalar = self.options['alpha']
 
         # Metadata setup
         self.iter_count = 0
@@ -133,10 +134,44 @@ class Newton(NonLinearSolver):
                 system.solve_linear(system.dumat, system.drmat,
                                     [None], mode='fwd', solver=self.ln_solver)
 
-            # Step in that direction,
             self.iter_count += 1
-            f_norm = self.line_search.solve(params, unknowns, resids, system,
-                                            self, alpha, f_norm0, metadata)
+
+            # Allow different alphas for each value so we can keep moving when we
+            # hit a bound.
+            alpha = alpha_scalar*np.ones(len(unknowns.vec))
+
+            # If our step will violate any upper or lower bounds, then reduce
+            # alpha so that we only step to that boundary.
+            alpha = unknowns.distance_along_vector_to_limit(alpha, result)
+
+            # Cache the base_u so that we can backtrack correctly with bounds
+            if self.line_search:
+                base_u = np.array(unknowns.vec.shape)
+                base_u[:] = unknowns.vec
+
+            # Apply step that doesn't violate bounds
+            unknowns.vec += alpha*result.vec
+
+            # Metadata update
+            update_local_meta(local_meta, (self.iter_count, 0))
+
+            # Just evaluate the model with the new points
+            if self.options['solve_subsystems']:
+                system.children_solve_nonlinear(local_meta)
+            system.apply_nonlinear(params, unknowns, resids, local_meta)
+
+            self.recorders.record_iteration(system, local_meta)
+
+            f_norm = resids.norm()
+            if self.options['iprint'] > 0:
+                self.print_norm(self.print_name, system.pathname, self.iter_count,
+                                f_norm, f_norm0)
+
+            # Line Search to determine how far to step in the Newton direction
+            if self.line_search:
+                f_norm = self.line_search.solve(params, unknowns, resids, system,
+                                                self, alpha, f_norm0, metadata)
+
 
         # Need to make sure the whole workflow is executed at the final
         # point, not just evaluated.
@@ -166,4 +201,5 @@ class Newton(NonLinearSolver):
         """ Turns on iprint for this solver and all subsolvers. Override if
         your solver has subsolvers."""
         self.options['iprint'] = 1
-        self.line_search.options['iprint'] = 1
+        if self.line_search:
+            self.line_search.options['iprint'] = 1

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -47,6 +47,7 @@ class TestBackTracking(unittest.TestCase):
 
         top = Problem()
         top.root = SellarStateConnection()
+        top.root.nl_solver.line_search = BackTracking()
         top.root.nl_solver.line_search.options['atol'] = 1e-12
         top.root.nl_solver.line_search.options['rtol'] = 1e-12
         top.root.nl_solver.line_search.options['maxiter'] = 3
@@ -66,6 +67,7 @@ class TestBackTracking(unittest.TestCase):
 
         top = Problem()
         top.root = SellarStateConnection()
+        top.root.nl_solver.line_search = BackTracking()
         top.root.nl_solver.line_search.options['atol'] = 1e-12
         top.root.nl_solver.line_search.options['rtol'] = 1e-12
         top.root.nl_solver.line_search.options['maxiter'] = 2

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -1,11 +1,9 @@
-""" Unit testing for the Backtracking sub-solver. """
+""" Test for the Backktracking Line Search"""
 
 import unittest
 from math import exp
 
 import numpy as np
-
-""" Test for the Backktracking Line Search"""
 
 from openmdao.api import Problem, Group, NonLinearSolver, IndepVarComp, \
                          Component, AnalysisError

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -1,10 +1,14 @@
 """ Unit testing for the Backtracking sub-solver. """
 
 import unittest
+from math import exp
 
 import numpy as np
 
-from openmdao.api import Problem, Group, NonLinearSolver, IndepVarComp, Component, AnalysisError
+""" Test for the Backktracking Line Search"""
+
+from openmdao.api import Problem, Group, NonLinearSolver, IndepVarComp, \
+                         Component, AnalysisError
 from openmdao.solvers.backtracking import BackTracking
 from openmdao.solvers.newton import Newton
 from openmdao.solvers.scipy_gmres import ScipyGMRES
@@ -12,53 +16,66 @@ from openmdao.test.sellar import SellarStateConnection
 from openmdao.test.util import assert_rel_error
 
 
-class FakeSolver(NonLinearSolver):
-    """ Does nothing but invoke a line search."""
+class TrickyComp(Component):
 
     def __init__(self):
-        super(FakeSolver, self).__init__()
-        self.sub = BackTracking()
+        super(TrickyComp, self).__init__()
 
-    def solve(self, params, unknowns, resids, system, metadata=None):
-        """ Calc deriv then do line search."""
+        # Inputs
+        self.add_param('y', 1.2278849186466743)
 
-        # Perform an initial run to propagate srcs to targets.
-        system.children_solve_nonlinear(None)
-        system.apply_nonlinear(params, unknowns, resids)
+        # States
+        self.add_state('x', val=1.0)
 
-        # Linearize Model with partial derivatives
-        system._sys_linearize(params, unknowns, resids, total_derivs=False)
+    def apply_nonlinear(self, params, unknowns, resids):
+        """ Don't solve; just calculate the residual."""
 
-        # Calculate direction to take step
-        arg = system.drmat[None]
-        result = system.dumat[None]
+        y = params['y']
+        x = unknowns['x']
 
-        # Step waaaaay to far so we have to backtrack
-        arg.vec[:] = resids.vec*100
-        system.solve_linear(system.dumat, system.drmat, [None], mode='fwd')
+        resids['x'] = 0.5*x*x + 2.0*x + exp(-16.0*x*x) + 2.0*exp(-5.0*x) - y
+        #print('x', x, 'res', resids['x'])
 
-        unknowns.vec += result.vec
+    def solve_nonlinear(self, params, unknowns, resids):
+        """ This is a dummy comp that doesn't modify its state."""
+        pass
 
-        self.sub.solve(params, unknowns, resids, system, self, 1.0, 1.0, 1.0)
+    def linearize(self, params, unknowns, resids):
+        """Analytical derivatives."""
+
+        x = unknowns['x']
+
+        J = {}
+
+        # State equation
+        J[('x', 'y')] = -1.0
+        J[('x', 'x')] = x + 2.0 - 32.0*x*exp(-16.0*x*x) - 10.0*exp(-5.0*x)
+
+        return J
+
 
 class TestBackTracking(unittest.TestCase):
 
     def test_newton_with_backtracking(self):
 
         top = Problem()
-        top.root = SellarStateConnection()
-        top.root.nl_solver.line_search = BackTracking()
-        top.root.nl_solver.line_search.options['maxiter'] = 13
-        top.root.nl_solver.line_search.options['c'] = 0.5
-        top.root.nl_solver.options['alpha'] = 1.0
+        root = top.root = Group()
+        root.add('comp', TrickyComp())
+        root.add('p', IndepVarComp('y', 1.2278849186466743))
+        root.connect('p.y', 'comp.y')
 
-        top.print_all_convergence()
+        root.nl_solver = Newton()
+        root.ln_solver = ScipyGMRES()
+        root.nl_solver.line_search = BackTracking()
+        root.nl_solver.line_search.options['maxiter'] = 100
+        root.nl_solver.line_search.options['c'] = 0.5
+        root.nl_solver.options['alpha'] = 10.0
 
         top.setup(check=False)
+        top['comp.x'] = 1.0
         top.run()
 
-        assert_rel_error(self, top['y1'], 25.58830273, .00001)
-        assert_rel_error(self, top['state_eq.y2_command'], 12.05848819, .00001)
+        assert_rel_error(self, top['comp.x'], .3968459, .0001)
 
     def test_newton_with_backtracking_analysis_error(self):
 
@@ -68,7 +85,7 @@ class TestBackTracking(unittest.TestCase):
         top.root.nl_solver.line_search.options['maxiter'] = 2
         top.root.nl_solver.line_search.options['err_on_maxiter'] = True
         top.root.nl_solver.line_search.options['c'] = 1.0
-        top.root.nl_solver.options['alpha'] = 1.0
+        top.root.nl_solver.options['alpha'] = 10.0
 
         top.setup(check=False)
 

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -48,14 +48,11 @@ class TestBackTracking(unittest.TestCase):
         top = Problem()
         top.root = SellarStateConnection()
         top.root.nl_solver.line_search = BackTracking()
-        top.root.nl_solver.line_search.options['atol'] = 1e-12
-        top.root.nl_solver.line_search.options['rtol'] = 1e-12
-        top.root.nl_solver.line_search.options['maxiter'] = 3
+        top.root.nl_solver.line_search.options['maxiter'] = 13
+        top.root.nl_solver.line_search.options['c'] = 0.5
+        top.root.nl_solver.options['alpha'] = 1.0
 
-        # This is a very contrived test, but we step 8 times farther than we
-        # should, then allow the line search to backtrack 3 steps, which
-        # takes us back to 1.0.
-        top.root.nl_solver.options['alpha'] = 8.0
+        top.print_all_convergence()
 
         top.setup(check=False)
         top.run()
@@ -68,15 +65,10 @@ class TestBackTracking(unittest.TestCase):
         top = Problem()
         top.root = SellarStateConnection()
         top.root.nl_solver.line_search = BackTracking()
-        top.root.nl_solver.line_search.options['atol'] = 1e-12
-        top.root.nl_solver.line_search.options['rtol'] = 1e-12
         top.root.nl_solver.line_search.options['maxiter'] = 2
         top.root.nl_solver.line_search.options['err_on_maxiter'] = True
-
-        # This is a very contrived test, but we step 8 times farther than we
-        # should, then allow the line search to backtrack 3 steps, which
-        # takes us back to 1.0.
-        top.root.nl_solver.options['alpha'] = 8.0
+        top.root.nl_solver.line_search.options['c'] = 1.0
+        top.root.nl_solver.options['alpha'] = 1.0
 
         top.setup(check=False)
 


### PR DESCRIPTION
1. Modified Newton so that it doesn't need a line search -- moved iprint code up to Newton
2. Fixed improper implementation of the backtracking check over to a Armijo-Goldstein condition check (slightly modified for our case.)
3. Fixed bug where, when we had bounds, the line-search backtracked along the modified alpha vector instead of being recomputed along the original vector.