### PR TITLE
fix for array scalers on desvar or constraint with array jacobian return under fd

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1397,14 +1397,14 @@ class Problem(object):
                     pd = Jfd[u, fd_ikey]
                     rows, cols = pd.shape
 
-                    for row in range(0, rows):
-                        for col in range(0, cols):
-                            J[ui+row][pi+col] = pd[row][col]
-                            # Driver scaling
-                            if p in dv_scale:
-                                J[ui+row][pi+col] *= dv_scale[p]
-                            if u in cn_scale:
-                                J[ui+row][pi+col] *= cn_scale[u]
+                    J[ui:ui+rows, pi:pi+cols] = pd
+
+                    # Driver scaling
+                    if p in dv_scale:
+                        J[ui:ui+rows, pi:pi+cols] *= dv_scale[p]
+                    if u in cn_scale:
+                        J[ui:ui+rows, pi:pi+cols] *= cn_scale[u]
+
                     pi += cols
                 ui += rows
         return J


### PR DESCRIPTION
Fix for keyerror when you have an array scaler on a design variable or constraint and are using SLSQP (so the return_type for jacobian is array) under full_model fd.

Note: The old code had a double loop, which was doing it that way is what caused this bug in the first place.