### PR TITLE
strip vars before comparing to keys in _expr_dict

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -18,7 +18,7 @@ var_rgx = re.compile('([_a-zA-Z]\w*(?::[_a-zA-Z]\w*)*[ ]*\(?)')
 
 def _parse_for_vars(s):
     return set([x.strip() for x in re.findall(var_rgx, s)
-                       if not x.endswith('(') and x not in _expr_dict])
+                       if not x.endswith('(') and x.strip() not in _expr_dict])
 
 def _valid_name(s, exprs):
     """Replace colons with numbers such that the new name does not exist in any


### PR DESCRIPTION
must strip `x` before checking to see if it is inside `_expr_dict`, otherwise something like this: `y = pi * x` will recognize `pi` as its own variable.