### PR TITLE
fix parsing of equations with spaces in ExecComp

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -18,7 +18,7 @@ var_rgx = re.compile('([_a-zA-Z]\w*(?::[_a-zA-Z]\w*)*[ ]*\(?)')
 
 def _parse_for_vars(s):
     return set([x.strip() for x in re.findall(var_rgx, s)
-                       if not x.endswith('(') and x not in _expr_dict])
+                    if not x.endswith('(') and x.strip() not in _expr_dict])
 
 def _valid_name(s, exprs):
     """Replace colons with numbers such that the new name does not exist in any

--- a/openmdao/components/test/test_exec_comp.py
+++ b/openmdao/components/test/test_exec_comp.py
@@ -39,6 +39,18 @@ class TestExecComp(unittest.TestCase):
 
         assert_rel_error(self, C1.unknowns['y'], 3.0, 0.00001)
 
+    def test_for_spaces(self):
+        prob = Problem(root=Group())
+        C1 = prob.root.add('C1', ExecComp('y = pi * x', x=2.0))
+        self.assertTrue('x' in C1._init_params_dict)
+        self.assertTrue('y' in C1._init_unknowns_dict)
+        self.assertTrue('pi' not in C1._init_params_dict)
+
+        prob.setup(check=False)
+        prob.run()
+
+        assert_rel_error(self, C1.unknowns['y'], 2 * math.pi, 0.00001)
+
     def test_units(self):
         prob = Problem(root=Group())
         C1 = prob.root.add('C1', ExecComp('y=x+z+1.', x=2.0, z=2.0, units={'x':'m','y':'m'}))


### PR DESCRIPTION
* added `.strip()` to varnames check against `_expr_dict` in `_parse_for_vars`.
* added a test for `ExecComp` from functions with spaces to test for something like: `y = pi * x` and ensure that `pi` is not recognized as a variable.