### PR TITLE
Overhaul of solver iprint display

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2340,7 +2340,8 @@ class Problem(object):
         ----
         level : int(2)
             iprint level. Set to 2 to print residuals each iteration; set to 1
-            to print just the iteration totals.
+            to print just the iteration totals; set to 0 to disable all printing
+            except for failures.
         """
 
         root = self.root

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2326,15 +2326,22 @@ class Problem(object):
 
         return dangling
 
-    def print_all_convergence(self):
-        """ Sets iprint to True for all solvers and subsolvers in the model."""
+    def print_all_convergence(self, level=2):
+        """ Sets iprint to True for all solvers and subsolvers in the model.
+
+        Args
+        ----
+        level : int(2)
+            iprint level. Set to 2 to print residuals each iteration; set to 1
+            to print just the iteration totals.
+        """
 
         root = self.root
-        root.ln_solver.print_all_convergence()
-        root.nl_solver.print_all_convergence()
+        root.ln_solver.print_all_convergence(level=level)
+        root.nl_solver.print_all_convergence(level=level)
         for grp in root.subgroups(recurse=True):
-            grp.ln_solver.print_all_convergence()
-            grp.nl_solver.print_all_convergence()
+            grp.ln_solver.print_all_convergence(level=level)
+            grp.nl_solver.print_all_convergence(level=level)
 
 def _assign_parameters(connections):
     """Map absolute system names to the absolute names of the

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -866,7 +866,7 @@ class TestProblem(unittest.TestCase):
         self.assertEqual(printed.count('NEWTON'), 3)
         self.assertEqual(printed.count('GMRES'), 4)
         self.assertTrue('[root] NL: NEWTON   0 | ' in printed)
-        self.assertTrue('   [root.sub] LN: GMRES   0 | ' in printed)
+        self.assertTrue('   [root.sub] LN: GMRES   1 | ' in printed)
 
         # Now, test out level = 1
 
@@ -886,10 +886,10 @@ class TestProblem(unittest.TestCase):
             sys.stdout = base_stdout
 
         printed = ostream.getvalue()
-        self.assertEqual(printed.count('NEWTON'), 1)
-        self.assertEqual(printed.count('GMRES'), 2)
+        self.assertEqual(printed.count('NEWTON'), 2)
+        self.assertEqual(printed.count('GMRES'), 4)
         self.assertTrue('[root] NL: NEWTON   0 | ' not in printed)
-        self.assertTrue('   [root.sub] LN: GMRES   0 | ' not in printed)
+        self.assertTrue('   [root.sub] LN: GMRES   1 | ' not in printed)
 
 
     def test_error_change_after_setup(self):

--- a/openmdao/core/test/test_problem.py
+++ b/openmdao/core/test/test_problem.py
@@ -868,6 +868,30 @@ class TestProblem(unittest.TestCase):
         self.assertTrue('[root] NL: NEWTON   0 | ' in printed)
         self.assertTrue('   [root.sub] LN: GMRES   0 | ' in printed)
 
+        # Now, test out level = 1
+
+        top = Problem()
+        top.root = SellarStateConnection()
+        top.setup(check=False)
+
+        base_stdout = sys.stdout
+
+        top.print_all_convergence(level=1)
+
+        try:
+            ostream = cStringIO()
+            sys.stdout = ostream
+            top.run()
+        finally:
+            sys.stdout = base_stdout
+
+        printed = ostream.getvalue()
+        self.assertEqual(printed.count('NEWTON'), 1)
+        self.assertEqual(printed.count('GMRES'), 2)
+        self.assertTrue('[root] NL: NEWTON   0 | ' not in printed)
+        self.assertTrue('   [root.sub] LN: GMRES   0 | ' not in printed)
+
+
     def test_error_change_after_setup(self):
 
         # Tests error messages for the 5 options that we should never change

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -1,5 +1,7 @@
 """ Backtracking line search using the Armijo-Goldstein condition."""
 
+from math import isnan
+
 import numpy as np
 
 from openmdao.core.system import AnalysisError
@@ -16,8 +18,8 @@ class BackTracking(LineSearch):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout
-        each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout
     options['maxiter'] :  int(10)
         Maximum number of line searches.
     options['solve_subsystems'] :  bool(True)
@@ -132,12 +134,26 @@ class BackTracking(LineSearch):
             solver.recorders.record_iteration(system, local_meta)
 
             fnorm = resids.norm()
-            if self.options['iprint'] > 0:
+            if self.options['iprint'] == 2:
                 self.print_norm(self.print_name, system.pathname, itercount,
                                 fnorm, fnorm0, indent=1, solver='LS')
 
-        if itercount >= maxiter and self.options['err_on_maxiter']:
-            raise AnalysisError("Solve in '%s': BackTracking failed to converge after %d "
-                                "iterations." % (system.pathname, maxiter))
+        if itercount >= maxiter or isnan(fnorm):
+
+            if self.options['err_on_maxiter']:
+                msg = "Solve in '{}': BackTracking failed to converge after {} " \
+                      "iterations."
+                raise AnalysisError(msg.format(system.pathname, maxiter))
+
+            msg = 'FAILED to converge after %d iterations' % itercount
+            fail = True
+        else:
+            msg = 'Converged in %d iterations' % itercount
+            fail = False
+
+        if self.options['iprint'] > 0 or fail:
+
+            self.print_norm(self.print_name, system.pathname, itercount,
+                            fnorm, fnorm0, msg=msg, indent=1, solver='LS')
 
         return fnorm

--- a/openmdao/solvers/backtracking.py
+++ b/openmdao/solvers/backtracking.py
@@ -138,6 +138,12 @@ class BackTracking(LineSearch):
                 self.print_norm(self.print_name, system.pathname, itercount,
                                 fnorm, fnorm0, indent=1, solver='LS')
 
+
+        # Final residual print if you only want the last one
+        if self.options['iprint'] == 1:
+            self.print_norm(self.print_name, system.pathname, itercount,
+                            fnorm, fnorm0, indent=1, solver='LS')
+
         if itercount >= maxiter or isnan(fnorm):
 
             if self.options['err_on_maxiter']:

--- a/openmdao/solvers/brent.py
+++ b/openmdao/solvers/brent.py
@@ -25,7 +25,8 @@ class Brent(NonLinearSolver):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] :  int(100)
         if convergence is not achieved in maxiter iterations, and error is raised. Must be >= 0.
     options['rtol'] :  float64(4.4408920985e-16)
@@ -193,7 +194,7 @@ class Brent(NonLinearSolver):
         if self.options['iprint'] > 0:
 
             if not failed:
-                msg = 'converged'
+                msg = 'Converged'
 
             self.print_norm(self.print_name, system.pathname, self.iter_count,
                             resid_norm, resid_norm_0, msg=msg)
@@ -215,7 +216,7 @@ class Brent(NonLinearSolver):
 
         self.recorders.record_iteration(self.sys, self.local_meta)
 
-        if self.options['iprint'] > 0:
+        if self.options['iprint'] == 2:
             normval = abs(resids._dat[self.s_var_name].val[idx])
             self.print_norm(self.print_name, self.sys.pathname, self.iter_count, normval,
                             self.basenorm)

--- a/openmdao/solvers/ln_direct.py
+++ b/openmdao/solvers/ln_direct.py
@@ -18,9 +18,8 @@ class DirectSolver(MultLinearSolver):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to
-        stdout each iteration, set to 2 to print subiteration residuals as
-        well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['mode'] :  str('auto')
         Derivative calculation mode, set to 'fwd' for forward mode, 'rev' for
         reverse mode, or 'auto' to let OpenMDAO determine the best mode.

--- a/openmdao/solvers/ln_gauss_seidel.py
+++ b/openmdao/solvers/ln_gauss_seidel.py
@@ -210,6 +210,11 @@ class LinearGaussSeidel(LinearSolver):
                 self.print_norm(self.print_name, system.pathname, self.iter_count,
                                 f_norm, f_norm0, indent=1, solver='LN')
 
+        # Final residual print if you only want the last one
+        if self.options['iprint'] == 1:
+            self.print_norm(self.print_name, system.pathname, self.iter_count,
+                            f_norm, f_norm0, indent=1, solver='LN')
+
         if maxiter > 1 and self.iter_count >= maxiter:
             msg = 'FAILED to converge after %d iterations' % self.iter_count
             failed = True

--- a/openmdao/solvers/ln_gauss_seidel.py
+++ b/openmdao/solvers/ln_gauss_seidel.py
@@ -19,7 +19,8 @@ class LinearGaussSeidel(LinearSolver):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] :  int(1)
         Maximum number of iterations.
     options['mode'] :  str('auto')
@@ -205,7 +206,7 @@ class LinearGaussSeidel(LinearSolver):
             else:
                 f_norm = self._norm(system, mode, rhs_mat)
 
-            if self.options['iprint'] > 0:
+            if self.options['iprint'] == 2:
                 self.print_norm(self.print_name, system.pathname, self.iter_count,
                                 f_norm, f_norm0, indent=1, solver='LN')
 
@@ -213,11 +214,10 @@ class LinearGaussSeidel(LinearSolver):
             msg = 'FAILED to converge after %d iterations' % self.iter_count
             failed = True
         else:
+            msg = 'Converged in %d iterations' % self.iter_count
             failed = False
 
-        if self.options['iprint'] > 0:
-            if not failed:
-                msg = 'converged'
+        if failed or self.options['iprint'] > 0:
 
             self.print_norm(self.print_name, system.pathname, self.iter_count, f_norm,
                             f_norm0, indent=1, solver='LN', msg=msg)

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -200,11 +200,10 @@ class Newton(NonLinearSolver):
                                   f_norm, f_norm0, metadata)
 
 
-        # Need to make sure the whole workflow is executed at the final
-        # point, not just evaluated.
-        #self.iter_count += 1
-        #update_local_meta(local_meta, (self.iter_count, 0))
-        #system.children_solve_nonlinear(local_meta)
+        # Final residual print if you only want the last one
+        if self.options['iprint'] == 1:
+            self.print_norm(self.print_name, system.pathname, self.iter_count,
+                            f_norm, f_norm0, u_norm=u_norm)
 
         # Return system's FD status back to what it was
         system.deriv_options['type'] = save_type

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -26,8 +26,8 @@ class Newton(NonLinearSolver):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout
-        each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] :  int(20)
         Maximum number of iterations.
     options['rtol'] :  float(1e-10)
@@ -131,7 +131,7 @@ class Newton(NonLinearSolver):
         f_norm = resids.norm()
         f_norm0 = f_norm
 
-        if self.options['iprint'] > 0:
+        if self.options['iprint'] == 2:
             self.print_norm(self.print_name, system.pathname, 0, f_norm,
                             f_norm0)
 
@@ -184,7 +184,7 @@ class Newton(NonLinearSolver):
 
             f_norm = resids.norm()
             u_norm = np.linalg.norm(unknowns.vec - unknowns_cache)
-            if self.options['iprint'] > 0:
+            if self.options['iprint'] == 2:
                 self.print_norm(self.print_name, system.pathname, self.iter_count,
                                 f_norm, f_norm0, u_norm=u_norm)
 
@@ -205,7 +205,7 @@ class Newton(NonLinearSolver):
             msg = 'FAILED to converge after %d iterations' % self.iter_count
             fail = True
         else:
-            msg = 'converged'
+            msg = 'Converged in %d iterations' % self.iter_count
             fail = False
 
         if self.options['iprint'] > 0 or fail:
@@ -217,9 +217,19 @@ class Newton(NonLinearSolver):
             raise AnalysisError("Solve in '%s': Newton %s" % (system.pathname,
                                                               msg))
 
-    def print_all_convergence(self):
+    def print_all_convergence(self, level=2):
         """ Turns on iprint for this solver and all subsolvers. Override if
-        your solver has subsolvers."""
-        self.options['iprint'] = 1
+        your solver has subsolvers.
+
+        Args
+        ----
+        level : int(2)
+            iprint level. Set to 2 to print residuals each iteration; set to 1
+            to print just the iteration totals.
+        """
+        self.options['iprint'] = level
         if self.line_search:
-            self.line_search.options['iprint'] = 1
+            self.line_search.options['iprint'] = level
+        if self.ln_solver:
+            self.ln_solver.options['iprint'] = level
+

--- a/openmdao/solvers/nl_gauss_seidel.py
+++ b/openmdao/solvers/nl_gauss_seidel.py
@@ -22,7 +22,8 @@ class NLGaussSeidel(NonLinearSolver):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] :  int(100)
         Maximum number of iterations.
     options['rtol'] :  float(1e-06)
@@ -112,8 +113,8 @@ class NLGaussSeidel(NonLinearSolver):
         basenorm = normval if normval > atol else 1.0
         u_norm = 1.0e99
 
-        if self.options['iprint'] > 0:
-            self.print_norm(self.print_name, system.pathname, 0, normval, basenorm)
+        if self.options['iprint'] == 2:
+            self.print_norm(self.print_name, system.pathname, 1, normval, basenorm)
 
         while self.iter_count < maxiter and \
                 normval > atol and \
@@ -134,7 +135,7 @@ class NLGaussSeidel(NonLinearSolver):
             normval = resids.norm()
             u_norm = np.linalg.norm(unknowns.vec - unknowns_cache)
 
-            if self.options['iprint'] > 0:
+            if self.options['iprint'] == 2:
                 self.print_norm(self.print_name, system.pathname, self.iter_count, normval,
                                 basenorm, u_norm=u_norm)
 
@@ -146,7 +147,7 @@ class NLGaussSeidel(NonLinearSolver):
 
         if self.options['iprint'] > 0 or fail:
             if not fail:
-                msg = 'converged'
+                msg = 'Converged in %d iterations' % self.iter_count
 
             self.print_norm(self.print_name, system.pathname, self.iter_count, normval,
                             basenorm, msg=msg)

--- a/openmdao/solvers/nl_gauss_seidel.py
+++ b/openmdao/solvers/nl_gauss_seidel.py
@@ -139,6 +139,11 @@ class NLGaussSeidel(NonLinearSolver):
                 self.print_norm(self.print_name, system.pathname, self.iter_count, normval,
                                 basenorm, u_norm=u_norm)
 
+        # Final residual print if you only want the last one
+        if self.options['iprint'] == 1:
+            self.print_norm(self.print_name, system.pathname, self.iter_count, normval,
+                            basenorm, u_norm=u_norm)
+
         if self.iter_count >= maxiter or isnan(normval):
             msg = 'FAILED to converge after %d iterations' % self.iter_count
             fail = True

--- a/openmdao/solvers/petsc_ksp.py
+++ b/openmdao/solvers/petsc_ksp.py
@@ -52,11 +52,13 @@ class Monitor(object):
         """ Stores pointer to the ksp solver """
         self._ksp = ksp
         self._norm0 = 1.0
+        self._norm = 1.0
 
     def __call__(self, ksp, counter, norm):
         """ Store norm if first iteration, and print norm """
         if counter == 0 and norm != 0.0:
             self._norm0 = norm
+        self._norm = norm
 
         ksp = self._ksp
         ksp.iter_count += 1
@@ -220,6 +222,12 @@ class PetscKSP(LinearSolver):
             self.iter_count = 0
             ksp.solve(self.rhs_buf_petsc, self.sol_buf_petsc)
             self.system = None
+
+            # Final residual print if you only want the last one
+            if self.options['iprint'] == 1:
+                mon = ksp.getMonitor()[0][0]
+                self.print_norm(self.print_name, system.pathname, self.iter_count,
+                                mon._norm, mon._norm0, indent=1, solver='LN')
 
             if self.iter_count >= maxiter:
                 msg = 'FAILED to converge in %d iterations' % self.iter_count

--- a/openmdao/solvers/petsc_ksp.py
+++ b/openmdao/solvers/petsc_ksp.py
@@ -61,7 +61,7 @@ class Monitor(object):
         ksp = self._ksp
         ksp.iter_count += 1
 
-        if ksp.options['iprint'] > 0:
+        if ksp.options['iprint'] == 2:
             ksp.print_norm(ksp.print_name, ksp.system.pathname, ksp.iter_count,
                            norm, self._norm0, indent=1, solver='LN')
 
@@ -77,7 +77,8 @@ class PetscKSP(LinearSolver):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] :  int(100)
         Maximum number of iterations.
     options['mode'] :  str('auto')
@@ -224,13 +225,12 @@ class PetscKSP(LinearSolver):
                 msg = 'FAILED to converge in %d iterations' % self.iter_count
                 fail = True
             else:
+                msg = 'Converged in %d iterations' % self.iter_count
                 fail = False
 
-            if self.options['iprint'] > 0:
-                if not fail:
-                    msg = 'Converged'
+            if fail or self.options['iprint'] > 0:
                 self.print_norm(self.print_name, system.pathname,
-                                self.iter_count, 0, 0, msg=msg, solver='LN')
+                                self.iter_count, 0, 0, msg=msg, indent=1, solver='LN')
 
             unknowns_mat[voi] = sol_vec
 
@@ -258,8 +258,6 @@ class PetscKSP(LinearSolver):
 
         system = self.system
         mode = self.mode
-
-        self.iter_count += 1
 
         voi = self.voi
         if mode == 'fwd':

--- a/openmdao/solvers/run_once.py
+++ b/openmdao/solvers/run_once.py
@@ -12,8 +12,8 @@ class RunOnce(NonLinearSolver):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout,
-        set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
 
     """
 

--- a/openmdao/solvers/scipy_gmres.py
+++ b/openmdao/solvers/scipy_gmres.py
@@ -24,8 +24,8 @@ class ScipyGMRES(MultLinearSolver):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each
-        iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] :  int(1000)
         Maximum number of iterations.
     options['mode'] :  str('auto')
@@ -139,15 +139,15 @@ class ScipyGMRES(MultLinearSolver):
                     raise AnalysisError(msg)
                 print(msg)
                 msg = 'FAILED to converge after max iterations'
+                failed = True
             elif info < 0:
-                msg = "ERROR in solve in '{}': gmres failed".format(system.pathname)
-                raise RuntimeError(msg)
-                #logger.error(msg, system.name)
-                #msg = 'ERROR returned from GMRES'
+                msg = "ERROR in solve in '{}': gmres failed with code {}"
+                raise RuntimeError(msg.format(system.pathname, info))
             else:
-                msg = 'Converged'
+                msg = 'Converged in %d iterations' % self.iter_count
+                failed = False
 
-            if self.options['iprint'] > 0:
+            if failed or self.options['iprint'] > 0:
                 self.print_norm(self.print_name, system.pathname, self.iter_count,
                                 0, 0, msg=msg, indent=1, solver='LN')
 
@@ -208,7 +208,7 @@ class ScipyGMRES(MultLinearSolver):
             Current residual.
         """
 
-        if self.options['iprint'] > 0:
+        if self.options['iprint'] == 2:
             f_norm = np.linalg.norm(res)
             if self.iter_count == 0:
                 if f_norm != 0.0:

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -12,9 +12,9 @@ class SolverBase(object):
     def __init__(self):
         self.iter_count = 0
         self.options = OptionsDictionary()
-        desc = 'Set to 0 to disable printing, set to 1 to print the ' \
-               'residual to stdout each iteration, set to 2 to print ' \
-               'subiteration residuals as well.'
+        desc =  "Set to 0 to disable printing, set to 1 to print iteration totals to " \
+        "stdout, set to 2 to print the residual each iteration to stdout."
+
         self.options.add_option('iprint', 0, values=[0, 1, 2], desc=desc)
         self.options.add_option('err_on_maxiter', False,
             desc='If True, raise an AnalysisError if not converged at maxiter.')
@@ -96,10 +96,17 @@ class SolverBase(object):
 
         print(form % (name, solver, solver_string, iteration, res, res/res0))
 
-    def print_all_convergence(self):
+    def print_all_convergence(self, level=2):
         """ Turns on iprint for this solver and all subsolvers. Override if
-        your solver has subsolvers."""
-        self.options['iprint'] = 1
+        your solver has subsolvers.
+
+        Args
+        ----
+        level : int(2)
+            iprint level. Set to 2 to print residuals each iteration; set to 1
+            to print just the iteration totals.
+        """
+        self.options['iprint'] = level
 
     def generate_docstring(self):
         """
@@ -136,8 +143,8 @@ class LinearSolver(SolverBase):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout
-        each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     """
 
     def add_recorder(self, recorder):
@@ -222,8 +229,8 @@ class NonLinearSolver(SolverBase):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout
-        each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     """
 
     def __init__(self):
@@ -277,8 +284,8 @@ class LineSearch(SolverBase):
     Options
     -------
     options['iprint'] :  int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout
-        each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to
+        stdout, set to 2 to print the residual each iteration to stdout.
     """
 
     def solve(self, params, unknowns, resids, system, solver, alpha, fnorm,

--- a/openmdao/solvers/test/test_backtracking.py
+++ b/openmdao/solvers/test/test_backtracking.py
@@ -71,6 +71,7 @@ class TestBackTracking(unittest.TestCase):
 
         top.setup(check=False)
         top['comp.x'] = 1.0
+        top.print_all_convergence(level=1)
         top.run()
 
         assert_rel_error(self, top['comp.x'], .3968459, .0001)

--- a/openmdao/solvers/test/test_brent_multicomp.py
+++ b/openmdao/solvers/test/test_brent_multicomp.py
@@ -56,7 +56,6 @@ class Combined(Group):
 
         # self.nl_solver = Newton()
         self.nl_solver = Brent()
-        # self.nl_solver.options['iprint'] = 1
         self.nl_solver.options['state_var'] = 'x'
 
         self.ln_solver = ScipyGMRES()

--- a/openmdao/solvers/test/test_ln_gauss_seidel.py
+++ b/openmdao/solvers/test/test_ln_gauss_seidel.py
@@ -356,7 +356,6 @@ class TestLinearGaussSeidel(unittest.TestCase):
         prob.root.ln_solver.options['maxiter'] = 10
         prob.root.ln_solver.options['atol'] = 1e-12
         prob.root.ln_solver.options['rtol'] = 1e-12
-        #prob.root.ln_solver.options['iprint'] = 1
 
         prob.root.nl_solver.options['atol'] = 1e-12
         prob.setup(check=False)
@@ -447,7 +446,6 @@ class TestLinearGaussSeidel(unittest.TestCase):
         prob.root = SellarDerivativesGrouped()
         prob.root.ln_solver = LinearGaussSeidel()
         prob.root.ln_solver.options['maxiter'] = 15
-        #prob.root.ln_solver.options['iprint'] = 1
 
         prob.root.mda.nl_solver.options['atol'] = 1e-12
         prob.setup(check=False)
@@ -496,12 +494,10 @@ class TestLinearGaussSeidel(unittest.TestCase):
         prob.root = SellarDerivativesGrouped()
         prob.root.ln_solver = LinearGaussSeidel()
         prob.root.ln_solver.options['maxiter'] = 15
-        #prob.root.ln_solver.options['iprint'] = 1
 
         prob.root.mda.nl_solver.options['atol'] = 1e-12
         prob.root.mda.ln_solver = LinearGaussSeidel()
         prob.root.mda.ln_solver.options['maxiter'] = 15
-        #prob.root.mda.ln_solver.options['iprint'] = 1
         prob.setup(check=False)
         prob.run()
 

--- a/openmdao/solvers/test/test_nl_gauss_seidel.py
+++ b/openmdao/solvers/test/test_nl_gauss_seidel.py
@@ -60,7 +60,7 @@ class TestNLGaussSeidel(unittest.TestCase):
         prob.root.nl_solver = NLGaussSeidel()
         prob.root.nl_solver.options['atol'] = 1e-9
         prob.root.mda.nl_solver.options['atol'] = 1e-3
-        prob.root.nl_solver.options['iprint'] = 1 # so that print_norm is in coverage
+        prob.root.nl_solver.options['iprint'] = 2 # so that print_norm is in coverage
 
         prob.setup(check=False)
 

--- a/openmdao/solvers/test/test_petsc_ksp.py
+++ b/openmdao/solvers/test/test_petsc_ksp.py
@@ -300,7 +300,7 @@ class TestPetscKSPSerial(unittest.TestCase):
         try:
             J = prob.calc_gradient(indep_list, unknown_list, mode='fwd', return_format='dict')
         except AnalysisError as err:
-            self.assertEqual(str(err), "Solve in '': PetscKSP FAILED to converge in 6 iterations")
+            self.assertEqual(str(err), "Solve in '': PetscKSP FAILED to converge in 3 iterations")
         else:
             self.fail("expected AnalysisError")
 

--- a/openmdao/solvers/test/test_scipy_gmres.py
+++ b/openmdao/solvers/test/test_scipy_gmres.py
@@ -427,7 +427,7 @@ class TestScipyGMRES(unittest.TestCase):
     options['err_on_maxiter'] : bool(False)
         If True, raise an AnalysisError if not converged at maxiter.
     options['iprint'] : int(0)
-        Set to 0 to disable printing, set to 1 to print the residual to stdout each iteration, set to 2 to print subiteration residuals as well.
+        Set to 0 to disable printing, set to 1 to print iteration totals to stdout, set to 2 to print the residual each iteration to stdout.
     options['maxiter'] : int(1000)
         Maximum number of iterations.
     options['mode'] : str('auto')

--- a/openmdao/util/test/test_options.py
+++ b/openmdao/util/test/test_options.py
@@ -33,14 +33,14 @@ class TestOptions(unittest.TestCase):
 
         # Check enum out of range
 
-        self.options.add_option('iprint', 0, values = [0, 1, 2, 3])
+        self.options.add_option('xyzzy', 0, values = [0, 1, 2, 3])
         for value in [0,1,2,3]:
-            self.options['iprint'] = value
+            self.options['xyzzy'] = value
 
         with self.assertRaises(ValueError) as cm:
-            self.options['iprint'] = 4
+            self.options['xyzzy'] = 4
 
-        self.assertEqual("'iprint' must be one of the following values: '[0, 1, 2, 3]'", str(cm.exception))
+        self.assertEqual("'xyzzy' must be one of the following values: '[0, 1, 2, 3]'", str(cm.exception))
 
         # Type checking for boolean
 


### PR DESCRIPTION
1. problem.print_all_convergence now has an argument level that lets you choose between:
  0 -- only display failures
  1 -- display iteration counts
  2 -- display residuals each iteration (this is the default)
2. All iterative solvers support these 3 levels.
3. Fixed a bug where KSP was double-counting each iteration.
4. Cleaned up any formatting inconsistencies I found in the messages. 
5. Hitting max iteration triggers a message that displays at all iprint levels.