### PR TITLE
Separate defaults for FD and CS that persist when you change 'type' unless users change the step_size beforehand.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -41,24 +41,20 @@ class DerivOptionsDict(OptionsDictionary):
         super(DerivOptionsDict, self).__setitem__(name, value)
 
         if name == 'type':
-            
             if self._options['step_size']['changed']:
                 return
             
             if value == 'fd':
                 self._options['step_size']['val'] = DEFAULT_STEP_SIZE_FD
-
             if value == 'cs':
                 self._options['step_size']['val'] = DEFAULT_STEP_SIZE_CS
 
         if name == 'check_type':
-            
             if self._options['check_step_size']['changed']:
                 return
             
             if value == 'fd':
                 self._options['check_step_size']['val'] = DEFAULT_STEP_SIZE_FD
-
             if value == 'cs':
                 self._options['check_step_size']['val'] = DEFAULT_STEP_SIZE_CS
 

--- a/openmdao/core/test/test_component.py
+++ b/openmdao/core/test/test_component.py
@@ -223,18 +223,6 @@ class TestComponent(unittest.TestCase):
         np.testing.assert_array_equal(unknowns["s4"]["val"], np.zeros((2,)))
         self.assertEqual(unknowns["s5"], {'val': 0.0, 'state': True, 'shape': 1, 'pathname': 's5', 'size': 1})
 
-    def test_generate_numpydocstring(self):
-        self.comp.add_param("x", 0.0)
-        self.comp.add_param("y", shape=2)
-        self.comp.add_output("z", -1)
-        self.comp.add_state("s", 0.0)
-
-        test_string = self.comp.generate_docstring()
-        original_string = '    """\n\n    Params\n    ----------\n    x: param ({\'shape\': 1, \'size\': 1, \'val\': 0.0})\n    y: param ({\'shape\': (2,), \'size\': 2, \'val\': [ 0.  0.]})\n    z : unknown ({\'pass_by_obj\': True, \'size\': 0, \'val\': -1})\n    s : unknown ({\'shape\': 1, \'size\': 1, \'state\': True, \'val\': 0.0})\n\n    Options\n    -------\n    deriv_options[\'check_form\'] : str(\'forward\')\n        Finite difference mode: ("forward", "backward", "central") During check_partial_derivatives, the difference form that is used for the check\n    deriv_options[\'check_step_calc\'] : str(\'absolute\')\n        Set to \'absolute\' or \'relative\'. Default finite difference step calculation for the finite difference check in check_partial_derivatives.\n    deriv_options[\'check_step_size\'] : float(1e-06)\n        Default finite difference stepsize for the finite difference check in check_partial_derivatives.\n    deriv_options[\'check_type\'] : str(\'fd\')\n        Type of derivative check for check_partial_derivatives. Set to \'fd\' to finite difference this system. Set to \'cs\' to perform the complex step method if your components support it.\n    deriv_options[\'form\'] : str(\'forward\')\n        Finite difference mode. (forward, backward, central) \n    deriv_options[\'linearize\'] : bool(False)\n        Set to True if you want linearize to be called even though you are using FD.\n    deriv_options[\'step_calc\'] : str(\'absolute\')\n        Set to absolute, relative\n    deriv_options[\'step_size\'] : float(1e-06)\n        Default finite difference stepsize\n    deriv_options[\'type\'] : str(\'user\')\n        Default is \'user\', where derivative is calculated from user-supplied derivatives. Set to \'fd\' to finite difference this system. Set to \'cs\' to perform the complex step if your components support it.\n\n    """\n'
-
-        for sorig, stest in zip(original_string.split('\n'), test_string.split('\n')):
-            self.assertEqual(sorig, stest)
-
     def test_add_var_pbo_check(self):
         p = Problem(root=Group())
         root = p.root

--- a/openmdao/core/test/test_group_derivatives.py
+++ b/openmdao/core/test/test_group_derivatives.py
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import IndepVarComp, Component, Group, Problem
+from openmdao.core.system import DEFAULT_STEP_SIZE_CS, DEFAULT_STEP_SIZE_FD
 from openmdao.test.converge_diverge import ConvergeDivergeGroups
 from openmdao.test.simple_comps import SimpleCompDerivMatVec
 from openmdao.test.util import assert_rel_error
@@ -167,5 +168,42 @@ class TestGroupDerivatves(unittest.TestCase):
         assert_rel_error(self, J[0][0], 8.0, 1e-6)
         assert_rel_error(self, J[1][0], 16.0, 1e-6)
 
+
+    def test_step_size_defaults(self):
+        
+        p = Problem()
+        p.root = Group()
+        opt = p.root.deriv_options
+        
+        opt['type'] = 'fd'
+        self.assertEqual(opt['step_size'], DEFAULT_STEP_SIZE_FD)
+
+        opt['type'] = 'cs'
+        self.assertEqual(opt['step_size'], DEFAULT_STEP_SIZE_CS)
+
+        opt['type'] = 'fd'
+        self.assertEqual(opt['step_size'], DEFAULT_STEP_SIZE_FD)
+
+        opt['step_size'] = 1.5
+        self.assertEqual(opt['step_size'], 1.5)
+
+        opt['type'] = 'cs'
+        self.assertEqual(opt['step_size'], 1.5)
+
+        opt['check_type'] = 'fd'
+        self.assertEqual(opt['check_step_size'], DEFAULT_STEP_SIZE_FD)
+
+        opt['check_type'] = 'cs'
+        self.assertEqual(opt['check_step_size'], DEFAULT_STEP_SIZE_CS)
+
+        opt['check_type'] = 'fd'
+        self.assertEqual(opt['check_step_size'], DEFAULT_STEP_SIZE_FD)
+
+        opt['check_step_size'] = 1.5
+        self.assertEqual(opt['check_step_size'], 1.5)
+
+        opt['check_type'] = 'cs'
+        self.assertEqual(opt['check_step_size'], 1.5)
+        
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/util/options.py
+++ b/openmdao/util/options.py
@@ -68,7 +68,8 @@ class OptionsDictionary(object):
             'upper' : upper,
             'values' : values,
             'desc' : desc,
-            'lock_on_setup' : lock_on_setup
+            'lock_on_setup' : lock_on_setup,
+            'changed' : False
         }
 
         self._check(name, value, opt)
@@ -133,6 +134,7 @@ class OptionsDictionary(object):
         opt = self._options[name]
         self._check(name, value, opt)
         opt['val'] = value
+        opt['changed'] = True
 
     def __setattr__(self, name, value):
         """ To prevent user error, disallow direct setting."""


### PR DESCRIPTION
1. OptionsDicts are aware of which keys are changed from the original values.
2. The `deriv_options` dictionary has new behavior
 - If the 'type' is changed to 'fd' or 'cs', then the appropriate default 'step_size' (1e-6 or 1e-30) is used
 - If the user manually changes the 'step_size', then always use that
 - The same rules apply to 'check_type' and 'check_step_size'
3. Got rid of another annoying generate_numpy_docstring test.