### PR TITLE
New error handling for numpy overflow, divide by zero, and invalid numbers.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -154,7 +154,7 @@ class Driver(object):
                 continue
 
             self.fn_conversions[name] = scaler
-            
+
     def _setup_communicators(self, comm, parent_dir):
         """
         Assign a communicator to the root `System`.
@@ -333,16 +333,6 @@ class Driver(object):
             if high is not None and upper is None:
                 upper = high
 
-        if isinstance(lower, np.ndarray):
-            lower = lower.flatten()
-        elif lower is None or lower == -float('inf'):
-            lower = -sys.float_info.max
-
-        if isinstance(upper, np.ndarray):
-            upper = upper.flatten()
-        elif upper is None or upper == float('inf'):
-            upper = sys.float_info.max
-
         if isinstance(adder, np.ndarray):
             adder = adder.flatten().astype('float')
         else:
@@ -353,9 +343,21 @@ class Driver(object):
         else:
             scaler = float(scaler)
 
-        # Scale the lower and upper values
-        lower = (lower + adder)*scaler
-        upper = (upper + adder)*scaler
+        if isinstance(lower, np.ndarray):
+            lower = lower.flatten()
+            lower = (lower + adder)*scaler
+        elif lower is None or lower == -float('inf'):
+            lower = -sys.float_info.max
+        else:
+            lower = (lower + adder)*scaler
+
+        if isinstance(upper, np.ndarray):
+            upper = upper.flatten()
+            upper = (upper + adder)*scaler
+        elif upper is None or upper == float('inf'):
+            upper = sys.float_info.max
+        else:
+            upper = (upper + adder)*scaler
 
         param = OrderedDict()
         param['lower'] = lower

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -40,6 +40,11 @@ from openmdao.util.dict_util import _jac_to_flat_dict
 force_check = os.environ.get('OPENMDAO_FORCE_CHECK_SETUP')
 trace = os.environ.get('OPENMDAO_TRACE')
 
+# Default numpy error behavior: we want to raise whenever we can.
+np.seterr(over='raise')
+np.seterr(under='raise')
+np.seterr(divide='raise')
+np.seterr(invalid='raise')
 
 class _ProbData(object):
     """
@@ -1060,13 +1065,13 @@ class Problem(object):
             for name, meta in iteritems(driver.get_constraint_metadata()):
                 if meta.get('active_tol') is not None:
                     actives.append(name)
-                    
+
             if len(actives) > 0:
                 print("Driver does not support an active set method, but a tolerance "
-                      "has been added to these constraints: %s" % actives, 
-                      file=out_stream)   
+                      "has been added to these constraints: %s" % actives,
+                      file=out_stream)
                 drivprobs['active_tol'] = actives
-                    
+
         return drivprobs
 
     def check_setup(self, out_stream=sys.stdout):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -40,9 +40,10 @@ from openmdao.util.dict_util import _jac_to_flat_dict
 force_check = os.environ.get('OPENMDAO_FORCE_CHECK_SETUP')
 trace = os.environ.get('OPENMDAO_TRACE')
 
-# Default numpy error behavior: we want to raise whenever we can.
+# Default numpy error behavior: we want to raise whenever we can, except for
+# underflow.
 np.seterr(over='raise')
-np.seterr(under='raise')
+np.seterr(under='ignore')
 np.seterr(divide='raise')
 np.seterr(invalid='raise')
 

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -5,7 +5,7 @@ from math import isnan
 import numpy as np
 
 from openmdao.core.system import AnalysisError
-from openmdao.solvers.solver_base import NonLinearSolver
+from openmdao.solvers.solver_base import ErrorWrapNL, NonLinearSolver
 from openmdao.util.record_util import update_local_meta, create_local_meta
 
 
@@ -100,6 +100,7 @@ class Newton(NonLinearSolver):
         if self.ln_solver:
             self.ln_solver.print_all_convergence(level)
 
+    @ErrorWrapNL
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Solves the system using a Netwon's Method.
 

--- a/openmdao/solvers/newton.py
+++ b/openmdao/solvers/newton.py
@@ -5,7 +5,7 @@ from math import isnan
 import numpy as np
 
 from openmdao.core.system import AnalysisError
-from openmdao.solvers.solver_base import ErrorWrapNL, NonLinearSolver
+from openmdao.solvers.solver_base import error_wrap_nl, NonLinearSolver
 from openmdao.util.record_util import update_local_meta, create_local_meta
 
 
@@ -100,7 +100,7 @@ class Newton(NonLinearSolver):
         if self.ln_solver:
             self.ln_solver.print_all_convergence(level)
 
-    @ErrorWrapNL
+    @error_wrap_nl
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Solves the system using a Netwon's Method.
 

--- a/openmdao/solvers/nl_gauss_seidel.py
+++ b/openmdao/solvers/nl_gauss_seidel.py
@@ -5,7 +5,7 @@ from math import isnan
 import numpy as np
 
 from openmdao.core.system import AnalysisError
-from openmdao.solvers.solver_base import ErrorWrapNL, NonLinearSolver
+from openmdao.solvers.solver_base import error_wrap_nl, NonLinearSolver
 from openmdao.util.record_util import update_local_meta, create_local_meta
 
 
@@ -60,7 +60,7 @@ class NLGaussSeidel(NonLinearSolver):
         if sub.is_active():
             self.unknowns_cache = np.empty(sub.unknowns.vec.shape)
 
-    @ErrorWrapNL
+    @error_wrap_nl
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Solves the system using Gauss Seidel.
 

--- a/openmdao/solvers/nl_gauss_seidel.py
+++ b/openmdao/solvers/nl_gauss_seidel.py
@@ -5,7 +5,7 @@ from math import isnan
 import numpy as np
 
 from openmdao.core.system import AnalysisError
-from openmdao.solvers.solver_base import NonLinearSolver
+from openmdao.solvers.solver_base import ErrorWrapNL, NonLinearSolver
 from openmdao.util.record_util import update_local_meta, create_local_meta
 
 
@@ -60,6 +60,7 @@ class NLGaussSeidel(NonLinearSolver):
         if sub.is_active():
             self.unknowns_cache = np.empty(sub.unknowns.vec.shape)
 
+    @ErrorWrapNL
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Solves the system using Gauss Seidel.
 

--- a/openmdao/solvers/run_once.py
+++ b/openmdao/solvers/run_once.py
@@ -1,7 +1,7 @@
 """ The RunOnce solver just performs solve_nonlinear on the system hierarchy
 with no iteration."""
 
-from openmdao.solvers.solver_base import ErrorWrapNL, NonLinearSolver
+from openmdao.solvers.solver_base import error_wrap_nl, NonLinearSolver
 from openmdao.util.record_util import create_local_meta, update_local_meta
 
 
@@ -23,7 +23,7 @@ class RunOnce(NonLinearSolver):
         self.options.remove_option('err_on_maxiter')
         self.print_name = 'RUN_ONCE'
 
-    @ErrorWrapNL
+    @error_wrap_nl
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Executes each item in the system hierarchy sequentially.
 

--- a/openmdao/solvers/run_once.py
+++ b/openmdao/solvers/run_once.py
@@ -1,7 +1,7 @@
 """ The RunOnce solver just performs solve_nonlinear on the system hierarchy
 with no iteration."""
 
-from openmdao.solvers.solver_base import NonLinearSolver
+from openmdao.solvers.solver_base import ErrorWrapNL, NonLinearSolver
 from openmdao.util.record_util import create_local_meta, update_local_meta
 
 
@@ -23,6 +23,7 @@ class RunOnce(NonLinearSolver):
         self.options.remove_option('err_on_maxiter')
         self.print_name = 'RUN_ONCE'
 
+    @ErrorWrapNL
     def solve(self, params, unknowns, resids, system, metadata=None):
         """ Executes each item in the system hierarchy sequentially.
 

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 
 from functools import wraps
 import sys
-from six import iterkeys, PY3
+from six import iterkeys, PY3, reraise
 
 import numpy as np
 
@@ -26,7 +26,7 @@ def error_wrap_nl(fn):
 
             # So we don't keep re-appending in a solver stack.
             if hasattr(exc_info[1], 'seen'):
-                raise exc_info[0], exc_info[1], exc_info[2]
+                reraise(exc_info[0], exc_info[1], exc_info[2])
 
             # The user may need some help figuring things out, so let them know where
             x_unknowns = []
@@ -61,12 +61,7 @@ def error_wrap_nl(fn):
             # So we don't keep re-appending in a solver stack.
             new_err.seen = True
 
-            if PY3:
-                raise exc_info[0].with_traceback(new_err, exc_info[2])
-            else:
-                # exec needed here since otherwise python3 will
-                # barf with a syntax error  :(
-                exec('raise exc_info[0], new_err, exc_info[2]') in globals(), locals()
+            reraise(exc_info[0], new_err, exc_info[2])
 
     return wrapper
 

--- a/openmdao/solvers/solver_base.py
+++ b/openmdao/solvers/solver_base.py
@@ -48,7 +48,7 @@ def error_wrap_nl(fn):
                 if not all(np.isfinite(params._dat[var].val)):
                     x_params.append(var)
 
-            msg = exc_info[1].message
+            msg = str(err)
             if x_unknowns:
                 msg += '\nThe following unknowns are nonfinite: %s' % x_unknowns
             if x_resids:

--- a/openmdao/solvers/test/test_brent_solver.py
+++ b/openmdao/solvers/test/test_brent_solver.py
@@ -27,7 +27,14 @@ class CompTest(Component):
         pass
 
     def apply_nonlinear(self, p, u, r):
-        r['x'] = p['a'] * u['x']**p['n'] + p['b'] * u['x'] - p['c']
+
+        # Can't take fractional power of negative number
+        if u['x'] >= 0.0:
+            fact = u['x']**p['n']
+        else:
+            fact = - (-u['x'])**p['n']
+
+        r['x'] = p['a'] * fact + p['b'] * u['x'] - p['c']
 
 
 class IndexCompTest(Component):
@@ -48,7 +55,14 @@ class IndexCompTest(Component):
 
     def apply_nonlinear(self, p, u, r):
         x = u['x'][2]
-        r['x'][2] = p['a'] * x**p['n'] + p['b'] * x - p['c']
+
+        # Can't take fractional power of negative number
+        if x >= 0.0:
+            fact = x**p['n']
+        else:
+            fact = - (-x)**p['n']
+
+        r['x'][2] = p['a'] * fact + p['b'] * x - p['c']
 
 
 class TestBrentSolver(unittest.TestCase):
@@ -163,7 +177,8 @@ class TestBrentSolver(unittest.TestCase):
         p['b'] = 55.
         p.run()
 
-        assert_rel_error(self, p.root.unknowns['x'], 110, .0001)
+        assert_rel_error(self, p.root.resids['x'], 0, .0001)
+        assert_rel_error(self, p.root.unknowns['x'], 2.06720359226, .0001)
 
     def test_data_pass_bounds_idx(self):
 
@@ -190,7 +205,8 @@ class TestBrentSolver(unittest.TestCase):
         p['b'] = 55.
         p.run()
 
-        assert_rel_error(self, p.root.unknowns['x'][2], 110, .0001)
+        assert_rel_error(self, p.root.resids['x'][2], 0, .0001)
+        assert_rel_error(self, p.root.unknowns['x'][2], 2.06720359226, .0001)
 
 
 class BracketTestComponent(Component):

--- a/openmdao/solvers/test/test_solver_np_error.py
+++ b/openmdao/solvers/test/test_solver_np_error.py
@@ -47,7 +47,9 @@ class TestNPError(unittest.TestCase):
             top.run()
 
         expected_msg = "divide by zero encountered in divide"
-        self.assertEqual(str(err.exception), expected_msg)
+        msg = str(err.exception)
+        msg = msg.replace('in true_divide', 'in divide')
+        self.assertEqual(msg, expected_msg)
 
     def test_indirect_errors_divide(self):
 
@@ -70,7 +72,7 @@ class TestNPError(unittest.TestCase):
         self.assertEqual(str(err.exception), expected_msg)
 
     def test_indirect_errors_divide_subbed(self):
-        
+
         # Make sure that two stacked solvers don't double append.
 
         top = Problem()

--- a/openmdao/solvers/test/test_solver_np_error.py
+++ b/openmdao/solvers/test/test_solver_np_error.py
@@ -1,0 +1,74 @@
+""" Test out our new error handler helper. """
+
+import sys
+import unittest
+
+from six.moves import cStringIO
+import numpy as np
+
+from openmdao.api import Problem, Group, Component, NLGaussSeidel, ScipyGMRES
+
+
+class ErrorComp(Component):
+    """ This component generates numpy errors."""
+
+    def __init__(self, mode):
+        super(ErrorComp, self).__init__()
+
+        self.add_param('in', val=np.array([1.0]))
+        self.add_output('out', val=np.array([1.0]))
+
+        self.mode = mode
+
+        self.deriv_options['type'] = 'fd'
+
+    def solve_nonlinear(self, params, unknowns, resids):
+        """Produce various types of errors."""
+
+        if self.mode == 'divide':
+            unknowns['out'] = params['in']/0.0
+        if self.mode == 'indirect_divide':
+            unknowns['out'] = np.array([np.inf])
+        else:
+            unknowns['out'] = params['in']/0.99
+
+
+class TestNPError(unittest.TestCase):
+
+    def test_direct_errors_divide(self):
+
+        top = Problem()
+        top.root = root = Group()
+        root.add('comp', ErrorComp('divide'))
+
+        top.setup(check=False)
+
+        with self.assertRaises(FloatingPointError) as err:
+            top.run()
+
+        expected_msg = "divide by zero encountered in divide"
+        self.assertEqual(str(err.exception), expected_msg)
+
+    def test_indirect_errors_divide(self):
+
+        top = Problem()
+        top.root = root = Group()
+        root.add('comp1', ErrorComp('xx'))
+        root.add('comp2', ErrorComp('indirect_divide'))
+        root.connect('comp1.out', 'comp2.in')
+        root.connect('comp2.out', 'comp1.in')
+
+        root.nl_solver = NLGaussSeidel()
+        root.ln_solver = ScipyGMRES()
+
+        top.setup(check=False)
+
+        with self.assertRaises(FloatingPointError) as err:
+            top.run()
+
+        expected_msg = "invalid value encountered in subtract\nThe following unknowns are nonfinite: ['comp1.out', 'comp2.out']\nThe following resids are nonfinite: ['comp1.out']\nThe following params are nonfinite: ['comp1.in']"
+        self.assertEqual(str(err.exception), expected_msg)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
1. Default numpy behavior for overflow, divide by zero, and invalid numbers has been changed from "warn" to "raise"..
2. A decorator has been added to `solve` on the nl_solvers. This wraps the functions in a try block so that more information can be appended to the exception message telling the user which variables have become non-finite.
3. The behavior for numpy underflow remains the same as the numpy default.
4. Fixed a test in the Brent solver tests which really wasn't being solved properly.