### PR TITLE
added error msg when low/high are used in add_param/add_unknown/add_s…

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -166,11 +166,11 @@ class Component(System):
             meta['shape'] = (shape,)
 
         if 'low' in kwargs:
-            raise NameError("Used arg 'low' when adding variable '%s'. "
+            raise TypeError("Used arg 'low' when adding variable '%s'. "
                             "Use 'lower' instead." % name)
 
         if 'high' in kwargs:
-            raise NameError("Used arg 'high' when adding variable '%s'. "
+            raise TypeError("Used arg 'high' when adding variable '%s'. "
                             "Use 'upper' instead." % name)
 
         return meta

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -165,6 +165,14 @@ class Component(System):
         if isinstance(shape, int) and shape > 1:
             meta['shape'] = (shape,)
 
+        if 'low' in kwargs:
+            raise NameError("Used arg 'low' when adding variable '%s'. "
+                            "Use 'lower' instead." % name)
+
+        if 'high' in kwargs:
+            raise NameError("Used arg 'high' when adding variable '%s'. "
+                            "Use 'upper' instead." % name)
+
         return meta
 
     def add_param(self, name, val=_NotSet, **kwargs):

--- a/openmdao/core/test/test_component.py
+++ b/openmdao/core/test/test_component.py
@@ -223,6 +223,37 @@ class TestComponent(unittest.TestCase):
         np.testing.assert_array_equal(unknowns["s4"]["val"], np.zeros((2,)))
         self.assertEqual(unknowns["s5"], {'val': 0.0, 'state': True, 'shape': 1, 'pathname': 's5', 'size': 1})
 
+    def test_low_high(self):
+        with self.assertRaises(NameError) as err:
+            self.comp.add_param('foo1', low=0.0)
+
+        self.assertEqual(str(err.exception), "Used arg 'low' when adding variable 'foo1'. Use 'lower' instead.")
+
+        with self.assertRaises(NameError) as err:
+            self.comp.add_param('foo2', high=0.0)
+
+        self.assertEqual(str(err.exception), "Used arg 'high' when adding variable 'foo2'. Use 'upper' instead.")
+
+        with self.assertRaises(NameError) as err:
+            self.comp.add_output('foo3', 1.0, low=0.0)
+
+        self.assertEqual(str(err.exception), "Used arg 'low' when adding variable 'foo3'. Use 'lower' instead.")
+
+        with self.assertRaises(NameError) as err:
+            self.comp.add_output('foo4', 1.0, high=5.0)
+
+        self.assertEqual(str(err.exception), "Used arg 'high' when adding variable 'foo4'. Use 'upper' instead.")
+
+        with self.assertRaises(NameError) as err:
+            self.comp.add_state('foo5', 1.0, low=0.0)
+
+        self.assertEqual(str(err.exception), "Used arg 'low' when adding variable 'foo5'. Use 'lower' instead.")
+
+        with self.assertRaises(NameError) as err:
+            self.comp.add_state('foo6', 1.0, high=4.0)
+
+        self.assertEqual(str(err.exception), "Used arg 'high' when adding variable 'foo6'. Use 'upper' instead.")
+
     def test_add_var_pbo_check(self):
         p = Problem(root=Group())
         root = p.root

--- a/openmdao/core/test/test_component.py
+++ b/openmdao/core/test/test_component.py
@@ -224,32 +224,32 @@ class TestComponent(unittest.TestCase):
         self.assertEqual(unknowns["s5"], {'val': 0.0, 'state': True, 'shape': 1, 'pathname': 's5', 'size': 1})
 
     def test_low_high(self):
-        with self.assertRaises(NameError) as err:
+        with self.assertRaises(TypeError) as err:
             self.comp.add_param('foo1', low=0.0)
 
         self.assertEqual(str(err.exception), "Used arg 'low' when adding variable 'foo1'. Use 'lower' instead.")
 
-        with self.assertRaises(NameError) as err:
+        with self.assertRaises(TypeError) as err:
             self.comp.add_param('foo2', high=0.0)
 
         self.assertEqual(str(err.exception), "Used arg 'high' when adding variable 'foo2'. Use 'upper' instead.")
 
-        with self.assertRaises(NameError) as err:
+        with self.assertRaises(TypeError) as err:
             self.comp.add_output('foo3', 1.0, low=0.0)
 
         self.assertEqual(str(err.exception), "Used arg 'low' when adding variable 'foo3'. Use 'lower' instead.")
 
-        with self.assertRaises(NameError) as err:
+        with self.assertRaises(TypeError) as err:
             self.comp.add_output('foo4', 1.0, high=5.0)
 
         self.assertEqual(str(err.exception), "Used arg 'high' when adding variable 'foo4'. Use 'upper' instead.")
 
-        with self.assertRaises(NameError) as err:
+        with self.assertRaises(TypeError) as err:
             self.comp.add_state('foo5', 1.0, low=0.0)
 
         self.assertEqual(str(err.exception), "Used arg 'low' when adding variable 'foo5'. Use 'lower' instead.")
 
-        with self.assertRaises(NameError) as err:
+        with self.assertRaises(TypeError) as err:
             self.comp.add_state('foo6', 1.0, high=4.0)
 
         self.assertEqual(str(err.exception), "Used arg 'high' when adding variable 'foo6'. Use 'upper' instead.")


### PR DESCRIPTION
…tate.   Didn't add a deprecation warning because we never supported low/high in that context.