### PR TITLE
Removed the tightening of numpy errors and made it an option set by passing `debug=True` into the Problem init.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -345,19 +345,17 @@ class Driver(object):
 
         if isinstance(lower, np.ndarray):
             lower = lower.flatten()
-            lower = (lower + adder)*scaler
         elif lower is None or lower == -float('inf'):
             lower = -sys.float_info.max
-        else:
-            lower = (lower + adder)*scaler
+
+        lower = (lower + adder)*scaler
 
         if isinstance(upper, np.ndarray):
             upper = upper.flatten()
-            upper = (upper + adder)*scaler
         elif upper is None or upper == float('inf'):
             upper = sys.float_info.max
-        else:
-            upper = (upper + adder)*scaler
+
+        upper = (upper + adder)*scaler
 
         param = OrderedDict()
         param['lower'] = lower

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -40,13 +40,6 @@ from openmdao.util.dict_util import _jac_to_flat_dict
 force_check = os.environ.get('OPENMDAO_FORCE_CHECK_SETUP')
 trace = os.environ.get('OPENMDAO_TRACE')
 
-# Default numpy error behavior: we want to raise whenever we can, except for
-# underflow.
-np.seterr(over='raise')
-np.seterr(under='ignore')
-np.seterr(divide='raise')
-np.seterr(invalid='raise')
-
 class _ProbData(object):
     """
     A container for Problem level data that is needed by subsystems
@@ -116,9 +109,14 @@ class Problem(object):
     comm : an MPI communicator (real or fake), optional
         A communicator that can be used for distributed operations when running
         under MPI. If not specified, the default "COMM_WORLD" will be used.
+
+    debug : bool(False)
+        If set to True, all numpy floating point errors raise exceptions and
+        the variable locations that go to inf or nan are printed when they can
+        be determined.
     """
 
-    def __init__(self, root=None, driver=None, impl=None, comm=None):
+    def __init__(self, root=None, driver=None, impl=None, comm=None, debug=False):
         super(Problem, self).__init__()
         self.root = root
         self._probdata = _ProbData()
@@ -142,6 +140,14 @@ class Problem(object):
 
         self.pathname = ''
         self._parent_dir = None
+
+        # Default numpy error behavior: we want to raise whenever we can, except for
+        # underflow.
+        if debug == True:
+            np.seterr(over='raise')
+            np.seterr(under='ignore')
+            np.seterr(divide='raise')
+            np.seterr(invalid='raise')
 
     def __getitem__(self, name):
         """Retrieve unflattened value of named unknown or unconnected

--- a/openmdao/solvers/test/test_solver_np_error.py
+++ b/openmdao/solvers/test/test_solver_np_error.py
@@ -37,7 +37,7 @@ class TestNPError(unittest.TestCase):
 
     def test_direct_errors_divide(self):
 
-        top = Problem()
+        top = Problem(debug=True)
         top.root = root = Group()
         root.add('comp', ErrorComp('divide'))
 
@@ -53,7 +53,7 @@ class TestNPError(unittest.TestCase):
 
     def test_indirect_errors_divide(self):
 
-        top = Problem()
+        top = Problem(debug=True)
         top.root = root = Group()
         root.add('comp1', ErrorComp('xx'))
         root.add('comp2', ErrorComp('indirect_divide'))
@@ -75,7 +75,7 @@ class TestNPError(unittest.TestCase):
 
         # Make sure that two stacked solvers don't double append.
 
-        top = Problem()
+        top = Problem(debug=True)
         top.root = root = Group()
         sub = root.add('sub', Group())
         sub.add('comp1', ErrorComp('xx'))


### PR DESCRIPTION
This should make Pointer tests pass again.