### PR TITLE
Added version number of format for sqlite and hdf5 case recording files

### DIFF
--- a/mpitest/test_par_doe.py
+++ b/mpitest/test_par_doe.py
@@ -7,6 +7,7 @@ import sys
 import time
 import traceback
 import numpy as np
+import unittest
 
 from openmdao.api import IndepVarComp, Component, Group, Problem, \
                          FullFactorialDriver, AnalysisError
@@ -227,6 +228,9 @@ class LBParallelDOETestCase(MPITestCase):
             self.assertEqual(num_cases, num_levels)
 
     def test_load_balanced_doe_crit_fail(self):
+
+        if MPI is None:
+            raise unittest.SkipTest("Can't run this test (even in serial) without mpi4py and petsc4py")
 
         problem = Problem(impl=impl)
         root = problem.root = Group()

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -453,7 +453,7 @@ Which will print out the dictionary:
 Finally, since our code told the recorder to record metadata, we can read that from the file as well.
 Notice that since metadata is only recorded once, it is a top level element of the dictionary, rather than a
 sub-dictionary of an interation coordinate. It contains sub-dictionaries for metadata about
-`Unknowns`, `Parameters`, `Resids`.
+`Unknowns`, and `Parameters`. It also contains the version number for the format of the case recorder file, `om_case_version`. T
 
 .. testcode:: reading
 
@@ -462,6 +462,7 @@ sub-dictionary of an interation coordinate. It contains sub-dictionaries for met
     pprint(u_meta)
     p_meta = data['Parameters']
     pprint(p_meta)
+    print data['om_case_version']
 
 .. testoutput:: reading
    :hide:
@@ -497,6 +498,7 @@ sub-dictionary of an interation coordinate. It contains sub-dictionaries for met
              'size': 1,
              'top_promoted_name': 'p.y',
              'val': 0.0}}
+    1
 
 This code prints out the following:
 
@@ -530,6 +532,7 @@ This code prints out the following:
              'size': 1,
              'top_promoted_name': 'p.y',
              'val': 0.0}}
+    1
 
 
 .. testcleanup:: reading

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -462,7 +462,7 @@ sub-dictionary of an interation coordinate. It contains sub-dictionaries for met
     pprint(u_meta)
     p_meta = data['Parameters']
     pprint(p_meta)
-    print(data['om_case_version'])
+    print(data['format_version'])
 
 .. testoutput:: reading
    :hide:

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -462,7 +462,7 @@ sub-dictionary of an interation coordinate. It contains sub-dictionaries for met
     pprint(u_meta)
     p_meta = data['Parameters']
     pprint(p_meta)
-    print data['om_case_version']
+    print(data['om_case_version'])
 
 .. testoutput:: reading
    :hide:

--- a/openmdao/recorders/hdf5_recorder.py
+++ b/openmdao/recorders/hdf5_recorder.py
@@ -10,7 +10,7 @@ from h5py import File
 from openmdao.recorders.base_recorder import BaseRecorder
 from openmdao.util.record_util import format_iteration_coordinate
 
-om_case_version = 1
+format_version = 1
 
 class HDF5Recorder(BaseRecorder):
     """
@@ -65,7 +65,7 @@ class HDF5Recorder(BaseRecorder):
 
         group = f.require_group('metadata')
 
-        group.create_dataset('om_case_version', data = om_case_version)
+        group.create_dataset('format_version', data = format_version)
 
         pairings = (
                 (group.create_group("Parameters"), params),

--- a/openmdao/recorders/hdf5_recorder.py
+++ b/openmdao/recorders/hdf5_recorder.py
@@ -10,6 +10,8 @@ from h5py import File
 from openmdao.recorders.base_recorder import BaseRecorder
 from openmdao.util.record_util import format_iteration_coordinate
 
+om_case_version = 1
+
 class HDF5Recorder(BaseRecorder):
     """
     A recorder that stores data using HDF5. This format naturally handles
@@ -62,6 +64,8 @@ class HDF5Recorder(BaseRecorder):
         f = self.out
 
         group = f.require_group('metadata')
+
+        group.create_dataset('om_case_version', data = om_case_version)
 
         pairings = (
                 (group.create_group("Parameters"), params),

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -7,6 +7,8 @@ from openmdao.util.record_util import format_iteration_coordinate
 
 from openmdao.core.mpi_wrap import MPI
 
+om_case_version = 1  
+
 class SqliteRecorder(BaseRecorder):
     """ Recorder that saves cases in an SQLite dictionary.
 
@@ -62,7 +64,9 @@ class SqliteRecorder(BaseRecorder):
         resids = group.resids.iteritems()
         unknowns = group.unknowns.iteritems()
 
-        data = OrderedDict([('Parameters', dict(params)),
+        data = OrderedDict([
+                            ('om_case_version', om_case_version),
+                            ('Parameters', dict(params)),
                             ('Unknowns', dict(unknowns)),
                             ])
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -7,7 +7,7 @@ from openmdao.util.record_util import format_iteration_coordinate
 
 from openmdao.core.mpi_wrap import MPI
 
-om_case_version = 1  
+format_version = 1  
 
 class SqliteRecorder(BaseRecorder):
     """ Recorder that saves cases in an SQLite dictionary.
@@ -65,7 +65,7 @@ class SqliteRecorder(BaseRecorder):
         unknowns = group.unknowns.iteritems()
 
         data = OrderedDict([
-                            ('om_case_version', om_case_version),
+                            ('format_version', format_version),
                             ('Parameters', dict(params)),
                             ('Unknowns', dict(unknowns)),
                             ])

--- a/openmdao/recorders/test/test_hdf5.py
+++ b/openmdao/recorders/test/test_hdf5.py
@@ -16,6 +16,8 @@ from openmdao.test.example_groups import ExampleGroup
 from openmdao.util.record_util import format_iteration_coordinate
 from openmdao.test.util import assert_rel_error
 
+from openmdao.recorders.hdf5_recorder import om_case_version
+
 SKIP = False
 
 def run_problem(problem):
@@ -63,7 +65,8 @@ class TestHDF5Recorder(unittest.TestCase):
             self.assertIsNone(metadata)
             return
 
-        self.assertEquals(len(metadata), 2)
+        self.assertEquals(len(metadata), 3)
+        self.assertEqual( om_case_version, metadata.get('om_case_version').value)
 
         pairings = zip(expected, (metadata[x] for x in ('Parameters', 'Unknowns')))
 

--- a/openmdao/recorders/test/test_hdf5.py
+++ b/openmdao/recorders/test/test_hdf5.py
@@ -16,8 +16,6 @@ from openmdao.test.example_groups import ExampleGroup
 from openmdao.util.record_util import format_iteration_coordinate
 from openmdao.test.util import assert_rel_error
 
-from openmdao.recorders.hdf5_recorder import om_case_version
-
 SKIP = False
 
 def run_problem(problem):
@@ -28,7 +26,7 @@ def run_problem(problem):
     return t0, t1
 
 try:
-    from openmdao.recorders.hdf5_recorder import HDF5Recorder
+    from openmdao.recorders.hdf5_recorder import HDF5Recorder, om_case_version
     import h5py
 except ImportError:
     # Necessary for the file to parse

--- a/openmdao/recorders/test/test_hdf5.py
+++ b/openmdao/recorders/test/test_hdf5.py
@@ -26,7 +26,7 @@ def run_problem(problem):
     return t0, t1
 
 try:
-    from openmdao.recorders.hdf5_recorder import HDF5Recorder, om_case_version
+    from openmdao.recorders.hdf5_recorder import HDF5Recorder, format_version
     import h5py
 except ImportError:
     # Necessary for the file to parse
@@ -64,7 +64,7 @@ class TestHDF5Recorder(unittest.TestCase):
             return
 
         self.assertEquals(len(metadata), 3)
-        self.assertEqual( om_case_version, metadata.get('om_case_version').value)
+        self.assertEqual( format_version, metadata.get('format_version').value)
 
         pairings = zip(expected, (metadata[x] for x in ('Parameters', 'Unknowns')))
 

--- a/openmdao/recorders/test/test_sqlite.py
+++ b/openmdao/recorders/test/test_sqlite.py
@@ -21,7 +21,7 @@ from openmdao.test.sellar import SellarDerivativesGrouped
 from openmdao.test.util import assert_rel_error
 from openmdao.util.record_util import format_iteration_coordinate
 
-from openmdao.recorders.sqlite_recorder import om_case_version
+from openmdao.recorders.sqlite_recorder import format_version
 
 # check that pyoptsparse is installed
 # if it is, try to use SLSQP
@@ -113,7 +113,7 @@ def _assertMetadataRecorded(test, db, expected):
         return
 
     test.assertEquals(len(metadata), 3)
-    test.assertEqual( om_case_version, metadata['om_case_version'])
+    test.assertEqual( format_version, metadata['format_version'])
 
     pairings = zip(expected, (metadata[x] for x in ('Parameters', 'Unknowns')))
 

--- a/openmdao/recorders/test/test_sqlite.py
+++ b/openmdao/recorders/test/test_sqlite.py
@@ -21,6 +21,8 @@ from openmdao.test.sellar import SellarDerivativesGrouped
 from openmdao.test.util import assert_rel_error
 from openmdao.util.record_util import format_iteration_coordinate
 
+from openmdao.recorders.sqlite_recorder import om_case_version
+
 # check that pyoptsparse is installed
 # if it is, try to use SLSQP
 OPT = None
@@ -110,7 +112,9 @@ def _assertMetadataRecorded(test, db, expected):
         test.assertIsNone(metadata)
         return
 
-    test.assertEquals(len(metadata), 2)
+    test.assertEquals(len(metadata), 3)
+    test.assertEqual( om_case_version, metadata['om_case_version'])
+
     pairings = zip(expected, (metadata[x] for x in ('Parameters', 'Unknowns')))
 
     for expected, actual in pairings:


### PR DESCRIPTION
Also fixed a small error in the recording tutorial.

Also, just once, one mpitest failed when testflo was run. Added check for MPI and SkipTest since it really shouldn't even run without MPI.