### PR TITLE
some cleanup of setup_variables.  Second call with compute_indices=Tr…

### DIFF
--- a/openmdao/components/indep_var_comp.py
+++ b/openmdao/components/indep_var_comp.py
@@ -46,20 +46,13 @@ class IndepVarComp(Component):
                              "`str` or an iterable of tuples of the form (name, value) or "
                              "(name, value, keyword_dict).")
 
-    def _setup_variables(self, compute_indices=False):
+    def _setup_variables(self):
         """
         Returns copies of our params and unknowns dictionaries,
         re-keyed to use absolute variable names.
 
-        Args
-        ----
-
-        compute_indices : bool, optional
-            If True, call setup_distrib() to set values of
-            'src_indices' metadata.
-
         """
-        pdict, udict = super(IndepVarComp, self)._setup_variables(compute_indices)
+        pdict, udict = super(IndepVarComp, self)._setup_variables()
 
         # mark our vars as belonging to an IndepVarComp so we can check later
         # for illegal setting of non-IndepVarComp variables.

--- a/openmdao/components/meta_model.py
+++ b/openmdao/components/meta_model.py
@@ -139,19 +139,13 @@ class MetaModel(Component):
         else:
             self._init_unknowns_dict[name]['default_surrogate'] = True
 
-    def _setup_variables(self, compute_indices=False):
+    def _setup_variables(self):
         """Returns our params and unknowns dictionaries,
         re-keyed to use absolute variable names.
 
         Also instantiates surrogates for the output variables
         that use the default surrogate.
 
-        Args
-        ----
-
-        compute_indices : bool, optional
-            If True, call setup_distrib() to set values of
-            'src_indices' metadata.
         """
         # create an instance of the default surrogate for outputs that
         # did not have a surrogate specified
@@ -164,7 +158,7 @@ class MetaModel(Component):
         # training will occur on first execution after setup
         self.train = True
 
-        return super(MetaModel, self)._setup_variables(compute_indices)
+        return super(MetaModel, self)._setup_variables()
 
     def check_setup(self, out_stream=sys.stdout):
         """Write a report to the given stream indicating any potential problems found

--- a/openmdao/components/subproblem.py
+++ b/openmdao/components/subproblem.py
@@ -165,17 +165,10 @@ class SubProblem(Component):
                                    "be overwritten by a connected output or it "
                                    "doesn't exist." % p)
 
-    def _setup_variables(self, compute_indices=False):
+    def _setup_variables(self):
         """
         Returns copies of our params and unknowns dictionaries,
         re-keyed to use absolute variable names.
-
-        Args
-        ----
-
-        compute_indices : bool, optional
-            If True, call setup_distrib() to set values of
-            'src_indices' metadata.
 
         """
         to_prom_name = self._sysdata.to_prom_name = {}

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -356,17 +356,10 @@ class Component(System):
         if include_self:
             yield self
 
-    def _setup_variables(self, compute_indices=False):
+    def _setup_variables(self):
         """
         Returns copies of our params and unknowns dictionaries,
         re-keyed to use absolute variable names.
-
-        Args
-        ----
-
-        compute_indices : bool, optional
-            If True, call setup_distrib() to set values of
-            'src_indices' metadata.
 
         """
         to_prom_name = self._sysdata.to_prom_name = {}
@@ -375,7 +368,7 @@ class Component(System):
         to_prom_uname = self._sysdata.to_prom_uname = OrderedDict()
         to_prom_pname = self._sysdata.to_prom_pname = OrderedDict()
 
-        if MPI and compute_indices and self.is_active():
+        if MPI and self.setup_distrib is not Component.setup_distrib and self.is_active():
             if hasattr(self, 'setup_distrib_idxs'):
                 warnings.simplefilter('always', DeprecationWarning)
                 warnings.warn("setup_distrib_idxs is deprecated, use setup_distrib instead.",

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -269,18 +269,12 @@ class Group(System):
         for sub in itervalues(self._subsystems):
             sub._init_sys_data(self.pathname, probdata)
 
-    def _setup_variables(self, compute_indices=False):
+    def _setup_variables(self):
         """
         Create dictionaries of metadata for parameters and for unknowns for
         this `Group` and stores them as attributes of the `Group`. The
         promoted name of subsystem variables with respect to this `Group`
         is included in the metadata.
-
-        Args
-        ----
-        compute_indices : bool, optional
-            If True, call setup_distrib() to set values of
-            'src_indices' metadata.
 
         Returns
         -------
@@ -303,7 +297,7 @@ class Group(System):
         to_prom_pname = self._sysdata.to_prom_pname = OrderedDict()
 
         for sub in itervalues(self._subsystems):
-            subparams, subunknowns = sub._setup_variables(compute_indices)
+            subparams, subunknowns = sub._setup_variables()
             for p, meta in iteritems(subparams):
                 prom = self._promoted_name(sub._sysdata.to_prom_pname[p], sub)
                 params_dict[p] = meta

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -460,9 +460,6 @@ class Problem(object):
         # _setup_variables and _setup_connections again
         tree_changed = False
 
-        # call _setup_variables again if we change metadata
-        meta_changed = False
-
         self._probdata = _ProbData()
 
         if isinstance(self.root.ln_solver, LinearGaussSeidel):
@@ -537,25 +534,12 @@ class Problem(object):
         #       If we modify the system tree here, we'll have to call
         #       the full setup over again...
 
-        if MPI:
-            for s in self.root.components(recurse=True):
-                # TODO: get rid of check for setup_distrib_idxs when we move to beta
-                if hasattr(s, 'setup_distrib_idxs') or (
-                         hasattr(s, 'setup_distrib') and (s.setup_distrib
-                                                is not Component.setup_distrib)):
-                    # component defines its own setup_distrib, so
-                    # the metadata will change
-                    meta_changed = True
-
         # All changes to the system tree or variable metadata
         # must be complete at this point.
 
         # if the system tree has changed, we have to redo the entire setup
         if tree_changed:
             return self.setup(check=check, out_stream=out_stream)
-        elif meta_changed:
-            params_dict, unknowns_dict = \
-                self.root._setup_variables(compute_indices=True)
 
         # perform additional checks on connections
         # (e.g. for compatible types and shapes)


### PR DESCRIPTION
…ue is no longer needed since we moved setup_communicators so that it runs before the first call to setup_variables.