### PR TITLE
fix unicode bug on python2

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -6,7 +6,7 @@ import sys
 import os
 import re
 from collections import Counter, OrderedDict
-from six import iteritems, itervalues
+from six import iteritems, itervalues, string_types
 from six.moves import zip_longest
 from itertools import chain
 from collections import Iterable
@@ -179,10 +179,10 @@ class Group(System):
             distributed source value to the target.
         """
 
-        if isinstance(targets, str):
+        if isinstance(targets, string_types):
             targets = (targets,)
 
-        if isinstance(src_indices, str):
+        if isinstance(src_indices, string_types):
             suggestion = list(targets)
             suggestion.append(src_indices)
             raise TypeError("src_indices must be an index array, did you mean"

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -9,7 +9,7 @@ import warnings
 import traceback
 from collections import OrderedDict
 from itertools import chain
-from six import iteritems, itervalues
+from six import iteritems, itervalues, string_types
 from six.moves import cStringIO
 
 import networkx as nx
@@ -1564,12 +1564,12 @@ class Problem(object):
         if return_format == 'dict':
             J = OrderedDict()
             for okeys in unknown_list:
-                if isinstance(okeys, str):
+                if isinstance(okeys, string_types):
                     okeys = (okeys,)
                 for okey in okeys:
                     J[okey] = OrderedDict()
                     for ikeys in indep_list:
-                        if isinstance(ikeys, str):
+                        if isinstance(ikeys, string_types):
                             ikeys = (ikeys,)
                         for ikey in ikeys:
 
@@ -1616,7 +1616,7 @@ class Problem(object):
 
         input_set = set()
         for inp in input_list:
-            if isinstance(inp, str):
+            if isinstance(inp, string_types):
                 input_set.add(inp)
             else:
                 input_set.update(inp)
@@ -1635,7 +1635,7 @@ class Problem(object):
         # IOI and OOI.
         flat_voi = [item for sublist in all_vois for item in sublist]
         for items in input_list:
-            if isinstance(items, str):
+            if isinstance(items, string_types):
                 items = (items,)
             for item in items:
                 if item not in flat_voi:

--- a/openmdao/core/test/test_driver_interface.py
+++ b/openmdao/core/test/test_driver_interface.py
@@ -415,6 +415,33 @@ class TestDriver(unittest.TestCase):
         assert_rel_error(self, top['p1.X'][0], 6.666667/1000.0, 1e-3)
         assert_rel_error(self, top['p1.X'][1], -7.333333/0.01, 1e-3)
 
+    def test_driver_unicode_variable(self):
+        # this tests that unicode design variables and objectives works in python 2.
+        prob = Problem(root=Group())
+        root = prob.root
+
+        # simple paraboloid example from tutorial
+        root.add('p1', IndepVarComp('x0', 3.0), promotes=['*'])
+        root.add('p2', IndepVarComp('y0', -4.0), promotes=['*'])
+        root.add('p', ExecComp('f_xy = (x0 - 3.0)**2 + x0 * y0 + (y0 + 4.0)**2 - 3.0'), promotes=['*'])
+
+        prob.driver = ScipyOptimizer()
+        prob.driver.options['optimizer'] = 'SLSQP'
+
+        prob.driver.add_desvar(u'x0', lower=-50, upper=50)
+        prob.driver.add_desvar(u'y0', lower=-50, upper=50)
+        prob.driver.add_objective(u'f_xy')
+        prob.driver.options['disp'] = False
+
+        prob.setup(check=False)
+
+        prob['x0'] = 3.0
+        prob['y0'] = -4.0
+
+        prob.run()
+
+        assert_rel_error(self, prob['f_xy'], -27.33333, 1e-3)
+
     def test_eq_ineq_error_messages(self):
 
         prob = Problem()


### PR DESCRIPTION
This pull request fixes a bug where if the user uses unicode strings in connect() function in Group or use unicode variable names in Driver in python2, then the program crashes because it fails to correctly identify them as strings.  Two simple test cases are also added to test against this bug.