### PR TITLE
adding automodule, autoclass, automethod examples to style guide

### DIFF
--- a/openmdao/docs/style_guide/doc_style_guide.rst
+++ b/openmdao/docs/style_guide/doc_style_guide.rst
@@ -135,6 +135,51 @@ Detailed docstring rules:
     """
 
 
+Embedding Autodocumentation Snippets into Documentation
+-------------------------------------------------------
+
+Sometimes in a Feature Doc, you want to highlight a particular method or class or module
+right there within the text.  The syntax to do this is provided by the `sphinx.ext.autodoc`
+module, in three commands, `automodule`, `autoclass`, and `automethod`.  The syntax of these
+is detailed in the following example code:
+
+::
+
+    **AUTOMODULE EXAMPLE:**
+
+      .. automodule:: openmdao.core.group
+        :noindex:
+
+    **AUTOCLASS EXAMPLE:**
+
+      .. autoclass:: openmdao.core.group.Group
+        :noindex:
+
+    **AUTOMETHOD EXAMPLE:**
+
+      .. automethod:: openmdao.core.group.Group.add
+        :noindex:
+
+
+The `:noindex:` argument is needed to prevent unwanted replication interactions with the OpenMDAO
+source documentation.  The above syntax will pull docstring info and produce the following output:
+
+**AUTOMODULE EXAMPLE:**
+
+  .. automodule:: openmdao.core.group
+    :noindex:
+
+**AUTOCLASS EXAMPLE:**
+
+  .. autoclass:: openmdao.core.group.Group
+    :noindex:
+
+**AUTOMETHOD EXAMPLE:**
+  .. automethod:: openmdao.core.group.Group.add
+    :noindex:
+
+
+
 
 Feature Docs and their Custom Directives for Including Code in Documentation
 ----------------------------------------------------------------------------


### PR DESCRIPTION
instead of `insert-autodoc` we will use the sphinx.ext.autodoc directives that already exist.  This addition gives example syntax for devs to use when creating their feature docs that may require autodoc embedding.