### PR TITLE
Fixing a couple of errors in the interleaving formatting

### DIFF
--- a/openmdao/docs/_exts/embed_test.py
+++ b/openmdao/docs/_exts/embed_test.py
@@ -29,7 +29,7 @@ def depart_skipped_or_failed_node(self, node):
         self.body.append("output only available for HTML\n")
         return
 
-    html = '<div class="output"><div class="prompt output_prompt">Out&nbsp;[{}]:<div class="{}"><pre>{}</pre></div>'.format(node["number"], node["kind"], cgiesc.escape(node["text"]))
+    html = '<div class="container"><div class="cell border-box-sizing code_cell rendered"><div class="output"><div class="prompt output_prompt">Out&nbsp;[{}]:</div><div class="inner_cell"><div class="{}"><pre>{}</pre></div></div></div></div></div>'.format(node["number"], node["kind"], node["text"])
     self.body.append(html)
 
 class in_or_out_node(nodes.Element):
@@ -43,9 +43,9 @@ def depart_in_or_out_node(self, node):
         self.body.append("output only available for HTML\n")
         return
     if node["kind"] == "In":
-        html = '<div class="container"><div class="cell border-box-sizing code_cell rendered"><div class="input"><div class="prompt input_prompt">{}&nbsp;[{}]:</div><div class="inner_cell"><div class="input_area"><div class=" highlight hl-ipython3"><pre>{}</pre></div></div></div></div></div></div>'.format(node["kind"], node["number"], node["text"])
+        html = '<div class="container"><div class="cell border-box-sizing code_cell rendered"><div class="input"><div class="prompt input_prompt">{}&nbsp;[{}]:</div><div class="inner_cell"><div class="input_area"><div class="highlight"><pre>{}</pre></div></div></div></div></div></div>'.format(node["kind"], node["number"], node["text"])
     elif node["kind"] == "Out":
-        html = '<div class="container"><div class="cell border-box-sizing code_cell rendered"><div class="output"><div class="prompt output_prompt">{}&nbsp;[{}]:</div><div class="inner_cell"><div class="output_area"><div class=" highlight hl-ipython3"><pre>{}</pre></div></div></div></div></div></div>'.format(node["kind"], node["number"], node["text"])
+        html = '<div class="container"><div class="cell border-box-sizing code_cell rendered"><div class="output"><div class="prompt output_prompt">{}&nbsp;[{}]:</div><div class="inner_cell"><div class="output_area"><div class="highlight"><pre>{}</pre></div></div></div></div></div></div>'.format(node["kind"], node["number"], node["text"])
 
     self.body.append(html)
 

--- a/openmdao/docs/_theme/static/style.css
+++ b/openmdao/docs/_theme/static/style.css
@@ -108,10 +108,12 @@ a code {
 
 div.skipped pre {
   background-color: rgba(213, 236, 22, 0.35);
+    border-radius: 2px;
 }
 
 div.failed pre {
   background-color: rgba(255, 0, 0, 0.35);
+    border-radius: 2px;
 }
 
 

--- a/openmdao/docs/_utils/docutil.py
+++ b/openmdao/docs/_utils/docutil.py
@@ -456,6 +456,25 @@ def insert_output_start_stop_indicators(src):
         input_block_number += 1
     return src_with_out_start_stop_indicators
 
+def clean_up_empty_output_blocks(input_blocks, output_blocks):
+    '''Some of the blocks do not generate output. We only want to have
+            input blocks that have outputs
+    '''
+
+    new_input_blocks = []
+    new_output_blocks = []
+    current_in_block = ''
+    for in_block, out_block in zip(input_blocks, output_blocks):
+        if current_in_block and not current_in_block.endswith('\n'):
+            current_in_block += '\n'
+        current_in_block += in_block
+        if out_block:
+            new_input_blocks.append(current_in_block)
+            new_output_blocks.append(out_block)
+            current_in_block = ''
+
+    return new_input_blocks, new_output_blocks
+
 def extract_output_blocks(run_output):
     '''
     '''
@@ -606,6 +625,10 @@ def get_unit_test_source_and_run_outputs_in_out(method_path):
         ### 6. Extract from run_outputs, the Out blocks -> output_blocks ###
         #####################
         output_blocks = extract_output_blocks(run_outputs)
+
+        # Need to deal with the cases when there is no outputblock for a given input block
+        # Merge an input block with the previous block and throw away the output block
+        input_blocks, output_blocks = clean_up_empty_output_blocks(input_blocks, output_blocks)
         skipped_failed_output = None
     else:
         input_blocks = output_blocks = None

--- a/openmdao/docs/features/building_components/indepvarcomp.rst
+++ b/openmdao/docs/features/building_components/indepvarcomp.rst
@@ -24,23 +24,23 @@ Usage
 
 1. Define one independent variable and set its value.
 
-  .. embed-test::
-      openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple
+.. embed-test::
+    openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple
 
 2. Define one independent variable with a default value.
 
-  .. embed-test::
-      openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple_default
+.. embed-test::
+    openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple_default
 
 3. Define one independent variable with a default value and additional options.
 
-  .. embed-test::
-      openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple_kwargs
+.. embed-test::
+    openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple_kwargs
 
 4. Define one independent array variable.
 
-  .. embed-test::
-      openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple_array
+.. embed-test::
+    openmdao.core.tests.test_indep_var_comp.TestIndepVarComp.test_simple_array
 
 5. Define two independent variables using the :code:`add_output` method with additional options.
 


### PR DESCRIPTION
There were two problems, now fixed:
1.) setup calls that made no output were leaving blank text blocks that would mess up the next line.
2.) skipped/failed test output wasn't formatted properly, was going to the next line and screwing up further formatting.