### PR TITLE
add desvar_meta and constraint_meta to recorder metadata

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -95,6 +95,7 @@ class Driver(object):
                 rootmeta = root.unknowns.metadata(name)
                 if newitem is desvars:
                     rootmeta['is_desvar'] = True
+                    rootmeta['desvar_meta'] = item[name]
                     if not rootmeta.get('_canset_', False):
                         raise RuntimeError("'%s' has been specified as a design "
                                            "variable but that var is a component "
@@ -104,6 +105,7 @@ class Driver(object):
                     rootmeta['is_objective'] = True
                 if newitem is cons:
                     rootmeta['is_constraint'] = True
+                    rootmeta['constraint_meta'] = item[name]
 
                 if MPI and 'src_indices' in rootmeta:
                     raise ValueError("'%s' is a distributed variable and may "


### PR DESCRIPTION
the current Unknowns metadata passed to recorders only contain the entry `is_desvar` or `is_constraint`, but doesn't allow the user to check whether the constraint is violated or not, since bounds are not recorded anywhere.

adding `desvar_meta` and `constraint_meta` with the dicts for each desvar/constraint now makes this possible.

The `is_desvar` or `is_constraint` are sort of obsolete but kept for backward compatibility.