### PR TITLE
Fixes for changes in scipy (mostly from fzahle)

### DIFF
--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -330,7 +330,7 @@ etc. To access the data from our run, we can use the following code:
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: [-27.33333333]
+                Current function value: -27.33333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -533,7 +533,7 @@ The name of the SQLite table containing the derivatives is called `metadata`.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: [-27.33333333]
+                Current function value: -27.33333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -737,7 +737,7 @@ then the derivatives are also recorded to the case recording file.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: [-27.33333333]
+                Current function value: -27.33333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -874,7 +874,7 @@ coordinate string descriptor, or as a standard python index.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: [-27.33333333]
+                Current function value: -27.33333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -86,7 +86,7 @@ by demonstrating how to save the data generated for future use. Consider the cod
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.33333333
+                Current function value: -27.3333333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -330,7 +330,7 @@ etc. To access the data from our run, we can use the following code:
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.33333333
+                Current function value: -27.3333333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -533,7 +533,7 @@ The name of the SQLite table containing the derivatives is called `metadata`.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.33333333
+                Current function value: -27.3333333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -737,7 +737,7 @@ then the derivatives are also recorded to the case recording file.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.33333333
+                Current function value: -27.3333333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -874,7 +874,7 @@ coordinate string descriptor, or as a standard python index.
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.33333333
+                Current function value: -27.3333333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -83,10 +83,10 @@ by demonstrating how to save the data generated for future use. Consider the cod
 
 .. testoutput:: recording_run
    :hide:
-   :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.3333333333
+                Current function value: ...-27.3333333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -327,10 +327,10 @@ etc. To access the data from our run, we can use the following code:
 
 .. testoutput:: reading
    :hide:
-   :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.3333333333
+                Current function value: ...-27.3333333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -530,10 +530,10 @@ The name of the SQLite table containing the derivatives is called `metadata`.
 
 .. testoutput:: reading_metadata
    :hide:
-   :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.3333333333
+                Current function value: ...-27.3333333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -734,10 +734,10 @@ then the derivatives are also recorded to the case recording file.
 
 .. testoutput:: reading_derivs
    :hide:
-   :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.3333333333
+                Current function value: ...-27.3333333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -871,10 +871,10 @@ coordinate string descriptor, or as a standard python index.
 
 .. testoutput:: casereader
    :hide:
-   :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
+   :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: -27.3333333333
+                Current function value: ...-27.3333333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -86,7 +86,7 @@ by demonstrating how to save the data generated for future use. Consider the cod
    :options: -ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: [-27.33333333]
+                Current function value: -27.33333333
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5

--- a/openmdao/docs/usr-guide/tutorials/recording.rst
+++ b/openmdao/docs/usr-guide/tutorials/recording.rst
@@ -86,7 +86,7 @@ by demonstrating how to save the data generated for future use. Consider the cod
    :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: ...-27.3333333333...
+                Current function value: ...-27.333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -330,7 +330,7 @@ etc. To access the data from our run, we can use the following code:
    :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: ...-27.3333333333...
+                Current function value: ...-27.333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -533,7 +533,7 @@ The name of the SQLite table containing the derivatives is called `metadata`.
    :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: ...-27.3333333333...
+                Current function value: ...-27.333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5
@@ -874,7 +874,7 @@ coordinate string descriptor, or as a standard python index.
    :options: +ELLIPSIS, +NORMALIZE_WHITESPACE
 
     Optimization terminated successfully.    (Exit mode 0)
-                Current function value: ...-27.3333333333...
+                Current function value: ...-27.333333...
                 Iterations: 5
                 Function evaluations: 6
                 Gradient evaluations: 5

--- a/openmdao/drivers/test/test_scipy_optimizer.py
+++ b/openmdao/drivers/test/test_scipy_optimizer.py
@@ -281,7 +281,7 @@ class TestScipyOptimize(unittest.TestCase):
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.add_desvar('x', lower=-50.0, upper=50.0, scaler=np.array([1.0, 1.0]))
 
-        prob.driver.add_objective('o', scaler=np.array([1.0, 1.0]))
+        prob.driver.add_objective('o', scaler=1.0)
         prob.driver.add_constraint('c', equals=0.0, scaler=np.array([1.0, 1.0]))
         prob.driver.options['disp'] = False
 
@@ -306,7 +306,7 @@ class TestScipyOptimize(unittest.TestCase):
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.add_desvar('x', lower=-50.0, upper=50.0, scaler=np.array([1.0, 1.0]))
 
-        prob.driver.add_objective('o', scaler=np.array([1.0, 1.0]))
+        prob.driver.add_objective('o', scaler=1.0)
         prob.driver.add_constraint('c1', lower=0.0, scaler=np.array([1.0, 1.0]))
         prob.driver.add_constraint('c2', upper=0.0, scaler=np.array([1.0, 1.0]))
         prob.driver.options['disp'] = False


### PR DESCRIPTION
1. A change in scipy uncovered an error in a couple of our scipy optimizer tests (where we gave a scaler/adder that was too wide).
2. Fixed some doctest output to accomodate changes in the scipy optimizer's output printing in scipy 0.19.