### PR TITLE
Move ParaboloidMatVec out of paraboloid.py

### DIFF
--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -10,7 +10,7 @@ from openmdao.api import Group, ExplicitComponent, IndepVarComp, Problem, NLRunO
                          ImplicitComponent
 from openmdao.devtools.testutil import assert_rel_error
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayMatVec
-from openmdao.test_suite.components.paraboloid import ParaboloidMatVec
+from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
 
 class TestProblemCheckPartials(unittest.TestCase):

--- a/openmdao/test_suite/components/paraboloid.py
+++ b/openmdao/test_suite/components/paraboloid.py
@@ -38,32 +38,6 @@ class Paraboloid(ExplicitComponent):
         partials['f_xy', 'y'] = 2.0*y + 8.0 + x
 
 
-class ParaboloidMatVec(Paraboloid):
-    """ Use matrix-vector product instead."""
-
-    def compute_partials(self, inputs, outputs, partials):
-        """Analytical derivatives."""
-        pass
-
-    def compute_jacvec_product(self, inputs, outputs, dinputs, dresids, mode):
-        """Returns the product of the incoming vector with the Jacobian."""
-
-        x = inputs['x']
-        y = inputs['y']
-
-        if mode == 'fwd':
-            if 'x' in dinputs:
-                dresids['f_xy'] += (2.0*x - 6.0 + y)*dinputs['x']
-            if 'y' in dinputs:
-                dresids['f_xy'] += (2.0*y + 8.0 + x)*dinputs['y']
-
-        elif mode == 'rev':
-            if 'x' in dinputs:
-                dinputs['x'] += (2.0*x - 6.0 + y)*dresids['f_xy']
-            if 'y' in dinputs:
-                dinputs['y'] += (2.0*y + 8.0 + x)*dresids['f_xy']
-
-
 if __name__ == "__main__":
     from openmdao.core.problem import Problem
     from openmdao.core.group import Group

--- a/openmdao/test_suite/components/paraboloid_mat_vec.py
+++ b/openmdao/test_suite/components/paraboloid_mat_vec.py
@@ -1,0 +1,27 @@
+from openmdao.test_suite.components.paraboloid import Paraboloid
+
+
+class ParaboloidMatVec(Paraboloid):
+    """ Use matrix-vector product."""
+
+    def compute_partials(self, inputs, outputs, partials):
+        """Analytical derivatives."""
+        pass
+
+    def compute_jacvec_product(self, inputs, outputs, dinputs, dresids, mode):
+        """Returns the product of the incoming vector with the Jacobian."""
+
+        x = inputs['x']
+        y = inputs['y']
+
+        if mode == 'fwd':
+            if 'x' in dinputs:
+                dresids['f_xy'] += (2.0*x - 6.0 + y)*dinputs['x']
+            if 'y' in dinputs:
+                dresids['f_xy'] += (2.0*y + 8.0 + x)*dinputs['y']
+
+        elif mode == 'rev':
+            if 'x' in dinputs:
+                dinputs['x'] += (2.0*x - 6.0 + y)*dresids['f_xy']
+            if 'y' in dinputs:
+                dinputs['y'] += (2.0*y + 8.0 + x)*dresids['f_xy']


### PR DESCRIPTION
Move ParaboloidMatVec into its own file because it isn't used in the first tutorial. Can reference in later tutorials instead