### PR TITLE
in docs embedded code/tests, the logger is causing the message for setup() to be displayed out of order

### DIFF
--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -1,5 +1,6 @@
 """A module containing various configuration checks for an OpenMDAO Problem."""
 
+import sys
 import logging
 
 import numpy as np
@@ -34,7 +35,7 @@ def check_config(problem, logger=None):
         if _set_logger is None:
             logger = logging.getLogger("config_check")
             _set_logger = logger
-            console = logging.StreamHandler()
+            console = logging.StreamHandler(sys.stdout)
             # set a format which is simpler for console use
             formatter = logging.Formatter('%(levelname)s: %(message)s')
             # tell the handler to use this format


### PR DESCRIPTION
Pivotal #141622363

The docs capture output via `subprocess.check_output` and expect that output to be synchronized as a single stream.

In the event of multiple output streams, `check_output` seems to just concatenate them, so they are not synchronized.

Changing the default logger for `check_config` to write to stdout ensures that the output is inline for the docs.