### PR TITLE
Some small tweaks based on openmdao training class.

### DIFF
--- a/openmdao/docs/_exts/embed_options.py
+++ b/openmdao/docs/_exts/embed_options.py
@@ -43,7 +43,7 @@ class EmbedOptionsDirective(Directive):
         options = getattr(obj, attribute_name)
 
         outputs = []
-        for option_name, option_data in iteritems(options._dict):
+        for option_name, option_data in sorted(iteritems(options._dict)):
             name = option_name
             default = option_data['value']
             values = option_data['values']

--- a/openmdao/docs/basic_guide/first_mdao.rst
+++ b/openmdao/docs/basic_guide/first_mdao.rst
@@ -9,7 +9,7 @@ Here is the mathematical problem formulation for the Sellar optimziation problem
 .. math::
 
     \begin{align}
-    \text{min}: & \ \ \ & x_1^2 + z_2 + y_1 + e^-{y_2} \\
+    \text{min}: & \ \ \ & x_1^2 + z_2 + y_1 + e^{-y_2} \\
     \text{w.r.t.}: & \ \ \ &  x_1, z_1, z_2 \\
     \text{subject to}: & \ \ \ & \\
     & \ \ \ & 3.16 - y_1 <=0 \\

--- a/openmdao/docs/getting_started/index.rst
+++ b/openmdao/docs/getting_started/index.rst
@@ -27,4 +27,5 @@ Copy the code into a file named `hello_world.py` and run it by typing:
 
 .. embed-test::
     openmdao.test_suite.test_examples.tldr_paraboloid.TestParaboloidTLDR.test_tldr
+    :no-split:
 

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -241,6 +241,39 @@ class TestScipyOptimizer(unittest.TestCase):
         assert_rel_error(self, prob['x'], 7.16667, 1e-4)
         assert_rel_error(self, prob['y'], -7.833334, 1e-4)
 
+    def test_unsupported_equality(self):
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = ScipyOptimizer()
+        prob.driver.options['optimizer'] = 'COBYLA'
+        prob.driver.options['tol'] = 1e-9
+        prob.driver.options['disp'] = False
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_objective('f_xy')
+        model.add_constraint('c', equals=-15.0)
+
+        prob.setup(check=False)
+
+        with self.assertRaises(Exception) as raises_cm:
+            prob.run_driver()
+
+        exception = raises_cm.exception
+
+        msg = "Constraints of type 'eq' not handled by COBYLA."
+
+        self.assertEqual(exception.args[0], msg)
+
     def test_simple_paraboloid_double_sided_low(self):
 
         prob = Problem()


### PR DESCRIPTION
1. Make TLDR tutorial no-split.
2. Options were printing in hash order. Made it alphabetical for sensibility.
3. Fixed error in latex formula for Sellar.
4. Verified (with test) that we raise an error if you try to use Cobyla with an equality constraint.