### PR TITLE
Fix the pyoptsparse installation; Change from py3.4 to py3.6; change numpy version to 1.12.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ install:
 
 - if [ "$PY" = "3.4" ]; then
     wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
-    tar -xvf 99af3264429b9.zip;
+    unzip 99af3264429b9.zip;
     cd 99af3264429b9;
     python setup.py install;
     cd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
 - PY=3.6 MPI=1
 - PY=2.7 MPI=
 - PY=3.6 MPI=
-#- PY=3.6 MPI=
 
 addons:
   apt:
@@ -70,7 +69,7 @@ install:
 # keeping numpy pinned at 1.12 because snopt dies with 1.13 because numpy broke callback
 - conda install --yes python=$PY numpy==1.12 scipy nose sphinx mock swig
 
-#trying a manual install of pyoptsparse
+# trying a manual install of pyoptsparse
 - if [ "$PY" = "2.7" ]; then
     pip install mercurial;
     hg clone https://bitbucket.org/mdolab/pyoptsparse;
@@ -79,8 +78,8 @@ install:
     cd ..;
   fi
 
+# if tip breaks, we once worked on commit 9af3264429b9
 - if [ "$PY" = "3.6" ]; then
-    #if tip breaks, we once worked on commit 9af3264429b9
     wget https://bitbucket.org/mdolab/pyoptsparse/get/tip.zip;
     unzip tip.zip;
     cd mdolab-pyoptsparse-tip;

--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
 #trying a manual install of pyoptsparse
 - pip install mercurial
 - hg clone https://bitbucket.org/mdolab/pyoptsparse
-- cd pyoptspare
+- cd pyoptsparse
 - python setup.py install
 - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,7 +92,7 @@ install:
     cd ..;
   fi
 
-- if [ "$PY" = "3.4" or "$PY" = "3.6"]; then
+- if [ "$PY" = "3.4" ]; then
     wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
     tar -xvf 99af3264429b9.zip;
     cd 99af3264429b9;

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,7 +80,7 @@ install:
 
 - if [ "$PY" = "3.6" ]; then
     wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
-    unzip tip.9af3264429b9;
+    unzip 9af3264429b9.zip;
     cd mdolab-pyoptsparse-9af3264429b9;
     python setup.py install;
     cd ..;

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,21 +66,28 @@ before_install:
 
 install:
 - conda install --yes python=$PY numpy==1.11.2 scipy nose sphinx mock swig
-- if [ "$OS" = "Linux" ]; then
-    if [ "$PY" = "2.7" ]; then
-      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp27-none-linux_x86_64.whl;
-    elif [ "$PY" = "3.4" ]; then
-      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-py3-none-linux_x86_64.whl;
-    fi
-  fi
+#- if [ "$OS" = "Linux" ]; then
+#    if [ "$PY" = "2.7" ]; then
+#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp27-none-linux_x86_64.whl;
+#    elif [ "$PY" = "3.4" ]; then
+#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-py3-none-linux_x86_64.whl;
+#    fi
+#  fi
+#
+#- if [ "$OS" = "MacOSX" ]; then
+#    if [ "$PY" = "2.7" ]; then
+#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-py2-none-macosx_10_5_x86_64.whl;
+#    elif [ "$PY" = "3.4" ]; then
+#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp34-none-macosx_10_5_x86_64.whl;
+#    fi
+#  fi
 
-- if [ "$OS" = "MacOSX" ]; then
-    if [ "$PY" = "2.7" ]; then
-      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-py2-none-macosx_10_5_x86_64.whl;
-    elif [ "$PY" = "3.4" ]; then
-      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp34-none-macosx_10_5_x86_64.whl;
-    fi
-  fi
+#trying a manual install of pyoptsparse
+- pip install mercurial
+- hg clone https://bitbucket.org/mdolab/pyoptsparse
+- cd pyoptspare
+- python setup.py install
+- cd ..
 
 - if [ "$MPI" ]; then
     pip install mpi4py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,11 +83,22 @@ install:
 #  fi
 
 #trying a manual install of pyoptsparse
-- pip install mercurial
-- hg clone https://bitbucket.org/mdolab/pyoptsparse
-- cd pyoptsparse
-- python setup.py install
-- cd ..
+if [ "$PY" = "2.7" ]; then
+  pip install --upgrade pip;
+  pip install mercurial;
+  hg clone https://bitbucket.org/mdolab/pyoptsparse;
+  cd pyoptsparse;
+  python setup.py install;
+  cd ..;
+fi
+
+if [ "$PY" = "3.4" or "$PY" = "3.6"]; then
+  wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
+  tar -xvf 99af3264429b9.zip;
+  cd 99af3264429b9.zip;
+  python setup.py install;
+  cd ..;
+fi
 
 - if [ "$MPI" ]; then
     pip install mpi4py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,11 +78,10 @@ install:
     cd ..;
   fi
 
-# if tip breaks, we once worked on commit 9af3264429b9
 - if [ "$PY" = "3.6" ]; then
-    wget https://bitbucket.org/mdolab/pyoptsparse/get/tip.zip;
-    unzip tip.zip;
-    cd mdolab-pyoptsparse-tip;
+    wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
+    unzip tip.9af3264429b9;
+    cd mdolab-pyoptsparse-9af3264429b9;
     python setup.py install;
     cd ..;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -94,8 +94,8 @@ install:
 
 - if [ "$PY" = "3.4" ]; then
     wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
-    unzip 99af3264429b9.zip;
-    cd 99af3264429b9;
+    unzip 9af3264429b9.zip;
+    cd 9af3264429b9;
     python setup.py install;
     cd ..;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
     cd ..;
   fi
 
-- if [ "$PY" = "3.4" ]; then
+- if [ "$PY" = "3.6" ]; then
     wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
     unzip 9af3264429b9.zip;
     cd mdolab-pyoptsparse-9af3264429b9;

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ language: generic
 
 env:
 - PY=2.7 MPI=1
-- PY=3.4 MPI=1
+- PY=3.6 MPI=1
 - PY=2.7 MPI=
-- PY=3.4 MPI=
 - PY=3.6 MPI=
+#- PY=3.6 MPI=
 
 addons:
   apt:
@@ -34,6 +34,8 @@ notifications:
     secure: Dd+tpZkz48Q47Y+PtdL4b+KAs55PsvWjt9ybhip6xljhA5kVsba9oZS+KsAC8RLWSzVJLOSjz3Cu3MsRym4sTd/g4Pbqyh0ldK2Xnl+n2JOgpPFSXtFuH4Ln3uWB6kYtUK6+aGIC8qhbvEt8tukTBT0RduEmdRyVIZ3oN7YjETPSZXvujeiUFLssfpZW2mqoA/tIgJHFSlySAp6J5694t2Z/p8sHOrK8G/Nm+qlk4xqXHvJ3xablcSBG4BZCrpqmMMdTLXBt2E2K9Rc1P2ZBIrSHVWfSLx+4n79U2385+og7miN1Zuf3gY3YuGKIwnBTtEzTu20905idkr4QdKELCBEcU4azdznwjvUkXWkiFAJII9UELTluSQmZX602zWk4AgJNeHxhN3EbBSMezfYVZjprhlAlwnZZv6t4qAkvuzb7KOA4s679xWzWOBOn1wkynfIF8A66APqssveyz/PvZHSjnHQoLgMU+kwzoX759o0Z/HuRlhCcjv0W9DWxU2bFNi/zVh9YyvR8fG15biGthzOyuf+CHjxohw+J6M+YdR1RIf1g/60nGUPHx4j4SN3kEFPmEDxzZT/f349gvaZGOmKXBi0wH8iY/i9RinM9LJB4t6chj2MkKwUA26bYaVaIO6FYPfE7r+tTG6OXdck4voCs/s4aa9VKEX97yhh0i9g=
 
 before_install:
+- pip install --upgrade pip;
+
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     openssl aes-256-cbc -K $encrypted_74d70a284b7d_key -iv $encrypted_74d70a284b7d_iv -in travis_deploy_rsa.enc -out /tmp/travis_deploy_rsa -d;
   fi
@@ -65,26 +67,11 @@ before_install:
   fi
 
 install:
-- conda install --yes python=$PY numpy==1.11.2 scipy nose sphinx mock swig
-#- if [ "$OS" = "Linux" ]; then
-#    if [ "$PY" = "2.7" ]; then
-#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp27-none-linux_x86_64.whl;
-#    elif [ "$PY" = "3.4" ]; then
-#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-py3-none-linux_x86_64.whl;
-#    fi
-#  fi
-#
-#- if [ "$OS" = "MacOSX" ]; then
-#    if [ "$PY" = "2.7" ]; then
-#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-py2-none-macosx_10_5_x86_64.whl;
-#    elif [ "$PY" = "3.4" ]; then
-#      pip install https://openmdao.org/dists/pyoptsparse-1.0.0-cp34-none-macosx_10_5_x86_64.whl;
-#    fi
-#  fi
+#- conda install --yes python=$PY numpy==1.11.2 scipy nose sphinx mock swig
+- conda install --yes python=$PY numpy==1.12 scipy nose sphinx mock swig
 
 #trying a manual install of pyoptsparse
 - if [ "$PY" = "2.7" ]; then
-    pip install --upgrade pip;
     pip install mercurial;
     hg clone https://bitbucket.org/mdolab/pyoptsparse;
     cd pyoptsparse;

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,22 +83,22 @@ install:
 #  fi
 
 #trying a manual install of pyoptsparse
-if [ "$PY" = "2.7" ]; then
-  pip install --upgrade pip;
-  pip install mercurial;
-  hg clone https://bitbucket.org/mdolab/pyoptsparse;
-  cd pyoptsparse;
-  python setup.py install;
-  cd ..;
-fi
+- if [ "$PY" = "2.7" ]; then
+    pip install --upgrade pip;
+    pip install mercurial;
+    hg clone https://bitbucket.org/mdolab/pyoptsparse;
+    cd pyoptsparse;
+    python setup.py install;
+    cd ..;
+  fi
 
-if [ "$PY" = "3.4" or "$PY" = "3.6"]; then
-  wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
-  tar -xvf 99af3264429b9.zip;
-  cd 99af3264429b9.zip;
-  python setup.py install;
-  cd ..;
-fi
+- if [ "$PY" = "3.4" or "$PY" = "3.6"]; then
+    wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
+    tar -xvf 99af3264429b9.zip;
+    cd 99af3264429b9;
+    python setup.py install;
+    cd ..;
+  fi
 
 - if [ "$MPI" ]; then
     pip install mpi4py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,25 +66,15 @@ before_install:
   fi
 
 install:
-# keeping numpy pinned at 1.12 because snopt dies with 1.13 because numpy broke callback
+# keeping numpy pinned at 1.12 because pySNOPT dies with 1.13 because numpy broke callback
 - conda install --yes python=$PY numpy==1.12 scipy nose sphinx mock swig
 
 # trying a manual install of pyoptsparse
-- if [ "$PY" = "2.7" ]; then
-    pip install mercurial;
-    hg clone https://bitbucket.org/mdolab/pyoptsparse;
-    cd pyoptsparse;
-    python setup.py install;
-    cd ..;
-  fi
-
-- if [ "$PY" = "3.6" ]; then
-    wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
-    unzip 9af3264429b9.zip;
-    cd mdolab-pyoptsparse-9af3264429b9;
-    python setup.py install;
-    cd ..;
-  fi
+- wget https://bitbucket.org/mdolab/pyoptsparse/get/tip.zip;
+- unzip tip.zip;
+- cd mdolab-pyoptsparse*;
+- python setup.py install;
+- cd ..;
 
 - if [ "$MPI" ]; then
     pip install mpi4py;

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ before_install:
   fi
 
 install:
-#- conda install --yes python=$PY numpy==1.11.2 scipy nose sphinx mock swig
+# keeping numpy pinned at 1.12 because snopt dies with 1.13 because numpy broke callback
 - conda install --yes python=$PY numpy==1.12 scipy nose sphinx mock swig
 
 #trying a manual install of pyoptsparse
@@ -80,9 +80,10 @@ install:
   fi
 
 - if [ "$PY" = "3.6" ]; then
-    wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
-    unzip 9af3264429b9.zip;
-    cd mdolab-pyoptsparse-9af3264429b9;
+    #if tip breaks, we once worked on commit 9af3264429b9
+    wget https://bitbucket.org/mdolab/pyoptsparse/get/tip.zip;
+    unzip tip.zip;
+    cd mdolab-pyoptsparse-tip;
     python setup.py install;
     cd ..;
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,7 @@ install:
 - if [ "$PY" = "3.4" ]; then
     wget https://bitbucket.org/mdolab/pyoptsparse/get/9af3264429b9.zip;
     unzip 9af3264429b9.zip;
-    cd 9af3264429b9;
+    cd mdolab-pyoptsparse-9af3264429b9;
     python setup.py install;
     cd ..;
   fi

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -987,7 +987,7 @@ class TestPyoptSparse(unittest.TestCase):
         if OPTIMIZER == 'SNOPT':
             prob.driver.opt_settings['Verify level'] = 3
         elif OPTIMIZER == 'SLSQP':
-            prob.driver.opt_settings['ACC'] = 1e-9
+            prob.driver.opt_settings['ACC'] = 1e-3
         prob.driver.options['print_results'] = False
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
@@ -1001,7 +1001,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
         assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 1e-3)
+        assert_rel_error(self, prob['x'], 0.0, 4e-3)
 
     def test_sellar_analysis_error(self):
         # One discipline of Sellar will something raise analysis error. This is to test that

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -987,7 +987,7 @@ class TestPyoptSparse(unittest.TestCase):
         if OPTIMIZER == 'SNOPT':
             prob.driver.opt_settings['Verify level'] = 3
         elif OPTIMIZER == 'SLSQP':
-            self.prob.driver.opt_settings['ACC'] = 1e-9
+            prob.driver.opt_settings['ACC'] = 1e-9
         prob.driver.options['print_results'] = False
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))


### PR DESCRIPTION
Here's a solution  where we grab the pyoptsparse code straight from bitbucket, build it, and it works. It will now work the same for Linux and MacOS (if we ever bring that testing back online), so was able to get rid of the calls for Mac pyoptsparse wheels.

It works on python3.6 and python 2.7; py3.4 machines were eliminated from the build matrix.

Numpy was moved up from 1.11.2 to 1.12 and pinned there, with comments made to remind us WHY we pinned it there.

Once pyoptsparse was actually installed, a pyoptsparse test failed.  So, I also include a couple of @Kenneth-T-Moore-approved changes to the test openmdao/drivers/tests/test_pyoptsparse_driver.py.

Also, skipped tests on this PR drop from 94 to 42, and Coverage rises from 90% to 92% with the installation of pyoptsparse.
