### PR TITLE
Tags bug fix; two very minor other tweaks found while investigating it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,9 +96,9 @@ script:
 - testflo -n 1 openmdao  --coverage  --coverpkg openmdao --cover-omit \*tests/\*  --cover-omit \*devtools/\* --cover-omit \*test_suite/\* --cover-omit \*docs/\*
 
 after_success:
-- coveralls -v --rcfile=../../.coveragerc --output=coveralls.json
+- coveralls --rcfile=../../.coveragerc --output=coveralls.json
 - sed 's/\/home\/travis\/miniconda\/lib\/python'"$PY"'\/site-packages\///g' < coveralls.json > coveralls-upd.json
-- coveralls -v --upload=coveralls-upd.json
+- coveralls --upload=coveralls-upd.json
 
 before_deploy:
 - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/openmdao/docs/_utils/preprocess_tags.py
+++ b/openmdao/docs/_utils/preprocess_tags.py
@@ -89,7 +89,8 @@ Tags in OpenMDAO
 
 def tag():
     # Set the directories in which to find tags
-    docdirs = ['examples', 'getting_started', 'features', 'style_guide', 'theory_manual', 'user_guide']
+    # Let's make tags for dirs in this dr that don't start with an underscore.
+    docdirs = [x for x in os.listdir('.') if os.path.isdir(x) and not x.startswith('_')]
     tagdir = make_tagdir()
     make_tagfiles(docdirs, tagdir)
     make_tagindex(tagdir)

--- a/openmdao/docs/feature_reference/building_blocks/components/external_code.rst
+++ b/openmdao/docs/feature_reference/building_blocks/components/external_code.rst
@@ -37,9 +37,8 @@ for simplicity, this example only uses one of each.
   and could be turned directly an OpenMDAO `Component`. Just keep in mind that any external code will
   work here, not just python scripts!
 
-Here is the script for this external code. It simply reads its inputs, `x` and `y`, from an external file,
-does the same computation as the :ref:`Paraboloid Tutorial <paraboloid_tutorial>` and writes the output,
-`f_xy`, to an output file.
+Here is the script for this external code. It simply reads its inputs, `x` and `y`, from an external file, calculates
+f_xy from the equation for a paraboloid, and writes the output, `f_xy`, to an output file.
 
 
 .. embed-code::


### PR DESCRIPTION
*fixing tags problem: the crux was when JG did a big docs overhaul/rename a little while back, I was looking for specific dirs in which to find tags.  Those names changed, so tags stopped working.  A more robust approach, and the original intent anyway, is to preprocess files in /docs dirs that do not start with an underscore.

*removing two forgotten `-v` debug flags from coveralls: accidentally left in code from last week's coveralls fixes, but now make travis logs WAY too long.

*fixing a docbuild warning--a leftover old reference from clippy docs was causing a warning, Ken looked at it and excised old ref