### PR TITLE
Fix for tag linking problem...

### DIFF
--- a/openmdao/docs/_exts/tags.py
+++ b/openmdao/docs/_exts/tags.py
@@ -57,7 +57,6 @@ class TagDirective(Directive):
         for tagg in taggs:
             # Create Sphinx doc refs of format :ref:`Tagname<Tagname>`
             link = ":ref:`" + tagg + "<" + tagg + ">`"
-            #link = "`" + tagg + " <http://openmdao.org/twodocs/versions/latest/tags/" + tagg + ".html>`_"
             links.append(link)
         # Put links back in a single comma-separated string together
         linkjoin = ", ".join(links)

--- a/openmdao/docs/_exts/tags.py
+++ b/openmdao/docs/_exts/tags.py
@@ -55,11 +55,9 @@ class TagDirective(Directive):
         links = []
 
         for tagg in taggs:
-            # Create rst hyperlinks of format `Python <http://www.python.org/>`_.
-            import os
-            cwd = os.getcwd()
-            html_dir = os.path.join(cwd, "_build", "html")
-            link = "`" + tagg + " <" + html_dir + os.sep + "tags" + os.sep + tagg + ".html>`_ "
+            # Create Sphinx doc refs of format :ref:`Tagname<Tagname>`
+            link = ":ref:`" + tagg + "<" + tagg + ">`"
+            #link = "`" + tagg + " <http://openmdao.org/twodocs/versions/latest/tags/" + tagg + ".html>`_"
             links.append(link)
         # Put links back in a single comma-separated string together
         linkjoin = ", ".join(links)

--- a/openmdao/docs/_utils/preprocess_tags.py
+++ b/openmdao/docs/_utils/preprocess_tags.py
@@ -52,6 +52,7 @@ def make_tagfiles(docdirs, tagdir):
 
                         # If the tagfile doesn't exist, let's put in a header
                         if not os.path.exists(filepath):
+                            tagfilelabel = ".. _" + tag + ": \n"
                             tagfileheader = """
 =========================
 %s
@@ -59,8 +60,10 @@ def make_tagfiles(docdirs, tagdir):
   .. toctree::
 """ % tag
 
+
                             # Write the header for this tag's file.
                             with open(filepath, 'a') as tagfile:
+                                tagfile.write(tagfilelabel)
                                 tagfile.write(tagfileheader)
                         # Write a link into an existing tagfile.
                         with open(filepath, 'a') as tagfile:
@@ -71,9 +74,8 @@ def make_tagindex(tagdir):
     # Once all the files exist, create a simple index.rst file
     indexfile = tagdir + "/index.rst"
 
-    for filepath, dirnames, filenames in os.walk(tagdir):
-        with open(indexfile, 'a') as index:
-            index.write("""
+    with open(indexfile, 'a') as index:
+        index.write("""
 :orphan:
 
 ================

--- a/openmdao/docs/examples/index.rst
+++ b/openmdao/docs/examples/index.rst
@@ -1,4 +1,4 @@
-.. _Examples:
+.. _OpenMDAO_Examples:
 
 ********
 Examples

--- a/openmdao/docs/feature_reference/core_features/working_with_derivatives/specifying_partials.rst
+++ b/openmdao/docs/feature_reference/core_features/working_with_derivatives/specifying_partials.rst
@@ -43,5 +43,4 @@ Here are several examples of how you can specify derivative values for different
     openmdao.jacobians.tests.test_jacobian_features.SimpleCompConst
 
 
-.. tags:: Partial Derivatives
-
+.. tags:: PartialDerivatives


### PR DESCRIPTION
When I fixed the tagging bug last week, I failed to notice that while the tag links worked fine locally, the links were dependent on the file system where they were built.  This meant that the link for the tags docs that were built on the Travis CI machines were not correct when served on WebFaction. After trying a couple things to get relative paths working, I realized the timing was such in the preprocessing that I could insert Sphinx RST doc references in, and have those get turned into appropriately pathed links when built and transferred from anywhere.

This PR:
1. Adds in a doc ref at the top of every `tags/tagname.rst` file, (e.g. `.. _BalanceComp:`) 
2. Refers to that ref when the `.. tags:: ` directive is being parsed, so that the tag will link to the proper doc.
3. Changed a doc ref "Examples" that already existed in the docs to "OpenMDAO_Examples", and let the tag "Examples" have that doc label name.
4. Fixed a couple other specific warnings that popped up.

For what it's worth, I built the docs locally, and then pushed them to WF to test that it would work when built here and served there, and it does (I left those docs up in latest, since the tag links worked.)  Technically have not had them build on Travis and move to WF yet, but it should work similarly.
