### PR TITLE
API Change:  BalanceComp now has a "use_mult" argument

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -32,8 +32,8 @@ class BalanceComp(ImplicitComponent):
         Where :math:`f_{lhs}` represents the left-hand-side of the equation,
         :math:`f_{rhs}` represents the right-hand-side, and :math:`f_{mult}`
         is an optional multiplier on the left hand side.  At least one of these
-        quantities should be a function of the associated state variable.  If left
-        unconnected the multiplier is simply 1.0.
+        quantities should be a function of the associated state variable.  If
+        use_mult is True the default value of the multiplier is 1.
 
         New state variables, and their associated residuals are created by
         calling `add_balance`.  As an example, solving the equation
@@ -68,7 +68,7 @@ class BalanceComp(ImplicitComponent):
             prob.run_model()
 
         The arguments to add_balance can be provided on initialization to provide a balance
-        with a one state/residual without the need to call `add_output`:
+        with a one state/residual without the need to call `add_balance`:
 
         ::
             prob = Problem(model=Group())

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -16,7 +16,8 @@ class BalanceComp(ImplicitComponent):
     """
 
     def __init__(self, name=None, eq_units=None, lhs_name=None,
-                 rhs_name=None, rhs_val=0.0, mult_name=None, mult_val=1.0, **kwargs):
+                 rhs_name=None, rhs_val=0.0, guess_func=None,
+                 use_mult=False, mult_name=None, mult_val=1.0, **kwargs):
         r"""
         Initialize a BalanceComp, optionally creating a new implicit state variable.
 
@@ -111,6 +112,13 @@ class BalanceComp(ImplicitComponent):
         rhs_val : int, float, or np.array
             Default value for the RHS of the given state.  Must be compatible
             with the shape (optionally) given by the val option in kwargs.
+        guess_func : callable or None
+            A callable function in the form f(inputs, resids) that returns an initial "guess" value
+            of the state variable based on the inputs to the BalanceComp.  Note you may have to
+            add additional inputs to the BalanceComp in order to evaluate this function.
+        use_mult : bool
+            Specifies whether the LHS multiplier is to be used.  If True, adds the input specified
+            by mult_name with the default value given by mult_val.  Default is False.
         mult_name : str or None
             Optional name for the LHS multiplier variable associated with the implicit state
             variable. If None, the default will be used: 'mult:{name}'.
@@ -123,8 +131,8 @@ class BalanceComp(ImplicitComponent):
         super(BalanceComp, self).__init__()
         self._state_vars = {}
         if name is not None:
-            self.add_balance(name, eq_units, lhs_name, rhs_name, rhs_val,
-                             mult_name, mult_val, **kwargs)
+            self.add_balance(name, eq_units, lhs_name, rhs_name, rhs_val, guess_func,
+                             use_mult, mult_name, mult_val, **kwargs)
 
     def setup(self):
         """
@@ -155,9 +163,10 @@ class BalanceComp(ImplicitComponent):
                            val=options['rhs_val'] * np.ones(n),
                            units=options['eq_units'])
 
-            self.add_input(options['mult_name'],
-                           val=options['mult_val'] * np.ones(n),
-                           units=None)
+            if options['use_mult']:
+                self.add_input(options['mult_name'],
+                               val=options['mult_val'] * np.ones(n),
+                               units=None)
 
             self._scale_factor = np.ones(n)
             self._dscale_drhs = np.ones(n)
@@ -165,7 +174,9 @@ class BalanceComp(ImplicitComponent):
             ar = np.arange(n)
             self.declare_partials(of=name, wrt=options['lhs_name'], rows=ar, cols=ar, val=1.0)
             self.declare_partials(of=name, wrt=options['rhs_name'], rows=ar, cols=ar, val=1.0)
-            self.declare_partials(of=name, wrt=options['mult_name'], rows=ar, cols=ar, val=1.0)
+
+            if options['use_mult']:
+                self.declare_partials(of=name, wrt=options['mult_name'], rows=ar, cols=ar, val=1.0)
 
     def apply_nonlinear(self, inputs, outputs, residuals):
         """
@@ -174,11 +185,15 @@ class BalanceComp(ImplicitComponent):
         for name, options in iteritems(self._state_vars):
             lhs_name = options['lhs_name']
             rhs_name = options['rhs_name']
-            mult_name = options['mult_name']
 
             lhs = inputs[lhs_name]
             rhs = inputs[rhs_name]
-            mult = inputs[mult_name]
+
+            if options['use_mult']:
+                mult_name = options['mult_name']
+                mult = inputs[mult_name]
+            else:
+                mult = 1.0
 
             # Indices where the rhs is near zero or not near zero
             idxs_nz = np.where(np.abs(rhs) < 2)[0]
@@ -198,11 +213,15 @@ class BalanceComp(ImplicitComponent):
         for name, options in iteritems(self._state_vars):
             lhs_name = options['lhs_name']
             rhs_name = options['rhs_name']
-            mult_name = options['mult_name']
 
             lhs = inputs[lhs_name]
             rhs = inputs[rhs_name]
-            mult = inputs[mult_name]
+
+            if options['use_mult']:
+                mult_name = options['mult_name']
+                mult = inputs[mult_name]
+            else:
+                mult = 1.0
 
             # Indices where the rhs is near zero or not near zero
             idxs_nz = np.where(np.abs(rhs) < 2)[0]
@@ -222,10 +241,20 @@ class BalanceComp(ImplicitComponent):
             jacobian[name, lhs_name] = mult * self._scale_factor
 
             # Partials of residual wrt mult
-            jacobian[name, mult_name] = lhs * self._scale_factor
+            if options['use_mult']:
+                jacobian[name, mult_name] = lhs * self._scale_factor
+
+    def guess_nonlinear(self, inputs, outputs, residuals):
+        """
+        Provide an "guess" for each output based on the values of the inputs and resids.
+        """
+        for name, options in iteritems(self._state_vars):
+            if options['guess_func'] is not None:
+                outputs[name] = options['guess_func'](inputs, residuals)
 
     def add_balance(self, name, eq_units=None, lhs_name=None,
-                    rhs_name=None, rhs_val=0.0, mult_name=None, mult_val=1.0, **kwargs):
+                    rhs_name=None, rhs_val=0.0, guess_func=None,
+                    use_mult=False, mult_name=None, mult_val=1.0, **kwargs):
         """
         Add a new state variable and associated equation to be balanced.
 
@@ -248,6 +277,13 @@ class BalanceComp(ImplicitComponent):
         rhs_val : int, float, or np.array
             Default value for the RHS.  Must be compatible with the shape (optionally)
             given by the val option in kwargs.
+        guess_func : callable or None
+            A callable function in the form f(inputs, resids) that returns an initial "guess" value
+            of the state variable based on the inputs to the BalanceComp.  Note you may have to
+            add additional inputs to the BalanceComp in order to evaluate this function.
+        use_mult : bool
+            Specifies whether the LHS multiplier is to be used.  If True, adds the input specified
+            by mult_name with the default value given by mult_val.  Default is False.
         mult_name : str or None
             Optional name for the LHS multiplier variable associated with the implicit state
             variable. If None, the default will be used: 'mult:{name}'.
@@ -257,10 +293,16 @@ class BalanceComp(ImplicitComponent):
         kwargs : dict
             Additional arguments to be passed for the creation of the implicit state variable.
         """
+        if guess_func is not None and not callable(guess_func):
+            print(guess_func)
+            raise ValueError("Argument 'guess_func' must be a callable if specified")
+
         self._state_vars[name] = {'kwargs': kwargs,
                                   'eq_units': eq_units,
                                   'lhs_name': lhs_name,
                                   'rhs_name': rhs_name,
                                   'rhs_val': rhs_val,
+                                  'guess_func': guess_func,
+                                  'use_mult': use_mult,
                                   'mult_name': mult_name,
                                   'mult_val': mult_val}

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -156,7 +156,7 @@ class TestBalanceComp(unittest.TestCase):
 
         bal = BalanceComp()
 
-        bal.add_balance('x', val=np.ones(n))
+        bal.add_balance('x', val=np.ones(n), use_mult=True)
 
         tgt = IndepVarComp(name='y_tgt', val=4*np.ones(n))
 
@@ -209,7 +209,7 @@ class TestBalanceComp(unittest.TestCase):
 
         prob = Problem(model=Group())
 
-        bal = BalanceComp('x', val=np.ones(n), mult_val=2.0)
+        bal = BalanceComp('x', val=np.ones(n), use_mult=True, mult_val=2.0)
 
         tgt = IndepVarComp(name='y_tgt', val=4 * np.ones(n))
 
@@ -295,6 +295,104 @@ class TestBalanceComp(unittest.TestCase):
         for (of, wrt) in cpd['balance']:
             assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
 
+    def test_scalar_with_guess_func(self):
+
+        n = 1
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x', guess_func=lambda inputs, resids: np.sqrt(inputs['rhs:x']))
+
+        tgt = IndepVarComp(name='y_tgt', val=4)
+
+        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+
+        prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
+    def test_scalar_with_guess_func_additional_input(self):
+
+        n = 1
+
+        prob = Problem(model=Group())
+
+        bal = BalanceComp()
+
+        bal.add_balance('x', guess_func=lambda inputs, resids: inputs['guess_x'])
+        bal.add_input('guess_x', val=0.0)
+
+        ivc = IndepVarComp()
+        ivc.add_output(name='y_tgt', val=4)
+        ivc.add_output(name='guess_x', val=2.5)
+
+        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+
+        prob.model.add_subsystem(name='ivc', subsys=ivc, promotes_outputs=['y_tgt', 'guess_x'])
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('guess_x', 'balance.guess_x')
+        prob.model.connect('y_tgt', 'balance.rhs:x')
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.linear_solver = DirectSolver()
+
+        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.nonlinear_solver.options['maxiter'] = 100
+        prob.model.nonlinear_solver.options['iprint'] = 0
+
+        prob.model.jacobian = DenseJacobian()
+
+        prob.setup()
+
+        prob['balance.x'] = np.random.rand(n)
+
+        prob.run_model()
+
+        assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
+
+        np.set_printoptions(linewidth=1024)
+
+        cpd = prob.check_partials()
+
+        for (of, wrt) in cpd['balance']:
+            assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
+
     def test_rhs_val(self):
         """ Test solution with a default RHS value and no connected RHS variable. """
 
@@ -344,7 +442,7 @@ class TestBalanceComp(unittest.TestCase):
 
         bal = BalanceComp()
 
-        bal.add_balance('x')
+        bal.add_balance('x', use_mult=True)
 
         tgt = IndepVarComp(name='y_tgt', val=4)
 
@@ -395,7 +493,7 @@ class TestBalanceComp(unittest.TestCase):
 
         bal = BalanceComp()
 
-        bal.add_balance('x', mult_name='MUL', lhs_name='XSQ', rhs_name='TARGETXSQ')
+        bal.add_balance('x', use_mult=True, mult_name='MUL', lhs_name='XSQ', rhs_name='TARGETXSQ')
 
         tgt = IndepVarComp(name='y_tgt', val=4)
 
@@ -448,7 +546,7 @@ class TestBalanceComp(unittest.TestCase):
 
         bal = BalanceComp()
 
-        bal.add_balance('x')
+        bal.add_balance('x', use_mult=True)
 
         tgt = IndepVarComp(name='y_tgt', val=4)
 


### PR DESCRIPTION
… which is False by default.  This will silence unconnected input warnings in the majority of use cases.  

User can now specify a guess_func when adding a balance.  guess_func is a callable in the form f(inputs, residuals) which returns the initial guess of the implicit state variable.  If None, the default initial guess is not overridden.