### PR TITLE
Fixed bug with running sqlite in parallel

### DIFF
--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -161,9 +161,10 @@ class SqliteRecorder(BaseRecorder):
         # store the updated abs2prom and prom2abs
         abs2prom = pickle.dumps(self._abs2prom)
         prom2abs = pickle.dumps(self._prom2abs)
-        with self.con:
-            self.con.execute("UPDATE metadata SET abs2prom=?, prom2abs=?",
-                             (abs2prom, prom2abs))
+        if self._open_close_sqlite:
+            with self.con:
+                self.con.execute("UPDATE metadata SET abs2prom=?, prom2abs=?",
+                                 (abs2prom, prom2abs))
 
     def record_iteration_driver(self, recording_requester, data, metadata):
         """


### PR DESCRIPTION
If you run the test_distrib_record_driver test using mpirun -n 2, you get this error. ( when you run it using testflo, it just hangs )

======================================================================
ERROR: test_distrib_record_driver (__main__.DistributedRecorderTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test_distrib_sqlite_recorder.py", line 177, in test_distrib_record_driver
    t0, t1 = run_driver(prob)
  File "/Users/hschilli/Documents/OpenMDAO/dev/distrib_recorder_not_working/openmdao/recorders/tests/recorder_test_utils.py", line 5, in run_driver
    problem.run_driver()
  File "/Users/hschilli/Documents/OpenMDAO/dev/distrib_recorder_not_working/openmdao/core/problem.py", line 302, in run_driver
    self.final_setup()
  File "/Users/hschilli/Documents/OpenMDAO/dev/distrib_recorder_not_working/openmdao/core/problem.py", line 425, in final_setup
    self.driver._setup_driver(self)
  File "/Users/hschilli/Documents/OpenMDAO/dev/distrib_recorder_not_working/openmdao/core/driver.py", line 312, in _setup_driver
    self._rec_mgr.startup(self)
  File "/Users/hschilli/Documents/OpenMDAO/dev/distrib_recorder_not_working/openmdao/recorders/recording_manager.py", line 91, in startup
    recorder.startup(recording_requester)
  File "/Users/hschilli/Documents/OpenMDAO/dev/distrib_recorder_not_working/openmdao/recorders/sqlite_recorder.py", line 167, in startup
    with self.con:
AttributeError: 'SqliteRecorder' object has no attribute 'con'