### PR TITLE
added more info to error message for access to non-unique inputs

### DIFF
--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -278,7 +278,6 @@ class TestConnections(unittest.TestCase):
 class TestConnectionsPromoted(unittest.TestCase):
 
     def test_inp_inp_promoted_no_src(self):
-        raise unittest.SkipTest("connected inputs w/o src not supported yet")
 
         p = Problem(model=Group())
         root = p.model
@@ -293,12 +292,14 @@ class TestConnectionsPromoted(unittest.TestCase):
         C3 = G4.add_subsystem("C3", ExecComp('y=x*2.0'), promotes=['x'])
         C4 = G4.add_subsystem("C4", ExecComp('y=x*2.0'), promotes=['x'])
 
-        p.setup(check=False)
+        p.setup()
+        p.final_setup()
 
         # setting promoted name should set both inputs mapped to that name
-        p['G3.x'] = 999.
-        self.assertEqual(C3._inputs['x'], 999.)
-        self.assertEqual(C4._inputs['x'], 999.)
+        with self.assertRaises(Exception) as context:
+            p['G3.x'] = 999.
+        self.assertEqual(str(context.exception),
+                         "The promoted name G3.x is invalid because it refers to multiple inputs: [G3.G4.C3.x, G3.G4.C4.x] that are not connected to an output variable.")
 
     def test_inp_inp_promoted_w_prom_src(self):
         p = Problem(model=Group())

--- a/openmdao/core/tests/test_getset_vars.py
+++ b/openmdao/core/tests/test_getset_vars.py
@@ -207,15 +207,18 @@ class TestGetSetVariables(unittest.TestCase):
         # -------------------------------------------------------------------
 
         msg1 = 'Variable name "{}" not found.'
-        msg2 = ('The promoted name "{}" is invalid because it is non-unique. '
-                'Access the value from the connected output variable "{}" instead.')
+        msg2 = "The promoted name x is invalid because it refers to multiple inputs: [g.c2.x ,g.c3.x]. Access the value from the connected output variable x instead."
+
         inputs, outputs, residuals = g.get_nonlinear_vectors()
 
         # inputs
-        with assertRaisesRegex(self, KeyError, msg2.format('x', 'x')):
+        with self.assertRaises(Exception) as context:
             inputs['x'] = 5.0
-        with assertRaisesRegex(self, KeyError, msg2.format('x', 'x')):
+        self.assertEqual(str(context.exception), msg2)
+        with self.assertRaises(Exception) as context:
             self.assertEqual(inputs['x'], 5.0)
+        self.assertEqual(str(context.exception), msg2)
+
         with assertRaisesRegex(self, KeyError, msg1.format('g.c2.x')):
             inputs['g.c2.x'] = 5.0
         with assertRaisesRegex(self, KeyError, msg1.format('g.c2.x')):
@@ -231,10 +234,14 @@ class TestGetSetVariables(unittest.TestCase):
         with g.jacobian_context() as jac:
 
             # d(outputs)/d(inputs)
-            with assertRaisesRegex(self, KeyError, msg2.format('x', 'x')):
+            with self.assertRaises(Exception) as context:
                 jac['y', 'x'] = 5.0
-            with assertRaisesRegex(self, KeyError, msg2.format('x', 'x')):
+            self.assertEqual(str(context.exception), msg2)
+            
+            with self.assertRaises(Exception) as context:
                 self.assertEqual(jac['y', 'x'], 5.0)
+            self.assertEqual(str(context.exception), msg2)
+
             with assertRaisesRegex(self, KeyError, msg1.format('g.c2.y', 'g.c2.x')):
                 jac['g.c2.y', 'g.c2.x'] = 5.0
             with assertRaisesRegex(self, KeyError, msg1.format('g.c2.y', 'g.c2.x')):
@@ -268,13 +275,15 @@ class TestGetSetVariables(unittest.TestCase):
 
         # -------------------------------------------------------------------
 
-        msg1 = ('The promoted name "{}" is invalid because it is non-unique. '
-                'Access the value from the connected output variable instead.')
+        msg1 = "The promoted name g.x is invalid because it refers to multiple inputs: [g.c2.x, g.c3.x] that are not connected to an output variable."
 
         # inputs (g.x is not connected)
-        with assertRaisesRegex(self, KeyError, msg1.format('g.x')):
+        #with assertRaisesRegex(self, RuntimeError, msg1.format('g.x')):
+        with self.assertRaises(Exception) as context:
             p['g.x'] = 5.0
             p.final_setup()
+
+        self.assertEqual(str(context.exception), msg1)
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
@@ -283,29 +292,32 @@ class TestGetSetVariables(unittest.TestCase):
 
         # -------------------------------------------------------------------
 
-        msg1 = ('The promoted name "{}" is invalid because it is non-unique. '
-                'Access the value from the connected output variable instead.')
-
         # inputs (g.x is not connected)
-        with assertRaisesRegex(self, KeyError, msg1.format('g.x')):
+        with self.assertRaises(Exception) as context:
             p['g.x'] = 5.0
             p.final_setup()
+        self.assertEqual(str(context.exception), msg1)
 
         # Start from a clean state again
         p = Problem(model)
         p.setup(check=False)
 
-        with assertRaisesRegex(self, KeyError, msg1.format('g.x')):
+        with self.assertRaises(Exception) as context:
             self.assertEqual(p['g.x'], 5.0)
+        self.assertEqual(str(context.exception), msg1)
+
+        msg2 = "The promoted name x is invalid because it refers to multiple inputs: [g.c2.x, g.c3.x] that are not connected to an output variable."
 
         with g.jacobian_context() as jac:
 
             # d(outputs)/d(inputs)
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 jac['y', 'x'] = 5.0
+            self.assertEqual(str(context.exception), msg2)
 
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 self.assertEqual(jac['y', 'x'], 5.0)
+            self.assertEqual(str(context.exception), msg2)
 
         # -------------------------------------------------------------------
 
@@ -314,19 +326,24 @@ class TestGetSetVariables(unittest.TestCase):
         p.setup(check=False)
         p.final_setup()
 
-        with assertRaisesRegex(self, KeyError, msg1.format('g.x')):
+        with self.assertRaises(Exception) as context:
             self.assertEqual(p['g.x'], 5.0)
+        self.assertEqual(str(context.exception), msg1)
 
         with g.jacobian_context() as jac:
 
             # d(outputs)/d(inputs)
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 jac['y', 'x'] = 5.0
+            self.assertEqual(str(context.exception), msg2)
 
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 self.assertEqual(jac['y', 'x'], 5.0)
+            self.assertEqual(str(context.exception), msg2)
 
         # -------------------------------------------------------------------
+
+        msg1 = "The promoted name g.x is invalid because it refers to multiple inputs: [g.c2.x ,g.c3.x]. Access the value from the connected output variable x instead."
 
         # From here, 'g.x' has a valid source.
         model.connect('x', 'g.x')
@@ -334,58 +351,60 @@ class TestGetSetVariables(unittest.TestCase):
         p = Problem(model)
         p.setup(check=False)
 
-        msg2 = ('The promoted name "{}" is invalid because it is non-unique. '
-                'Access the value from the connected output variable "{}" instead.')
-
         # inputs (g.x is connected to x)
         p['g.x'] = 5.0
-        with assertRaisesRegex(self, KeyError, msg2.format('g.x', 'x')):
+        with self.assertRaises(Exception) as context:
             p.final_setup()
+        self.assertEqual(str(context.exception), msg1)
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
         p.setup(check=False)
         p.final_setup()
 
-        msg2 = ('The promoted name "{}" is invalid because it is non-unique. '
-                'Access the value from the connected output variable "{}" instead.')
-
         # inputs (g.x is connected to x)
-        with assertRaisesRegex(self, KeyError, msg2.format('g.x', 'x')):
+        with self.assertRaises(Exception) as context:
             p['g.x'] = 5.0
+        self.assertEqual(str(context.exception), msg1)
 
         # Final test, the getitem
         p = Problem(model)
         p.setup(check=False)
 
-        with assertRaisesRegex(self, KeyError, msg2.format('g.x', 'x')):
+        with self.assertRaises(Exception) as context:
             self.assertEqual(p['g.x'], 5.0)
+        self.assertEqual(str(context.exception), msg1)
 
         with g.jacobian_context() as jac:
 
             # d(outputs)/d(inputs)
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 jac['y', 'x'] = 5.0
+            self.assertEqual(str(context.exception), msg2)
 
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 self.assertEqual(jac['y', 'x'], 5.0)        # Start from a clean state again
+            self.assertEqual(str(context.exception), msg2)
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
         p.setup(check=False)
         p.final_setup()
 
-        with assertRaisesRegex(self, KeyError, msg2.format('g.x', 'x')):
+        with self.assertRaises(Exception) as context:
             self.assertEqual(p['g.x'], 5.0)
+        self.assertEqual(str(context.exception), msg1)
 
         with g.jacobian_context() as jac:
 
             # d(outputs)/d(inputs)
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 jac['y', 'x'] = 5.0
+            self.assertEqual(str(context.exception), msg2)
 
-            with assertRaisesRegex(self, KeyError, msg1.format('x')):
+            with self.assertRaises(Exception) as context:
                 self.assertEqual(jac['y', 'x'], 5.0)
+            self.assertEqual(str(context.exception), msg2)
 
 
 if __name__ == '__main__':

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -116,7 +116,9 @@ def _get_out_of_order_subs(group, input_srcs):
 
 def _check_hanging_inputs(problem, logger):
     """
-    Issue a logger warning if any promoted inputs are not connected.
+    Issue a logger warning if any inputs are not connected.
+
+    Promoted inputs are shown alongside their corresponding absolute names.
 
     Parameters
     ----------

--- a/openmdao/error_checking/test/test_check_config.py
+++ b/openmdao/error_checking/test/test_check_config.py
@@ -38,15 +38,15 @@ class TestCheckConfig(unittest.TestCase):
         self.assertEqual(len(testlogger.get('warning')), 1)
 
         expected = [
-            'G1.G2.C1.w',
-            'G3.G4.C3.u',
-            'G3.G4.C3.x',
             'G3.G4.C4.v',
-            'G3.G4.C4.x'
+            'G3.G4.C4.x',
+            'G3.G4.u',
+            'G3.G4.x',
+            'w',
         ]
 
         actual = testlogger.get('warning')[0].splitlines()[1:]
-        actual = [a.strip().strip("'") for a in actual]
+        actual = [a.split(':', 1)[0].strip().strip("'") for a in actual]
 
         self.assertEqual(expected, actual)
 
@@ -79,10 +79,12 @@ class TestCheckConfig(unittest.TestCase):
         p.final_setup()
 
         warnings = testlogger.get('warning')
-        self.assertEqual(len(warnings), 2)
+        info = testlogger.get('info')
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(len(info), 1)
 
-        self.assertEqual(warnings[0], "Group '' has the following cycles: [['C1', 'C2', 'C4']]")
-        self.assertEqual(warnings[1], "System 'C3' executes out-of-order with respect to its source systems ['C4']")
+        self.assertEqual(info[0], "Group '' has the following cycles: [['C1', 'C2', 'C4']]")
+        self.assertEqual(warnings[0], "System 'C3' executes out-of-order with respect to its source systems ['C4']")
 
     def test_dataflow_multi_level(self):
 
@@ -117,11 +119,12 @@ class TestCheckConfig(unittest.TestCase):
         p.final_setup()
 
         warnings = testlogger.get('warning')
-        self.assertEqual(len(warnings), 3)
+        self.assertEqual(len(warnings), 2)
+        info = testlogger.get('info')
 
-        self.assertEqual(warnings[0], "Group '' has the following cycles: [['G1', 'C4']]")
-        self.assertEqual(warnings[1], "System 'C3' executes out-of-order with respect to its source systems ['C4']")
-        self.assertEqual(warnings[2], "System 'G1.C1' executes out-of-order with respect to its source systems ['G1.C2']")
+        self.assertEqual(info[0], "Group '' has the following cycles: [['G1', 'C4']]")
+        self.assertEqual(warnings[0], "System 'C3' executes out-of-order with respect to its source systems ['C4']")
+        self.assertEqual(warnings[1], "System 'G1.C1' executes out-of-order with respect to its source systems ['G1.C2']")
 
         # test comps_only cycle check
         graph = root.compute_sys_graph(comps_only=True)
@@ -196,12 +199,15 @@ class TestCheckConfig(unittest.TestCase):
         p.final_setup()
 
         warnings = testlogger.get('warning')
-        self.assertEqual(len(warnings), 4)
+        self.assertEqual(len(warnings), 3)
+        
+        info = testlogger.get('info')
+        self.assertEqual(len(info), 1)
 
-        self.assertTrue("The following inputs are not connected:" in warnings[0])
-        self.assertEqual(warnings[1], "Group 'G1' has the following cycles: [['C13', 'C12', 'C11'], ['C23', 'C22', 'C21'], ['C3', 'C2', 'C1']]")
-        self.assertEqual(warnings[2], "System 'G1.C2' executes out-of-order with respect to its source systems ['G1.N3']")
-        self.assertEqual(warnings[3], "System 'G1.C3' executes out-of-order with respect to its source systems ['G1.C11']")
+        self.assertEqual(info[0], "Group 'G1' has the following cycles: [['C13', 'C12', 'C11'], ['C23', 'C22', 'C21'], ['C3', 'C2', 'C1']]")
+        self.assertEqual(warnings[0], "System 'G1.C2' executes out-of-order with respect to its source systems ['G1.N3']")
+        self.assertEqual(warnings[1], "System 'G1.C3' executes out-of-order with respect to its source systems ['G1.C11']")
+        self.assertTrue("The following inputs are not connected:" in warnings[2])
 
 
 if __name__ == "__main__":

--- a/openmdao/utils/name_maps.py
+++ b/openmdao/utils/name_maps.py
@@ -119,9 +119,15 @@ def prom_name2abs_name(system, prom_name, type_):
             src_name = system._conn_global_abs_in2out.get(abs_list[0])
             if src_name and src_name in system._var_abs2prom['output']:
                 src_name = system._var_abs2prom['output'][src_name]  # use promoted name
-            raise KeyError('The promoted name "{}" is invalid because it is non-unique. '
-                           'Access the value from the connected output variable{} instead.'
-                           .format(prom_name, ' "%s"' % src_name if src_name else ''))
+            if src_name:  # input is connected
+                raise RuntimeError("The promoted name {} is invalid because it refers to "
+                                   "multiple inputs: [{}]. "
+                                   "Access the value from the connected output variable {} instead."
+                                   .format(prom_name, ' ,'.join(abs_list), src_name))
+            else:
+                raise RuntimeError("The promoted name {} is invalid because it refers to "
+                                   "multiple inputs: [{}] that are not connected to an output "
+                                   "variable.".format(prom_name, ', '.join(abs_list)))
     else:
         return None
 


### PR DESCRIPTION
- also updated 'openmdao check -c hanging_inputs' to list promoted inputs by their promoted name alongside their absolute names.