### PR TITLE
fix to prevent exception when using size=1 matrixmatrix var

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1502,7 +1502,7 @@ class Problem(object):
 
                         len_val = len(deriv_val)
 
-                        if store and ncol > 1 and len(deriv_val.shape) == 1:
+                        if store and matmat and len(deriv_val.shape) == 1:
                             deriv_val = np.atleast_2d(deriv_val).T
 
                         if return_format == 'flat_dict':

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1289,7 +1289,7 @@ class Problem(object):
                 meta = input_vois[name]
                 parallel_deriv_color = meta['parallel_deriv_color']
                 simul_coloring = meta['simul_deriv_color']
-                matmat = (meta['vectorize_derivs'] and meta['size'] > 1)
+                matmat = meta['vectorize_derivs']
             else:
                 parallel_deriv_color = simul_coloring = None
                 use_rel_reduction = False
@@ -1400,9 +1400,13 @@ class Problem(object):
                     if matmat:
                         if input_name in dinputs:
                             vec = dinputs._views_flat[input_name]
-                            for ii, idx in enumerate(idxs):
-                                if start <= idx < end:
-                                    dinputs._views_flat[input_name][idx - start, ii] = 1.0
+                            if vec.size == 1:
+                                if start <= idxs[0] < end:
+                                    vec[idxs[0] - start] = 1.0
+                            else:
+                                for ii, idx in enumerate(idxs):
+                                    if start <= idx < end:
+                                        vec[idx - start, ii] = 1.0
                     elif simul is not None:
                         ii = idxs[i]
                         final_idxs = ii[np.logical_and(ii >= start, ii < end)]

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1413,7 +1413,7 @@ class System(object):
             self._jacobian._system = self
             self._jacobian._initialize()
 
-            for s in self.system_iter(local=True, recurse=True):
+            for s in self.system_iter(recurse=True):
                 if s._views_assembled_jac:
                     self._jacobian._init_view(s)
 
@@ -1914,15 +1914,13 @@ class System(object):
         """
         pass
 
-    def system_iter(self, local=True, include_self=False, recurse=True,
+    def system_iter(self, include_self=False, recurse=True,
                     typ=None):
         """
-        Yield a generator of subsystems of this system.
+        Yield a generator of local subsystems of this system.
 
         Parameters
         ----------
-        local : bool
-            If True, only iterate over systems on this proc.
         include_self : bool
             If True, include this system in the iteration.
         recurse : bool
@@ -1931,19 +1929,14 @@ class System(object):
             If not None, only yield Systems that match that are instances of the
             given type.
         """
-        if local:
-            sysiter = self._subsystems_myproc
-        else:
-            sysiter = self._subsystems_allprocs
-
         if include_self and (typ is None or isinstance(self, typ)):
             yield self
 
-        for s in sysiter:
+        for s in self._subsystems_myproc:
             if typ is None or isinstance(s, typ):
                 yield s
             if recurse:
-                for sub in s.system_iter(local=local, recurse=True, typ=typ):
+                for sub in s.system_iter(recurse=True, typ=typ):
                     yield sub
 
     def add_design_var(self, name, lower=None, upper=None, ref=None,

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -306,6 +306,7 @@ class TestParallelGroups(unittest.TestCase):
             self.assertTrue(msg in testlogger.get('info')[0])
 
 
+@unittest.skipUnless(PETScVector, "PETSc is required.")
 class MatMatParDevTestCase(unittest.TestCase):
     N_PROCS = 2
 

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -3,7 +3,7 @@
 from __future__ import division, print_function
 
 import unittest
-import numpy
+import numpy as np
 
 from openmdao.api import Problem, Group, ParallelGroup, ExecComp, IndepVarComp, \
                          ExplicitComponent
@@ -216,7 +216,7 @@ class TestParallelGroups(unittest.TestCase):
                 outputs['y'] = inputs['x'] * self.mult
 
             def compute_partials(self, inputs, partials):
-                partials['y', 'x'] = numpy.array([self.mult])
+                partials['y', 'x'] = np.array([self.mult])
 
         prob = Problem()
 
@@ -304,6 +304,33 @@ class TestParallelGroups(unittest.TestCase):
             self.assertTrue(msg in testlogger.get('error')[0])
             self.assertTrue(msg in testlogger.get('warning')[0])
             self.assertTrue(msg in testlogger.get('info')[0])
+
+
+class MatMatParDevTestCase(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_size_1_matmat(self):
+        p = Problem()
+        indeps = p.model.add_subsystem('indeps', IndepVarComp('x', np.ones(2)))
+        indeps.add_output('y', 1.0)
+        par = p.model.add_subsystem('par', ParallelGroup())
+        par.add_subsystem('C1', ExecComp('y=2*x', x=np.zeros(2), y=np.zeros(2)))
+        par.add_subsystem('C2', ExecComp('y=3*x'))
+        p.model.connect("indeps.x", "par.C1.x")
+        p.model.connect("indeps.y", "par.C2.x")
+        p.model.add_design_var('indeps.x', vectorize_derivs=True, parallel_deriv_color='foo')
+        p.model.add_design_var('indeps.y', vectorize_derivs=True, parallel_deriv_color='foo')
+        par.add_objective('C2.y')
+        par.add_constraint('C1.y', lower=0.0)
+        p.setup(vector_class=PETScVector, mode='fwd')
+        p.run_model()
+
+        # prior to bug fix, this would raise an exception
+        J = p._compute_totals()
+        np.testing.assert_array_equal(J['par.C1.y', 'indeps.x'], np.eye(2)*2.)
+        np.testing.assert_array_equal(J['par.C2.y', 'indeps.x'], np.zeros((1,2)))
+        np.testing.assert_array_equal(J['par.C1.y', 'indeps.y'], np.zeros((2,1)))
+        np.testing.assert_array_equal(J['par.C2.y', 'indeps.y'], np.array([[3.]]))
 
 
 if __name__ == "__main__":

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -129,7 +129,7 @@ class AssembledJacobian(Jacobian):
             in_ranges[abs_name] = self._get_var_range(abs_name, 'input')
 
         # set up view ranges for all subsystems
-        for s in system.system_iter(local=True, recurse=True, include_self=True):
+        for s in system.system_iter(recurse=True, include_self=True):
             min_res_offset = sys.maxsize
             max_res_offset = 0
             min_in_offset = sys.maxsize
@@ -251,8 +251,7 @@ class AssembledJacobian(Jacobian):
             src_indices_dict[abs_name] = \
                 system._var_abs2meta['input'][abs_name]['src_indices']
 
-        for s in system.system_iter(local=True, recurse=True,
-                                    include_self=True, typ=Component):
+        for s in system.system_iter(recurse=True, include_self=True, typ=Component):
             for res_abs_name in s._var_abs_names['output']:
                 res_offset = self._get_var_range(res_abs_name, 'output')[0]
                 res_size = abs2meta_out[res_abs_name]['size']


### PR DESCRIPTION
- also includes unrelated fix to system_iter.  local=False option was removed because it no longer makes any sense.