### PR TITLE
relevance reduction fix

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1776,36 +1776,28 @@ def get_relevant_vars(connections, desvars, responses, mode):
     # also connect it to its corresponding component.
     graph = nx.DiGraph()
     for tgt, src in iteritems(connections):
-        src_sys = src.rsplit('.', 1)[0]
-        if src_sys not in graph:
-            graph.add_node(src_sys, type_='comp')
         if src not in graph:
             graph.add_node(src, type_='out')
         graph.add_node(tgt, type_='in')
 
+        src_sys = src.rsplit('.', 1)[0]
         graph.add_edge(src_sys, src)
 
         tgt_sys = tgt.rsplit('.', 1)[0]
-        if tgt_sys not in graph:
-            graph.add_node(tgt_sys, type_='comp')
-
         graph.add_edge(tgt, tgt_sys)
+
         graph.add_edge(src, tgt)
 
     for dv in desvars:
         if dv not in graph:
             graph.add_node(dv, type_='out')
             system = dv.rsplit('.', 1)[0]
-            if system not in graph:
-                graph.add_node(system, type_='comp')
             graph.add_edge(system, dv)
 
     for res in responses:
         if res not in graph:
             graph.add_node(res, type_='out')
             system = res.rsplit('.', 1)[0]
-            if system not in graph:
-                graph.add_node(system, type_='comp')
             graph.add_edge(system, res)
 
     nodes = graph.nodes
@@ -1828,17 +1820,18 @@ def get_relevant_vars(connections, desvars, responses, mode):
                 output_deps = set()
                 sys_deps = set()
                 for node in common:
-                    typ = nodes[node]['type_']
-                    if typ == 'in':
-                        input_deps.add(node)
-                        system = node.rsplit('.', 1)[0]
-                        if system not in sys_deps:
-                            sys_deps.update(all_ancestors(system))
-                    elif typ == 'out':
-                        output_deps.add(node)
-                        system = node.rsplit('.', 1)[0]
-                        if system not in sys_deps:
-                            sys_deps.update(all_ancestors(system))
+                    if 'type_' in nodes[node]:
+                        typ = nodes[node]['type_']
+                        if typ == 'in':  # input var
+                            input_deps.add(node)
+                            system = node.rsplit('.', 1)[0]
+                            if system not in sys_deps:
+                                sys_deps.update(all_ancestors(system))
+                        else:  # output var
+                            output_deps.add(node)
+                            system = node.rsplit('.', 1)[0]
+                            if system not in sys_deps:
+                                sys_deps.update(all_ancestors(system))
 
             elif desvar == response:
                 input_deps = set()

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1809,7 +1809,7 @@ def get_relevant_vars(connections, desvars, responses, mode):
             graph.add_edge(system, res)
 
     nodes = graph.nodes
-    grev = graph.reverse()
+    grev = graph.reverse(copy=False)
 
     for desvar in desvars:
         dv = (desvar, 'dv')

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -698,9 +698,8 @@ class TestProblem(unittest.TestCase):
 
         p.setup(check=False, mode='rev')
 
-        g = p.model.compute_sys_graph(comps_only=True)
-        relevant = get_relevant_vars(g, ['indep1.x', 'indep2.x'], ['C8.y', 'Unconnected.y'],
-                                     mode='rev')
+        relevant = get_relevant_vars(model._conn_global_abs_in2out, ['indep1.x', 'indep2.x'],
+                                     ['C8.y', 'Unconnected.y'], mode='rev')
 
         indep1_ins = set(['C3.b', 'C3.c', 'C8.b', 'G1.C1.a', 'G2.C5.a', 'G2.C5.b'])
         indep1_outs = set(['C3.y', 'C8.y', 'G1.C1.z', 'G2.C5.x', 'indep1.x'])

--- a/openmdao/error_checking/test/test_check_config.py
+++ b/openmdao/error_checking/test/test_check_config.py
@@ -4,7 +4,6 @@ from six.moves import range
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp
 from openmdao.utils.logger_utils import TestLogger
-from openmdao.utils.graph_utils import all_connected_edges
 from openmdao.error_checking.check_config import get_sccs_topo
 
 
@@ -200,7 +199,7 @@ class TestCheckConfig(unittest.TestCase):
 
         warnings = testlogger.get('warning')
         self.assertEqual(len(warnings), 3)
-        
+
         info = testlogger.get('info')
         self.assertEqual(len(info), 1)
 

--- a/openmdao/utils/graph_utils.py
+++ b/openmdao/utils/graph_utils.py
@@ -25,10 +25,9 @@ def get_sccs_topo(graph):
     return sccs
 
 
-def all_connected_edges(graph, start):
+def all_connected_nodes(graph, start):
     """
-
-    Yield all downstream edges starting at the given node.
+    Yield all downstream nodes starting at the given node.
 
     Parameters
     ----------
@@ -40,14 +39,15 @@ def all_connected_edges(graph, start):
     Yields
     ------
     list
-        A list of all edges found when traversal starts at start.
+        A list of all nodes found when traversal starts at start.
     """
     stack = [start]
     visited = set(stack)
+    yield start
     while stack:
         src = stack.pop()
         for tgt in graph[src]:
-            yield src, tgt
+            yield tgt
             if tgt not in visited:
                 visited.add(tgt)
                 stack.append(tgt)


### PR DESCRIPTION
Relevance reduction now uses specific variable to variable connection information to determine relevance, rather than relying on the component graph alone, which introduced dependencies that didn't actually exist, making the relevance reduction too conservative.