### PR TITLE
metadata feature docs should include example of setting numpy array as the type

### DIFF
--- a/openmdao/core/tests/test_distrib_driver_debug_print_options.py
+++ b/openmdao/core/tests/test_distrib_driver_debug_print_options.py
@@ -26,6 +26,8 @@ class DistributedDriverDebugPrintOptionsTest(unittest.TestCase):
 
         if OPTIMIZER:
             from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+        else:
+            raise unittest.SkipTest("pyOptSparseDriver is required.")
 
         class Mygroup(Group):
 

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -176,7 +176,9 @@ class DistributedAdderTest(unittest.TestCase):
 
         if OPTIMIZER:
             from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
-
+        else:
+            raise unittest.SkipTest("pyOptSparseDriver is required.")
+            
         from openmdao.core.parallel_group import ParallelGroup
         from openmdao.components.exec_comp import ExecComp
 

--- a/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
+++ b/openmdao/docs/feature_reference/core_features/defining_components/metadata.rst
@@ -9,25 +9,30 @@ as well as to do the mapping that computes the outputs given the inputs.
 Often, however, there are incidental parameters that affect the behavior of the component,
 but which are not considered input variables in the sense of being computed as an output of another component.
 
-OpenMDAO provides a way of declaring these parameters, which are referred to as *metadata*.
-They are declared in the 'initialize' method of the user's component,
-and the values are typically passed in upon instantiation of the component.
-Once the values are passed in during instantiation, they are automatically set into the metadata object
-and are available for use in any method other than 'initialize'.
+OpenMDAO provides a way of declaring these parameters, which are contained in an
+`OptionsDictionary` named *metadata* that is available in every component. Metadata
+associated with a particular component must be declared in the `initialize` method
+of the component definition. A default value can be provided as well as various checks
+for validity, such as a list of acceptable values or types.
 
-Alternatively, the values can be set at any time, whether in any method of the component
-(except for 'initialize') or outside of the component definition after the component is instantiated.
-Metadata can be declared along with their default values and various checks for validity,
-such as a list of acceptable values or types.
-The full list of options can be found in the method signature below.
+The full list of options is shown in the method signature below.
 
 .. automethod:: openmdao.utils.options_dictionary.OptionsDictionary.declare
     :noindex:
 
+Metadata values are typically passed at component instantiation time as keyword arguments,
+which are automatically assigned into the metadata dictionary. The metadata is then available
+for use in the component's other methods, such as `setup` and `compute`.
+
+Alternatively, values can be set at a later time, in another method of the component
+(except for `initialize`) or outside of the component definition after the component is
+instantiated.
+
 A Simple Example
 ----------------
 
-Metadata is commonly used to specify the shape or size of the component's input and output variables.
+Metadata is commonly used to specify the shape or size of the component's input and output 
+variables, such as in this simple example.
 
 .. embed-code::
     openmdao.test_suite.components.metadata_feature_vector
@@ -35,13 +40,41 @@ Metadata is commonly used to specify the shape or size of the component's input 
 .. embed-test::
     openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_simple
 
-In this example, 'size' is required; the first time we try to get 'size',
-we would have gotten an error if we:
+
+Not setting a default value when declaring a metadata parameter implies that the value must be set by the user.
+
+In this example, 'size' is required; We would have gotten an error if we:
 
 1. did not pass in 'size' when instantiating 'VectorDoublingComp' and
 2. did not set its value in the code for VectorDoublingComp.
 
-Not setting a default value when declaring it implies that the value must be set prior to getting it.
+
+.. embed-test::
+    openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_simple_fail
+
+
+Metadata Types
+--------------
+
+Metadata is not limited to simple types like :code:`int`.  In the following example, the
+component takes a `Numpy` array as metadata:
+
+
+.. embed-code::
+    openmdao.test_suite.components.metadata_feature_array
+
+.. embed-test::
+    openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_simple_array
+
+
+It is even possible to provide a function as metadata:
+
+
+.. embed-code::
+    openmdao.test_suite.components.metadata_feature_function
+
+.. embed-test::
+    openmdao.utils.tests.test_options_dictionary_feature.TestOptionsDictionaryFeature.test_simple_function
 
 Providing Default Values
 ------------------------
@@ -62,9 +95,9 @@ Specifying Values or Types
 
 Another commonly-used metadata feature is specifying acceptable values or types.
 If only the list of acceptable values is specified,
-the default value and the value passed in must be one of these values, or None if allow_none is True.
+the default value and the value passed in must be one of these values, or None if `allow_none` is True.
 If only the list of acceptable types is specified,
-the default value and the value passed in must be an instance one of these types, or None if allow_none is True.
+the default value and the value passed in must be an instance one of these types, or None if `allow_none` is True.
 It is an error to attempt to specify both a list of acceptable values and a list of acceptable types.
 
 .. tags:: Metadata

--- a/openmdao/test_suite/components/metadata_feature_array.py
+++ b/openmdao/test_suite/components/metadata_feature_array.py
@@ -1,0 +1,23 @@
+"""
+A component that multiplies an array by an input value, where
+the array is given as metadata of type 'numpy.ndarray'.
+"""
+import numpy as np
+
+from openmdao.api import ExplicitComponent
+
+class ArrayMultiplyComp(ExplicitComponent):
+
+    def initialize(self):
+        self.metadata.declare('array', types=np.ndarray)
+
+    def setup(self):
+        array = self.metadata['array']
+
+        self.add_input('x', 1.)
+        self.add_output('y', shape=array.shape)
+        
+        self.declare_partials(of='*', wrt='*')
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = self.metadata['array'] * inputs['x']

--- a/openmdao/test_suite/components/metadata_feature_function.py
+++ b/openmdao/test_suite/components/metadata_feature_function.py
@@ -1,16 +1,16 @@
 """
-Component for a metadata feature test.
+A component that computes y = func(x), where func
+is a function given as metadata.
 """
-import numpy as np
+
 from types import FunctionType
 
 from openmdao.api import ExplicitComponent
 
-
 class UnitaryFunctionComp(ExplicitComponent):
 
     def initialize(self):
-        self.metadata.declare('func', values=('exp', 'cos', 'sin'), types=FunctionType)
+        self.metadata.declare('func', types=FunctionType)
 
     def setup(self):
         self.add_input('x')
@@ -19,12 +19,4 @@ class UnitaryFunctionComp(ExplicitComponent):
 
     def compute(self, inputs, outputs):
         func = self.metadata['func']
-
-        if func == 'exp':
-            outputs['y'] = np.exp(inputs['x'])
-        elif func == 'cos':
-            outputs['y'] = np.cos(inputs['x'])
-        elif func == 'sin':
-            outputs['y'] = np.sin(inputs['x'])
-        else:
-            outputs['y'] = func(inputs['x'])
+        outputs['y'] = func(inputs['x'])

--- a/openmdao/test_suite/components/metadata_feature_lincomb.py
+++ b/openmdao/test_suite/components/metadata_feature_lincomb.py
@@ -1,10 +1,10 @@
 """
-Component for a metadata feature test.
+A component that computes y = a*x + b, where a and b
+are given as metadata of type 'numpy.ScalarType'.
 """
 import numpy as np
 
 from openmdao.api import ExplicitComponent
-
 
 class LinearCombinationComp(ExplicitComponent):
 

--- a/openmdao/test_suite/components/metadata_feature_vector.py
+++ b/openmdao/test_suite/components/metadata_feature_vector.py
@@ -1,10 +1,10 @@
 """
-Component for a metadata feature test.
+A component that multiplies a vector by 2, where the 
+size of the vector is given as metadata of type 'int'.
 """
 import numpy as np
 
 from openmdao.api import ExplicitComponent
-
 
 class VectorDoublingComp(ExplicitComponent):
 
@@ -16,7 +16,9 @@ class VectorDoublingComp(ExplicitComponent):
 
         self.add_input('x', shape=size)
         self.add_output('y', shape=size)
-        self.declare_partials('y', 'x', val=2., rows=np.arange(size), cols=np.arange(size))
+        self.declare_partials('y', 'x', val=2., 
+                              rows=np.arange(size),
+                              cols=np.arange(size))
 
     def compute(self, inputs, outputs):
         outputs['y'] = 2 * inputs['x']

--- a/openmdao/utils/tests/test_options_dictionary_feature.py
+++ b/openmdao/utils/tests/test_options_dictionary_feature.py
@@ -12,28 +12,85 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
         from openmdao.test_suite.components.metadata_feature_vector import VectorDoublingComp
 
         prob = Problem()
-        prob.model.add_subsystem('input_comp', IndepVarComp('x', shape=3))
-        prob.model.add_subsystem('main_comp', VectorDoublingComp(size=3))
-        prob.model.connect('input_comp.x', 'main_comp.x')
+        prob.model.add_subsystem('inputs', IndepVarComp('x', shape=3))
+        prob.model.add_subsystem('double', VectorDoublingComp(size=3))  # 'size' is metadata
+        prob.model.connect('inputs.x', 'double.x')
+
         prob.setup()
 
-        prob['input_comp.x'] = [1., 2., 3.]
+        prob['inputs.x'] = [1., 2., 3.]
+
         prob.run_model()
-        assert_rel_error(self, prob['main_comp.y'], [2., 4., 6.])
+        assert_rel_error(self, prob['double.y'], [2., 4., 6.])
+
+    def test_simple_fail(self):
+        from openmdao.api import Problem, IndepVarComp
+        from openmdao.test_suite.components.metadata_feature_vector import VectorDoublingComp
+
+        prob = Problem()
+        prob.model.add_subsystem('inputs', IndepVarComp('x', shape=3))
+        prob.model.add_subsystem('double', VectorDoublingComp())  # 'size' not specified
+        prob.model.connect('inputs.x', 'double.x')
+
+        try:
+            prob.setup()
+        except RuntimeError as err:
+            self.assertEqual(str(err), "Entry 'size' is required but has not been set.")
 
     def test_with_default(self):
         from openmdao.api import Problem, IndepVarComp
         from openmdao.test_suite.components.metadata_feature_lincomb import LinearCombinationComp
 
         prob = Problem()
-        prob.model.add_subsystem('input_comp', IndepVarComp('x'))
-        prob.model.add_subsystem('main_comp', LinearCombinationComp(a=2.))
-        prob.model.connect('input_comp.x', 'main_comp.x')
+        prob.model.add_subsystem('inputs', IndepVarComp('x'))
+        prob.model.add_subsystem('linear', LinearCombinationComp(a=2.))  # 'b' not specified
+        prob.model.connect('inputs.x', 'linear.x')
+
         prob.setup()
 
-        prob['input_comp.x'] = 3
+        prob['inputs.x'] = 3
+
         prob.run_model()
-        self.assertEqual(prob['main_comp.y'], 7.)
+        self.assertEqual(prob['linear.y'], 7.)
+
+    def test_simple_array(self):
+        import numpy as np
+
+        from openmdao.api import Problem, IndepVarComp
+        from openmdao.test_suite.components.metadata_feature_array import ArrayMultiplyComp
+
+        prob = Problem()
+        prob.model.add_subsystem('inputs', IndepVarComp('x', 1.))
+        prob.model.add_subsystem('a_comp', ArrayMultiplyComp(array=np.array([1, 2, 3])))
+        prob.model.connect('inputs.x', 'a_comp.x')
+
+        prob.setup()
+
+        prob['inputs.x'] = 5.
+
+        prob.run_model()
+
+        assert_rel_error(self, prob['a_comp.y'], [5., 10., 15.])
+
+    def test_simple_function(self):
+        from openmdao.api import Problem, IndepVarComp
+        from openmdao.test_suite.components.metadata_feature_function import UnitaryFunctionComp
+
+        def my_func(x):
+            return x*2
+
+        prob = Problem()
+        prob.model.add_subsystem('inputs', IndepVarComp('x', 1.))
+        prob.model.add_subsystem('f_comp', UnitaryFunctionComp(func=my_func))
+        prob.model.connect('inputs.x', 'f_comp.x')
+
+        prob.setup()
+
+        prob['inputs.x'] = 5.
+
+        prob.run_model()
+
+        assert_rel_error(self, prob['f_comp.y'], 10.)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
pivotal #154634568
more examples for docs
fix a couple tests to not fail without pyoptsparse
