### PR TITLE
some performance tweaks

### DIFF
--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -135,10 +135,8 @@ class ComplexStep(ApproximationScheme):
                 in_idx = system._owns_approx_wrt_idx[wrt]
                 in_size = len(in_idx)
             else:
-                if wrt in system._var_abs2meta['input']:
-                    in_size = system._var_abs2meta['input'][wrt]['size']
-                elif wrt in system._var_abs2meta['output']:
-                    in_size = system._var_abs2meta['output'][wrt]['size']
+                if wrt in system._var_abs2meta:
+                    in_size = system._var_abs2meta[wrt]['size']
 
                 in_idx = range(in_size)
 
@@ -153,7 +151,7 @@ class ComplexStep(ApproximationScheme):
                     out_idx = system._owns_approx_of_idx[of]
                     out_size = len(out_idx)
                 else:
-                    out_size = system._var_abs2meta['output'][of]['size']
+                    out_size = system._var_abs2meta[of]['size']
 
                 outputs.append((of, np.zeros((out_size, in_size))))
 

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -198,11 +198,7 @@ class FiniteDifference(ApproximationScheme):
                 in_idx = system._owns_approx_wrt_idx[wrt]
                 in_size = len(in_idx)
             else:
-                if wrt in system._var_abs2meta['input']:
-                    in_size = system._var_abs2meta['input'][wrt]['size']
-                elif wrt in system._var_abs2meta['output']:
-                    in_size = system._var_abs2meta['output'][wrt]['size']
-
+                in_size = system._var_abs2meta[wrt]['size']
                 in_idx = range(in_size)
 
             result.set_vec(system._outputs)
@@ -218,7 +214,7 @@ class FiniteDifference(ApproximationScheme):
                     out_idx = system._owns_approx_of_idx[of]
                     out_size = len(out_idx)
                 else:
-                    out_size = system._var_abs2meta['output'][of]['size']
+                    out_size = system._var_abs2meta[of]['size']
                 outputs.append((of, np.zeros((out_size, in_size))))
 
             for i_count, idx in enumerate(in_idx):

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -170,13 +170,13 @@ class Component(System):
                 abs2prom[type_][abs_name] = prom_name
 
                 # Compute allprocs_abs2meta
-                allprocs_abs2meta[type_][abs_name] = {
+                allprocs_abs2meta[abs_name] = {
                     meta_name: metadata[meta_name]
                     for meta_name in global_meta_names[type_]
                 }
 
                 # Compute abs2meta
-                abs2meta[type_][abs_name] = metadata
+                abs2meta[abs_name] = metadata
 
     def _setup_var_sizes(self, recurse=True):
         """
@@ -209,14 +209,15 @@ class Component(System):
                 for set_name, nvars in iteritems(self._num_var_byset[vec_name][type_]):
                     sizes_byset[vec_name][type_][set_name] = np.zeros((nproc, nvars), int)
 
+            allprocs_abs2idx_byset_t = self._var_allprocs_abs2idx_byset[vec_name]
+
             # Compute _var_sizes and _var_sizes_byset
+            abs2meta = self._var_abs2meta
             for type_ in ('input', 'output'):
                 sz = sizes[vec_name][type_]
                 sz_byset = sizes_byset[vec_name][type_]
-                abs2meta_t = self._var_abs2meta[type_]
-                allprocs_abs2idx_byset_t = self._var_allprocs_abs2idx_byset[vec_name][type_]
                 for idx, abs_name in enumerate(self._var_allprocs_relevant_names[vec_name][type_]):
-                    meta = abs2meta_t[abs_name]
+                    meta = abs2meta[abs_name]
                     set_name = meta['var_set']
                     size = meta['size']
                     idx_byset = allprocs_abs2idx_byset_t[abs_name]
@@ -552,15 +553,16 @@ class Component(System):
             if not wrt_matches:
                 raise ValueError('No matches were found for wrt="{}"'.format(wrt_pattern))
 
+            info = self._subjacs_info
             for rel_key in product(of_matches, wrt_matches):
-                meta_changes = {
-                    'method': method,
-                }
                 abs_key = rel_key2abs_key(self, rel_key)
-                meta = self._subjacs_info.get(abs_key, SUBJAC_META_DEFAULTS.copy())
-                meta.update(meta_changes)
+                if abs_key in info:
+                    meta = info[abs_key]
+                else:
+                    meta = SUBJAC_META_DEFAULTS.copy()
+                meta['method'] = method
                 meta.update(kwargs)
-                self._subjacs_info[abs_key] = meta
+                info[abs_key] = meta
 
     def declare_partials(self, of, wrt, dependent=True, rows=None, cols=None, val=None,
                          method='exact', **kwargs):
@@ -726,6 +728,9 @@ class Component(System):
             Value of subjacobian.  If rows and cols are not None, this will
             contain the values found at each (row, col) location in the subjac.
         """
+        if not dependent:
+            return
+
         if val is not None and not issparse(val):
             val = np.atleast_1d(val)
             # np.promote_types  will choose the smallest dtype that can contain both arguments
@@ -824,11 +829,8 @@ class Component(System):
             Metadata dictionary from declare_partials.
         """
         if meta['dependent']:
-            out_size = np.prod(self._var_abs2meta['output'][abs_key[0]]['shape'])
-            if abs_key[1] in self._var_abs2meta['input']:
-                in_size = self._var_abs2meta['input'][abs_key[1]]['size']
-            else:  # assume output (or get a KeyError)
-                in_size = self._var_abs2meta['output'][abs_key[1]]['size']
+            out_size = np.prod(self._var_abs2meta[abs_key[0]]['shape'])
+            in_size = self._var_abs2meta[abs_key[1]]['size']
 
             if in_size == 0 and self.comm.rank != 0:  # 'inactive' component
                 return
@@ -872,12 +874,15 @@ class Component(System):
         """
         with self.jacobian_context() as J:
             for key, meta in iteritems(self._subjacs_info):
+                if not meta['dependent']:
+                    continue
                 self._check_partials_meta(key, meta)
                 J._set_partials_meta(key, meta)
 
-                method = meta.get('method', False)
-                if method and meta['dependent']:
-                    self._approx_schemes[method].add_approximation(key, meta)
+                if 'method' in meta:
+                    method = meta['method']
+                    if method:
+                        self._approx_schemes[method].add_approximation(key, meta)
 
         for approx in itervalues(self._approx_schemes):
             approx._init_approximations()

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -74,14 +74,14 @@ class ExplicitComponent(Component):
         """
         super(ExplicitComponent, self)._setup_partials()
 
-        abs2meta_out = self._var_abs2meta['output']
+        abs2meta = self._var_abs2meta
         abs2prom_out = self._var_abs2prom['output']
 
         # Note: These declare calls are outside of setup_partials so that users do not have to
         # call the super version of setup_partials. This is still in the final setup.
         other_names = []
         for out_abs in self._var_abs_names['output']:
-            meta = abs2meta_out[out_abs]
+            meta = abs2meta[out_abs]
             out_name = abs2prom_out[out_abs]
             arange = np.arange(meta['size'])
 
@@ -171,31 +171,19 @@ class ExplicitComponent(Component):
         """
         Set subjacobian info into our jacobian.
         """
+        abs2prom = self._var_abs2prom
+
         with self.jacobian_context() as J:
-            outputs = self._var_abs_names['output']
-            inputs = self._var_abs_names['input']
+            for abs_key, meta in iteritems(self._subjacs_info):
+                if meta['value'] is None:
+                    out_size = self._var_abs2meta[abs_key[0]]['size']
+                    in_size = self._var_abs2meta[abs_key[1]]['size']
+                    meta['value'] = np.zeros((out_size, in_size))
 
-            for wrt_name, wrt_vars in (('output', outputs), ('input', inputs)):
-                for abs_key in product(outputs, wrt_vars):
-                    if abs_key in self._subjacs_info:
-                        meta = self._subjacs_info[abs_key]
-                    else:
-                        meta = SUBJAC_META_DEFAULTS.copy()
-                    dependent = meta['dependent']
+                J._set_partials_meta(abs_key, meta, abs_key[1] in abs2prom['input'])
 
-                    if not dependent:
-                        continue
-
-                    if meta['value'] is None:
-                        out_size = self._var_abs2meta['output'][abs_key[0]]['size']
-                        in_size = self._var_abs2meta[wrt_name][abs_key[1]]['size']
-                        meta['value'] = np.zeros((out_size, in_size))
-
-                    J._set_partials_meta(abs_key, meta, wrt_name == 'input')
-
-                    method = meta.get('method', False)
-                    if method:
-                        self._approx_schemes[method].add_approximation(abs_key, meta)
+                if 'method' in meta and meta['method']:
+                    self._approx_schemes[meta['method']].add_approximation(abs_key, meta)
 
         for approx in itervalues(self._approx_schemes):
             approx._init_approximations()

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -379,15 +379,15 @@ class Group(System):
         for subsys in self._subsystems_myproc:
             var_maps = subsys._get_maps(subsys._var_allprocs_prom2abs_list)
 
+            # Assemble allprocs_abs2meta and abs2meta
+            allprocs_abs2meta.update(subsys._var_allprocs_abs2meta)
+            abs2meta.update(subsys._var_abs2meta)
+
             for type_ in ['input', 'output']:
 
                 # Assemble abs_names and allprocs_abs_names
                 allprocs_abs_names[type_].extend(subsys._var_allprocs_abs_names[type_])
                 abs_names[type_].extend(subsys._var_abs_names[type_])
-
-                # Assemble allprocs_abs2meta and abs2meta
-                allprocs_abs2meta[type_].update(subsys._var_allprocs_abs2meta[type_])
-                abs2meta[type_].update(subsys._var_abs2meta[type_])
 
                 # Assemble abs2prom
                 for abs_name in subsys._var_abs_names[type_]:
@@ -432,13 +432,13 @@ class Group(System):
                 self._has_output_scaling |= oscale
                 self._has_resid_scaling |= rscale
 
+                # Assemble in parallel allprocs_abs2meta
+                allprocs_abs2meta.update(myproc_abs2meta)
+
                 for type_ in ['input', 'output']:
 
                     # Assemble in parallel allprocs_abs_names
                     allprocs_abs_names[type_].extend(myproc_abs_names[type_])
-
-                    # Assemble in parallel allprocs_abs2meta
-                    allprocs_abs2meta[type_].update(myproc_abs2meta[type_])
 
                     # Assemble in parallel allprocs_prom2abs_list
                     for prom_name, abs_names_list in iteritems(myproc_prom2abs_list[type_]):
@@ -542,8 +542,7 @@ class Group(System):
 
         allprocs_prom2abs_list_in = self._var_allprocs_prom2abs_list['input']
         allprocs_prom2abs_list_out = self._var_allprocs_prom2abs_list['output']
-        abs2meta_in = self._var_abs2meta['input']
-        abs2meta_out = self._var_abs2meta['output']
+        abs2meta = self._var_abs2meta
         pathname = self.pathname
 
         abs_in2out = {}
@@ -611,8 +610,8 @@ class Group(System):
                                        "for connection in '%s' from '%s' to '%s'." %
                                        (self.pathname, prom_out, prom_in))
 
-                if src_indices is not None and abs_in in abs2meta_in:
-                    meta = abs2meta_in[abs_in]
+                if src_indices is not None and abs_in in abs2meta:
+                    meta = abs2meta[abs_in]
                     if meta['src_indices'] is not None:
                         raise RuntimeError("%s: src_indices has been defined "
                                            "in both connect('%s', '%s') "
@@ -718,8 +717,7 @@ class Group(System):
         else:
             path_len = len(pathname) + 1
 
-        allprocs_abs2meta_out = self._var_allprocs_abs2meta['output']
-        allprocs_abs2meta_in = self._var_allprocs_abs2meta['input']
+        allprocs_abs2meta = self._var_allprocs_abs2meta
 
         # Check input/output units here, and set _has_input_scaling
         # to True for this Group if units are defined and different, or if
@@ -735,15 +733,15 @@ class Group(System):
 
             # if connected output has scaling then we need input scaling
             if not self._has_input_scaling:
-                out_units = allprocs_abs2meta_out[abs_out]['units']
-                in_units = allprocs_abs2meta_in[abs_in]['units']
+                out_units = allprocs_abs2meta[abs_out]['units']
+                in_units = allprocs_abs2meta[abs_in]['units']
 
                 # if units are defined and different, we need input scaling.
                 needs_input_scaling = (in_units and out_units and in_units != out_units)
 
                 # we also need it if a connected output has any scaling.
                 if not needs_input_scaling:
-                    out_meta = allprocs_abs2meta_out[abs_out]
+                    out_meta = allprocs_abs2meta[abs_out]
 
                     ref = out_meta['ref']
                     if np.isscalar(ref):
@@ -771,13 +769,12 @@ class Group(System):
         # check unit/shape compatibility, but only for connections that are
         # either owned by (implicit) or declared by (explicit) this Group.
         # This way, we don't repeat the error checking in multiple groups.
-        abs2meta_in = self._var_abs2meta['input']
-        abs2meta_out = self._var_abs2meta['output']
+        abs2meta = self._var_abs2meta
 
         for abs_in, abs_out in iteritems(abs_in2out):
             # check unit compatibility
-            out_units = allprocs_abs2meta_out[abs_out]['units']
-            in_units = allprocs_abs2meta_in[abs_in]['units']
+            out_units = allprocs_abs2meta[abs_out]['units']
+            in_units = allprocs_abs2meta[abs_in]['units']
 
             if out_units:
                 if not in_units:
@@ -795,20 +792,20 @@ class Group(System):
                               "no units." % (abs_in, in_units, abs_out))
 
             # check shape compatibility
-            if abs_in in abs2meta_in and abs_out in abs2meta_out:
+            if abs_in in abs2meta and abs_out in abs2meta:
                 # get output shape from allprocs meta dict, since it may
                 # be distributed (we want global shape)
-                out_shape = allprocs_abs2meta_out[abs_out]['global_shape']
+                out_shape = allprocs_abs2meta[abs_out]['global_shape']
                 # get input shape and src_indices from the local meta dict
                 # (input is always local)
-                in_shape = abs2meta_in[abs_in]['shape']
-                src_indices = abs2meta_in[abs_in]['src_indices']
-                flat = abs2meta_in[abs_in]['flat_src_indices']
+                in_shape = abs2meta[abs_in]['shape']
+                src_indices = abs2meta[abs_in]['src_indices']
+                flat = abs2meta[abs_in]['flat_src_indices']
 
                 if src_indices is None and out_shape != in_shape:
                     # out_shape != in_shape is allowed if
                     # there's no ambiguity in storage order
-                    if not (np.prod(out_shape) == abs2meta_in[abs_in]['size']
+                    if not (np.prod(out_shape) == abs2meta[abs_in]['size']
                             == np.max(out_shape) == np.max(in_shape)):
                         msg = ("The source and target shapes do not match or are ambiguous"
                                " for the connection '%s' to '%s'. Expected %s but got %s.")
@@ -864,8 +861,8 @@ class Group(System):
                             raise ValueError(msg % (abs_out, abs_in,
                                              bad_idx, out_size))
                         if src_indices.ndim > 1:
-                            abs2meta_in[abs_in]['src_indices'] = \
-                                abs2meta_in[abs_in]['src_indices'].flatten()
+                            abs2meta[abs_in]['src_indices'] = \
+                                abs2meta[abs_in]['src_indices'].flatten()
                     else:
                         for d in range(source_dimensions):
                             # when running under MPI, there is a value for each proc
@@ -986,8 +983,8 @@ class Group(System):
                 for abs_name in subsys._var_allprocs_abs_names[type_]:
                     abs2isub[type_][abs_name] = isub
 
-        abs2meta_in = self._var_abs2meta['input']
-        allprocs_abs2meta_out = self._var_allprocs_abs2meta['output']
+        abs2meta = self._var_abs2meta
+        allprocs_abs2meta = self._var_allprocs_abs2meta
 
         transfers = self._transfers
         vectors = self._vectors
@@ -1013,8 +1010,7 @@ class Group(System):
                         rev_xfer_in[isub][key] = []
                         rev_xfer_out[isub][key] = []
 
-            allprocs_abs2idx_byset_in = self._var_allprocs_abs2idx_byset[vec_name]['input']
-            allprocs_abs2idx_byset_out = self._var_allprocs_abs2idx_byset[vec_name]['output']
+            allprocs_abs2idx_byset = self._var_allprocs_abs2idx_byset[vec_name]
             sizes_byset_in = self._var_sizes_byset[vec_name]['input']
             sizes_byset_out = self._var_sizes_byset[vec_name]['output']
 
@@ -1024,17 +1020,17 @@ class Group(System):
                     continue
 
                 # Only continue if the input exists on this processor
-                if abs_in in abs2meta_in and abs_in in relvars['input']:
+                if abs_in in abs2meta and abs_in in relvars['input']:
 
                     # Get meta
-                    meta_in = abs2meta_in[abs_in]
-                    meta_out = allprocs_abs2meta_out[abs_out]
+                    meta_in = abs2meta[abs_in]
+                    meta_out = allprocs_abs2meta[abs_out]
 
                     # Get varset info
                     set_name_in = meta_in['var_set']
                     set_name_out = meta_out['var_set']
-                    idx_byset_in = allprocs_abs2idx_byset_in[abs_in]
-                    idx_byset_out = allprocs_abs2idx_byset_out[abs_out]
+                    idx_byset_in = allprocs_abs2idx_byset[abs_in]
+                    idx_byset_out = allprocs_abs2idx_byset[abs_out]
 
                     # Get the sizes (byset) array
                     sizes_in = sizes_byset_in[set_name_in]
@@ -1654,7 +1650,10 @@ class Group(System):
                     if key[1] in self._owns_approx_wrt_idx:
                         meta_changes['idx_wrt'] = self._owns_approx_wrt_idx[key[1]]
 
-                    meta = self._subjacs_info.get(key, SUBJAC_META_DEFAULTS.copy())
+                    if key in self._subjacs_info:
+                        meta = self._subjacs_info[key]
+                    else:
+                        meta = SUBJAC_META_DEFAULTS.copy()
 
                     # A group under approximation needs all keys from below, so set dependent to
                     # True.

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -171,15 +171,12 @@ class Problem(object):
             else:
                 proms = self.model._var_allprocs_prom2abs_list
                 meta = self.model._var_abs2meta
-                if name in meta['input']:
+                if name in meta:
                     if name in self.model._conn_abs_in2out:
                         src_name = self.model._conn_abs_in2out[name]
-                        val = meta['input'][src_name]['value']
+                        val = meta[src_name]['value']
                     else:
-                        val = meta['input'][name]['value']
-
-                elif name in meta['output']:
-                    val = meta['output'][name]['value']
+                        val = meta[name]['value']
 
                 elif name in proms['input']:
                     abs_name = proms['input'][name][0]
@@ -192,16 +189,16 @@ class Problem(object):
                             # This triggers a check for unconnected non-unique inputs, and
                             # raises the same error as vector access.
                             abs_name = prom_name2abs_name(self.model, name, 'input')
-                        val = meta['output'][src_name]['value']
+                        val = meta[src_name]['value']
                     else:
                         # This triggers a check for unconnected non-unique inputs, and
                         # raises the same error as vector access.
                         abs_name = prom_name2abs_name(self.model, name, 'input')
-                        val = meta['input'][abs_name]['value']
+                        val = meta[abs_name]['value']
 
                 elif name in proms['output']:
                     abs_name = prom_name2abs_name(self.model, name, 'output')
-                    val = meta['output'][abs_name]['value']
+                    val = meta[abs_name]['value']
 
                 else:
                     msg = 'Variable name "{}" not found.'
@@ -674,20 +671,20 @@ class Problem(object):
                             if deriv_value is None:
                                 # Missing derivatives are assumed 0.
                                 try:
-                                    in_size = comp._var_abs2meta['input'][wrt]['size']
+                                    in_size = comp._var_abs2meta[wrt]['size']
                                 except KeyError:
-                                    in_size = comp._var_abs2meta['output'][wrt]['size']
+                                    in_size = comp._var_abs2meta[wrt]['size']
 
-                                out_size = comp._var_abs2meta['output'][of]['size']
+                                out_size = comp._var_abs2meta[of]['size']
                                 deriv_value = np.zeros((out_size, in_size))
 
                             if force_dense:
                                 if isinstance(deriv_value, list):
                                     try:
-                                        in_size = comp._var_abs2meta['input'][wrt]['size']
+                                        in_size = comp._var_abs2meta[wrt]['size']
                                     except KeyError:
-                                        in_size = comp._var_abs2meta['output'][wrt]['size']
-                                    out_size = comp._var_abs2meta['output'][of]['size']
+                                        in_size = comp._var_abs2meta[wrt]['size']
+                                    out_size = comp._var_abs2meta[of]['size']
                                     tmp_value = np.zeros((out_size, in_size))
                                     jac_val, jac_i, jac_j = deriv_value
                                     # if a scalar value is provided (in declare_partials),
@@ -1099,8 +1096,8 @@ class Problem(object):
                 dinputs = input_vec[vecname]
                 doutputs = output_vec[vecname]
 
-                in_var_idx = model._var_allprocs_abs2idx[vecname]['output'][input_name]
-                in_var_meta = model._var_allprocs_abs2meta['output'][input_name]
+                in_var_idx = model._var_allprocs_abs2idx[vecname][input_name]
+                in_var_meta = model._var_allprocs_abs2meta[input_name]
 
                 dup = not in_var_meta['distributed']
 
@@ -1187,7 +1184,7 @@ class Problem(object):
         relevant = model._relevant
         fwd = (mode == 'fwd')
         prom2abs = model._var_allprocs_prom2abs_list['output']
-        abs2idx_out = model._var_allprocs_abs2idx['linear']['output']
+        abs2idx = model._var_allprocs_abs2idx['linear']
 
         if wrt is None:
             wrt = list(self.driver._designvars)
@@ -1462,7 +1459,7 @@ class Problem(object):
                         if use_rel_reduction and output_name not in relevant[input_name]:
                             # irrelevant output, just give zeros
                             if out_idxs is None:
-                                out_var_idx = abs2idx_out[output_name]
+                                out_var_idx = abs2idx[output_name]
                                 if output_name in remote_outputs:
                                     _, sz = remote_outputs[output_name]
                                 else:
@@ -1488,7 +1485,7 @@ class Problem(object):
                                     deriv_val = deriv_val[out_idxs]
 
                             if dup and nproc > 1:
-                                out_var_idx = abs2idx_out[output_name]
+                                out_var_idx = abs2idx[output_name]
                                 root = owning_ranks[output_name]
                                 if deriv_val is None:
                                     if out_idxs is not None:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -90,17 +90,17 @@ class System(object):
         For outputs, the list will have length one since promoted output names are unique.
     _var_abs2prom : {'input': dict, 'output': dict}
         Dictionary mapping absolute names to promoted names, on current proc.
-    _var_allprocs_abs2meta : {'input': dict, 'output': dict}
+    _var_allprocs_abs2meta : {}
         Dictionary mapping absolute names to metadata dictionaries for allprocs variables.
         The keys are
         ('units', 'shape', 'size', 'var_set') for inputs and
         ('units', 'shape', 'size', 'var_set', 'ref', 'ref0', 'res_ref', 'distributed') for outputs.
-    _var_abs2meta : {'input': dict, 'output': dict}
+    _var_abs2meta : {}
         Dictionary mapping absolute names to metadata dictionaries for myproc variables.
-    _var_allprocs_abs2idx : {'input': dict, 'output': dict}
+    _var_allprocs_abs2idx : dict
         Dictionary mapping absolute names to their indices among this system's allprocs variables.
         Therefore, the indices range from 0 to the total number of this system's variables.
-    _var_allprocs_abs2idx_byset : {<vec_name>:{'input': dict of dict, 'output': dict of dict}, ...}
+    _var_allprocs_abs2idx_byset : {<vec_name>: {dict of dict}, ...}
         Same as above, but by var_set name.
     _var_sizes : {'input': ndarray, 'output': ndarray}
         Array of local sizes of this system's allprocs variables.
@@ -295,10 +295,10 @@ class System(object):
         self._var_abs_names = {'input': [], 'output': []}
         self._var_allprocs_prom2abs_list = None
         self._var_abs2prom = {'input': {}, 'output': {}}
-        self._var_allprocs_abs2meta = {'input': {}, 'output': {}}
-        self._var_abs2meta = {'input': {}, 'output': {}}
+        self._var_allprocs_abs2meta = {}
+        self._var_abs2meta = {}
 
-        self._var_allprocs_abs2idx = {'input': {}, 'output': {}}
+        self._var_allprocs_abs2idx = {}
         self._var_allprocs_abs2idx_byset = None
 
         self._var_sizes = None
@@ -595,7 +595,7 @@ class System(object):
                                 ncol = voi['size']
                             else:
                                 owner = self._owning_rank['output'][vec_name]
-                                ncol = sizes[owner, abs2idx[vec_name]['output'][vec_name]]
+                                ncol = sizes[owner, abs2idx[vec_name][vec_name]]
                         rdct, _ = relevant[vec_name]['@all']
                         rel = rdct['output']
 
@@ -883,8 +883,8 @@ class System(object):
         self._var_abs_names = {'input': [], 'output': []}
         self._var_allprocs_prom2abs_list = {'input': {}, 'output': {}}
         self._var_abs2prom = {'input': {}, 'output': {}}
-        self._var_allprocs_abs2meta = {'input': {}, 'output': {}}
-        self._var_abs2meta = {'input': {}, 'output': {}}
+        self._var_allprocs_abs2meta = {}
+        self._var_abs2meta = {}
 
     def _setup_var_index_maps(self, recurse=True):
         """
@@ -897,19 +897,17 @@ class System(object):
         """
         self._var_allprocs_abs2idx = abs2idx = {}
         self._var_allprocs_abs2idx_byset = abs2idx_byset = {}
+        abs2meta = self._var_allprocs_abs2meta
 
         for vec_name in self._lin_rel_vec_name_list:
-            abs2idx[vec_name] = {'input': {}, 'output': {}}
-            abs2idx_byset[vec_name] = {'input': {}, 'output': {}}
+            abs2idx[vec_name] = abs2idx_t = {}
+            abs2idx_byset[vec_name] = abs2idx_byset_t = {}
             for type_ in ['input', 'output']:
                 counter = defaultdict(int)
-                abs2idx_t = abs2idx[vec_name][type_]
-                abs2idx_byset_t = abs2idx_byset[vec_name][type_]
-                abs2meta_t = self._var_allprocs_abs2meta[type_]
 
                 for i, abs_name in enumerate(self._var_allprocs_relevant_names[vec_name][type_]):
                     abs2idx_t[abs_name] = i
-                    set_name = abs2meta_t[abs_name]['var_set']
+                    set_name = abs2meta[abs_name]['var_set']
                     abs2idx_byset_t[abs_name] = counter[set_name]
                     counter[set_name] += 1
 
@@ -938,7 +936,7 @@ class System(object):
         """
         Compute the global size and shape of all variables on this system.
         """
-        meta = self._var_allprocs_abs2meta['output']
+        meta = self._var_allprocs_abs2meta
 
         # now set global sizes and shapes into metadata for distributed outputs
         sizes = self._var_sizes['nonlinear']['output']
@@ -1181,7 +1179,9 @@ class System(object):
         self._upper_bounds = upper = vector_class(
             'nonlinear', 'output', self, root_upper, resize=resize)
 
-        for abs_name, meta in iteritems(self._var_abs2meta['output']):
+        abs2meta = self._var_abs2meta
+        for abs_name in self._var_abs_names['output']:
+            meta = abs2meta[abs_name]
             shape = meta['shape']
             ref0 = meta['ref0']
             ref = meta['ref']
@@ -1221,8 +1221,8 @@ class System(object):
             ('input', 'norm'): (0.0, 1.0)
         })
 
-        abs2meta_in = self._var_abs2meta['input']
-        allprocs_meta_out = self._var_allprocs_abs2meta['output']
+        abs2meta_in = self._var_abs2meta
+        allprocs_meta_out = self._var_allprocs_abs2meta
 
         for abs_name in self._var_allprocs_abs_names['output']:
             meta = allprocs_meta_out[abs_name]
@@ -1421,11 +1421,12 @@ class System(object):
         """
         Set all input and output variables to their declared initial values.
         """
-        for abs_name, meta in iteritems(self._var_abs2meta['input']):
-            self._inputs._views[abs_name][:] = meta['value']
+        abs2meta = self._var_abs2meta
+        for abs_name in self._var_abs_names['input']:
+            self._inputs._views[abs_name][:] = abs2meta[abs_name]['value']
 
-        for abs_name, meta in iteritems(self._var_abs2meta['output']):
-            self._outputs._views[abs_name][:] = meta['value']
+        for abs_name in self._var_abs_names['output']:
+            self._outputs._views[abs_name][:] = abs2meta[abs_name]['value']
 
     def _transfer(self, vec_name, mode, isub=None):
         """
@@ -1586,7 +1587,7 @@ class System(object):
                 if abs_in in self._conn_global_abs_in2out:
                     abs_out = self._conn_global_abs_in2out[abs_in]
 
-                    if abs_out not in excl_sub._var_allprocs_abs2idx['linear']['output']:
+                    if abs_out not in excl_sub._var_allprocs_abs2idx['linear']:
                         scope_in.add(abs_in)
 
         self._scope_cache[excl_sub] = (scope_out, scope_in)
@@ -2378,7 +2379,7 @@ class System(object):
         if get_sizes:
             # Size them all
             sizes = self._var_sizes['nonlinear']['output']
-            abs2idx = self._var_allprocs_abs2idx['nonlinear']['output']
+            abs2idx = self._var_allprocs_abs2idx['nonlinear']
             for name in out:
                 if 'size' not in out[name]:
                     out[name]['size'] = sizes[self._owning_rank['output'][name], abs2idx[name]]
@@ -2430,7 +2431,7 @@ class System(object):
         if get_sizes:
             # Size them all
             sizes = self._var_sizes['nonlinear']['output']
-            abs2idx = self._var_allprocs_abs2idx['nonlinear']['output']
+            abs2idx = self._var_allprocs_abs2idx['nonlinear']
             for name in out:
                 if 'size' not in out[name]:
                     out[name]['size'] = sizes[self._owning_rank['output'][name], abs2idx[name]]
@@ -2549,7 +2550,7 @@ class System(object):
             if values:
                 outs['value'] = val
             if units:
-                outs['units'] = meta['input'][name]['units']
+                outs['units'] = meta[name]['units']
             inputs.append((name, outs))
 
         if out_stream:
@@ -2635,16 +2636,16 @@ class System(object):
             if residuals:
                 outs['resids'] = self._residuals._views[name]
             if units:
-                outs['units'] = meta['output'][name]['units']
+                outs['units'] = meta[name]['units']
             if shape:
                 outs['shape'] = val.shape
             if bounds:
-                outs['lower'] = meta['output'][name]['lower']
-                outs['upper'] = meta['output'][name]['upper']
+                outs['lower'] = meta[name]['lower']
+                outs['upper'] = meta[name]['upper']
             if scaling:
-                outs['ref'] = meta['output'][name]['ref']
-                outs['ref0'] = meta['output'][name]['ref0']
-                outs['res_ref'] = meta['output'][name]['res_ref']
+                outs['ref'] = meta[name]['ref']
+                outs['ref0'] = meta[name]['ref0']
+                outs['res_ref'] = meta[name]['res_ref']
             if name in states:
                 impl_outputs.append((name, outs))
             else:
@@ -2699,7 +2700,7 @@ class System(object):
             return
 
         # Only local metadata but the most complete
-        meta = self._var_abs2meta[in_or_out]
+        meta = self._var_abs2meta
 
         # Make a dict of outputs. Makes it easier to work with in this method
         dict_of_outputs = OrderedDict()

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -27,13 +27,13 @@ class TestExplicitComponent(unittest.TestCase):
 
         # check optional metadata (desc)
         self.assertEqual(
-            comp._var_abs2meta['input']['length']['desc'],
+            comp._var_abs2meta['length']['desc'],
             'length of rectangle')
         self.assertEqual(
-            comp._var_abs2meta['input']['width']['desc'],
+            comp._var_abs2meta['width']['desc'],
             'width of rectangle')
         self.assertEqual(
-            comp._var_abs2meta['output']['area']['desc'],
+            comp._var_abs2meta['area']['desc'],
             'area of rectangle')
 
         prob['length'] = 3.

--- a/openmdao/core/tests/test_core_simple.py
+++ b/openmdao/core/tests/test_core_simple.py
@@ -60,7 +60,7 @@ class Test(unittest.TestCase):
     def test_var_indices(self):
         def get_inds(p, sname, type_):
             system = p.model._get_subsystem(sname) if sname else p.model
-            idxs = p.model._var_allprocs_abs2idx['linear'][type_]
+            idxs = p.model._var_allprocs_abs2idx['linear']
             return np.array([
                 idxs[name] for name in system._var_abs_names[type_]
             ])

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -56,7 +56,7 @@ def dump_dist_idxs(problem, vec_name='nonlinear', stream=sys.stdout):  # pragma:
             set_total = 0
             for rank in range(g.comm.size):
                 for ivar, vname in enumerate(vnames[type_]):
-                    vset = abs2meta[type_][vname]['var_set']
+                    vset = abs2meta[vname]['var_set']
                     if vset == sname:
                         sz = sizes[type_][vset][rank, set_idxs[type_][vname]]
                         if sz > 0:
@@ -210,7 +210,7 @@ def config_summary(problem, stream=sys.stdout):
     sysnames = [s.pathname for s in allsystems]
     maxdepth = max([len(name.split('.')) for name in sysnames])
     setup_done = problem._setup_status == 2
-    meta_in = model._var_allprocs_abs2meta['input']
+    meta = model._var_allprocs_abs2meta
 
     print("============== Problem Summary ============", file=stream)
     print("Groups:           %5d" % len(allgroups), file=stream)
@@ -252,7 +252,7 @@ def config_summary(problem, stream=sys.stdout):
         print(file=stream)
         conns = model._conn_global_abs_in2out
         print("Total connections: %d   Total transfer data size: %d" %
-              (len(conns), sum(meta_in[n]['size'] for n in conns)), file=stream)
+              (len(conns), sum(meta[n]['size'] for n in conns)), file=stream)
 
     print(file=stream)
     print("Driver type: %s" % problem.driver.__class__.__name__, file=stream)

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -46,7 +46,7 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
         children = []
         for typ in ['input', 'output']:
             for ind, abs_name in enumerate(system._var_abs_names[typ]):
-                meta = system._var_abs2meta[typ][abs_name]
+                meta = system._var_abs2meta[abs_name]
                 name = system._var_abs2prom[typ][abs_name]
 
                 var_dict = OrderedDict()
@@ -280,7 +280,7 @@ def view_model(problem_or_filename, outfile='n2.html', show_browser=True, embedd
         index = index.replace('{{draw_potential_connections}}', 'true')
     else:
         index = index.replace('{{draw_potential_connections}}', 'false')
-        
+
     with open(outfile, 'w') as f:
         f.write(index)
 

--- a/openmdao/devtools/viewconns.py
+++ b/openmdao/devtools/viewconns.py
@@ -62,15 +62,13 @@ def view_connections(root, outfile='connections.html', show_browser=True,
 
     src2tgts = {}
     units = {n: data.get('units','')
-                for n, data in iteritems(system._var_allprocs_abs2meta['input'])}
-    units.update({n: data.get('units','')
-                for n, data in iteritems(system._var_allprocs_abs2meta['output'])})
+                for n, data in iteritems(system._var_allprocs_abs2meta)}
     vals = {}
 
     with printoptions(precision=precision, suppress=True, threshold=10000):
 
         for t in system._var_abs_names['input']:
-            tmeta = system._var_abs2meta['input'][t]
+            tmeta = system._var_abs2meta[t]
             idxs = tmeta['src_indices']
             flat = tmeta['flat_src_indices']
             if idxs is None:

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -99,7 +99,7 @@ class AssembledJacobian(Jacobian):
 
         sizes = system._var_sizes['nonlinear'][type_]
         iproc = system.comm.rank
-        idx = system._var_allprocs_abs2idx['nonlinear'][type_][abs_name]
+        idx = system._var_allprocs_abs2idx['nonlinear'][abs_name]
 
         ind1 = np.sum(sizes[iproc, :idx])
         ind2 = np.sum(sizes[iproc, :idx + 1])
@@ -113,8 +113,7 @@ class AssembledJacobian(Jacobian):
         # var_indices are the *global* indices for variables on this proc
         system = self._system
 
-        abs2meta_in = system._var_abs2meta['input']
-        abs2meta_out = system._var_abs2meta['output']
+        abs2meta = system._var_abs2meta
 
         self._int_mtx = int_mtx = self.options['matrix_class'](system.comm)
         ext_mtx = self.options['matrix_class'](system.comm)
@@ -152,42 +151,25 @@ class AssembledJacobian(Jacobian):
             self._view_ranges[s.pathname] = (
                 min_res_offset, max_res_offset, min_in_offset, max_in_offset)
 
+        abs2prom_out = system._var_abs2prom['output']
+        conns = system._conn_global_abs_in2out
+
         # create the matrix subjacs
-        for res_abs_name in system._var_abs_names['output']:
+        for abs_key, (info, shape) in iteritems(self._subjacs_info):
+            if not info['dependent']:
+                continue
+            res_abs_name, wrt_abs_name = abs_key
             res_offset, _ = out_ranges[res_abs_name]
-            res_size = abs2meta_out[res_abs_name]['size']
-
-            for out_abs_name in system._var_abs_names['output']:
-                out_offset, _ = out_ranges[out_abs_name]
-
-                abs_key = (res_abs_name, out_abs_name)
-                if abs_key in self._subjacs_info:
-                    info, shape = self._subjacs_info[abs_key]
-                else:
-                    info = SUBJAC_META_DEFAULTS
-                    shape = (res_size, abs2meta_out[out_abs_name]['size'])
-
+            if wrt_abs_name in abs2prom_out:
+                out_offset, _ = out_ranges[wrt_abs_name]
                 int_mtx._add_submat(
                     abs_key, info, res_offset, out_offset, None, shape)
-
-            for in_abs_name in system._var_abs_names['input']:
-                abs_key = (res_abs_name, in_abs_name)
-
-                if abs_key in self._subjacs_info:
-                    info, shape = self._subjacs_info[abs_key]
-                else:
-                    info = SUBJAC_META_DEFAULTS
-                    shape = (res_size, abs2meta_in[in_abs_name]['size'])
-
-                if not info['dependent']:
-                    continue
-
-                if in_abs_name in system._conn_global_abs_in2out:
-                    out_abs_name = system._conn_global_abs_in2out[in_abs_name]
-
+            else:
+                if wrt_abs_name in conns:  # connected input
+                    out_abs_name = conns[wrt_abs_name]
                     # calculate unit conversion
-                    in_units = abs2meta_in[in_abs_name]['units']
-                    out_units = abs2meta_out[out_abs_name]['units']
+                    in_units = abs2meta[wrt_abs_name]['units']
+                    out_units = abs2meta[out_abs_name]['units']
                     if in_units and out_units and in_units != out_units:
                         factor, _ = get_conversion(out_units, in_units)
                         if factor == 1.0:
@@ -196,7 +178,7 @@ class AssembledJacobian(Jacobian):
                         factor = None
 
                     out_offset, _ = out_ranges[out_abs_name]
-                    src_indices = abs2meta_in[in_abs_name]['src_indices']
+                    src_indices = abs2meta[wrt_abs_name]['src_indices']
                     if src_indices is None:
                         int_mtx._add_submat(
                             abs_key, info, res_offset, out_offset, None, shape,
@@ -210,9 +192,10 @@ class AssembledJacobian(Jacobian):
                         int_mtx._add_submat(
                             abs_key2, info, res_offset, out_offset,
                             src_indices, shape, factor)
-                else:
+
+                else:  # input connected to src outside current system
                     ext_mtx._add_submat(
-                        abs_key, info, res_offset, in_ranges[in_abs_name][0],
+                        abs_key, info, res_offset, in_ranges[wrt_abs_name][0],
                         None, shape)
 
                 if abs_key not in self._keymap:
@@ -240,8 +223,7 @@ class AssembledJacobian(Jacobian):
         system : <System>
             The system being solved using a sub-view of the jacobian.
         """
-        abs2meta_in = system._var_abs2meta['input']
-        abs2meta_out = system._var_abs2meta['output']
+        abs2meta = system._var_abs2meta
         ranges = self._view_ranges[system.pathname]
 
         ext_mtx = self.options['matrix_class'](system.comm)
@@ -251,12 +233,12 @@ class AssembledJacobian(Jacobian):
         for abs_name in system._var_allprocs_abs_names['input']:
             in_ranges[abs_name] = self._get_var_range(abs_name, 'input')[0]
             src_indices_dict[abs_name] = \
-                system._var_abs2meta['input'][abs_name]['src_indices']
+                system._var_abs2meta[abs_name]['src_indices']
 
         for s in system.system_iter(recurse=True, include_self=True, typ=Component):
             for res_abs_name in s._var_abs_names['output']:
                 res_offset = self._get_var_range(res_abs_name, 'output')[0]
-                res_size = abs2meta_out[res_abs_name]['size']
+                res_size = abs2meta[res_abs_name]['size']
 
                 for in_abs_name in s._var_abs_names['input']:
                     if in_abs_name not in system._conn_global_abs_in2out:
@@ -264,9 +246,10 @@ class AssembledJacobian(Jacobian):
 
                         if abs_key in self._subjacs_info:
                             info, shape = self._subjacs_info[abs_key]
+                            if not info['dependent']:
+                                continue
                         else:
-                            info = SUBJAC_META_DEFAULTS
-                            shape = (res_size, abs2meta_in[in_abs_name]['size'])
+                            continue
 
                         ext_mtx._add_submat(
                             abs_key, info, res_offset - ranges[0],
@@ -291,15 +274,15 @@ class AssembledJacobian(Jacobian):
         """
         system = self._system
         int_mtx = self._int_mtx
-        subjacs = self._subjacs
-        keymap = self._keymap
         ext_mtx = self._ext_mtx[system.pathname]
-        global_conns = system._conn_global_abs_in2out
-        output_names = system._var_abs_names['output']
-        input_names = system._var_abs_names['input']
+        subjacs = self._subjacs
 
         subjac_iters = self._subjac_iters[system.pathname]
         if subjac_iters is None:
+            keymap = self._keymap
+            global_conns = system._conn_global_abs_in2out
+            output_names = system._var_abs_names['output']
+            input_names = system._var_abs_names['input']
 
             # This is the level where the AssembledJacobian is slotted.
             # The of and wrt are the inputs and outputs that it sees, if they are in the subjacs.

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -68,10 +68,7 @@ class Jacobian(object):
             local size of the input variable.
         """
         abs2meta = self._system._var_abs2meta
-
-        if abs_key[1] in abs2meta['output']:
-            return (abs2meta['output'][abs_key[0]]['size'], abs2meta['output'][abs_key[1]]['size'])
-        return (abs2meta['output'][abs_key[0]]['size'], abs2meta['input'][abs_key[1]]['size'])
+        return (abs2meta[abs_key[0]]['size'], abs2meta[abs_key[1]]['size'])
 
     def _multiply_subjac(self, abs_key, val):
         """

--- a/openmdao/matrices/dense_matrix.py
+++ b/openmdao/matrices/dense_matrix.py
@@ -56,12 +56,11 @@ class DenseMatrix(Matrix):
 
                     metadata[key] = (irows, icols, type(val), factor)
             else:  # list format [data, rows, cols]
-                cols = info['cols']
                 if src_indices is None:
                     irows = rows + irow
-                    icols = cols + icol
+                    icols = info['cols'] + icol
                 else:
-                    irows, icols, idxs = _compute_index_map(rows, cols,
+                    irows, icols, idxs = _compute_index_map(rows, info['cols'],
                                                             irow, icol,
                                                             src_indices)
                     revidxs = np.argsort(idxs)

--- a/openmdao/utils/name_maps.py
+++ b/openmdao/utils/name_maps.py
@@ -223,16 +223,14 @@ def key2abs_key(system, key):
     (str, str) or None
         Absolute name pair of sub-Jacobian if unique abs_key found or None otherwise.
     """
-    abs2meta_out = system._var_abs2meta['output']
-    abs2meta_in = system._var_abs2meta['input']
+    abs2meta = system._var_abs2meta
 
     abs_key = prom_key2abs_key(system, key)
     if abs_key is not None:
         return abs_key
 
     abs_key = rel_key2abs_key(system, key)
-    if (abs_key[0] in abs2meta_out
-            and (abs_key[1] in abs2meta_out or abs_key[1] in abs2meta_in)):
+    if abs_key[0] in abs2meta and abs_key[1] in abs2meta:
         return abs_key
     else:
         return None

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -124,11 +124,11 @@ class DefaultVector(Vector):
                 indices[set_name] = np.empty(size, int)
 
         if nsets > 1:
-            abs2meta_t = system._var_abs2meta[type_]
-            allprocs_abs2idx_byset_t = system._var_allprocs_abs2idx_byset[self._name][type_]
-            allprocs_abs2idx_t = system._var_allprocs_abs2idx[self._name][type_]
+            abs2meta = system._var_abs2meta
+            allprocs_abs2idx_byset_t = system._var_allprocs_abs2idx_byset[self._name]
+            allprocs_abs2idx_t = system._var_allprocs_abs2idx[self._name]
             for abs_name in system._var_relevant_names[self._name][type_]:
-                set_name = abs2meta_t[abs_name]['var_set']
+                set_name = abs2meta[abs_name]['var_set']
 
                 idx_byset = allprocs_abs2idx_byset_t[abs_name]
                 ind_byset1 = np.sum(sizes_byset_t[set_name][iproc, :idx_byset])
@@ -343,16 +343,16 @@ class DefaultVector(Vector):
         self._imag_views = imag_views = {}
         self._imag_views_flat = imag_views_flat = {}
 
-        allprocs_abs2idx_byset_t = system._var_allprocs_abs2idx_byset[self._name][type_]
+        allprocs_abs2idx_byset_t = system._var_allprocs_abs2idx_byset[self._name]
         sizes_byset_t = system._var_sizes_byset[self._name][type_]
-        abs2meta_t = system._var_abs2meta[type_]
+        abs2meta = system._var_abs2meta
         for abs_name in system._var_relevant_names[self._name][type_]:
             idx_byset = allprocs_abs2idx_byset_t[abs_name]
-            set_name = abs2meta_t[abs_name]['var_set']
+            set_name = abs2meta[abs_name]['var_set']
 
             ind_byset1 = np.sum(sizes_byset_t[set_name][iproc, :idx_byset])
             ind_byset2 = np.sum(sizes_byset_t[set_name][iproc, :idx_byset + 1])
-            shape = abs2meta_t[abs_name]['shape']
+            shape = abs2meta[abs_name]['shape']
             if ncol > 1:
                 if not isinstance(shape, tuple):
                     shape = (shape,)


### PR DESCRIPTION
- got rid of unnecessary looping and unnecessary creation of metadata dicts for deriv key pairs when dependent==False.
- got rid of unnecessary dict layer for _var_allprocs_abs2meta and _var_abs2meta.

This results in an approx. 10x improvement (40 sec down to 4 sec) in the setup time for the CFM56 model.