### PR TITLE
verified that simul coloring works with ScipyOptimizeDriver

### DIFF
--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -29,6 +29,7 @@ class RunOnceCounter(LinearRunOnce):
 
 def run_opt(driver_class, options, color_info=None):
 
+    # note: size must be an even number
     SIZE = 10
     p = Problem()
 
@@ -79,8 +80,8 @@ def run_opt(driver_class, options, color_info=None):
 
     IND = np.arange(SIZE, dtype=int)
     ODD_IND = IND[0::2]  # all odd indices
-    p.model.add_constraint('theta_con.g', lower=-1e-5, upper=1e-5, indices=ODD_IND)#  equals=0,)
-    p.model.add_constraint('delta_theta_con.g', lower=-1e-5, upper=1e-5) # equals=0)
+    p.model.add_constraint('theta_con.g', lower=-1e-5, upper=1e-5, indices=ODD_IND)
+    p.model.add_constraint('delta_theta_con.g', lower=-1e-5, upper=1e-5)
 
     # this constrains x[0] to be 1 (see definition of l_conx)
     p.model.add_constraint('l_conx.g', equals=0, linear=False, indices=[0,])
@@ -104,8 +105,6 @@ class SimulColoringTestCase(unittest.TestCase):
 
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_simul_coloring_snopt(self):
-
-        #note: size must always be an even number!!
 
         # first, run w/o coloring
         p = run_opt(pyOptSparseDriver, {'optimizer': 'SNOPT', 'print_results': False})
@@ -165,8 +164,6 @@ class SimulColoringTestCase(unittest.TestCase):
         except:
             raise unittest.SkipTest("This test requires pyoptsparse SLSQP.")
 
-        #note: size must always be an even number!!
-
         # first, run w/o coloring
         p = run_opt(pyOptSparseDriver, {'optimizer': 'SLSQP', 'print_results': False})
 
@@ -218,8 +215,6 @@ class SimulColoringTestCase(unittest.TestCase):
 class SimulColoringScipyTestCase(unittest.TestCase):
 
     def test_simul_coloring(self):
-
-        #note: size must always be an even number!!
 
         # first, run w/o coloring
         p = run_opt(ScipyOptimizeDriver, {'optimizer': 'SLSQP', 'disp': False})
@@ -273,6 +268,7 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         from openmdao.api import Problem, IndepVarComp, ExecComp, ScipyOptimizeDriver
         import numpy as np
 
+        # note: size must be an even number
         SIZE = 10
         p = Problem()
 

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -7,7 +7,7 @@ import math
 from numpy.testing import assert_array_almost_equal, assert_almost_equal
 
 from openmdao.api import Problem, IndepVarComp, ExecComp, DenseJacobian, DirectSolver,\
-    ExplicitComponent, LinearRunOnce
+    ExplicitComponent, LinearRunOnce, ScipyOptimizeDriver
 from openmdao.utils.assert_utils import assert_rel_error
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
@@ -27,13 +27,12 @@ class RunOnceCounter(LinearRunOnce):
         super(RunOnceCounter, self)._iter_execute()
         self._solve_count += 1
 
-def run_opt(color_info=None):
+def run_opt(driver_class, options, color_info=None):
 
     SIZE = 10
     p = Problem()
 
     p.model.linear_solver = RunOnceCounter()
-
     indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
 
     # the following were randomly generated using np.random.random(10)*2-1 to randomly
@@ -46,7 +45,6 @@ def run_opt(color_info=None):
 
     p.model.add_subsystem('circle', ExecComp('area=pi*r**2'))
 
-    # nonlinear constraints
     p.model.add_subsystem('r_con', ExecComp('g=x**2 + y**2 - r',
                                             g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
@@ -60,8 +58,6 @@ def run_opt(color_info=None):
 
     thetas = np.linspace(0, np.pi/4, SIZE)
 
-
-    # linear constraint
     p.model.add_subsystem('l_conx', ExecComp('g=x-1', g=np.ones(SIZE), x=np.ones(SIZE)))
 
     p.model.connect('r', ('circle.r', 'r_con.r'))
@@ -71,23 +67,25 @@ def run_opt(color_info=None):
 
     p.model.connect('y', ['r_con.y', 'theta_con.y', 'delta_theta_con.y'])
 
-    p.driver = pyOptSparseDriver()
-    p.driver.options['optimizer'] = OPTIMIZER
-    p.driver.options['print_results'] = False
+    p.driver = driver_class()
+    p.driver.options.update(options)
 
     p.model.add_design_var('x')
     p.model.add_design_var('y')
     p.model.add_design_var('r', lower=.5, upper=10)
+
+    # nonlinear constraints
     p.model.add_constraint('r_con.g', equals=0)
 
     IND = np.arange(SIZE, dtype=int)
-    ODD_IND = IND[0::2]
-    p.model.add_constraint('theta_con.g', equals=0, indices=ODD_IND)
-    p.model.add_constraint('delta_theta_con.g', equals=0)
+    ODD_IND = IND[0::2]  # all odd indices
+    p.model.add_constraint('theta_con.g', lower=-1e-5, upper=1e-5, indices=ODD_IND)#  equals=0,)
+    p.model.add_constraint('delta_theta_con.g', lower=-1e-5, upper=1e-5) # equals=0)
 
-    #TODO: setting this one to true breaks the optimization
-    # p.model.add_constraint('l_conx.g', equals=0, linear=False)
+    # this constrains x[0] to be 1 (see definition of l_conx)
     p.model.add_constraint('l_conx.g', equals=0, linear=False, indices=[0,])
+
+    # linear constraint
     p.model.add_constraint('y', equals=0, indices=[0,], linear=True)
 
     p.model.add_objective('circle.area', ref=-1)
@@ -102,15 +100,15 @@ def run_opt(color_info=None):
     return p
 
 
-@unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
 class SimulColoringTestCase(unittest.TestCase):
 
-    def test_simul_coloring(self):
+    @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
+    def test_simul_coloring_snopt(self):
 
         #note: size must always be an even number!!
 
         # first, run w/o coloring
-        p = run_opt()
+        p = run_opt(pyOptSparseDriver, {'optimizer': 'SNOPT', 'print_results': False})
 
         color_info = (
         {
@@ -144,7 +142,122 @@ class SimulColoringTestCase(unittest.TestCase):
             }
         })
 
-        p_color = run_opt(color_info)
+        p_color = run_opt(pyOptSparseDriver, {'optimizer': 'SNOPT', 'print_results': False},
+                          color_info)
+
+        assert_almost_equal(p['circle.area'], np.pi, decimal=7)
+        assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
+
+        # - coloring saves 16 solves per driver iter  (5 vs 21)
+        # - initial solve for linear constraints takes 21 in both cases (only done once)
+        # - (total_solves - 21) / (solves_per_iter) should be equal between the two cases
+        self.assertEqual((p.model.linear_solver._solve_count - 21) / 21,
+                         (p_color.model.linear_solver._solve_count - 21) / 5)
+
+    def test_simul_coloring_pyoptsparse_slsqp(self):
+        try:
+            from pyoptsparse import OPT
+        except ImportError:
+            raise unittest.SkipTest("This test requires pyoptsparse.")
+
+        try:
+            OPT('SLSQP')
+        except:
+            raise unittest.SkipTest("This test requires pyoptsparse SLSQP.")
+
+        #note: size must always be an even number!!
+
+        # first, run w/o coloring
+        p = run_opt(pyOptSparseDriver, {'optimizer': 'SLSQP', 'print_results': False})
+
+        color_info = (
+        {
+            'indeps.y': [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+            'x': [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+        },
+        {
+            'delta_theta_con.g': {
+                'indeps.y': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8]),
+                    1: ([0, 1, 2, 3, 4], [1, 3, 5, 7, 9])},
+                'indeps.x': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8]),
+                    1: ([0, 1, 2, 3, 4], [1, 3, 5, 7, 9])}},
+            'r_con.g': {
+                'indeps.y': {
+                    0: ([0, 2, 4, 6, 8], [0, 2, 4, 6, 8]),
+                    1: ([1, 3, 5, 7, 9], [1, 3, 5, 7, 9])},
+                'x': {
+                    0: ([0, 2, 4, 6, 8], [0, 2, 4, 6, 8]),
+                    1: ([1, 3, 5, 7, 9], [1, 3, 5, 7, 9])}},
+            'l_conx.g': {
+                'indeps.x': {
+                    0: ([0], [0])}},
+            'theta_con.g': {
+                'indeps.y': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8])},
+                'indeps.x': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8])
+                }
+            }
+        })
+
+        p_color = run_opt(pyOptSparseDriver, {'optimizer': 'SLSQP', 'print_results': False},
+                          color_info)
+
+        assert_almost_equal(p['circle.area'], np.pi, decimal=7)
+        assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
+
+        # - coloring saves 16 solves per driver iter  (5 vs 21)
+        # - initial solve for linear constraints takes 21 in both cases (only done once)
+        # - (total_solves - 21) / (solves_per_iter) should be equal between the two cases
+        self.assertEqual((p.model.linear_solver._solve_count - 21) / 21,
+                         (p_color.model.linear_solver._solve_count - 21) / 5)
+
+
+class SimulColoringScipyTestCase(unittest.TestCase):
+
+    def test_simul_coloring(self):
+
+        #note: size must always be an even number!!
+
+        # first, run w/o coloring
+        p = run_opt(ScipyOptimizeDriver, {'optimizer': 'SLSQP', 'disp': False})
+
+        color_info = (
+        {
+            'indeps.y': [0, 1, 0, 1, 0, 1, 0, 1, 0, 1],
+            'x': [0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+        },
+        {
+            'delta_theta_con.g': {
+                'indeps.y': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8]),
+                    1: ([0, 1, 2, 3, 4], [1, 3, 5, 7, 9])},
+                'indeps.x': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8]),
+                    1: ([0, 1, 2, 3, 4], [1, 3, 5, 7, 9])}},
+            'r_con.g': {
+                'indeps.y': {
+                    0: ([0, 2, 4, 6, 8], [0, 2, 4, 6, 8]),
+                    1: ([1, 3, 5, 7, 9], [1, 3, 5, 7, 9])},
+                'x': {
+                    0: ([0, 2, 4, 6, 8], [0, 2, 4, 6, 8]),
+                    1: ([1, 3, 5, 7, 9], [1, 3, 5, 7, 9])}},
+            'l_conx.g': {
+                'indeps.x': {
+                    0: ([0], [0])}},
+            'theta_con.g': {
+                'indeps.y': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8])},
+                'indeps.x': {
+                    0: ([0, 1, 2, 3, 4], [0, 2, 4, 6, 8])
+                }
+            }
+        })
+
+        p_color = run_opt(ScipyOptimizeDriver, {'optimizer': 'SLSQP', 'disp': False},
+                    color_info)
 
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
@@ -157,7 +270,7 @@ class SimulColoringTestCase(unittest.TestCase):
 
     def test_simul_coloring_example(self):
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, pyOptSparseDriver
+        from openmdao.api import Problem, IndepVarComp, ExecComp, ScipyOptimizeDriver
         import numpy as np
 
         SIZE = 10
@@ -175,7 +288,6 @@ class SimulColoringTestCase(unittest.TestCase):
 
         p.model.add_subsystem('circle', ExecComp('area=pi*r**2'))
 
-        # nonlinear constraints
         p.model.add_subsystem('r_con', ExecComp('g=x**2 + y**2 - r',
                                                 g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
@@ -198,22 +310,26 @@ class SimulColoringTestCase(unittest.TestCase):
 
         p.model.connect('y', ['r_con.y', 'theta_con.y', 'delta_theta_con.y'])
 
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
-        p.driver.options['print_results'] = False
+        p.driver = ScipyOptimizeDriver()
+        p.driver.options['optimizer'] = 'SLSQP'
+        p.driver.options['disp'] = False
 
         p.model.add_design_var('x')
         p.model.add_design_var('y')
         p.model.add_design_var('r', lower=.5, upper=10)
+
+        # nonlinear constraints
         p.model.add_constraint('r_con.g', equals=0)
 
         IND = np.arange(SIZE, dtype=int)
         ODD_IND = IND[0::2]  # all odd indices
-        p.model.add_constraint('theta_con.g', equals=0, indices=ODD_IND)
-        p.model.add_constraint('delta_theta_con.g', equals=0)
+        p.model.add_constraint('theta_con.g', lower=-1e-5, upper=1e-5, indices=ODD_IND)
+        p.model.add_constraint('delta_theta_con.g', lower=-1e-5, upper=1e-5)
 
         # this constrains x[0] to be 1 (see definition of l_conx)
         p.model.add_constraint('l_conx.g', equals=0, linear=False, indices=[0,])
+
+        # linear constraint
         p.model.add_constraint('y', equals=0, indices=[0,], linear=True)
 
         p.model.add_objective('circle.area', ref=-1)

--- a/openmdao/docs/examples/simul_deriv_example/simul_deriv_example.rst
+++ b/openmdao/docs/examples/simul_deriv_example/simul_deriv_example.rst
@@ -10,8 +10,8 @@ distributed within a unit circle centered about the origin.  The locations of ou
 determined by the values of the *x* and *y* arrays defined in our problem.
 
 
-.. embed-code::
-    openmdao.core.tests.test_coloring.SimulColoringTestCase.test_simul_coloring_example
+.. embed-test::
+    openmdao.core.tests.test_coloring.SimulColoringScipyTestCase.test_simul_coloring_example
 
 
 Total derivatives with respect to *x* and *y* will be solved for simultaneously based on the

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -530,12 +530,12 @@ class pyOptSparseDriver(Driver):
 
     def _get_name(self):
         """
-        Get name of current driver.
+        Get name of current optimizer.
 
         Returns
         -------
-        optimizer : str
-            The name of the current driver.
+        str
+            The name of the current optimizer.
         """
         return self.options['optimizer']
 

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -108,6 +108,7 @@ class ScipyOptimizeDriver(Driver):
         self.supports['equality_constraints'] = True
         self.supports['two_sided_constraints'] = True
         self.supports['linear_constraints'] = True
+        self.supports['simultaneous_derivatives'] = True
 
         # What we don't support
         self.supports['multiple_objectives'] = False
@@ -140,6 +141,17 @@ class ScipyOptimizeDriver(Driver):
         self._exc_info = None
 
         self.cite = CITATIONS
+
+    def _get_name(self):
+        """
+        Get name of current driver.
+
+        Returns
+        -------
+        optimizer : str
+            The name of the current driver.
+        """
+        return self.options['optimizer']
 
     def _setup_driver(self, problem):
         """

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -144,12 +144,12 @@ class ScipyOptimizeDriver(Driver):
 
     def _get_name(self):
         """
-        Get name of current driver.
+        Get name of current optimizer.
 
         Returns
         -------
-        optimizer : str
-            The name of the current driver.
+        str
+            The name of the current optimizer.
         """
         return self.options['optimizer']
 


### PR DESCRIPTION
- added a test to check calls to solve_linear in the colored and non-colored cases for scipy SLSQP
- turned embedded coloring example back into an active embedded test and changed it to use ScipyOptimizeDriver SLSQP instead of pyoptsparse with SNOPT.
- updated the 'supports' metadata for ScipyOptimizeDriver to say it support simultaneous derivs.
- added a missing _get_name method to ScipyOptimizeDriver.