### PR TITLE
Fix command line tools in Windows

### DIFF
--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -260,21 +260,23 @@ def config_summary(problem, stream=sys.stdout):
                                                          allgroups)),
           file=stream)
 
+try:
+    import resource
 
-def max_mem_usage():
-    """
-    Returns
-    -------
-    The max memory used by this process and its children, in MB.
-    """
-    from resource import getrusage, RUSAGE_SELF, RUSAGE_CHILDREN
-
-    denom = 1024.
-    if sys.platform == 'darwin':
-        denom *= denom
-    total = getrusage(RUSAGE_SELF).ru_maxrss / denom
-    total += getrusage(RUSAGE_CHILDREN).ru_maxrss / denom
-    return total
+    def max_mem_usage():
+        """
+        Returns
+        -------
+        The max memory used by this process and its children, in MB.
+        """
+        denom = 1024.
+        if sys.platform == 'darwin':
+            denom *= denom
+        total = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / denom
+        total += resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss / denom
+        return total
+except ImportError:
+    pass
 
 try:
     import psutil

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -5,8 +5,6 @@ from __future__ import print_function
 import sys
 import os
 
-from resource import getrusage, RUSAGE_SELF, RUSAGE_CHILDREN
-
 from six.moves import zip_longest
 from openmdao.core.problem import Problem
 from openmdao.core.group import Group, System
@@ -269,6 +267,8 @@ def max_mem_usage():
     -------
     The max memory used by this process and its children, in MB.
     """
+    from resource import getrusage, RUSAGE_SELF, RUSAGE_CHILDREN
+
     denom = 1024.
     if sys.platform == 'darwin':
         denom *= denom


### PR DESCRIPTION
When trying to use the command line tool ``openmdao view_model`` in Windows, an error is thrown because ``om.py`` loads the ``openmdao.devtools.debug`` module which then imports the ``resource`` module. But ``resource`` is a [Unix-specific service](https://docs.python.org/2/library/resource.html) and isn't available in Windows. The nature of this error means that all command line tools should cause an error when run on Windows. 

A simple fix is to move the ``import resource`` line to inside the ``max_mem_usage()`` function since those tools are only used within that function. Now ``openmdao view_model`` works in Windows.