### PR TITLE
P155914185 Error msg from asser_check_partials needs to be more clear

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -26,6 +26,7 @@ from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.general_utils import warn_deprecation, ContainsAll
 from openmdao.utils.mpi import MPI, FakeComm
 from openmdao.utils.name_maps import prom_name2abs_name
+from openmdao.utils.general_utils import pad_name
 from openmdao.vectors.default_vector import DefaultVector
 
 try:
@@ -1745,12 +1746,12 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                 if totals:
                     header = "{0} wrt {1} | {2} | {3} | {4} | {5}"\
                         .format(
-                            _pad_name('<output>', 30, quotes=True),
-                            _pad_name('<variable>', 30, quotes=True),
-                            _pad_name('calc mag.'),
-                            _pad_name('check mag.'),
-                            _pad_name('a(cal-chk)'),
-                            _pad_name('r(cal-chk)'),
+                            pad_name('<output>', 30, quotes=True),
+                            pad_name('<variable>', 30, quotes=True),
+                            pad_name('calc mag.'),
+                            pad_name('check mag.'),
+                            pad_name('a(cal-chk)'),
+                            pad_name('r(cal-chk)'),
                         )
                 else:
                     max_width_of = len("'<output>'")
@@ -1763,27 +1764,27 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                         header = \
                             "{0} wrt {1} | {2} | {3} | {4} | {5} | {6} | {7} | {8} | {9} | {10}" \
                             .format(
-                                _pad_name('<output>', max_width_of, quotes=True),
-                                _pad_name('<variable>', max_width_wrt, quotes=True),
-                                _pad_name('fwd mag.'),
-                                _pad_name('rev mag.'),
-                                _pad_name('check mag.'),
-                                _pad_name('a(fwd-chk)'),
-                                _pad_name('a(rev-chk)'),
-                                _pad_name('a(fwd-rev)'),
-                                _pad_name('r(fwd-chk)'),
-                                _pad_name('r(rev-chk)'),
-                                _pad_name('r(fwd-rev)')
+                                pad_name('<output>', max_width_of, quotes=True),
+                                pad_name('<variable>', max_width_wrt, quotes=True),
+                                pad_name('fwd mag.'),
+                                pad_name('rev mag.'),
+                                pad_name('check mag.'),
+                                pad_name('a(fwd-chk)'),
+                                pad_name('a(rev-chk)'),
+                                pad_name('a(fwd-rev)'),
+                                pad_name('r(fwd-chk)'),
+                                pad_name('r(rev-chk)'),
+                                pad_name('r(fwd-rev)')
                             )
                     else:
                         header = "{0} wrt {1} | {2} | {3} | {4} | {5}"\
                             .format(
-                                _pad_name('<output>', max_width_of, quotes=True),
-                                _pad_name('<variable>', max_width_wrt, quotes=True),
-                                _pad_name('fwd mag.'),
-                                _pad_name('check mag.'),
-                                _pad_name('a(fwd-chk)'),
-                                _pad_name('r(fwd-chk)'),
+                                pad_name('<output>', max_width_of, quotes=True),
+                                pad_name('<variable>', max_width_wrt, quotes=True),
+                                pad_name('fwd mag.'),
+                                pad_name('check mag.'),
+                                pad_name('a(fwd-chk)'),
+                                pad_name('r(fwd-chk)'),
                             )
                 if out_stream:
                     out_buffer.write(header + '\n')
@@ -1838,8 +1839,8 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                     if totals:
                         if out_stream:
                             out_stream.write(deriv_line.format(
-                                _pad_name(of, 30, quotes=True),
-                                _pad_name(wrt, 30, quotes=True),
+                                pad_name(of, 30, quotes=True),
+                                pad_name(wrt, 30, quotes=True),
                                 magnitude.forward,
                                 magnitude.fd,
                                 abs_err.forward,
@@ -1875,8 +1876,8 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                             if not all_comps_provide_jacs:
                                 deriv_info_line = \
                                     deriv_line.format(
-                                        _pad_name(of, max_width_of, quotes=True),
-                                        _pad_name(wrt, max_width_wrt, quotes=True),
+                                        pad_name(of, max_width_of, quotes=True),
+                                        pad_name(wrt, max_width_wrt, quotes=True),
                                         magnitude.forward,
                                         _format_if_not_matrix_free(
                                             system.matrix_free, magnitude.reverse),
@@ -1895,8 +1896,8 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                             else:
                                 deriv_info_line = \
                                     deriv_line.format(
-                                        _pad_name(of, max_width_of, quotes=True),
-                                        _pad_name(wrt, max_width_wrt, quotes=True),
+                                        pad_name(of, max_width_of, quotes=True),
+                                        pad_name(wrt, max_width_wrt, quotes=True),
                                         magnitude.forward,
                                         magnitude.fd,
                                         abs_err.forward,
@@ -2017,42 +2018,7 @@ def _format_if_not_matrix_free(matrix_free, val):
     if matrix_free:
         return '{0:.4e}'.format(val)
     else:
-        return _pad_name('n/a')
-
-
-def _pad_name(name, pad_num=10, quotes=False):
-    """
-    Pad a string so that they all line up when stacked.
-
-    Parameters
-    ----------
-    name : str
-        The string to pad.
-    pad_num : int
-        The number of total spaces the string should take up.
-    quotes : bool
-        If name should be quoted.
-
-    Returns
-    -------
-    str
-        Padded string
-    """
-    l_name = len(name)
-    quotes_len = 2 if quotes else 0
-    if l_name + quotes_len < pad_num:
-        pad = pad_num - (l_name + quotes_len)
-        if quotes:
-            pad_str = "'{name}'{sep:<{pad}}"
-        else:
-            pad_str = "{name}{sep:<{pad}}"
-        pad_name = pad_str.format(name=name, sep='', pad=pad)
-        return pad_name
-    else:
-        if quotes:
-            return "'{0}'".format(name)
-        else:
-            return '{0}'.format(name)
+        return pad_name('n/a')
 
 
 def _format_error(error, tol):

--- a/openmdao/docs/features/core_features/working_with_derivatives/unit_testing_partials.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/unit_testing_partials.rst
@@ -19,5 +19,5 @@ Usage
 -----
 
 .. embed-code::
-    openmdao.utils.tests.test_assert_utils.TestAssertUtils.test_assert_check_partials_no_exception_expected
+    openmdao.utils.tests.test_assert_utils.TestAssertUtils.test_feature_assert_check_partials_exception_expected
     :layout: interleave

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -349,3 +349,38 @@ def find_matches(pattern, var_list):
     elif pattern in var_list:
         return [pattern]
     return [name for name in var_list if fnmatchcase(name, pattern)]
+
+
+def pad_name(name, pad_num=10, quotes=False):
+    """
+    Pad a string so that they all line up when stacked.
+
+    Parameters
+    ----------
+    name : str
+        The string to pad.
+    pad_num : int
+        The number of total spaces the string should take up.
+    quotes : bool
+        If name should be quoted.
+
+    Returns
+    -------
+    str
+        Padded string
+    """
+    l_name = len(name)
+    quotes_len = 2 if quotes else 0
+    if l_name + quotes_len < pad_num:
+        pad = pad_num - (l_name + quotes_len)
+        if quotes:
+            pad_str = "'{name}'{sep:<{pad}}"
+        else:
+            pad_str = "{name}{sep:<{pad}}"
+        pad_name = pad_str.format(name=name, sep='', pad=pad)
+        return pad_name
+    else:
+        if quotes:
+            return "'{0}'".format(name)
+        else:
+            return '{0}'.format(name)

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -82,11 +82,20 @@ class TestAssertUtils(unittest.TestCase):
         rtol = 1.e-6
         try:
             assert_check_partials(data, atol, rtol)
-        except AssertionError as err:
+        except ValueError as err:
+            err_string = str(err)
+            self.assertEqual(err_string.count('Assert Check Partials failed for the following Components'), 1)
+            self.assertEqual(err_string.count('1e-06'), 2)
+            self.assertEqual(err_string.count('Component:'), 1)
+            self.assertEqual(err_string.count('< output > wrt < variable >'), 1)
+            self.assertEqual(err_string.count('norm'), 2)
+            self.assertEqual(err_string.count('y wrt x1'), 4)
+            self.assertEqual(err_string.count('y wrt x2'), 4)
+            self.assertEqual(err_string.count('abs'), 6)
+            self.assertEqual(err_string.count('rel'), 6)
+            self.assertEqual(err_string.count('fwd-fd'), 4)
+            self.assertEqual(err_string.count('rev-fd'), 4)
             expected_str = "error in partial of y wrt x1 in"
-            self.assertTrue(expected_str in str(err),
-                            msg="\n\nActual err msg:\n{} \n\ndoes not contain expected string:\n\n{}".format(str(err),
-                                                                                                     expected_str))
         else:
             self.fail('Exception expected.')
 

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -95,9 +95,45 @@ class TestAssertUtils(unittest.TestCase):
             self.assertEqual(err_string.count('rel'), 6)
             self.assertEqual(err_string.count('fwd-fd'), 4)
             self.assertEqual(err_string.count('rev-fd'), 4)
-            expected_str = "error in partial of y wrt x1 in"
         else:
             self.fail('Exception expected.')
+
+    def test_feature_assert_check_partials_exception_expected(self):
+        class MyComp(ExplicitComponent):
+            def setup(self):
+                self.add_input('x1', 3.0)
+                self.add_input('x2', 5.0)
+
+                self.add_output('y', 5.5)
+
+                self.declare_partials(of='*', wrt='*')
+
+            def compute(self, inputs, outputs):
+                """ Compute outputs. """
+                outputs['y'] = 3.0 * inputs['x1'] + 4.0 * inputs['x2']
+
+            def compute_partials(self, inputs, partials):
+                """Intentionally incorrect derivative."""
+                J = partials
+                J['y', 'x1'] = np.array([4.0])
+                J['y', 'x2'] = np.array([40])
+
+        prob = Problem()
+        prob.model = MyComp()
+
+        prob.set_solver_print(level=0)
+
+        prob.setup(check=False)
+        prob.run_model()
+
+        data = prob.check_partials(suppress_output=True)
+
+        atol = 1.e-6
+        rtol = 1.e-6
+        try:
+            assert_check_partials(data, atol, rtol)
+        except ValueError as err:
+            print(str(err))
 
     def test_assert_no_approx_partials_exception_expected(self):
 


### PR DESCRIPTION
We currently get the following: 
```Traceback (most recent call last):
  File "test_usatm1976.py", line 27, in test_derivs
    assert_check_partials(data, atol=1e-6, rtol=1e-6)
  File "/Users/justingray/work/blue/openmdao/utils/assert_utils.py", line 49, in assert_check_partials
    verbose=True)
  File "/Users/justingray/anaconda3/lib/python3.6/site-packages/numpy/testing/utils.py", line 1411, in assert_allclose
    verbose=verbose, header=header, equal_nan=equal_nan)
  File "/Users/justingray/anaconda3/lib/python3.6/site-packages/numpy/testing/utils.py", line 796, in assert_array_compare
    raise AssertionError(msg)
AssertionError: 
Not equal to tolerance rtol=1e-07, atol=1e-06
rel error error in partial of Ts wrt alt in component std_1976
(mismatch 66.66666666666666%)
 x: array([  7.483854e-06,   7.483854e-06,   0.000000e+00])
 y: array([ 0.,  0.,  0.])```

I believe thats supposed to be fwd-fd, rev-fd, fd-rev? The message needs to make it more clear what the problem is. Not just spit out 6 numbers