### PR TITLE
Embed code error

### DIFF
--- a/openmdao/devtools/docs_experiment/experimental_guide/examples/bezier_plot.py
+++ b/openmdao/devtools/docs_experiment/experimental_guide/examples/bezier_plot.py
@@ -1,3 +1,5 @@
+# Adding a comment and a future import to make sure it works.
+from __future__ import print_function
 import matplotlib.path as mpath
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt

--- a/openmdao/docs/_exts/embed_code.py
+++ b/openmdao/docs/_exts/embed_code.py
@@ -137,13 +137,12 @@ class EmbedCodeDirective(Directive):
                 idx = code_to_run.find("from __future__")
                 idx = code_to_run.find('\n', idx) if idx >= 0 else 0
                 code_to_run = code_to_run[:idx] + mpl_import + code_to_run[idx:]
-                parts = [code_to_run]
 
                 if 'plot' in layout:
-                    parts.append('matplotlib.pyplot.savefig("%s")' % plot_file_abs)
+                    code_to_run = code_to_run + ('\nmatplotlib.pyplot.savefig("%s")' % plot_file_abs)
 
                 skipped, failed, run_outputs = \
-                    run_code('\n'.join(parts), path, module=module, cls=class_,
+                    run_code(code_to_run, path, module=module, cls=class_,
                              shows_plot=True)
             else:
                 skipped, failed, run_outputs = \

--- a/openmdao/docs/_exts/embed_code.py
+++ b/openmdao/docs/_exts/embed_code.py
@@ -132,7 +132,7 @@ class EmbedCodeDirective(Directive):
         skipped = failed = False
         if do_run:
             if shows_plot:
-                # fixes problem where the use("Agg") line ends up before the future import.
+                # fixes problem where 'matplotlib.use("Agg")' was inserted before __future__ import.
                 if "from __future__" in code_to_run:
                     # We will split up code_to_run, insert our plotting lines after __future__ import,
                     # then put it back together.
@@ -144,8 +144,7 @@ class EmbedCodeDirective(Directive):
                         if "from __future__" in line:
                             new_order.append('import matplotlib')
                             new_order.append('matplotlib.use("Agg")')
-                    new_code_to_run = '\n'.join(new_order)
-                    parts = [new_code_to_run]
+                    parts = ['\n'.join(new_order)]
                     
                 else:
                     # insert lines to generate the plot file

--- a/openmdao/docs/_exts/embed_code.py
+++ b/openmdao/docs/_exts/embed_code.py
@@ -132,6 +132,7 @@ class EmbedCodeDirective(Directive):
         skipped = failed = False
         if do_run:
             if shows_plot:
+                # import matplotlib AFTER __future__ (if it's there)
                 mpl_import = "\nimport matplotlib\nmatplotlib.use('Agg')\n"
                 idx = code_to_run.find("from __future__")
                 idx = code_to_run.find('\n', idx) if idx >= 0 else 0

--- a/openmdao/docs/_exts/embed_code.py
+++ b/openmdao/docs/_exts/embed_code.py
@@ -132,23 +132,11 @@ class EmbedCodeDirective(Directive):
         skipped = failed = False
         if do_run:
             if shows_plot:
-                # fixes problem where 'matplotlib.use("Agg")' was inserted before __future__ import.
-                if "from __future__" in code_to_run:
-                    # We will split up code_to_run, insert our plotting lines after __future__ import,
-                    # then put it back together.
-                    new_order = []
-                    lines = code_to_run.split("\n")
-
-                    for line in lines:
-                        new_order.append(line)
-                        if "from __future__" in line:
-                            new_order.append('import matplotlib')
-                            new_order.append('matplotlib.use("Agg")')
-                    parts = ['\n'.join(new_order)]
-                    
-                else:
-                    # insert lines to generate the plot file
-                    parts = ['import matplotlib', 'matplotlib.use("Agg")', code_to_run]
+                mpl_import = "\nimport matplotlib\nmatplotlib.use('Agg')\n"
+                idx = code_to_run.find("from __future__")
+                idx = code_to_run.find('\n', idx) if idx >= 0 else 0
+                code_to_run = code_to_run[:idx] + mpl_import + code_to_run[idx:]
+                parts = [code_to_run]
 
                 if 'plot' in layout:
                     parts.append('matplotlib.pyplot.savefig("%s")' % plot_file_abs)

--- a/openmdao/docs/config_params.py
+++ b/openmdao/docs/config_params.py
@@ -1,4 +1,4 @@
-MOCK_MODULES = ['h5py', 'petsc4py', 'mpi4py', 'pyoptsparse']
+MOCK_MODULES = ['h5py', 'petsc4py', 'mpi4py', 'pyoptsparse', 'pyDOE',]
 IGNORE_LIST = [
         'docs', 'tests', 'devtools', '__pycache__', 'code_review', 'test_suite', 'utils'
     ]


### PR DESCRIPTION
*Gives a better error message when an embed fails, and adds a traceback. (for code embeds that blow up during the docutils.)
e.g. of new output, with traceback :

```
Sphinx error:
Problem with embed of openmdao.core.tests.test_indep_var_comp.TestForDocs.test: 
Traceback (most recent call last):
  File "/Users/kmarstel/Work/Dec1/OpenMDAO/openmdao/docs/_exts/embed_code.py", line 101, in run
    source = replace_asserts_with_prints(dedent(strip_header(source)))
  File "/Users/kmarstel/Work/Dec1/OpenMDAO/openmdao/docs/_utils/docutil.py", line 225, in replace_asserts_with_prints
    remove_redbaron_node(assert_node.value[1], -1)  # remove the expected value
  File "/Users/kmarstel/Work/Dec1/OpenMDAO/openmdao/docs/_utils/docutil.py", line 160, in remove_redbaron_node
    node.value.remove(node.value[index])
AttributeError: 'str' object has no attribute 'remove'
```

*Fixes a bug that cropped up when attempting to use plotting output in and `embed_code` that also used a `from __future__` import.  The embed was inserting the matplotlib directives before the __future__ import, causing an error. 