### PR TITLE
P156112639 fix embed-code so that it can be passed a bare function

### DIFF
--- a/openmdao/docs/_exts/embed_code.py
+++ b/openmdao/docs/_exts/embed_code.py
@@ -62,7 +62,7 @@ class EmbedCodeDirective(Directive):
         except Exception as err:
             raise SphinxError(str(err))
 
-        is_test = class_ is not None and issubclass(class_, unittest.TestCase)
+        is_test = class_ is not None and inspect.isclass(class_) and issubclass(class_, unittest.TestCase)
         shows_plot = '.show(' in source
 
         if 'layout' in self.options:


### PR DESCRIPTION
currently is_test = class_ is not None and issubclass(class_, unittest.TestCase) is broken, when class_ happens to be a function


