### PR TITLE
check for class object arg to `add_subsystem`

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -5,6 +5,7 @@ from collections import Iterable, Counter, OrderedDict, defaultdict
 from itertools import product, chain
 from numbers import Number
 import warnings
+import inspect
 
 from six import iteritems, string_types, itervalues
 from six.moves import range
@@ -1201,6 +1202,10 @@ class Group(System):
             enable users to instantiate and add a subsystem at the
             same time, and get the reference back.
         """
+        if inspect.isclass(subsys):
+            raise TypeError("Subsystem '%s' should be an instance, "
+                            "but a class object was found." % name)
+
         for sub in chain(self._subsystems_allprocs,
                          self._static_subsystems_allprocs):
             if name == sub.name:

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -74,6 +74,16 @@ class ReportOrderComp(ExplicitComponent):
 
 class TestGroup(unittest.TestCase):
 
+    def test_add_subsystem_class(self):
+        p = Problem()
+        try:
+            p.model.add_subsystem('comp', IndepVarComp)
+        except TypeError as err:
+            self.assertEqual(str(err), "Subsystem 'comp' should be an instance, "
+                                       "but a class object was found.")
+        else:
+            self.fail('Exception expected.')
+
     def test_same_sys_name(self):
         """Test error checking for the case where we add two subsystems with the same name."""
         p = Problem()


### PR DESCRIPTION
If user gives a class (instead of an instance) to add_subsystem they will get a clear error with stack-trace to that call
Pivotal #156344988