### PR TITLE
(attempting to) change coveralls to only run coverage on one machine.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ script:
     testflo -n 1 openmdao --coverage  --coverpkg openmdao --cover-omit \*tests/\*  --cover-omit \*devtools/\* --cover-omit \*test_suite/\* --cover-omit \*docs/\*;
   else
     testflo -n 1 openmdao;
+  fi
 
 after_success:
 # again, only run coverage operations on the upload machine after success.
@@ -112,6 +113,7 @@ after_success:
     coveralls --rcfile=../../.coveragerc --output=coveralls.json;
     sed 's/\/home\/travis\/miniconda\/lib\/python'"$PY"'\/site-packages\///g' < coveralls.json > coveralls-upd.json;
     coveralls --upload=coveralls-upd.json;
+  fi
 
 deploy:
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,6 @@ before_install:
 - if  [ "$TRAVIS_REPO_SLUG" = "OpenMDAO/OpenMDAO" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     MASTER_BUILD=1;
   fi
-- export OPENMDAO_TEST_DOCS=1
 
 install:
 # get key decrypted, placed, chmodded, and added for passwordless access to WebFaction
@@ -101,13 +100,18 @@ script:
   fi
 
 # run the tests from down here to see if it can work without being at top level
-- testflo -n 1 openmdao  -m "ptest*"
-- testflo -n 1 openmdao --coverage  --coverpkg openmdao --cover-omit \*tests/\*  --cover-omit \*devtools/\* --cover-omit \*test_suite/\* --cover-omit \*docs/\*
+# only do coverage on the upload machine.
+- if [ "$UPLOAD_DOCS" ]; then
+    testflo -n 1 openmdao --coverage  --coverpkg openmdao --cover-omit \*tests/\*  --cover-omit \*devtools/\* --cover-omit \*test_suite/\* --cover-omit \*docs/\*;
+  else
+    testflo -n 1 openmdao;
 
 after_success:
-- coveralls --rcfile=../../.coveragerc --output=coveralls.json
-- sed 's/\/home\/travis\/miniconda\/lib\/python'"$PY"'\/site-packages\///g' < coveralls.json > coveralls-upd.json
-- coveralls --upload=coveralls-upd.json
+# again, only run coverage operations on the upload machine after success.
+- if [ "$UPLOAD_DOCS" ]; then
+    coveralls --rcfile=../../.coveragerc --output=coveralls.json;
+    sed 's/\/home\/travis\/miniconda\/lib\/python'"$PY"'\/site-packages\///g' < coveralls.json > coveralls-upd.json;
+    coveralls --upload=coveralls-upd.json;
 
 deploy:
   provider: script


### PR DESCRIPTION
Coverage has been kinda useless recently, and also has been setting off false alarms.

This PR runs coverage on only one machine, the one that runs the most tests (MPI), and also removes parametric testing, and one line of vestigial garbage.