### PR TITLE
Fix for TypeError during check_totals on x57 model.

### DIFF
--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -120,6 +120,11 @@ class ComplexStep(ApproximationScheme):
         out_tmp = system._outputs.get_data()
         results_clone = current_vec._clone(True)
 
+        # To support driver src_indices, we need to override some checks in Jacobian, but do it
+        # selectively.
+        uses_src_indices = (system._owns_approx_of_idx or system._owns_approx_wrt_idx) and \
+            not isinstance(jac, dict)
+
         for key, approximations in groupby(self._exec_list, self._key_fun):
             # groupby (along with this key function) will group all 'of's that have the same wrt and
             # step size.
@@ -170,7 +175,11 @@ class ComplexStep(ApproximationScheme):
 
             for of, subjac in outputs:
                 rel_key = abs_key2rel_key(system, (of, wrt))
+                if uses_src_indices:
+                    jac._override_checks = True
                 jac[rel_key] = subjac
+                if uses_src_indices:
+                    jac._override_checks = False
 
         # Turn off complex step.
         system._inputs._vector_info._under_complex_step = False

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -168,6 +168,11 @@ class FiniteDifference(ApproximationScheme):
         out_tmp = current_vec.get_data()
         in_tmp = system._inputs.get_data()
 
+        # To support driver src_indices, we need to override some checks in Jacobian, but do it
+        # selectively.
+        uses_src_indices = (system._owns_approx_of_idx or system._owns_approx_wrt_idx) and \
+            not isinstance(jac, dict)
+
         for key, approximations in groupby(self._exec_list, self._key_fun):
             # groupby (along with this key function) will group all 'of's that have the same wrt and
             # step size.
@@ -248,4 +253,8 @@ class FiniteDifference(ApproximationScheme):
 
             for of, subjac in outputs:
                 rel_key = abs_key2rel_key(system, (of, wrt))
+                if uses_src_indices:
+                    jac._override_checks = True
                 jac[rel_key] = subjac
+                if uses_src_indices:
+                    jac._override_checks = False

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1540,9 +1540,6 @@ class Group(System):
             sub_do_ln = (self._linear_solver is not None) and \
                         (self._linear_solver._linearize_children())
 
-            for subsys in self._subsystems_myproc:
-                subsys._linearize(do_nl=sub_do_nl, do_ln=sub_do_ln)
-
             # Group finite difference
             if self._owns_approx_jac:
                 with self._unscaled_context(outputs=[self._outputs]):
@@ -1551,9 +1548,14 @@ class Group(System):
 
                 J._update()
 
-            # Update jacobian
-            elif self._owns_assembled_jac or self._views_assembled_jac:
-                J._update()
+            else:
+                # Only linearize subsystems if we aren't approximating the derivs at this level.
+                for subsys in self._subsystems_myproc:
+                    subsys._linearize(do_nl=sub_do_nl, do_ln=sub_do_ln)
+
+                # Update jacobian
+                if self._owns_assembled_jac or self._views_assembled_jac:
+                    J._update()
 
         if self._nonlinear_solver is not None and do_nl:
             self._nonlinear_solver._linearize()

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -703,11 +703,12 @@ class Problem(object):
             model._outputs.set_vec(output_cache)
             # Make sure we're in a valid state
             model.run_apply_nonlinear()
-            model.run_linearize()
 
             jac_key = 'J_' + mode
 
             for comp in comps:
+
+                comp.run_linearize()
 
                 # Skip IndepVarComps
                 if isinstance(comp, IndepVarComp):

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -7,7 +7,8 @@ from six.moves import cStringIO
 import numpy as np
 
 from openmdao.api import Group, ExplicitComponent, IndepVarComp, Problem, NonlinearRunOnce, \
-                         ImplicitComponent, NonlinearBlockGS
+                         ImplicitComponent, NonlinearBlockGS, CSCJacobian, DirectSolver, ExecComp, \
+                         ScipyKrylov, CSCJacobian, NewtonSolver
 from openmdao.core.tests.test_impl_comp import QuadraticLinearize, QuadraticJacVec
 from openmdao.core.tests.test_matmat import MultiJacVec
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayMatVec
@@ -1864,6 +1865,99 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         assert_rel_error(self, totals['pz.z', 'pz.z']['J_fwd'], [[0.0, 1.0]], 1e-5)
         assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], [[0.0, 1.0]], 1e-5)
+
+    def test_bug_fd_with_sparse(self):
+        # This bug was found via the x57 model in pointer.
+
+        class TimeComp(ExplicitComponent):
+
+            def setup(self):
+                self.node_ptau = node_ptau = np.array([-1., 0., 1.])
+
+                self.add_input('t_duration', val=1.)
+                self.add_output('time', shape=len(node_ptau))
+
+                # Setup partials
+                nn = 3
+                rs = np.arange(nn)
+                cs = np.zeros(nn)
+
+                self.declare_partials(of='time', wrt='t_duration', rows=rs, cols=cs, val=1.0)
+
+            def compute(self, inputs, outputs):
+                node_ptau = self.node_ptau
+                t_duration = inputs['t_duration']
+
+                outputs['time'][:] = 0.5 * (node_ptau + 33) * t_duration
+
+            def compute_partials(self, inputs, jacobian):
+                node_ptau = self.node_ptau
+
+                jacobian['time', 't_duration'] = 0.5 * (node_ptau + 33)
+
+
+        class CellComp(ExplicitComponent):
+
+            def initialize(self):
+                self.metadata.declare('num_nodes', types=int)
+
+            def setup(self):
+                n = self.metadata['num_nodes']
+
+                self.add_input('I_Li', val=3.25*np.ones(n))
+                self.add_output('zSOC', val=np.ones(n))
+
+                # Partials
+                ar = np.arange(n)
+                self.declare_partials(of='zSOC', wrt='I_Li', rows=ar, cols=ar)
+
+            def compute(self, inputs, outputs):
+                I_Li = inputs['I_Li']
+                outputs['zSOC'] = -I_Li / (3600.0)
+
+            def compute_partials(self, inputs, partials):
+                partials['zSOC', 'I_Li'] = -1./(3600.0)
+
+
+        class GaussLobattoPhase(Group):
+
+            def setup(self):
+                self.connect('t_duration', 'time.t_duration')
+
+                indep = IndepVarComp()
+                indep.add_output('t_duration', val=1.0)
+                self.add_subsystem('time_extents', indep, promotes_outputs=['*'])
+                self.add_design_var('t_duration', 5.0, 25.0)
+
+                time_comp = TimeComp()
+                self.add_subsystem('time', time_comp, promotes_outputs=['time'])
+
+                self.add_subsystem(name='cell', subsys=CellComp(num_nodes=3))
+
+                self.linear_solver = ScipyKrylov()
+                self.nonlinear_solver = NewtonSolver()
+                self.nonlinear_solver.options['maxiter'] = 1
+
+            def initialize(self):
+                self.metadata.declare('ode_class', desc='System defining the ODE')
+
+
+        p = Problem(model=GaussLobattoPhase())
+
+        p.model.add_objective('time', index=-1)
+
+        p.model.jacobian = CSCJacobian()
+        p.model.linear_solver=ScipyKrylov()
+
+        p.setup(mode='fwd')
+        p.set_solver_print(level=0)
+        p.run_model()
+
+        # Make sure we don't bomb out with an error.
+        J = p.check_totals(out_stream=None)
+
+        assert_rel_error(self, J[('time.time', 'time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
+        assert_rel_error(self, J[('time.time', 'time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
 
 
 @unittest.skipIf(MPI and not PETScVector, "only run under MPI if we have PETSc.")

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1040,13 +1040,9 @@ class _TotalJacInfo(object):
 
         model._setup_jacobians(recurse=False)
 
-        # Need to temporarily disable size checking to support indices in des_vars and quantities.
-        model.jacobian._override_checks = True
-
         # Linearize Model
         model._linearize()
 
-        model.jacobian._override_checks = False
         approx_jac = model._jacobian._subjacs
 
         of_idx = model._owns_approx_of_idx


### PR DESCRIPTION
1. Changed linearization strategy so that we aren't doing unnecessary linearization under FD or during selective check_partials.
2. Modified how we override some checks for the case with src_indices in desvar or responses: tightened so that it only performs this where and when it is needed.