### PR TITLE
added dynamic simultaneous deriv coloring

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -388,6 +388,8 @@ class Driver(object):
         if self.recording_options['record_metadata']:
             self._rec_mgr.record_metadata(self)
 
+        desvar_size = np.sum(data['size'] for data in itervalues(self._designvars))
+
         # set up simultaneous deriv coloring
         if (coloring_mod._use_sparsity and self._simul_coloring_info and
                 self.supports['simultaneous_derivatives']):
@@ -395,8 +397,6 @@ class Driver(object):
                 self._setup_simul_coloring(problem._mode)
             else:
                 raise RuntimeError("simultaneous derivs are currently not supported in rev mode.")
-
-        desvar_size = np.sum(data['size'] for data in itervalues(self._designvars))
 
         # if we're using simultaneous derivatives then our effective design var size is less
         # than the full design var size
@@ -922,21 +922,20 @@ class Driver(object):
         if not coloring_mod._use_sparsity:
             return
 
-        prom2abs = self._problem.model._var_allprocs_prom2abs_list['output']
-
         if isinstance(self._simul_coloring_info, string_types):
             with open(self._simul_coloring_info, 'r') as f:
                 self._simul_coloring_info = json.load(f)
-                tup = self._simul_coloring_info
-                column_lists, row_map = tup[:2]
-                if len(tup) > 2:
-                    sparsity = tup[2]
-                    if self._total_jac_sparsity is not None:
-                        raise RuntimeError("Total jac sparsity was set in both _simul_coloring_info"
-                                           " and _total_jac_sparsity.")
-                    self._total_jac_sparsity = sparsity
 
-                self._simul_coloring_info = column_lists, row_map
+        tup = self._simul_coloring_info
+        column_lists, row_map = tup[:2]
+        if len(tup) > 2:
+            sparsity = tup[2]
+            if self._total_jac_sparsity is not None:
+                raise RuntimeError("Total jac sparsity was set in both _simul_coloring_info"
+                                   " and _total_jac_sparsity.")
+            self._total_jac_sparsity = sparsity
+
+        self._simul_coloring_info = column_lists, row_map
 
     def _pre_run_model_debug_print(self):
         """

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -191,7 +191,8 @@ class SimulColoringTestCase(unittest.TestCase):
         # - coloring saves 16 solves per driver iter  (5 vs 21)
         # - initial solve for linear constraints takes 21 in both cases (only done once)
         # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - 21) / (solves_per_iter) should be equal between the two cases
+        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
+        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
         self.assertEqual((p.model.linear_solver._solve_count - 21) / 21,
                          (p_color.model.linear_solver._solve_count - 21 * 4) / 5)
 
@@ -299,7 +300,8 @@ class SimulColoringTestCase(unittest.TestCase):
         # - coloring saves 16 solves per driver iter  (5 vs 21)
         # - initial solve for linear constraints takes 21 in both cases (only done once)
         # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - 21) / (solves_per_iter) should be equal between the two cases
+        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
+        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
         self.assertEqual((p.model.linear_solver._solve_count - 21) / 21,
                          (p_color.model.linear_solver._solve_count - 21 * 4) / 5)
 
@@ -365,7 +367,8 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         # - coloring saves 16 solves per driver iter  (5 vs 21)
         # - initial solve for linear constraints takes 21 in both cases (only done once)
         # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - 21) / (solves_per_iter) should be equal between the two cases
+        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
+        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
         self.assertEqual((p.model.linear_solver._solve_count - 21) / 21,
                          (p_color.model.linear_solver._solve_count - 21 * 4) / 5)
 

--- a/openmdao/docs/features/core_features/working_with_derivatives/simul_derivs.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/simul_derivs.rst
@@ -48,6 +48,9 @@ For example:
     prob.driver.options['dynamic_simul_derivs_repeats'] = 2
 
 
+Whenever a dynamic coloring is computed, the coloring is written to a file called *coloring.json*
+for later inspection.
+
 
 Static Coloring
 ===============

--- a/openmdao/docs/features/core_features/working_with_derivatives/simul_derivs.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/simul_derivs.rst
@@ -61,7 +61,7 @@ Driver.
     :noindex:
 
 
-While this has the advantage of removing the runtime cost of the computation of the coloring,
+While this has the advantage of removing the runtime cost of computing the coloring,
 it should be used with care, because any changes in the model, design variables, or responses
 can make the existing coloring invalid.  If *anything* about the optimization changes, it's recommended
 to always regenerate the coloring before re-running the optimization.

--- a/openmdao/docs/theory_manual/total_derivs/separable.rst
+++ b/openmdao/docs/theory_manual/total_derivs/separable.rst
@@ -108,7 +108,7 @@ but the chance of having any incidental zero values is now very small. The likel
 computing the total-derivative Jacobian multiple times with different, random left-hand sides, and summing the absolute values of the
 resulting total-derivative Jacobians together.
 
-Hence the cost of the coloring algorithm increases with the cost of :math:`n` computations of the full total-derivative Jacobian.
+Hence the cost of the coloring algorithm increases by the cost of :math:`n` computations of the full total-derivative Jacobian.
 The larger you choose to make :math:`n`, the more reliable your coloring will be.
 If the model is intended to be used in an optimization context, then it is fair to assume that the total-derivative Jacobian is inexpensive enough to compute many times,
 and using a few additional computations to compute a coloring will not significantly impact the overall compute cost.

--- a/openmdao/docs/theory_manual/total_derivs/separable.rst
+++ b/openmdao/docs/theory_manual/total_derivs/separable.rst
@@ -105,9 +105,10 @@ So we need to compute the sparsity pattern of the total Jacobian, given the spar
 We can minimize the chance of having incidental zeros in the inverse by setting random numbers into the nonzero entries of the partial-derivative matrix,
 then computing the resulting total-derivative Jacobian using the randomized values. The derivatives computed in this way will not be physically meaningful,
 but the chance of having any incidental zero values is now very small. The likelihood of incidental zeros can be further reduced by
-computing the total-derivative Jacobian multiple times with different, random left-hand sides, and summing the resulting total-derivative Jacobians together.
+computing the total-derivative Jacobian multiple times with different, random left-hand sides, and summing the absolute values of the
+resulting total-derivative Jacobians together.
 
-Hence the cost of the coloring algorithm is equivalent to the cost of :math:`n` computations of the full total-derivative Jacobian.
+Hence the cost of the coloring algorithm increases with the cost of :math:`n` computations of the full total-derivative Jacobian.
 The larger you choose to make :math:`n`, the more reliable your coloring will be.
 If the model is intended to be used in an optimization context, then it is fair to assume that the total-derivative Jacobian is inexpensive enough to compute many times,
 and using a few additional computations to compute a coloring will not significantly impact the overall compute cost.

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -242,14 +242,7 @@ class pyOptSparseDriver(Driver):
 
         # compute dynamic simul deriv coloring if option is set
         if coloring_mod._use_sparsity and self.options['dynamic_simul_derivs']:
-            self._total_jac = None
-            repeats = self.options['dynamic_simul_derivs_repeats']
-            coloring = coloring_mod.get_simul_meta(problem, mode=problem._mode, repeats=repeats,
-                                                   tol=1.e-15, include_sparsity=True,
-                                                   setup=False, run_model=False, stream=None)
-            self.set_simul_deriv_color(coloring)
-            self._setup_simul_coloring(mode=problem._mode)
-            self._setup_tot_jac_sparsity()
+            coloring_mod.dynamic_simul_coloring(self, do_sparsity=True)
 
         opt_prob = Optimization(self.options['title'], self._objfunc)
 

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -157,6 +157,9 @@ class pyOptSparseDriver(Driver):
                              desc='Finite difference implementation to use')
         self.options.declare('dynamic_simul_derivs', default=False, types=bool,
                              desc='Compute simultaneous derivative coloring dynamically if True')
+        self.options.declare('dynamic_simul_derivs_repeats', default=3, types=int,
+                             desc='Number of compute_totals calls during dynamic computation of '
+                                  'simultaneous derivative coloring')
 
         # The user places optimizer-specific settings in here.
         self.opt_settings = {}
@@ -235,7 +238,8 @@ class pyOptSparseDriver(Driver):
         # compute dynamic simul deriv coloring if option is set
         if coloring_mod._use_sparsity and self.options['dynamic_simul_derivs']:
             self._total_jac = None
-            coloring = coloring_mod.get_simul_meta(problem, mode=problem._mode, repeats=3,
+            repeats = self.options['dynamic_simul_derivs_repeats']
+            coloring = coloring_mod.get_simul_meta(problem, mode=problem._mode, repeats=repeats,
                                                    tol=1.e-15, include_sparsity=True,
                                                    setup=False, run_model=False, stream=None)
             self.set_simul_deriv_color(coloring)

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -94,6 +94,11 @@ class pyOptSparseDriver(Driver):
         Finite difference implementation to use ('snopt_fd' may only be used with SNOPT)
     options['title'] :  str('Optimization using pyOpt_sparse')
         Title of this optimization run
+    options['dynamic_simul_derivs'] : bool(False)
+        Set to True to turn on dynamic computation of simultaneous total derivative coloring.
+    options['dynamic_simul_derivs_repeats'] : int(3)
+        Set the number of compute_totals calls made during computation of simultaneous derivative
+        coloring.
 
     Attributes
     ----------

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -331,13 +331,7 @@ class ScipyOptimizeDriver(Driver):
 
         # compute dynamic simul deriv coloring if option is set
         if coloring_mod._use_sparsity and self.options['dynamic_simul_derivs']:
-            self._total_jac = None
-            repeats = self.options['dynamic_simul_derivs_repeats']
-            coloring = coloring_mod.get_simul_meta(problem, mode=problem._mode, repeats=repeats,
-                                                   tol=1.e-15, include_sparsity=True,
-                                                   setup=False, run_model=False, stream=None)
-            self.set_simul_deriv_color(coloring)
-            self._setup_simul_coloring(mode=problem._mode)
+            coloring_mod.dynamic_simul_coloring(self)
 
         # optimize
         try:

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -64,6 +64,11 @@ class ScipyOptimizeDriver(Driver):
         Name of optimizer to use
     options['tol'] :  float(1e-06)
         Tolerance for termination. For detailed control, use solver-specific options.
+    options['dynamic_simul_derivs'] : bool(False)
+        Set to True to turn on dynamic computation of simultaneous total derivative coloring.
+    options['dynamic_simul_derivs_repeats'] : int(3)
+        Set the number of compute_totals calls made during computation of simultaneous derivative
+        coloring.
 
     Attributes
     ----------

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -175,6 +175,10 @@ def _get_bool_jac(prob, mode='fwd', repeats=3, tol=1e-15, setup=False, run_model
         Starting tolerance on values in jacobian.  Actual tolerance is computed based on
         consistent numbers of zero entries over a sweep of tolerances.  Anything smaller in
         magnitude than the computed tolerance will be set to 0.0.
+    setup : bool
+        If True, run setup before calling compute_totals.
+    run_model : bool
+        If True, run run_model before calling compute_totals.
 
     Returns
     -------
@@ -450,6 +454,10 @@ def get_sparsity(problem, mode='fwd', repeats=1, tol=1.e-15, show_jac=False,
         If True, display a visualiation of the final total jacobian used to compute the coloring.
     stream : file-like or None
         Stream where output coloring info will be written.
+    setup : bool
+        If True, run setup before calling compute_totals.
+    run_model : bool
+        If True, run run_model before calling compute_totals.
 
     Returns
     -------
@@ -499,6 +507,10 @@ def get_simul_meta(problem, mode='fwd', repeats=1, tol=1.e-15, show_jac=False,
     include_sparsity : bool
         If True, include the sparsity structure of the total jacobian mapped to design vars
         and responses.  (This info is used by pyOptSparseDriver).
+    setup : bool
+        If True, run setup before calling compute_totals.
+    run_model : bool
+        If True, run run_model before calling compute_totals.
     stream : file-like or None
         Stream where output coloring info will be written.
 

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -601,6 +601,32 @@ def simul_coloring_summary(problem, color_info, stream=sys.stdout):
                      (tot_colors, tot_size, ((tot_size - tot_colors) / tot_size * 100)))
 
 
+def dynamic_simul_coloring(driver, do_sparsity=False):
+    """
+    Compute simultaneous deriv coloring during runtime.
+
+    Parameters
+    ----------
+    driver : <Driver>
+        The driver performing the optimization.
+    do_sparsity : bool
+        If True, setup the total jacobian sparsity (needed by pyOptSparseDriver).
+    """
+    problem = driver._problem
+    driver._total_jac = None
+    repeats = driver.options['dynamic_simul_derivs_repeats']
+
+    # save the coloring.json file for later inspection
+    with open("coloring.json", "w") as f:
+        coloring = get_simul_meta(problem, mode=problem._mode, repeats=repeats,
+                                  tol=1.e-15, include_sparsity=True,
+                                  setup=False, run_model=False, stream=f)
+    driver.set_simul_deriv_color(coloring)
+    driver._setup_simul_coloring(mode=problem._mode)
+    if do_sparsity:
+        driver._setup_tot_jac_sparsity()
+
+
 def _simul_coloring_setup_parser(parser):
     """
     Set up the openmdao subparser for the 'openmdao simul_coloring' command.


### PR DESCRIPTION
- added two options to pyoptsparse driver and scipy optimizer:
     - dynamic_simul_derivs  : turns dynamic coloring on if True
     - dynamic_simul_derivs_repeats :  sets the number of compute_totals calls when computing the total jac sparsity (default=3)