### PR TITLE
Three small stories

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -427,7 +427,7 @@ class Group(System):
 
             for type_ in ['input', 'output']:
                 allprocs_abs_names[type_] = []
-                allprocs_prom2abs_list[type_] = defaultdict(list)
+                allprocs_prom2abs_list[type_] = OrderedDict()
 
             for myproc_abs_names, myproc_prom2abs_list, myproc_abs2meta, oscale, rscale in gathered:
                 self._has_output_scaling |= oscale
@@ -443,6 +443,8 @@ class Group(System):
 
                     # Assemble in parallel allprocs_prom2abs_list
                     for prom_name, abs_names_list in iteritems(myproc_prom2abs_list[type_]):
+                        if prom_name not in allprocs_prom2abs_list[type_]:
+                            allprocs_prom2abs_list[type_][prom_name] = []
                         allprocs_prom2abs_list[type_][prom_name].extend(abs_names_list)
 
     def _setup_var_sizes(self, recurse=True):

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -517,6 +517,19 @@ class TestConstraintOnModel(unittest.TestCase):
         prob.model.add_constraint('con1', lower=0.0, upper=5.0,
                                           indices=range(2))
 
+    def test_error_eq_ineq_con(self):
+        prob = Problem()
+
+        prob.model = SellarDerivatives()
+        prob.model.nonlinear_solver = NonlinearBlockGS()
+
+        with self.assertRaises(ValueError) as context:
+            prob.model.add_constraint('con1', lower=0.0, upper=5.0, equals=3.0,
+                                      indices='foo')
+
+        msg = "Constraint 'con1' cannot be both equality and inequality."
+        self.assertEqual(str(context.exception), msg)
+
 
 @unittest.skipUnless(PETScVector, "PETSc is required.")
 class TestAddConstraintMPI(unittest.TestCase):

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -512,6 +512,36 @@ class TestConstraintOnModel(unittest.TestCase):
         prob.model.add_constraint('con1', lower=0.0, upper=5.0,
                                           indices=range(2))
 
+    def test_error_eq_ineq_con(self):
+        prob = Problem()
+
+        prob.model = SellarDerivatives()
+        prob.model.nonlinear_solver = NonlinearBlockGS()
+
+        with self.assertRaises(ValueError) as context:
+            prob.model.add_constraint('con1', lower=0.0, upper=5.0, equals=3.0,
+                                      indices='foo')
+
+        msg = "Constraint 'con1' cannot be both equality and inequality."
+        self.assertEqual(str(context.exception), msg)
+
+    def test_bad_con(self):
+        prob = Problem()
+        model = prob.model
+
+        sub = model.add_subsystem('sub', SellarDerivatives())
+        sub.nonlinear_solver = NonlinearBlockGS()
+
+        #with self.assertRaises(ValueError) as context:
+        sub.add_constraint('d1.junk', equals=0.0, cache_linear_solution=True)
+
+        from openmdao.api import PETScVector
+        prob.setup(vector_class=PETScVector, mode='rev')
+        prob.setup(vector_class=PETScVector, mode='rev')
+
+        msg = "Constraint 'con1' cannot be both equality and inequality."
+        self.assertEqual(str(context.exception), msg)
+
 
 class TestObjectiveOnModel(unittest.TestCase):
 

--- a/openmdao/docs/features/core_features/adding_desvars_objs_consts/adding_constraints.rst
+++ b/openmdao/docs/features/core_features/adding_desvars_objs_consts/adding_constraints.rst
@@ -5,7 +5,7 @@
 Adding a Constraint
 *******************
 
-To add a constraint to an optimization, use the *add_constraintr* method
+To add a constraint to an optimization, use the *add_constraint* method
 on System.
 
 .. automethod:: openmdao.core.system.System.add_constraint

--- a/openmdao/docs/features/core_features/defining_components/declaring_variables.rst
+++ b/openmdao/docs/features/core_features/defining_components/declaring_variables.rst
@@ -16,6 +16,10 @@ An example is given below.
 .. embed-code::
     openmdao.test_suite.components.expl_comp_simple.TestExplCompSimple
 
+.. note::
+
+    Variable names have few restrictions, but the following characters are not allowed in a variable name: '.', '*', '?', '!', '[', ']'.
+
 Method Signatures
 -----------------
 

--- a/openmdao/docs/features/core_features/grouping_components/add_subsystem.rst
+++ b/openmdao/docs/features/core_features/grouping_components/add_subsystem.rst
@@ -19,6 +19,12 @@ Add a Component to a Group
     openmdao.core.tests.test_group.TestGroup.test_group_simple
     :layout: interleave
 
+.. note::
+
+    Group names must be Pythonic, so they can only contain alphanumeric characters plus the underscore. In addtion, the
+    first character in the group name needs to be a letter of the alphabet. Also, the system name should no duplicate
+    any method or attribute of the `System` API.
+
 Promote the input and output of a Component
 -------------------------------------------
 Because the promoted names of `indep.a` and `comp.a` are the same, `indep.a` is automatically connected to `comp1.a`.

--- a/openmdao/docs/features/core_features/grouping_components/add_subsystem.rst
+++ b/openmdao/docs/features/core_features/grouping_components/add_subsystem.rst
@@ -22,7 +22,7 @@ Add a Component to a Group
 .. note::
 
     Group names must be Pythonic, so they can only contain alphanumeric characters plus the underscore. In addtion, the
-    first character in the group name needs to be a letter of the alphabet. Also, the system name should no duplicate
+    first character in the group name needs to be a letter of the alphabet. Also, the system name should not duplicate
     any method or attribute of the `System` API.
 
 Promote the input and output of a Component

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -206,6 +206,9 @@ class TestBetzLimit(unittest.TestCase):
         # There is a bug in scipy version < 1.0 that causes this value to be wrong.
         if LooseVersion(scipy.__version__) >= LooseVersion("1.0"):
             assert_rel_error(self, prob['Area'], 1.0, 1e-4)
+        else:
+            msg = "Outdated version of Scipy detected; this problem does not solve properly."
+            raise unittest.SkipTest(msg)
 
     def test_betz_derivatives(self):
         from openmdao.api import Problem, IndepVarComp

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -1,6 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
+from distutils.version import LooseVersion
 import unittest
+
+import scipy
 
 from openmdao.utils.assert_utils import assert_rel_error
 
@@ -200,8 +203,9 @@ class TestBetzLimit(unittest.TestCase):
         # minimum value
         assert_rel_error(self, prob['a_disk.Cp'], 16./27., 1e-4)
         assert_rel_error(self, prob['a'], 0.33333, 1e-4)
-        # TODO: this is a bad value. Should be 1.0! The problem is a related to a bug in scipy, which is fixed in version > 1.0
-        # assert_rel_error(self, prob['Area'], 5.65272869, 1e-4)
+        # There is a bug in scipy version < 1.0 that causes this value to be wrong.
+        if LooseVersion(scipy.__version__) >= LooseVersion("1.0"):
+            assert_rel_error(self, prob['Area'], 1.0, 1e-4)
 
     def test_betz_derivatives(self):
         from openmdao.api import Problem, IndepVarComp


### PR DESCRIPTION
1. Adding a non-existent var as a constraint under mpi yields a confusing error message.
2. Explain valid system and var names in the docs.
3. Uncommented Betz test now that scipy has fixed the bug.