### PR TITLE
very small fix to docstring fixes problem in sourcedocs

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -63,10 +63,13 @@ class BalanceComp(ImplicitComponent):
             prob.model.add_subsystem(name='balance', subsys=bal)
 
             prob.model.connect('y_tgt', 'balance.rhs:x')
+
             prob.model.connect('balance.x', 'exec.x')
+
             prob.model.connect('exec.y', 'balance.lhs:x')
 
             prob.model.linear_solver = DirectSolver()
+
             prob.model.nonlinear_solver = NewtonSolver()
 
             prob.setup()
@@ -92,10 +95,13 @@ class BalanceComp(ImplicitComponent):
             prob.model.add_subsystem(name='balance', subsys=bal)
 
             prob.model.connect('y_tgt', 'balance.rhs:x')
+
             prob.model.connect('balance.x', 'exec.x')
+
             prob.model.connect('exec.y', 'balance.lhs:x')
 
             prob.model.linear_solver = DirectSolver()
+
             prob.model.nonlinear_solver = NewtonSolver()
 
             prob.setup()

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -45,67 +45,42 @@ class BalanceComp(ImplicitComponent):
         calling `add_balance`.  As an example, solving the equation
         :math:`x**2 = 2` implicitly can be be accomplished as follows:
 
-        ::
+        .. code-block:: python
+
             prob = Problem(model=Group())
-
             bal = BalanceComp()
-
             bal.add_balance('x', val=1.0)
-
             tgt = IndepVarComp(name='y_tgt', val=2)
-
             exec_comp = ExecComp('y=x**2')
-
             prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
-
             prob.model.add_subsystem(name='exec', subsys=exec_comp)
-
             prob.model.add_subsystem(name='balance', subsys=bal)
-
             prob.model.connect('y_tgt', 'balance.rhs:x')
-
             prob.model.connect('balance.x', 'exec.x')
-
             prob.model.connect('exec.y', 'balance.lhs:x')
-
             prob.model.linear_solver = DirectSolver()
-
             prob.model.nonlinear_solver = NewtonSolver()
-
             prob.setup()
-
             prob.run_model()
 
         The arguments to add_balance can be provided on initialization to provide a balance
         with a one state/residual without the need to call `add_balance`:
 
-        ::
+        .. code-block:: python
+
             prob = Problem(model=Group())
-
             bal = BalanceComp('x', val=1.0)
-
             tgt = IndepVarComp(name='y_tgt', val=2)
-
             exec_comp = ExecComp('y=x**2')
-
             prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
-
             prob.model.add_subsystem(name='exec', subsys=exec_comp)
-
             prob.model.add_subsystem(name='balance', subsys=bal)
-
             prob.model.connect('y_tgt', 'balance.rhs:x')
-
             prob.model.connect('balance.x', 'exec.x')
-
             prob.model.connect('exec.y', 'balance.lhs:x')
-
             prob.model.linear_solver = DirectSolver()
-
             prob.model.nonlinear_solver = NewtonSolver()
-
             prob.setup()
-
             prob.run_model()
 
         Parameters

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -136,7 +136,7 @@ class ExecComp(ExplicitComponent):
         ExecComp that takes an array 'x' as input and outputs a float variable
         'y' which is the sum of the entries in 'x'.
 
-        ::
+        .. code-block:: python
 
             import numpy
             from openmdao.api import ExecComp
@@ -149,7 +149,7 @@ class ExecComp(ExplicitComponent):
         If you want to assign certain metadata for 'x' in addition to its
         initial value, you can do it as follows:
 
-        ::
+        .. code-block:: python
 
             excomp = ExecComp('y=sum(x)',
                               x={'value': numpy.ones(10,dtype=float),

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -886,6 +886,7 @@ class Driver(object):
                         ...
                     }
                 )
+
         """
         if self.supports['simultaneous_derivatives']:
             self._simul_coloring_info = simul_info

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -76,7 +76,7 @@ def setup(methods=None, finalize=True):
         entry is the method name or glob pattern and the second is a tuple of class
         objects used for isinstance checking.  The default set of methods is:
 
-        ::
+        .. code-block:: python
 
             [
                 "*": (System, Jacobian, Matrix, Solver, Driver, Problem),


### PR DESCRIPTION
super-simple docstring formatting problem was screwing up the look of sourcedocs for balance comp.