### PR TITLE
Create an undeclare for OptionsDictionary

### DIFF
--- a/openmdao/solvers/linear/linear_runonce.py
+++ b/openmdao/solvers/linear/linear_runonce.py
@@ -27,7 +27,6 @@ class LinearRunOnce(LinearBlockGS):
         # Remove unused options from base options.
         self.options.undeclare("atol")
         self.options.undeclare("rtol")
-        # self.options.undeclare("maxiter") # eventually want to undeclare this
 
     def solve(self, vec_names, mode, rel_systems=None):
         """

--- a/openmdao/solvers/linear/linear_runonce.py
+++ b/openmdao/solvers/linear/linear_runonce.py
@@ -13,6 +13,22 @@ class LinearRunOnce(LinearBlockGS):
 
     SOLVER = 'LN: RUNONCE'
 
+    def __init__(self, **kwargs):
+        """
+        Initialize all attributes.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Options dictionary.
+        """
+        super(LinearRunOnce, self).__init__(**kwargs)
+
+        # Remove unused options from base options.
+        self.options.undeclare("atol")
+        self.options.undeclare("rtol")
+        # self.options.undeclare("maxiter") # eventually want to undeclare this
+
     def solve(self, vec_names, mode, rel_systems=None):
         """
         Run the solver.

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -72,6 +72,10 @@ class BoundsEnforceLS(NonlinearSolver):
 
         # Parent solver sets this to control whether to solve subsystems.
         self._do_subsolve = False
+        # Remove unused options from base options.
+        self.options.undeclare("atol")
+        self.options.undeclare("rtol")
+        # self.options.undeclare("maxiter") # eventually want to undeclare this
 
     def _declare_options(self):
         """

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -75,7 +75,8 @@ class BoundsEnforceLS(NonlinearSolver):
         # Remove unused options from base options.
         self.options.undeclare("atol")
         self.options.undeclare("rtol")
-        # self.options.undeclare("maxiter") # eventually want to undeclare this
+        self.options.undeclare("maxiter")
+        self.options.undeclare("err_on_maxiter")
 
     def _declare_options(self):
         """

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -456,8 +456,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top.model.nonlinear_solver = NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 3
 
-        ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
-        ls.options['maxiter'] = 10
+        top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
         top.set_solver_print(level=0)
 
         top.setup(check=False)

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -148,6 +148,19 @@ class OptionsDictionary(object):
         if default_provided:
             self._assert_valid(name, default)
 
+    def undeclare(self, name):
+        """
+        Remove entry from the OptionsDictionary, for classes that don't use that option.
+
+        Parameters
+        ----------
+        name : str
+            The name of a key, the entry of which will be removed from the internal dictionary.
+
+        """
+        if name in self._dict:
+            del self._dict[name]
+
     def update(self, in_dict):
         """
         Update the internal dictionary with the given one.

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -168,6 +168,23 @@ class TestOptionsDict(unittest.TestCase):
         expected_msg = ("Value of -3.0 exceeds minimum of 0.0 for option 'x'")
         assertRegex(self, str(context.exception), expected_msg)
 
+    def test_undeclare(self):
+        # create an entry in the dict
+        self.dict.declare('test', types=int)
+        self.dict['test'] = 1
+
+        # prove it's in the dict
+        self.assertEqual(self.dict['test'], 1)
+
+        # remove entry from the dict
+        self.dict.undeclare("test")
+
+        # prove it is no longer in the dict
+        with self.assertRaises(KeyError) as context:
+            self.dict['test']
+
+        expected_msg = "\"Option 'test' cannot be found\""
+        self.assertEqual(expected_msg, str(context.exception))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Certain classes have misleading documentation of their options, because they don't actually use options from their base. (e.g. `maxiter` is not used in non-iterative solvers).  Provided a way to remove these options, `undeclare`, then used it in two classes.  

A follow-up story is needed for getting `maxiter` removed from LinearRunOnce.