### PR TITLE
Deriv debug print should print the whole derivative value.  Also, more flushing.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -5,6 +5,7 @@ import os
 import json
 from collections import OrderedDict
 import pprint
+import sys
 import warnings
 
 from six import iteritems, itervalues, string_types
@@ -999,6 +1000,8 @@ class Driver(object):
                     print("None")
                 print()
 
+        sys.stdout.flush()
+
     def _post_run_model_debug_print(self):
         """
         Optionally print some debugging information after the model runs.
@@ -1032,6 +1035,8 @@ class Driver(object):
                 else:
                     print("None")
                 print()
+
+        sys.stdout.flush()
 
 
 class RecordingDebugging(Recording):

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -5,6 +5,7 @@ from __future__ import print_function, division
 
 from collections import OrderedDict
 from copy import deepcopy
+import pprint
 from six import iteritems
 from six.moves import zip
 import sys
@@ -1027,6 +1028,11 @@ class _TotalJacInfo(object):
 
         if self.has_scaling:
             self._do_scaling(self.J_dict)
+
+        if debug_print:
+            # Debug outputs scaled derivatives.
+            sys.stdout.flush()
+            pprint.pprint(self.J_dict)
 
         recording_iteration.stack.pop()
 

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1031,7 +1031,7 @@ class _TotalJacInfo(object):
 
         if debug_print:
             # Debug outputs scaled derivatives.
-            self._print_debug_derivatives()
+            self._print_derivatives()
 
         recording_iteration.stack.pop()
 
@@ -1212,7 +1212,7 @@ class _TotalJacInfo(object):
             raise RuntimeError("Derivative scaling by the driver only supports the 'dict' and "
                                "'array' formats at present.")
 
-    def _print_debug_derivatives(self):
+    def _print_derivatives(self):
         """
         Print out the derivatives when debug_print is True.
         """

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1223,8 +1223,8 @@ class _TotalJacInfo(object):
             for of in inputs:
                 for wrt in outputs:
                     pprint.pprint({(of, wrt): J[of][wrt]})
-        else:
 
+        else:
             abs2meta = self.model._var_allprocs_abs2meta
             in_meta, in_size = self._get_tuple_map(self.input_list, self.input_meta, abs2meta)
             out_meta = self.out_meta

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1235,7 +1235,9 @@ class _TotalJacInfo(object):
                 for j, wrt in enumerate(inputs):
                     pprint.pprint({(of, wrt): J[out_slice, in_meta[wrt][0]]})
 
+        print('')
         sys.stdout.flush()
+
 
 def _get_subjac(jac, prom_out, prom_in, of_idx, wrt_idx):
     """

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1031,8 +1031,7 @@ class _TotalJacInfo(object):
 
         if debug_print:
             # Debug outputs scaled derivatives.
-            sys.stdout.flush()
-            pprint.pprint(self.J_dict)
+            self._print_debug_derivatives()
 
         recording_iteration.stack.pop()
 
@@ -1213,6 +1212,30 @@ class _TotalJacInfo(object):
             raise RuntimeError("Derivative scaling by the driver only supports the 'dict' and "
                                "'array' formats at present.")
 
+    def _print_debug_derivatives(self):
+        """
+        Print out the derivatives when debug_print is True.
+        """
+        inputs = self.input_list
+        outputs = self.output_list
+        if self.return_format == 'dict':
+            J = self.J_dict
+            for of in inputs:
+                for wrt in outputs:
+                    pprint.pprint({(of, wrt): J[of][wrt]})
+        else:
+
+            abs2meta = self.model._var_allprocs_abs2meta
+            in_meta, in_size = self._get_tuple_map(self.input_list, self.input_meta, abs2meta)
+            out_meta = self.out_meta
+            J = self.J
+
+            for i, of in enumerate(outputs):
+                out_slice = out_meta[of][0]
+                for j, wrt in enumerate(inputs):
+                    pprint.pprint({(of, wrt): J[out_slice, in_meta[wrt][0]]})
+
+        sys.stdout.flush()
 
 def _get_subjac(jac, prom_out, prom_in, of_idx, wrt_idx):
     """

--- a/openmdao/docs/features/debugging/debugging_drivers.rst
+++ b/openmdao/docs/features/debugging/debugging_drivers.rst
@@ -28,7 +28,7 @@ printed are unscaled, physical values.
       :layout: interleave
 
 We can also use the debug printing to print some basic information about the derivative calculations so that you can see
-which derivative is being solved and how long it takes, by including the 'totals' string in the "debug_print" list.
+which derivative is being solved, how long it takes, and the computed values by including the 'totals' string in the "debug_print" list.
 
   .. embed-code::
       openmdao.drivers.tests.test_scipy_optimizer.TestScipyOptimizeDriverFeatures.test_debug_print_option_totals

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -7,6 +7,7 @@ from collections import OrderedDict
 import os
 import pprint
 import re
+import sys
 
 import numpy as np
 
@@ -642,6 +643,8 @@ class NonlinearSolver(Solver):
                 f.write(out_str)
                 print("Inputs and outputs at start of iteration have been "
                       "saved to '%s'." % filename)
+
+            sys.stdout.flush()
 
         return fail, abs_err, rel_err
 


### PR DESCRIPTION
1. Modified debug print so that derivative values are printed out too.
2. Added a couple more buffer flushes.