### PR TITLE
Undeclare updates

### DIFF
--- a/openmdao/solvers/linear/linear_runonce.py
+++ b/openmdao/solvers/linear/linear_runonce.py
@@ -24,10 +24,6 @@ class LinearRunOnce(LinearBlockGS):
         """
         super(LinearRunOnce, self).__init__(**kwargs)
 
-        # Remove unused options from base options.
-        self.options.undeclare("atol")
-        self.options.undeclare("rtol")
-
     def solve(self, vec_names, mode, rel_systems=None):
         """
         Run the solver.
@@ -85,3 +81,8 @@ class LinearRunOnce(LinearBlockGS):
         self.options.declare('maxiter', default=0, values=(0,),
                              desc='maximum number of iterations '
                                   '(this solver does not iterate)')
+
+        # Remove unused options from base options here, so that users
+        # attempting to set them will get KeyErrors.
+        self.options.undeclare("atol")
+        self.options.undeclare("rtol")

--- a/openmdao/solvers/linear/tests/test_linear_runonce.py
+++ b/openmdao/solvers/linear/tests/test_linear_runonce.py
@@ -46,16 +46,11 @@ class TestLinearRunOnceSolver(unittest.TestCase):
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class, cause an
-        # error if they are passed into LinearRunOnce. atol and rtol are not allowed in LinearRunOnce
-        from openmdao.api import Problem, Group, IndepVarComp, LinearRunOnce
-        from openmdao.test_suite.components.paraboloid import Paraboloid
+        # error if they are set in LinearRunOnce. atol and rtol are not allowed in LinearRunOnce
+        from openmdao.api import Problem, Group, LinearRunOnce
 
         prob = Problem()
         model = prob.model = Group()
-
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
-        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         with self.assertRaises(KeyError) as context:
             model.linear_solver = LinearRunOnce(atol=1.0)

--- a/openmdao/solvers/linear/tests/test_linear_runonce.py
+++ b/openmdao/solvers/linear/tests/test_linear_runonce.py
@@ -89,6 +89,5 @@ class TestLinearRunOnceSolver(unittest.TestCase):
         assert_rel_error(self, derivs['f_xy']['x'], [[-6.0]], 1e-6)
         assert_rel_error(self, derivs['f_xy']['y'], [[8.0]], 1e-6)
 
-
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/linear/tests/test_linear_runonce.py
+++ b/openmdao/solvers/linear/tests/test_linear_runonce.py
@@ -44,6 +44,31 @@ class TestLinearRunOnceSolver(unittest.TestCase):
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
         assert_rel_error(self, J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
 
+    def test_undeclared_options(self):
+        # Test that using options that should not exist in class, cause an
+        # error if they are passed into LinearRunOnce. atol and rtol are not allowed in LinearRunOnce
+        from openmdao.api import Problem, Group, IndepVarComp, LinearRunOnce
+        from openmdao.test_suite.components.paraboloid import Paraboloid
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+
+        with self.assertRaises(KeyError) as context:
+            model.linear_solver = LinearRunOnce(atol=1.0)
+
+        self.assertEqual(str(context.exception), "\"Key 'atol' cannot be set because it "
+                                                 "has not been declared.\"")
+
+        with self.assertRaises(KeyError) as context:
+            model.linear_solver = LinearRunOnce(rtol=1.0)
+
+        self.assertEqual(str(context.exception), "\"Key 'rtol' cannot be set because it "
+                                                 "has not been declared.\"")
+
     def test_feature_solver(self):
         from openmdao.api import Problem, Group, IndepVarComp, LinearRunOnce
         from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -67,6 +92,7 @@ class TestLinearRunOnceSolver(unittest.TestCase):
 
         assert_rel_error(self, derivs['f_xy']['x'], [[-6.0]], 1e-6)
         assert_rel_error(self, derivs['f_xy']['y'], [[8.0]], 1e-6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/linear/tests/test_linear_runonce.py
+++ b/openmdao/solvers/linear/tests/test_linear_runonce.py
@@ -46,7 +46,8 @@ class TestLinearRunOnceSolver(unittest.TestCase):
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class, cause an
-        # error if they are set in LinearRunOnce. atol and rtol are not allowed in LinearRunOnce
+        # error if they are set when instantiating LinearRunOnce.
+        # atol and rtol are not used in LinearRunOnce
         from openmdao.api import Problem, Group, LinearRunOnce
 
         prob = Problem()

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -89,7 +89,7 @@ class BoundsEnforceLS(NonlinearSolver):
                     "back to their bounds.")
 
         # Remove unused options from base options here, so that users
-        #  attempting to set them will get KeyErrors.
+        # attempting to set them will get KeyErrors.
         opt.undeclare("atol")
         opt.undeclare("rtol")
         opt.undeclare("maxiter")

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -72,11 +72,6 @@ class BoundsEnforceLS(NonlinearSolver):
 
         # Parent solver sets this to control whether to solve subsystems.
         self._do_subsolve = False
-        # Remove unused options from base options.
-        self.options.undeclare("atol")
-        self.options.undeclare("rtol")
-        self.options.undeclare("maxiter")
-        self.options.undeclare("err_on_maxiter")
 
     def _declare_options(self):
         """
@@ -92,6 +87,13 @@ class BoundsEnforceLS(NonlinearSolver):
         opt.declare('print_bound_enforce', default=False,
                     desc="Set to True to print out names and values of variables that are pulled "
                     "back to their bounds.")
+
+        # Remove unused options from base options here, so that users
+        #  attempting to set them will get KeyErrors.
+        opt.undeclare("atol")
+        opt.undeclare("rtol")
+        opt.undeclare("maxiter")
+        opt.undeclare("err_on_maxiter")
 
     def _run_iterator(self):
         """

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -414,7 +414,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
             self.assertTrue(2.4 <= top['comp.z'][ind] <= self.ub[ind])
 
     def test_error_handling(self):
-        # Make sure the debug_print doen't bomb out.
+        # Make sure the debug_print doesn't bomb out.
 
         class Bad(ExplicitComponent):
 
@@ -464,6 +464,34 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         # Make sure we don't raise an error when we reach the final debug print.
         top.run_model()
 
+    def test_undeclared_options(self):
+        # Test that using options that should not exist in class, cause an
+        # error if they are passed into BoundsEnforceLS
+
+        top = self.top
+
+        with self.assertRaises(KeyError) as context:
+            top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar', atol=1.0)
+
+        self.assertEqual(str(context.exception), "\"Key 'atol' cannot be set because it "
+                                                 "has not been declared.\"")
+
+        with self.assertRaises(KeyError) as context:
+            top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar', rtol=2.0)
+
+        self.assertEqual(str(context.exception), "\"Key 'rtol' cannot be set because it "
+                                                 "has not been declared.\"")
+
+        with self.assertRaises(KeyError) as context:
+            top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar', maxiter=1)
+
+        self.assertEqual(str(context.exception), "\"Key 'maxiter' cannot be set because it "
+                                                 "has not been declared.\"")
+        with self.assertRaises(KeyError) as context:
+            top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar', err_on_maxiter=True)
+
+        self.assertEqual(str(context.exception), "\"Key 'err_on_maxiter' cannot be set because it "
+                                                 "has not been declared.\"")
 
 class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
 

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -466,7 +466,8 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class, cause an
-        # error if they are passed into BoundsEnforceLS
+        # error if they are passed into BoundsEnforceLS.
+        # atol, rtol, maxiter, and err_on_maxiter are not used in BoundsEnforceLS
 
         top = self.top
 

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -466,7 +466,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class, cause an
-        # error if they are passed into BoundsEnforceLS.
+        # error if they are set when instantiating BoundsEnforceLS.
         # atol, rtol, maxiter, and err_on_maxiter are not used in BoundsEnforceLS
 
         top = self.top

--- a/openmdao/solvers/nonlinear/nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/nonlinear_runonce.py
@@ -63,6 +63,10 @@ class NonlinearRunOnce(NonlinearSolver):
         self.options.declare('maxiter', default=0, values=(0,),
                              desc='maximum number of iterations '
                                   '(this solver does not iterate)')
+        # Remove unused options from base options here, so that users
+        #  attempting to set them will get KeyErrors.
+        self.options.undeclare("atol")
+        self.options.undeclare("rtol")
 
 
 class NonLinearRunOnce(NonlinearRunOnce):

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -40,6 +40,31 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
         # Make sure value is fine.
         assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
 
+    def test_undeclared_options(self):
+        # Test that using options that should not exist in class, cause an
+        # error if they are passed into LinearRunOnce. atol and rtol are not allowed in LinearRunOnce
+        from openmdao.api import Problem, Group, IndepVarComp, LinearRunOnce
+        from openmdao.test_suite.components.paraboloid import Paraboloid
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+
+        with self.assertRaises(KeyError) as context:
+            model.linear_solver = NonlinearRunOnce(atol=1.0)
+
+        self.assertEqual(str(context.exception), "\"Key 'atol' cannot be set because it "
+                                                 "has not been declared.\"")
+
+        with self.assertRaises(KeyError) as context:
+            model.linear_solver = NonlinearRunOnce(rtol=2.0)
+
+        self.assertEqual(str(context.exception), "\"Key 'rtol' cannot be set because it "
+                                                 "has not been declared.\"")
+
     def test_feature_solver(self):
         from openmdao.api import Problem, Group, NonlinearRunOnce, IndepVarComp
         from openmdao.test_suite.components.paraboloid import Paraboloid

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -41,17 +41,12 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
         assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
 
     def test_undeclared_options(self):
-        # Test that using options that should not exist in class, cause an
-        # error if they are passed into LinearRunOnce. atol and rtol are not allowed in LinearRunOnce
-        from openmdao.api import Problem, Group, IndepVarComp, LinearRunOnce
-        from openmdao.test_suite.components.paraboloid import Paraboloid
+        # Test that using options that should not exist in class, cause an error if they
+        #  are set in NonlinearRunOnce. atol and rtol are not allowed in NonlinearRunOnce
+        from openmdao.api import Problem, Group, NonlinearRunOnce
 
         prob = Problem()
         model = prob.model = Group()
-
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
-        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         with self.assertRaises(KeyError) as context:
             model.linear_solver = NonlinearRunOnce(atol=1.0)

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -41,8 +41,9 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
         assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
 
     def test_undeclared_options(self):
-        # Test that using options that should not exist in class, cause an error if they
-        #  are set in NonlinearRunOnce. atol and rtol are not allowed in NonlinearRunOnce
+        # Test that using options that should not exist in the class, cause an
+        # error if they are set while instantiating NonlinearRunOnce.
+        # atol and rtol are not used in NonlinearRunOnce
         from openmdao.api import Problem, Group, NonlinearRunOnce
 
         prob = Problem()


### PR DESCRIPTION
@swryan pointed out that while `undeclare` was working in the sense of the options being documented correctly, it should be noted that someone instantiating one of these solvers and setting an undeclared option, e.g. 

` model.linear_solver = NonlinearRunOnce(rtol=2.0)`

would receive no notice of the fact that `rtol` shouldn't be used in `NonlinearRunOnce`.  The declaration would just be done, then subsequently undeclared.  This fix (moving the `undeclare` calls to `_declare_options`) should remedy that, giving a user a KeyError if they try to use one of the now-disallowed options.  

*Remedied the fact that NonlinearRunOnce was left out of the original story.

*Added 3 tests (one for each solver) to make sure that declaring an instance while setting one of those undeclared options does in fact throw a KeyError.