### PR TITLE
Add a repr to OptionsDictionary

### DIFF
--- a/openmdao/docs/_exts/embed_options.py
+++ b/openmdao/docs/_exts/embed_options.py
@@ -42,79 +42,13 @@ class EmbedOptionsDirective(Directive):
         if not isinstance(options, OptionsDictionary):
             raise TypeError("Object '%s' is not an OptionsDictionary." % attribute_name)
 
-        outputs = []
-        for option_name, option_data in sorted(iteritems(options._dict)):
-            name = option_name
-            default = option_data['value'] if option_data['value'] is not _undefined \
-                else '**Required**'
-            values = option_data['values']
-            types = option_data['types']
-            desc = option_data['desc']
-
-            if types is None:
-                types = "N/A"
-
-            elif types is not None:
-                if not isinstance(types, (tuple, list)):
-                    types = (types,)
-
-                types = [type_.__name__ for type_ in types]
-
-            if values is None:
-                values = "N/A"
-
-            elif values is not None:
-                if not isinstance(values, (tuple, list)):
-                    values = (values,)
-
-                values = [value for value in values]
-
-            outputs.append([name, default, values, types, desc])
-
         lines = ViewList()
 
-        col_heads = ['Option', 'Default', 'Acceptable Values', 'Acceptable Types', 'Description']
-
-        max_sizes = {}
-        for j, col in enumerate(col_heads):
-            max_sizes[j] = len(col)
-
-        for output in outputs:
-            for j, item in enumerate(output):
-                length = len(str(item))
-                if max_sizes[j] < length:
-                    max_sizes[j] = length
-
-        header = ""
-        titles = ""
-        for key, val in iteritems(max_sizes):
-            header += '=' * val + ' '
-
-        for j, head in enumerate(col_heads):
-            titles += "%s " % head
-            size = max_sizes[j]
-            space = size - len(head)
-            if space > 0:
-                titles += space*' '
-
-        lines.append(header, "options table", 1)
-        lines.append(titles, "options table", 2)
-        lines.append(header, "options table", 3)
-
-        n = 3
-        for output in outputs:
-            line = ""
-            for j, item in enumerate(output):
-                line += "%s " % str(item)
-                size = max_sizes[j]
-                space = size - len(str(item))
-                if space > 0:
-                    line += space*' '
-
+        n = 0
+        for line in options.__rst__():
             lines.append(line, "options table", n)
             n += 1
 
-        lines.append(header, "options table", n)
         lines.append("", "options table", n+1)  # Blank line required after table.
         lines.append("Note: Options can be passed as keyword arguments at initialization.",
                      "options table", n+2)

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -66,7 +66,7 @@ class DOEDriver(Driver):
         Parameters
         ----------
         generator : DOEGenerator or None
-            The case generator.
+            The case generator. If None, no cases will be generated.
 
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
@@ -96,7 +96,7 @@ class DOEDriver(Driver):
         self.options.declare('generator', types=(DOEGenerator), default=DOEGenerator(),
                              desc='The case generator. If default, no cases are generated.')
 
-        self.options.declare('parallel', default=False, types=(bool, int), lower=0,
+        self.options.declare('parallel', default=False,
                              desc='True or number of cases to run in parallel. '
                                   'If True, cases will be run on all available processors. '
                                   'If an integer, each case will get COMM.size/<number> '
@@ -116,41 +116,12 @@ class DOEDriver(Driver):
         MPI.Comm or <FakeComm> or None
             The communicator for the Problem model.
         """
-        import sys
         parallel = self.options['parallel']
         if MPI and parallel:
             self._comm = comm
-            comm_size = comm.size
 
-            if parallel == 1:
-                size = 1
-                color = self._color = comm.rank
-                print('size:', size)
-                sys.stdout.flush()
-            else:
-                size = comm_size // parallel
-                print('comm_size:', comm_size)
-                sys.stdout.flush()
-                print('parallel:', parallel)
-                sys.stdout.flush()
-                print('size * parallel:', size * parallel)
-                sys.stdout.flush()
-                if comm_size != size * parallel:
-                    raise RuntimeError("The number of processors is not evenly divisable by "
-                                       "the specified number of parallel cases.\n Provide a "
-                                       "number of processors that is a multiple of %d, or "
-                                       "specify a number of parallel cases that divides "
-                                       "into %d." % (parallel, comm_size))
-                color = self._color = comm.rank % size
-
-            print('comm_size:', comm_size)
-            sys.stdout.flush()
-            print('parallel:', parallel)
-            sys.stdout.flush()
-            print('size:', size)
-            sys.stdout.flush()
-            print('color:', color)
-            sys.stdout.flush()
+            size = comm.size // parallel
+            color = self._color = comm.rank % size
 
             model_comm = comm.Split(color)
         else:

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -539,6 +539,21 @@ class TestParallelDOE(unittest.TestCase):
         except OSError:
             pass
 
+    def test_parallel_error(self):
+        prob = Problem()
+
+        prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
+        prob.driver.options['parallel'] =  3
+
+        with self.assertRaises(RuntimeError) as context:
+            prob.setup()
+
+        self.assertEqual(str(context.exception),
+                         "The number of processors is not evenly divisable by the "
+                         "specified number of parallel cases.\n Provide a number of "
+                         "processors that is a multiple of 3, or specify a number "
+                         "of parallel cases that divides into 4.")
+
     def test_full_factorial(self):
         prob = Problem()
         model = prob.model
@@ -604,6 +619,75 @@ class TestParallelDOE(unittest.TestCase):
 
     def test_fan_in_grouped(self):
         doe_parallel = 2
+
+        prob = Problem(FanInGrouped())
+        model = prob.model
+
+        model.add_design_var('iv.x1', lower=0.0, upper=1.0)
+        model.add_design_var('iv.x2', lower=0.0, upper=1.0)
+
+        model.add_objective('c3.y')
+
+        prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
+        prob.driver.add_recorder(SqliteRecorder("CASES.db"))
+        prob.driver.options['parallel'] =  doe_parallel
+
+        prob.setup(check=False)
+
+        failed, output = run_driver(prob)
+        self.assertFalse(failed)
+
+        prob.cleanup()
+
+        expected = {
+            0: {'iv.x1': np.array([0.]), 'iv.x2': np.array([0.]), 'c3.y': np.array([ 0.0])},
+            1: {'iv.x1': np.array([.5]), 'iv.x2': np.array([0.]), 'c3.y': np.array([-3.0])},
+            2: {'iv.x1': np.array([1.]), 'iv.x2': np.array([0.]), 'c3.y': np.array([-6.0])},
+
+            3: {'iv.x1': np.array([0.]), 'iv.x2': np.array([.5]), 'c3.y': np.array([17.5])},
+            4: {'iv.x1': np.array([.5]), 'iv.x2': np.array([.5]), 'c3.y': np.array([14.5])},
+            5: {'iv.x1': np.array([1.]), 'iv.x2': np.array([.5]), 'c3.y': np.array([11.5])},
+
+            6: {'iv.x1': np.array([0.]), 'iv.x2': np.array([1.]), 'c3.y': np.array([35.0])},
+            7: {'iv.x1': np.array([.5]), 'iv.x2': np.array([1.]), 'c3.y': np.array([32.0])},
+            8: {'iv.x1': np.array([1.]), 'iv.x2': np.array([1.]), 'c3.y': np.array([29.0])},
+        }
+
+        rank = prob.comm.rank
+        size = prob.comm.size // doe_parallel
+
+        num_cases = 0
+
+        # cases will be split across files for each proc up to the number requested
+        if rank < doe_parallel:
+            filename = "CASES.db_%d" % rank
+
+            expect_msg = "Cases from rank %d are being written to %s." % (rank, filename)
+            self.assertTrue(expect_msg in output)
+
+            cases = CaseReader(filename).driver_cases
+
+            # cases recorded on this proc
+            num_cases = cases.num_cases
+            self.assertEqual(num_cases, len(expected)//size+(rank<len(expected)%size))
+
+            for n in range(num_cases):
+                case = cases.get_case(n)
+                idx = n * size + rank  # index of expected case
+
+                self.assertEqual(cases.get_case(n).outputs['iv.x1'], expected[idx]['iv.x1'])
+                self.assertEqual(cases.get_case(n).outputs['iv.x2'], expected[idx]['iv.x2'])
+                self.assertEqual(cases.get_case(n).outputs['c3.y'], expected[idx]['c3.y'])
+        else:
+            self.assertFalse("Cases from rank %d are being written" % rank in output)
+
+        # total number of cases recorded across all requested procs
+        num_cases = prob.comm.allgather(num_cases)
+        self.assertEqual(sum(num_cases), len(expected))
+
+    @unittest.skip("broken")
+    def test_fan_in_grouped_error(self):
+        doe_parallel = True
 
         prob = Problem(FanInGrouped())
         model = prob.model

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -39,6 +39,17 @@ class OptionsDictionary(object):
         self._dict = {}
         self._read_only = read_only
 
+    def __repr__(self):
+        """
+        Returns a dictionary representation of the options.
+
+        Returns
+        -------
+        dict
+            The options dictionary.
+        """
+        return self._dict
+
     def __rst__(self):
         """
         Generate reStructuredText view of the options table.
@@ -131,16 +142,38 @@ class OptionsDictionary(object):
 
         return lines
 
-    def __repr__(self):
+    def __str__(self, width=100):
         """
         Generate string representation of the options table.
+
+        Parameters
+        ----------
+        width : int
+            The maximum width of the text.
 
         Returns
         -------
         str
-            A rendition of the options as an rST table.
+            A rendition of the options as text.
         """
-        return '\n'.join(self.__rst__())
+        rst = self.__rst__()
+        cols = [len(header) for header in rst[0].split()]
+        desc_col = sum(cols[:-1]) + len(cols) - 1
+        desc_len = width - desc_col
+
+        text = []
+        for row in rst:
+            if len(row) > width:
+                text.append(row[:width])
+                if not row.startswith('==='):
+                    row = row[width:].rstrip()
+                    while(len(row) > 0):
+                        text.append(' '*desc_col + row[:desc_len])
+                        row = row[desc_len:]
+            else:
+                text.append(row)
+
+        return '\n'.join(text)
 
     def _assert_valid(self, name, value):
         """

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -162,7 +162,7 @@ class OptionsDictionary(object):
         desc_len = width - desc_col
 
         # if it won't fit in allowed width, just return the rST
-        if desc_len < 0:
+        if desc_len < 10:
             return '\n'.join(rst)
 
         text = []

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -41,7 +41,7 @@ class OptionsDictionary(object):
 
     def __repr__(self):
         """
-        Returns a dictionary representation of the options.
+        Return a dictionary representation of the options.
 
         Returns
         -------
@@ -119,7 +119,7 @@ class OptionsDictionary(object):
             size = max_sizes[j]
             space = size - len(head)
             if space > 0:
-                titles += space*' '
+                titles += space * ' '
 
         lines.append(header)
         lines.append(titles)
@@ -133,7 +133,7 @@ class OptionsDictionary(object):
                 size = max_sizes[j]
                 space = size - len(str(item))
                 if space > 0:
-                    line += space*' '
+                    line += space * ' '
 
             lines.append(line)
             n += 1
@@ -144,7 +144,7 @@ class OptionsDictionary(object):
 
     def __str__(self, width=100):
         """
-        Generate string representation of the options table.
+        Generate text string representation of the options table.
 
         Parameters
         ----------
@@ -154,7 +154,7 @@ class OptionsDictionary(object):
         Returns
         -------
         str
-            A rendition of the options as text.
+            A text representation of the options table.
         """
         rst = self.__rst__()
         cols = [len(header) for header in rst[0].split()]
@@ -168,7 +168,7 @@ class OptionsDictionary(object):
                 if not row.startswith('==='):
                     row = row[width:].rstrip()
                     while(len(row) > 0):
-                        text.append(' '*desc_col + row[:desc_len])
+                        text.append(' ' * desc_col + row[:desc_len])
                         row = row[desc_len:]
             else:
                 text.append(row)

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -161,6 +161,10 @@ class OptionsDictionary(object):
         desc_col = sum(cols[:-1]) + len(cols) - 1
         desc_len = width - desc_col
 
+        # if it won't fit in allowed width, just return the rST
+        if desc_len < 0:
+            return '\n'.join(rst)
+
         text = []
         for row in rst:
             if len(row) > width:

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -26,7 +26,6 @@ class TestOptionsDict(unittest.TestCase):
 
         self.assertEqual(self.dict.__repr__(), self.dict._dict)
 
-        print(self.dict.__str__(width=83))
         self.assertEqual(self.dict.__str__(width=83), '\n'.join([
             "========= ============ ================= ===================== ====================",
             "Option    Default      Acceptable Values Acceptable Types      Description         ",

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -7,18 +7,18 @@ from six import PY3, assertRegex
 class TestOptionsDict(unittest.TestCase):
 
     def setUp(self):
-        self.options = OptionsDictionary()
+        self.dict = OptionsDictionary()
 
     def test_reprs(self):
-        self.options.declare('test', types=int, desc='Test integer value')
-        self.options.declare('flag', default=False, types=bool)
-        self.options.declare('long_desc', types=str,
-                             desc='This description is ridiculously long and verbose, so much '
-                                  'so that it takes up multiple lines in the options table.')
+        self.dict.declare('test', types=int, desc='Test integer value')
+        self.dict.declare('flag', default=False, types=bool)
+        self.dict.declare('long_desc', types=str,
+                          desc='This description is ridiculously long and verbose, so much '
+                               'so that it takes up multiple lines in the options table.')
 
-        self.assertEqual(self.options.__repr__(), self.options._dict)
+        self.assertEqual(self.dict.__repr__(), self.dict._dict)
 
-        self.assertEqual(self.options.__str__(width=80), '\n'.join([
+        self.assertEqual(self.dict.__str__(width=80), '\n'.join([
             "========= ============ ================= ================ ======================",
             "Option    Default      Acceptable Values Acceptable Types Description           ",
             "========= ============ ================= ================ ======================",
@@ -34,53 +34,53 @@ class TestOptionsDict(unittest.TestCase):
         ]))
 
     def test_type_checking(self):
-        self.options.declare('test', types=int, desc='Test integer value')
+        self.dict.declare('test', types=int, desc='Test integer value')
 
-        self.options['test'] = 1
-        self.assertEqual(self.options['test'], 1)
+        self.dict['test'] = 1
+        self.assertEqual(self.dict['test'], 1)
 
         with self.assertRaises(TypeError) as context:
-            self.options['test'] = ''
+            self.dict['test'] = ''
 
         class_or_type = 'class' if PY3 else 'type'
         expected_msg = "Option 'test' has the wrong type (<{} 'int'>)".format(class_or_type)
         self.assertEqual(expected_msg, str(context.exception))
 
         # make sure bools work
-        self.options.declare('flag', default=False, types=bool)
-        self.assertEqual(self.options['flag'], False)
-        self.options['flag'] = True
-        self.assertEqual(self.options['flag'], True)
+        self.dict.declare('flag', default=False, types=bool)
+        self.assertEqual(self.dict['flag'], False)
+        self.dict['flag'] = True
+        self.assertEqual(self.dict['flag'], True)
 
     def test_allow_none(self):
-        self.options.declare('test', types=int, allow_none=True, desc='Test integer value')
-        self.options['test'] = None
-        self.assertEqual(self.options['test'], None)
+        self.dict.declare('test', types=int, allow_none=True, desc='Test integer value')
+        self.dict['test'] = None
+        self.assertEqual(self.dict['test'], None)
 
     def test_type_and_values(self):
         # Test with only type_
-        self.options.declare('test1', types=int)
-        self.options['test1'] = 1
-        self.assertEqual(self.options['test1'], 1)
+        self.dict.declare('test1', types=int)
+        self.dict['test1'] = 1
+        self.assertEqual(self.dict['test1'], 1)
 
         # Test with only values
-        self.options.declare('test2', values=['a', 'b'])
-        self.options['test2'] = 'a'
-        self.assertEqual(self.options['test2'], 'a')
+        self.dict.declare('test2', values=['a', 'b'])
+        self.dict['test2'] = 'a'
+        self.assertEqual(self.dict['test2'], 'a')
 
         # Test with both type_ and values
         with self.assertRaises(Exception) as context:
-            self.options.declare('test3', types=int, values=['a', 'b'])
+            self.dict.declare('test3', types=int, values=['a', 'b'])
         self.assertEqual(str(context.exception),
                          "'types' and 'values' were both specified for option 'test3'.")
 
     def test_isvalid(self):
-        self.options.declare('even_test', types=int, is_valid=lambda x: x % 2 == 0)
-        self.options['even_test'] = 2
-        self.options['even_test'] = 4
+        self.dict.declare('even_test', types=int, is_valid=lambda x: x % 2 == 0)
+        self.dict['even_test'] = 2
+        self.dict['even_test'] = 4
 
         with self.assertRaises(ValueError) as context:
-            self.options['even_test'] = 3
+            self.dict['even_test'] = 3
 
         expected_msg = "Function is_valid returns False for {}.".format('even_test')
         self.assertEqual(expected_msg, str(context.exception))
@@ -89,46 +89,46 @@ class TestOptionsDict(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.options.declare('even_test', type_=int, is_valid=lambda x: x % 2 == 0)
+            self.dict.declare('even_test', type_=int, is_valid=lambda x: x % 2 == 0)
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[-1].message), "In declaration of option 'even_test' the '_type' arg is deprecated.  Use 'types' instead.")
 
-        self.options['even_test'] = 2
-        self.options['even_test'] = 4
+        self.dict['even_test'] = 2
+        self.dict['even_test'] = 4
 
         with self.assertRaises(ValueError) as context:
-            self.options['even_test'] = 3
+            self.dict['even_test'] = 3
 
         expected_msg = "Function is_valid returns False for {}.".format('even_test')
         self.assertEqual(expected_msg, str(context.exception))
 
     def test_unnamed_args(self):
         with self.assertRaises(KeyError) as context:
-            self.options['test'] = 1
+            self.dict['test'] = 1
 
         # KeyError ends up with an extra set of quotes.
         expected_msg = "\"Key 'test' cannot be set because it has not been declared.\""
         self.assertEqual(expected_msg, str(context.exception))
 
     def test_contains(self):
-        self.options.declare('test')
+        self.dict.declare('test')
 
-        contains = 'undeclared' in self.options
+        contains = 'undeclared' in self.dict
         self.assertTrue(not contains)
 
-        contains = 'test' in self.options
+        contains = 'test' in self.dict
         self.assertTrue(contains)
 
     def test_update(self):
-        self.options.declare('test', default='Test value', types=object)
+        self.dict.declare('test', default='Test value', types=object)
 
         obj = object()
-        self.options.update({'test': obj})
-        self.assertIs(self.options['test'], obj)
+        self.dict.update({'test': obj})
+        self.assertIs(self.dict['test'], obj)
 
     def test_update_extra(self):
         with self.assertRaises(KeyError) as context:
-            self.options.update({'test': 2})
+            self.dict.update({'test': 2})
 
         # KeyError ends up with an extra set of quotes.
         expected_msg = "\"Key 'test' cannot be set because it has not been declared.\""
@@ -136,7 +136,7 @@ class TestOptionsDict(unittest.TestCase):
 
     def test_get_missing(self):
         with self.assertRaises(KeyError) as context:
-            self.options['missing']
+            self.dict['missing']
 
         expected_msg = "\"Option 'missing' cannot be found\""
         self.assertEqual(expected_msg, str(context.exception))
@@ -145,23 +145,23 @@ class TestOptionsDict(unittest.TestCase):
         obj_def = object()
         obj_new = object()
 
-        self.options.declare('test', default=obj_def, types=object)
+        self.dict.declare('test', default=obj_def, types=object)
 
-        self.assertIs(self.options['test'], obj_def)
+        self.assertIs(self.dict['test'], obj_def)
 
-        self.options['test'] = obj_new
-        self.assertIs(self.options['test'], obj_new)
+        self.dict['test'] = obj_new
+        self.assertIs(self.dict['test'], obj_new)
 
     def test_values(self):
         obj1 = object()
         obj2 = object()
-        self.options.declare('test', values=[obj1, obj2])
+        self.dict.declare('test', values=[obj1, obj2])
 
-        self.options['test'] = obj1
-        self.assertIs(self.options['test'], obj1)
+        self.dict['test'] = obj1
+        self.assertIs(self.dict['test'], obj1)
 
         with self.assertRaises(ValueError) as context:
-            self.options['test'] = object()
+            self.dict['test'] = object()
 
         expected_msg = ("Option 'test''s value is not one of \[<object object at 0x[0-9A-Fa-f]+>,"
                         " <object object at 0x[0-9A-Fa-f]+>\]")
@@ -178,34 +178,34 @@ class TestOptionsDict(unittest.TestCase):
         assertRegex(self, str(context.exception), expected_msg)
 
     def test_bounds(self):
-        self.options.declare('x', default=1.0, lower=0.0, upper=2.0)
+        self.dict.declare('x', default=1.0, lower=0.0, upper=2.0)
 
         with self.assertRaises(ValueError) as context:
-            self.options['x'] = 3.0
+            self.dict['x'] = 3.0
 
         expected_msg = ("Value of 3.0 exceeds maximum of 2.0 for option 'x'")
         assertRegex(self, str(context.exception), expected_msg)
 
         with self.assertRaises(ValueError) as context:
-            self.options['x'] = -3.0
+            self.dict['x'] = -3.0
 
         expected_msg = ("Value of -3.0 exceeds minimum of 0.0 for option 'x'")
         assertRegex(self, str(context.exception), expected_msg)
 
     def test_undeclare(self):
         # create an entry in the dict
-        self.options.declare('test', types=int)
-        self.options['test'] = 1
+        self.dict.declare('test', types=int)
+        self.dict['test'] = 1
 
         # prove it's in the dict
-        self.assertEqual(self.options['test'], 1)
+        self.assertEqual(self.dict['test'], 1)
 
         # remove entry from the dict
-        self.options.undeclare("test")
+        self.dict.undeclare("test")
 
         # prove it is no longer in the dict
         with self.assertRaises(KeyError) as context:
-            self.options['test']
+            self.dict['test']
 
         expected_msg = "\"Option 'test' cannot be found\""
         self.assertEqual(expected_msg, str(context.exception))

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -40,6 +40,27 @@ class TestOptionsDict(unittest.TestCase):
             "========= ================= ================= ===================== ================",
         ]))
 
+        # if the table can't be represented in specified width, then we get the full width version
+        self.assertEqual(self.dict.__str__(width=40), '\n'.join([
+            "========= ================= ================= ===================== ================"
+            "========================================================================= ",
+            "Option    Default           Acceptable Values Acceptable Types      Description     "
+            "                                                                          ",
+            "========= ================= ================= ===================== ================"
+            "========================================================================= ",
+            "comp      ExplicitComponent N/A               ['ExplicitComponent']                 "
+            "                                                                          ",
+            "flag      False             N/A               ['bool']                              "
+            "                                                                          ",
+            "long_desc **Required**      N/A               ['str']               This description"
+            " is long and verbose, so it takes up multiple lines in the options table. ",
+            "test      **Required**      ['a', 'b']        N/A                   Test integer val"
+            "ue                                                                        ",
+            "========= ================= ================= ===================== ================"
+            "========================================================================= ",
+        ]))
+
+
     def test_type_checking(self):
         self.dict.declare('test', types=int, desc='Test integer value')
 

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -12,7 +12,10 @@ class TestOptionsDict(unittest.TestCase):
         self.dict = OptionsDictionary()
 
     def test_reprs(self):
-        my_comp = ExplicitComponent()
+        class MyComp(ExplicitComponent):
+            pass
+
+        my_comp = MyComp()
 
         self.dict.declare('test', values=['a', 'b'], desc='Test integer value')
         self.dict.declare('flag', default=False, types=bool)
@@ -23,41 +26,40 @@ class TestOptionsDict(unittest.TestCase):
 
         self.assertEqual(self.dict.__repr__(), self.dict._dict)
 
-        self.assertEqual(self.dict.__str__(width=84), '\n'.join([
-            "========= ================= ================= ===================== ================",
-            "Option    Default           Acceptable Values Acceptable Types      Description     ",
-            "========= ================= ================= ===================== ================",
-            "comp      ExplicitComponent N/A               ['ExplicitComponent']                 ",
-            "flag      False             N/A               ['bool']                              ",
-            "long_desc **Required**      N/A               ['str']               This description",
-            "                                                                     is long and ver",
-            "                                                                    bose, so it take",
-            "                                                                    s up multiple li",
-            "                                                                    nes in the optio",
-            "                                                                    ns table.",
-            "test      **Required**      ['a', 'b']        N/A                   Test integer val",
-            "                                                                    ue",
-            "========= ================= ================= ===================== ================",
+        print(self.dict.__str__(width=83))
+        self.assertEqual(self.dict.__str__(width=83), '\n'.join([
+            "========= ============ ================= ===================== ====================",
+            "Option    Default      Acceptable Values Acceptable Types      Description         ",
+            "========= ============ ================= ===================== ====================",
+            "comp      MyComp       N/A               ['ExplicitComponent']                     ",
+            "flag      False        N/A               ['bool']                                  ",
+            "long_desc **Required** N/A               ['str']               This description is ",
+            "                                                               long and verbose, so",
+            "                                                                it takes up multipl",
+            "                                                               e lines in the optio",
+            "                                                               ns table.",
+            "test      **Required** ['a', 'b']        N/A                   Test integer value  ",
+            "========= ============ ================= ===================== ====================",
         ]))
 
         # if the table can't be represented in specified width, then we get the full width version
         self.assertEqual(self.dict.__str__(width=40), '\n'.join([
-            "========= ================= ================= ===================== ================"
-            "========================================================================= ",
-            "Option    Default           Acceptable Values Acceptable Types      Description     "
-            "                                                                          ",
-            "========= ================= ================= ===================== ================"
-            "========================================================================= ",
-            "comp      ExplicitComponent N/A               ['ExplicitComponent']                 "
-            "                                                                          ",
-            "flag      False             N/A               ['bool']                              "
-            "                                                                          ",
-            "long_desc **Required**      N/A               ['str']               This description"
-            " is long and verbose, so it takes up multiple lines in the options table. ",
-            "test      **Required**      ['a', 'b']        N/A                   Test integer val"
-            "ue                                                                        ",
-            "========= ================= ================= ===================== ================"
-            "========================================================================= ",
+            "========= ============ ================= ===================== ====================="
+            "==================================================================== ",
+            "Option    Default      Acceptable Values Acceptable Types      Description          "
+            "                                                                     ",
+            "========= ============ ================= ===================== ====================="
+            "==================================================================== ",
+            "comp      MyComp       N/A               ['ExplicitComponent']                      "
+            "                                                                     ",
+            "flag      False        N/A               ['bool']                                   "
+            "                                                                     ",
+            "long_desc **Required** N/A               ['str']               This description is l"
+            "ong and verbose, so it takes up multiple lines in the options table. ",
+            "test      **Required** ['a', 'b']        N/A                   Test integer value   "
+            "                                                                     ",
+            "========= ============ ================= ===================== ====================="
+            "==================================================================== ",
         ]))
 
 

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -7,56 +7,80 @@ from six import PY3, assertRegex
 class TestOptionsDict(unittest.TestCase):
 
     def setUp(self):
-        self.dict = OptionsDictionary()
+        self.options = OptionsDictionary()
+
+    def test_reprs(self):
+        self.options.declare('test', types=int, desc='Test integer value')
+        self.options.declare('flag', default=False, types=bool)
+        self.options.declare('long_desc', types=str,
+                             desc='This description is ridiculously long and verbose, so much '
+                                  'so that it takes up multiple lines in the options table.')
+
+        self.assertEqual(self.options.__repr__(), self.options._dict)
+
+        self.assertEqual(self.options.__str__(width=80), '\n'.join([
+            "========= ============ ================= ================ ======================",
+            "Option    Default      Acceptable Values Acceptable Types Description           ",
+            "========= ============ ================= ================ ======================",
+            "flag      False        N/A               ['bool']                               ",
+            "long_desc **Required** N/A               ['str']          This description is ri",
+            "                                                          diculously long and ve",
+            "                                                          rbose, so much so that",
+            "                                                           it takes up multiple ",
+            "                                                          lines in the options t",
+            "                                                          able.",
+            "test      **Required** N/A               ['int']          Test integer value    ",
+            "========= ============ ================= ================ ======================"
+        ]))
 
     def test_type_checking(self):
-        self.dict.declare('test', types=int, desc='Test integer value')
+        self.options.declare('test', types=int, desc='Test integer value')
 
-        self.dict['test'] = 1
-        self.assertEqual(self.dict['test'], 1)
+        self.options['test'] = 1
+        self.assertEqual(self.options['test'], 1)
 
         with self.assertRaises(TypeError) as context:
-            self.dict['test'] = ''
+            self.options['test'] = ''
 
         class_or_type = 'class' if PY3 else 'type'
         expected_msg = "Option 'test' has the wrong type (<{} 'int'>)".format(class_or_type)
         self.assertEqual(expected_msg, str(context.exception))
 
         # make sure bools work
-        self.dict.declare('flag', default=False, types=bool)
-        self.assertEqual(self.dict['flag'], False)
-        self.dict['flag'] = True
-        self.assertEqual(self.dict['flag'], True)
+        self.options.declare('flag', default=False, types=bool)
+        self.assertEqual(self.options['flag'], False)
+        self.options['flag'] = True
+        self.assertEqual(self.options['flag'], True)
 
     def test_allow_none(self):
-        self.dict.declare('test', types=int, allow_none=True, desc='Test integer value')
-        self.dict['test'] = None
-        self.assertEqual(self.dict['test'], None)
+        self.options.declare('test', types=int, allow_none=True, desc='Test integer value')
+        self.options['test'] = None
+        self.assertEqual(self.options['test'], None)
 
     def test_type_and_values(self):
         # Test with only type_
-        self.dict.declare('test1', types=int)
-        self.dict['test1'] = 1
-        self.assertEqual(self.dict['test1'], 1)
+        self.options.declare('test1', types=int)
+        self.options['test1'] = 1
+        self.assertEqual(self.options['test1'], 1)
 
         # Test with only values
-        self.dict.declare('test2', values=['a', 'b'])
-        self.dict['test2'] = 'a'
-        self.assertEqual(self.dict['test2'], 'a')
+        self.options.declare('test2', values=['a', 'b'])
+        self.options['test2'] = 'a'
+        self.assertEqual(self.options['test2'], 'a')
 
         # Test with both type_ and values
         with self.assertRaises(Exception) as context:
-            self.dict.declare('test3', types=int, values=['a', 'b'])
+            self.options.declare('test3', types=int, values=['a', 'b'])
         self.assertEqual(str(context.exception),
                          "'types' and 'values' were both specified for option 'test3'.")
 
     def test_isvalid(self):
-        self.dict.declare('even_test', types=int, is_valid=lambda x: x%2 == 0)
-        self.dict['even_test'] = 2
-        self.dict['even_test'] = 4
+        self.options.declare('even_test', types=int, is_valid=lambda x: x % 2 == 0)
+        self.options['even_test'] = 2
+        self.options['even_test'] = 4
 
         with self.assertRaises(ValueError) as context:
-            self.dict['even_test'] = 3
+            self.options['even_test'] = 3
 
         expected_msg = "Function is_valid returns False for {}.".format('even_test')
         self.assertEqual(expected_msg, str(context.exception))
@@ -65,46 +89,46 @@ class TestOptionsDict(unittest.TestCase):
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.dict.declare('even_test', type_=int, is_valid=lambda x: x%2 == 0)
+            self.options.declare('even_test', type_=int, is_valid=lambda x: x % 2 == 0)
             self.assertEqual(len(w), 1)
             self.assertEqual(str(w[-1].message), "In declaration of option 'even_test' the '_type' arg is deprecated.  Use 'types' instead.")
 
-        self.dict['even_test'] = 2
-        self.dict['even_test'] = 4
+        self.options['even_test'] = 2
+        self.options['even_test'] = 4
 
         with self.assertRaises(ValueError) as context:
-            self.dict['even_test'] = 3
+            self.options['even_test'] = 3
 
         expected_msg = "Function is_valid returns False for {}.".format('even_test')
         self.assertEqual(expected_msg, str(context.exception))
 
     def test_unnamed_args(self):
         with self.assertRaises(KeyError) as context:
-            self.dict['test'] = 1
+            self.options['test'] = 1
 
         # KeyError ends up with an extra set of quotes.
         expected_msg = "\"Key 'test' cannot be set because it has not been declared.\""
         self.assertEqual(expected_msg, str(context.exception))
 
     def test_contains(self):
-        self.dict.declare('test')
+        self.options.declare('test')
 
-        contains = 'undeclared' in self.dict
+        contains = 'undeclared' in self.options
         self.assertTrue(not contains)
 
-        contains = 'test' in self.dict
+        contains = 'test' in self.options
         self.assertTrue(contains)
 
     def test_update(self):
-        self.dict.declare('test', default='Test value', types=object)
+        self.options.declare('test', default='Test value', types=object)
 
         obj = object()
-        self.dict.update({'test': obj})
-        self.assertIs(self.dict['test'], obj)
+        self.options.update({'test': obj})
+        self.assertIs(self.options['test'], obj)
 
     def test_update_extra(self):
         with self.assertRaises(KeyError) as context:
-            self.dict.update({'test': 2})
+            self.options.update({'test': 2})
 
         # KeyError ends up with an extra set of quotes.
         expected_msg = "\"Key 'test' cannot be set because it has not been declared.\""
@@ -112,7 +136,7 @@ class TestOptionsDict(unittest.TestCase):
 
     def test_get_missing(self):
         with self.assertRaises(KeyError) as context:
-            self.dict['missing']
+            self.options['missing']
 
         expected_msg = "\"Option 'missing' cannot be found\""
         self.assertEqual(expected_msg, str(context.exception))
@@ -121,23 +145,23 @@ class TestOptionsDict(unittest.TestCase):
         obj_def = object()
         obj_new = object()
 
-        self.dict.declare('test', default=obj_def, types=object)
+        self.options.declare('test', default=obj_def, types=object)
 
-        self.assertIs(self.dict['test'], obj_def)
+        self.assertIs(self.options['test'], obj_def)
 
-        self.dict['test'] = obj_new
-        self.assertIs(self.dict['test'], obj_new)
+        self.options['test'] = obj_new
+        self.assertIs(self.options['test'], obj_new)
 
     def test_values(self):
         obj1 = object()
         obj2 = object()
-        self.dict.declare('test', values=[obj1, obj2])
+        self.options.declare('test', values=[obj1, obj2])
 
-        self.dict['test'] = obj1
-        self.assertIs(self.dict['test'], obj1)
+        self.options['test'] = obj1
+        self.assertIs(self.options['test'], obj1)
 
         with self.assertRaises(ValueError) as context:
-            self.dict['test'] = object()
+            self.options['test'] = object()
 
         expected_msg = ("Option 'test''s value is not one of \[<object object at 0x[0-9A-Fa-f]+>,"
                         " <object object at 0x[0-9A-Fa-f]+>\]")
@@ -154,37 +178,38 @@ class TestOptionsDict(unittest.TestCase):
         assertRegex(self, str(context.exception), expected_msg)
 
     def test_bounds(self):
-        self.dict.declare('x', default=1.0, lower=0.0, upper=2.0)
+        self.options.declare('x', default=1.0, lower=0.0, upper=2.0)
 
         with self.assertRaises(ValueError) as context:
-            self.dict['x'] = 3.0
+            self.options['x'] = 3.0
 
         expected_msg = ("Value of 3.0 exceeds maximum of 2.0 for option 'x'")
         assertRegex(self, str(context.exception), expected_msg)
 
         with self.assertRaises(ValueError) as context:
-            self.dict['x'] = -3.0
+            self.options['x'] = -3.0
 
         expected_msg = ("Value of -3.0 exceeds minimum of 0.0 for option 'x'")
         assertRegex(self, str(context.exception), expected_msg)
 
     def test_undeclare(self):
         # create an entry in the dict
-        self.dict.declare('test', types=int)
-        self.dict['test'] = 1
+        self.options.declare('test', types=int)
+        self.options['test'] = 1
 
         # prove it's in the dict
-        self.assertEqual(self.dict['test'], 1)
+        self.assertEqual(self.options['test'], 1)
 
         # remove entry from the dict
-        self.dict.undeclare("test")
+        self.options.undeclare("test")
 
         # prove it is no longer in the dict
         with self.assertRaises(KeyError) as context:
-            self.dict['test']
+            self.options['test']
 
         expected_msg = "\"Option 'test' cannot be found\""
         self.assertEqual(expected_msg, str(context.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -3,6 +3,8 @@ import unittest
 import warnings
 from six import PY3, assertRegex
 
+from openmdao.core.explicitcomponent import ExplicitComponent
+
 
 class TestOptionsDict(unittest.TestCase):
 
@@ -10,27 +12,32 @@ class TestOptionsDict(unittest.TestCase):
         self.dict = OptionsDictionary()
 
     def test_reprs(self):
-        self.dict.declare('test', types=int, desc='Test integer value')
+        my_comp = ExplicitComponent()
+
+        self.dict.declare('test', values=['a', 'b'], desc='Test integer value')
         self.dict.declare('flag', default=False, types=bool)
+        self.dict.declare('comp', default=my_comp, types=ExplicitComponent)
         self.dict.declare('long_desc', types=str,
-                          desc='This description is ridiculously long and verbose, so much '
-                               'so that it takes up multiple lines in the options table.')
+                          desc='This description is long and verbose, so it '
+                               'takes up multiple lines in the options table.')
 
         self.assertEqual(self.dict.__repr__(), self.dict._dict)
 
-        self.assertEqual(self.dict.__str__(width=80), '\n'.join([
-            "========= ============ ================= ================ ======================",
-            "Option    Default      Acceptable Values Acceptable Types Description           ",
-            "========= ============ ================= ================ ======================",
-            "flag      False        N/A               ['bool']                               ",
-            "long_desc **Required** N/A               ['str']          This description is ri",
-            "                                                          diculously long and ve",
-            "                                                          rbose, so much so that",
-            "                                                           it takes up multiple ",
-            "                                                          lines in the options t",
-            "                                                          able.",
-            "test      **Required** N/A               ['int']          Test integer value    ",
-            "========= ============ ================= ================ ======================"
+        self.assertEqual(self.dict.__str__(width=84), '\n'.join([
+            "========= ================= ================= ===================== ================",
+            "Option    Default           Acceptable Values Acceptable Types      Description     ",
+            "========= ================= ================= ===================== ================",
+            "comp      ExplicitComponent N/A               ['ExplicitComponent']                 ",
+            "flag      False             N/A               ['bool']                              ",
+            "long_desc **Required**      N/A               ['str']               This description",
+            "                                                                     is long and ver",
+            "                                                                    bose, so it take",
+            "                                                                    s up multiple li",
+            "                                                                    nes in the optio",
+            "                                                                    ns table.",
+            "test      **Required**      ['a', 'b']        N/A                   Test integer val",
+            "                                                                    ue",
+            "========= ================= ================= ===================== ================",
         ]))
 
     def test_type_checking(self):


### PR DESCRIPTION
Pivotal #157510111
`__repr__` returns the options dict
`__str__` returns a printable version of the options table based on the rST used in docs
the logic to generate the rST has been moved from the docs extension to the class