### PR TITLE
SimpleGADriver can support multiple evaluations of parallel models if there are procs for it.

### DIFF
--- a/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
@@ -84,9 +84,12 @@ To illustrate this, we will demonstrate performing a DOE on a model based on the
     :layout: code
 
 In this case, the model itself requires two processors, so in order to run cases
-concurrently we need to allocate at least four processors in total.  With four
-processors we can run two cases at a time, which is done by specifying
-:code:`options['parallel']=2`.
+concurrently we need to allocate at least four processors in total. We can allocate
+as many procs as we have available, however the number of procs must be a multiple
+of the number of procs per model, which is 2 here. Regardless of how many processors
+we allocate, we need to tell the `DOEDriver` that the model needs 2 processors, which
+is done by specifying :code:`options['procs_per_model']=2`. From this, the driver
+figures out how many models it can run in parallel, which in this case is also 2.
 
 The `SqliteRecorder` will record cases on the first two processors, which serve as
 the "root" processors for the parallel cases.

--- a/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
@@ -85,8 +85,8 @@ To illustrate this, we will demonstrate performing a DOE on a model based on the
 
 In this case, the model itself requires two processors, so in order to run cases
 concurrently we need to allocate at least four processors in total. We can allocate
-as many procs as we have available, however the number of procs must be a multiple
-of the number of procs per model, which is 2 here. Regardless of how many processors
+as many processors as we have available, however the number of processors must be a multiple
+of the number of processors per model, which is 2 here. Regardless of how many processors
 we allocate, we need to tell the `DOEDriver` that the model needs 2 processors, which
 is done by specifying :code:`options['procs_per_model']=2`. From this, the driver
 figures out how many models it can run in parallel, which in this case is also 2.

--- a/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
@@ -50,13 +50,13 @@ Running a DOE in Parallel
 -------------------------
 
 In a parallel processing environment, it is possible for `DOEDriver` to run
-cases concurrently. This is done by specifying the `parallel` option as shown
+cases concurrently. This is done by setting the `run_parallel` option to True as shown
 in the following example.
 
 Here we are using the `FullFactorialGenerator` with 3 levels to generate inputs
 for our `Paraboloid` model. With two inputs, :math:`3^2=9` cases have been
 generated. In this case we are running on two processors and have specified
-:code:`options['parallel']=True` to run cases on all available processors.
+:code:`options['run_parallel']=True` to run cases on all available processors.
 The cases have therefore been split with 5 cases run on the first processor
 and 4 cases on the second.
 

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -57,7 +57,7 @@ Running a GA on a Parallel Model in Parallel
 --------------------------------------------
 
 If you have a model that does contain distributed components or parallel groups, you can also use
-`TestFeatureSimpleGA` to optimize it. If you have enough processors, you can also simultaneously
+`SimpleGADriver` to optimize it. If you have enough processors, you can also simultaneously
 evaluate multiple points in your population by turning on the "parallel" option and setting the
 "procs_per_model" to the number of processors that your model requires. Take care that you submit
 your parallel run with enough processors such that the number of processors the model requires

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -61,7 +61,7 @@ If you have a model that does contain distributed components or parallel groups,
 evaluate multiple points in your population by turning on the "paralllel" option and setting the
 "procs_per_model" to the number of processors that your model requires. Take care that you submit
 your parallel run with enough processors such that the number of processors the model requires
-divide evenly into it, as in this example, where the model requires 2 and we give it 4.
+divides evenly into it, as in this example, where the model requires 2 and we give it 4.
 
 .. embed-code::
     openmdao.drivers.tests.test_genetic_algorithm_driver.MPIFeatureTests4.test_option_procs_per_model

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -58,7 +58,7 @@ Running a GA on a Parallel Model in Parallel
 
 If you have a model that does contain distributed components or parallel groups, you can also use
 `TestFeatureSimpleGA` to optimize it. If you have enough processors, you can also simultaneously
-evaluate multiple points in your population by turning on the "paralllel" option and setting the
+evaluate multiple points in your population by turning on the "parallel" option and setting the
 "procs_per_model" to the number of processors that your model requires. Take care that you submit
 your parallel run with enough processors such that the number of processors the model requires
 divides evenly into it, as in this example, where the model requires 2 and we give it 4.

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -43,11 +43,28 @@ bits for all variables encoded.
     openmdao.drivers.tests.test_genetic_algorithm_driver.TestFeatureSimpleGA.test_option_pop_size
     :layout: interleave
 
+Running a GA in Parallel
+------------------------
+
 If you have a model that doesn't contain any distributed components or parallel groups, then the model
 evaluations for a new generation can be performed in parallel by turning on the "parallel" option:
 
 .. embed-code::
     openmdao.drivers.tests.test_genetic_algorithm_driver.MPIFeatureTests.test_option_parallel
+    :layout: interleave
+
+Running a GA on a Parallel Model in Parallel
+--------------------------------------------
+
+If you have a model that does contain distributed components or parallel groups, you can also use
+`TestFeatureSimpleGA` to optimize it. If you have enough processors, you can also simultaneously
+evaluate multiple points in your population by turning on the "paralllel" option and setting the
+"procs_per_model" to the number of processors that your model requires. Take care that you submit
+your parallel run with enough processors such that the number of processors the model requires
+divide evenly into it, as in this example, where the model requires 2 and we give it 4.
+
+.. embed-code::
+    openmdao.drivers.tests.test_genetic_algorithm_driver.MPIFeatureTests4.test_option_procs_per_model
     :layout: interleave
 
 .. tags:: Driver, Optimizer, Optimization

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -53,6 +53,8 @@ class DOEDriver(Driver):
 
     Attributes
     ----------
+    _color : int or None
+        In MPI, the cached color is used to determine which cases to run on this proc.
     _name : str
         The name used to identify this driver in recorded cases.
     _recorders : list
@@ -88,6 +90,7 @@ class DOEDriver(Driver):
 
         self._name = ''
         self._recorders = []
+        self._color = None
 
     def _declare_options(self):
         """
@@ -121,7 +124,6 @@ class DOEDriver(Driver):
             self._comm = comm
 
             if parallel == 1:  # True == 1
-                size = 1
                 color = self._color = comm.rank
             else:
                 comm_size = comm.size

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -98,7 +98,8 @@ class DOEDriver(Driver):
         """
         self.options.declare('generator', types=(DOEGenerator), default=DOEGenerator(),
                              desc='The case generator. If default, no cases are generated.')
-
+        self.options.declare('run_parallel', default=False,
+                             desc='Set to True to execute cases in parallel.')
         self.options.declare('procs_per_model', default=1, lower=1,
                              desc='Number of processors to give each model under MPI.')
 
@@ -116,7 +117,7 @@ class DOEDriver(Driver):
         MPI.Comm or <FakeComm> or None
             The communicator for the Problem model.
         """
-        if MPI:
+        if MPI and self.options['run_parallel']:
             self._comm = comm
             procs_per_model = self.options['procs_per_model']
 

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -265,9 +265,10 @@ class DOEDriver(Driver):
         Set up case recording.
         """
         if MPI:
+            procs_per_model = self.options['procs_per_model']
+
             for recorder in self._recorders:
                 recorder._parallel = True
-                procs_per_model = self.options['procs_per_model']
 
                 # if SqliteRecorder, write cases only on procs up to the number
                 # of parallel DOEs (i.e. on the root procs for the cases)

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -124,7 +124,7 @@ class DOEDriver(Driver):
             full_size = comm.size
             size = full_size // procs_per_model
             if full_size != size * procs_per_model:
-                raise RuntimeError("The total number of processors is not evenly divisable by the "
+                raise RuntimeError("The total number of processors is not evenly divisible by the "
                                    "specified number of processors per model.\n Provide a "
                                    "number of processors that is a multiple of %d, or "
                                    "specify a number of processors per model that divides "

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -146,7 +146,7 @@ class SimpleGADriver(Driver):
             The communicator for the Problem model.
         """
         procs_per_model = self.options['procs_per_model']
-        if MPI and procs_per_model > 1:
+        if MPI and self.options['run_parallel'] and procs_per_model > 1:
 
             full_size = comm.size
             size = full_size // procs_per_model
@@ -165,6 +165,8 @@ class SimpleGADriver(Driver):
 
             return model_comm
 
+        self._concurrent_pop_size = 0
+        self._concurrent_color = 0
         return comm
 
     def run(self):

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -20,7 +20,6 @@ from six.moves import range, zip
 import numpy as np
 from pyDOE2 import lhs
 
-from openmdao.core.driver import Driver
 from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.utils.concurrent import concurrent_eval
 from openmdao.utils.mpi import MPI

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -155,7 +155,7 @@ class SimpleGADriver(Driver):
                 raise RuntimeError("The total number of processors is not evenly divisable by the "
                                    "specified number of processors per model.\n Provide a "
                                    "number of processors that is a multiple of %d, or "
-                                   "specify a number of parallel cases that divides "
+                                   "specify a number of processors per model that divides "
                                    "into %d." % (procs_per_model, full_size))
             color = comm.rank % size
             model_comm = comm.Split(color)

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -97,7 +97,7 @@ class SimpleGADriver(Driver):
                              'as four times the number of bits.')
         self.options.declare('run_parallel', default=False,
                              desc='Set to True to execute the points in a generation in parallel.')
-        self.options.declare('procs_per_model', default=1,
+        self.options.declare('procs_per_model', default=1, lower=1,
                              desc='Number of processors to give each model under MPI.')
 
     def _setup_driver(self, problem):
@@ -149,19 +149,19 @@ class SimpleGADriver(Driver):
         procs_per_model = self.options['procs_per_model']
         if MPI and procs_per_model > 1:
 
-            comm_size = comm.size
-            model_size = comm_size // procs_per_model
-            if comm_size != model_size * procs_per_model:
-                raise RuntimeError("The number of processors per model is not evenly divisable by "
-                                   "the specified number of parallel cases.\n Provide a "
+            full_size = comm.size
+            size = full_size // procs_per_model
+            if full_size != size * procs_per_model:
+                raise RuntimeError("The total number of processors is not evenly divisable by the "
+                                   "specified number of processors per model.\n Provide a "
                                    "number of processors that is a multiple of %d, or "
                                    "specify a number of parallel cases that divides "
-                                   "into %d." % (procs_per_model, comm_size))
-            color = comm.rank % model_size
+                                   "into %d." % (procs_per_model, full_size))
+            color = comm.rank % size
             model_comm = comm.Split(color)
 
             # Everything we need to figure out which case to run.
-            self._concurrent_pop_size = model_size
+            self._concurrent_pop_size = size
             self._concurrent_color = color
 
             return model_comm

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -122,12 +122,10 @@ class SimpleGADriver(Driver):
             raise RuntimeError(msg)
 
         model_mpi = None
+        comm = self._problem.comm
         if self._concurrent_pop_size > 0:
-            comm = self._problem.comm
             model_mpi = (self._concurrent_pop_size, self._concurrent_color)
-        elif self.options['run_parallel']:
-            comm = self._problem.comm
-        else:
+        elif not self.options['run_parallel']:
             comm = None
 
         self._ga = GeneticAlgorithm(self.objective_callback, comm=comm, model_mpi=model_mpi)
@@ -168,8 +166,7 @@ class SimpleGADriver(Driver):
 
             return model_comm
 
-        else:
-            return comm
+        return comm
 
     def run(self):
         """
@@ -411,7 +408,7 @@ class GeneticAlgorithm():
 
                 fitness[:] = np.inf
                 for result in results:
-                    returns, traceback, _ = result
+                    returns, traceback = result
 
                     if returns:
                         val, success, ii = returns

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -309,7 +309,7 @@ class GeneticAlgorithm():
     model_mpi : None or tuple
         If the model in objfun is also parallel, then this will contain a tuple with the the
         total number of population points to evaluate concurrently, and the color of the point
-        to evalutate on this rank.
+        to evaluate on this rank.
     npop : int
         Population size.
     objfun : function
@@ -329,7 +329,7 @@ class GeneticAlgorithm():
         model_mpi : None or tuple
             If the model in objfun is also parallel, then this will contain a tuple with the the
             total number of population points to evaluate concurrently, and the color of the point
-            to evalutate on this rank.
+            to evaluate on this rank.
         """
         self.objfun = objfun
         self.comm = comm

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -151,7 +151,7 @@ class SimpleGADriver(Driver):
             full_size = comm.size
             size = full_size // procs_per_model
             if full_size != size * procs_per_model:
-                raise RuntimeError("The total number of processors is not evenly divisable by the "
+                raise RuntimeError("The total number of processors is not evenly divisible by the "
                                    "specified number of processors per model.\n Provide a "
                                    "number of processors that is a multiple of %d, or "
                                    "specify a number of processors per model that divides "

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -21,7 +21,7 @@ import numpy as np
 from pyDOE2 import lhs
 
 from openmdao.core.driver import Driver
-from openmdao.recorders.recording_iteration_stack import Recording
+from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.utils.concurrent import concurrent_eval
 from openmdao.utils.mpi import MPI
 
@@ -230,7 +230,7 @@ class SimpleGADriver(Driver):
             val = desvar_new[i:j]
             self.set_design_var(name, val)
 
-        with Recording('SimpleGA', self.iter_count, self) as rec:
+        with RecordingDebugging('SimpleGA', self.iter_count, self) as rec:
             model._solve_nonlinear()
             rec.abs = 0.0
             rec.rel = 0.0
@@ -266,7 +266,7 @@ class SimpleGADriver(Driver):
             self.set_design_var(name, x[i:j])
 
         # Execute the model
-        with Recording('SimpleGA', self.iter_count, self) as rec:
+        with RecordingDebugging('SimpleGA', self.iter_count, self) as rec:
             self.iter_count += 1
             try:
                 model._solve_nonlinear()

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -593,7 +593,7 @@ class TestParallelDOE(unittest.TestCase):
         model.add_design_var('y', lower=0.0, upper=1.0)
         model.add_objective('f_xy')
 
-        prob.driver = DOEDriver(FullFactorialGenerator(levels=3), procs_per_model=True,
+        prob.driver = DOEDriver(FullFactorialGenerator(levels=3), procs_per_model=1,
                                 run_parallel=True)
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -551,6 +551,7 @@ class TestParallelDOE(unittest.TestCase):
         prob = Problem()
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
+        prob.driver.options['run_parallel'] =  True
         prob.driver.options['procs_per_model'] =  3
 
         with self.assertRaises(RuntimeError) as context:
@@ -570,6 +571,7 @@ class TestParallelDOE(unittest.TestCase):
 
         # run cases on all procs
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
+        prob.driver.options['run_parallel'] =  True
         prob.driver.options['procs_per_model'] =  1
 
         with self.assertRaises(RuntimeError) as context:
@@ -591,7 +593,8 @@ class TestParallelDOE(unittest.TestCase):
         model.add_design_var('y', lower=0.0, upper=1.0)
         model.add_objective('f_xy')
 
-        prob.driver = DOEDriver(FullFactorialGenerator(levels=3), procs_per_model=True)
+        prob.driver = DOEDriver(FullFactorialGenerator(levels=3), procs_per_model=True,
+                                run_parallel=True)
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
 
         prob.setup()
@@ -656,6 +659,7 @@ class TestParallelDOE(unittest.TestCase):
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        prob.driver.options['run_parallel'] =  True
         prob.driver.options['procs_per_model'] =  doe_parallel
 
         prob.setup(check=False)
@@ -726,6 +730,7 @@ class TestParallelDOE(unittest.TestCase):
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        prob.driver.options['run_parallel'] =  True
         prob.driver.options['procs_per_model'] =  doe_parallel
 
         prob.setup(check=False)
@@ -896,6 +901,7 @@ class TestParallelDOEFeature(unittest.TestCase):
         model.add_objective('f_xy')
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
+        prob.driver.options['run_parallel'] =  True
         prob.driver.options['procs_per_model'] =  1
 
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
@@ -987,6 +993,7 @@ class TestParallelDOEFeature2(unittest.TestCase):
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
+        prob.driver.options['run_parallel'] =  True
 
         # run 2 cases at a time, each using 2 of our 4 procs
         doe_parallel = prob.driver.options['procs_per_model'] = 2

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -547,7 +547,7 @@ class TestParallelDOE(unittest.TestCase):
         except OSError:
             pass
 
-    def test_indivisable_error(self):
+    def test_indivisible_error(self):
         prob = Problem()
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
@@ -558,7 +558,7 @@ class TestParallelDOE(unittest.TestCase):
             prob.setup()
 
         self.assertEqual(str(context.exception),
-                         "The total number of processors is not evenly divisable by the "
+                         "The total number of processors is not evenly divisible by the "
                          "specified number of processors per model.\n Provide a number of "
                          "processors that is a multiple of 3, or specify a number "
                          "of processors per model that divides into 4.")

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -551,16 +551,16 @@ class TestParallelDOE(unittest.TestCase):
         prob = Problem()
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
-        prob.driver.options['parallel'] =  3
+        prob.driver.options['procs_per_model'] =  3
 
         with self.assertRaises(RuntimeError) as context:
             prob.setup()
 
         self.assertEqual(str(context.exception),
-                         "The number of processors is not evenly divisable by the "
-                         "specified number of parallel cases.\n Provide a number of "
+                         "The total number of processors is not evenly divisable by the "
+                         "specified number of processors per model.\n Provide a number of "
                          "processors that is a multiple of 3, or specify a number "
-                         "of parallel cases that divides into 4.")
+                         "of processors per model that divides into 4.")
 
     def test_minprocs_error(self):
         prob = Problem(FanInGrouped())
@@ -570,7 +570,7 @@ class TestParallelDOE(unittest.TestCase):
 
         # run cases on all procs
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
-        prob.driver.options['parallel'] =  True
+        prob.driver.options['procs_per_model'] =  1
 
         with self.assertRaises(RuntimeError) as context:
             prob.setup()
@@ -591,7 +591,7 @@ class TestParallelDOE(unittest.TestCase):
         model.add_design_var('y', lower=0.0, upper=1.0)
         model.add_objective('f_xy')
 
-        prob.driver = DOEDriver(FullFactorialGenerator(levels=3), parallel=True)
+        prob.driver = DOEDriver(FullFactorialGenerator(levels=3), procs_per_model=True)
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
 
         prob.setup()
@@ -656,7 +656,7 @@ class TestParallelDOE(unittest.TestCase):
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
-        prob.driver.options['parallel'] =  doe_parallel
+        prob.driver.options['procs_per_model'] =  doe_parallel
 
         prob.setup(check=False)
 
@@ -714,7 +714,7 @@ class TestParallelDOE(unittest.TestCase):
 
     def test_fan_in_grouped_serial(self):
         # run cases on all procs (parallel model will run on single proc)
-        doe_parallel = True
+        doe_parallel = 1
 
         prob = Problem(FanInGrouped())
         model = prob.model
@@ -726,7 +726,7 @@ class TestParallelDOE(unittest.TestCase):
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
-        prob.driver.options['parallel'] =  doe_parallel
+        prob.driver.options['procs_per_model'] =  doe_parallel
 
         prob.setup(check=False)
 
@@ -896,7 +896,7 @@ class TestParallelDOEFeature(unittest.TestCase):
         model.add_objective('f_xy')
 
         prob.driver = DOEDriver(FullFactorialGenerator(levels=3))
-        prob.driver.options['parallel'] =  True
+        prob.driver.options['procs_per_model'] =  1
 
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
 
@@ -989,7 +989,7 @@ class TestParallelDOEFeature2(unittest.TestCase):
         prob.driver.add_recorder(SqliteRecorder("cases.sql"))
 
         # run 2 cases at a time, each using 2 of our 4 procs
-        doe_parallel = prob.driver.options['parallel'] = 2
+        doe_parallel = prob.driver.options['procs_per_model'] = 2
 
         prob.setup()
         prob.run_driver()

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -185,7 +185,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 300
+        prob.driver.options['max_gen'] = 125
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
 
@@ -226,7 +226,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 300
+        prob.driver.options['max_gen'] = 125
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = False
         prob.driver.options['procs_per_model'] = 2
@@ -274,7 +274,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 300
+        prob.driver.options['max_gen'] = 125
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
@@ -502,7 +502,7 @@ class MPIFeatureTests4(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 300
+        prob.driver.options['max_gen'] = 125
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -288,7 +288,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         assert_rel_error(self, prob['comp.f'], 0.98799098, 1e-4)
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
-    def test_indivisable_error(self):
+    def test_indivisible_error(self):
         prob = Problem()
         model = prob.model = Group()
         par = model.add_subsystem('par', ParallelGroup())
@@ -301,7 +301,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
             prob.setup()
 
         self.assertEqual(str(context.exception),
-                         "The total number of processors is not evenly divisable by the "
+                         "The total number of processors is not evenly divisible by the "
                          "specified number of processors per model.\n Provide a number of "
                          "processors that is a multiple of 3, or specify a number "
                          "of processors per model that divides into 4.")

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -185,7 +185,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 100
+        prob.driver.options['max_gen'] = 90
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
 
@@ -226,7 +226,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 100
+        prob.driver.options['max_gen'] = 90
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = False
         prob.driver.options['procs_per_model'] = 2
@@ -274,7 +274,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 100
+        prob.driver.options['max_gen'] = 90
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
@@ -457,7 +457,7 @@ class MPIFeatureTests(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 100
+        prob.driver.options['max_gen'] = 90
         prob.driver.options['run_parallel'] = True
 
         prob.setup(check=False)
@@ -503,7 +503,7 @@ class MPIFeatureTests4(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 100
+        prob.driver.options['max_gen'] = 90
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -304,7 +304,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
                          "The total number of processors is not evenly divisable by the "
                          "specified number of processors per model.\n Provide a number of "
                          "processors that is a multiple of 3, or specify a number "
-                         "of parallel cases that divides into 4.")
+                         "of processors per model that divides into 4.")
 
 
 class TestFeatureSimpleGA(unittest.TestCase):

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -288,6 +288,24 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         assert_rel_error(self, prob['comp.f'], 0.98799098, 1e-4)
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
+    def test_indivisable_error(self):
+        prob = Problem()
+        model = prob.model = Group()
+        par = model.add_subsystem('par', ParallelGroup())
+
+        prob.driver = SimpleGADriver()
+        prob.driver.options['run_parallel'] = False
+        prob.driver.options['procs_per_model'] = 3
+
+        with self.assertRaises(RuntimeError) as context:
+            prob.setup()
+
+        self.assertEqual(str(context.exception),
+                         "The number of processors per model is not evenly divisable by the "
+                         "specified number of parallel cases.\n Provide a number of "
+                         "processors that is a multiple of 3, or specify a number "
+                         "of parallel cases that divides into 4.")
+
 
 class TestFeatureSimpleGA(unittest.TestCase):
 
@@ -420,7 +438,7 @@ class MPIFeatureTests(unittest.TestCase):
     N_PROCS = 2
 
     def test_option_parallel(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver, PETScVector
+        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
@@ -440,6 +458,56 @@ class MPIFeatureTests(unittest.TestCase):
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['run_parallel'] = True
+
+        prob.setup(check=False)
+        prob.run_driver()
+
+        # Optimal solution
+        print('comp.f', prob['comp.f'])
+        print('p2.xI', prob['p2.xI'])
+        print('p1.xC', prob['p1.xC'])
+
+
+@unittest.skipUnless(PETScVector, "PETSc is required.")
+@unittest.skipUnless(MPI, "MPI is required.")
+class MPIFeatureTests4(unittest.TestCase):
+    N_PROCS = 4
+
+    def test_option_procs_per_model(self):
+        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver, ParallelGroup
+        from openmdao.test_suite.components.branin import Branin
+
+        prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        par = model.add_subsystem('par', ParallelGroup())
+
+        par.add_subsystem('comp1', Branin())
+        par.add_subsystem('comp2', Branin())
+
+        model.connect('p2.xI', 'par.comp1.x0')
+        model.connect('p1.xC', 'par.comp1.x1')
+        model.connect('p2.xI', 'par.comp2.x0')
+        model.connect('p1.xC', 'par.comp2.x1')
+
+        model.add_subsystem('comp', ExecComp('f = f1 + f2'))
+        model.connect('par.comp1.f', 'comp.f1')
+        model.connect('par.comp2.f', 'comp.f2')
+
+        model.add_design_var('p2.xI', lower=-5.0, upper=10.0)
+        model.add_design_var('p1.xC', lower=0.0, upper=15.0)
+        model.add_objective('comp.f')
+
+        prob.driver = SimpleGADriver()
+        prob.driver.options['bits'] = {'p1.xC': 8}
+        prob.driver.options['max_gen'] = 400
+        prob.driver.options['pop_size'] = 25
+        prob.driver.options['run_parallel'] = True
+        prob.driver.options['procs_per_model'] = 2
+
+        prob.driver._randomstate = 1
 
         prob.setup(check=False)
         prob.run_driver()

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -185,7 +185,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 90
+        prob.driver.options['max_gen'] = 50
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
 
@@ -226,7 +226,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 90
+        prob.driver.options['max_gen'] = 50
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = False
         prob.driver.options['procs_per_model'] = 2
@@ -274,7 +274,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 90
+        prob.driver.options['max_gen'] = 50
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
@@ -457,7 +457,7 @@ class MPIFeatureTests(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 90
+        prob.driver.options['max_gen'] = 50
         prob.driver.options['run_parallel'] = True
 
         prob.setup(check=False)
@@ -503,7 +503,7 @@ class MPIFeatureTests4(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 90
+        prob.driver.options['max_gen'] = 50
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -185,7 +185,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 400
+        prob.driver.options['max_gen'] = 300
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
 
@@ -226,7 +226,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 400
+        prob.driver.options['max_gen'] = 300
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = False
         prob.driver.options['procs_per_model'] = 2
@@ -274,7 +274,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 400
+        prob.driver.options['max_gen'] = 300
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
@@ -301,8 +301,8 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
             prob.setup()
 
         self.assertEqual(str(context.exception),
-                         "The number of processors per model is not evenly divisable by the "
-                         "specified number of parallel cases.\n Provide a number of "
+                         "The total number of processors is not evenly divisable by the "
+                         "specified number of processors per model.\n Provide a number of "
                          "processors that is a multiple of 3, or specify a number "
                          "of parallel cases that divides into 4.")
 
@@ -502,7 +502,7 @@ class MPIFeatureTests4(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 400
+        prob.driver.options['max_gen'] = 300
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -85,7 +85,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver(max_gen=400, pop_size=25)
+        prob.driver = SimpleGADriver(max_gen=100, pop_size=25)
         prob.driver.options['bits'] = {'p1.xC': 8}
 
         prob.driver._randomstate = 1
@@ -185,7 +185,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 125
+        prob.driver.options['max_gen'] = 100
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
 
@@ -226,7 +226,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 125
+        prob.driver.options['max_gen'] = 100
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = False
         prob.driver.options['procs_per_model'] = 2
@@ -274,7 +274,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 125
+        prob.driver.options['max_gen'] = 100
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
@@ -294,7 +294,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         par = model.add_subsystem('par', ParallelGroup())
 
         prob.driver = SimpleGADriver()
-        prob.driver.options['run_parallel'] = False
+        prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 3
 
         with self.assertRaises(RuntimeError) as context:
@@ -502,7 +502,7 @@ class MPIFeatureTests4(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
-        prob.driver.options['max_gen'] = 125
+        prob.driver.options['max_gen'] = 100
         prob.driver.options['pop_size'] = 25
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -457,6 +457,7 @@ class MPIFeatureTests(unittest.TestCase):
 
         prob.driver = SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
+        prob.driver.options['max_gen'] = 100
         prob.driver.options['run_parallel'] = True
 
         prob.setup(check=False)

--- a/openmdao/utils/concurrent.py
+++ b/openmdao/utils/concurrent.py
@@ -195,7 +195,7 @@ def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
         If True, the results will be allgathered to all procs in the comm.
         Otherwise, results will be gathered to rank 0 only.
     model_mpi : None or tuple
-        If the model in objfun is also parallel, then this will contain a tuple with the the
+        If the function in func is to be run in parallel, then this will contain a tuple with the
         total number of population points to evaluate concurrently, and the color of the point
         to evalutate on this rank.
 

--- a/openmdao/utils/concurrent.py
+++ b/openmdao/utils/concurrent.py
@@ -174,7 +174,7 @@ def _concurrent_eval_lb_worker(func, comm):
         comm.send((comm.rank, retval, err), 0, tag=2)
 
 
-def concurrent_eval(func, cases, comm, allgather=False):
+def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
     """
     Run the given function concurrently on all procs in the communicator.
 
@@ -194,6 +194,10 @@ def concurrent_eval(func, cases, comm, allgather=False):
     allgather : bool(False)
         If True, the results will be allgathered to all procs in the comm.
         Otherwise, results will be gathered to rank 0 only.
+    model_mpi : None or tuple
+        If the model in objfun is also parallel, then this will contain a tuple with the the
+        total number of population points to evaluate concurrently, and the color of the point
+        to evalutate on this rank.
 
     Returns
     -------
@@ -203,9 +207,15 @@ def concurrent_eval(func, cases, comm, allgather=False):
     results = []
 
     if comm is None:
+        rank = 0
         it = cases
     else:
-        it = islice(cases, comm.rank, None, comm.size)
+        rank = comm.rank
+        if model_mpi is not None:
+            size, color = model_mpi
+            it = islice(cases, color, None, size)
+        else:
+            it = islice(cases, rank, None, comm.size)
 
     for args, kwargs in it:
         try:
@@ -219,15 +229,25 @@ def concurrent_eval(func, cases, comm, allgather=False):
         else:
             err = None
 
-        results.append((retval, err))
+        results.append((retval, err, rank))
 
     if comm is not None:
         if allgather:
             allresults = comm.allgather(results)
+
+            # Limit results to 1 set from each color.
+            if model_mpi is not None:
+                allresults = allresults[:size]
+
             results = list(chain(*allresults))
         else:
             allresults = comm.gather(results, root=0)
             if comm.rank == 0:
+
+                # Limit results to 1 set from each color.
+                if model_mpi is not None:
+                    allresults = allresults[:size]
+
                 results = list(chain(*allresults))
             else:
                 results = None

--- a/openmdao/utils/concurrent.py
+++ b/openmdao/utils/concurrent.py
@@ -195,9 +195,9 @@ def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
         If True, the results will be allgathered to all procs in the comm.
         Otherwise, results will be gathered to rank 0 only.
     model_mpi : None or tuple
-        If the function in func runs in parallel, then this will contain a tuple with the
-        total number of population points to evaluate concurrently, and the color of the point
-        to evalutate on this rank.
+        If the function in func runs in parallel, then this will be a tuple containing the total
+        number of cases to evaluate concurrently, and the color of the cases to evalutate on this
+        rank.
 
     Returns
     -------

--- a/openmdao/utils/concurrent.py
+++ b/openmdao/utils/concurrent.py
@@ -196,7 +196,7 @@ def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
         Otherwise, results will be gathered to rank 0 only.
     model_mpi : None or tuple
         If the function in func runs in parallel, then this will be a tuple containing the total
-        number of cases to evaluate concurrently, and the color of the cases to evalutate on this
+        number of cases to evaluate concurrently, and the color of the cases to evaluate on this
         rank.
 
     Returns

--- a/openmdao/utils/concurrent.py
+++ b/openmdao/utils/concurrent.py
@@ -195,7 +195,7 @@ def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
         If True, the results will be allgathered to all procs in the comm.
         Otherwise, results will be gathered to rank 0 only.
     model_mpi : None or tuple
-        If the function in func is to be run in parallel, then this will contain a tuple with the
+        If the function in func runs in parallel, then this will contain a tuple with the
         total number of population points to evaluate concurrently, and the color of the point
         to evalutate on this rank.
 

--- a/openmdao/utils/concurrent.py
+++ b/openmdao/utils/concurrent.py
@@ -207,7 +207,6 @@ def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
     results = []
 
     if comm is None:
-        rank = 0
         it = cases
     else:
         rank = comm.rank
@@ -229,7 +228,7 @@ def concurrent_eval(func, cases, comm, allgather=False, model_mpi=None):
         else:
             err = None
 
-        results.append((retval, err, rank))
+        results.append((retval, err))
 
     if comm is not None:
         if allgather:


### PR DESCRIPTION
1. Also fixed a bug where GA was ineffective if a seed wasn't set.
2. Switched DOE driver over to use "procs_per_model" instead of "parallel".