### PR TITLE
MetaModelStructuredComp analysis error

### DIFF
--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -17,6 +17,7 @@ import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.utils.general_utils import warn_deprecation
+from openmdao.core.analysis_error import AnalysisError
 
 
 class OutOfBoundsError(Exception):
@@ -758,7 +759,7 @@ class MetaModelStructuredComp(ExplicitComponent):
                     "was out of bounds ('{}', '{}') with " \
                     "value '{}'".format(out_name, self.pathname, varname_causing_error,
                                         err.lower, err.upper, err.value)
-                raise_from(ValueError(errmsg), None)
+                raise_from(AnalysisError(errmsg), None)
             except ValueError as err:
                 raise ValueError("Error interpolating output '%s' in %s:\n%s" %
                                  (out_name, self.pathname, str(err)))

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -9,6 +9,7 @@ from copy import deepcopy
 from openmdao.core.problem import Problem
 from openmdao.core.group import Group
 from openmdao.core.indepvarcomp import IndepVarComp
+from openmdao.core.analysis_error import AnalysisError
 from openmdao.utils.assert_utils import assert_rel_error
 import numpy as np
 import unittest
@@ -964,7 +965,7 @@ class TestRegularGridMap(unittest.TestCase):
         #   dict so no guarantee on the order except for Python 3.6 !
         msg = "Error interpolating output '[f|g]' in 'comp' because input 'comp.z' was " \
               "out of bounds \('.*', '.*'\) with value '9.0'"
-        with assertRaisesRegex(self, ValueError, msg):
+        with assertRaisesRegex(self, AnalysisError, msg):
             self.run_and_check_derivs(self.prob)
 
     def test_training_gradient(self):

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1049,7 +1049,7 @@ class TestRegularGridMap(unittest.TestCase):
 
         p.setup()
 
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(AnalysisError) as cm:
             p.run_model()
 
         msg = ("Error interpolating output 'y' in 'MM' because input 'MM.x' was out of bounds ('0.0', '1.0') with value '1.1'")


### PR DESCRIPTION
MetaModelStructuredComp raises AnalysisError instead of ValueError when inputs are out of bounds and extrapolation is disabled.