### PR TITLE
Add `case_prefix` argument to `run_model` and `run_driver`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -141,15 +141,15 @@ install:
 # finally, install OpenMDAO
 - pip install .;  # Not using -e on purpose here, to catch pkging errors
 
+# display summary of installed packages and their versions
+- pip list
+
 script:
 # make docs first
 - cd openmdao/docs;
 - if [ "$PETSc" ]; then
     make all;
   fi
-
-# display version of installed packages
-- pip list
 
 # run the tests from down here to see if it can work without being at top level
 # only do coverage on the upload machine.

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -17,7 +17,7 @@ from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.record_util import create_local_meta, check_path
 from openmdao.utils.mpi import MPI
-from openmdao.recorders.recording_iteration_stack import get_formatted_iteration_coordinate
+from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.options_dictionary import OptionsDictionary
 import openmdao.utils.coloring as coloring_mod
 
@@ -989,7 +989,7 @@ class Driver(object):
 
         if not MPI or MPI.COMM_WORLD.rank == 0:
             header = 'Driver debug print for iter coord: {}'.format(
-                get_formatted_iteration_coordinate())
+                recording_iteration.get_formatted_iteration_coordinate())
             print(header)
             print(len(header) * '-')
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -413,9 +413,8 @@ class Driver(object):
             # TODO Eventually, we think we can get rid of this next check. But to be safe,
             #       we are leaving it in there.
             if not model.is_active():
-                raise RuntimeError(
-                    "RecordingManager.startup should never be called when "
-                    "running in parallel on an inactive System")
+                raise RuntimeError("RecordingManager.startup should never be called when "
+                                   "running in parallel on an inactive System")
             rrank = problem.comm.rank
             rowned = model._owning_rank
             mydesvars = [n for n in mydesvars if rrank == rowned[n]]

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -420,7 +420,7 @@ class Problem(object):
                          "with OpenMDAO <= 1.x ; use 'model' instead.")
         self.model = model
 
-    def run_model(self, case_prefix=None):
+    def run_model(self, case_prefix=None, reset_iter_counts=True):
         """
         Run the model by calling the root system's solve_nonlinear.
 
@@ -428,6 +428,9 @@ class Problem(object):
         ----------
         case_prefix : str or None
             Prefix to prepend to coordinates when recording.
+
+        reset_iter_counts : bool
+            If True and model has been run previously, reset all iteration counters.
 
         Returns
         -------
@@ -448,11 +451,15 @@ class Problem(object):
         else:
             recording_iteration.prefix = None
 
+        if self.model.iter_count > 0 and reset_iter_counts:
+            self.driver.iter_count = 0
+            self.model._reset_iter_counts()
+
         self.final_setup()
         self.model._clear_iprint()
         return self.model.run_solve_nonlinear()
 
-    def run_driver(self, case_prefix=None):
+    def run_driver(self, case_prefix=None, reset_iter_counts=True):
         """
         Run the driver on the model.
 
@@ -460,6 +467,9 @@ class Problem(object):
         ----------
         case_prefix : str or None
             Prefix to prepend to coordinates when recording.
+
+        reset_iter_counts : bool
+            If True and model has been run previously, reset all iteration counters.
 
         Returns
         -------
@@ -475,6 +485,10 @@ class Problem(object):
             recording_iteration.prefix = case_prefix
         else:
             recording_iteration.prefix = None
+
+        if self.model.iter_count > 0 and reset_iter_counts:
+            self.driver.iter_count = 0
+            self.model._reset_iter_counts()
 
         self.final_setup()
         self.model._clear_iprint()

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -442,6 +442,8 @@ class Problem(object):
             raise RuntimeError("The `setup` method must be called before `run_model`.")
 
         if case_prefix:
+            if not isinstance(case_prefix, str):
+                raise TypeError("The 'case_prefix' argument should be a string.")
             recording_iteration.prefix = case_prefix
         else:
             recording_iteration.prefix = None
@@ -468,6 +470,8 @@ class Problem(object):
             raise RuntimeError("The `setup` method must be called before `run_driver`.")
 
         if case_prefix:
+            if not isinstance(case_prefix, str):
+                raise TypeError("The 'case_prefix' argument should be a string.")
             recording_iteration.prefix = case_prefix
         else:
             recording_iteration.prefix = None

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -420,9 +420,14 @@ class Problem(object):
                          "with OpenMDAO <= 1.x ; use 'model' instead.")
         self.model = model
 
-    def run_model(self):
+    def run_model(self, case_prefix=None):
         """
         Run the model by calling the root system's solve_nonlinear.
+
+        Parameters
+        ----------
+        case_prefix : str or None
+            Prefix to prepend to coordinates when recording.
 
         Returns
         -------
@@ -436,13 +441,23 @@ class Problem(object):
         if self._mode is None:
             raise RuntimeError("The `setup` method must be called before `run_model`.")
 
+        if case_prefix:
+            recording_iteration.prefix = case_prefix
+        else:
+            recording_iteration.prefix = None
+
         self.final_setup()
         self.model._clear_iprint()
         return self.model.run_solve_nonlinear()
 
-    def run_driver(self):
+    def run_driver(self, case_prefix=None):
         """
         Run the driver on the model.
+
+        Parameters
+        ----------
+        case_prefix : str or None
+            Prefix to prepend to coordinates when recording.
 
         Returns
         -------
@@ -451,6 +466,11 @@ class Problem(object):
         """
         if self._mode is None:
             raise RuntimeError("The `setup` method must be called before `run_driver`.")
+
+        if case_prefix:
+            recording_iteration.prefix = case_prefix
+        else:
+            recording_iteration.prefix = None
 
         self.final_setup()
         self.model._clear_iprint()

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2929,7 +2929,7 @@ class System(object):
 
     def _reset_iter_counts(self):
         """
-        Recursively reset iteration counter for all solvers.
+        Recursively reset iteration counter for all systems and solvers.
         """
         for s in self.system_iter(include_self=True, recurse=True):
             s.iter_count = 0

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2926,3 +2926,17 @@ class System(object):
         Clear out the iprint stack from the solvers.
         """
         self.nonlinear_solver._solver_info.clear()
+
+    def _reset_iter_counts(self):
+        """
+        Recursively reset iteration counter for all solvers.
+        """
+        for s in self.system_iter(include_self=True, recurse=True):
+            s.iter_count = 0
+            if s._linear_solver:
+                s._linear_solver._iter_count = 0
+            if s._nonlinear_solver:
+                nl = s._nonlinear_solver
+                nl._iter_count = 0
+                if hasattr(nl, 'linesearch') and nl.linesearch:
+                    nl.linesearch._iter_count = 0

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -18,8 +18,7 @@ from openmdao.jacobians.assembled_jacobian import AssembledJacobian, DenseJacobi
 from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, warn_deprecation, ContainsAll
 from openmdao.recorders.recording_manager import RecordingManager
-from openmdao.recorders.recording_iteration_stack import recording_iteration, \
-    get_formatted_iteration_coordinate
+from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.vectors.vector import INT_DTYPE
 from openmdao.vectors.default_vector import DefaultVector
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2833,10 +2833,14 @@ class System(object):
             Flag indicating if the recorder should be added to all the subsystems.
         """
         if MPI:
-            raise RuntimeError(
-                "Recording of Systems when running parallel code is not supported yet")
-        for s in self.system_iter(include_self=True, recurse=recurse):
-            s._rec_mgr.append(recorder)
+            raise RuntimeError("Recording of Systems when running parallel "
+                               "code is not supported yet")
+
+        self._rec_mgr.append(recorder)
+
+        if recurse:
+            for s in self.system_iter(include_self=False, recurse=recurse):
+                s._rec_mgr.append(recorder)
 
     def record_iteration(self):
         """

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -270,9 +270,8 @@ class MPITests2(unittest.TestCase):
         root.linear_solver = LinearBlockGS()
         sub.linear_solver = LinearBlockGS()
 
-        prob.model.suppress_solver_output = True
-        sub.suppress_solver_output = True
-        prob.setup(check=False, mode='fwd')
+        prob.set_solver_print(0)
+        prob.setup(mode='fwd')
         prob.run_driver()
 
         diag1 = numpy.diag([-6.0, -6.0, -3.0])

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -236,7 +236,7 @@ class TestDriver(unittest.TestCase):
         strout = StringIO()
         sys.stdout = strout
         try:
-            prob.run_driver()
+            prob.run_driver(reset_iter_counts=False)
         finally:
             sys.stdout = stdout
         output = strout.getvalue().split('\n')

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -9,7 +9,7 @@ import numpy as np
 
 from openmdao.core.group import get_relevant_vars
 from openmdao.api import Problem, Group, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, \
-     ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov
+    ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov
 from openmdao.utils.assert_utils import assert_rel_error
 
 from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -80,7 +80,7 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, totals[('comp.f_xy','p1.x')][0][0], -4.0)
         assert_rel_error(self, totals[('comp.f_xy','p2.y')][0][0], 3.0)
 
-        totals = prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'], return_format= 'dict')
+        totals = prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'], return_format='dict')
         assert_rel_error(self, totals['comp.f_xy']['p1.x'][0][0], -4.0)
         assert_rel_error(self, totals['comp.f_xy']['p2.y'][0][0], 3.0)
 
@@ -596,7 +596,7 @@ class TestProblem(unittest.TestCase):
                                                          yy={'units': 'degC'}),
                                         promotes=['xx', 'yy'])
         comp = prob.model.add_subsystem('acomp', ExecComp('y=x-25.', x={'value': np.array([77.0, 95.0]), 'units': 'degF'},
-                                                         y={'units': 'degC'}))
+                                                          y={'units': 'degC'}))
         comp = prob.model.add_subsystem('aprom', ExecComp('ayy=axx-25.', axx={'value': np.array([77.0, 95.0]), 'units': 'degF'},
                                                           ayy={'units': 'degC'}),
                                         promotes=['axx', 'ayy'])
@@ -745,7 +745,7 @@ class TestProblem(unittest.TestCase):
 
         prob = Problem()
         comp = prob.model.add_subsystem('comp', ExecComp('y=x+1.', x={'value': np.array([100.0, 33.3]), 'units': 'cm'},
-                                                         y={'shape' : (2, ), 'units': 'm'}))
+                                                         y={'shape': (2, ), 'units': 'm'}))
 
         prob.setup()
         prob.run_model()
@@ -896,6 +896,29 @@ class TestProblem(unittest.TestCase):
             self.assertEqual(str(err), msg)
         else:
             self.fail('Expecting RuntimeError')
+
+    def test_run_with_invalid_prefix(self):
+        # Test error message when running with invalid prefix.
+
+        msg = "The 'case_prefix' argument should be a string."
+
+        prob = Problem()
+
+        try:
+            prob.setup()
+            prob.run_model(case_prefix=1234)
+        except TypeError as err:
+            self.assertEqual(str(err), msg)
+        else:
+            self.fail('Expecting TypeError')
+
+        try:
+            prob.setup()
+            prob.run_driver(case_prefix=12.34)
+        except TypeError as err:
+            self.assertEqual(str(err), msg)
+        else:
+            self.fail('Expecting TypeError')
 
     def test_root_deprecated(self):
         # testing the root property
@@ -1293,30 +1316,32 @@ class TestProblem(unittest.TestCase):
         sys.stdout = strout
         try:
             prob.list_problem_vars(
-                                   desvar_opts=['lower', 'upper', 'ref', 'ref0',
-                                                'indices', 'adder', 'scaler',
-                                                'parallel_deriv_color',
-                                                'vectorize_derivs', 'simul_deriv_color',
-                                                'cache_linear_solution'],
-                                   cons_opts=['lower', 'upper', 'equals', 'ref', 'ref0',
-                                              'indices', 'adder', 'scaler', 'linear',
-                                              'parallel_deriv_color',
-                                              'vectorize_derivs', 'simul_deriv_color', 'simul_map',
-                                              'cache_linear_solution'],
-                                   objs_opts=['ref', 'ref0',
-                                              'indices', 'adder', 'scaler',
-                                              'parallel_deriv_color',
-                                              'vectorize_derivs', 'simul_deriv_color', 'simul_map',
-                                              'cache_linear_solution'],
-                                   )
+                desvar_opts=['lower', 'upper', 'ref', 'ref0',
+                             'indices', 'adder', 'scaler',
+                             'parallel_deriv_color',
+                             'vectorize_derivs', 'simul_deriv_color',
+                             'cache_linear_solution'],
+                cons_opts=['lower', 'upper', 'equals', 'ref', 'ref0',
+                           'indices', 'adder', 'scaler', 'linear',
+                           'parallel_deriv_color',
+                           'vectorize_derivs', 'simul_deriv_color', 'simul_map',
+                           'cache_linear_solution'],
+                objs_opts=['ref', 'ref0',
+                           'indices', 'adder', 'scaler',
+                           'parallel_deriv_color',
+                           'vectorize_derivs', 'simul_deriv_color', 'simul_map',
+                           'cache_linear_solution'],
+            )
         finally:
             sys.stdout = stdout
         output = strout.getvalue().split('\n')
-        assertRegex(self, output[3],'^name\s+value\s+size\s+lower\s+upper\s+ref\s+ref0\s+'
-                         'indices\s+adder\s+scaler\s+parallel_deriv_color\s+'
-                         'vectorize_derivs\s+simul_deriv_color\s+cache_linear_solution')
-        assertRegex(self, output[5],'^pz.z\s+\|[0-9.e+-]+\|\s+2\s+\|10.0\|\s+\|[0-9.e+-]+\|\s+None\s+'
-                         'None\s+None\s+None\s+None\s+None\s+False\s+None\s+False')
+        assertRegex(self, output[3],
+                    '^name\s+value\s+size\s+lower\s+upper\s+ref\s+ref0\s+'
+                    'indices\s+adder\s+scaler\s+parallel_deriv_color\s+'
+                    'vectorize_derivs\s+simul_deriv_color\s+cache_linear_solution')
+        assertRegex(self, output[5],
+                    '^pz.z\s+\|[0-9.e+-]+\|\s+2\s+\|10.0\|\s+\|[0-9.e+-]+\|\s+None\s+'
+                    'None\s+None\s+None\s+None\s+None\s+False\s+None\s+False')
 
         # With all the optional columns and print_arrays
         stdout = sys.stdout
@@ -1385,6 +1410,7 @@ class TestProblem(unittest.TestCase):
                                           'vectorize_derivs', 'simul_deriv_color', 'simul_map',
                                           'cache_linear_solution'],
                                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/docs/_exts/embed_options.py
+++ b/openmdao/docs/_exts/embed_options.py
@@ -49,9 +49,11 @@ class EmbedOptionsDirective(Directive):
             lines.append(line, "options table", n)
             n += 1
 
-        lines.append("", "options table", n+1)  # Blank line required after table.
-        lines.append("Note: Options can be passed as keyword arguments at initialization.",
-                     "options table", n+2)
+        # Note applicable to System, Solver and Driver 'options', but not to 'recording_options'
+        if attribute_name != 'recording_options':
+            lines.append("", "options table", n+1)  # Blank line required after table.
+            lines.append("Note: Options can be passed as keyword arguments at initialization.",
+                         "options table", n+2)
 
         # Create a node.
         node = nodes.section()

--- a/openmdao/docs/features/recording/saving_data.rst
+++ b/openmdao/docs/features/recording/saving_data.rst
@@ -25,14 +25,13 @@ SqliteRecorder exists), and name the output file that you would like to write to
 Setting Recording Options
 +++++++++++++++++++++++++
 
-There are many recorder options that can be set. This affects the amount of information retained by the recorders.
+There are many recording options that can be set. This affects the amount of information retained by the recorders.
 These options are associated with the System, Driver or Solver that is being recorded.
 
-A basic example of how to set an option:
 
-.. code-block:: console
+The following examples use the :ref:`Sellar <sellar>` model and demonstrate setting the recording options on
+each of these types.
 
-    prob.driver.recording_options['record_desvars'] = True
 
 Recording on System Objects
 ---------------------------
@@ -90,3 +89,16 @@ error. Below is a basic example of adding a recorder to a solver object and reco
 
 .. note::
     A recorder can be attached to more than one object. Also, more than one recorder can be attached to an object.
+
+
+Specifying a Case Prefix
+------------------------
+
+It is possible to record data from multiple executions by specifying a prefix that will be used to differentiate the
+cases.  This prefix can be specified when calling `run_model` or `run_driver` and will be prepended to the case ID
+in the recorded case data:
+
+
+.. embed-code::
+    openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_record_with_prefix
+    :layout: interleave

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -445,7 +445,8 @@ class TestJacobianForDocs(unittest.TestCase):
         model.add_subsystem('input_comp', comp, promotes=['x', 'y1', 'y2', 'y3', 'z'])
 
         problem = Problem(model=model)
-        model.suppress_solver_output = True
+        problem.set_solver_print(0)
+
         model.linear_solver = DirectSolver()
         model.jacobian = DenseJacobian()
         model.add_subsystem('simple', SimpleCompConst(),

--- a/openmdao/recorders/base_recorder.py
+++ b/openmdao/recorders/base_recorder.py
@@ -6,7 +6,7 @@ from six import StringIO
 from openmdao.core.system import System
 from openmdao.core.driver import Driver
 from openmdao.solvers.solver import Solver
-from openmdao.recorders.recording_iteration_stack import get_formatted_iteration_coordinate
+from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.mpi import MPI
 
 
@@ -159,7 +159,7 @@ class BaseRecorder(object):
 
         self._counter += 1
 
-        self._iteration_coordinate = get_formatted_iteration_coordinate()
+        self._iteration_coordinate = recording_iteration.get_formatted_iteration_coordinate()
 
         if isinstance(recording_requester, Driver):
             self.record_iteration_driver(recording_requester, data, metadata)

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -24,52 +24,50 @@ class _RecIteration(object):
         self.stack = []
         self.prefix = None
 
+    def print_recording_iteration_stack(self):
+        """
+        Print the record iteration stack.
+
+        Used for debugging.
+        """
+        print()
+        for name, iter_count in reversed(self.stack):
+            print('^^^', name, iter_count)
+        print(60 * '^')
+
+    def get_formatted_iteration_coordinate(self):
+        """
+        Format the iteration coordinate into human-readable form.
+
+        'rank0:pyoptsparsedriver|6|root._solve_nonlinear|6|mda._solve_nonlinear|6|mda.d1._solve_nonlinear|45'
+
+        Returns
+        -------
+        str :
+            the iteration coordinate formatted in our proprietary way.
+        """
+        separator = '|'
+
+        # prefix
+        if self.prefix:
+            prefix = '%s_' % self.prefix
+        else:
+            prefix = ''
+
+        if MPI:
+            prefix += 'rank%d:' % MPI.COMM_WORLD.rank
+        else:
+            prefix += 'rank0:'
+
+        # iteration hierarchy
+        coord_list = []
+        for name, iter_count in self.stack:
+            coord_list.append('{}{}{}'.format(name, separator, iter_count))
+
+        return prefix + separator.join(coord_list)
+
 
 recording_iteration = _RecIteration()
-
-
-def print_recording_iteration_stack():
-    """
-    Print the record iteration stack.
-
-    Used for debugging.
-    """
-    print()
-    for name, iter_count in reversed(recording_iteration.stack):
-        print('^^^', name, iter_count)
-    print(60 * '^')
-
-
-def get_formatted_iteration_coordinate():
-    """
-    Format the iteration coordinate into human-readable form.
-
-    'rank0:pyoptsparsedriver|6|root._solve_nonlinear|6|mda._solve_nonlinear|6|mda.d1._solve_nonlinear|45'
-
-    Returns
-    -------
-    str :
-        the iteration coordinate formatted in our proprietary way.
-    """
-    separator = '|'
-
-    # prefix
-    if recording_iteration.prefix:
-        prefix = '%s_' % recording_iteration.prefix
-    else:
-        prefix = ''
-
-    if MPI:
-        prefix += 'rank%d:' % MPI.COMM_WORLD.rank
-    else:
-        prefix += 'rank0:'
-
-    # iteration hierarchy
-    coord_list = []
-    for name, iter_count in recording_iteration.stack:
-        coord_list.append('{}{}{}'.format(name, separator, iter_count))
-
-    return prefix + separator.join(coord_list)
 
 
 class Recording(object):

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -77,10 +77,8 @@ class SqliteRecorder(BaseRecorder):
     ----------
     model_viewer_data : dict
         Dict that holds the data needed to generate N2 diagram.
-    con : sqlite connection object
+    connection : sqlite connection object
         Connection to the sqlite3 database.
-    cursor : sqlite cursor object
-        Sqlite3 system cursor via the con.
     _abs2prom : {'input': dict, 'output': dict}
         Dictionary mapping absolute names to promoted names.
     _prom2abs : {'input': dict, 'output': dict}
@@ -114,7 +112,7 @@ class SqliteRecorder(BaseRecorder):
         if append:
             raise NotImplementedError("Append feature not implemented for SqliteRecorder")
 
-        self.con = None
+        self.connection = None
         self.model_viewer_data = None
 
         self._abs2prom = {'input': {}, 'output': {}}
@@ -153,37 +151,32 @@ class SqliteRecorder(BaseRecorder):
             except OSError:
                 pass
 
-            self.con = sqlite3.connect(filepath)
-            with self.con:
-                self.cursor = self.con.cursor()
-                self.cursor.execute("CREATE TABLE metadata( format_version INT, "
-                                    "abs2prom BLOB, prom2abs BLOB, abs2meta BLOB)")
-                self.cursor.execute("INSERT INTO metadata(format_version, abs2prom, "
-                                    "prom2abs) VALUES(?,?,?)",
-                                    (format_version, None, None))
+            self.connection = sqlite3.connect(filepath)
+            with self.connection as c:
+                c.execute("CREATE TABLE metadata( format_version INT, "
+                          "abs2prom BLOB, prom2abs BLOB, abs2meta BLOB)")
+                c.execute("INSERT INTO metadata(format_version, abs2prom, prom2abs) "
+                          "VALUES(?,?,?)", (format_version, None, None))
 
                 # used to keep track of the order of the case records across all three tables
-                self.cursor.execute("CREATE TABLE global_iterations(id INTEGER PRIMARY KEY, "
-                                    "record_type TEXT, rowid INT)")
-                self.cursor.execute("CREATE TABLE driver_iterations(id INTEGER PRIMARY KEY, "
-                                    "counter INT,iteration_coordinate TEXT, timestamp REAL, "
-                                    "success INT, msg TEXT, inputs BLOB, outputs BLOB)")
-                self.cursor.execute("CREATE TABLE system_iterations(id INTEGER PRIMARY KEY, "
-                                    "counter INT, iteration_coordinate TEXT,  timestamp REAL, "
-                                    "success INT, msg TEXT, inputs BLOB, outputs BLOB, "
-                                    "residuals BLOB)")
-                self.cursor.execute("CREATE TABLE solver_iterations(id INTEGER PRIMARY KEY, "
-                                    "counter INT, iteration_coordinate TEXT, timestamp REAL, "
-                                    "success INT, msg TEXT, abs_err REAL, rel_err REAL, "
-                                    "solver_inputs BLOB, solver_output BLOB, "
-                                    "solver_residuals BLOB)")
-
-                self.cursor.execute("CREATE TABLE driver_metadata(id TEXT PRIMARY KEY, "
-                                    "model_viewer_data BLOB)")
-                self.cursor.execute("CREATE TABLE system_metadata(id TEXT PRIMARY KEY, "
-                                    "scaling_factors BLOB, component_metadata BLOB)")
-                self.cursor.execute("CREATE TABLE solver_metadata(id TEXT PRIMARY KEY, "
-                                    "solver_options BLOB, solver_class TEXT)")
+                c.execute("CREATE TABLE global_iterations(id INTEGER PRIMARY KEY, "
+                          "record_type TEXT, rowid INT)")
+                c.execute("CREATE TABLE driver_iterations(id INTEGER PRIMARY KEY, "
+                          "counter INT,iteration_coordinate TEXT, timestamp REAL, "
+                          "success INT, msg TEXT, inputs BLOB, outputs BLOB)")
+                c.execute("CREATE TABLE system_iterations(id INTEGER PRIMARY KEY, "
+                          "counter INT, iteration_coordinate TEXT, timestamp REAL, "
+                          "success INT, msg TEXT, inputs BLOB, outputs BLOB, residuals BLOB)")
+                c.execute("CREATE TABLE solver_iterations(id INTEGER PRIMARY KEY, "
+                          "counter INT, iteration_coordinate TEXT, timestamp REAL, "
+                          "success INT, msg TEXT, abs_err REAL, rel_err REAL, "
+                          "solver_inputs BLOB, solver_output BLOB, solver_residuals BLOB)")
+                c.execute("CREATE TABLE driver_metadata(id TEXT PRIMARY KEY, "
+                          "model_viewer_data BLOB)")
+                c.execute("CREATE TABLE system_metadata(id TEXT PRIMARY KEY, "
+                          "scaling_factors BLOB, component_metadata BLOB)")
+                c.execute("CREATE TABLE solver_metadata(id TEXT PRIMARY KEY, "
+                          "solver_options BLOB, solver_class TEXT)")
 
         self._database_initialized = True
 
@@ -221,7 +214,7 @@ class SqliteRecorder(BaseRecorder):
                         (desvars, 'desvar'), (responses, 'response'),
                         (objectives, 'objective'), (constraints, 'constraint')]
 
-        if self.con:
+        if self.connection:
             # merge current abs2prom and prom2abs with this system's version
             for io in ['input', 'output']:
                 for v in system._var_abs2prom[io]:
@@ -258,9 +251,9 @@ class SqliteRecorder(BaseRecorder):
             prom2abs = pickle.dumps(self._prom2abs)
             abs2meta = pickle.dumps(self._abs2meta)
 
-            with self.con:
-                self.con.execute("UPDATE metadata SET abs2prom=?, prom2abs=?, abs2meta=?",
-                                 (abs2prom, prom2abs, abs2meta))
+            with self.connection as c:
+                c.execute("UPDATE metadata SET abs2prom=?, prom2abs=?, abs2meta=?",
+                          (abs2prom, prom2abs, abs2meta))
 
     def record_iteration_driver(self, recording_requester, data, metadata):
         """
@@ -275,7 +268,7 @@ class SqliteRecorder(BaseRecorder):
         metadata : dict
             Dictionary containing execution metadata.
         """
-        if self.con:
+        if self.connection:
             outputs = data['out']
             inputs = data['in']
 
@@ -285,16 +278,17 @@ class SqliteRecorder(BaseRecorder):
             outputs_blob = array_to_blob(outputs_array)
             inputs_blob = array_to_blob(inputs_array)
 
-            with self.con:
-                self.cursor.execute("INSERT INTO driver_iterations(counter, iteration_coordinate, "
-                                    "timestamp, success, msg, inputs, outputs) "
-                                    "VALUES(?,?,?,?,?,?,?)",
-                                    (self._counter, self._iteration_coordinate,
-                                     metadata['timestamp'], metadata['success'],
-                                     metadata['msg'], inputs_blob, outputs_blob))
+            with self.connection as c:
+                c = c.cursor()  # need a real cursor for lastrowid
 
-                self.con.execute("INSERT INTO global_iterations(record_type, rowid) VALUES(?,?)",
-                                 ('driver', self.cursor.lastrowid))
+                c.execute("INSERT INTO driver_iterations(counter, iteration_coordinate, "
+                          "timestamp, success, msg, inputs, outputs) VALUES(?,?,?,?,?,?,?)",
+                          (self._counter, self._iteration_coordinate,
+                           metadata['timestamp'], metadata['success'], metadata['msg'],
+                           inputs_blob, outputs_blob))
+
+                c.execute("INSERT INTO global_iterations(record_type, rowid) VALUES(?,?)",
+                          ('driver', c.lastrowid))
 
     def record_iteration_system(self, recording_requester, data, metadata):
         """
@@ -309,7 +303,7 @@ class SqliteRecorder(BaseRecorder):
         metadata : dict
             Dictionary containing execution metadata.
         """
-        if self.con:
+        if self.connection:
             inputs = data['i']
             outputs = data['o']
             residuals = data['r']
@@ -322,17 +316,18 @@ class SqliteRecorder(BaseRecorder):
             outputs_blob = array_to_blob(outputs_array)
             residuals_blob = array_to_blob(residuals_array)
 
-            with self.con:
-                self.cursor.execute("INSERT INTO system_iterations(counter, iteration_coordinate, "
-                                    "timestamp, success, msg, inputs , outputs , residuals ) "
-                                    "VALUES(?,?,?,?,?,?,?,?)",
-                                    (self._counter, self._iteration_coordinate,
-                                     metadata['timestamp'], metadata['success'],
-                                     metadata['msg'], inputs_blob,
-                                     outputs_blob, residuals_blob))
+            with self.connection as c:
+                c = c.cursor()  # need a real cursor for lastrowid
 
-                self.cursor.execute("INSERT INTO global_iterations(record_type, rowid) VALUES(?,?)",
-                                    ('system', self.cursor.lastrowid))
+                c.execute("INSERT INTO system_iterations(counter, iteration_coordinate, "
+                          "timestamp, success, msg, inputs , outputs , residuals ) "
+                          "VALUES(?,?,?,?,?,?,?,?)",
+                          (self._counter, self._iteration_coordinate,
+                           metadata['timestamp'], metadata['success'], metadata['msg'],
+                           inputs_blob, outputs_blob, residuals_blob))
+
+                c.execute("INSERT INTO global_iterations(record_type, rowid) VALUES(?,?)",
+                          ('system', c.lastrowid))
 
     def record_iteration_solver(self, recording_requester, data, metadata):
         """
@@ -347,7 +342,7 @@ class SqliteRecorder(BaseRecorder):
         metadata : dict
             Dictionary containing execution metadata.
         """
-        if self.con:
+        if self.connection:
             abs = data['abs']
             rel = data['rel']
             inputs = data['i']
@@ -362,19 +357,19 @@ class SqliteRecorder(BaseRecorder):
             outputs_blob = array_to_blob(outputs_array)
             residuals_blob = array_to_blob(residuals_array)
 
-            with self.con:
-                self.cursor.execute("INSERT INTO solver_iterations(counter, iteration_coordinate, "
-                                    "timestamp, success, msg, abs_err, rel_err, "
-                                    "solver_inputs, solver_output, solver_residuals) "
-                                    "VALUES(?,?,?,?,?,?,?,?,?,?)",
-                                    (self._counter, self._iteration_coordinate,
-                                     metadata['timestamp'],
-                                     metadata['success'], metadata['msg'],
-                                     abs, rel,
-                                     inputs_blob, outputs_blob, residuals_blob))
+            with self.connection as c:
+                c = c.cursor()  # need a real cursor for lastrowid
 
-                self.cursor.execute("INSERT INTO global_iterations(record_type, rowid) VALUES(?,?)",
-                                    ('solver', self.cursor.lastrowid))
+                c.execute("INSERT INTO solver_iterations(counter, iteration_coordinate, "
+                          "timestamp, success, msg, abs_err, rel_err, "
+                          "solver_inputs, solver_output, solver_residuals) "
+                          "VALUES(?,?,?,?,?,?,?,?,?,?)",
+                          (self._counter, self._iteration_coordinate,
+                           metadata['timestamp'], metadata['success'], metadata['msg'],
+                           abs, rel, inputs_blob, outputs_blob, residuals_blob))
+
+                c.execute("INSERT INTO global_iterations(record_type, rowid) VALUES(?,?)",
+                          ('solver', c.lastrowid))
 
     def record_metadata_driver(self, recording_requester):
         """
@@ -385,15 +380,16 @@ class SqliteRecorder(BaseRecorder):
         recording_requester : Driver
             The Driver that would like to record its metadata.
         """
-        if self.con:
+        if self.connection:
             driver_class = type(recording_requester).__name__
             model_viewer_data = pickle.dumps(recording_requester._model_viewer_data,
                                              self._pickle_version)
+            model_viewer_data = sqlite3.Binary(model_viewer_data)
 
             try:
-                with self.con:
-                    self.con.execute("INSERT INTO driver_metadata(id, model_viewer_data) VALUES(?,?)",
-                                     (driver_class, sqlite3.Binary(model_viewer_data)))
+                with self.connection as c:
+                    c.execute("INSERT INTO driver_metadata(id, model_viewer_data) "
+                              "VALUES(?,?)", (driver_class, model_viewer_data))
             except sqlite3.IntegrityError:
                 print("Metadata has already been recorded for %s." % driver_class)
 
@@ -406,7 +402,7 @@ class SqliteRecorder(BaseRecorder):
         recording_requester : System
             The System that would like to record its metadata.
         """
-        if self.con:
+        if self.connection:
             # Cannot handle PETScVector yet
             from openmdao.api import PETScVector
             if PETScVector and isinstance(recording_requester._outputs, PETScVector):
@@ -444,11 +440,12 @@ class SqliteRecorder(BaseRecorder):
             if not path:
                 path = 'root'
 
-            with self.con:
-                self.con.execute("INSERT INTO system_metadata(id, scaling_factors, component_metadata) \
-                                  VALUES(?,?, ?)",
-                                 (path, sqlite3.Binary(scaling_factors),
-                                  sqlite3.Binary(pickled_metadata)))
+            scaling_factors = sqlite3.Binary(scaling_factors)
+            pickled_metadata = sqlite3.Binary(pickled_metadata)
+
+            with self.connection as c:
+                c.execute("INSERT INTO system_metadata(id, scaling_factors, component_metadata) "
+                          "VALUES(?,?,?)", (path, scaling_factors, pickled_metadata))
 
     def record_metadata_solver(self, recording_requester):
         """
@@ -459,7 +456,7 @@ class SqliteRecorder(BaseRecorder):
         recording_requester : Solver
             The Solver that would like to record its metadata.
         """
-        if self.con:
+        if self.connection:
             path = recording_requester._system.pathname
             solver_class = type(recording_requester).__name__
             if not path:
@@ -468,14 +465,13 @@ class SqliteRecorder(BaseRecorder):
 
             solver_options = pickle.dumps(recording_requester.options, self._pickle_version)
 
-            with self.con:
-                self.con.execute(
-                    "INSERT INTO solver_metadata(id, solver_options, solver_class) "
-                    "VALUES(?,?,?)", (id, sqlite3.Binary(solver_options), solver_class))
+            with self.connection as c:
+                c.execute("INSERT INTO solver_metadata(id, solver_options, solver_class) "
+                          "VALUES(?,?,?)", (id, sqlite3.Binary(solver_options), solver_class))
 
     def close(self):
         """
         Close `out`.
         """
-        if self.con:
-            self.con.close()
+        if self.connection:
+            self.connection.close()

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -390,9 +390,12 @@ class SqliteRecorder(BaseRecorder):
             model_viewer_data = pickle.dumps(recording_requester._model_viewer_data,
                                              self._pickle_version)
 
-            with self.con:
-                self.con.execute("INSERT INTO driver_metadata(id, model_viewer_data) VALUES(?,?)",
-                                 (driver_class, sqlite3.Binary(model_viewer_data)))
+            try:
+                with self.con:
+                    self.con.execute("INSERT INTO driver_metadata(id, model_viewer_data) VALUES(?,?)",
+                                     (driver_class, sqlite3.Binary(model_viewer_data)))
+            except sqlite3.IntegrityError:
+                print("Metadata has already been recorded for %s." % driver_class)
 
     def record_metadata_system(self, recording_requester):
         """

--- a/openmdao/recorders/tests/recorder_test_utils.py
+++ b/openmdao/recorders/tests/recorder_test_utils.py
@@ -1,8 +1,8 @@
 import time
 
-def run_driver(problem):
+def run_driver(problem, **kwargs):
     t0 = time.time()
-    problem.run_driver()
+    problem.run_driver(**kwargs)
     t1 = time.time()
     return t0, t1
 

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -164,6 +164,7 @@ def assertSolverIterDataRecorded(test, expected, tolerance, prefix=None):
 
             output_actual = blob_to_array(output_blob)
             residuals_actual = blob_to_array(residuals_blob)
+
             # Does the timestamp make sense?
             test.assertTrue(t0 <= timestamp and timestamp <= t1, 'timestamp should be between when the model '
                                                                  'started and stopped')

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -5,240 +5,290 @@ if PY2:
 if PY3:
     import pickle
 
+import sqlite3
+
 import numpy as np
+
+from contextlib import contextmanager
 
 from openmdao.utils.record_util import format_iteration_coordinate
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.recorders.sqlite_recorder import blob_to_array, format_version
 
-def assertDriverIterationDataRecorded(test, db_cur, expected, tolerance):
+
+@contextmanager
+def database_cursor(filename):
+    """
+    Context manager managing a cursor for the SQLite database with the given file name.
+    """
+    con = sqlite3.connect(filename)
+    cur = con.cursor()
+
+    yield cur
+
+    con.close()
+
+
+def assertDriverIterationDataRecorded(test, expected, tolerance):
     """
         Expected can be from multiple cases.
     """
-    # iterate through the cases
-    for coord, (t0, t1), outputs_expected, inputs_expected in expected:
-        iter_coord = format_iteration_coordinate(coord)
+    with database_cursor(test.filename) as db_cur:
 
-        # from the database, get the actual data recorded
-        db_cur.execute("SELECT * FROM driver_iterations WHERE "
-                       "iteration_coordinate=:iteration_coordinate",
-                       {"iteration_coordinate": iter_coord})
-        row_actual = db_cur.fetchone()
+        # iterate through the cases
+        for coord, (t0, t1), outputs_expected, inputs_expected in expected:
+            iter_coord = format_iteration_coordinate(coord)
 
-        db_cur.execute("SELECT abs2meta FROM metadata")
-        row_abs2meta = db_cur.fetchone()
+            # from the database, get the actual data recorded
+            db_cur.execute("SELECT * FROM driver_iterations WHERE "
+                           "iteration_coordinate=:iteration_coordinate",
+                           {"iteration_coordinate": iter_coord})
+            row_actual = db_cur.fetchone()
 
-        test.assertTrue(row_actual,
-            'Driver iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
+            db_cur.execute("SELECT abs2meta FROM metadata")
+            row_abs2meta = db_cur.fetchone()
 
-        counter, global_counter, iteration_coordinate, timestamp, success, msg,\
-            input_blob, output_blob = row_actual
+            test.assertTrue(row_actual,
+                            'Driver iterations table does not contain the requested '
+                            'iteration coordinate: "{}"'.format(iter_coord))
+
+            counter, global_counter, iteration_coordinate, timestamp, success, msg,\
+                input_blob, output_blob = row_actual
+
+            if PY2:
+                abs2meta = pickle.loads(str(row_abs2meta[0])) if row_abs2meta[0] is not None else None
+            else:
+                abs2meta = pickle.loads(row_abs2meta[0]) if row_abs2meta[0] is not None else None
+
+            inputs_actual = blob_to_array(input_blob)
+            outputs_actual = blob_to_array(output_blob)
+
+            # Does the timestamp make sense?
+            test.assertTrue(t0 <= timestamp and timestamp <= t1)
+
+            test.assertEqual(success, 1)
+            test.assertEqual(msg, '')
+
+            for vartype, actual, expected in (
+                ('outputs', outputs_actual, outputs_expected),
+                ('inputs', inputs_actual, inputs_expected)
+            ):
+
+                if expected is None:
+                    test.assertEqual(actual, np.array(None, dtype=object))
+                else:
+                    actual = actual[0]
+                    # Check to see if the number of values in actual and expected match
+                    test.assertEqual(len(actual), len(expected))
+                    for key, value in iteritems(expected):
+                        # Check to see if the keys in the actual and expected match
+                        test.assertTrue(key in actual.dtype.names,
+                                        '{} variable not found in actual data'
+                                        ' from recorder'.format(key))
+                        # Check to see if the values in actual and expected match
+                        assert_rel_error(test, actual[key], expected[key], tolerance)
+
+
+def assertSystemIterationDataRecorded(test, expected, tolerance):
+    """
+        Expected can be from multiple cases.
+    """
+    with database_cursor(test.filename) as db_cur:
+
+        # iterate through the cases
+        for coord, (t0, t1), inputs_expected, outputs_expected, residuals_expected in expected:
+            iter_coord = format_iteration_coordinate(coord)
+
+            # from the database, get the actual data recorded
+            db_cur.execute("SELECT * FROM system_iterations WHERE "
+                           "iteration_coordinate=:iteration_coordinate",
+                           {"iteration_coordinate": iter_coord})
+            row_actual = db_cur.fetchone()
+            test.assertTrue(row_actual, 'System iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
+
+            counter, global_counter, iteration_coordinate, timestamp, success, msg, inputs_blob, \
+                outputs_blob, residuals_blob = row_actual
+
+            inputs_actual = blob_to_array(inputs_blob)
+            outputs_actual = blob_to_array(outputs_blob)
+            residuals_actual = blob_to_array(residuals_blob)
+
+            # Does the timestamp make sense?
+            test.assertTrue(t0 <= timestamp and timestamp <= t1)
+
+            test.assertEqual(success, 1)
+            test.assertEqual(msg, '')
+
+            for vartype, actual, expected in (
+                ('inputs', inputs_actual, inputs_expected),
+                ('outputs', outputs_actual, outputs_expected),
+                ('residuals', residuals_actual, residuals_expected),
+            ):
+
+                if expected is None:
+                    test.assertEqual(actual, np.array(None, dtype=object))
+                else:
+                    # Check to see if the number of values in actual and expected match
+                    test.assertEqual(len(actual[0]), len(expected))
+                    for key, value in iteritems(expected):
+                        # Check to see if the keys in the actual and expected match
+                        test.assertTrue(key in actual[0].dtype.names,
+                                        '{} variable not found in actual data '
+                                        'from recorder'.format(key))
+                        # Check to see if the values in actual and expected match
+                        assert_rel_error(test, actual[0][key], expected[key], tolerance)
+
+
+def assertSolverIterationDataRecorded(test, expected, tolerance):
+    """
+        Expected can be from multiple cases.
+    """
+    with database_cursor(test.filename) as db_cur:
+
+        # iterate through the cases
+        for coord, (t0, t1), expected_abs_error, expected_rel_error, expected_output, \
+                expected_solver_residuals in expected:
+
+            iter_coord = format_iteration_coordinate(coord)
+
+            # from the database, get the actual data recorded
+            db_cur.execute("SELECT * FROM solver_iterations WHERE iteration_coordinate=:iteration_coordinate",
+                           {"iteration_coordinate": iter_coord})
+            row_actual = db_cur.fetchone()
+            test.assertTrue(row_actual, 'Solver iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
+
+            counter, global_counter, iteration_coordinate, timestamp, success, msg, abs_err, rel_err, \
+                input_blob, output_blob, residuals_blob = row_actual
+
+            output_actual = blob_to_array(output_blob)
+            residuals_actual = blob_to_array(residuals_blob)
+            # Does the timestamp make sense?
+            test.assertTrue(t0 <= timestamp and timestamp <= t1, 'timestamp should be between when the model '
+                                                                 'started and stopped')
+
+            test.assertEqual(success, 1)
+            test.assertEqual(msg, '')
+            if expected_abs_error:
+                test.assertTrue(abs_err, 'Expected absolute error but none recorded')
+                assert_rel_error(test, abs_err, expected_abs_error, tolerance)
+            if expected_rel_error:
+                test.assertTrue(rel_err, 'Expected relative error but none recorded')
+                assert_rel_error(test, rel_err, expected_rel_error, tolerance)
+
+            for vartype, actual, expected in (
+                    ('outputs', output_actual, expected_output),
+                    ('residuals', residuals_actual, expected_solver_residuals),
+            ):
+
+                if expected is None:
+                    test.assertEqual(actual, np.array(None, dtype=object))
+                else:
+                    # Check to see if the number of values in actual and expected match
+                    test.assertEqual(len(actual[0]), len(expected))
+                    for key, value in iteritems(expected):
+                        # Check to see if the keys in the actual and expected match
+                        test.assertTrue(key in actual[0].dtype.names, '{} variable not found in actual '
+                                                                      'data from recorder'.format(key))
+                        # Check to see if the values in actual and expected match
+                        assert_rel_error(test, actual[0][key], expected[key], tolerance)
+
+
+def assertMetadataRecorded(test, expected_prom2abs, expected_abs2prom):
+
+    with database_cursor(test.filename) as db_cur:
+
+        db_cur.execute("SELECT format_version, prom2abs, abs2prom FROM metadata")
+        row = db_cur.fetchone()
+
+        format_version_actual = row[0]
+        format_version_expected = format_version
 
         if PY2:
-            abs2meta = pickle.loads(str(row_abs2meta[0])) if row_abs2meta[0] is not None else None
+            prom2abs = pickle.loads(str(row[1])) if row[1] is not None else None
+            abs2prom = pickle.loads(str(row[2])) if row[2] is not None else None
+        if PY3:
+            prom2abs = pickle.loads(row[1]) if row[1] is not None else None
+            abs2prom = pickle.loads(row[2]) if row[2] is not None else None
+
+        if prom2abs is None:
+            test.assertIsNone(expected_prom2abs)
         else:
-            abs2meta = pickle.loads(row_abs2meta[0]) if row_abs2meta[0] is not None else None
+            for io in ['input', 'output']:
+                for var in prom2abs[io]:
+                    test.assertEqual(prom2abs[io][var].sort(), expected_prom2abs[io][var].sort())
+        if abs2prom is None:
+            test.assertIsNone(expected_abs2prom)
+        else:
+            for io in ['input', 'output']:
+                for var in abs2prom[io]:
+                    test.assertEqual(abs2prom[io][var], expected_abs2prom[io][var])
 
-        inputs_actual = blob_to_array(input_blob)
-        outputs_actual = blob_to_array(output_blob)
-
-        # Does the timestamp make sense?
-        test.assertTrue(t0 <= timestamp and timestamp <= t1)
-
-        test.assertEqual(success, 1)
-        test.assertEqual(msg, '')
-
-        for vartype, actual, expected in (
-            ('outputs', outputs_actual, outputs_expected),
-            ('inputs', inputs_actual, inputs_expected)
-        ):
-
-            if expected is None:
-                test.assertEqual(actual, np.array(None, dtype=object))
-            else:
-                actual = actual[0]
-                # Check to see if the number of values in actual and expected match
-                test.assertEqual(len(actual), len(expected))
-                for key, value in iteritems(expected):
-                    # Check to see if the keys in the actual and expected match
-                    test.assertTrue(key in actual.dtype.names,
-                                    '{} variable not found in actual data'
-                                    ' from recorder'.format(key))
-                    # Check to see if the values in actual and expected match
-                    assert_rel_error(test, actual[key], expected[key], tolerance)
-        return
-
-def assertSystemIterationDataRecorded(test, db_cur, expected, tolerance):
-    """
-        Expected can be from multiple cases.
-    """
-
-    # iterate through the cases
-    for coord, (t0, t1), inputs_expected, outputs_expected, residuals_expected in expected:
-        iter_coord = format_iteration_coordinate(coord)
-
-        # from the database, get the actual data recorded
-        db_cur.execute("SELECT * FROM system_iterations WHERE "
-                       "iteration_coordinate=:iteration_coordinate",
-                       {"iteration_coordinate": iter_coord})
-        row_actual = db_cur.fetchone()
-        test.assertTrue(row_actual, 'System iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
-
-        counter, global_counter, iteration_coordinate, timestamp, success, msg, inputs_blob, \
-            outputs_blob, residuals_blob = row_actual
-
-        inputs_actual = blob_to_array(inputs_blob)
-        outputs_actual = blob_to_array(outputs_blob)
-        residuals_actual = blob_to_array(residuals_blob)
-
-        # Does the timestamp make sense?
-        test.assertTrue(t0 <= timestamp and timestamp <= t1)
-
-        test.assertEqual(success, 1)
-        test.assertEqual(msg, '')
-
-        for vartype, actual, expected in (
-            ('inputs', inputs_actual, inputs_expected),
-            ('outputs', outputs_actual, outputs_expected),
-            ('residuals', residuals_actual, residuals_expected),
-        ):
-
-            if expected is None:
-                test.assertEqual(actual, np.array(None, dtype=object))
-            else:
-                # Check to see if the number of values in actual and expected match
-                test.assertEqual(len(actual[0]), len(expected))
-                for key, value in iteritems(expected):
-                    # Check to see if the keys in the actual and expected match
-                    test.assertTrue(key in actual[0].dtype.names,
-                                    '{} variable not found in actual data '
-                                    'from recorder'.format(key))
-                    # Check to see if the values in actual and expected match
-                    assert_rel_error(test, actual[0][key], expected[key], tolerance)
-        return
+        # this always gets recorded
+        test.assertEqual(format_version_actual, format_version_expected)
 
 
-def assertSolverIterationDataRecorded(test, db_cur, expected, tolerance):
-    """
-        Expected can be from multiple cases.
-    """
+def assertDriverMetadataRecorded(test, expected, expect_none_viewer_data=False):
 
-    # iterate through the cases
-    for coord, (t0, t1), expected_abs_error, expected_rel_error, expected_output, \
-            expected_solver_residuals in expected:
+    with database_cursor(test.filename) as db_cur:
 
-        iter_coord = format_iteration_coordinate(coord)
+        db_cur.execute("SELECT model_viewer_data FROM driver_metadata")
+        row = db_cur.fetchone()
 
-        # from the database, get the actual data recorded
-        db_cur.execute("SELECT * FROM solver_iterations WHERE iteration_coordinate=:iteration_coordinate",
-                       {"iteration_coordinate": iter_coord})
-        row_actual = db_cur.fetchone()
-        test.assertTrue(row_actual, 'Solver iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
+        if expected is None and not expect_none_viewer_data:
+            test.assertIsNone(row)
+            return
 
-        counter, global_counter, iteration_coordinate, timestamp, success, msg, abs_err, rel_err, \
-            input_blob, output_blob, residuals_blob = row_actual
+        if PY2:
+            model_viewer_data = pickle.loads(str(row[0]))
+        if PY3:
+            model_viewer_data = pickle.loads(row[0])
 
-        output_actual = blob_to_array(output_blob)
-        residuals_actual = blob_to_array(residuals_blob)
-        # Does the timestamp make sense?
-        test.assertTrue(t0 <= timestamp and timestamp <= t1, 'timestamp should be between when the model '
-                                                             'started and stopped')
+        if expect_none_viewer_data:
+            test.assertIsNone(model_viewer_data)
+            return
 
-        test.assertEqual(success, 1)
-        test.assertEqual(msg, '')
-        if expected_abs_error:
-            test.assertTrue(abs_err, 'Expected absolute error but none recorded')
-            assert_rel_error(test, abs_err, expected_abs_error, tolerance)
-        if expected_rel_error:
-            test.assertTrue(rel_err, 'Expected relative error but none recorded')
-            assert_rel_error(test, rel_err, expected_rel_error, tolerance)
+        test.assertTrue(isinstance(model_viewer_data, dict))
 
-        for vartype, actual, expected in (
-                ('outputs', output_actual, expected_output),
-                ('residuals', residuals_actual, expected_solver_residuals),
-        ):
+        test.assertEqual(2, len(model_viewer_data))
 
-            if expected is None:
-                test.assertEqual(actual, np.array(None, dtype=object))
-            else:
-                # Check to see if the number of values in actual and expected match
-                test.assertEqual(len(actual[0]), len(expected))
-                for key, value in iteritems(expected):
-                    # Check to see if the keys in the actual and expected match
-                    test.assertTrue(key in actual[0].dtype.names, '{} variable not found in actual '
-                                                                  'data from recorder'.format(key))
-                    # Check to see if the values in actual and expected match
-                    assert_rel_error(test, actual[0][key], expected[key], tolerance)
-        return
+        test.assertTrue(isinstance(model_viewer_data['connections_list'], list))
 
-def assertMetadataRecorded(test, db_cur, expected_prom2abs, expected_abs2prom):
+        test.assertEqual(expected['connections_list_length'],
+                         len(model_viewer_data['connections_list']))
 
-    db_cur.execute("SELECT format_version, prom2abs, abs2prom FROM metadata")
-    row = db_cur.fetchone()
+        test.assertEqual(expected['tree_length'], len(model_viewer_data['tree']))
 
-    format_version_actual = row[0]
-    format_version_expected = format_version
+        tr = model_viewer_data['tree']
+        test.assertEqual(set(['name', 'type', 'subsystem_type', 'children']), set(tr.keys()))
+        test.assertEqual(expected['tree_children_length'], len(model_viewer_data['tree']['children']))
 
-    if PY2:
-        prom2abs = pickle.loads(str(row[1])) if row[1] is not None else None
-        abs2prom = pickle.loads(str(row[2])) if row[2] is not None else None
-    if PY3:
-        prom2abs = pickle.loads(row[1]) if row[1] is not None else None
-        abs2prom = pickle.loads(row[2]) if row[2] is not None else None
+        cl = model_viewer_data['connections_list']
+        for c in cl:
+            test.assertTrue(set(c.keys()).issubset(set(['src', 'tgt', 'cycle_arrows'])))
 
-    if prom2abs is None:
-        test.assertIsNone(expected_prom2abs)
-    else:
-        for io in ['input', 'output']:
-            for var in prom2abs[io]:
-                test.assertEqual(prom2abs[io][var].sort(), expected_prom2abs[io][var].sort())
-    if abs2prom is None:
-        test.assertIsNone(expected_abs2prom)
-    else:
-        for io in ['input', 'output']:
-            for var in abs2prom[io]:
-                test.assertEqual(abs2prom[io][var], expected_abs2prom[io][var])
 
-    # this always gets recorded
-    test.assertEqual(format_version_actual, format_version_expected)
+def assertSystemMetadataIdsRecorded(test, ids):
 
-    return
+    with database_cursor(test.filename) as cur:
 
-def assertDriverMetadataRecorded(test, db_cur, expected, expect_none_viewer_data=False):
+        for id in ids:
+            cur.execute("SELECT * FROM system_metadata WHERE id=:id", {"id": id})
+            row_actual = cur.fetchone()
+            test.assertTrue(row_actual,
+                            'System metadata table does not contain the '
+                            'requested id: "{}"'.format(id))
 
-    db_cur.execute("SELECT model_viewer_data FROM driver_metadata")
-    row = db_cur.fetchone()
 
-    if expected is None and not expect_none_viewer_data:
-        test.assertIsNone(row)
-        return
+def assertSystemIterationCoordinatesRecorded(test, iteration_coordinates):
 
-    if PY2:
-        model_viewer_data = pickle.loads(str(row[0]))
-    if PY3:
-        model_viewer_data = pickle.loads(row[0])
+    with database_cursor(test.filename) as cur:
 
-    if expect_none_viewer_data:
-        test.assertIsNone(model_viewer_data)
-        return
-
-    test.assertTrue(isinstance(model_viewer_data, dict))
-
-    test.assertEqual(2, len(model_viewer_data))
-
-    test.assertTrue(isinstance(model_viewer_data['connections_list'], list))
-
-    test.assertEqual(expected['connections_list_length'],
-                     len(model_viewer_data['connections_list']))
-
-    test.assertEqual(expected['tree_length'], len(model_viewer_data['tree']))
-
-    tr = model_viewer_data['tree']
-    test.assertEqual(set(['name', 'type', 'subsystem_type', 'children']), set(tr.keys()))
-    test.assertEqual(expected['tree_children_length'], len(model_viewer_data['tree']['children']))
-
-    cl = model_viewer_data['connections_list']
-    for c in cl:
-        test.assertTrue(set(c.keys()).issubset(set(['src', 'tgt', 'cycle_arrows'])))
-
-    return
+        for iteration_coordinate in iteration_coordinates:
+            cur.execute("SELECT * FROM system_iterations WHERE "
+                        "iteration_coordinate=:iteration_coordinate",
+                        {"iteration_coordinate": iteration_coordinate})
+            row_actual = cur.fetchone()
+            test.assertTrue(row_actual,
+                            'System iterations table does not contain the '
+                            'requested iteration coordinate: "{}"'.
+                            format(iteration_coordinate))

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -29,7 +29,7 @@ def database_cursor(filename):
     con.close()
 
 
-def assertDriverIterationDataRecorded(test, expected, tolerance, prefix=None):
+def assertDriverIterDataRecorded(test, expected, tolerance, prefix=None):
     """
         Expected can be from multiple cases.
     """
@@ -89,7 +89,7 @@ def assertDriverIterationDataRecorded(test, expected, tolerance, prefix=None):
                         assert_rel_error(test, actual[key], expected[key], tolerance)
 
 
-def assertSystemIterationDataRecorded(test, expected, tolerance):
+def assertSystemIterDataRecorded(test, expected, tolerance, prefix=None):
     """
         Expected can be from multiple cases.
     """
@@ -97,7 +97,7 @@ def assertSystemIterationDataRecorded(test, expected, tolerance):
 
         # iterate through the cases
         for coord, (t0, t1), inputs_expected, outputs_expected, residuals_expected in expected:
-            iter_coord = format_iteration_coordinate(coord)
+            iter_coord = format_iteration_coordinate(coord, prefix=prefix)
 
             # from the database, get the actual data recorded
             db_cur.execute("SELECT * FROM system_iterations WHERE "
@@ -140,7 +140,7 @@ def assertSystemIterationDataRecorded(test, expected, tolerance):
                         assert_rel_error(test, actual[0][key], expected[key], tolerance)
 
 
-def assertSolverIterationDataRecorded(test, expected, tolerance):
+def assertSolverIterDataRecorded(test, expected, tolerance, prefix=None):
     """
         Expected can be from multiple cases.
     """
@@ -150,7 +150,7 @@ def assertSolverIterationDataRecorded(test, expected, tolerance):
         for coord, (t0, t1), expected_abs_error, expected_rel_error, expected_output, \
                 expected_solver_residuals in expected:
 
-            iter_coord = format_iteration_coordinate(coord)
+            iter_coord = format_iteration_coordinate(coord, prefix=prefix)
 
             # from the database, get the actual data recorded
             db_cur.execute("SELECT * FROM solver_iterations WHERE iteration_coordinate=:iteration_coordinate",
@@ -281,7 +281,7 @@ def assertSystemMetadataIdsRecorded(test, ids):
                             'requested id: "{}"'.format(id))
 
 
-def assertSystemIterationCoordinatesRecorded(test, iteration_coordinates):
+def assertSystemIterCoordsRecorded(test, iteration_coordinates):
 
     with database_cursor(test.filename) as cur:
 

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -104,7 +104,8 @@ def assertSystemIterationDataRecorded(test, expected, tolerance):
                            "iteration_coordinate=:iteration_coordinate",
                            {"iteration_coordinate": iter_coord})
             row_actual = db_cur.fetchone()
-            test.assertTrue(row_actual, 'System iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
+            test.assertTrue(row_actual, 'System iterations table does not contain the requested '
+                                        'iteration coordinate: "{}"'.format(iter_coord))
 
             counter, global_counter, iteration_coordinate, timestamp, success, msg, inputs_blob, \
                 outputs_blob, residuals_blob = row_actual
@@ -155,7 +156,8 @@ def assertSolverIterationDataRecorded(test, expected, tolerance):
             db_cur.execute("SELECT * FROM solver_iterations WHERE iteration_coordinate=:iteration_coordinate",
                            {"iteration_coordinate": iter_coord})
             row_actual = db_cur.fetchone()
-            test.assertTrue(row_actual, 'Solver iterations table does not contain the requested iteration coordinate: "{}"'.format(iter_coord))
+            test.assertTrue(row_actual, 'Solver iterations table does not contain the requested '
+                                        'iteration coordinate: "{}"'.format(iter_coord))
 
             counter, global_counter, iteration_coordinate, timestamp, success, msg, abs_err, rel_err, \
                 input_blob, output_blob, residuals_blob = row_actual

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -29,7 +29,7 @@ def database_cursor(filename):
     con.close()
 
 
-def assertDriverIterationDataRecorded(test, expected, tolerance):
+def assertDriverIterationDataRecorded(test, expected, tolerance, prefix=None):
     """
         Expected can be from multiple cases.
     """
@@ -37,7 +37,7 @@ def assertDriverIterationDataRecorded(test, expected, tolerance):
 
         # iterate through the cases
         for coord, (t0, t1), outputs_expected, inputs_expected in expected:
-            iter_coord = format_iteration_coordinate(coord)
+            iter_coord = format_iteration_coordinate(coord, prefix=prefix)
 
             # from the database, get the actual data recorded
             db_cur.execute("SELECT * FROM driver_iterations WHERE "

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -24,7 +24,7 @@ if OPTIMIZER:
 from openmdao.api import ExecComp, ExplicitComponent, Problem, \
     Group, ParallelGroup, IndepVarComp, SqliteRecorder
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.recorders.tests.sqlite_recorder_test_utils import assertDriverIterationDataRecorded
+from openmdao.recorders.tests.sqlite_recorder_test_utils import assertDriverIterDataRecorded
 from openmdao.recorders.tests.recorder_test_utils import run_driver
 
 
@@ -183,7 +183,7 @@ class DistributedRecorderTest(unittest.TestCase):
             expected_outputs.update(expected_objectives)
 
             expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
-            assertDriverIterationDataRecorded(self, expected_data, self.eps)
+            assertDriverIterDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -258,7 +258,7 @@ class DistributedRecorderTest(unittest.TestCase):
             coordinate = [0, 'SLSQP', (48,)]
 
             expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
-            assertDriverIterationDataRecorded(self, expected_data, self.eps)
+            assertDriverIterDataRecorded(self, expected_data, self.eps)
 
 
 if __name__ == "__main__":

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -182,8 +182,8 @@ class DistributedRecorderTest(unittest.TestCase):
             expected_outputs = expected_desvars
             expected_outputs.update(expected_objectives)
 
-            assertDriverIterationDataRecorded(self,
-                ((coordinate, (t0, t1), expected_outputs, None),), self.eps)
+            expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
+            assertDriverIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -256,8 +256,9 @@ class DistributedRecorderTest(unittest.TestCase):
             expected_outputs.update(expected_includes)
 
             coordinate = [0, 'SLSQP', (48,)]
-            assertDriverIterationDataRecorded(self,
-                ((coordinate, (t0, t1), expected_outputs, None),), self.eps)
+
+            expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
+            assertDriverIterationDataRecorded(self, expected_data, self.eps)
 
 
 if __name__ == "__main__":

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -100,9 +100,8 @@ class Mygroup(Group):
         self.add_constraint('c', lower=-3.)
 
 
-@unittest.skipIf(PETScVector is None or os.environ.get("TRAVIS"),
-                 "PETSc is required." if PETScVector is None
-                 else "Unreliable on Travis CI.")
+@unittest.skipIf(PETScVector is None, "PETSc is required.")
+# @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
 class DistributedRecorderTest(unittest.TestCase):
 
     N_PROCS = 2
@@ -143,7 +142,6 @@ class DistributedRecorderTest(unittest.TestCase):
             self.fail('RuntimeError expected.')
 
     def test_distrib_record_driver(self):
-
         size = 100  # how many items in the array
         prob = Problem()
         prob.model = Group()

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -27,6 +27,7 @@ from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.recorders.tests.sqlite_recorder_test_utils import assertDriverIterationDataRecorded
 from openmdao.recorders.tests.recorder_test_utils import run_driver
 
+
 class DistributedAdder(ExplicitComponent):
     """
     Distributes the work of adding 10 to every item in the param vector
@@ -120,12 +121,6 @@ class DistributedRecorderTest(unittest.TestCase):
             if e.errno not in (errno.ENOENT, errno.EACCES, errno.EPERM):
                 raise e
 
-    def assertDriverIterationDataRecorded(self, expected, tolerance):
-        con = sqlite3.connect(self.filename)
-        cur = con.cursor()
-        assertDriverIterationDataRecorded(self, cur, expected, tolerance)
-        con.close()
-
     def test_distrib_record_system(self):
         prob = Problem()
         prob.model = Group()
@@ -187,11 +182,11 @@ class DistributedRecorderTest(unittest.TestCase):
             expected_outputs = expected_desvars
             expected_outputs.update(expected_objectives)
 
-            self.assertDriverIterationDataRecorded(((coordinate, (t0, t1), expected_outputs,
-                                                     None),), self.eps)
+            assertDriverIterationDataRecorded(self,
+                ((coordinate, (t0, t1), expected_outputs, None),), self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed" )
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP" )
+    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
+    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_recording_remote_voi(self):
         prob = Problem()
 
@@ -261,7 +256,8 @@ class DistributedRecorderTest(unittest.TestCase):
             expected_outputs.update(expected_includes)
 
             coordinate = [0, 'SLSQP', (48,)]
-            self.assertDriverIterationDataRecorded(((coordinate, (t0, t1), expected_outputs, None),), self.eps)
+            assertDriverIterationDataRecorded(self,
+                ((coordinate, (t0, t1), expected_outputs, None),), self.eps)
 
 
 if __name__ == "__main__":

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -789,26 +789,14 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.assertEqual(iter_count_before, iter_count_after + 1)
 
     def test_load_solver_cases(self):
-        prob = Problem()
+        prob = SellarProblem()
+        prob.setup()
+
         model = prob.model
-
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
-        model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
-        model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
-                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
-
-        model.linear_solver = LinearBlockGS()
         model.nonlinear_solver = NewtonSolver()
+        model.linear_solver = LinearBlockGS()
         model.linear_solver.add_recorder(self.recorder)
 
-        prob.set_solver_print(0)
-
-        prob.setup()
         prob.run_model()
         prob.cleanup()
 
@@ -816,11 +804,11 @@ class TestSqliteCaseReader(unittest.TestCase):
         case = cr.solver_cases.get_case(0)
 
         # Add one to all the inputs just to change the model
-        #   so we can see if loading the case values really changes the model
+        # so we can see if loading the case values really changes the model
         for name in prob.model._inputs:
-            prob.model._inputs[name] += 1.0
+            model._inputs[name] += 1.0
         for name in prob.model._outputs:
-            prob.model._outputs[name] += 1.0
+            model._outputs[name] += 1.0
 
         # Now load in the case we recorded
         prob.load_case(case)

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -118,7 +118,7 @@ class TestSqliteCaseReader(unittest.TestCase):
                                        decimal=2,
                                        err_msg='Case reader gives '
                                        'incorrect Parameter value'
-                                               ' for {0}'.format('pz.z'))
+                                       ' for {0}'.format('pz.z'))
 
         # Test values from one case, the last case
         last_case = cr.driver_cases.get_case(-1)

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -102,7 +102,7 @@ class TestSqliteCaseReader(unittest.TestCase):
     def test_format_version(self):
         prob = SellarProblem()
         prob.model.add_recorder(self.recorder)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -114,7 +114,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         """ Test that CaseReader returns an SqliteCaseReader. """
         prob = SellarProblem()
         prob.model.add_recorder(self.recorder)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -137,7 +137,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver.recording_options['record_constraints'] = True
         driver.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -185,7 +185,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         prob.model.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.model.d1.add_recorder(self.recorder)  # SellarDis1withDerivatives (an ExplicitComp)
         prob.model.obj_cmp.add_recorder(self.recorder)  # an ExecComp
@@ -226,7 +226,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_reading_solver_cases(self):
         prob = SellarProblem()
-        prob.setup(check=False)
+        prob.setup()
 
         solver = prob.model.nonlinear_solver
         solver.add_recorder(self.recorder)
@@ -269,7 +269,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.setup_sellar_model_with_units()
         self.prob.driver.add_recorder(self.recorder)
 
-        self.prob.setup(check=False)
+        self.prob.setup()
         self.prob.run_driver()
         self.prob.cleanup()
 
@@ -292,7 +292,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_reading_solver_metadata(self):
         prob = SellarProblem(linear_solver=LinearBlockGS())
-        prob.setup(check=False)
+        prob.setup()
 
         prob.model.nonlinear_solver.add_recorder(self.recorder)
         prob.model.linear_solver.add_recorder(self.recorder)
@@ -329,7 +329,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver.recording_options['includes'] = ['mda.d2.y2',]
         driver.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -364,7 +364,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver.recording_options['record_constraints'] = True
         driver.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
 
         model = prob.model
         model.add_recorder(self.recorder)
@@ -429,7 +429,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         model.add_recorder(self.recorder)
         model.nonlinear_solver.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -455,7 +455,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.model.add_recorder(self.recorder)
         prob.model.recording_options['record_residuals'] = True
 
-        prob.setup(check=False)
+        prob.setup()
 
         d1 = prob.model.d1  # SellarDis1withDerivatives (an ExplicitComp)
         d1.nonlinear_solver = NonlinearBlockGS(maxiter=5)
@@ -527,7 +527,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.model.add_recorder(self.recorder)
         prob.model.recording_options['record_residuals'] = True
 
-        prob.setup(check=False)
+        prob.setup()
 
         d1 = prob.model.d1  # SellarDis1withDerivatives (an ExplicitComp)
         d1.nonlinear_solver = NonlinearBlockGS(maxiter=5)
@@ -578,7 +578,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_get_vars(self):
         prob = SellarProblem()
-        prob.setup(check=False)
+        prob.setup()
 
         prob.model.add_recorder(self.recorder)
         prob.model.recording_options['record_residuals'] = True
@@ -620,7 +620,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         model.recording_options['record_residuals'] = True
         model.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_driver()
         prob.cleanup()
@@ -654,7 +654,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -663,7 +663,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # try to load it into a completely different model
         prob = SellarProblem()
-        prob.setup(check=False)
+        prob.setup()
 
         error_msg = "Input variable, '[^']+', recorded in the case is not found in the model"
         with assertRaisesRegex(self, KeyError, error_msg):
@@ -671,7 +671,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_subsystem_load_system_cases(self):
         prob = SellarProblem()
-        prob.setup(check=False)
+        prob.setup()
 
         model = prob.model
         model.recording_options['record_inputs'] = True
@@ -722,7 +722,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         case = cr.system_cases.get_case(0)
 
         # Add one to all the inputs just to change the model
-        #   so we can see if loading the case values really changes the model
+        # so we can see if loading the case values really changes the model
         for name in model._inputs:
             model._inputs[name] += 1.0
         for name in model._outputs:
@@ -747,7 +747,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 
@@ -768,7 +768,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver.options['tol'] = 1e-9
         driver.options['disp'] = False
 
-        prob.setup(check=False)
+        prob.setup()
         prob.load_case(third_case)
         prob.run_driver()
         prob.cleanup()
@@ -847,7 +847,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         prob.driver.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         prob.cleanup()
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -37,12 +37,14 @@ class SellarProblem(Problem):
     def __init__(self, model_class=SellarDerivatives, **kwargs):
         super(SellarProblem, self).__init__(model_class(**kwargs))
 
-        self.model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
-        self.model.add_design_var('x', lower=0.0, upper=10.0)
-        self.model.add_objective('obj')
-        self.model.add_constraint('con1', upper=0.0)
-        self.model.add_constraint('con2', upper=0.0)
+        model = self.model
+        model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
+        model.add_design_var('x', lower=0.0, upper=10.0)
+        model.add_objective('obj')
+        model.add_constraint('con1', upper=0.0)
+        model.add_constraint('con2', upper=0.0)
 
+        self.set_solver_print(0)
 
 class TestSqliteCaseReader(unittest.TestCase):
 
@@ -804,6 +806,8 @@ class TestSqliteCaseReader(unittest.TestCase):
         model.nonlinear_solver = NewtonSolver()
         model.linear_solver.add_recorder(self.recorder)
 
+        prob.set_solver_print(0)
+
         prob.setup()
         prob.run_model()
         prob.cleanup()
@@ -846,6 +850,8 @@ class TestSqliteCaseReader(unittest.TestCase):
         model.add_constraint('c', lower=15.0)
 
         prob.driver.add_recorder(self.recorder)
+
+        prob.set_solver_print(0)
 
         prob.setup()
         prob.run_driver()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -51,17 +51,17 @@ class TestSqliteCaseReader(unittest.TestCase):
     def setUp(self):
         recording_iteration.stack = []  # reset to avoid problems from earlier tests
 
-        self.original_path = os.getcwd()
-        self.dir = mkdtemp()
-        os.chdir(self.dir)
+        self.orig_dir = os.getcwd()
+        self.temp_dir = mkdtemp()
+        os.chdir(self.temp_dir)
 
-        self.filename = os.path.join(self.dir, "sqlite_test")
+        self.filename = os.path.join(self.temp_dir, "sqlite_test")
         self.recorder = SqliteRecorder(self.filename)
 
     def tearDown(self):
-        os.chdir(self.original_path)
+        os.chdir(self.orig_dir)
         try:
-            rmtree(self.dir)
+            rmtree(self.temp_dir)
         except OSError as e:
             # If directory already deleted, keep going
             if e.errno not in (errno.ENOENT, errno.EACCES, errno.EPERM):
@@ -155,18 +155,19 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_reading_system_cases(self):
         prob = SellarProblem()
+        model = prob.model
 
-        prob.model.recording_options['record_inputs'] = True
-        prob.model.recording_options['record_outputs'] = True
-        prob.model.recording_options['record_residuals'] = True
-        prob.model.recording_options['record_metadata'] = False
+        model.recording_options['record_inputs'] = True
+        model.recording_options['record_outputs'] = True
+        model.recording_options['record_residuals'] = True
+        model.recording_options['record_metadata'] = False
 
-        prob.model.add_recorder(self.recorder)
+        model.add_recorder(self.recorder)
 
         prob.setup()
 
-        prob.model.d1.add_recorder(self.recorder)  # SellarDis1withDerivatives (an ExplicitComp)
-        prob.model.obj_cmp.add_recorder(self.recorder)  # an ExecComp
+        model.d1.add_recorder(self.recorder)  # SellarDis1withDerivatives (an ExplicitComp)
+        model.obj_cmp.add_recorder(self.recorder)  # an ExecComp
 
         prob.run_driver()
         prob.cleanup()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -846,40 +846,6 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         _assert_model_matches_case(case, model)
 
-    def test_driver_case_prefix(self):
-        prob = Problem()
-        model = prob.model
-
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
-        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
-
-        prob.set_solver_print(level=0)
-
-        prob.driver = ScipyOptimizeDriver()
-        prob.driver.options['optimizer'] = 'SLSQP'
-        prob.driver.options['tol'] = 1e-9
-        prob.driver.options['disp'] = False
-
-        model.add_design_var('x', lower=-50.0, upper=50.0)
-        model.add_design_var('y', lower=-50.0, upper=50.0)
-
-        model.add_objective('f_xy')
-        model.add_constraint('c', lower=15.0)
-
-        prob.driver.add_recorder(self.recorder)
-
-        prob.set_solver_print(0)
-
-        prob.setup()
-        prob.run_driver()
-        prob.run_driver(case_prefix='Run2')
-        prob.cleanup()
-
-        cr = CaseReader(self.filename)
-        print(cr.driver_cases.list_cases())
-
     def test_system_options_pickle_fail(self):
         # simple paraboloid model
         model = Group()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -20,7 +20,7 @@ from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.core.tests.test_units import SpeedComp
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDerivativesGrouped, \
-    SellarDis1withDerivatives, SellarDis2withDerivatives
+    SellarDis1withDerivatives, SellarDis2withDerivatives, SellarProblem
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 
@@ -29,22 +29,6 @@ OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
-
-class SellarProblem(Problem):
-    """
-    The Sellar problem with configurable model class.
-    """
-    def __init__(self, model_class=SellarDerivatives, **kwargs):
-        super(SellarProblem, self).__init__(model_class(**kwargs))
-
-        model = self.model
-        model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
-        model.add_design_var('x', lower=0.0, upper=10.0)
-        model.add_objective('obj')
-        model.add_constraint('con1', upper=0.0)
-        model.add_constraint('con2', upper=0.0)
-
-        self.set_solver_print(0)
 
 class TestSqliteCaseReader(unittest.TestCase):
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -398,6 +398,9 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.cleanup()
 
+        #
+        # check data from 'd1'
+        #
         coordinate = [0, 'Driver', (0, ), 'root._solve_nonlinear', (0, ),
                       'NonlinearBlockGS', (6, ), 'd1._solve_nonlinear', (6, )]
         expected_inputs = {
@@ -411,6 +414,9 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
         assertSystemIterationDataRecorded(self, expected_data, self.eps)
 
+        #
+        # check data from 'obj_cmp'
+        #
         coordinate = [0, 'Driver', (0, ), 'root._solve_nonlinear', (0, ),
                       'NonlinearBlockGS', (6, ), 'obj_cmp._solve_nonlinear', (6, )]
         expected_inputs = {
@@ -421,8 +427,9 @@ class TestSqliteRecorder(unittest.TestCase):
         }
         expected_outputs = {"obj_cmp.obj": [28.58830816, ], }
         expected_residuals = {"obj_cmp.obj": [0.0, ], }
-        assertSystemIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),), self.eps)
+
+        expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
+        assertSystemIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -478,8 +485,8 @@ class TestSqliteRecorder(unittest.TestCase):
             "con.y": -7.8333333
         }
 
-        assertDriverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_outputs, expected_inputs), ), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_outputs, expected_inputs),)
+        assertDriverIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -534,8 +541,8 @@ class TestSqliteRecorder(unittest.TestCase):
             "con.y": -7.8333333
         }
 
-        assertDriverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_outputs, expected_inputs),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_outputs, expected_inputs),)
+        assertDriverIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -573,9 +580,11 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.cleanup()
 
+        #
+        # check data for 'd1'
+        #
         coordinate = [0, 'SLSQP', (0, ), 'root._solve_nonlinear', (0, ), 'NLRunOnce', (0, ),
                       'mda._solve_nonlinear', (0, ), 'NonlinearBlockGS', (4,), 'mda.d1._solve_nonlinear', (4, )]
-        # Coord: rank0:SLSQP | 0 | NLRunOnce | 0 | NonlinearBlockGS | 4 | mda.d1._solve_nonlinear | 4
 
         expected_inputs = {
             "mda.d1.z": [5.0, 2.0],
@@ -585,17 +594,21 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_outputs = {"mda.d1.y1": [25.5883027, ], }
         expected_residuals = {"mda.d1.y1": [0.0, ], }
 
-        assertSystemIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
+        assertSystemIterationDataRecorded(self, expected_data, self.eps)
 
+        #
+        # check data for 'pz'
+        #
         coordinate = [0, 'SLSQP', (1, ), 'root._solve_nonlinear', (1, ), 'NLRunOnce', (0, ),
                       'pz._solve_nonlinear', (1, )]
 
         expected_inputs = None
         expected_outputs = {"pz.z": [2.8640616, 0.825643, ], }
         expected_residuals = {"pz.z": [0.0, 0.0], }
-        assertSystemIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals), ), self.eps)
+
+        expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
+        assertSystemIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver(self):
         prob = SellarProblem()
@@ -636,9 +649,9 @@ class TestSqliteRecorder(unittest.TestCase):
             "px.x": [0.0]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error, expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_line_search_armijo_goldstein(self):
         prob = SellarProblem()
@@ -672,11 +685,9 @@ class TestSqliteRecorder(unittest.TestCase):
             "px.x": [1.0]
         }
         expected_solver_residuals = None
-
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_line_search_bounds_enforce(self):
         prob = SellarProblem()
@@ -748,10 +759,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [0.]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-            expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_nonlinear_block_jac(self):
         prob = SellarProblem(linear_solver=LinearBlockGS, nonlinear_solver=NonlinearBlockJac)
@@ -778,10 +788,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [-11.94151185]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_nonlinear_newton(self):
         prob = SellarProblem(linear_solver=LinearBlockGS, nonlinear_solver=NewtonSolver)
@@ -807,10 +816,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [-11.94151185]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_nonlinear_nonlinear_run_once(self):
         prob = SellarProblem()
@@ -840,10 +848,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [-11.72742947]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_linear_direct_solver(self):
         prob = SellarProblem()
@@ -885,10 +892,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [-0.]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self,expected_data, self.eps)
 
     def test_record_solver_linear_scipy_iterative_solver(self):
         prob = SellarProblem()
@@ -928,10 +934,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [0.41167877]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(PETScVector is None, "PETSc is required.")
     @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
@@ -972,10 +977,10 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp1.con1': [0.77049654],
             'con_cmp2.con2': [0.41167877]
         }
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_linear_block_gs(self):
         prob = SellarProblem()
@@ -1015,10 +1020,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [0.]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_linear_linear_run_once(self):
         prob = SellarProblem()
@@ -1058,10 +1062,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [-4.10568454e-06]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_linear_block_jac(self):
         prob = SellarProblem()
@@ -1101,10 +1104,9 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2.con2': [1.42027975e-15]
         }
 
-        assertSolverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_abs_error,
-             expected_rel_error, expected_solver_output,
-             expected_solver_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -1292,8 +1294,9 @@ class TestSqliteRecorder(unittest.TestCase):
         }
         expected_outputs = {"comp2.x": [3.0, ], }
         expected_residuals = {"comp2.x": [0.0, ], }
-        assertSystemIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),), self.eps)
+
+        expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
+        assertSystemIterationDataRecorded(self, expected_data, self.eps)
 
     def test_multidimensional_arrays(self):
         # component TestExplCompArray, put in a model and run it; its outputs are multi-d-arrays.
@@ -1332,8 +1335,8 @@ class TestSqliteRecorder(unittest.TestCase):
             'areas': [[0., 0.], [0., 0.]],
         }
 
-        assertSystemIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
+        assertSystemIterationDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
     @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
@@ -1427,8 +1430,8 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_outputs.update(expected_constraints)
         expected_outputs.update(expected_sysincludes)
 
-        assertDriverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_outputs, None),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
+        assertDriverIterationDataRecorded(self, expected_data, self.eps)
 
     def test_recorder_file_already_exists_no_append(self):
         prob = SellarProblem()
@@ -1468,8 +1471,8 @@ class TestSqliteRecorder(unittest.TestCase):
 
         expected_outputs = {"px.x": [1.0, ], "pz.z": [5.0, 2.0]}
 
-        assertDriverIterationDataRecorded(self,
-            ((coordinate, (t0, t1), expected_outputs, None),), self.eps)
+        expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
+        assertDriverIterationDataRecorded(self, expected_data, self.eps)
 
 
 class TestFeatureSqliteRecorder(unittest.TestCase):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -174,6 +174,7 @@ class TestSqliteRecorder(unittest.TestCase):
         model.add_constraint('c', upper=-15.0)
 
         driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
+        driver.options['print_results'] = False
         driver.opt_settings['ACC'] = 1e-9
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_responses'] = True
@@ -184,7 +185,6 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'SLSQP', (3, )]
@@ -224,6 +224,7 @@ class TestSqliteRecorder(unittest.TestCase):
         model.add_constraint('c', upper=-15.0)
 
         driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
+        driver.options['print_results'] = False
         driver.opt_settings['ACC'] = 1e-9
         driver.add_recorder(self.recorder)
 
@@ -261,10 +262,7 @@ class TestSqliteRecorder(unittest.TestCase):
         driver.add_recorder(self.recorder)
 
         prob.setup()
-
-        # Conclude setup but don't run model.
-        prob.final_setup()
-
+        prob.final_setup()  # Conclude setup but don't run model.
         prob.cleanup()
 
         prom2abs = {
@@ -325,7 +323,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.driver.add_recorder(self.recorder)
 
         prob.setup()
-        prob.final_setup()
+        prob.final_setup()  # Conclude setup but don't run model.
         prob.cleanup()
 
         assertDriverMetadataRecorded(self, None, True)
@@ -337,7 +335,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.driver.add_recorder(self.recorder)
 
         prob.setup()
-        prob.final_setup()
+        prob.final_setup()  # Conclude setup but don't run model.
         prob.cleanup()
 
         assertDriverMetadataRecorded(self, None)
@@ -709,8 +707,8 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.model.nonlinear_solver.add_recorder(self.recorder)
         prob.model.nonlinear_solver.recording_options['record_solver_residuals'] = True
 
+        prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NonlinearBlockGS', (6, )]
@@ -747,8 +745,8 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.model.nonlinear_solver.add_recorder(self.recorder)
 
+        prob.set_solver_print(-1)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NonlinearBlockJac', (9,)]
@@ -778,8 +776,8 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.model.nonlinear_solver.add_recorder(self.recorder)
 
+        prob.set_solver_print(-1)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NewtonSolver', (2,)]
@@ -809,8 +807,8 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.model.nonlinear_solver.add_recorder(self.recorder)
 
+        prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         # No norms so no expected norms
@@ -847,8 +845,8 @@ class TestSqliteRecorder(unittest.TestCase):
         ln.recording_options['record_solver_residuals'] = True
         ln.add_recorder(self.recorder)
 
+        prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         # No norms so no expected norms
@@ -893,8 +891,8 @@ class TestSqliteRecorder(unittest.TestCase):
         ln.recording_options['record_solver_residuals'] = True
         ln.add_recorder(self.recorder)
 
+        prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NewtonSolver', (2,), 'ScipyKrylov', (1,)]
@@ -985,8 +983,8 @@ class TestSqliteRecorder(unittest.TestCase):
         ln.recording_options['record_solver_residuals'] = True
         ln.add_recorder(self.recorder)
 
+        prob.set_solver_print(-1)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NewtonSolver', (2,), 'LinearBlockGS', (6,)]
@@ -1030,8 +1028,8 @@ class TestSqliteRecorder(unittest.TestCase):
         ln.recording_options['record_solver_residuals'] = True
         ln.add_recorder(self.recorder)
 
+        prob.set_solver_print(-1)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NewtonSolver', (9,), 'LinearRunOnce', (0,)]
@@ -1075,8 +1073,8 @@ class TestSqliteRecorder(unittest.TestCase):
         ln.recording_options['record_solver_residuals'] = True
         ln.add_recorder(self.recorder)
 
+        prob.set_solver_print(-1)
         t0, t1 = run_driver(prob)
-
         prob.cleanup()
 
         coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'NewtonSolver', (3,), 'LinearBlockJac', (9,)]
@@ -1261,8 +1259,13 @@ class TestSqliteRecorder(unittest.TestCase):
     def test_implicit_component(self):
         from openmdao.core.tests.test_impl_comp import QuadraticLinearize, QuadraticJacVec
 
+        indeps = IndepVarComp()
+        indeps.add_output('a', 1.0)
+        indeps.add_output('b', 1.0)
+        indeps.add_output('c', 1.0)
+
         group = Group()
-        group.add_subsystem('comp1', IndepVarComp([('a', 1.0), ('b', 1.0), ('c', 1.0)]))
+        group.add_subsystem('comp1', indeps)
         group.add_subsystem('comp2', QuadraticLinearize())
         group.add_subsystem('comp3', QuadraticJacVec())
         group.connect('comp1.a', 'comp2.a')
@@ -1961,7 +1964,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         from openmdao.api import Problem, ScipyOptimizeDriver, CaseReader
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model = SellarDerivatives())
+        prob = Problem(model=SellarDerivatives())
         model = prob.model
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                                   upper=np.array([10.0, 10.0]))

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -990,7 +990,7 @@ class TestSqliteRecorder(unittest.TestCase):
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
     @unittest.skipIf(PETScVector is None, "PETSc is required.")
-    @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
+    # @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
     def test_record_solver_linear_petsc_ksp(self):
         prob = SellarProblem()
         prob.setup()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -20,7 +20,7 @@ from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import create_local_meta, check_path
-from openmdao.recorders.recording_iteration_stack import get_formatted_iteration_coordinate
+from openmdao.recorders.recording_iteration_stack import recording_iteration
 
 
 class SolverInfo(object):
@@ -626,7 +626,7 @@ class NonlinearSolver(Solver):
         fail, abs_err, rel_err = self._run_iterator()
 
         if fail and self.options['debug_print']:
-            coord = get_formatted_iteration_coordinate()
+            coord = recording_iteration.get_formatted_iteration_coordinate()
 
             out_str = "\n# Inputs and outputs at start of iteration '%s':\n" % coord
             for vec_type, vec in iteritems(self._err_cache):

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -17,6 +17,7 @@ from openmdao.core.indepvarcomp import IndepVarComp
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.core.group import Group
+from openmdao.core.problem import Problem
 from openmdao.solvers.nonlinear.nonlinear_block_gs import NonlinearBlockGS
 from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov
 from openmdao.solvers.nonlinear.newton import NewtonSolver
@@ -583,3 +584,21 @@ class SellarImplicitDis2(ImplicitComponent):
         J['y2', 'y1'] = -.5*y1**-.5
         J['y2', 'z'] = -np.array([[1.0, 1.0]])
         J['y2', 'y2'] = 1.0
+
+
+class SellarProblem(Problem):
+    """
+    The Sellar problem with configurable model class.
+    """
+    def __init__(self, model_class=SellarDerivatives, **kwargs):
+        super(SellarProblem, self).__init__(model_class(**kwargs))
+
+        model = self.model
+        model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
+        model.add_design_var('x', lower=0.0, upper=10.0)
+        model.add_objective('obj')
+        model.add_constraint('con1', upper=0.0)
+        model.add_constraint('con2', upper=0.0)
+
+        # default to non-verbose
+        self.set_solver_print(0)

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -10,6 +10,8 @@ From Sellar's analytic problem.
 
 import numpy as np
 
+import inspect
+
 from openmdao.components.exec_comp import ExecComp
 from openmdao.core.indepvarcomp import IndepVarComp
 from openmdao.core.explicitcomponent import ExplicitComponent
@@ -230,14 +232,14 @@ class SellarDerivatives(Group):
     """
 
     def initialize(self):
-        self.options.declare('nonlinear_solver', default=NonlinearBlockGS(),
-                             desc='Nonlinear solver for Sellar MDA')
+        self.options.declare('nonlinear_solver', default=NonlinearBlockGS,
+                             desc='Nonlinear solver (class or instance) for Sellar MDA')
         self.options.declare('nl_atol', default=None,
                              desc='User-specified atol for nonlinear solver.')
         self.options.declare('nl_maxiter', default=None,
                              desc='Iteration limit for nonlinear solver.')
-        self.options.declare('linear_solver', default=ScipyKrylov(),
-                             desc='Linear solver')
+        self.options.declare('linear_solver', default=ScipyKrylov,
+                             desc='Linear solver (class or instance)')
         self.options.declare('ln_atol', default=None,
                              desc='User-specified atol for linear solver.')
         self.options.declare('ln_maxiter', default=None,
@@ -257,13 +259,15 @@ class SellarDerivatives(Group):
         self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        self.nonlinear_solver = self.options['nonlinear_solver']
+        nl = self.options['nonlinear_solver']
+        self.nonlinear_solver = nl() if inspect.isclass(nl) else nl
         if self.options['nl_atol']:
             self.nonlinear_solver.options['atol'] = self.options['nl_atol']
         if self.options['nl_maxiter']:
             self.nonlinear_solver.options['maxiter'] = self.options['nl_maxiter']
 
-        self.linear_solver = self.options['linear_solver']
+        ln = self.options['linear_solver']
+        self.linear_solver = ln() if inspect.isclass(ln) else ln
         if self.options['ln_atol']:
             self.linear_solver.options['atol'] = self.options['ln_atol']
         if self.options['ln_maxiter']:
@@ -303,14 +307,14 @@ class SellarDerivativesGrouped(Group):
     """
 
     def initialize(self):
-        self.options.declare('nonlinear_solver', default=NonlinearBlockGS(),
-                             desc='Nonlinear solver for Sellar MDA')
+        self.options.declare('nonlinear_solver', default=NonlinearBlockGS,
+                             desc='Nonlinear solver (class or instance) for Sellar MDA')
         self.options.declare('nl_atol', default=None,
                              desc='User-specified atol for nonlinear solver.')
         self.options.declare('nl_maxiter', default=None,
                              desc='Iteration limit for nonlinear solver.')
-        self.options.declare('linear_solver', default=ScipyKrylov(),
-                             desc='Linear solver')
+        self.options.declare('linear_solver', default=ScipyKrylov,
+                             desc='Linear solver (class or instance)')
         self.options.declare('ln_atol', default=None,
                              desc='User-specified atol for linear solver.')
         self.options.declare('ln_maxiter', default=None,
@@ -331,15 +335,15 @@ class SellarDerivativesGrouped(Group):
         self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        self.linear_solver = ScipyKrylov()
-
-        self.nonlinear_solver = self.options['nonlinear_solver']
+        nl = self.options['nonlinear_solver']
+        self.nonlinear_solver = nl() if inspect.isclass(nl) else nl
         if self.options['nl_atol']:
             self.nonlinear_solver.options['atol'] = self.options['nl_atol']
         if self.options['nl_maxiter']:
             self.nonlinear_solver.options['maxiter'] = self.options['nl_maxiter']
 
-        self.linear_solver = self.options['linear_solver']
+        ln = self.options['linear_solver']
+        self.linear_solver = ln() if inspect.isclass(ln) else ln
         if self.options['ln_atol']:
             self.linear_solver.options['atol'] = self.options['ln_atol']
         if self.options['ln_maxiter']:
@@ -396,14 +400,14 @@ class SellarStateConnection(Group):
     """
 
     def initialize(self):
-        self.options.declare('nonlinear_solver', default=NewtonSolver(),
-                             desc='Nonlinear solver for Sellar MDA')
+        self.options.declare('nonlinear_solver', default=NewtonSolver,
+                             desc='Nonlinear solver (class or instance) for Sellar MDA')
         self.options.declare('nl_atol', default=None,
                              desc='User-specified atol for nonlinear solver.')
         self.options.declare('nl_maxiter', default=None,
                              desc='Iteration limit for nonlinear solver.')
-        self.options.declare('linear_solver', default=ScipyKrylov(),
-                             desc='Linear solver')
+        self.options.declare('linear_solver', default=ScipyKrylov,
+                             desc='Linear solver (class or instance)')
         self.options.declare('ln_atol', default=None,
                              desc='User-specified atol for linear solver.')
         self.options.declare('ln_maxiter', default=None,
@@ -433,13 +437,15 @@ class SellarStateConnection(Group):
         self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
         self.connect('d2.y2', 'con_cmp2.y2')
 
-        self.nonlinear_solver = self.options['nonlinear_solver']
+        nl = self.options['nonlinear_solver']
+        self.nonlinear_solver = nl() if inspect.isclass(nl) else nl
         if self.options['nl_atol']:
             self.nonlinear_solver.options['atol'] = self.options['nl_atol']
         if self.options['nl_maxiter']:
             self.nonlinear_solver.options['maxiter'] = self.options['nl_maxiter']
 
-        self.linear_solver = self.options['linear_solver']
+        ln = self.options['linear_solver']
+        self.linear_solver = ln() if inspect.isclass(ln) else ln
         if self.options['ln_atol']:
             self.linear_solver.options['atol'] = self.options['ln_atol']
         if self.options['ln_maxiter']:

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -33,7 +33,7 @@ def create_local_meta(name):
     return local_meta
 
 
-def format_iteration_coordinate(coord):
+def format_iteration_coordinate(coord, prefix=None):
     """
     Format the iteration coordinate to a human-readable string.
 
@@ -41,6 +41,9 @@ def format_iteration_coordinate(coord):
     ----------
     coord : list
         List containing the iteration coordinate.
+
+    prefix : str or None
+        Prefix to prepend to iteration coordinates.
 
     Returns
     -------
@@ -58,7 +61,12 @@ def format_iteration_coordinate(coord):
         coord_str = iteration_number_separator.join(iter_str)
         iteration_coordinate.append(coord_str)
 
-    return ':'.join(["rank%d" % coord[0], separator.join(iteration_coordinate)])
+    if prefix:
+        prefix = "%s_rank%d" % (prefix, coord[0])
+    else:
+        prefix = "rank%d" % (coord[0])
+
+    return ':'.join([prefix, separator.join(iteration_coordinate)])
 
 
 def is_valid_sqlite3_db(filename):


### PR DESCRIPTION
Pivotal #149861856: User can give a case-prefix when the call run_model or run_driver...
Pivotal #157897525: embed-options should not include the 'keyword args' note in some instances

- added option to reset iteration counters when re-running model (default is True)
- changed embed-options to not display kwargs note for `recording_options`
- changed `add_recorder` on System to not recurse on its direct descendants unless recurse is True
- changed record_iteration related functions into methods since they use attributes of the instance
- changed sqlite recorder methods to use context cursor for database connections
- cleaned up some redundant/duplicative code in tests, use common Sellar model from test_suite
- cleaned up some lint warnings in tests
- re-enabled some tests that were noted to be unreliable on Travis (seem to be working fine... we'll see)
