### PR TITLE
Fix one more usage of nose_parameterized

### DIFF
--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -25,7 +25,7 @@ from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.general_utils import run_model
 from openmdao.utils.general_utils import printoptions
 
-from nose_parameterized import parameterized
+from parameterized import parameterized
 
 
 nonlinear_solvers = [


### PR DESCRIPTION
`nose_parameterized` has been replaced with `parameterized`.  This has been fixed everywhere else.