### PR TITLE
DirectSolver detects nans and returns var location.

### DIFF
--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -72,7 +72,6 @@ class MyCompGoodPartials(ExplicitComponent):
         self.declare_partials(of='*', wrt='*')
 
     def compute(self, inputs, outputs):
-        """ Doesn't do much. """
         outputs['y'] = 3.0 * inputs['x1'] + 4.0 * inputs['x2']
 
     def compute_partials(self, inputs, partials):
@@ -90,7 +89,6 @@ class MyCompBadPartials(ExplicitComponent):
         self.declare_partials(of='*', wrt='*')
 
     def compute(self, inputs, outputs):
-        """ Doesn't do much. """
         outputs['z'] = 3.0 * inputs['y1'] + 4.0 * inputs['y2']
 
     def compute_partials(self, inputs, partials):
@@ -110,7 +108,6 @@ class MyComp(ExplicitComponent):
         self.declare_partials(of='*', wrt='*')
 
     def compute(self, inputs, outputs):
-        """ Doesn't do much. """
         outputs['y'] = 3.0*inputs['x1'] + 4.0*inputs['x2']
 
     def compute_partials(self, inputs, partials):
@@ -208,7 +205,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0*inputs['x1'] + 4.0*inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -893,7 +889,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0*inputs['x1'] + 4.0*inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -910,7 +905,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['really_long_variable_name_y'] = 3.0*inputs['really_long_variable_name_x1'] + 4.0*inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -1034,7 +1028,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['z'] = 3.0 * inputs['x1'] + -4444.0 * inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -1260,7 +1253,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0*inputs['x1'] + 4.0*inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -1311,7 +1303,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0*inputs['x1'] + 4.0*inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -1572,7 +1563,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0 * inputs['x1'] + 4.0 * inputs['x2']
 
             def compute_partials(self, inputs, partials):
@@ -1589,7 +1579,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['z'] = 3.0 * inputs['y1'] + 4.0 * inputs['y2']
 
             def compute_partials(self, inputs, partials):

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -784,7 +784,6 @@ class TestUnitConversion(unittest.TestCase):
                 #self.dx2count = 0
 
             #def solve_nonlinear(self, inputs, outputs, resids):
-                #""" Doesn't do much. """
                 #x1 = inputs['x1']
                 #x2 = inputs['x2']
                 #outputs['y'] = 1.01*(x1 + x2)

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -19,7 +19,7 @@ from openmdao.matrices.dense_matrix import DenseMatrix
 from openmdao.recorders.recording_iteration_stack import Recording
 
 
-def format_singluar_error(err, system, mtx):
+def format_singular_error(err, system, mtx):
     """
     Format a coherent error message when the matrix is singular.
 
@@ -68,7 +68,7 @@ def format_singluar_error(err, system, mtx):
     return msg.format(system.pathname, loc_txt, varname)
 
 
-def format_singluar_csc_error(system, matrix):
+def format_singular_csc_error(system, matrix):
     """
     Format a coherent error message when the CSC matrix is singular.
 
@@ -192,7 +192,7 @@ class DirectSolver(LinearSolver):
                         self._lup = scipy.linalg.lu_factor(matrix)
 
                     except RuntimeWarning as err:
-                        raise RuntimeError(format_singluar_error(err, system, matrix))
+                        raise RuntimeError(format_singular_error(err, system, matrix))
 
                     # NaN in matrix.
                     except ValueError as err:
@@ -208,7 +208,7 @@ class DirectSolver(LinearSolver):
                     self._lu = scipy.sparse.linalg.splu(matrix)
                 except RuntimeError as err:
                     if 'exactly singular' in str(err):
-                        raise RuntimeError(format_singluar_csc_error(system, matrix))
+                        raise RuntimeError(format_singular_csc_error(system, matrix))
                     else:
                         reraise(*sys.exc_info())
 
@@ -247,7 +247,7 @@ class DirectSolver(LinearSolver):
                     self._lup = scipy.linalg.lu_factor(mtx)
 
                 except RuntimeWarning as err:
-                    raise RuntimeError(format_singluar_error(err, system, mtx))
+                    raise RuntimeError(format_singular_error(err, system, mtx))
 
                 # NaN in matrix.
                 except ValueError as err:

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -58,9 +58,10 @@ def format_singluar_error(err, system, mtx):
     n = 0
     varname = "Unknown"
     for name in system._var_allprocs_abs_names['output']:
-        n += len(system._outputs._views_flat[name])
+        relname = system._var_abs2prom['output'][name]
+        n += len(system._outputs[relname])
         if loc <= n:
-            varname = name
+            varname = relname
             break
 
     msg = "Singular entry found in '{}' for {} associated with state/residual '{}'."
@@ -134,9 +135,10 @@ def format_nan_error(system, matrix):
     for row in rows:
         n = 0
         for name in all_vars:
-            n += len(system._outputs._views_flat[name])
+            relname = system._var_abs2prom['output'][name]
+            n += len(system._outputs[relname])
             if row <= n:
-                varname.append("'%s'" % name)
+                varname.append("'%s'" % relname)
                 break
 
     msg = "NaN entries found in '{}' for rows associated with states/residuals [{}]."
@@ -194,7 +196,7 @@ class DirectSolver(LinearSolver):
 
                     # NaN in matrix.
                     except ValueError as err:
-                        raise RuntimeError(format_nan_error(system, mtx))
+                        raise RuntimeError(format_nan_error(system, matrix))
 
             elif isinstance(mtx, (CSRMatrix, CSCMatrix)):
                 if system._views_assembled_jac:
@@ -250,7 +252,6 @@ class DirectSolver(LinearSolver):
                 # NaN in matrix.
                 except ValueError as err:
                     raise RuntimeError(format_nan_error(system, mtx))
-
 
     def _mat_vec(self, in_vec, out_vec):
         """

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -23,7 +23,6 @@ class NanComp(ExplicitComponent):
         self.declare_partials(of='*', wrt='*')
 
     def compute(self, inputs, outputs):
-        """ Doesn't do much. """
         outputs['y'] = 3.0*inputs['x']
 
     def compute_partials(self, inputs, partials):
@@ -41,7 +40,6 @@ class NanComp2(ExplicitComponent):
         self.declare_partials(of='*', wrt='*')
 
     def compute(self, inputs, outputs):
-        """ Doesn't do much. """
         outputs['y'] = 3.0*inputs['x']
         outputs['y2'] = 2.0*inputs['x']
 

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -27,7 +27,6 @@ class TestAssertUtils(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0 * inputs['x1'] + 4.0 * inputs['x2']
 
             def compute_partials(self, inputs,     partials):
@@ -59,7 +58,6 @@ class TestAssertUtils(unittest.TestCase):
                 self.declare_partials(of='*', wrt='*')
 
             def compute(self, inputs, outputs):
-                """ Doesn't do much. """
                 outputs['y'] = 3.0 * inputs['x1'] + 4.0 * inputs['x2']
 
             def compute_partials(self, inputs, partials):


### PR DESCRIPTION
1. DirectSolver now returns an error message that gives the variables associated with NaNs in the matrix.
2. All directsolver singularity messages now give promoted names.
3. Added missing coverage for error message when using sparse assembled jacobians..