### PR TITLE
Show traceback for poptsparse optimizer import errors.

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -5,14 +5,14 @@ pyoptsparse is based on pyOpt, which is an object-oriented framework for
 formulating and solving nonlinear constrained optimization problems, with
 additional MPI capability.
 """
-
 from __future__ import print_function
+
 from collections import OrderedDict
 import json
 import sys
 import traceback
 
-from six import iteritems, itervalues, string_types, PY3
+from six import iteritems, itervalues, string_types, reraise
 
 import numpy as np
 from scipy.sparse import coo_matrix
@@ -324,11 +324,7 @@ class pyOptSparseDriver(Driver):
             # Change whatever pyopt gives us to an ImportError, give it a readable message,
             # but raise with the original traceback.
             msg = "Optimizer %s is not available in this installation." % optimizer
-            etype, value, traceback = sys.exc_info()
-            if PY3:
-                raise ImportError(msg).with_traceback(traceback)
-            else:
-                raise ImportError, msg, traceback
+            reraise(ImportError, ImportError(msg), sys.exc_info()[2])
 
         # Set optimization options
         for option, value in self.opt_settings.items():

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -30,26 +30,9 @@ grad_drivers = {'CONMIN', 'FSQP', 'IPOPT', 'NLPQLP',
 # names of optimizers that allow multiple objectives
 multi_obj_drivers = {'NSGA2'}
 
-
-def _check_imports():
-    """
-    Dynamically remove optimizers we don't have.
-
-    Returns
-    -------
-    list of str
-        List of valid optimizer strings.
-    """
-    optlist = ['ALPSO', 'CONMIN', 'FSQP', 'IPOPT', 'NLPQLP',
-               'NSGA2', 'PSQP', 'SLSQP', 'SNOPT', 'NLPY_AUGLAG', 'NOMAD']
-
-    for optimizer in optlist[:]:
-        try:
-            __import__('pyoptsparse', globals(), locals(), [optimizer], 0)
-        except ImportError:
-            optlist.remove(optimizer)
-
-    return optlist
+# All optimizers in pyoptsparse
+optlist = ['ALPSO', 'CONMIN', 'FSQP', 'IPOPT', 'NLPQLP',
+           'NSGA2', 'PSQP', 'SLSQP', 'SNOPT', 'NLPY_AUGLAG', 'NOMAD']
 
 
 CITATIONS = """
@@ -160,7 +143,7 @@ class pyOptSparseDriver(Driver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        self.options.declare('optimizer', default='SLSQP', values=_check_imports(),
+        self.options.declare('optimizer', default='SLSQP', values=optlist,
                              desc='Name of optimizers to use')
         self.options.declare('title', default='Optimization using pyOpt_sparse',
                              desc='Title of this optimization run')

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -13,8 +13,6 @@ from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDens
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
 
-from pyoptsparse.pyOpt_error import Error
-
 # check that pyoptsparse is installed
 # if it is, try to use SNOPT but fall back to SLSQP
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
@@ -1461,9 +1459,11 @@ class TestPyoptSparse(unittest.TestCase):
         prob.driver.options['optimizer'] = 'IPOPT'
         prob.setup(check=False)
 
-        # Test that we get exception. This exception is whatever pyopt wants it to be.
-        with self.assertRaises(Error) as raises_cm:
+        # Test that we get exception.
+        with self.assertRaises(ImportError) as raises_cm:
             prob.run_driver()
+
+        self.assertTrue("IPOPT is not available" in str(raises_cm.exception))
 
 
 @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")


### PR DESCRIPTION
Instead of hiding the error behind an OptionDictionary "value not in values" error, now we catch thhe exception on import and raise an ImportError with descriptive message and full original traceback.