### PR TITLE
change note to warning

### DIFF
--- a/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
@@ -132,7 +132,7 @@ as a list:
     :layout: interleave
 
 
-.. note::
+.. warning::
     When using pre-generated cases via `CSVGenerator` or `ListGenerator`, there is no
     enforcement of the declared bounds on a design variable as with the algorithmic
     generators.


### PR DESCRIPTION
Change the note at the bottom of the DOE feature docs about not respecting bounds for CSV and List generators to a warning. 