### PR TITLE
P157746717 User can use an ImplicitExternalCode comp from standard library

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -17,6 +17,7 @@ from openmdao.components.dot_product_comp import DotProductComp
 from openmdao.components.exec_comp import ExecComp
 from openmdao.components.external_code_comp import ExternalCode
 from openmdao.components.external_code_comp import ExternalCodeComp
+from openmdao.components.external_code_comp import ExternalCodeImplicitComp
 from openmdao.components.ks_comp import KSComp
 from openmdao.components.ks_comp import KSComponent
 from openmdao.components.linear_system_comp import LinearSystemComp

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -401,3 +401,21 @@ class ExternalCodeImplicitComp(ImplicitComponent):
             unscaled, dimensional residuals written to via residuals[key]
         """
         self._external_code_runner.run_component()
+
+    def solve_nonlinear(self, inputs, outputs):
+        """
+        Compute outputs given inputs. The model is assumed to be in an unscaled state.
+
+        Parameters
+        ----------
+        inputs : Vector
+            unscaled, dimensional input variables read via inputs[key]
+        outputs : Vector
+            unscaled, dimensional output variables read via outputs[key]
+
+        Returns
+        -------
+        None or bool or (bool, float, float)
+            The bool is the failure flag; and the two floats are absolute and relative error.
+        """
+        self._external_code_runner.run_component()

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -412,10 +412,5 @@ class ExternalCodeImplicitComp(ImplicitComponent):
             unscaled, dimensional input variables read via inputs[key]
         outputs : Vector
             unscaled, dimensional output variables read via outputs[key]
-
-        Returns
-        -------
-        None or bool or (bool, float, float)
-            The bool is the failure flag; and the two floats are absolute and relative error.
         """
         self._external_code_runner.run_component()

--- a/openmdao/components/tests/extcode_mach.py
+++ b/openmdao/components/tests/extcode_mach.py
@@ -1,56 +1,58 @@
 #!/usr/bin/env python
 #
-# usage: extcode_mach.py input_filename output_filename residual_filename
+# usage: extcode_mach.py input_filename output_filename
 #
 # Evaluates the output and residual for the implicit relationship
-#     between the area ratio and mach number .
+#     between the area ratio and mach number.
 #
 # Read the value of `area_ratio` from input file
-# and writes the values and residuals of `mach` to output file.
-import sys
+# and writes the values or residuals of `mach` to output file depending on what is requested.
+# What is requested is given by the first line in the file read. It can be either 'residuals' or
+# 'outputs'.
 
-from scipy.optimize import fsolve
-
-# explicit relationship between Mach number and Area ratio
-def area_ratio_explicit(Mach):
-    """isentropic relationship between area ratio and Mach number"""
+def area_ratio_explicit(mach):
+    """Explicit isentropic relationship between area ratio and Mach number"""
     gamma = 1.4
     gamma_p_1 = gamma + 1
     gamma_m_1 = gamma - 1
     exponent = gamma_p_1 / (2 * gamma_m_1)
     return (gamma_p_1 / 2.) ** -exponent * (
-            (1 + gamma_m_1 / 2. * Mach ** 2) ** exponent) / Mach
+            (1 + gamma_m_1 / 2. * mach ** 2) ** exponent) / mach
 
-# If area_ratio is known, then finding Mach is an implicit relationship
-def mach_residual(Mach, area_ratio_target):
-    return area_ratio_target - area_ratio_explicit(Mach)
+def mach_residual(mach, area_ratio_target):
+    """If area_ratio is known, then finding Mach is an implicit relationship"""
+    return area_ratio_target - area_ratio_explicit(mach)
 
 def mach_solve(area_ratio, super_sonic=False):
+    """Solve for mach, given area ratio"""
     if super_sonic:
         initial_guess = 4
     else:
         initial_guess = .1
-
     mach = fsolve(func=mach_residual, x0=initial_guess, args=(area_ratio,))[0]
-
     return mach
 
-input_filename = sys.argv[1]
-output_filename = sys.argv[2]
+if __name__ == '__main__':
+    import sys
+    from scipy.optimize import fsolve
 
-with open(input_filename, 'r') as input_file:
-    output_or_resids = input_file.readline().strip()
-    area_ratio = float(input_file.readline())
+    input_filename = sys.argv[1]
+    output_filename = sys.argv[2]
+
+    with open(input_filename, 'r') as input_file:
+        output_or_resids = input_file.readline().strip()
+        area_ratio = float(input_file.readline())
+        if output_or_resids == 'residuals':
+            mach = float(input_file.readline())
+        else: # outputs
+            super_sonic = (input_file.readline().strip() == "True")
+
+    if output_or_resids == 'outputs':
+        mach_output = mach_solve(area_ratio,super_sonic=super_sonic)
+        with open(output_filename, 'w') as output_file:
+            output_file.write('%.16f\n' % mach_output)
+
     if output_or_resids == 'residuals':
-        mach = float(input_file.readline())
-    else: # outputs
-        super_sonic = input_file.readline().strip() == "True"
-
-if output_or_resids == 'outputs':
-    mach = mach_solve(area_ratio,super_sonic=super_sonic)
-    with open(output_filename, 'w') as output_file:
-        output_file.write('%.16f\n' % mach)
-
-if output_or_resids == 'residuals':
-    with open(output_filename, 'w') as output_file:
-        output_file.write('%.16f\n' % mach_residual(mach, area_ratio))
+        mach_resid = mach_residual(mach, area_ratio)
+        with open(output_filename, 'w') as output_file:
+            output_file.write('%.16f\n' % mach_resid)

--- a/openmdao/components/tests/extcode_mach.py
+++ b/openmdao/components/tests/extcode_mach.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+#
+# usage: extcode_mach.py input_filename output_filename residual_filename
+#
+# Evaluates the output and residual for the implicit relationship
+#     between the area ratio and mach number .
+#
+# Read the value of `area_ratio` from input file
+# and writes the values and residuals of `mach` to output file.
+import sys
+
+from scipy.optimize import fsolve
+
+# explicit relationship between Mach number and Area ratio
+def area_ratio_explicit(Mach):
+    """isentropic relationship between area ratio and Mach number"""
+    gamma = 1.4
+    gamma_p_1 = gamma + 1
+    gamma_m_1 = gamma - 1
+    exponent = gamma_p_1 / (2 * gamma_m_1)
+    return (gamma_p_1 / 2.) ** -exponent * (
+            (1 + gamma_m_1 / 2. * Mach ** 2) ** exponent) / Mach
+
+# If area_ratio is known, then finding Mach is an implicit relationship
+def mach_residual(Mach, area_ratio_target):
+    return area_ratio_target - area_ratio_explicit(Mach)
+
+def mach_solve(area_ratio, super_sonic=False):
+    if super_sonic:
+        initial_guess = 4
+    else:
+        initial_guess = .1
+
+    mach = fsolve(func=mach_residual, x0=initial_guess, args=(area_ratio,))[0]
+
+    return mach
+
+input_filename = sys.argv[1]
+output_filename = sys.argv[2]
+
+with open(input_filename, 'r') as input_file:
+    output_or_resids = input_file.readline().strip()
+    area_ratio = float(input_file.readline())
+    if output_or_resids == 'residuals':
+        mach = float(input_file.readline())
+    else: # outputs
+        super_sonic = input_file.readline().strip() == "True"
+
+if output_or_resids == 'outputs':
+    mach = mach_solve(area_ratio,super_sonic=super_sonic)
+    with open(output_filename, 'w') as output_file:
+        output_file.write('%.16f\n' % mach)
+
+if output_or_resids == 'residuals':
+    with open(output_filename, 'w') as output_file:
+        output_file.write('%.16f\n' % mach_residual(mach, area_ratio))

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -562,100 +562,6 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
         except OSError:
             pass
 
-    # def test_simple_external_code_implicit_comp(self):
-    #     from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-    #     from openmdao.test_suite.test_examples.test_circuit_analysis import Diode, Node, Resistor
-    #     from openmdao.components.external_code_comp import ExternalCodeComp, \
-    #         ExternalCodeImplicitComp
-    #     from scipy.optimize import fsolve
-    #
-    #     gamma = 1.4
-    #
-    #     class MachExternalCodeComp(ExternalCodeImplicitComp):
-    #
-    #         def initialize(self):
-    #             pass
-    #
-    #         def setup(self):
-    #             self.add_input('area_ratio', val=5., units=None)
-    #             self.add_output('mach', val=5., units=None)
-    #             self.declare_partials(of='mach', wrt='area_ratio', method='fd')
-    #
-    #             self.input_file = 'mach_input.dat'
-    #             self.output_file = 'mach_output.dat'
-    #             self.residual_file = 'mach_residual.dat'
-    #
-    #             # providing these is optional; the component will verify that any input
-    #             # files exist before execution and that the output files exist after.
-    #             self.options['external_input_files'] = [self.input_file, ]
-    #             self.options['external_output_files'] = [self.output_file, self.residual_file]
-    #
-    #             self.options['command'] = [
-    #                 'python', 'extcode_mach.py', self.input_file, self.output_file,
-    #                 self.residual_file
-    #             ]
-    #
-    #         def apply_nonlinear(self, inputs, outputs, residuals):
-    #             with open(self.input_file, 'w') as input_file:
-    #                 input_file.write('{}\n'.format(inputs['area_ratio'][0]))
-    #
-    #             # the parent apply_nonlinear function actually runs the external code
-    #             super(MachExternalCodeComp, self).apply_nonlinear(inputs, outputs, residuals)
-    #
-    #             # parse the output file from the external code and set the value of area_ratio
-    #             with open(self.output_file, 'r') as output_file:
-    #                 area_ratio = float(output_file.read())
-    #
-    #             residuals['mach'] = area_ratio
-    #
-    #         def solve_nonlinear(self, inputs, outputs):
-    #             with open(self.input_file, 'w') as input_file:
-    #                 input_file.write('{}\n'.format(inputs['area_ratio'][0]))
-    #
-    #             # the parent apply_nonlinear function actually runs the external code
-    #             super(MachExternalCodeComp, self).solve_nonlinear(inputs, outputs)
-    #
-    #             # parse the output file from the external code and set the value of area_ratio
-    #             with open(self.output_file, 'r') as output_file:
-    #                 area_ratio = float(output_file.read())
-    #
-    #             outputs['mach'] = area_ratio
-    #
-    #     def area_ratio_explicit(Mach):
-    #         """isentropic relationship between area ratio and Mach number"""
-    #         gamma_p_1 = gamma + 1
-    #         gamma_m_1 = gamma - 1
-    #         exponent = gamma_p_1 / (2 * gamma_m_1)
-    #         return (gamma_p_1 / 2.) ** -exponent * (
-    #                 (1 + gamma_m_1 / 2. * Mach ** 2) ** exponent) / Mach
-    #
-    #     def mach_residual(Mach, area_ratio_target):
-    #         return area_ratio_target - area_ratio_explicit(Mach)
-    #
-    #     def mach_solve(area_ratio, super_sonic=False):
-    #         if super_sonic:
-    #             initial_guess = 4
-    #         else:
-    #             initial_guess = .1
-    #
-    #         mach = fsolve(func=mach_residual, x0=initial_guess, args=(area_ratio,))[0]
-    #
-    #         return mach
-    #
-    #     p = Problem()
-    #     mach = 0.5
-    #     #  super_sonic=False ????????????????
-    #     comp = MachExternalCodeComp()
-    #     p.model.add_subsystem('comp', comp, promotes=['*'])
-    #     p.setup()
-    #
-    #     area_ratio = area_ratio_explicit(mach)
-    #
-    #     p['area_ratio'] = area_ratio
-    #     p.run_model()
-    #
-    #     assert_rel_error(self, p['mach'], mach, 1e-8)
-
     def test_simple_external_code_implicit_comp_with_solver(self):
         from openmdao.api import Group, NewtonSolver, Problem, IndepVarComp, ScipyKrylov
         from openmdao.components.external_code_comp import ExternalCodeImplicitComp
@@ -694,7 +600,6 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
                 # parse the output file from the external code and set the value of mach
                 with open(self.output_file, 'r') as output_file:
                     mach = float(output_file.read())
-
                 residuals['mach'] = mach
 
             def solve_nonlinear(self, inputs, outputs):
@@ -708,7 +613,6 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
                 # parse the output file from the external code and set the value of mach
                 with open(self.output_file, 'r') as output_file:
                     mach = float(output_file.read())
-
                 outputs['mach'] = mach
 
         group = Group()

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -562,9 +562,9 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
         except OSError:
             pass
 
-    def test_simple_external_code_implicit_comp_with_solver(self):
-        from openmdao.api import Group, NewtonSolver, Problem, IndepVarComp, ScipyKrylov
-        from openmdao.components.external_code_comp import ExternalCodeImplicitComp
+    def test_simple_external_code_implicit_comp(self):
+        from openmdao.api import Group, NewtonSolver, Problem, IndepVarComp, DirectSolver, \
+            ExternalCodeImplicitComp
 
         class MachExternalCodeComp(ExternalCodeImplicitComp):
 
@@ -621,7 +621,10 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
         prob = Problem(model=group)
         group.nonlinear_solver = NewtonSolver()
         group.nonlinear_solver.options['solve_subsystems'] = True
-        group.linear_solver = ScipyKrylov()
+        group.nonlinear_solver.options['iprint'] = 0
+        group.nonlinear_solver.options['maxiter'] = 20
+        group.linear_solver = DirectSolver()
+
         prob.setup(check=False)
 
         area_ratio = 1.3
@@ -638,160 +641,6 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
         prob.run_model()
         assert_rel_error(self, prob['mach'], mach_solve(area_ratio, super_sonic=super_sonic), 1e-8)
 
-    def test_circuit_plain_newton_using_extcode(self):
-        # Use external code for the resistor and node.
-        from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-        from openmdao.test_suite.test_examples.test_circuit_analysis import Diode, Node, Resistor
-        from openmdao.components.external_code_comp import ExternalCodeComp, \
-            ExternalCodeImplicitComp
-
-        class ResistorExternalCodeComp(ExternalCodeComp):
-
-            def initialize(self):
-                self.options.declare('R', default=1., desc='Resistance in Ohms')
-
-            def setup(self):
-                self.add_input('V_in', units='V')
-                self.add_input('V_out', units='V')
-                self.add_output('I', units='A')
-
-                self.declare_partials(of='I', wrt='V_in', method='fd')
-                self.declare_partials(of='I', wrt='V_out', method='fd')
-
-                self.input_file = 'resistor_input.dat'
-                self.output_file = 'resistor_output.dat'
-
-                # providing these is optional; the component will verify that any input
-                # files exist before execution and that the output files exist after.
-                self.options['external_input_files'] = [self.input_file, ]
-                self.options['external_output_files'] = [self.output_file, ]
-
-                self.options['command'] = [
-                    'python', 'extcode_resistor.py', self.input_file, self.output_file
-                ]
-
-            def compute(self, inputs, outputs):
-                V_in = inputs['V_in']
-                V_out = inputs['V_out']
-                R = self.options['R']
-
-                # generate the input file for the paraboloid external code
-                with open(self.input_file, 'w') as input_file:
-                    input_file.write('%.16f\n%.16f\n%.16f\n' % (V_in, V_out, R))
-
-                # the parent compute function actually runs the external code
-                super(ResistorExternalCodeComp, self).compute(inputs, outputs)
-
-                # parse the output file from the external code and set the value of I
-                with open(self.output_file, 'r') as output_file:
-                    I = float(output_file.read())
-
-                outputs['I'] = I
-
-        class NodeExternalCodeComp(ExternalCodeImplicitComp):
-
-            def initialize(self):
-                self.options.declare('n_in', default=1, types=int,
-                                     desc='number of connections with + assumed in')
-                self.options.declare('n_out', default=1, types=int,
-                                     desc='number of current connections + assumed out')
-
-            def setup(self):
-                self.add_output('V', val=5., units='V')
-
-                for i in range(self.options['n_in']):
-                    i_name = 'I_in:{}'.format(i)
-                    self.add_input(i_name, units='A')
-
-                for i in range(self.options['n_out']):
-                    i_name = 'I_out:{}'.format(i)
-                    self.add_input(i_name, units='A')
-
-                # note: we don't declare any partials wrt `V` here,
-                #      because the residual doesn't directly depend on it
-                self.declare_partials(of='V', wrt='I*', method='fd')
-
-                self.input_file = 'node_input.dat'
-                self.output_file = 'node_output.dat'
-
-                # providing these is optional; the component will verify that any input
-                # files exist before execution and that the output files exist after.
-                self.options['external_input_files'] = [self.input_file, ]
-                self.options['external_output_files'] = [self.output_file, ]
-
-                self.options['command'] = [
-                    'python', 'extcode_node.py', self.input_file, self.output_file
-                ]
-
-            def apply_nonlinear(self, inputs, outputs, residuals):
-                with open(self.input_file, 'w') as input_file:
-                    n_in = self.options['n_in']
-                    input_file.write('{}\n'.format(n_in))
-                    for i_conn in range(n_in):
-                        input_file.write('{}\n'.format(inputs['I_in:{}'.format(i_conn)][0] ))
-                    n_out = self.options['n_out']
-                    input_file.write('{}\n'.format(n_out))
-                    for i_conn in range(n_out):
-                        input_file.write('{}\n'.format(inputs['I_out:{}'.format(i_conn)][0] ))
-
-                # the parent apply_nonlinear function actually runs the external code
-                super(NodeExternalCodeComp, self).apply_nonlinear(inputs, outputs, residuals)
-
-                # parse the output file from the external code and set the value of I
-                with open(self.output_file, 'r') as output_file:
-                    resid_V = float(output_file.read())
-
-                residuals['V'] = resid_V
-
-        class Circuit(Group):
-
-            def setup(self):
-                self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])
-                self.add_subsystem('n2', NodeExternalCodeComp())  # leaving defaults
-
-                self.add_subsystem('R1', Resistor(R=100.), promotes_inputs=[('V_out', 'Vg')])
-                self.add_subsystem('R2', ResistorExternalCodeComp(R=10000.))
-                self.add_subsystem('D1', Diode(), promotes_inputs=[('V_out', 'Vg')])
-
-                self.connect('n1.V', ['R1.V_in', 'R2.V_in'])
-                self.connect('R1.I', 'n1.I_out:0')
-                self.connect('R2.I', 'n1.I_out:1')
-
-                self.connect('n2.V', ['R2.V_out', 'D1.V_in'])
-                self.connect('R2.I', 'n2.I_in:0')
-                self.connect('D1.I', 'n2.I_out:0')
-
-                self.nonlinear_solver = NewtonSolver()
-                self.nonlinear_solver.options['iprint'] = 2
-                self.nonlinear_solver.options['maxiter'] = 20
-                self.linear_solver = DirectSolver()
-
-        p = Problem()
-        model = p.model
-
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
-        model.add_subsystem('circuit', Circuit())
-
-        model.connect('source.I', 'circuit.I_in')
-        model.connect('ground.V', 'circuit.Vg')
-
-        p.setup(check=True)
-
-        # set some initial guesses
-        p['circuit.n1.V'] = 10.
-        p['circuit.n2.V'] = 1.
-
-        p.run_model()
-
-        assert_rel_error(self, p['circuit.n1.V'], 9.90830282, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.73858486, 1e-5)
-        assert_rel_error(self, p['circuit.R1.I'], 0.09908303, 1e-5)
-        assert_rel_error(self, p['circuit.R2.I'], 0.00091697, 1e-5)
-        assert_rel_error(self, p['circuit.D1.I'], 0.00091697, 1e-5)
-
-        # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
 
 

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -12,6 +12,12 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
 
 `ExternalCodeImplicitComp` has the same options as `ExternalCodeComp`.
 
+    .. embed-options::
+        openmdao.components.external_code_comp
+        ExternalCodeImplicitComp
+        options
+
+
 ExternalCodeImplicitComp Example
 --------------------------------
 

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -21,9 +21,9 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
 ExternalCodeImplicitComp Example
 ---------------------------------------
 
-Here is a simple example of the use of a `ExternalCodeImplicitComp` Component. The external code is a Python script
-that evaluates the output and residual for the implicit relationship between the area ratio and mach number in an
-isentropic flow.
+Here is a simple example of the use of an `ExternalCodeImplicitComp` Component. The external code in the example
+is a Python script that evaluates the output and residual for the implicit relationship between the area ratio and
+mach number in an isentropic flow.
 
 .. embed-code::
     openmdao.components.tests.extcode_mach
@@ -31,7 +31,7 @@ isentropic flow.
 The following model makes use of this external code.
 
 .. embed-code::
-    openmdao.components.tests.test_external_code_comp.TestExternalCodeImplicitCompFeature.test_simple_external_code_implicit_comp_with_solver
+    openmdao.components.tests.test_external_code_comp.TestExternalCodeImplicitCompFeature.test_simple_external_code_implicit_comp
     :layout: interleave
 
 

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -21,10 +21,8 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
 ExternalCodeImplicitComp Example
 --------------------------------
 
-The only difference between `ExternalCodeImplicitComp` and `ExternalCodeComp` is that for the former, an `apply_nonlinear`
-method must be defined, while for the latter, a `compute` method must be defined.
-
-To show the difference, we will use an example. We will modify the code given in
+Here is another example where there are external codes for both an `ImplicitComponent` and `ExplicitComponent`.
+We will modify the code given in
 :ref:`the circuit tutorial <defining_icomps_tutorial>`. We will replace one of the nodes and one of the resistors
 in the model with external codes.
 

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -18,7 +18,7 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
         options
 
 
-Simple ExternalCodeImplicitComp Example
+ExternalCodeImplicitComp Example
 ---------------------------------------
 
 Here is a simple example of the use of a `ExternalCodeImplicitComp` Component. The external code is a Python script
@@ -34,29 +34,6 @@ The following model makes use of this external code.
     openmdao.components.tests.test_external_code_comp.TestExternalCodeImplicitCompFeature.test_simple_external_code_implicit_comp_with_solver
     :layout: interleave
 
-
-
-Example with both ExternalCodeComp and ExternalCodeImplicitComp
----------------------------------------------------------------
-
-Here is another example where there are external codes for both an `ImplicitComponent` and `ExplicitComponent`.
-We will modify the code given in
-:ref:`the circuit tutorial <defining_icomps_tutorial>`. We will replace one of the nodes and one of the resistors
-in the model with external codes.
-
-In this example, our external codes will be simple Python scripts. Here they are:
-
-.. embed-code::
-    openmdao.components.tests.extcode_resistor
-
-.. embed-code::
-    openmdao.components.tests.extcode_node
-
-Here is the modified circuit example using these external codes.
-
-.. embed-code::
-    openmdao.components.tests.test_external_code_comp.TestExternalCodeImplicitCompFeature.test_circuit_plain_newton_using_extcode
-    :layout: interleave
 
 
 .. tags:: ExternalCodeImplicitComp, ExternalCodeComp, FileWrapping, Component

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -18,8 +18,26 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
         options
 
 
-ExternalCodeImplicitComp Example
---------------------------------
+Simple ExternalCodeImplicitComp Example
+---------------------------------------
+
+Here is a simple example of the use of a `ExternalCodeImplicitComp` Component. The external code is a Python script
+that evaluates the output and residual for the implicit relationship between the area ratio and mach number in an
+isentropic flow.
+
+.. embed-code::
+    openmdao.components.tests.extcode_mach
+
+The following model makes use of this external code.
+
+.. embed-code::
+    openmdao.components.tests.test_external_code_comp.TestExternalCodeImplicitCompFeature.test_simple_external_code_implicit_comp_with_solver
+    :layout: interleave
+
+
+
+Example with both ExternalCodeComp and ExternalCodeImplicitComp
+---------------------------------------------------------------
 
 Here is another example where there are external codes for both an `ImplicitComponent` and `ExplicitComponent`.
 We will modify the code given in


### PR DESCRIPTION
wrap an external code, but treat it as implicit component. All partials are FD around the apply_nonlinear method.

