### PR TITLE
Pivotal #151883644: check_partials fails if a component in the model has no outputs.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1422,7 +1422,7 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
         else:
             sys_type = type(system).__name__
 
-        if not sys_name in derivative_data:
+        if sys_name not in derivative_data:
             msg = "No derivative data found for %s '%s'." % (sys_type, sys_name)
             warnings.warn(msg)
             continue

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1422,6 +1422,11 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
         else:
             sys_type = type(system).__name__
 
+        if not sys_name in derivative_data:
+            msg = "No derivative data found for %s '%s'." % (sys_type, sys_name)
+            warnings.warn(msg)
+            continue
+
         derivatives = derivative_data[sys_name]
 
         if totals:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5,24 +5,20 @@ from contextlib import contextmanager
 from collections import OrderedDict, Iterable, defaultdict
 from fnmatch import fnmatchcase
 import sys
-from itertools import product
 from numbers import Integral
 
 from six import iteritems, string_types
-from six.moves import range
 
 import numpy as np
 
-from openmdao.jacobians.assembled_jacobian import AssembledJacobian, DenseJacobian, CSCJacobian
+from openmdao.jacobians.assembled_jacobian import DenseJacobian, CSCJacobian
 from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, warn_deprecation, ContainsAll
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.vectors.vector import INT_DTYPE
-from openmdao.vectors.default_vector import DefaultVector
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
-from openmdao.utils.array_utils import convert_neg
 from openmdao.utils.record_util import create_local_meta, check_path
 from openmdao.utils.write_outputs import write_outputs
 

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -8,8 +8,8 @@ import warnings
 
 import numpy as np
 
-from openmdao.api import Problem, Group, ExplicitComponent, ImplicitComponent, IndepVarComp, \
-    ExecComp, NonlinearRunOnce, NonlinearBlockGS, DirectSolver, ScipyKrylov, NewtonSolver
+from openmdao.api import Problem, Group, ExplicitComponent, ImplicitComponent, \
+    IndepVarComp, ExecComp, NonlinearRunOnce, NonlinearBlockGS, ScipyKrylov, NewtonSolver
 from openmdao.core.tests.test_impl_comp import QuadraticLinearize, QuadraticJacVec
 from openmdao.core.tests.test_matmat import MultiJacVec
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayMatVec

--- a/openmdao/core/tests/test_core_simple.py
+++ b/openmdao/core/tests/test_core_simple.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import unittest
 
-from openmdao.api import Problem, IndepVarComp, ExplicitComponent, Group, DefaultVector, PETScVector
+from openmdao.api import Problem, IndepVarComp, ExplicitComponent, Group, PETScVector
 from openmdao.utils.assert_utils import assert_rel_error
 
 

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, \
-                         ScipyOptimizeDriver, DefaultVector, DirectSolver, \
+                         ScipyOptimizeDriver, DirectSolver, \
                          ImplicitComponent, LinearBlockGS
 from openmdao.utils.assert_utils import assert_rel_error
 

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -11,10 +11,11 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, LinearBlockGS, DefaultVector, \
+from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, LinearBlockGS, \
     ExecComp, ExplicitComponent, PETScVector, ScipyKrylov, NonlinearBlockGS
 from openmdao.utils.mpi import MPI
-from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1withDerivatives, SellarDis2withDerivatives
+from openmdao.test_suite.components.sellar import SellarDerivatives, \
+    SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.groups.parallel_groups import FanOutGrouped, FanInGrouped
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.recorders.recording_iteration_stack import recording_iteration
@@ -25,6 +26,7 @@ if MPI:
         from openmdao.vectors.petsc_vector import PETScVector
     except ImportError:
         PETScVector = None
+
 
 @unittest.skipUnless(MPI and PETScVector, "only run with MPI and PETSc.")
 class ParDerivTestCase(unittest.TestCase):
@@ -561,7 +563,7 @@ class MatMatTestCase(unittest.TestCase):
         prob.model.add_constraint('c3.y', upper=0.0, parallel_deriv_color='par', vectorize_derivs=True)
         prob.model.add_constraint('c4.y', upper=0.0, parallel_deriv_color='par', vectorize_derivs=True)
 
-        prob.setup( check=False, mode='rev')
+        prob.setup(check=False, mode='rev')
         prob.run_driver()
 
         J = prob.compute_totals(['c3.y', 'c4.y'], ['p1.x', 'p2.x'],

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -299,8 +299,8 @@ class TestParallelGroups(unittest.TestCase):
             self.assertEqual(len(testlogger.get('info')), 0)
         else:
             self.assertEqual(len(testlogger.get('error')), 1)
-            self.assertTrue(testlogger.contains_line('warning',
-                                                      "Only want to see this on rank 0"))
+            self.assertTrue(testlogger.contains('warning',
+                                                "Only want to see this on rank 0"))
             self.assertEqual(len(testlogger.get('info')), 1)
             self.assertTrue(msg in testlogger.get('error')[0])
             self.assertTrue(msg in testlogger.get('info')[0])

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -3,7 +3,7 @@ from __future__ import print_function
 import unittest
 
 from openmdao.api import Problem, Group, ExecComp
-from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, LinearBlockGS, DefaultVector, \
+from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, LinearBlockGS, \
     ExecComp, ExplicitComponent, PETScVector, ScipyKrylov, NonlinearBlockGS
 from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_rel_error
@@ -12,6 +12,7 @@ try:
     from openmdao.api import PETScVector
 except:
     PETScVector = None
+
 
 def _build_model(nsubs, min_procs=None, max_procs=None, weights=None, top=None, mode='fwd'):
     p = Problem()
@@ -28,7 +29,7 @@ def _build_model(nsubs, min_procs=None, max_procs=None, weights=None, top=None, 
     par = model.add_subsystem('par', ParallelGroup())
     for i in range(nsubs):
         par.add_subsystem("C%d" % i, ExecComp("y=2.0*x"),
-                            min_procs=min_procs[i], max_procs=max_procs[i], proc_weight=weights[i])
+                          min_procs=min_procs[i], max_procs=max_procs[i], proc_weight=weights[i])
         model.connect('indep.x', 'par.C%d.x' % i)
 
     s_sum = '+'.join(['x%d' % i for i in range(nsubs)])
@@ -44,6 +45,7 @@ def _build_model(nsubs, min_procs=None, max_procs=None, weights=None, top=None, 
     p.final_setup()
 
     return p
+
 
 def _get_which_procs(group):
     sub_inds = [i for i, s in enumerate(group._subsystems_allprocs)
@@ -208,6 +210,7 @@ class ProcTestCase6(unittest.TestCase):
 class ProcTestCase8(unittest.TestCase):
 
     N_PROCS = 8
+
     def test_4_subs_weighted(self):
         p = _build_model(nsubs=4, weights=[1.0, 2.0, 1.0, 4.0], mode='rev')
         all_inds = _get_which_procs(p.model.par)

--- a/openmdao/core/tests/test_reconf.py
+++ b/openmdao/core/tests/test_reconf.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, DefaultVector
+from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_rel_error
 
 try:

--- a/openmdao/core/tests/test_reconf_parallel_group.py
+++ b/openmdao/core/tests/test_reconf_parallel_group.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, DefaultVector, ExecComp
+from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, ExecComp
 from openmdao.api import NewtonSolver, PETScKrylov, NonlinearBlockGS, LinearBlockGS
 from openmdao.utils.assert_utils import assert_rel_error
 

--- a/openmdao/core/tests/test_varsets_simple.py
+++ b/openmdao/core/tests/test_varsets_simple.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import unittest
 
-from openmdao.api import Problem, ExplicitComponent, Group, ParallelGroup, DefaultVector
+from openmdao.api import Problem, ExplicitComponent, Group, ParallelGroup
 from openmdao.utils.assert_utils import assert_rel_error
 
 try:

--- a/openmdao/devtools/iprof_mem.py
+++ b/openmdao/devtools/iprof_mem.py
@@ -7,7 +7,7 @@ import argparse
 from collections import defaultdict
 
 from openmdao.devtools.iprof_utils import _create_profile_callback, find_qualified_name, func_group, \
-     _collect_methods, _setup_func_group, _get_methods
+     _collect_methods, _setup_func_group, _get_methods, _Options
 from openmdao.utils.mpi import MPI
 
 
@@ -76,6 +76,8 @@ def setup(methods=None):
     methods : list of (glob, (classes...)) or None
         Methods to be profiled, based on glob patterns and isinstance checks.
     """
+    if not func_group:
+        _setup_func_group()
     _setup(_Options(methods=methods))
 
 

--- a/openmdao/devtools/tests/test_iprof_mem.py
+++ b/openmdao/devtools/tests/test_iprof_mem.py
@@ -1,0 +1,46 @@
+import unittest
+
+import types
+
+from openmdao.api import Problem
+from openmdao.test_suite.components.sellar import SellarNoDerivatives
+
+from openmdao.devtools import iprof_mem
+
+
+@unittest.skip("interactive test, not to be run with test suite")
+class TestProfileMemory(unittest.TestCase):
+
+    def test_sellar(self):
+        prob = Problem(SellarNoDerivatives()).setup()
+
+        iprof_mem.setup()
+
+        # check that the callback has been registered as expected
+        self.assertTrue(iprof_mem._registered)
+        self.assertTrue(isinstance(iprof_mem._trace_memory, types.FunctionType))
+        self.assertTrue(isinstance(iprof_mem.mem_usage, types.FunctionType))
+
+        # can't check output (it comes at system exit)
+        # just make sure no exceptions are raised
+        iprof_mem.start()
+        prob.run_model()
+        iprof_mem.stop()
+
+        # expect output similar to the following:
+        #
+        # Memory (MB)   Calls  File:Line:Function
+        # ---------------------------------------
+        #     0.1406        1  path/to/openmdao/vectors/default_vector.py:251:_initialize_views
+        #     0.1406        1  path/to/openmdao/vectors/vector.py:115:__init__
+        #     0.2812        2  path/to/openmdao/core/system.py:1109:_setup_bounds
+        #      0.332        1  path/to/openmdao/core/problem.py:424:run_model
+        #      0.332        1  path/to/openmdao/core/system.py:728:_final_setup
+        #      0.332        1  path/to/openmdao/core/problem.py:613:final_setup
+        #     0.5742        3  path/to/openmdao/core/system.py:1065:_setup_vectors
+        # ---------------------------------------
+        # Memory (MB)   Calls  File:Line:Function
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -200,6 +200,27 @@ def _check_hanging_inputs(problem, logger):
         logger.warning(''.join(msg))
 
 
+def _check_comp_has_no_outputs(problem, logger):
+    """
+    Issue a logger warning if any components do not have any outputs.
+
+    Parameters
+    ----------
+    problem : <Problem>
+        The problem being checked.
+    logger : object
+        The object that manages logging output.
+    """
+    msg = []
+
+    for comp in problem.model.system_iter(include_self=True, recurse=True, typ=Component):
+        if len(comp._var_allprocs_abs_names['output']) == 0:
+            msg.append("   %s\n" % comp.pathname)
+
+    if msg:
+        logger.warning(''.join(["The following Components do not have any outputs:\n"] + msg))
+
+
 def _check_system_configs(problem, logger):
     """
     Perform any system specific configuration checks.
@@ -338,6 +359,7 @@ _checks = {
     'solvers': _check_solvers,
     'dup_inputs': _check_dup_comp_inputs,
     'missing_recorders': _check_missing_recorders,
+    'comp_has_no_outputs': _check_comp_has_no_outputs,
 }
 
 

--- a/openmdao/error_checking/tests/test_check_solvers.py
+++ b/openmdao/error_checking/tests/test_check_solvers.py
@@ -43,15 +43,15 @@ class TestCheckSolvers(unittest.TestCase):
 
         # should trigger warnings due to having states without solves
 
-        self.assertTrue(testlogger.contains_line('warning',
+        self.assertTrue(testlogger.contains('warning',
                         "StateConnection 'statecomp' contains implicit variables, "
-                         "but does not have an iterative nonlinear solver and does not "
-                         "implement 'solve_nonlinear'."))
+                        "but does not have an iterative nonlinear solver and does not "
+                        "implement 'solve_nonlinear'."))
 
-        self.assertTrue(testlogger.contains_line('warning',
+        self.assertTrue(testlogger.contains('warning',
                         "StateConnection 'statecomp' contains implicit variables, "
-                         "but does not have an iterative linear solver and does not "
-                         "implement 'solve_linear'."))
+                        "but does not have an iterative linear solver and does not "
+                        "implement 'solve_linear'."))
 
     def test_implicit_without_solve_linear(self):
         prob = Problem()
@@ -68,10 +68,10 @@ class TestCheckSolvers(unittest.TestCase):
         prob.final_setup()
 
         # should trigger solver warning because there is no linear solve
-        self.assertTrue(testlogger.contains_line('warning',
+        self.assertTrue(testlogger.contains('warning',
                         "StateConnWithSolveNonlinear 'statecomp' contains implicit "
-                         "variables, but does not have an iterative linear solver "
-                         "and does not implement 'solve_linear'."))
+                        "variables, but does not have an iterative linear solver "
+                        "and does not implement 'solve_linear'."))
 
     def test_implicit_without_solve_nonlinear(self):
         prob = Problem()
@@ -88,10 +88,10 @@ class TestCheckSolvers(unittest.TestCase):
         prob.final_setup()
 
         # should trigger solver warning because there is no nonlinear solve
-        self.assertTrue(testlogger.contains_line('warning',
+        self.assertTrue(testlogger.contains('warning',
                         "StateConnWithSolveLinear 'statecomp' contains implicit "
-                         "variables, but does not have an iterative nonlinear solver "
-                         "and does not implement 'solve_nonlinear'."))
+                        "variables, but does not have an iterative nonlinear solver "
+                        "and does not implement 'solve_nonlinear'."))
 
     def test_implicit_with_solves(self):
         prob = Problem()
@@ -187,10 +187,10 @@ class TestCheckSolvers(unittest.TestCase):
         prob.final_setup()
 
         # should trigger a linear solver warning only for group 2
-        self.assertTrue(testlogger.contains_line('warning',
+        self.assertTrue(testlogger.contains('warning',
                         "StateConnection 'G2.statecomp2' contains implicit "
-                         "variables, but does not have an iterative linear solver "
-                         "and does not implement 'solve_linear'."))
+                        "variables, but does not have an iterative linear solver "
+                        "and does not implement 'solve_linear'."))
 
     def test_cycle(self):
         prob = Problem()
@@ -210,12 +210,12 @@ class TestCheckSolvers(unittest.TestCase):
         prob.final_setup()
 
         # should trigger warnings because cycle requires iterative solvers
-        self.assertTrue(testlogger.contains_line('warning',
-                                "Group '' contains cycles [['C1', 'C2', 'C3']], but "
-                                "does not have an iterative nonlinear solver."))
-        self.assertTrue(testlogger.contains_line('warning',
-                                "Group '' contains cycles [['C1', 'C2', 'C3']], but " 
-                                "does not have an iterative linear solver."))
+        self.assertTrue(testlogger.contains('warning',
+                        "Group '' contains cycles [['C1', 'C2', 'C3']], but "
+                        "does not have an iterative nonlinear solver."))
+        self.assertTrue(testlogger.contains('warning',
+                        "Group '' contains cycles [['C1', 'C2', 'C3']], but "
+                        "does not have an iterative linear solver."))
 
     def test_cycle_iter(self):
         prob = Problem()

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -11,7 +11,6 @@ from openmdao.core.group import Group
 from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.indepvarcomp import IndepVarComp
-from openmdao.vectors.default_vector import DefaultVector
 from openmdao.test_suite.components.exec_comp_for_test import ExecComp4Test
 
 from openmdao.utils.mpi import MPI

--- a/openmdao/utils/logger_utils.py
+++ b/openmdao/utils/logger_utils.py
@@ -178,17 +178,17 @@ class TestLogger(object):
         """
         return self._msgs[typ]
 
-    def contains_line(self, typ, line):
+    def contains(self, typ, message):
         """
-        Do any of the lines of stored messages of a specific type equal the given line.
+        Do any of the stored messages of a specific type equal the given message.
 
         Parameters
         ----------
         typ : str
             Type of messages ('error', 'warning', 'info') to be returned.
 
-        line : str
-            Line used to look for matches.
+        message : str
+            The message to match.
 
         Returns
         -------
@@ -196,7 +196,7 @@ class TestLogger(object):
             True if any of the lines of stored messages of a specific type equal the line.
         """
         for s in self._msgs[typ]:
-            if s == line:
+            if s == message:
                 return True
 
         return False


### PR DESCRIPTION
add check to `check_config` for comps with no outputs
`check_partials` will issue a warning instead of an exception if a comp has no outputs
removed some unused imports and fixed some PEP/Lint issues
made a fix to `iprof_mem` for using it programmatically (with a test case for interactive testing) 

