### PR TITLE
Fixing things/simplifying Appveyor run

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda
-  - conda install numpy=1.11.2 scipy nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy scipy nose hdf5 h5py sphinx mock pip --quiet
   #Grab testflo for running tests, to ensure examples are run
   - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,6 @@ environment:
     - PYTHON: 3.6
       CONDA: "C:\\Miniconda36-x64"
 
-init:
-  #Uncomment the following line to gain RDP access to an appveyor machine.
-  #Login info will appear in the console
-  #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
-
 install:
   - echo %CONDA%
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
@@ -29,37 +24,11 @@ install:
   #Grab testflo for running tests, to ensure examples are run
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install matplotlib
-  #We need to run these two lines to have nmake available for doctests
-  - cd "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC"
-  - vcvarsall amd64
-#  - ps: |
-#      If ($env:CONDA -eq "C:\\Miniconda36-x64") {
-#        If ((Test-Path Env:\MSMPI_BIN)) {throw "error: MSMPI_BIN env var exists. Msmpi already installed before we go to install it."}
-#        If ((Get-Command "mpiexec.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpiexec.exe already exists before we go to install it"}
-#        If ((Get-Command "mpirun.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpirun.exe already exists before we go to install it"}
-#        $client = new-object System.Net.WebClient
-#        $client.DownloadFile("http://openmdao.org/dists/MSMpiSetup.exe", "$pwd\MSMpiSetup.exe")
-#        .\MSMpiSetup.exe -unattend -force  | Out-Null #pipe to Out-Null in order to block until install is finished
-#      }
-
-#Do these pip installs outside of powershell
-#  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/mpi4py-2.0.0-cp34-none-win_amd64.whl)
-#  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/petsc4py-3.6.0-cp34-none-win_amd64.whl)
 
   #Return back to continue install of OpenMDAO
   - cd C:\projects\OpenMDAO*
   - pip install -e .
 
 test_script:
-  - ps: |
-        If ($env:CONDA -eq "C:\\Miniconda36-x64") {
-          $env:MSMPI_BIN = [System.Environment]::GetEnvironmentVariable("MSMPI_BIN","Machine")
-          $env:Path = $env:Path + ";" + $env:MSMPI_BIN
-          If ((Get-Command "mpiexec.exe" -ErrorAction SilentlyContinue) -eq $null) {throw "error: can't find mpiexec.exe after install"}
-          cd openmdao/docs
-          nmake /f Makefile.nmake clean
-          nmake /f Makefile.nmake all
-          cd ../..
-        }
   - testflo . -n 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,15 +17,11 @@ install:
   - echo %CONDA%
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
-  # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda
   - conda install python=%PYTHON% numpy=1.14.2 scipy=1.0.1 nose hdf5 h5py sphinx mock pip --quiet
   - pip install redbaron
-  #Grab testflo for running tests, to ensure examples are run
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install matplotlib
-
-  #Return back to continue install of OpenMDAO
   - cd C:\projects\OpenMDAO*
   - pip install -e .
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,27 +24,27 @@ install:
   - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda
-  - conda install python=%PYTHON% numpy=1.14.2 scipy nose hdf5 h5py sphinx mock pip --quiet
-  #Grab testflo for running tests, to ensure examples are run
+  - conda install python=%PYTHON% numpy=1.14.2 scipy=1.0.1 nose hdf5 h5py sphinx mock pip --quiet
   - pip install redbaron
+  #Grab testflo for running tests, to ensure examples are run
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install matplotlib
   #We need to run these two lines to have nmake available for doctests
   - cd "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC"
   - vcvarsall amd64
-  - ps: |
-      If ($env:CONDA -eq "C:\\Miniconda36-x64") {
-        If ((Test-Path Env:\MSMPI_BIN)) {throw "error: MSMPI_BIN env var exists. Msmpi already installed before we go to install it."}
-        If ((Get-Command "mpiexec.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpiexec.exe already exists before we go to install it"}
-        If ((Get-Command "mpirun.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpirun.exe already exists before we go to install it"}
-        $client = new-object System.Net.WebClient
-        $client.DownloadFile("http://openmdao.org/dists/MSMpiSetup.exe", "$pwd\MSMpiSetup.exe")
-        .\MSMpiSetup.exe -unattend -force  | Out-Null #pipe to Out-Null in order to block until install is finished
-      }
+#  - ps: |
+#      If ($env:CONDA -eq "C:\\Miniconda36-x64") {
+#        If ((Test-Path Env:\MSMPI_BIN)) {throw "error: MSMPI_BIN env var exists. Msmpi already installed before we go to install it."}
+#        If ((Get-Command "mpiexec.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpiexec.exe already exists before we go to install it"}
+#        If ((Get-Command "mpirun.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpirun.exe already exists before we go to install it"}
+#        $client = new-object System.Net.WebClient
+#        $client.DownloadFile("http://openmdao.org/dists/MSMpiSetup.exe", "$pwd\MSMpiSetup.exe")
+#        .\MSMpiSetup.exe -unattend -force  | Out-Null #pipe to Out-Null in order to block until install is finished
+#      }
 
-  #Do these pip installs outside of powershell
-  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/mpi4py-2.0.0-cp34-none-win_amd64.whl)
-  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/petsc4py-3.6.0-cp34-none-win_amd64.whl)
+#Do these pip installs outside of powershell
+#  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/mpi4py-2.0.0-cp34-none-win_amd64.whl)
+#  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/petsc4py-3.6.0-cp34-none-win_amd64.whl)
 
   #Return back to continue install of OpenMDAO
   - cd C:\projects\OpenMDAO*
@@ -63,7 +63,3 @@ test_script:
         }
   - testflo . -n 1
 
-#after tests, need to cd down so that conf.py can be found for docbuild
-# - cd openmdao/docs
-# - nmake /f Makefile.nmake clean
-# - nmake /f Makefile.nmake all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,5 @@
 build: false
 version: 2.3.1.{build}-{branch}
-
 platform: x64
 
 environment:
@@ -12,14 +11,16 @@ environment:
       CONDA: "C:\\Miniconda36-x64"
 
 install:
-  - echo %CONDA%
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   - conda update conda
   - conda install python=%PYTHON% numpy scipy=1.0 nose hdf5 h5py sphinx mock pip --quiet
+  - pip install matplotlib
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - cd C:\projects\OpenMDAO*
   - pip install -e .
+  - pip list
+  - conda list
 
 test_script:
   - testflo . -n 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,12 +19,11 @@ install:
   - conda config --set always_yes yes
   - conda update conda
   - conda install python=%PYTHON% numpy scipy nose hdf5 h5py sphinx mock pip --quiet
-  - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git
-  - pip install matplotlib
-  #- cd C:\projects\OpenMDAO*
-  #- pip install -e .
-  - pip install git+git://github.com/OpenMDAO/OpenMDAO.git@ce324e2341ba44f93de686deb7f8923c3b553656
+  - conda install git
+  - cd C:\projects\OpenMDAO*
+  - git reset --hard ce324e2341ba44f93de686deb7f8923c3b553656
+  - pip install -e .
 
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install python=%PYTHON% numpy=1.14.2 scipy=1.0.1 nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy scipy=1.0 nose hdf5 h5py sphinx mock pip --quiet
   - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install matplotlib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install python=%PYTHON% numpy scipy=1.0 nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy scipy nose hdf5 h5py sphinx mock pip --quiet
   - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install matplotlib

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda
+  - if "%PYTHON%" == "3.6" (conda uninstall enum34)
   - conda install python=%PYTHON% numpy scipy nose hdf5 h5py sphinx mock pip --quiet
   #Grab testflo for running tests, to ensure examples are run
   - pip install redbaron
@@ -46,7 +47,7 @@ install:
   - if "%CONDA%" == "Miniconda3-x64" (pip install http://openmdao.org/dists/petsc4py-3.6.0-cp34-none-win_amd64.whl)
 
   #Return back to continue install of OpenMDAO
-  - cd C:\projects\blue*
+  - cd C:\projects\OpenMDAO*
   - pip install -e .
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ install:
   - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda
-  - conda install python=%PYTHON% numpy=1.14 scipy nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy=1.14.2 scipy nose hdf5 h5py sphinx mock pip --quiet
   #Grab testflo for running tests, to ensure examples are run
   - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,10 @@ platform:
 environment:
   matrix:
     - PYTHON: 2.7
+      CONDA: "C:\\Miniconda-x64"
+
     - PYTHON: 3.6
+      CONDA: "C:\\Miniconda36-x64"
 
 init:
   #Uncomment the following line to gain RDP access to an appveyor machine.
@@ -16,15 +19,12 @@ init:
   #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 install:
-  - set CONDA=Miniconda
-  - if "%PLATFORM%" == "x64" (set CONDA=%CONDA%-x64)
   - echo %CONDA%
-  - set PATH=C:\%CONDA%;C:\%CONDA%\Scripts;%PATH%
+  - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   # We need to do this first as other commands may not work with older versions of conda.
   - conda update conda
-  - if "%PYTHON%" == "3.6" (conda uninstall enum34)
-  - conda install python=%PYTHON% numpy scipy nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy=1.14 scipy nose hdf5 h5py sphinx mock pip --quiet
   #Grab testflo for running tests, to ensure examples are run
   - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git
@@ -33,7 +33,7 @@ install:
   - cd "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC"
   - vcvarsall amd64
   - ps: |
-      If ($env:CONDA -eq "Miniconda3-x64") {
+      If ($env:CONDA -eq "C:\\Miniconda36-x64") {
         If ((Test-Path Env:\MSMPI_BIN)) {throw "error: MSMPI_BIN env var exists. Msmpi already installed before we go to install it."}
         If ((Get-Command "mpiexec.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpiexec.exe already exists before we go to install it"}
         If ((Get-Command "mpirun.exe" -ErrorAction SilentlyContinue) -ne $null) {throw "error: mpirun.exe already exists before we go to install it"}
@@ -43,8 +43,8 @@ install:
       }
 
   #Do these pip installs outside of powershell
-  - if "%CONDA%" == "Miniconda3-x64" (pip install http://openmdao.org/dists/mpi4py-2.0.0-cp34-none-win_amd64.whl)
-  - if "%CONDA%" == "Miniconda3-x64" (pip install http://openmdao.org/dists/petsc4py-3.6.0-cp34-none-win_amd64.whl)
+  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/mpi4py-2.0.0-cp34-none-win_amd64.whl)
+  - if "%CONDA%" == "C:\\Miniconda36-x64" (pip install http://openmdao.org/dists/petsc4py-3.6.0-cp34-none-win_amd64.whl)
 
   #Return back to continue install of OpenMDAO
   - cd C:\projects\OpenMDAO*
@@ -52,7 +52,7 @@ install:
 
 test_script:
   - ps: |
-        If ($env:CONDA -eq "Miniconda3-x64") {
+        If ($env:CONDA -eq "C:\\Miniconda36-x64") {
           $env:MSMPI_BIN = [System.Environment]::GetEnvironmentVariable("MSMPI_BIN","Machine")
           $env:Path = $env:Path + ";" + $env:MSMPI_BIN
           If ((Get-Command "mpiexec.exe" -ErrorAction SilentlyContinue) -eq $null) {throw "error: can't find mpiexec.exe after install"}
@@ -61,7 +61,6 @@ test_script:
           nmake /f Makefile.nmake all
           cd ../..
         }
-  - testflo . -n 1 -m "ptest*"
   - testflo . -n 1
 
 #after tests, need to cd down so that conf.py can be found for docbuild

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - conda install git
   - cd C:\projects\OpenMDAO*
-  - git reset --hard ce324e2341ba44f93de686deb7f8923c3b553656
+  - git reset --hard b715ec0dc87ad08e6169a4776dc146f2d05a1d14
   - pip install -e .
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,7 @@ install:
   - conda install python=%PYTHON% numpy scipy=1.0 nose hdf5 h5py sphinx mock pip --quiet
   - pip install matplotlib
   - pip install git+https://github.com/OpenMDAO/testflo.git
-  - cd C:\projects\OpenMDAO*
+  - cd C:\projects\blue*
   - pip install -e .
   - pip list
   - conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,4 @@
+build: false
 version: 2.3.1.{build}-{branch}
 
 platform: x64

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,6 @@
-build: false
+version: 2.3.1.{build}-{branch}
 
-version: 2.0.{build}
-
-platform:
-  - x64
+platform: x64
 
 environment:
   matrix:
@@ -18,14 +15,10 @@ install:
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install python=%PYTHON% numpy scipy nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy scipy=1.0 nose hdf5 h5py sphinx mock pip --quiet
   - pip install git+https://github.com/OpenMDAO/testflo.git
-  - conda install git
   - cd C:\projects\OpenMDAO*
-  - git reset --hard b715ec0dc87ad08e6169a4776dc146f2d05a1d14
   - pip install -e .
-
 
 test_script:
   - testflo . -n 1
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,10 @@ install:
   - pip install redbaron
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - pip install matplotlib
-  - cd C:\projects\OpenMDAO*
-  - pip install -e .
+  #- cd C:\projects\OpenMDAO*
+  #- pip install -e .
+  - pip install git+git://github.com/OpenMDAO/OpenMDAO.git@ce324e2341ba44f93de686deb7f8923c3b553656
+
 
 test_script:
   - testflo . -n 1


### PR DESCRIPTION
*Appveyor was running only on 2.7 due to changes made at some point. 3.6 now works also, due to fixing the path to get to Miniconda

* Many lines of code were not even executing or working in any way, so I pared the file down to what works. (we weren't running docs/mpi/petsc/pyoptsparse on Windows anyway, so I removed the dead code that wasn't executing)

* Updated numpy to no longer be pinned, and run latest numpy release

* Had to pin scipy to 1.0.x in order to get one test that uses ScipyKrylov to pass (same problem that is seen in benchmark running of the tests.)

* Removed parametric testing