### PR TITLE
extend Problem.cleanup() to systems & solvers as well as driver

### DIFF
--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -46,26 +46,26 @@ class ExternalCodeDelegate(object):
         """
         comp = self._comp
 
-        comp.options.declare('command', [], desc='command to be executed')
-        comp.options.declare('env_vars', {}, desc='Environment variables required by the command')
+        comp.options.declare('command', [], desc='Command to be executed.')
+        comp.options.declare('env_vars', {}, desc='Environment variables required by the command.')
         comp.options.declare('poll_delay', 0.0, lower=0.0,
-                             desc='Delay between polling for command completion. A value of zero '
-                                  'will use an internally computed default')
+                             desc='Delay between polling for command completion. '
+                                  'A value of zero will use an internally computed default.')
         comp.options.declare('timeout', 0.0, lower=0.0,
-                             desc='Maximum time to wait for command completion. A value of zero '
-                                  'implies an infinite wait')
+                             desc='Maximum time to wait for command completion. '
+                                  'A value of zero implies an infinite wait.')
         comp.options.declare('external_input_files', [],
-                             desc='(optional) list of input file names to check the existence '
-                                  'of before solve_nonlinear')
+                             desc='List of input files that must exist before execution, '
+                                  'otherwise an Exception is raised.')
         comp.options.declare('external_output_files', [],
-                             desc='(optional) list of input file names to check the existence of '
-                                  'after solve_nonlinear')
+                             desc='List of output files that must exist after execution, '
+                                  'otherwise an Exception is raised.')
         comp.options.declare('fail_hard', True,
                              desc="If True, external code errors raise a 'hard' exception "
-                                  "(RuntimeError).  Otherwise raise a 'soft' exception "
+                                  "(RuntimeError), otherwise errors raise a 'soft' exception "
                                   "(AnalysisError).")
         comp.options.declare('allowed_return_codes', [0],
-                             desc="Set of return codes that are considered successful.")
+                             desc="List of return codes that are considered successful.")
 
     def check_config(self, logger):
         """
@@ -155,9 +155,8 @@ class ExternalCodeDelegate(object):
             elif return_code not in comp.options['allowed_return_codes']:
                 if isinstance(comp.stderr, str):
                     if os.path.exists(comp.stderr):
-                        stderrfile = open(comp.stderr, 'r')
-                        error_desc = stderrfile.read()
-                        stderrfile.close()
+                        with open(comp.stderr, 'r') as stderrfile:
+                            error_desc = stderrfile.read()
                         err_fragment = "\nError Output:\n%s" % error_desc
                     else:
                         err_fragment = "\n[stderr %r missing]" % comp.stderr
@@ -230,7 +229,7 @@ class ExternalCodeComp(ExplicitComponent):
     Run an external code as a component.
 
     Default stdin is the 'null' device, default stdout is the console, and
-    default stderr is ``error.out``.
+    default stderr is ``external_code_comp_error.out``.
 
     Attributes
     ----------
@@ -240,11 +239,6 @@ class ExternalCodeComp(ExplicitComponent):
         Output stream external code writes to.
     stderr : str or file object
         Error stream external code writes to.
-    DEV_NULL : File object
-        NULL device.
-    STDOUT : File object
-        Special value that can be used as the stderr argument to Popen and indicates
-        that standard error should go into the same handle as standard output.
     _external_code_runner: ExternalCodeDelegate object
         The delegate object that handles all the running of the external code for this object.
     return_code : int
@@ -332,7 +326,7 @@ class ExternalCodeImplicitComp(ImplicitComponent):
     Run an external code as a component.
 
     Default stdin is the 'null' device, default stdout is the console, and
-    default stderr is ``error.out``.
+    default stderr is ``external_code_comp_error.out``.
 
     Attributes
     ----------
@@ -342,11 +336,6 @@ class ExternalCodeImplicitComp(ImplicitComponent):
         Output stream external code writes to.
     stderr : str or file object
         Error stream external code writes to.
-    DEV_NULL : File object
-        NULL device.
-    STDOUT : File object
-        Special value that can be used as the stderr argument to Popen and indicates
-        that standard error should go into the same handle as standard output.
     _external_code_runner: ExternalCodeDelegate object
         The delegate object that handles all the running of the external code for this object.
     return_code : int

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -209,7 +209,8 @@ class Driver(object):
         """
         Clean up resources prior to exit.
         """
-        self._rec_mgr.close()
+        # shut down all recorders
+        self._rec_mgr.shutdown()
 
     def _declare_options(self):
         """

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -536,6 +536,8 @@ class Problem(object):
         Clean up resources prior to exit.
         """
         self.driver.cleanup()
+        for system in self.model.system_iter(include_self=True, recurse=True):
+            system.cleanup()
 
     def setup(self, vector_class=None, check=False, logger=None, mode='rev',
               force_alloc_complex=False, distributed_vector_class=PETScVector,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2905,3 +2905,16 @@ class System(object):
                 nl._iter_count = 0
                 if hasattr(nl, 'linesearch') and nl.linesearch:
                     nl.linesearch._iter_count = 0
+
+    def cleanup(self):
+        """
+        Clean up resources prior to exit.
+        """
+        # shut down all recorders
+        self._rec_mgr.shutdown()
+
+        # do any required cleanup on solvers
+        if self._nonlinear_solver:
+            self._nonlinear_solver.cleanup()
+        if self._linear_solver:
+            self._linear_solver.cleanup()

--- a/openmdao/devtools/problem_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/devtools/problem_viewer/tests/test_viewmodeldata.py
@@ -62,7 +62,7 @@ class TestViewModelData(unittest.TestCase):
         p.driver.add_recorder(r)
         p.setup(check=False)
         p.final_setup()
-        r.close()
+        r.shutdown()
 
         model_viewer_data = _get_viewer_data(self.sqlite_db_filename)
         tree_json = json.dumps(model_viewer_data['tree'])
@@ -94,7 +94,7 @@ class TestViewModelData(unittest.TestCase):
         p.driver.add_recorder(r)
         p.setup(check=False)
         p.final_setup()
-        r.close()
+        r.shutdown()
         view_model(self.sqlite_db_filename2, outfile=self.sqlite_filename, show_browser=False)
 
         # Check that the html file has been created and has something in it.

--- a/openmdao/recorders/base_recorder.py
+++ b/openmdao/recorders/base_recorder.py
@@ -215,8 +215,8 @@ class BaseRecorder(object):
         """
         raise NotImplementedError("record_iteration_solver has not been overridden")
 
-    def close(self):
+    def shutdown(self):
         """
-        Clean up the recorder.
+        Shut down the recorder.
         """
         pass

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -109,10 +109,10 @@ class RecordingManager(object):
 
     def shutdown(self):
         """
-        Close and remove all recorders in the manager.
+        Shut down and remove all recorders.
         """
         for recorder in self._recorders:
-            recorder.close()
+            recorder.shutdown()
         self._recorders = []
 
     def record_iteration(self, recording_requester, data, metadata):

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -107,12 +107,13 @@ class RecordingManager(object):
             if not recorder._parallel:
                 self._has_serial_recorders = True
 
-    def close(self):
+    def shutdown(self):
         """
-        Close all recorders in the manager.
+        Close and remove all recorders in the manager.
         """
         for recorder in self._recorders:
             recorder.close()
+        self._recorders = []
 
     def record_iteration(self, recording_requester, data, metadata):
         """

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -474,7 +474,7 @@ class SqliteRecorder(BaseRecorder):
 
     def close(self):
         """
-        Close `out`.
+        Close database connection.
         """
         if self.connection:
             self.connection.close()

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -472,7 +472,7 @@ class SqliteRecorder(BaseRecorder):
                 c.execute("INSERT INTO solver_metadata(id, solver_options, solver_class) "
                           "VALUES(?,?,?)", (id, sqlite3.Binary(solver_options), solver_class))
 
-    def close(self):
+    def shutdown(self):
         """
         Close database connection.
         """

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -474,7 +474,8 @@ class SqliteRecorder(BaseRecorder):
 
     def shutdown(self):
         """
-        Close database connection.
+        Shut down the recorder.
         """
+        # close database connection
         if self.connection:
             self.connection.close()

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -101,7 +101,6 @@ class Mygroup(Group):
 
 
 @unittest.skipIf(PETScVector is None, "PETSc is required.")
-# @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
 class DistributedRecorderTest(unittest.TestCase):
 
     N_PROCS = 2

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -18,8 +18,8 @@ from openmdao.api import Problem, Group, IndepVarComp, ExecComp, SqliteRecorder,
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.recorders.recording_iteration_stack import recording_iteration
 
-from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDerivativesGrouped, \
-    SellarDis1withDerivatives, SellarDis2withDerivatives, SellarProblem, SellarStateConnection
+from openmdao.test_suite.components.sellar import SellarProblem, \
+    SellarDerivatives, SellarDerivativesGrouped, SellarStateConnection
 from openmdao.test_suite.components.paraboloid import Paraboloid
 
 from openmdao.recorders.tests.sqlite_recorder_test_utils import assertMetadataRecorded, \

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1584,6 +1584,8 @@ class TestSqliteRecorder(unittest.TestCase):
                 recorder.connection.execute("SELECT * FROM metadata;")
             except sqlite3.ProgrammingError as err:
                 self.assertEqual(str(err), 'Cannot operate on a closed database.')
+            else:
+                self.fail('SqliteRecorder database was not closed.')
 
         prob = SellarProblem(SellarStateConnection)
         prob.setup()

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -28,11 +28,6 @@ from openmdao.recorders.tests.sqlite_recorder_test_utils import assertMetadataRe
 from openmdao.recorders.tests.recorder_test_utils import run_driver
 from openmdao.utils.assert_utils import assert_rel_error
 
-try:
-    from openmdao.vectors.petsc_vector import PETScVector
-except ImportError:
-    PETScVector = None
-
 if PY2:
     import cPickle as pickle
 if PY3:
@@ -386,8 +381,6 @@ class TestSqliteRecorder(unittest.TestCase):
 
         assertDriverMetadataRecorded(self, None)
 
-    @unittest.skipIf(PETScVector is None, "PETSc is required.")
-    # @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
     def test_record_system(self):
         prob = SellarProblem()
         prob.setup()
@@ -414,7 +407,6 @@ class TestSqliteRecorder(unittest.TestCase):
         obj_cmp.add_recorder(self.recorder)
 
         t0, t1 = run_driver(prob)
-        prob.cleanup()
 
         expected_data = [
             # data from 'd1'
@@ -630,7 +622,6 @@ class TestSqliteRecorder(unittest.TestCase):
         nl.add_recorder(self.recorder)
 
         t0, t1 = run_driver(prob)
-        prob.cleanup()
 
         coordinate = [0, 'Driver', (0, ), 'root._solve_nonlinear', (0, ), 'NonlinearBlockGS', (6, )]
 
@@ -989,8 +980,7 @@ class TestSqliteRecorder(unittest.TestCase):
                           expected_solver_output, expected_solver_residuals),)
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(PETScVector is None, "PETSc is required.")
-    # @unittest.skipIf(os.environ.get("TRAVIS"), "Unreliable on Travis CI.")
+    @unittest.skipIf(PETScKrylov is None, "PETScKrylov is required.")
     def test_record_solver_linear_petsc_ksp(self):
         prob = SellarProblem()
         prob.setup()
@@ -1695,7 +1685,6 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(list(cr.driver_metadata['tree'].keys()),
                          ['name', 'type', 'subsystem_type', 'children'])
 
-
     def test_feature_solver_metadata(self):
         from openmdao.api import Problem, SqliteRecorder, CaseReader
         from openmdao.test_suite.components.sellar import SellarDerivatives
@@ -1729,7 +1718,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
             'd1.NonlinearBlockGS', 'root.LinearBlockGS', 'root.NonlinearBlockGS'
         ])
         self.assertEqual(cr.solver_metadata['d1.NonlinearBlockGS']['solver_options']['maxiter'], 5)
-        self.assertEqual(cr.solver_metadata['root.NonlinearBlockGS']['solver_options']['maxiter'],10)
+        self.assertEqual(cr.solver_metadata['root.NonlinearBlockGS']['solver_options']['maxiter'], 10)
         self.assertEqual(cr.solver_metadata['root.LinearBlockGS']['solver_class'],'LinearBlockGS')
 
     def test_feature_system_metadata(self):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -13,7 +13,7 @@ from tempfile import mkdtemp
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, SqliteRecorder, \
     ScipyOptimizeDriver, NonlinearRunOnce, NonlinearBlockGS, NonlinearBlockJac, NewtonSolver, \
     LinearRunOnce, LinearBlockGS, LinearBlockJac, DirectSolver, ScipyKrylov, PETScKrylov, \
-    BoundsEnforceLS, ArmijoGoldsteinLS
+    BoundsEnforceLS, ArmijoGoldsteinLS, PETScVector
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.recorders.recording_iteration_stack import recording_iteration
@@ -996,7 +996,7 @@ class TestSqliteRecorder(unittest.TestCase):
                           expected_solver_output, expected_solver_residuals),)
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(PETScKrylov is None, "PETScKrylov is required.")
+    @unittest.skipIf(PETScVector is None, "PETSc is required.")
     def test_record_solver_linear_petsc_ksp(self):
         prob = SellarProblem()
         prob.setup()

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -11,7 +11,7 @@ from six import PY2, PY3
 from tempfile import mkdtemp
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, SqliteRecorder, \
-    NonlinearRunOnce, NonlinearBlockGS, NonlinearBlockJac, NewtonSolver, \
+    ScipyOptimizeDriver, NonlinearRunOnce, NonlinearBlockGS, NonlinearBlockJac, NewtonSolver, \
     LinearRunOnce, LinearBlockGS, LinearBlockJac, DirectSolver, ScipyKrylov, PETScKrylov, \
     BoundsEnforceLS, ArmijoGoldsteinLS
 
@@ -172,9 +172,44 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
         assertDriverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_simple_driver_recording(self):
+        prob = ParaboloidProblem()
+
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
+        driver.recording_options['record_desvars'] = True
+        driver.recording_options['record_responses'] = True
+        driver.recording_options['record_objectives'] = True
+        driver.recording_options['record_constraints'] = True
+        driver.add_recorder(self.recorder)
+
+        prob.setup()
+        prob.set_solver_print(0)
+        t0, t1 = run_driver(prob)
+        prob.cleanup()
+
+        coordinate = [0, 'SLSQP', (3, )]
+
+        expected_desvars = {"p1.x": [7.16706813], "p2.y": [-7.83293187]}
+        expected_objectives = {"comp.f_xy": [-27.0833]}
+        expected_constraints = {"con.c": [-15.0]}
+
+        expected_outputs = expected_desvars
+        expected_outputs.update(expected_objectives)
+        expected_outputs.update(expected_constraints)
+
+        expected_inputs = {
+            "con.x": 7.1666667,
+            "comp.y": -7.83333333,
+            "comp.x": 7.1666667,
+            "con.y": -7.8333333
+        }
+
+        expected_data = ((coordinate, (t0, t1), expected_outputs, expected_inputs),)
+        assertDriverIterDataRecorded(self, expected_data, self.eps)
+
+    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
+    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SLSQP")
+    def test_simple_driver_recording_pyoptsparse(self):
         prob = ParaboloidProblem()
 
         driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
@@ -211,14 +246,10 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_outputs, expected_inputs),)
         assertDriverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_simple_driver_recording_with_prefix(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_responses'] = True
         driver.recording_options['record_objectives'] = True
@@ -231,8 +262,8 @@ class TestSqliteRecorder(unittest.TestCase):
         run2_t0, run2_t1 = run_driver(prob, case_prefix='Run2')
         prob.cleanup()
 
-        run1_coord = [0, 'SLSQP', (4, )]  # 1st run, 5 iterations
-        run2_coord = [0, 'SLSQP', (1, )]  # 2nd run, 2 iterations
+        run1_coord = [0, 'SLSQP', (3, )]  # 1st run, 4 iterations
+        run2_coord = [0, 'SLSQP', (0, )]  # 2nd run, 1 iteration
 
         expected_desvars = {"p1.x": [7.16706813], "p2.y": [-7.83293187]}
         expected_objectives = {"comp.f_xy": [-27.0833]}
@@ -259,14 +290,10 @@ class TestSqliteRecorder(unittest.TestCase):
         )
         assertDriverIterDataRecorded(self, expected_data, self.eps, prefix='Run2')
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_driver_everything_recorded_by_default(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
         driver.add_recorder(self.recorder)
 
         prob.setup()
@@ -458,14 +485,11 @@ class TestSqliteRecorder(unittest.TestCase):
 
         assertSystemIterDataRecorded(self, expected_data, self.eps, prefix='Run#2')
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_includes(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
+
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_responses'] = True
         driver.recording_options['record_objectives'] = True
@@ -480,7 +504,7 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (4, )]
+        coordinate = [0, 'SLSQP', (3, )]
 
         expected_desvars = {"p1.x": prob["p1.x"]}
         expected_objectives = {"comp.f_xy": prob['comp.f_xy']}
@@ -503,14 +527,10 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_outputs, expected_inputs),)
         assertDriverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_includes_post_setup(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
 
         prob.setup()
 
@@ -527,7 +547,7 @@ class TestSqliteRecorder(unittest.TestCase):
         t0, t1 = run_driver(prob)
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (4, )]
+        coordinate = [0, 'SLSQP', (3, )]
 
         expected_desvars = {"p1.x": prob["p1.x"]}
         expected_objectives = {"comp.f_xy": prob['comp.f_xy']}
@@ -547,8 +567,6 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_outputs, expected_inputs),)
         assertDriverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_record_system_with_hierarchy(self):
         prob = SellarProblem(SellarDerivativesGrouped, nonlinear_solver=NonlinearRunOnce)
         prob.setup(mode='rev')
@@ -574,9 +592,7 @@ class TestSqliteRecorder(unittest.TestCase):
         d1.recording_options['record_metadata'] = True
         d1.add_recorder(self.recorder)
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
 
         t0, t1 = run_driver(prob)
         prob.cleanup()
@@ -584,8 +600,8 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # check data for 'd1'
         #
-        coordinate = [0, 'SLSQP', (0, ), 'root._solve_nonlinear', (0, ), 'NLRunOnce', (0, ),
-                      'mda._solve_nonlinear', (0, ), 'NonlinearBlockGS', (4,), 'mda.d1._solve_nonlinear', (4, )]
+        coordinate = [0, 'SLSQP', (0, ), 'root._solve_nonlinear', (1, ), 'NLRunOnce', (0, ),
+                      'mda._solve_nonlinear', (1, ), 'NonlinearBlockGS', (0,), 'mda.d1._solve_nonlinear', (7, )]
 
         expected_inputs = {
             "mda.d1.z": [5.0, 2.0],
@@ -601,8 +617,8 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # check data for 'pz'
         #
-        coordinate = [0, 'SLSQP', (1, ), 'root._solve_nonlinear', (1, ), 'NLRunOnce', (0, ),
-                      'pz._solve_nonlinear', (1, )]
+        coordinate = [0, 'SLSQP', (1, ), 'root._solve_nonlinear', (2, ), 'NLRunOnce', (0, ),
+                      'pz._solve_nonlinear', (2, )]
 
         expected_inputs = None
         expected_outputs = {"pz.z": [2.8640616, 0.825643, ], }
@@ -1161,17 +1177,13 @@ class TestSqliteRecorder(unittest.TestCase):
                           expected_solver_output, expected_solver_residuals),)
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_record_driver_system_solver(self):
         # Test what happens when all three types are recorded: Driver, System, and Solver
 
         prob = SellarProblem(SellarDerivativesGrouped, nonlinear_solver=NonlinearRunOnce)
         prob.setup(mode='rev')
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
 
         #
         # Add recorders
@@ -1209,7 +1221,7 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # Driver recording test
         #
-        coordinate = [0, 'SLSQP', (6, )]
+        coordinate = [0, 'SLSQP', (5, )]
 
         expected_desvars = {
             "pz.z": prob['pz.z'],
@@ -1233,8 +1245,8 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # System recording test
         #
-        coordinate = [0, 'SLSQP', (1, ), 'root._solve_nonlinear', (1, ), 'NLRunOnce', (0, ),
-                      'pz._solve_nonlinear', (1, )]
+        coordinate = [0, 'SLSQP', (1, ), 'root._solve_nonlinear', (2, ), 'NLRunOnce', (0, ),
+                      'pz._solve_nonlinear', (2, )]
 
         expected_inputs = None
         expected_outputs = {"pz.z": [2.8640616, 0.825643, ], }
@@ -1248,8 +1260,8 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # Solver recording test
         #
-        coordinate = [0, 'SLSQP', (5, ), 'root._solve_nonlinear', (5, ), 'NLRunOnce', (0, ),
-                      'mda._solve_nonlinear', (5, ), 'NonlinearBlockGS', (3, )]
+        coordinate = [0, 'SLSQP', (5, ), 'root._solve_nonlinear', (6, ), 'NLRunOnce', (0, ),
+                      'mda._solve_nonlinear', (6, ), 'NonlinearBlockGS', (4, )]
 
         expected_abs_error = 0.0,
         expected_rel_error = 0.0,
@@ -1268,18 +1280,13 @@ class TestSqliteRecorder(unittest.TestCase):
                                  expected_solver_output, expected_solver_residuals),)
         assertSolverIterDataRecorded(self, expected_solver_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_global_counter(self):
         # The case recorder maintains a global counter across all recordings
 
         prob = SellarProblem(SellarDerivativesGrouped, nonlinear_solver=NonlinearRunOnce)
         prob.setup(mode='rev')
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-2  # to speed the test up
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
 
         # Add recorders for Driver, System, Solver
         driver.add_recorder(self.recorder)
@@ -1401,8 +1408,6 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_inputs, expected_outputs, expected_residuals),)
         assertSystemIterDataRecorded(self, expected_data, self.eps)
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_record_system_recursively(self):
         # Test adding recorders to all Systems using the recurse option to add_recorder
 
@@ -1412,11 +1417,7 @@ class TestSqliteRecorder(unittest.TestCase):
         # Need to do recursive adding of recorders AFTER setup
         prob.model.add_recorder(self.recorder, recurse=True)
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
-
-        t0, t1 = run_driver(prob)
+        prob.run_model()
         prob.cleanup()
 
         # Just make sure all Systems had some metadata recorded
@@ -1432,17 +1433,17 @@ class TestSqliteRecorder(unittest.TestCase):
             'con_cmp2'
         ])
 
-        # Make sure all the Systems are recorded at least once
+        # Make sure all the Systems are recorded
         assertSystemIterCoordsRecorded(self, [
-            'rank0:SLSQP|0|root._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|con_cmp1._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|con_cmp2._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|mda._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|mda._solve_nonlinear|0|NonlinearBlockGS|0|mda.d1._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|mda._solve_nonlinear|0|NonlinearBlockGS|0|mda.d2._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|obj_cmp._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|px._solve_nonlinear|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|pz._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|con_cmp1._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|con_cmp2._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|mda._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|mda._solve_nonlinear|0|NonlinearBlockGS|0|mda.d1._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|mda._solve_nonlinear|0|NonlinearBlockGS|0|mda.d2._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|obj_cmp._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|px._solve_nonlinear|0',
+            'rank0:root._solve_nonlinear|0|NLRunOnce|0|pz._solve_nonlinear|0',
         ])
 
     def test_record_system_with_prefix(self):
@@ -1491,14 +1492,10 @@ class TestSqliteRecorder(unittest.TestCase):
             'Run2_rank0:root._solve_nonlinear|0|NLRunOnce|0|pz._solve_nonlinear|0',
         ])
 
-    @unittest.skipIf(OPT is None, "pyoptsparse is not installed")
-    @unittest.skipIf(OPTIMIZER is None, "pyoptsparse is not providing SNOPT or SLSQP")
     def test_driver_recording_with_system_vars(self):
         prob = SellarProblem(SellarDerivativesGrouped, nonlinear_solver=NonlinearRunOnce)
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
-        driver.options['print_results'] = False
-        driver.opt_settings['ACC'] = 1e-9
+        driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_responses'] = True
         driver.recording_options['record_objectives'] = True
@@ -1514,7 +1511,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         # Driver recording test
-        coordinate = [0, 'SLSQP', (6, )]
+        coordinate = [0, 'SLSQP', (5, )]
 
         expected_desvars = {
             "pz.z": prob['pz.z'],

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -288,3 +288,14 @@ class NewtonSolver(NonlinearSolver):
                 header += prefix + pathname + "\n"
                 header += prefix + nchar * "="
                 print(header)
+
+    def cleanup(self):
+        """
+        Clean up resources prior to exit.
+        """
+        super(NewtonSolver, self).cleanup()
+
+        if self.linear_solver:
+            self.linear_solver.cleanup()
+        if self.linesearch:
+            self.linesearch.cleanup()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -557,6 +557,13 @@ class Solver(object):
 
         self._rec_mgr.record_iteration(self, data, metadata)
 
+    def cleanup(self):
+        """
+        Clean up resources prior to exit.
+        """
+        # shut down all recorders
+        self._rec_mgr.shutdown()
+
 
 class NonlinearSolver(Solver):
     """


### PR DESCRIPTION
Pivotal #158466031: Not all case recorders are properly closed during Problem.cleanup
Also: changed sqlite recorder tests to use ScipyOptimizeDriver to avoid unnecessary skips
Also: fixed some erroneous docstrings in ExternalCodeComp