### PR TITLE
Normalization in EqConstraintComp and BalanceComp is optional.

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -320,8 +320,7 @@ class BalanceComp(ImplicitComponent):
             given by the val or shape option in kwargs.
         normalize : bool
             Specifies whether or not the resulting residual should be normalized by a quadratic
-            function of the RHS. When this option is True, the user-provided ref/ref0 scaler/adder
-            options below are typically unnecessary.
+            function of the RHS.
         **kwargs : dict
             Additional arguments to be passed for the creation of the implicit state variable.
             (see `add_output` method).

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -23,7 +23,7 @@ class BalanceComp(ImplicitComponent):
 
     def __init__(self, name=None, eq_units=None, lhs_name=None,
                  rhs_name=None, rhs_val=0.0, guess_func=None,
-                 use_mult=False, mult_name=None, mult_val=1.0, **kwargs):
+                 use_mult=False, mult_name=None, mult_val=1.0, normalize=True, **kwargs):
         r"""
         Initialize a BalanceComp, optionally creating a new implicit state variable.
 
@@ -32,13 +32,25 @@ class BalanceComp(ImplicitComponent):
 
         .. math::
 
-          f_{mult}(x,...) \times f_{lhs}(x,...) = f_{rhs}(x,...)
+            \mathcal{R}_{name} =
+            \frac{f_{mult}(x,...) \times f_{lhs}(x,...) - f_{rhs}(x,...)}{f_{norm}(f_{rhs}(x,...))}
+
 
         Where :math:`f_{lhs}` represents the left-hand-side of the equation,
         :math:`f_{rhs}` represents the right-hand-side, and :math:`f_{mult}`
         is an optional multiplier on the left hand side.  At least one of these
         quantities should be a function of the associated state variable.  If
-        use_mult is True the default value of the multiplier is 1.
+        use_mult is True the default value of the multiplier is 1. The optional normalization
+        function :math:`f_{norm}(f_{rhs}(x,...))` is computed as:
+
+        .. math::
+
+          f_{norm}(f_{rhs}(x,...)) =
+          \begin{cases}
+           \left| f_{rhs} \right|, & \text{if normalize and } \left| f_{rhs} \right| \geq 2 \\
+           0.25 f_{rhs}^2 + 1,     & \text{if normalize and } \left| f_{rhs} \right| < 2 \\
+           1,                      & \text{if not normalize}
+          \end{cases}
 
         New state variables, and their associated residuals are created by
         calling `add_balance`.  As an example, solving the equation
@@ -111,6 +123,9 @@ class BalanceComp(ImplicitComponent):
         mult_val : int, float, or np.array
             Default value for the LHS multiplier of the given state.  Must be compatible
             with the shape (optionally) given by the val or shape option in kwargs.
+        normalize : bool
+            Specifies whether or not the resulting residual should be normalized by a quadratic
+            function of the RHS.
         **kwargs : dict
             Additional arguments to be passed for the creation of the implicit state variable.
             (see `add_output` method).
@@ -119,7 +134,7 @@ class BalanceComp(ImplicitComponent):
         self._state_vars = {}
         if name is not None:
             self.add_balance(name, eq_units, lhs_name, rhs_name, rhs_val, guess_func,
-                             use_mult, mult_name, mult_val, **kwargs)
+                             use_mult, mult_name, mult_val, normalize, **kwargs)
 
     def setup(self):
         """
@@ -180,14 +195,17 @@ class BalanceComp(ImplicitComponent):
             lhs = inputs[options['lhs_name']]
             rhs = inputs[options['rhs_name']]
 
-            # Indices where the rhs is near zero or not near zero
-            idxs_nz = np.where(np.abs(rhs) < 2)[0]
-            idxs_nnz = np.where(np.abs(rhs) >= 2)[0]
+            if options['normalize']:
+                # Indices where the rhs is near zero or not near zero
+                idxs_nz = np.where(np.abs(rhs) < 2)[0]
+                idxs_nnz = np.where(np.abs(rhs) >= 2)[0]
 
-            # Compute scaling factors
-            # scale factor that normalizes by the rhs, except near 0
-            self._scale_factor[idxs_nnz] = 1.0 / np.abs(rhs[idxs_nnz])
-            self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+                # Compute scaling factors
+                # scale factor that normalizes by the rhs, except near 0
+                self._scale_factor[idxs_nnz] = 1.0 / np.abs(rhs[idxs_nnz])
+                self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+            else:
+                self._scale_factor[:] = 1.0
 
             if options['use_mult']:
                 residuals[name] = (inputs[options['mult_name']] * lhs - rhs) * self._scale_factor
@@ -214,16 +232,20 @@ class BalanceComp(ImplicitComponent):
             lhs = inputs[lhs_name]
             rhs = inputs[rhs_name]
 
-            # Indices where the rhs is near zero or not near zero
-            idxs_nz = np.where(np.abs(rhs) < 2)[0]
-            idxs_nnz = np.where(np.abs(rhs) >= 2)[0]
+            if options['normalize']:
+                # Indices where the rhs is near zero or not near zero
+                idxs_nz = np.where(np.abs(rhs) < 2)[0]
+                idxs_nnz = np.where(np.abs(rhs) >= 2)[0]
 
-            # scale factor that normalizes by the rhs, except near 0
-            self._scale_factor[idxs_nnz] = 1.0 / np.abs(rhs[idxs_nnz])
-            self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+                # scale factor that normalizes by the rhs, except near 0
+                self._scale_factor[idxs_nnz] = 1.0 / np.abs(rhs[idxs_nnz])
+                self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
 
-            self._dscale_drhs[idxs_nnz] = -np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
-            self._dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
+                self._dscale_drhs[idxs_nnz] = -np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
+                self._dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
+            else:
+                self._scale_factor[:] = 1.0
+                self._dscale_drhs[:] = 0.0
 
             if options['use_mult']:
                 mult_name = options['mult_name']
@@ -259,7 +281,7 @@ class BalanceComp(ImplicitComponent):
 
     def add_balance(self, name, eq_units=None, lhs_name=None,
                     rhs_name=None, rhs_val=0.0, guess_func=None,
-                    use_mult=False, mult_name=None, mult_val=1.0, **kwargs):
+                    use_mult=False, mult_name=None, mult_val=1.0, normalize=True, **kwargs):
         """
         Add a new state variable and associated equation to be balanced.
 
@@ -296,6 +318,10 @@ class BalanceComp(ImplicitComponent):
         mult_val : int, float, or np.array
             Default value for the LHS multiplier.  Must be compatible with the shape (optionally)
             given by the val or shape option in kwargs.
+        normalize : bool
+            Specifies whether or not the resulting residual should be normalized by a quadratic
+            function of the RHS. When this option is True, the user-provided ref/ref0 scaler/adder
+            options below are typically unnecessary.
         **kwargs : dict
             Additional arguments to be passed for the creation of the implicit state variable.
             (see `add_output` method).
@@ -311,4 +337,5 @@ class BalanceComp(ImplicitComponent):
                                   'guess_func': guess_func,
                                   'use_mult': use_mult,
                                   'mult_name': mult_name,
-                                  'mult_val': mult_val}
+                                  'mult_val': mult_val,
+                                  'normalize': normalize}

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -178,7 +178,6 @@ class EQConstraintComp(ExplicitComponent):
             else:
                 self._scale_factor[:] = 1.0
 
-
             if options['use_mult']:
                 outputs[name] = (inputs[options['mult_name']] * lhs - rhs) * self._scale_factor
             else:

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -77,9 +77,10 @@ class EQConstraintComp(ExplicitComponent):
             Default value for the LHS multiplier of the given output.  Must be compatible
             with the shape (optionally) given by the val or shape option in kwargs.
         normalize : bool
-            Specifies whether or not the resulting output should be normalized by a quadratic
-            function of the RHS. When this option is True, the user-provided ref/ref0 scaler/adder
-            options below are typically unnecessary.
+            Specifies whether or not the resulting output should be normalized by the RHS.  When
+            the RHS value is between [-2, 2], the normalization value is a quadratic function that
+            is close to one but still provides a C1 continuous function. When this option is True,
+            the user-provided ref/ref0 scaler/adder options below are typically unnecessary.
         add_constraint : bool
             Specifies whether to add an equality constraint.
         ref : float or ndarray, optional
@@ -282,7 +283,7 @@ class EQConstraintComp(ExplicitComponent):
             Value to add to the model value to get the scaled value. Adder
             is first in precedence. This option is only meaningful when add_constraint=True.
         scaler : float or ndarray, optional
-            value to multiply the model value to get the scaled value. Scaler
+            Value to multiply the model value to get the scaled value. Scaler
             is second in precedence. This option is only meaningful when add_constraint=True.
         **kwargs : dict
             Additional arguments to be passed for the creation of the output variable.

--- a/openmdao/docs/features/building_blocks/components/balance_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/balance_comp.rst
@@ -16,7 +16,19 @@ solves the following equation:
 
 .. math::
 
-    f_{mult}(x) \cdot f_{lhs}(x) = f_{rhs}(x)
+  \mathcal{R}_{name} =
+  \frac{f_{mult}(x,...) \times f_{lhs}(x,...) - f_{rhs}(x,...)}{f_{norm}(f_{rhs}(x,...))}
+
+The optional normalization function :math:`f_{norm}(f_{rhs})` is computed as:
+
+.. math::
+
+  f_{norm}(f_{rhs}(x,...)) =
+  \begin{cases}
+   \left| f_{rhs} \right|, & \text{if normalize and } \left| f_{rhs} \right| \geq 2 \\
+   0.25 f_{rhs}^2 + 1,     & \text{if normalize and } \left| f_{rhs} \right| < 2 \\
+   1,                      & \text{if not normalize}
+  \end{cases}
 
 The following inputs and outputs are associated with each implicit state.
 

--- a/openmdao/docs/features/building_blocks/components/eq_constraint_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/eq_constraint_comp.rst
@@ -15,8 +15,18 @@ computes the output value as:
 
 .. math::
 
-  name_{output} = name_{mult} \times name_{lhs} - name_{rhs}
+  name_{output} = \frac{ name_{mult} \times name_{lhs} - name_{rhs} }{f_{norm}(name_{rhs})}
 
+The normalization function :math:`f_{norm}(name_{rhs}) takes one of the following forms:
+
+.. math::
+
+  f_{norm}(name_{rhs}) =
+  \begin{cases}
+    \left| name_{rhs} \right|,      & \text{if normalize and } \left| name_{rhs} \right| \geq 2 \\
+    0.25 name_{rhs}^2 + 1,      & \text{if normalize and } \left| name_{rhs} \right| < 2 \\
+    1,      & \text{if not normalize}
+  \end{cases}
 
 The following inputs and outputs are associated with each output variable.
 


### PR DESCRIPTION
Makes normalization by the quadratic function in these components optional, but defaults to True (current behavior).

For EqConstraintComp, add scaler/adder/ref/ref0 options, which are especially meaningful when `normalize = False`.

Updated the docs to reflect the fact that this normalization optionally occurs, since previously it made no mention of the fact, and normalized outputs of EqConstraintComp might confuse users.