### PR TITLE
fixed indexing for reporting singular errors

### DIFF
--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -57,11 +57,11 @@ def format_singular_error(err, system, mtx):
 
     n = 0
     varname = "Unknown"
-    for name in system._var_allprocs_abs_names['output']:
-        relname = system._var_abs2prom['output'][name]
-        n += len(system._outputs[relname])
+    varsizes = system._var_sizes['nonlinear']['output']
+    for j, name in enumerate(system._var_allprocs_abs_names['output']):
+        n += varsizes[0][j]
         if loc <= n:
-            varname = relname
+            varname = system._var_abs2prom['output'][name]
             break
 
     msg = "Singular entry found in '{}' for {} associated with state/residual '{}'."
@@ -99,11 +99,11 @@ def format_singular_csc_error(system, matrix):
 
     n = 0
     varname = "Unknown"
-    for name in system._var_allprocs_abs_names['output']:
-        relname = system._var_abs2prom['output'][name]
-        n += len(system._outputs[relname])
+    varsizes = system._var_sizes['nonlinear']['output']
+    for j, name in enumerate(system._var_allprocs_abs_names['output']):
+        n += varsizes[0][j]
         if loc <= n:
-            varname = relname
+            varname = system._var_abs2prom['output'][name]
             break
 
     msg = "Singular entry found in '{}' for {} associated with state/residual '{}'."

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -59,7 +59,7 @@ def format_singular_error(err, system, mtx):
     varname = "Unknown"
     varsizes = system._var_sizes['nonlinear']['output']
     for j, name in enumerate(system._var_allprocs_abs_names['output']):
-        n += varsizes[0][j]
+        n += varsizes[system._owning_rank[name]][j]
         if loc < n:
             varname = system._var_abs2prom['output'][name]
             break
@@ -101,7 +101,7 @@ def format_singular_csc_error(system, matrix):
     varname = "Unknown"
     varsizes = system._var_sizes['nonlinear']['output']
     for j, name in enumerate(system._var_allprocs_abs_names['output']):
-        n += varsizes[0][j]
+        n += varsizes[system._owning_rank[name]][j]
         if loc < n:
             varname = system._var_abs2prom['output'][name]
             break
@@ -136,7 +136,7 @@ def format_nan_error(system, matrix):
     for row in rows:
         n = 0
         for j, name in enumerate(all_vars):
-            n += varsizes[0][j]
+            n += varsizes[system._owning_rank[name]][j]
             if row < n:
                 relname = system._var_abs2prom['output'][name]
                 varname.append("'%s'" % relname)

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -60,7 +60,7 @@ def format_singular_error(err, system, mtx):
     varsizes = system._var_sizes['nonlinear']['output']
     for j, name in enumerate(system._var_allprocs_abs_names['output']):
         n += varsizes[0][j]
-        if loc <= n:
+        if loc < n:
             varname = system._var_abs2prom['output'][name]
             break
 
@@ -102,7 +102,7 @@ def format_singular_csc_error(system, matrix):
     varsizes = system._var_sizes['nonlinear']['output']
     for j, name in enumerate(system._var_allprocs_abs_names['output']):
         n += varsizes[0][j]
-        if loc <= n:
+        if loc < n:
             varname = system._var_abs2prom['output'][name]
             break
 
@@ -132,12 +132,13 @@ def format_nan_error(system, matrix):
     # need to associate each index with a variable.
     varname = []
     all_vars = system._var_allprocs_abs_names['output']
+    varsizes = system._var_sizes['nonlinear']['output']
     for row in rows:
         n = 0
-        for name in all_vars:
-            relname = system._var_abs2prom['output'][name]
-            n += len(system._outputs[relname])
-            if row <= n:
+        for j, name in enumerate(all_vars):
+            n += varsizes[0][j]
+            if row < n:
+                relname = system._var_abs2prom['output'][name]
                 varname.append("'%s'" % relname)
                 break
 


### PR DESCRIPTION
These were off for some of the larger ones reported in pycycle. Luckily now we have _var_sizes cached in system so we don't have to try to sum up sizes anymore.