### PR TITLE
P158161973 model metadata optionally should be recorded

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -141,6 +141,8 @@ class Driver(object):
 
         self.recording_options.declare('record_metadata', types=bool, default=True,
                                        desc='Record metadata')
+        self.recording_options.declare('record_model_metadata', types=bool, default=True,
+                                       desc='Record metadata for all Systems in the model')
         self.recording_options.declare('record_desvars', types=bool, default=True,
                                        desc='Set to True to record design variables at the '
                                             'driver level')
@@ -408,6 +410,11 @@ class Driver(object):
                     from openmdao.devtools.problem_viewer.problem_viewer import _get_viewer_data
                     self._model_viewer_data = _get_viewer_data(problem)
             self._rec_mgr.record_metadata(self)
+
+        # Also record the system metadata to the recorders attached to this Driver
+        if self.recording_options['record_model_metadata']:
+            for sub in model.system_iter(recurse=True, include_self=True):
+                self._rec_mgr.record_metadata(sub)
 
     def _get_voi_val(self, name, meta, remote_vois, unscaled=False, ignore_indices=False):
         """

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -140,7 +140,7 @@ class Driver(object):
         self.recording_options = OptionsDictionary()
 
         self.recording_options.declare('record_metadata', types=bool, default=True,
-                                       desc='Record metadata')
+                                       desc='Record Driver metadata')
         self.recording_options.declare('record_model_metadata', types=bool, default=True,
                                        desc='Record metadata for all Systems in the model')
         self.recording_options.declare('record_desvars', types=bool, default=True,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -695,7 +695,7 @@ class System(object):
         self._setup_var_sizes(recurse=recurse)
         self._setup_connections(recurse=recurse)
 
-    def _setup_case_recording(self, recurse=True):
+    def _setup_recording(self, recurse=True):
         myinputs = myoutputs = myresiduals = set()
         incl = self.recording_options['includes']
         excl = self.recording_options['excludes']
@@ -726,7 +726,7 @@ class System(object):
         # Recursion
         if recurse:
             for subsys in self._subsystems_myproc:
-                subsys._setup_case_recording(recurse)
+                subsys._setup_recording(recurse)
 
     def _final_setup(self, comm, setup_mode, force_alloc_complex=False):
         """
@@ -785,7 +785,7 @@ class System(object):
         self._setup_partials(recurse=recurse)
         self._setup_jacobians(recurse=recurse)
 
-        self._setup_case_recording(recurse=recurse)
+        self._setup_recording(recurse=recurse)
 
         # If full or reconf setup, reset this system's variables to initial values.
         if setup_mode in ('full', 'reconf'):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -799,7 +799,7 @@ class System(object):
         # Also, optionally, record to the recorders attached to this System,
         #   the system metadata for all the subsystems
         if self.recording_options['record_model_metadata']:
-            for sub in self.system_iter(recurse=True, include_self=False):
+            for sub in self.system_iter(recurse=True, include_self=True):
                 self._rec_mgr.record_metadata(sub)
 
     def _setup_vars(self, recurse=True):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -262,8 +262,8 @@ class System(object):
                                        desc='Set to True to record residuals at the system level')
         self.recording_options.declare('record_metadata', types=bool, desc='Record metadata',
                                        default=True)
-        self.recording_options.declare('record_metadata_recursively', types=bool,
-                                       desc='Record metadata recursively below this system',
+        self.recording_options.declare('record_model_metadata', types=bool,
+                                       desc='Record metadata for all Systems in the model',
                                        default=True)
         self.recording_options.declare('includes', types=list, default=['*'],
                                        desc='Patterns for variables to include in recording')
@@ -791,12 +791,16 @@ class System(object):
         if setup_mode in ('full', 'reconf'):
             self.set_initial_values()
 
+        # Tell all subsystems to record their metadata if they have recorders attached
         for sub in self.system_iter(recurse=True, include_self=True):
             if sub.recording_options['record_metadata']:
                 sub._rec_mgr.record_metadata(sub)
-                if sub.recording_options['record_metadata_recursively']:
-                    for sub_sub in sub.system_iter(recurse=True, include_self=False):
-                        sub._rec_mgr.record_metadata(sub_sub)
+
+        # Also, optionally, record to the recorders attached to this System,
+        #   the system metadata for all the subsystems
+        if self.recording_options['record_model_metadata']:
+            for sub in self.system_iter(recurse=True, include_self=False):
+                self._rec_mgr.record_metadata(sub)
 
     def _setup_vars(self, recurse=True):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -260,10 +260,10 @@ class System(object):
                                        desc='Set to True to record outputs at the system level')
         self.recording_options.declare('record_residuals', types=bool, default=True,
                                        desc='Set to True to record residuals at the system level')
-        self.recording_options.declare('record_metadata', types=bool, desc='Record metadata',
-                                       default=True)
+        self.recording_options.declare('record_metadata', types=bool,
+                                       desc='Record metadata for this system', default=True)
         self.recording_options.declare('record_model_metadata', types=bool,
-                                       desc='Record metadata for all Systems in the model',
+                                       desc='Record metadata for all sub systems in the model',
                                        default=True)
         self.recording_options.declare('includes', types=list, default=['*'],
                                        desc='Patterns for variables to include in recording')

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -262,6 +262,9 @@ class System(object):
                                        desc='Set to True to record residuals at the system level')
         self.recording_options.declare('record_metadata', types=bool, desc='Record metadata',
                                        default=True)
+        self.recording_options.declare('record_metadata_recursively', types=bool,
+                                       desc='Record metadata recursively below this system',
+                                       default=True)
         self.recording_options.declare('includes', types=list, default=['*'],
                                        desc='Patterns for variables to include in recording')
         self.recording_options.declare('excludes', types=list, default=[],
@@ -789,7 +792,11 @@ class System(object):
             self.set_initial_values()
 
         for sub in self.system_iter(recurse=True, include_self=True):
-            sub._rec_mgr.record_metadata(sub)
+            if sub.recording_options['record_metadata']:
+                sub._rec_mgr.record_metadata(sub)
+                if sub.recording_options['record_metadata_recursively']:
+                    for sub_sub in sub.system_iter(recurse=True, include_self=False):
+                        sub._rec_mgr.record_metadata(sub_sub)
 
     def _setup_vars(self, recurse=True):
         """

--- a/openmdao/recorders/base_recorder.py
+++ b/openmdao/recorders/base_recorder.py
@@ -121,7 +121,7 @@ class BaseRecorder(object):
         # Cannot handle PETScVector yet
         from openmdao.api import PETScVector
         if PETScVector and isinstance(recording_requester._outputs, PETScVector):
-            return None, None # Cannot handle PETScVector yet
+            return None, None  # Cannot handle PETScVector yet
 
         from six import iteritems
         from openmdao.utils.options_dictionary import OptionsDictionary
@@ -143,7 +143,6 @@ class BaseRecorder(object):
         user_options._read_only = recording_requester.options._read_only
 
         return scaling_vecs, user_options
-
 
     def record_metadata_system(self, recording_requester):
         """

--- a/openmdao/recorders/base_recorder.py
+++ b/openmdao/recorders/base_recorder.py
@@ -1,7 +1,7 @@
 """
 Class definition for BaseRecorder, the base class for all recorders.
 """
-from six import StringIO
+from six import StringIO, iteritems
 
 from openmdao.core.system import System
 from openmdao.core.driver import Driver
@@ -9,6 +9,8 @@ from openmdao.solvers.solver import Solver
 from openmdao.core.problem import Problem
 from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.mpi import MPI
+from openmdao.utils.options_dictionary import OptionsDictionary
+from openmdao.utils.record_util import check_path
 
 
 class BaseRecorder(object):
@@ -122,10 +124,6 @@ class BaseRecorder(object):
         from openmdao.api import PETScVector
         if PETScVector and isinstance(recording_requester._outputs, PETScVector):
             return None, None  # Cannot handle PETScVector yet
-
-        from six import iteritems
-        from openmdao.utils.options_dictionary import OptionsDictionary
-        from openmdao.utils.record_util import check_path
 
         # collect scaling arrays
         scaling_vecs = {}

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -439,26 +439,12 @@ class SqliteRecorder(BaseRecorder):
             The System that would like to record its metadata.
         """
         if self.connection:
-            # Cannot handle PETScVector yet
-            from openmdao.api import PETScVector
-            if PETScVector and isinstance(recording_requester._outputs, PETScVector):
-                return  # Cannot handle PETScVector yet
+            scaling_vecs, user_options = self._get_metadata_system(recording_requester)
 
-            # collect scaling arrays
-            scaling_vecs = {}
-            for kind, odict in iteritems(recording_requester._vectors):
-                scaling_vecs[kind] = scaling = {}
-                for vecname, vec in iteritems(odict):
-                    scaling[vecname] = vec._scaling
+            if scaling_vecs == None:
+                return
+
             scaling_factors = pickle.dumps(scaling_vecs, self._pickle_version)
-
-            # create a copy of the system's metadata excluding what is in 'options_excludes'
-            user_options = OptionsDictionary()
-            excludes = recording_requester.recording_options['options_excludes']
-            for key in recording_requester.options._dict:
-                if check_path(key, [], excludes, True):
-                    user_options._dict[key] = recording_requester.options._dict[key]
-            user_options._read_only = recording_requester.options._read_only
 
             # try to pickle the metadata, report if it failed
             try:

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1777,6 +1777,9 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         # make sure we record metadata
         prob.driver.recording_options['record_metadata'] = True
 
+        # also record the metadata for all systems in the model
+        prob.driver.recording_options['record_model_metadata'] = True
+
         recorder = SqliteRecorder("cases.sql")
         prob.driver.add_recorder(recorder)
 
@@ -1804,6 +1807,11 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         # access the model tree stored in metadata
         self.assertEqual(list(cr.driver_metadata['tree'].keys()),
                          ['name', 'type', 'subsystem_type', 'children'])
+
+        # access the metadata for all the systems in the model
+        self.assertEqual(list(cr.system_metadata.keys()),
+                         ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2'])
+
 
     def test_feature_solver_metadata(self):
         from openmdao.api import Problem, SqliteRecorder, CaseReader

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1805,12 +1805,12 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
                                     "pz.z\tobj_cmp.z"]))
 
         # access the model tree stored in metadata
-        self.assertEqual(list(cr.driver_metadata['tree'].keys()),
-                         ['name', 'type', 'subsystem_type', 'children'])
+        self.assertEqual(set(cr.driver_metadata['tree'].keys()),
+                         {'name', 'type', 'subsystem_type', 'children'})
 
         # access the metadata for all the systems in the model
-        self.assertEqual(list(cr.system_metadata.keys()),
-                         ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2'])
+        self.assertEqual(set(cr.system_metadata.keys()),
+                         {'root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2'})
 
 
     def test_feature_solver_metadata(self):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -389,6 +389,7 @@ class TestSqliteRecorder(unittest.TestCase):
 
         recorder = SqliteRecorder("cases.sql")
         prob.model.add_recorder(recorder)
+        prob.model.recording_options['record_model_metadata'] = False
         prob.model.recording_options['record_metadata'] = False
 
         prob.setup()
@@ -398,7 +399,7 @@ class TestSqliteRecorder(unittest.TestCase):
         cr = CaseReader("cases.sql")
         self.assertEqual(len(cr.system_metadata.keys()), 0)
 
-    def test_record_system_metadata_recursively(self):
+    def test_system_record_model_metadata(self):
         # first check to see if recorded recursively, which is the default
         prob = Problem(model=SellarDerivatives())
         prob.setup()
@@ -419,14 +420,40 @@ class TestSqliteRecorder(unittest.TestCase):
 
         recorder = SqliteRecorder("cases.sql")
         prob.model.add_recorder(recorder)
-
-        prob.model.recording_options['record_metadata_recursively'] = False
+        prob.model.recording_options['record_model_metadata'] = False
 
         prob.run_model()
         prob.cleanup()
 
         cr = CaseReader("cases.sql")
         self.assertEqual(list(cr.system_metadata.keys()), ['root'])
+
+    def test_driver_record_model_metadata(self):
+        prob = Problem(model=SellarDerivatives())
+        prob.setup()
+
+        recorder = SqliteRecorder("cases.sql")
+        prob.driver.add_recorder(recorder)
+
+        prob.run_model()
+        prob.cleanup()
+
+        cr = CaseReader("cases.sql")
+        self.assertEqual(set(cr.system_metadata.keys()),
+                         set(['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']))
+
+        prob = Problem(model=SellarDerivatives())
+        prob.setup()
+
+        recorder = SqliteRecorder("cases.sql")
+        prob.driver.add_recorder(recorder)
+        prob.driver.recording_options['record_model_metadata'] = False
+
+        prob.run_model()
+        prob.cleanup()
+
+        cr = CaseReader("cases.sql")
+        self.assertEqual(len(cr.system_metadata.keys()), 0)
 
     def test_driver_without_n2_data(self):
         prob = SellarProblem()

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -411,8 +411,11 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         cr = CaseReader("cases.sql")
-        self.assertEqual(set(cr.system_metadata.keys()),
-                         set(['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']))
+        # Quick check to see that keys and values were recorded
+        for key in ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']:
+            self.assertTrue(key in cr.system_metadata.keys())
+            value = cr.system_metadata[key]['component_options']['assembled_jac_type']
+            self.assertEqual(value, 'csc') # quick check only. Too much to check exhaustively
 
         # second check to see if not recorded recursively, when option set to False
         prob = Problem(model=SellarDerivatives())
@@ -427,6 +430,8 @@ class TestSqliteRecorder(unittest.TestCase):
 
         cr = CaseReader("cases.sql")
         self.assertEqual(list(cr.system_metadata.keys()), ['root'])
+        self.assertEqual(cr.system_metadata['root']['component_options']['assembled_jac_type'],
+                         'csc')
 
     def test_driver_record_model_metadata(self):
         prob = Problem(model=SellarDerivatives())
@@ -439,8 +444,11 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         cr = CaseReader("cases.sql")
-        self.assertEqual(set(cr.system_metadata.keys()),
-                         set(['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']))
+        # Quick check to see that keys and values were recorded
+        for key in ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']:
+            self.assertTrue(key in cr.system_metadata.keys())
+            value = cr.system_metadata[key]['component_options']['assembled_jac_type']
+            self.assertEqual(value, 'csc') # quick check only. Too much to check exhaustively
 
         prob = Problem(model=SellarDerivatives())
         prob.setup()
@@ -1805,13 +1813,20 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
                                     "pz.z\tobj_cmp.z"]))
 
         # access the model tree stored in metadata
+        # Quick check to see that keys and values were recorded
         self.assertEqual(set(cr.driver_metadata['tree'].keys()),
                          {'name', 'type', 'subsystem_type', 'children'})
+        self.assertEqual(cr.driver_metadata['tree']['name'], 'root')
+        self.assertEqual(cr.driver_metadata['tree']['type'], 'root')
+        self.assertEqual(cr.driver_metadata['tree']['subsystem_type'], 'group')
+        self.assertEqual(len(cr.driver_metadata['tree']['children']), 7)
 
         # access the metadata for all the systems in the model
-        self.assertEqual(set(cr.system_metadata.keys()),
-                         {'root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2'})
-
+        # Quick check to see that keys and values were recorded
+        for key in ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']:
+            self.assertTrue(key in cr.system_metadata.keys())
+            value = cr.system_metadata[key]['component_options']['assembled_jac_type']
+            self.assertEqual(value, 'csc') # quick check only. Too much to check exhaustively
 
     def test_feature_solver_metadata(self):
         from openmdao.api import Problem, SqliteRecorder, CaseReader


### PR DESCRIPTION
Original story was:

If a recorder is attached to a system object, the metadata for that system and all systems below it should be recorded by default. If the recorder is attached to the driver or root, it should record the metadata for all systems by default.

Followed up by this simplification from Justin:

1) if you record any system meta-data you record it all (regardless of where its saved to) (edited)
2) i think the option should just be called `record_model_metadata` for both systems and driver. The docs can make it clear that this means ALL metadata from all groups/components will be saved

Also fixed the fact that `record_metadata` option on System was never used. Added test for that.