### PR TITLE
Make openmdao vectors "read-only" if the user should not set values in them.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install python=%PYTHON% numpy scipy=1.0.1 mkl==2018.0.2 nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy scipy=1.0.1 mkl==2018.0.2 nose sphinx mock pip --quiet
   - pip install matplotlib
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - cd C:\projects\blue*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ install:
   - set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
   - conda config --set always_yes yes
   - conda update conda
-  - conda install python=%PYTHON% numpy scipy=1.0 nose hdf5 h5py sphinx mock pip --quiet
+  - conda install python=%PYTHON% numpy scipy=1.0.1 mkl==2018.0.2 nose hdf5 h5py sphinx mock pip --quiet
   - pip install matplotlib
   - pip install git+https://github.com/OpenMDAO/testflo.git
   - cd C:\projects\blue*

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -270,16 +270,16 @@ class MetaModelUnStructuredComp(ExplicitComponent):
 
         # predict for current inputs
         if vec_size > 1:
-            inputs = self._vec_to_array_vectorized(inputs)
+            flat_inputs = self._vec_to_array_vectorized(inputs)
         else:
-            inputs = self._vec_to_array(inputs)
+            flat_inputs = self._vec_to_array(inputs)
 
         for name, shape in self._surrogate_output_names:
             surrogate = self._metadata(name).get('surrogate')
 
             if vec_size == 1:
                 # Non vectorized.
-                predicted = surrogate.predict(inputs)
+                predicted = surrogate.predict(flat_inputs)
                 if isinstance(predicted, tuple):  # rmse option
                     self._metadata(name)['rmse'] = predicted[1]
                     predicted = predicted[0]
@@ -288,7 +288,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
             elif overrides_method('vectorized_predict', surrogate, SurrogateModel):
                 # Vectorized; surrogate provides vectorized computation.
                 # TODO: This code is untested because no surrogates provide this option.
-                predicted = surrogate.vectorized_predict(inputs.flat)
+                predicted = surrogate.vectorized_predict(flat_inputs.flat)
                 if isinstance(predicted, tuple):  # rmse option
                     self._metadata(name)['rmse'] = predicted[1]
                     predicted = predicted[0]
@@ -303,7 +303,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
                 predicted = np.zeros(output_shape)
                 rmse = self._metadata(name)['rmse'] = []
                 for i in range(vec_size):
-                    pred_i = surrogate.predict(inputs[i])
+                    pred_i = surrogate.predict(flat_inputs[i])
                     if isinstance(pred_i, tuple):  # rmse option
                         rmse.append(pred_i[1])
                         pred_i = pred_i[0]

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -265,7 +265,8 @@ class ExplicitComponent(Component):
                     with self._unscaled_context(
                             outputs=[self._outputs], residuals=[d_residuals]):
 
-                        # set appropriate vector to read_only to help prevent user error
+                        # set appropriate vectors to read_only to help prevent user error
+                        self._inputs.read_only = True
                         if mode == 'fwd':
                             d_inputs.read_only = True
                         elif mode == 'rev':
@@ -290,7 +291,7 @@ class ExplicitComponent(Component):
                         else:
                             self.compute_jacvec_product(self._inputs, d_inputs, d_residuals, mode)
 
-                        d_inputs.read_only = d_residuals.read_only = False
+                        self._inputs.read_only = d_inputs.read_only = d_residuals.read_only = False
 
         self._inputs.read_only = False
 

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -355,8 +355,12 @@ class ExplicitComponent(Component):
                 approximation.compute_approximations(self, jac=self._jacobian)
 
             if self._has_compute_partials:
+                self._inputs.read_only = True
+
                 # We used to negate the jacobian here, and then re-negate after the hook.
                 self.compute_partials(self._inputs, self._jacobian)
+
+                self._inputs.read_only = False
 
     def compute(self, inputs, outputs):
         """

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -72,7 +72,6 @@ class ExplicitComponent(Component):
 
         # Note: These declare calls are outside of setup_partials so that users do not have to
         # call the super version of setup_partials. This is still in the final setup.
-        other_names = []
         for out_abs in self._var_abs_names['output']:
             meta = abs2meta[out_abs]
             out_name = abs2prom_out[out_abs]
@@ -155,9 +154,6 @@ class ExplicitComponent(Component):
         """
         Set subjacobian info into our jacobian.
         """
-        abs2prom = self._var_abs2prom
-        abs2meta = self._var_abs2meta
-
         for abs_key, meta in iteritems(self._subjacs_info):
 
             if meta['value'] is None:
@@ -211,11 +207,16 @@ class ExplicitComponent(Component):
         """
         super(ExplicitComponent, self)._solve_nonlinear()
 
+        self._inputs.read_only = True
+
         with Recording(self.pathname + '._solve_nonlinear', self.iter_count, self):
             with self._unscaled_context(
                     outputs=[self._outputs], residuals=[self._residuals]):
                 self._residuals.set_const(0.0)
                 failed = self.compute(self._inputs, self._outputs)
+
+        self._inputs.read_only = False
+
         return bool(failed), 0., 0.
 
     def _apply_linear(self, jac, vec_names, rel_systems, mode, scope_out=None, scope_in=None):

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -240,8 +240,6 @@ class ExplicitComponent(Component):
             Set of absolute input names in the scope of this mat-vec product.
             If None, all are in the scope.
         """
-        self._inputs.read_only = True
-
         J = self._jacobian if jac is None else jac
 
         with Recording(self.pathname + '._apply_linear', self.iter_count, self):
@@ -292,8 +290,6 @@ class ExplicitComponent(Component):
                             self.compute_jacvec_product(self._inputs, d_inputs, d_residuals, mode)
 
                         self._inputs.read_only = d_inputs.read_only = d_residuals.read_only = False
-
-        self._inputs.read_only = False
 
     def _solve_linear(self, vec_names, mode, rel_systems):
         """

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -69,15 +69,13 @@ class ImplicitComponent(Component):
         """
         Compute residuals. The model is assumed to be in a scaled state.
         """
-        self._inputs.read_only = True
-        self._outputs.read_only = True
+        self._inputs.read_only = self._outputs.read_only = True
 
         with self._unscaled_context(outputs=[self._outputs], residuals=[self._residuals]):
             with Recording(self.pathname + '._apply_nonlinear', self.iter_count, self):
                 self.apply_nonlinear(self._inputs, self._outputs, self._residuals)
 
-        self._inputs.read_only = False
-        self._outputs.read_only = False
+        self._inputs.read_only = self._outputs.read_only = False
 
     def _solve_nonlinear(self):
         """
@@ -272,7 +270,12 @@ class ImplicitComponent(Component):
             # override FD'd values.
             for approximation in itervalues(self._approx_schemes):
                 approximation.compute_approximations(self, jac=self._jacobian)
+
+            self._inputs.read_only = self._outputs.read_only = True
+
             self.linearize(self._inputs, self._outputs, self._jacobian)
+
+            self._inputs.read_only = self._outputs.read_only = False
 
         if (jac is None or jac is self._assembled_jac) and self._assembled_jac is not None:
             self._assembled_jac._update(self)

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -116,8 +116,12 @@ class ImplicitComponent(Component):
         """
         Provide initial guess for states.
         """
+        self._inputs.read_only = self._residuals.read_only = True
+
         with self._unscaled_context(outputs=[self._outputs], residuals=[self._residuals]):
             self.guess_nonlinear(self._inputs, self._outputs, self._residuals)
+
+        self._inputs.read_only = self._residuals.read_only = False
 
     def _apply_linear(self, jac, vec_names, rel_systems, mode, scope_out=None, scope_in=None):
         """

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -9,8 +9,7 @@ from six import assertRaisesRegex
 
 from openmdao.api import Problem, ExplicitComponent, Group, IndepVarComp
 from openmdao.core.component import Component
-from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimple, \
-    TestExplCompSimpleDense
+from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimple
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArray
 from openmdao.test_suite.components.impl_comp_simple import TestImplCompSimple
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray
@@ -295,37 +294,6 @@ class TestExplicitComponent(unittest.TestCase):
         # pretend we reconfigured
         prob.setup(check=False)
 
-    def test_compute_inputs_read_only(self):
-        class BadComp(TestExplCompSimple):
-            def compute(self, inputs, outputs):
-                super(BadComp, self).compute(inputs, outputs)
-                inputs['length'] = 0.  # should not be allowed
-
-        prob = Problem(BadComp())
-        prob.setup()
-
-        with self.assertRaises(ValueError) as cm:
-            prob.run_model()
-
-        self.assertEqual(str(cm.exception),
-                         "Attempt to set value of 'length' while in read only mode.")
-
-    def test_compute_partials_inputs_read_only(self):
-        class BadComp(TestExplCompSimpleDense):
-            def compute_partials(self, inputs, partials):
-                super(BadComp, self).compute_partials(inputs, partials)
-                inputs['length'] = 0.  # should not be allowed
-
-        prob = Problem(BadComp())
-        prob.setup()
-        prob.run_model()
-
-        with self.assertRaises(ValueError) as cm:
-            prob.check_partials()
-
-        self.assertEqual(str(cm.exception),
-                         "Attempt to set value of 'length' while in read only mode.")
-
 
 class TestImplicitComponent(unittest.TestCase):
 
@@ -349,42 +317,6 @@ class TestImplicitComponent(unittest.TestCase):
         prob['rhs'] = np.ones(2)
         prob.run_model()
         assert_rel_error(self, prob['x'], np.ones(2))
-
-    def test_apply_nonlinear_inputs_read_only(self):
-        class BadComp(TestImplCompSimple):
-            def apply_nonlinear(self, inputs, outputs, residuals):
-                super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)
-                inputs['a'] = 0.  # should not be allowed
-
-        prob = Problem()
-        prob.model.add_subsystem('bad', BadComp())
-        prob.setup()
-        prob.run_model()
-
-        # check input vector
-        with self.assertRaises(ValueError) as cm:
-            prob.model.run_apply_nonlinear()
-
-        self.assertEqual(str(cm.exception),
-                         "Attempt to set value of 'a' while in read only mode.")
-
-    def test_apply_nonlinear_outputs_read_only(self):
-        class BadComp(TestImplCompSimple):
-            def apply_nonlinear(self, inputs, outputs, residuals):
-                super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)
-                outputs['x'] = 0.  # should not be allowed
-
-        prob = Problem()
-        prob.model.add_subsystem('bad', BadComp())
-        prob.setup()
-        prob.run_model()
-
-        # check output vector
-        with self.assertRaises(ValueError) as cm:
-            prob.model.run_apply_nonlinear()
-
-        self.assertEqual(str(cm.exception),
-                         "Attempt to set value of 'x' while in read only mode.")
 
 
 class TestRangePartials(unittest.TestCase):

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -314,7 +314,7 @@ class TestExplicitComponent(unittest.TestCase):
         class BadComp(TestExplCompSimpleDense):
             def compute_partials(self, inputs, partials):
                 super(BadComp, self).compute_partials(inputs, partials)
-                inputs['length'] = -1.  # should not be allowed
+                inputs['length'] = 0.  # should not be allowed
 
         prob = Problem(BadComp())
         prob.setup()
@@ -350,7 +350,7 @@ class TestImplicitComponent(unittest.TestCase):
         prob.run_model()
         assert_rel_error(self, prob['x'], np.ones(2))
 
-    def test_inputs_read_only(self):
+    def test_apply_nonlinear_inputs_read_only(self):
         class BadComp(TestImplCompSimple):
             def apply_nonlinear(self, inputs, outputs, residuals):
                 super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)
@@ -368,7 +368,7 @@ class TestImplicitComponent(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' while in read only mode.")
 
-    def test_outputs_read_only(self):
+    def test_apply_nonlinear_outputs_read_only(self):
         class BadComp(TestImplCompSimple):
             def apply_nonlinear(self, inputs, outputs, residuals):
                 super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -670,7 +670,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'length' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_compute_partials_inputs_read_only(self):
         class BadComp(TestExplCompSimpleDense):
@@ -687,7 +687,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'length' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_compute_jacvec_product_inputs_read_only(self):
         class BadComp(RectangleJacVec):
@@ -704,7 +704,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'length' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -12,6 +12,8 @@ from openmdao.api import Problem, ExplicitComponent, NewtonSolver, ScipyKrylov, 
     IndepVarComp, LinearBlockGS
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.test_suite.components.double_sellar import SubSellar
+from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimple, \
+    TestExplCompSimpleDense
 from openmdao.utils.general_utils import printoptions
 
 
@@ -21,6 +23,7 @@ class RectangleComp(ExplicitComponent):
     """
     A simple Explicit Component that computes the area of a rectangle.
     """
+
     def setup(self):
         self.add_input('length', val=1.)
         self.add_input('width', val=1.)
@@ -126,19 +129,19 @@ class ExplCompTestCase(unittest.TestCase):
         # list inputs
         inputs = prob.model.list_inputs(out_stream=None)
         self.assertEqual(sorted(inputs), [
-            ('comp2.length', { 'value' :[3.]}),
-            ('comp2.width',  { 'value' :[2.]}),
-            ('comp3.length', { 'value' :[3.]}),
-            ('comp3.width',  { 'value' :[2.]}),
+            ('comp2.length', {'value': [3.]}),
+            ('comp2.width',  {'value': [2.]}),
+            ('comp3.length', {'value': [3.]}),
+            ('comp3.width',  {'value': [2.]}),
         ])
 
         # list explicit outputs
         outputs = prob.model.list_outputs(implicit=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('comp1.length', { 'value' :[3.]}),
-            ('comp1.width',  { 'value' :[2.]}),
-            ('comp2.area',   { 'value' :[6.]}),
-            ('comp3.area',   { 'value' :[6.]}),
+            ('comp1.length', {'value': [3.]}),
+            ('comp1.width',  {'value': [2.]}),
+            ('comp2.area',   {'value': [6.]}),
+            ('comp3.area',   {'value': [6.]}),
         ])
 
         # list states
@@ -160,16 +163,14 @@ class ExplCompTestCase(unittest.TestCase):
 
         model.add_subsystem('p1', IndepVarComp('x', 12.0,
                                                lower=1.0, upper=100.0,
-                                               ref = 1.1, ref0 = 2.1,
-                                               units='inch',
-                                               ))
+                                               ref=1.1, ref0=2.1,
+                                               units='inch'))
         model.add_subsystem('p2', IndepVarComp('y', 1.0,
                                                lower=2.0, upper=200.0,
-                                               ref = 1.2, res_ref = 2.2,
-                                               units='ft',
-                                               ))
+                                               ref=1.2, res_ref=2.2,
+                                               units='ft'))
         model.add_subsystem('comp', ExecComp('z=x+y',
-                                             x={'value': 0.0, 'units':'inch'},
+                                             x={'value': 0.0, 'units': 'inch'},
                                              y={'value': 0.0, 'units': 'inch'},
                                              z={'value': 0.0, 'units': 'inch'}))
         model.connect('p1.x', 'comp.x')
@@ -180,19 +181,18 @@ class ExplCompTestCase(unittest.TestCase):
         prob.run_model()
 
         # list_inputs tests
-        # Cannot do exact equality here because the units cause comp.y to be slightly different than 12.0
+        # Can't do exact equality here because units cause comp.y to be slightly different than 12.0
         stream = cStringIO()
         inputs = prob.model.list_inputs(units=True, out_stream=stream)
         tol = 1e-7
-        for actual, expected in zip(sorted(inputs),
-                                    [
-                                        ('comp.x', {'value': [12.], 'units':'inch'}),
-                                        ('comp.y', {'value': [12.], 'units':'inch'}),
-                                    ]
-                                    ):
+        for actual, expected in zip(sorted(inputs), [
+            ('comp.x', {'value': [12.], 'units': 'inch'}),
+            ('comp.y', {'value': [12.], 'units': 'inch'})
+        ]):
             self.assertEqual(expected[0], actual[0])
             self.assertEqual(expected[1]['units'], actual[1]['units'])
             assert_rel_error(self, expected[1]['value'], actual[1]['value'], tol)
+
         text = stream.getvalue()
         self.assertEqual(1, text.count("Input(s) in 'model'"))
         self.assertEqual(1, text.count('varname'))
@@ -202,7 +202,7 @@ class ExplCompTestCase(unittest.TestCase):
         self.assertEqual(1, text.count('    x'))
         self.assertEqual(1, text.count('    y'))
         num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
-        self.assertEqual(8,num_non_empty_lines)
+        self.assertEqual(8, num_non_empty_lines)
 
         # list_outputs tests
 
@@ -236,8 +236,7 @@ class ExplCompTestCase(unittest.TestCase):
                       'lower': [1.], 'upper': [100.], 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1}),
             ('p2.y', {'value': [1.], 'resids': [0.], 'units': 'ft', 'shape': (1,),
                       'lower': [2.], 'upper': [200.], 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
-                         ],
-            sorted(outputs))
+        ], sorted(outputs))
 
         text = stream.getvalue()
         self.assertEqual(1, text.count('varname'))
@@ -254,7 +253,7 @@ class ExplCompTestCase(unittest.TestCase):
         self.assertEqual(1, text.count('p2.y'))
         self.assertEqual(1, text.count('comp.z'))
         num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
-        self.assertEqual(9,num_non_empty_lines)
+        self.assertEqual(9, num_non_empty_lines)
 
     def test_for_feature_docs_list_vars_options(self):
 
@@ -265,12 +264,12 @@ class ExplCompTestCase(unittest.TestCase):
 
         model.add_subsystem('p1', IndepVarComp('x', 12.0,
                                                lower=1.0, upper=100.0,
-                                               ref = 1.1, ref0 = 2.1,
+                                               ref=1.1, ref0=2.1,
                                                units='inch',
                                                ))
         model.add_subsystem('p2', IndepVarComp('y', 1.0,
                                                lower=2.0, upper=200.0,
-                                               ref = 1.2, res_ref = 2.2,
+                                               ref=1.2, res_ref=2.2,
                                                units='ft',
                                                ))
         model.add_subsystem('comp', ExecComp('z=x+y',
@@ -298,14 +297,13 @@ class ExplCompTestCase(unittest.TestCase):
                                           print_arrays=False)
 
         self.assertEqual(sorted(outputs), [
-            ('comp.z', {'value': [ 24.], 'resids': [ 0.], 'units': 'inch', 'shape': (1,),
-                        'lower': None, 'upper': None, 'ref': 1.0, 'ref0': 0.0, 'res_ref': 1.0} ),
-            ('p1.x', {'value': [ 12.], 'resids': [ 0.], 'units': 'inch', 'shape': (1,),
-                      'lower': [ 1.], 'upper': [ 100.], 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1} ),
-            ('p2.y', {'value': [ 1.], 'resids': [ 0.], 'units': 'ft', 'shape': (1,),
-                      'lower': [ 2.], 'upper': [ 200.], 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
-            ]
-            )
+            ('comp.z', {'value': [24.], 'resids': [0.], 'units': 'inch', 'shape': (1,),
+                        'lower': None, 'upper': None, 'ref': 1.0, 'ref0': 0.0, 'res_ref': 1.0}),
+            ('p1.x', {'value': [12.], 'resids': [0.], 'units': 'inch', 'shape': (1,),
+                      'lower': [1.], 'upper': [100.], 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1}),
+            ('p2.y', {'value': [1.], 'resids': [0.], 'units': 'ft', 'shape': (1,),
+                      'lower': [2.], 'upper': [200.], 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
+        ])
 
         outputs = prob.model.list_outputs(implicit=False,
                                           values=True,
@@ -406,7 +404,8 @@ class ExplCompTestCase(unittest.TestCase):
         text = stream.getvalue()
         self.assertEqual(text.count('5 Explicit Output'), 1)
         # make sure they are in the correct order
-        self.assertTrue(text.find("pz.z") < text.find('sub1.sub2.g1.d1.y1') < text.find('sub1.sub2.g1.d2.y2') < \
+        self.assertTrue(text.find("pz.z") < text.find('sub1.sub2.g1.d1.y1') <
+                        text.find('sub1.sub2.g1.d2.y2') <
                         text.find('g2.d1.y1') < text.find('g2.d2.y2'))
         num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
         self.assertEqual(11, num_non_empty_lines)
@@ -447,12 +446,13 @@ class ExplCompTestCase(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = inputs['x'] + 10.0
 
-        size = 100 # how many items in the array
+        size = 100  # how many items in the array
 
         prob = Problem()
         prob.model = Group()
 
-        prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size), units='inch'), promotes=['x'])
+        prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size), units='inch'),
+                                 promotes=['x'])
         prob.model.add_subsystem('mult', ArrayAdder(size), promotes=['x', 'y'])
 
         prob.setup(check=False)
@@ -633,8 +633,8 @@ class ExplCompTestCase(unittest.TestCase):
                                print_arrays=True)
 
         with printoptions(edgeitems=3, infstr='inf',
-                          linewidth = 75, nanstr = 'nan', precision = 8,
-                          suppress = False, threshold = 1000, formatter = None):
+                          linewidth=75, nanstr='nan', precision=8,
+                          suppress=False, threshold=1000, formatter=None):
 
             prob.model.list_outputs(values=True,
                                     implicit=False,
@@ -655,6 +655,56 @@ class ExplCompTestCase(unittest.TestCase):
                                     scaling=True,
                                     hierarchical=True,
                                     print_arrays=True)
+
+    def test_compute_inputs_read_only(self):
+        class BadComp(TestExplCompSimple):
+            def compute(self, inputs, outputs):
+                super(BadComp, self).compute(inputs, outputs)
+                inputs['length'] = 0.  # should not be allowed
+
+        prob = Problem(BadComp())
+        prob.setup()
+
+        with self.assertRaises(ValueError) as cm:
+            prob.run_model()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'length' in input vector "
+                         "while it is in read only mode.")
+
+    def test_compute_partials_inputs_read_only(self):
+        class BadComp(TestExplCompSimpleDense):
+            def compute_partials(self, inputs, partials):
+                super(BadComp, self).compute_partials(inputs, partials)
+                inputs['length'] = 0.  # should not be allowed
+
+        prob = Problem(BadComp())
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(ValueError) as cm:
+            prob.check_partials()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'length' in input vector "
+                         "while it is in read only mode.")
+
+    def test_compute_jacvec_product_inputs_read_only(self):
+        class BadComp(RectangleJacVec):
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                super(BadComp, self).compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
+                inputs['length'] = 0.  # should not be allowed
+
+        prob = Problem(BadComp())
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(ValueError) as cm:
+            prob.check_partials()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'length' in input vector "
+                         "while it is in read only mode.")
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -513,7 +513,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_guess_nonlinear_resids_read_only(self):
         class ImpWithInitial(ImplicitComponent):
@@ -546,7 +546,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'y' in residual vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
 
 class ImplicitCompReadOnlyTestCase(unittest.TestCase):
@@ -568,7 +568,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_nonlinear_outputs_read_only(self):
         class BadComp(QuadraticComp):
@@ -587,7 +587,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_solve_nonlinear_inputs_read_only(self):
         class BadComp(QuadraticComp):
@@ -605,7 +605,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_linearize_inputs_read_only(self):
         class BadComp(QuadraticLinearize):
@@ -624,7 +624,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_linearize_outputs_read_only(self):
         class BadComp(QuadraticLinearize):
@@ -643,7 +643,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_linear_inputs_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -663,7 +663,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_linear_outputs_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -683,7 +683,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_linear_dinputs_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -703,7 +703,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_linear_doutputs_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -723,7 +723,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_linear_dresids_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -743,7 +743,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in residual vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_solve_linear_doutputs_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -763,7 +763,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_solve_linear_dresids_read_only(self):
         class BadComp(QuadraticJacVec):
@@ -783,7 +783,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in residual vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
 
 class QuadGroup(Group):

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -706,7 +706,7 @@ class MatMatTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_multi_linear_outputs_read_only(self):
         class BadComp(QuadraticCompVectorized):
@@ -725,7 +725,7 @@ class MatMatTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_multi_linear_dinputs_read_only(self):
         class BadComp(QuadraticCompVectorized):
@@ -744,7 +744,7 @@ class MatMatTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'a' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_multi_linear_doutputs_read_only(self):
         class BadComp(QuadraticCompVectorized):
@@ -763,7 +763,7 @@ class MatMatTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in output vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_apply_multi_linear_dresids_read_only(self):
         class BadComp(QuadraticCompVectorized):
@@ -782,7 +782,7 @@ class MatMatTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in residual vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
 
 class JacVec(ExplicitComponent):
@@ -926,7 +926,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
         p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='rev')
 
@@ -935,7 +935,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'f_xy' in residual vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_compute_jacvec_product_inputs_read_only(self):
         class BadComp(JacVec):
@@ -950,7 +950,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_compute_multi_jacvec_product_mode_read_only(self):
         class BadComp(JacVec):
@@ -975,7 +975,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
         p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='rev')
 
@@ -984,7 +984,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'f_xy' in residual vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
     def test_compute_multi_jacvec_product_inputs_read_only(self):
         class BadComp(JacVec):
@@ -999,7 +999,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          "Attempt to set value of 'x' in input vector "
-                         "while it is in read only mode.")
+                         "when it is read only.")
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -5,8 +5,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, \
-                         ScipyOptimizeDriver, DirectSolver, \
-                         ImplicitComponent, LinearBlockGS
+    ScipyOptimizeDriver, ImplicitComponent, LinearBlockGS
 from openmdao.utils.assert_utils import assert_rel_error
 
 
@@ -19,6 +18,7 @@ class QuadraticCompVectorized(ImplicitComponent):
     Solution via Quadratic Formula:
     x = (-b + sqrt(b^2 - 4ac)) / 2a
     """
+
     def setup(self):
         self.add_input('a', val=np.array([1.0, 2.0, 3.0]))
         self.add_input('b', val=np.array([2.0, 3.0, 4.0]))
@@ -83,6 +83,7 @@ class RectangleCompVectorized(ExplicitComponent):
     """
     A simple Explicit Component that computes the area of a rectangle.
     """
+
     def setup(self):
         self.add_input('length', val=np.array([3.0, 4.0, 5.0]))
         self.add_input('width', val=np.array([1.0, 2.0, 3.0]))
@@ -253,11 +254,13 @@ def lagrange_matrices(x_disc, x_interp):
 
     return Li, Di
 
+
 class LGLFit(ExplicitComponent):
     """
     Given values at discretization nodes, provide interpolated values at midpoint nodes and
     an approximation of arclength.
     """
+
     def initialize(self):
         self.options.declare(name='num_nodes', types=int)
 
@@ -322,7 +325,6 @@ class ArcLengthFunction(ExplicitComponent):
     def compute(self, inputs, outputs):
         outputs['f_arclength'] = np.sqrt(1 + inputs['yp_lgl']**2)
 
-
     def compute_partials(self, inputs, partials):
         partials['f_arclength', 'yp_lgl'] = inputs['yp_lgl'] / np.sqrt(1 + inputs['yp_lgl']**2)
 
@@ -331,6 +333,7 @@ class ArcLengthQuadrature(ExplicitComponent):
     """
     Computes the arclength of a polynomial segment whose values are given at the LGL nodes.
     """
+
     def initialize(self):
         self.options.declare(name='num_nodes', types=int)
 
@@ -343,9 +346,9 @@ class ArcLengthQuadrature(ExplicitComponent):
         _, self.w_lgl = lgl(n)
 
         self._mask = np.ones(n)
-        self._mask[0] = 2 # / (n * (n - 1))
-        self._mask[-1] = 2 # / (n * (n - 1))
-        #self._mask = self._mask * np.pi
+        self._mask[0] = 2  # / (n * (n - 1))
+        self._mask[-1] = 2  # / (n * (n - 1))
+        # self._mask = self._mask * np.pi
 
         da_df = np.atleast_2d(self.w_lgl*np.pi*self._mask)
 
@@ -371,16 +374,15 @@ class Phase(Group):
 
         # Step 1:  Make an indep var comp that provides the approximated values at the LGL nodes.
         self.add_subsystem('y_lgl_ivc', IndepVarComp('y_lgl', val=np.zeros(n), desc='values at LGL nodes'),
-                              promotes_outputs=['y_lgl'])
+                           promotes_outputs=['y_lgl'])
 
         # Step 2:  Make an indep var comp that provides the 'truth' values at the midpoint nodes.
         x_lgl, _ = lgl(n)
-        x_lgl = x_lgl * np.pi # put x_lgl on [-pi, pi]
-        x_mid = (x_lgl[1:] + x_lgl[:-1]) * 0.5 # midpoints on [-pi, pi]
+        x_lgl = x_lgl * np.pi  # put x_lgl on [-pi, pi]
+        x_mid = (x_lgl[1:] + x_lgl[:-1]) * 0.5  # midpoints on [-pi, pi]
         self.add_subsystem('truth', IndepVarComp('y_mid',
                                                  val=np.sin(x_mid),
                                                  desc='truth values at midpoint nodes'))
-
 
         # Step 3: Make a polynomial fitting component
         self.add_subsystem('lgl_fit', LGLFit(num_nodes=n))
@@ -391,7 +393,6 @@ class Phase(Group):
         # Step 5: Compute the integrand of the arclength function then quadrature it
         self.add_subsystem('arclength_func', ArcLengthFunction(num_nodes=n))
         self.add_subsystem('arclength_quad', ArcLengthQuadrature(num_nodes=n))
-
 
         self.connect('y_lgl', 'lgl_fit.y_lgl')
         self.connect('truth.y_mid', 'defect.y_truth')
@@ -418,6 +419,7 @@ class Summer(ExplicitComponent):
         for i in range(self.options['n_phases']):
             outputs['total_arc_length'] += inputs['arc_length:p%d' % i]
 
+
 def simple_model(order, dvgroup='pardv', congroup='parc', vectorize=False):
     n = order + 1
 
@@ -425,13 +427,13 @@ def simple_model(order, dvgroup='pardv', congroup='parc', vectorize=False):
 
     # Step 1:  Make an indep var comp that provides the approximated values at the LGL nodes.
     p.model.add_subsystem('y_lgl_ivc', IndepVarComp('y_lgl', val=np.zeros(n),
-                          desc='values at LGL nodes'),
+                                                    desc='values at LGL nodes'),
                           promotes_outputs=['y_lgl'])
 
     # Step 2:  Make an indep var comp that provides the 'truth' values at the midpoint nodes.
     x_lgl, _ = lgl(n)
-    x_lgl = x_lgl * np.pi # put x_lgl on [-pi, pi]
-    x_mid = (x_lgl[1:] + x_lgl[:-1])/2.0 # midpoints on [-pi, pi]
+    x_lgl = x_lgl * np.pi  # put x_lgl on [-pi, pi]
+    x_mid = (x_lgl[1:] + x_lgl[:-1])/2.0  # midpoints on [-pi, pi]
     p.model.add_subsystem('truth', IndepVarComp('y_mid',
                                                 val=np.sin(x_mid),
                                                 desc='truth values at midpoint nodes'))
@@ -452,11 +454,14 @@ def simple_model(order, dvgroup='pardv', congroup='parc', vectorize=False):
     p.model.connect('lgl_fit.yp_lgl', 'arclength_func.yp_lgl')
     p.model.connect('arclength_func.f_arclength', 'arclength_quad.f_arclength')
 
-    p.model.add_design_var('y_lgl', lower=-1000.0, upper=1000.0, parallel_deriv_color=dvgroup, vectorize_derivs=vectorize)
-    p.model.add_constraint('defect.defect', lower=-1e-6, upper=1e-6, parallel_deriv_color=congroup, vectorize_derivs=vectorize)
+    p.model.add_design_var('y_lgl', lower=-1000.0, upper=1000.0,
+                           parallel_deriv_color=dvgroup, vectorize_derivs=vectorize)
+    p.model.add_constraint('defect.defect', lower=-1e-6, upper=1e-6,
+                           parallel_deriv_color=congroup, vectorize_derivs=vectorize)
     p.model.add_objective('arclength_quad.arclength')
     p.driver = ScipyOptimizeDriver()
     return p, np.sin(x_lgl)
+
 
 def phase_model(order, nphases, dvgroup='pardv', congroup='parc', vectorize=False):
     N_PHASES = nphases
@@ -472,8 +477,10 @@ def phase_model(order, nphases, dvgroup='pardv', congroup='parc', vectorize=Fals
         p.model.add_subsystem(p_name, Phase(order=PHASE_ORDER))
         p.model.connect('%s.arclength_quad.arclength' % p_name, 'sum.arc_length:%s' % p_name)
 
-        p.model.add_design_var('%s.y_lgl' % p_name, lower=-1000.0, upper=1000.0, parallel_deriv_color=dvgroup, vectorize_derivs=vectorize)
-        p.model.add_constraint('%s.defect.defect' % p_name, lower=-1e-6, upper=1e-6, parallel_deriv_color=congroup, vectorize_derivs=vectorize)
+        p.model.add_design_var('%s.y_lgl' % p_name, lower=-1000.0, upper=1000.0,
+                               parallel_deriv_color=dvgroup, vectorize_derivs=vectorize)
+        p.model.add_constraint('%s.defect.defect' % p_name, lower=-1e-6, upper=1e-6,
+                               parallel_deriv_color=congroup, vectorize_derivs=vectorize)
 
     p.model.add_subsystem('sum', Summer(n_phases=N_PHASES))
 
@@ -481,19 +488,17 @@ def phase_model(order, nphases, dvgroup='pardv', congroup='parc', vectorize=Fals
     p.driver = ScipyOptimizeDriver()
 
     x_lgl, _ = lgl(n)
-    x_lgl = x_lgl * np.pi # put x_lgl on [-pi, pi]
-    x_mid = (x_lgl[1:] + x_lgl[:-1])/2.0 # midpoints on [-pi, pi]
+    x_lgl = x_lgl * np.pi  # put x_lgl on [-pi, pi]
+    # x_mid = (x_lgl[1:] + x_lgl[:-1])/2.0  # midpoints on [-pi, pi]
 
     return p, np.sin(x_lgl)
 
 
-
 class MatMatTestCase(unittest.TestCase):
-
 
     def test_feature_vectorized_derivs(self):
         import numpy as np
-        from openmdao.api import ExplicitComponent, ExecComp, IndepVarComp, Problem, ScipyOptimizeDriver
+        from openmdao.api import ExplicitComponent, IndepVarComp, Problem, ScipyOptimizeDriver
 
         SIZE = 5
 
@@ -538,7 +543,6 @@ class MatMatTestCase(unittest.TestCase):
 
                 J['g', 'y'] = 2*inputs['y']
 
-
         p = Problem()
 
         dvs = p.model.add_subsystem('des_vars', IndepVarComp(), promotes=['*'])
@@ -553,7 +557,6 @@ class MatMatTestCase(unittest.TestCase):
         p.model.add_constraint('g', upper=0, vectorize_derivs=True)
         p.model.add_objective('f')
 
-
         p.setup(mode='rev')
 
         p.run_model()
@@ -567,15 +570,15 @@ class MatMatTestCase(unittest.TestCase):
     def test_simple_multi_fwd(self):
         p, expected = simple_model(order=20, vectorize=True)
 
-        p.setup(check=False, mode='fwd')
+        p.setup(mode='fwd')
 
         p.run_driver()
 
-        #import matplotlib.pyplot as plt
+        # import matplotlib.pyplot as plt
 
-        #plt.plot(p['y_lgl'], 'bo')
-        #plt.plot(expected, 'go')
-        #plt.show()
+        # plt.plot(p['y_lgl'], 'bo')
+        # plt.plot(expected, 'go')
+        # plt.show()
 
         y_lgl = p['y_lgl']
         assert_rel_error(self, expected, y_lgl, 1.e-5)
@@ -583,7 +586,7 @@ class MatMatTestCase(unittest.TestCase):
     def test_simple_multi_rev(self):
         p, expected = simple_model(order=20, vectorize=True)
 
-        p.setup(check=False, mode='rev')
+        p.setup(mode='rev')
 
         p.run_driver()
 
@@ -594,7 +597,7 @@ class MatMatTestCase(unittest.TestCase):
         N_PHASES = 4
         p, expected = phase_model(order=20, nphases=N_PHASES, vectorize=True)
 
-        p.setup(check=False, mode='fwd')
+        p.setup(mode='fwd')
 
         p.run_driver()
 
@@ -614,7 +617,7 @@ class MatMatTestCase(unittest.TestCase):
         N_PHASES = 4
         p, expected = phase_model(order=20, nphases=N_PHASES, vectorize=True)
 
-        p.setup(check=False, mode='rev')
+        p.setup(mode='rev')
 
         p.run_driver()
 
@@ -639,7 +642,7 @@ class MatMatTestCase(unittest.TestCase):
         model.add_design_var('p.width', vectorize_derivs=True)
         model.add_constraint('comp.area', vectorize_derivs=True)
 
-        prob.setup(check=False, mode='rev')
+        prob.setup(mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(of=['comp.area'], wrt=['p.length', 'p.width'])
@@ -667,7 +670,7 @@ class MatMatTestCase(unittest.TestCase):
 
         model.linear_solver = LinearBlockGS()
 
-        prob.setup(check=False, mode='fwd')
+        prob.setup(mode='fwd')
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -675,6 +678,7 @@ class MatMatTestCase(unittest.TestCase):
         assert_rel_error(self, J['comp.x', 'p.a'], np.diag(np.array([-0.06066017, -0.05, -0.03971954])), 1e-4)
         assert_rel_error(self, J['comp.x', 'p.b'], np.diag(np.array([-0.14644661, -0.1, -0.07421663])), 1e-4)
         assert_rel_error(self, J['comp.x', 'p.c'], np.diag(np.array([-0.35355339, -0.2, -0.13867505])), 1e-4)
+
 
 class JacVec(ExplicitComponent):
 
@@ -712,8 +716,7 @@ class MultiJacVec(JacVec):
 
 
 class ComputeMultiJacVecTestCase(unittest.TestCase):
-    def setup_model(self, size, multi, vectorize, mode):
-        comp_class = MultiJacVec if multi else JacVec
+    def setup_model(self, size, comp_class, vectorize, mode):
         p = Problem()
         model = p.model
         model.add_subsystem('px', IndepVarComp('x', val=(np.arange(5, dtype=float) + 1.) * 3.0))
@@ -727,12 +730,12 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         model.add_design_var('py.y', vectorize_derivs=vectorize)
         model.add_constraint('comp.f_xy', vectorize_derivs=vectorize)
 
-        p.setup(check=False, mode=mode)
+        p.setup(mode=mode)
         p.run_model()
         return p
 
     def test_compute_multi_jacvec_prod_fwd(self):
-        p = self.setup_model(size=5, multi=False, vectorize=False, mode='fwd')
+        p = self.setup_model(size=5, comp_class=JacVec, vectorize=False, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -740,7 +743,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev(self):
-        p = self.setup_model(size=5, multi=False, vectorize=False, mode='rev')
+        p = self.setup_model(size=5, comp_class=JacVec, vectorize=False, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -748,7 +751,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_fwd_vectorize(self):
-        p = self.setup_model(size=5, multi=False, vectorize=True, mode='fwd')
+        p = self.setup_model(size=5, comp_class=JacVec, vectorize=True, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -756,7 +759,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev_vectorize(self):
-        p = self.setup_model(size=5, multi=False, vectorize=True, mode='rev')
+        p = self.setup_model(size=5, comp_class=JacVec, vectorize=True, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -764,7 +767,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_fwd_multi(self):
-        p = self.setup_model(size=5, multi=True, vectorize=False, mode='fwd')
+        p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=False, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -772,7 +775,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev_multi(self):
-        p = self.setup_model(size=5, multi=True, vectorize=False, mode='rev')
+        p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=False, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -780,7 +783,7 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_fwd_vectorize_multi(self):
-        p = self.setup_model(size=5, multi=True, vectorize=True, mode='fwd')
+        p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=True, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
@@ -788,12 +791,110 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev_vectorize_multi(self):
-        p = self.setup_model(size=5, multi=True, vectorize=True, mode='rev')
+        p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=True, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
         assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
         assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+
+    def test_compute_jacvec_product_mode_read_only(self):
+        class BadComp(JacVec):
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                # mode condition is reversed, should raise exception
+                if mode == 'rev':
+                    if 'x' in d_inputs:
+                        d_outputs['f_xy'] += d_inputs['x'] * inputs['y']
+                    if 'y' in d_inputs:
+                        d_outputs['f_xy'] += d_inputs['y'] * inputs['x']
+                else:
+                    d_fxy = d_outputs['f_xy']
+                    if 'x' in d_inputs:
+                        d_inputs['x'] += d_fxy * inputs['y']
+                    if 'y' in d_inputs:
+                        d_inputs['y'] += d_fxy * inputs['x']
+
+        p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='fwd')
+
+        with self.assertRaises(ValueError) as cm:
+            p.compute_totals()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'x' in input vector "
+                         "while it is in read only mode.")
+
+        p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='rev')
+
+        with self.assertRaises(ValueError) as cm:
+            p.compute_totals()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'f_xy' in residual vector "
+                         "while it is in read only mode.")
+
+    def test_compute_jacvec_product_inputs_read_only(self):
+        class BadComp(JacVec):
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                # inputs is read_only, should raise exception
+                inputs['x'] = np.zeros(self.size)
+
+        p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='fwd')
+
+        with self.assertRaises(ValueError) as cm:
+            p.compute_totals()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'x' in input vector "
+                         "while it is in read only mode.")
+
+    def test_compute_multi_jacvec_product_mode_read_only(self):
+        class BadComp(JacVec):
+            def compute_multi_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                # mode condition is reversed, should raise exception
+                if mode == 'rev':
+                    if 'x' in d_inputs:
+                        d_outputs['f_xy'] += d_inputs['x'] * inputs['y']
+                    if 'y' in d_inputs:
+                        d_outputs['f_xy'] += d_inputs['y'] * inputs['x']
+                else:
+                    d_fxy = d_outputs['f_xy']
+                    if 'x' in d_inputs:
+                        d_inputs['x'] += d_fxy * inputs['y']
+                    if 'y' in d_inputs:
+                        d_inputs['y'] += d_fxy * inputs['x']
+
+        p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='fwd')
+
+        with self.assertRaises(ValueError) as cm:
+            p.compute_totals()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'x' in input vector "
+                         "while it is in read only mode.")
+
+        p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='rev')
+
+        with self.assertRaises(ValueError) as cm:
+            p.compute_totals()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'f_xy' in residual vector "
+                         "while it is in read only mode.")
+
+    def test_compute_multi_jacvec_product_inputs_read_only(self):
+        class BadComp(JacVec):
+            def compute_multi_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                # inputs is read_only, should raise exception
+                inputs['x'] = np.zeros(self.size)
+
+        p = self.setup_model(size=5, comp_class=BadComp, vectorize=True, mode='fwd')
+
+        with self.assertRaises(ValueError) as cm:
+            p.compute_totals()
+
+        self.assertEqual(str(cm.exception),
+                         "Attempt to set value of 'x' in input vector "
+                         "while it is in read only mode.")
 
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/docs/features/core_features/defining_components/implicitcomp.rst
+++ b/openmdao/docs/features/core_features/defining_components/implicitcomp.rst
@@ -94,6 +94,6 @@ The implementation of each method will be illustrated using a simple implicit co
   find one of the roots of a second-order quadratic equation. Which root you get depends on the initial guess.
 
   .. embed-code::
-      openmdao.core.tests.test_impl_comp.ImplicitCompTestCase.test_guess_nonlinear_feature
+      openmdao.core.tests.test_impl_comp.ImplicitCompGuessTestCase.test_guess_nonlinear_feature
 
 .. tags:: Component, ImplicitComponent

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -107,7 +107,7 @@ class Vector(object):
         Listing of relevant citataions that should be referenced when
         publishing work that uses this class.
     read_only : bool
-        When True, values in the vector cannot be changed via the user getter/setter API.
+        When True, values in the vector cannot be changed via the user __setitem__ API.
     """
 
     _vector_info = VectorInfo()
@@ -397,12 +397,12 @@ class Vector(object):
         value : float or list or tuple or ndarray
             variable value to set (not scaled, not dimensionless)
         """
-        if self.read_only:
-            msg = "Attempt to set value of '{}' while in read only mode."
-            raise ValueError(msg.format(name))
-
         abs_name = name2abs_name(self._system, name, self._names, self._typ)
         if abs_name is not None:
+            if self.read_only:
+                msg = "Attempt to set value of '{}' while in read only mode."
+                raise ValueError(msg.format(name))
+
             if self._icol is None:
                 slc = _full_slice
                 oldval = self._views[abs_name]

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -400,7 +400,7 @@ class Vector(object):
         abs_name = name2abs_name(self._system, name, self._names, self._typ)
         if abs_name is not None:
             if self.read_only:
-                msg = "Attempt to set value of '{}' in {} vector while it is in read only mode."
+                msg = "Attempt to set value of '{}' in {} vector when it is read only."
                 raise ValueError(msg.format(name, self._kind))
 
             if self._icol is None:

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -183,7 +183,7 @@ class Vector(object):
             if root_vector is None:
                 raise RuntimeError(
                     'Cannot resize the vector because the root vector has not yet '
-                    + ' been created in system %s' % system.pathname)
+                    'been created in system %s' % system.pathname)
             self._update_root_data()
 
         self._initialize_data(root_vector)
@@ -400,8 +400,8 @@ class Vector(object):
         abs_name = name2abs_name(self._system, name, self._names, self._typ)
         if abs_name is not None:
             if self.read_only:
-                msg = "Attempt to set value of '{}' while in read only mode."
-                raise ValueError(msg.format(name))
+                msg = "Attempt to set value of '{}' in {} vector while it is in read only mode."
+                raise ValueError(msg.format(name, self._kind))
 
             if self._icol is None:
                 slc = _full_slice

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -106,6 +106,8 @@ class Vector(object):
     cite : str
         Listing of relevant citataions that should be referenced when
         publishing work that uses this class.
+    read_only : bool
+        When True, values in the vector cannot be changed via the user getter/setter API.
     """
 
     _vector_info = VectorInfo()
@@ -188,6 +190,8 @@ class Vector(object):
         self._initialize_views()
 
         self._length = np.sum(self._system._var_sizes[self._name][self._typ][self._iproc, :])
+
+        self.read_only = False
 
     def __str__(self):
         """
@@ -393,6 +397,10 @@ class Vector(object):
         value : float or list or tuple or ndarray
             variable value to set (not scaled, not dimensionless)
         """
+        if self.read_only:
+            msg = "Attempt to set value of '{}' while in read only mode."
+            raise ValueError(msg.format(name))
+
         abs_name = name2abs_name(self._system, name, self._names, self._typ)
         if abs_name is not None:
             if self._icol is None:


### PR DESCRIPTION
For ExplicitComponent:

1. inputs during `compute`
2. inputs during `compute_partials`
3. inputs and [d_inputs | d_resids] during `compute_jacvec_product`, depending on mode

For ImplicitComponent:

1. inputs during `solve_nonlinear`
2. inputs and outputs during `apply_nonlinear`
3. inputs and resids during `guess_nonlinear`
4. inputs, outputs and [(d_inputs, d_outputs) | d_resids] during `apply_linear`, depending on mode
5. [d_resids | d_outputs] during `solve_linear`, depending on mode
6. inputs and outputs during `linearize`

Pivotal #158984607
