### PR TITLE
SimpleGADriver AnalysisError import error fixed

### DIFF
--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -23,6 +23,7 @@ from pyDOE2 import lhs
 from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.utils.concurrent import concurrent_eval
 from openmdao.utils.mpi import MPI
+from openmdao.core.analysis_error import AnalysisError
 
 
 class SimpleGADriver(Driver):

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -165,9 +165,6 @@ class TestSimpleGA(unittest.TestCase):
         np.random.seed(1)
 
         class ValueErrorComp(ExplicitComponent):
-            """
-            Raises value error. AnalysisError should return the original error.
-            """
             def setup(self):
                 self.add_input('x', 1.0)
                 self.add_output('f', 1.0)


### PR DESCRIPTION
In genetic_algorithm_driver AnalysisError import error fixed by adding import statement for AnalysisError. 
Previously SimpleGADriver failed with NameError and did not return the original error from the model if an exception was raised during the execution of run_driver()
In test_genetic_algorithm_driver.py  test_analysis_error() test function added, which checks the type of the exception.