### PR TITLE
JSON Serialization fix

### DIFF
--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -26,6 +26,9 @@ from openmdao.solvers.solver import Solver
 """
 SQL case output format version history.
 ---------------------------------------
+5 -- OpenMDAO 2.4
+    More general handling of ndarray variable settings metadata.  Stores metadata keys which
+    are ndarrays in a separate 'ndarrays' entry to var_settings.
 4 -- OpenMDAO 2.4
     Added variable settings metadata that contains scaling info.
 3 -- OpenMDAO 2.4
@@ -262,10 +265,6 @@ class SqliteRecorder(BaseRecorder):
         # otherwise we trample on values that are used elsewhere
         var_settings = deepcopy(var_settings)
         for name in var_settings:
-            if 'lower' in var_settings[name]:
-                var_settings[name]['lower'] = convert_to_list(var_settings[name]['lower'])
-            if 'upper' in var_settings[name]:
-                var_settings[name]['upper'] = convert_to_list(var_settings[name]['upper'])
             for prop in var_settings[name]:
                 val = var_settings[name][prop]
                 if isinstance(val, np.int8) or isinstance(val, np.int16) or\
@@ -273,6 +272,8 @@ class SqliteRecorder(BaseRecorder):
                     var_settings[name][prop] = val.item()
                 elif isinstance(val, tuple):
                     var_settings[name][prop] = [int(v) for v in val]
+                elif isinstance(val, np.ndarray):
+                    var_settings[name][prop] = convert_to_list(var_settings[name][prop])
 
         return var_settings
 

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -602,3 +602,23 @@ class SellarProblem(Problem):
 
         # default to non-verbose
         self.set_solver_print(0)
+
+
+class SellarProblemWithArrays(Problem):
+    """
+    The Sellar problem with ndarray variable options
+    """
+
+    def __init__(self, model_class=SellarDerivatives, **kwargs):
+        super(SellarProblemWithArrays, self).__init__(model_class(**kwargs))
+
+        model = self.model
+        model.add_design_var('z', lower=np.array([-10.0, 0.0]),
+                             upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
+        model.add_design_var('x', lower=0.0, upper=10.0)
+        model.add_objective('obj')
+        model.add_constraint('con1', equals=np.zeros(1))
+        model.add_constraint('con2', upper=0.0)
+
+        # default to non-verbose
+        self.set_solver_print(0)


### PR DESCRIPTION
Sometimes the user might specify driver variable options, like `equals` or `indices` as ndarrays.  This breaks the initialization of the SQLiteRecorder, since ndarrays are not JSON serializable.  This fix converts any _var_settings that might be ndarrays to lists upon initialization of the SQLiteRecorder.  

Note that the values are not converted back to ndarray by the SQLiteCaseReader at this time, since we're not saving all possible ndarray attributes in _var_settings and doing so doesn't seem necessary.

Added recorder test that fails due to indices and equals var options being ndarrays, and that passes with this fix.