### PR TITLE
A couple of small doc-related stories.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ install:
     ./miniconda.sh -b  -p $HOME/miniconda;
     export PATH=$HOME/miniconda/bin:$PATH;
     conda install --yes python=$PY;
-    conda install --yes numpy==$NUMPY scipy=0.19.1 nose sphinx mock swig pip;
+    conda install --yes numpy==$NUMPY scipy=1.0.1 nose sphinx mock swig pip;
   else
     export PATH=$HOME/miniconda/bin:$PATH;
   fi

--- a/openmdao/docs/features/building_blocks/drivers/scipy_optimize_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/scipy_optimize_driver.rst
@@ -29,7 +29,10 @@ ScipyOptimizeDriver Option Examples
   of the optimizers in scipy.optimize except for 'dogleg' and 'trust-ncg'. Generally, the optimizers that
   you are most likely to use are "COBYLA" and "SLSQP", as these are the only ones that support constraints.
   Only SLSQP supports equality constraints. SLSQP also uses gradients provided by OpenMDAO, while COBYLA is
-  gradient-free.  Here we pass the optimizer option as a keyword argument.
+  gradient-free.  Also, SLSQP supports both equality and inequality constraints, but COBYLA only supports
+  inequality constraints.
+
+  Here we pass the optimizer option as a keyword argument.
 
   .. embed-code::
       openmdao.drivers.tests.test_scipy_optimizer.TestScipyOptimizeDriverFeatures.test_feature_optimizer


### PR DESCRIPTION
1. Bump travis scipy up to 1.0.1 so that betz problem doc example runs correctly.
2. Mention in feature docs that cobyla does not support equality constraints.