### PR TITLE
P159445512 case recorder needs to save the correct size variables even when its a driver case

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -559,7 +559,7 @@ class Driver(object):
 
         return {n: self._get_voi_val(n, self._responses[n], self._remote_objs) for n in resps}
 
-    def get_objective_values(self, unscaled=False, filter=None):
+    def get_objective_values(self, unscaled=False, filter=None, ignore_indices=False):
         """
         Return objective values.
 
@@ -569,6 +569,8 @@ class Driver(object):
             Set to True if unscaled (physical) design variables are desired.
         filter : list
             List of objective names used by recorders.
+        ignore_indices : bool
+            Set to True if the full array is desired, not just those indicated by indices.
 
         Returns
         -------
@@ -580,10 +582,12 @@ class Driver(object):
         else:
             objs = self._objs
 
-        return {n: self._get_voi_val(n, self._objs[n], self._remote_objs, unscaled=unscaled)
+        return {n: self._get_voi_val(n, self._objs[n], self._remote_objs, unscaled=unscaled,
+                                     ignore_indices=ignore_indices)
                 for n in objs}
 
-    def get_constraint_values(self, ctype='all', lintype='all', unscaled=False, filter=None):
+    def get_constraint_values(self, ctype='all', lintype='all', unscaled=False, filter=None,
+                              ignore_indices=False):
         """
         Return constraint values.
 
@@ -599,6 +603,8 @@ class Driver(object):
             Set to True if unscaled (physical) design variables are desired.
         filter : list
             List of constraint names used by recorders.
+        ignore_indices : bool
+            Set to True if the full array is desired, not just those indicated by indices.
 
         Returns
         -------
@@ -626,7 +632,8 @@ class Driver(object):
             if ctype == 'ineq' and meta['equals'] is not None:
                 continue
 
-            con_dict[name] = self._get_voi_val(name, meta, self._remote_cons, unscaled=unscaled)
+            con_dict[name] = self._get_voi_val(name, meta, self._remote_cons, unscaled=unscaled,
+                                               ignore_indices=ignore_indices)
 
         return con_dict
 
@@ -782,17 +789,17 @@ class Driver(object):
         filt = self._filtered_vars_to_record
 
         if opts['record_desvars']:
-            des_vars = self.get_design_var_values(unscaled=True)
+            des_vars = self.get_design_var_values(unscaled=True, ignore_indices=True)
         else:
             des_vars = {}
 
         if opts['record_objectives']:
-            obj_vars = self.get_objective_values(unscaled=True)
+            obj_vars = self.get_objective_values(unscaled=True, ignore_indices=True)
         else:
             obj_vars = {}
 
         if opts['record_constraints']:
-            con_vars = self.get_constraint_values(unscaled=True)
+            con_vars = self.get_constraint_values(unscaled=True, ignore_indices=True)
         else:
             con_vars = {}
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -262,10 +262,10 @@ class SqliteRecorder(BaseRecorder):
         # otherwise we trample on values that are used elsewhere
         var_settings = deepcopy(var_settings)
         for name in var_settings:
-            if 'lower' in var_settings[name]:
-                var_settings[name]['lower'] = convert_to_list(var_settings[name]['lower'])
-            if 'upper' in var_settings[name]:
-                var_settings[name]['upper'] = convert_to_list(var_settings[name]['upper'])
+            # if 'lower' in var_settings[name]:
+            #     var_settings[name]['lower'] = convert_to_list(var_settings[name]['lower'])
+            # if 'upper' in var_settings[name]:
+            #     var_settings[name]['upper'] = convert_to_list(var_settings[name]['upper'])
             for prop in var_settings[name]:
                 val = var_settings[name][prop]
                 if isinstance(val, np.int8) or isinstance(val, np.int16) or\
@@ -273,6 +273,8 @@ class SqliteRecorder(BaseRecorder):
                     var_settings[name][prop] = val.item()
                 elif isinstance(val, tuple):
                     var_settings[name][prop] = [int(v) for v in val]
+                elif isinstance(val, np.ndarray):
+                    var_settings[name][prop] = convert_to_list(var_settings[name][prop])
 
         return var_settings
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1005,6 +1005,91 @@ class TestSqliteCaseReader(unittest.TestCase):
                 self.assertTrue(case in case_type._cases)
                 self.assertEqual(case, case_type._cases[case].iteration_coordinate)
 
+
+    def test_reading_driver_cases_with_indices(self):
+        # note: size must be an even number
+        SIZE = 10
+        prob = Problem()
+
+        driver = prob.driver = ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.options['disp'] = False
+
+        recorder = SqliteRecorder(self.filename)
+        driver.add_recorder(recorder)
+        driver.recording_options['includes'] = ['*']
+
+        model = prob.model
+        indeps = model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
+
+        # the following were randomly generated using np.random.random(10)*2-1 to randomly
+        # disperse them within a unit circle centered at the origin.
+        indeps.add_output('x', np.array([ 0.55994437, -0.95923447, 0.21798656, -0.02158783, 0.62183717,
+            0.04007379, 0.46044942, -0.10129622, 0.27720413, -0.37107886]))
+        indeps.add_output('y', np.array([ 0.52577864, 0.30894559, 0.8420792 , 0.35039912, -0.67290778,
+            -0.86236787, -0.97500023, 0.47739414, 0.51174103, 0.10052582]))
+        indeps.add_output('r', .7)
+
+        model.add_subsystem('circle', ExecComp('area = pi * r**2'))
+
+        model.add_subsystem('r_con', ExecComp('g = x**2 + y**2 - r**2',
+            g = np.ones(SIZE), x = np.ones(SIZE), y = np.ones(SIZE)))
+
+        thetas = np.linspace(0, np.pi/4, SIZE)
+        model.add_subsystem('theta_con', ExecComp('g=arctan(y/x) - theta',
+                                 g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE),
+                                 theta=thetas))
+        model.add_subsystem('delta_theta_con',
+                                 ExecComp('g = arctan(y/x)[::2]-arctan(y/x)[1::2]',
+                                 g=np.ones(SIZE//2), x=np.ones(SIZE),
+                                 y=np.ones(SIZE)))
+
+        thetas = np.linspace(0, np.pi/4, SIZE)
+
+        model.add_subsystem('l_conx', ExecComp('g=x-1', g=np.ones(SIZE), x=np.ones(SIZE)))
+
+        model.connect('r', ('circle.r', 'r_con.r'))
+        model.connect('x', ['r_con.x', 'theta_con.x', 'delta_theta_con.x'])
+        model.connect('x', 'l_conx.x')
+        model.connect('y', ['r_con.y', 'theta_con.y', 'delta_theta_con.y'])
+
+        model.add_design_var('x', indices=[0,3])
+        model.add_design_var('y')
+        model.add_design_var('r', lower=.5, upper=10)
+
+        # nonlinear constraints
+        model.add_constraint('r_con.g', equals=0)
+
+        IND = np.arange(SIZE, dtype=int)
+        EVEN_IND = IND[0::2] # all odd indices
+        model.add_constraint('theta_con.g', lower=-1e-5, upper=1e-5, indices=EVEN_IND)
+        model.add_constraint('delta_theta_con.g', lower=-1e-5, upper=1e-5)
+
+        # this constrains x[0] to be 1 (see definition of l_conx)
+        model.add_constraint('l_conx.g', equals=0, linear=False, indices=[0,])
+
+        # linear constraint
+        model.add_constraint('y', equals=0, indices=[0], linear=True)
+
+        model.add_objective('circle.area', ref=-1)
+
+        prob.setup(mode='fwd')
+        prob.run_driver()
+        prob.cleanup()
+
+        # Add one to all the inputs just to change the model
+        #   so we can see if loading the case values really changes the model
+        for name in prob.model._inputs:
+            model._inputs[name] += 1.0
+        for name in prob.model._outputs:
+            model._outputs[name] += 1.0
+
+        # Now load in the case we recorded
+        cr = CaseReader(self.filename)
+        case = cr.driver_cases.get_case(0)
+        prob.load_case(case)
+
+
 def _assert_model_matches_case(case, system):
     '''
     Check to see if the values in the case match those in the model.


### PR DESCRIPTION
If you have a driver case with a design variable that had indices, then the variable size in the case is not saved correctly. This breaks load-case. What we need is that when a variable is accessed via the <case>.outputs[] dictionary, then it is always the correct size (regardless of the indices from the design variables)
