### PR TITLE
Update problem_viewer.py

### DIFF
--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -222,7 +222,7 @@ def view_model(problem_or_filename, outfile='n2.html', show_browser=True, embedd
     style_dir = os.path.join(vis_dir, "style")
 
     #grab the libraries
-    with open(os.path.join(libs_dir, "awesomplete.js"), "r") as f:
+    with open(os.path.join(libs_dir, "awesomplete.js"), "r", encoding="utf8") as f:
         awesomplete = f.read()
     with open(os.path.join(libs_dir, "d3.v4.min.js"), "r") as f:
         d3 = f.read()


### PR DESCRIPTION
1. Added an option [encoding="utf8"] to Ln.226, because there was some 'UnicodeDecodeError' when I was try to generate the N2 diagram using OpenMDAO CommandLine Tools.  Also imported "io" module and used "io.open" method to satisfy the python 2.7 environment instead of "open" method. The original error message was as follow :

    UnicodeDecodeError : 'cp949' codec can't decode byte 0xe2 in position 104: illegal multibyte sequence

 I am using the Windows 10 for Korean language as a development environment. The problem was solved after specifying Unicode as utf-8 via the option. Perhaps someone who has a similar problem with non-English operating systems will be able to solve the problem in the same way.