### PR TITLE
Make user warning for needing `force_alloc_complex` more clear. 

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1212,8 +1212,10 @@ class Problem(object):
 
         if len(comps_could_not_cs) > 0:
             msg = "The following components requested complex step, but force_alloc_complex " + \
-                "has not been set to True, so finite difference was used: "
+                  "has not been set to True, so finite difference was used: "
             msg += str(list(comps_could_not_cs))
+            msg += "\nTo enable complex step, specify 'force_alloc_complex=True' when calling " + \
+                   "setup on the problem, e.g. 'problem.setup(force_alloc_complex=True)'"
             warnings.warn(msg)
 
         _assemble_derivative_data(partials_data, rel_err_tol, abs_err_tol, out_stream,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -473,7 +473,6 @@ class System(object):
             relevant = self._relevant
             vec_names = self._rel_vec_name_list
             vois = self._vois
-            iproc = self.comm.rank
             abs2idx = self._var_allprocs_abs2idx
 
             # Check for complex step to set vectors up appropriately.
@@ -590,9 +589,7 @@ class System(object):
         """
         # 1. Full setup that must be called in the root system.
         if setup_mode == 'full':
-            initial = True
             recurse = True
-            resize = False
 
             self.pathname = ''
             self.comm = comm
@@ -601,14 +598,10 @@ class System(object):
             self._local_vector_class = local_vector_class
         # 2. Partial setup called in the system initiating the reconfiguration.
         elif setup_mode == 'reconf':
-            initial = False
             recurse = True
-            resize = True
         # 3. Update-mode setup called in all ancestors of the system initiating the reconf.
         elif setup_mode == 'update':
-            initial = False
             recurse = False
-            resize = False
 
         self._mode = mode
 
@@ -787,7 +780,6 @@ class System(object):
             Whether to call this method in subsystems.
         """
         self._var_allprocs_abs2idx = abs2idx = {}
-        abs2meta = self._var_allprocs_abs2meta
 
         for vec_name in self._lin_rel_vec_name_list:
             abs2idx[vec_name] = abs2idx_t = {}
@@ -1015,8 +1007,9 @@ class System(object):
         # This happens if you reconfigure and switch to 'cs' without forcing the vectors to be
         # initially allocated as complex.
         if not alloc_complex and 'cs' in self._approx_schemes:
-            msg = 'In order to activate complex step during reconfiguration, you need to set ' + \
-                '"force_alloc_complex" to True during setup.'
+            msg = "In order to activate complex step during reconfiguration, " \
+                  "you need to set 'force_alloc_complex' to True during setup. " \
+                  "e.g. 'problem.setup(force_alloc_complex=True)'"
             raise RuntimeError(msg)
 
         vector_class = self._vector_class

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -1145,8 +1145,9 @@ class TestComponentComplexStep(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             model.resetup(setup_mode='reconf')
 
-        msg = 'In order to activate complex step during reconfiguration, you need to set ' + \
-              '"force_alloc_complex" to True during setup.'
+        msg = "In order to activate complex step during reconfiguration, " \
+              "you need to set 'force_alloc_complex' to True during setup. " \
+              "e.g. 'problem.setup(force_alloc_complex=True)'"
         self.assertEqual(str(context.exception), msg)
 
         # This time, allocate complex in setup.

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -7,13 +7,12 @@ from parameterized import parameterized
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ScipyKrylov, ExecComp, NewtonSolver, \
-     ExplicitComponent, DefaultVector, NonlinearBlockGS, LinearRunOnce, ParallelGroup
+    ExplicitComponent, DefaultVector, NonlinearBlockGS, LinearRunOnce
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.mpi import MPI
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray, TestImplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.test_suite.components.sellar_feature import SellarNoDerivativesCS
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompC, TgtCompF, TgtCompK
 from openmdao.test_suite.groups.parallel_groups import FanInSubbedIDVC
@@ -22,7 +21,6 @@ try:
     from openmdao.parallel_api import PETScVector
     vector_class = PETScVector
 except ImportError:
-    from openmdao.api import DefaultVector
     vector_class = DefaultVector
     PETScVector = None
 
@@ -75,7 +73,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
 
                 outputs['f_xy'] = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
                 g_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
-                outputs['g_xy'] = g_xy *3
+                outputs['g_xy'] = g_xy * 3
 
                 self.count += 1
 
@@ -118,10 +116,9 @@ class TestGroupFiniteDifference(unittest.TestCase):
 
                 outputs['f_xy'] = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
                 g_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
-                outputs['g_xy'] = g_xy *3
+                outputs['g_xy'] = g_xy * 3
 
                 self.count += 1
-
 
         prob = Problem()
         model = prob.model
@@ -140,7 +137,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.setup(check=False)
         prob.run_model()
 
-        derivs = prob.driver._compute_totals(of=['parab.f_xy'], wrt=['px.x'], global_names=True)
+        prob.driver._compute_totals(of=['parab.f_xy'], wrt=['px.x'], global_names=True)
 
         # 1. run_model; 2. step x
         self.assertEqual(model.parab.count, 2)
@@ -312,12 +309,11 @@ class TestGroupFiniteDifference(unittest.TestCase):
                 """ Disable local solve."""
                 pass
 
-
         prob = Problem()
         model = prob.model = Group()
 
         model.add_subsystem('p_rhs', IndepVarComp('rhs', val=np.array([2, 4])))
-        comp = model.add_subsystem('comp', TestImplCompArrayDenseNoSolve())
+        model.add_subsystem('comp', TestImplCompArrayDenseNoSolve())
         model.connect('p_rhs.rhs', 'comp.rhs')
 
         model.nonlinear_solver = NewtonSolver()
@@ -335,7 +331,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['p_rhs.rhs']
         Jfd = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, Jfd['comp.x', 'p_rhs.rhs'], [[1.01020408, -0.01020408], [-0.01020408,  1.01020408]], 1e-5)
+        assert_rel_error(self, Jfd['comp.x', 'p_rhs.rhs'],
+                         [[1.01020408, -0.01020408], [-0.01020408, 1.01020408]], 1e-5)
 
     def test_step_size(self):
         # Test makes sure option metadata propagates to the fd function
@@ -419,13 +416,13 @@ class TestGroupFiniteDifference(unittest.TestCase):
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
         model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                               z=np.array([0.0, 0.0]), x=0.0),
-                           promotes=['obj', 'x', 'z', 'y1', 'y2'])
+                                                z=np.array([0.0, 0.0]), x=0.0),
+                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlbgs = prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = NonlinearBlockGS()
 
         model.approx_totals(method='fd', step=1e-5)
 
@@ -444,7 +441,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_desvar_with_indices(self):
-         # Just desvars on this one to cover code missed by desvar+response test.
+        # Just desvars on this one to cover code missed by desvar+response test.
 
         class ArrayComp2D(ExplicitComponent):
             """
@@ -569,7 +566,6 @@ class TestGroupFiniteDifference(unittest.TestCase):
             def solve(self, vec_names, mode, rel_systems=None):
                 raise RuntimeError("This solver should be ignored!")
 
-
         class Simple(ExplicitComponent):
             def setup(self):
                 self.add_input('x', val=0.0)
@@ -580,7 +576,6 @@ class TestGroupFiniteDifference(unittest.TestCase):
             def compute(self, inputs, outputs):
                 x = inputs['x']
                 outputs['y'] = 4.0*x
-
 
         prob = Problem()
         model = prob.model = Group()
@@ -617,8 +612,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
         model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                               z=np.array([0.0, 0.0]), x=0.0),
-                           promotes=['obj', 'x', 'z', 'y1', 'y2'])
+                                                z=np.array([0.0, 0.0]), x=0.0),
+                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
@@ -656,8 +651,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
         model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                               z=np.array([0.0, 0.0]), x=0.0),
-                           promotes=['obj', 'x', 'z', 'y1', 'y2'])
+                                                z=np.array([0.0, 0.0]), x=0.0),
+                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
@@ -719,10 +714,9 @@ class TestGroupComplexStep(unittest.TestCase):
         except:
             pass
 
-    @parameterized.expand(itertools.product(
-        [DefaultVector, PETScVector],
-        ), testcase_func_name=lambda f, n, p: 'test_paraboloid_'+'_'.join(title(a) for a in p.args)
-    )
+    @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
+                          testcase_func_name=lambda f, n, p:
+                          'test_paraboloid_'+'_'.join(title(a) for a in p.args))
     def test_paraboloid(self, vec_class):
 
         if not vec_class:
@@ -751,10 +745,9 @@ class TestGroupComplexStep(unittest.TestCase):
         # 1 output x 2 inputs
         self.assertEqual(len(model._approx_schemes['cs']._exec_list), 2)
 
-    @parameterized.expand(itertools.product(
-        [DefaultVector, PETScVector],
-        ), testcase_func_name=lambda f, n, p: 'test_paraboloid_subbed_'+'_'.join(title(a) for a in p.args)
-    )
+    @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
+                          testcase_func_name=lambda f, n, p:
+                          'test_paraboloid_subbed_'+'_'.join(title(a) for a in p.args))
     def test_paraboloid_subbed(self, vec_class):
 
         if not vec_class:
@@ -788,10 +781,9 @@ class TestGroupComplexStep(unittest.TestCase):
         # 1 output x 2 inputs
         self.assertEqual(len(sub._approx_schemes['cs']._exec_list), 2)
 
-    @parameterized.expand(itertools.product(
-        [DefaultVector, PETScVector],
-        ), testcase_func_name=lambda f, n, p: 'test_paraboloid_subbed_with_connections_'+'_'.join(title(a) for a in p.args)
-    )
+    @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
+                          testcase_func_name=lambda f, n, p:
+                          'test_paraboloid_subbed_with_connections_'+'_'.join(title(a) for a in p.args))
     def test_paraboloid_subbed_with_connections(self, vec_class):
 
         if not vec_class:
@@ -832,10 +824,9 @@ class TestGroupComplexStep(unittest.TestCase):
         # 3 outputs x 2 inputs
         self.assertEqual(len(sub._approx_schemes['cs']._exec_list), 6)
 
-    @parameterized.expand(itertools.product(
-        [DefaultVector, PETScVector],
-        ), testcase_func_name=lambda f, n, p: 'test_arrray_comp_'+'_'.join(title(a) for a in p.args)
-    )
+    @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
+                          testcase_func_name=lambda f, n, p:
+                          'test_arrray_comp_'+'_'.join(title(a) for a in p.args))
     def test_arrray_comp(self, vec_class):
 
         if not vec_class:
@@ -871,10 +862,9 @@ class TestGroupComplexStep(unittest.TestCase):
         assert_rel_error(self, Jfd['comp.y2', 'p1.x1'], comp.JJ[2:4, 0:2], 1e-6)
         assert_rel_error(self, Jfd['comp.y2', 'p2.x2'], comp.JJ[2:4, 2:4], 1e-6)
 
-    @parameterized.expand(itertools.product(
-        [DefaultVector, PETScVector],
-        ), testcase_func_name=lambda f, n, p: 'test_unit_conv_group_'+'_'.join(title(a) for a in p.args)
-    )
+    @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
+                          testcase_func_name=lambda f, n, p:
+                          'test_unit_conv_group_'+'_'.join(title(a) for a in p.args))
     def test_unit_conv_group(self, vec_class):
 
         if not vec_class:
@@ -923,10 +913,9 @@ class TestGroupComplexStep(unittest.TestCase):
         assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
         assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
-    @parameterized.expand(itertools.product(
-        [DefaultVector, PETScVector],
-        ), testcase_func_name=lambda f, n, p: 'test_sellar_'+'_'.join(title(a) for a in p.args)
-    )
+    @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
+                          testcase_func_name=lambda f, n, p:
+                          'test_sellar_'+'_'.join(title(a) for a in p.args))
     def test_sellar(self, vec_class):
         # Basic sellar test.
 
@@ -943,13 +932,13 @@ class TestGroupComplexStep(unittest.TestCase):
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
         model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                               z=np.array([0.0, 0.0]), x=0.0),
-                           promotes=['obj', 'x', 'z', 'y1', 'y2'])
+                                                z=np.array([0.0, 0.0]), x=0.0),
+                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlbgs = prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = NonlinearBlockGS()
 
         # Had to make this step larger so that solver would reconverge adequately.
         model.approx_totals(method='cs', step=1.0e-1)
@@ -1157,7 +1146,7 @@ class TestComponentComplexStep(unittest.TestCase):
             model.resetup(setup_mode='reconf')
 
         msg = 'In order to activate complex step during reconfiguration, you need to set ' + \
-            '"force_alloc_complex" to True during setup.'
+              '"force_alloc_complex" to True during setup.'
         self.assertEqual(str(context.exception), msg)
 
         # This time, allocate complex in setup.
@@ -1193,8 +1182,7 @@ class TestComponentComplexStep(unittest.TestCase):
                 outputs['y1'][1][0] -= 6.67
                 outputs['y1'][1][1] /= 2.34
 
-                pass #outputs['y1'] *= 1.0
-
+                pass  # outputs['y1'] *= 1.0
 
         prob = self.prob = Problem()
         model = prob.model = Group()
@@ -1235,7 +1223,6 @@ class ApproxTotalsFeature(unittest.TestCase):
                     outputs['y'] = np.arange(25) * x
                     self._exec_count += 1
 
-
         class CompTwo(ExplicitComponent):
 
                 def setup(self):
@@ -1247,7 +1234,6 @@ class ApproxTotalsFeature(unittest.TestCase):
                     y = inputs['y']
                     outputs['z'] = np.sum(y)
                     self._exec_count += 1
-
 
         prob = Problem()
         model = prob.model = Group()
@@ -1285,7 +1271,6 @@ class ApproxTotalsFeature(unittest.TestCase):
                     outputs['y'] = np.arange(25) * x
                     self._exec_count += 1
 
-
         class CompTwo(ExplicitComponent):
 
                 def setup(self):
@@ -1298,12 +1283,11 @@ class ApproxTotalsFeature(unittest.TestCase):
                     outputs['z'] = np.sum(y)
                     self._exec_count += 1
 
-
         prob = Problem()
         model = prob.model = Group()
         model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
         model.add_subsystem('comp1', CompOne(), promotes=['x', 'y'])
-        comp2 = model.add_subsystem('comp2', CompTwo(), promotes=['y', 'z'])
+        model.add_subsystem('comp2', CompTwo(), promotes=['y', 'z'])
 
         model.linear_solver = ScipyKrylov()
         model.approx_totals(method='cs')
@@ -1334,7 +1318,6 @@ class ApproxTotalsFeature(unittest.TestCase):
                     outputs['y'] = np.arange(25) * x
                     self._exec_count += 1
 
-
         class CompTwo(ExplicitComponent):
 
                 def setup(self):
@@ -1347,12 +1330,11 @@ class ApproxTotalsFeature(unittest.TestCase):
                     outputs['z'] = np.sum(y)
                     self._exec_count += 1
 
-
         prob = Problem()
         model = prob.model = Group()
         model.add_subsystem('p1', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('comp1', CompOne(), promotes=['x', 'y'])
-        comp2 = model.add_subsystem('comp2', CompTwo(), promotes=['y', 'z'])
+        model.add_subsystem('comp2', CompTwo(), promotes=['y', 'z'])
 
         model.linear_solver = ScipyKrylov()
         model.approx_totals(method='fd', step=1e-7, form='central', step_calc='rel')
@@ -1368,8 +1350,6 @@ class ApproxTotalsFeature(unittest.TestCase):
 
     def test_sellarCS(self):
         # Just tests Newton on Sellar with FD derivs.
-        import numpy as np
-
         from openmdao.api import Problem
         from openmdao.test_suite.components.sellar_feature import SellarNoDerivativesCS
 
@@ -1384,6 +1364,7 @@ class ApproxTotalsFeature(unittest.TestCase):
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -250,7 +250,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 J['y', 'x1'] = np.array([3.0])
                 self.lin_count += 1
 
-
         prob = Problem()
         prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
@@ -693,8 +692,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(len(w), 1)
 
         msg = "The following components requested complex step, but force_alloc_complex " + \
-            "has not been set to True, so finite difference was used: ['comp']"
-
+              "has not been set to True, so finite difference was used: ['comp']\n" + \
+              "To enable complex step, specify 'force_alloc_complex=True' when calling " + \
+              "setup on the problem, e.g. 'problem.setup(force_alloc_complex=True)'"
         self.assertEqual(str(w[0].message), msg)
 
         # Derivative still calculated, but with fd instead.
@@ -2132,7 +2132,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         # Try again with a direct solver and sparse assembled hierarchy.
 
         p = Problem()
-        sub = p.model.add_subsystem('sub', GaussLobattoPhase())
+        p.model.add_subsystem('sub', GaussLobattoPhase())
 
         p.model.sub.add_objective('time', index=-1)
 

--- a/openmdao/docs/features/core_features/working_with_derivatives/checking_partials.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/checking_partials.rst
@@ -60,7 +60,7 @@ define either :code:`compute_jacvec_product` or :code:`compute_multi_jacvec_prod
 Here, we show how to set the method. In this case, we use complex step on TrickyParaboloid because the finite difference is
 less accurate.
 
-**Note**: You need to set `force_alloc_complex` to True during setup to utilize complex Step during a check.
+**Note**: You need to set `force_alloc_complex` to True during setup to utilize complex step during a check.
 
 .. embed-code::
     openmdao.core.tests.test_check_derivs.TestCheckPartialsFeature.test_set_method_on_comp


### PR DESCRIPTION
Pivotal #159748801: User warning for needing `force_alloc_complex` needs to be more clear.  The user warning should explicitly say how to change the setup call.

Also cleaned up some lint issues in the test scripts and removed some no longer used variables in system.py