### PR TITLE
Fix ExternalCodeComp to to allow running a .bat file on Windows

### DIFF
--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -84,7 +84,7 @@ class ExternalCodeDelegate(object):
                     missing = self._check_for_files([program_to_execute])
                     if missing:
                         logger.error("The command to be executed, '%s', "
-                                    "cannot be found" % program_to_execute)
+                                     "cannot be found" % program_to_execute)
             else:
                 if not find_executable(program_to_execute):
                     logger.error("The command to be executed, '%s', "
@@ -206,7 +206,7 @@ class ExternalCodeDelegate(object):
                 missing = self._check_for_files([program_to_execute])
                 if missing:
                     raise ValueError("The command to be executed, '%s', "
-                                    "cannot be found" % program_to_execute)
+                                     "cannot be found" % program_to_execute)
             command_for_shell_proc = ['cmd.exe', '/c'] + command
         else:
             if not find_executable(program_to_execute):

--- a/openmdao/components/tests/extcode.bat
+++ b/openmdao/components/tests/extcode.bat
@@ -1,9 +1,0 @@
-@echo off
-rem usage: extcode.bat output_filename
-rem
-rem Just write 'test data' to the specified output file
-
-set DATA=test data
-set OUT_FILE=%1
-
-echo %DATA%>>%OUT_FILE%

--- a/openmdao/components/tests/extcode.bat
+++ b/openmdao/components/tests/extcode.bat
@@ -1,0 +1,9 @@
+@echo off
+rem usage: extcode.bat output_filename
+rem
+rem Just write 'test data' to the specified output file
+
+set DATA=test data
+set OUT_FILE=%1
+
+echo %DATA%>>%OUT_FILE%


### PR DESCRIPTION
Pivotal #159777840: 
On windows, if you try to use an ExternalCodeComp to run a .bat file, the find_executable pre-check doesn't recognize it as valid.