### PR TITLE
Complex Step Refactor

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -76,7 +76,7 @@ class ApproximationScheme(object):
         if deriv_type == 'total':
             run_model = system.run_solve_nonlinear
             results_vec = outputs
-        elif deriv_type == 'partial':
+        else:
             run_model = system.run_apply_nonlinear
             results_vec = system._residuals
 

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -79,8 +79,6 @@ class ApproximationScheme(object):
         elif deriv_type == 'partial':
             run_model = system.run_apply_nonlinear
             results_vec = system._residuals
-        else:
-            raise ValueError('deriv_type must be one of "total" or "partial"')
 
         for in_name, idxs, delta in input_deltas:
             if in_name in outputs._views_flat:

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -110,18 +110,14 @@ class ComplexStep(ApproximationScheme):
 
         if deriv_type == 'total':
             current_vec = system._outputs
-        elif deriv_type == 'partial':
+        else:
             current_vec = system._residuals
 
         # Clean vector for results
         results_clone = current_vec._clone(True)
 
         # Turn on complex step.
-        for sub in system.system_iter(include_self=True, recurse=True):
-            sub.under_complex_step = True
-            sub._inputs.set_complex_step_mode(True)
-            sub._outputs.set_complex_step_mode(True)
-            sub._residuals.set_complex_step_mode(True)
+        system._set_complex_step_mode(True)
         results_clone.set_complex_step_mode(True)
 
         # To support driver src_indices, we need to override some checks in Jacobian, but do it
@@ -183,11 +179,7 @@ class ComplexStep(ApproximationScheme):
                     jac._override_checks = False
 
         # Turn off complex step.
-        for sub in system.system_iter(include_self=True, recurse=True):
-            sub.under_complex_step = False
-            sub._inputs.set_complex_step_mode(False)
-            sub._outputs.set_complex_step_mode(False)
-            sub._residuals.set_complex_step_mode(False)
+        system._set_complex_step_mode(False)
 
     def _run_point_complex(self, system, input_deltas, result_clone, deriv_type='partial'):
         """
@@ -218,7 +210,7 @@ class ComplexStep(ApproximationScheme):
         if deriv_type == 'total':
             run_model = system.run_solve_nonlinear
             results_vec = outputs
-        elif deriv_type == 'partial':
+        else:
             run_model = system.run_apply_nonlinear
             results_vec = system._residuals
 

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -11,7 +11,7 @@ from openmdao.utils.name_maps import abs_key2rel_key
 
 
 DEFAULT_CS_OPTIONS = {
-    'step': 1e-15,
+    'step': 1e-40,
     'form': 'forward',
 }
 
@@ -102,6 +102,9 @@ class ComplexStep(ApproximationScheme):
             One of 'total' or 'partial', indicating if total or partial derivatives are
             being approximated.
         """
+        if len(self._exec_list) == 0:
+            return
+
         if jac is None:
             jac = system._jacobian
 
@@ -109,15 +112,17 @@ class ComplexStep(ApproximationScheme):
             current_vec = system._outputs
         elif deriv_type == 'partial':
             current_vec = system._residuals
-        else:
-            raise ValueError('deriv_type must be one of "total" or "partial"')
+
+        # Clean vector for results
+        results_clone = current_vec._clone(True)
 
         # Turn on complex step.
-        system._inputs._vector_info._under_complex_step = True
-
-        # create a scratch array
-        out_tmp = system._outputs._data.copy()
-        results_clone = current_vec._clone(True)
+        for sub in system.system_iter(include_self=True, recurse=True):
+            sub.under_complex_step = True
+            sub._inputs.set_complex_step_mode(True)
+            sub._outputs.set_complex_step_mode(True)
+            sub._residuals.set_complex_step_mode(True)
+        results_clone.set_complex_step_mode(True)
 
         # To support driver src_indices, we need to override some checks in Jacobian, but do it
         # selectively.
@@ -131,6 +136,7 @@ class ComplexStep(ApproximationScheme):
             if form == 'reverse':
                 delta *= -1.0
             fact = 1.0 / delta
+            delta *= 1j
 
             if wrt in system._owns_approx_wrt_idx:
                 in_idx = system._owns_approx_wrt_idx[wrt]
@@ -159,15 +165,14 @@ class ComplexStep(ApproximationScheme):
             for i_count, idx in enumerate(in_idx):
                 # Run the Finite Difference
                 input_delta = [(wrt, idx, delta)]
-                result = self._run_point_complex(system, input_delta, out_tmp, results_clone,
-                                                 deriv_type)
+                result = self._run_point_complex(system, input_delta, results_clone, deriv_type)
 
                 for of, subjac in outputs:
                     if of in system._owns_approx_of_idx:
                         out_idx = system._owns_approx_of_idx[of]
-                        subjac[:, i_count] = result._imag_views_flat[of][out_idx] * fact
+                        subjac[:, i_count] = (result._views_flat[of][out_idx] * fact).imag
                     else:
-                        subjac[:, i_count] = result._imag_views_flat[of] * fact
+                        subjac[:, i_count] = (result._views_flat[of] * fact).imag
 
             for of, subjac in outputs:
                 rel_key = abs_key2rel_key(system, (of, wrt))
@@ -178,9 +183,13 @@ class ComplexStep(ApproximationScheme):
                     jac._override_checks = False
 
         # Turn off complex step.
-        system._inputs._vector_info._under_complex_step = False
+        for sub in system.system_iter(include_self=True, recurse=True):
+            sub.under_complex_step = False
+            sub._inputs.set_complex_step_mode(False)
+            sub._outputs.set_complex_step_mode(False)
+            sub._residuals.set_complex_step_mode(False)
 
-    def _run_point_complex(self, system, input_deltas, out_tmp, result_clone, deriv_type='partial'):
+    def _run_point_complex(self, system, input_deltas, result_clone, deriv_type='partial'):
         """
         Perturb the system inputs with a complex step, runs, and returns the results.
 
@@ -190,8 +199,6 @@ class ComplexStep(ApproximationScheme):
             The system having its derivs approximated.
         input_deltas : list
             List of (input name, indices, delta) tuples, where input name is an absolute name.
-        out_tmp : ndarray
-            An array the same size as the system outputs that is used for temporary storage.
         result_clone : Vector
             A vector cloned from the outputs vector. Used to store the results.
         deriv_type : str
@@ -214,26 +221,21 @@ class ComplexStep(ApproximationScheme):
         elif deriv_type == 'partial':
             run_model = system.run_apply_nonlinear
             results_vec = system._residuals
-        else:
-            raise ValueError('deriv_type must be one of "total" or "partial"')
 
         for in_name, idxs, delta in input_deltas:
-            if in_name in outputs._imag_views_flat:
-                outputs._imag_views_flat[in_name][idxs] += delta
+            if in_name in outputs._views_flat:
+                outputs._views_flat[in_name][idxs] += delta
             else:
-                inputs._imag_views_flat[in_name][idxs] += delta
+                inputs._views_flat[in_name][idxs] += delta
 
-        out_tmp = results_vec._data.copy()
         run_model()
 
-        # TODO: Grab only results of interest
         result_clone.set_vec(results_vec)
-        results_vec._data[:] = out_tmp
 
         for in_name, idxs, delta in input_deltas:
-            if in_name in outputs._imag_views_flat:
-                outputs._imag_views_flat[in_name][idxs] -= delta
+            if in_name in outputs._views_flat:
+                outputs._views_flat[in_name][idxs] -= delta
             else:
-                inputs._imag_views_flat[in_name][idxs] -= delta
+                inputs._views_flat[in_name][idxs] -= delta
 
         return result_clone

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -160,6 +160,9 @@ class FiniteDifference(ApproximationScheme):
             One of 'total' or 'partial', indicating if total or partial derivatives are
             being approximated.
         """
+        if len(self._exec_list) == 0:
+            return
+
         if jac is None:
             jac = system._jacobian
 
@@ -167,8 +170,6 @@ class FiniteDifference(ApproximationScheme):
             current_vec = system._outputs
         elif deriv_type == 'partial':
             current_vec = system._residuals
-        else:
-            raise ValueError('deriv_type must be one of "total" or "partial"')
 
         result = system._outputs._clone(True)
         result_array = result._data.copy()

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -168,7 +168,7 @@ class FiniteDifference(ApproximationScheme):
 
         if deriv_type == 'total':
             current_vec = system._outputs
-        elif deriv_type == 'partial':
+        else:
             current_vec = system._residuals
 
         result = system._outputs._clone(True)

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -184,11 +184,6 @@ class ExplicitComponent(Component):
                 finally:
                     self._inputs.read_only = False
 
-                # Restore any complex views if under complex step.
-                if outputs._vector_info._under_complex_step:
-                    outputs._remove_complex_views()
-                    residuals._remove_complex_views()
-
                 residuals += outputs
                 outputs -= residuals
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -372,6 +372,7 @@ class Group(System):
         for subsys in self._subsystems_myproc:
             subsys._local_vector_class = self._local_vector_class
             subsys._distributed_vector_class = self._distributed_vector_class
+            subsys.force_alloc_complex = self.force_alloc_complex
 
             if self.pathname:
                 subsys._setup_procs('.'.join((self.pathname, subsys.name)), sub_comm, mode)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -770,6 +770,7 @@ class Problem(object):
             this enables the user to instantiate and setup in one line.
         """
         model = self.model
+        model.force_alloc_complex = force_alloc_complex
         comm = self.comm
 
         if vector_class is not None:
@@ -873,9 +874,7 @@ class Problem(object):
 
     def check_partials(self, out_stream=_DEFAULT_OUT_STREAM, includes=None, excludes=None,
                        compact_print=False, abs_err_tol=1e-6, rel_err_tol=1e-6,
-                       method='fd', step=DEFAULT_FD_OPTIONS['step'],
-                       form=DEFAULT_FD_OPTIONS['form'],
-                       step_calc=DEFAULT_FD_OPTIONS['step_calc'],
+                       method='fd', step=None, form='forward', step_calc='abs',
                        force_dense=True, show_only_incorrect=False):
         """
         Check partial derivatives comprehensively for all components in your model.
@@ -903,13 +902,14 @@ class Problem(object):
         method : str
             Method, 'fd' for finite difference or 'cs' for complex step. Default is 'fd'.
         step : float
-            Step size for approximation. Default is the default value of step for the 'fd' method.
+            Step size for approximation. Default is None, which means 1e-6 for 'fd' and 1e-40 for
+            'cs'.
         form : string
             Form for finite difference, can be 'forward', 'backward', or 'central'. Default
-            is the default value of step for the 'fd' method.
+            'forward'.
         step_calc : string
-            Step type for finite difference, can be 'abs' for absolute', or 'rel' for
-            relative. Default is the default value of step for the 'fd' method.
+            Step type for finite difference, can be 'abs' for absolute', or 'rel' for relative.
+            Default is 'abs'.
         force_dense : bool
             If True, analytic derivatives will be coerced into arrays. Default is True.
         show_only_incorrect : bool, optional
@@ -1239,7 +1239,7 @@ class Problem(object):
 
     def check_totals(self, of=None, wrt=None, out_stream=_DEFAULT_OUT_STREAM, compact_print=False,
                      driver_scaling=False, abs_err_tol=1e-6, rel_err_tol=1e-6,
-                     method='fd', step=1e-6, form='forward', step_calc='abs'):
+                     method='fd', step=None, form='forward', step_calc='abs'):
         """
         Check total derivatives for the model vs. finite difference.
 
@@ -1269,7 +1269,8 @@ class Problem(object):
         method : str
             Method, 'fd' for finite difference or 'cs' for complex step. Default is 'fd'
         step : float
-            Step size for approximation. Default is 1e-6.
+            Step size for approximation. Default is None, which means 1e-6 for 'fd' and 1e-40 for
+            'cs'.
         form : string
             Form for finite difference, can be 'forward', 'backward', or 'central'. Default
             'forward'.
@@ -1299,6 +1300,12 @@ class Problem(object):
             total_info = _TotalJacInfo(self, of, wrt, False, return_format='flat_dict',
                                        driver_scaling=driver_scaling)
             Jcalc = total_info.compute_totals()
+
+            if step is None:
+                if method == 'cs':
+                    step = DEFAULT_CS_OPTIONS['step']
+                else:
+                    step = DEFAULT_FD_OPTIONS['step']
 
             # Approximate FD
             fd_args = {

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -60,6 +60,10 @@ class System(object):
         options dictionary
     recording_options : OptionsDictionary
         Recording options dictionary
+    under_complex_step : bool
+        When True, this system is undergoing complex step.
+    force_alloc_complex : bool
+        When True, the vectors have been allocated for checking with complex step.
     iter_count : int
         Int that holds the number of times this system has iterated
         in a recording run.
@@ -317,6 +321,9 @@ class System(object):
         self._owns_approx_of = None
         self._owns_approx_wrt_idx = {}
         self._owns_approx_of_idx = {}
+
+        self.under_complex_step = False
+        self.force_alloc_complex = False
 
         self._design_vars = OrderedDict()
         self._responses = OrderedDict()
@@ -1351,18 +1358,10 @@ class System(object):
 
         for vec in outputs:
 
-            # Process any complex views if under complex step.
-            if vec._vector_info._under_complex_step:
-                vec._remove_complex_views()
-
             if self._has_output_scaling:
                 vec.scale('norm')
 
         for vec in residuals:
-
-            # Process any complex views if under complex step.
-            if vec._vector_info._under_complex_step:
-                vec._remove_complex_views()
 
             if self._has_resid_scaling:
                 vec.scale('norm')

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2842,6 +2842,23 @@ class System(object):
                 if hasattr(nl, 'linesearch') and nl.linesearch:
                     nl.linesearch._iter_count = 0
 
+    def _set_complex_step_mode(self, active):
+        """
+        Turn on or off complex stepping mode.
+
+        Recurses to turn on or off complex stepping mode in all subsystems and their vectors.
+
+        Parameters
+        ----------
+        active : bool
+            Complex mode flag; set to True prior to commencing complex step.
+        """
+        for sub in self.system_iter(include_self=True, recurse=True):
+            sub.under_complex_step = active
+            sub._inputs.set_complex_step_mode(active)
+            sub._outputs.set_complex_step_mode(active)
+            sub._residuals.set_complex_step_mode(active)
+
     def cleanup(self):
         """
         Clean up resources prior to exit.

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -1,5 +1,5 @@
 """ Testing for group finite differencing."""
-
+from six.moves import range
 import unittest
 import itertools
 from parameterized import parameterized
@@ -7,12 +7,13 @@ from parameterized import parameterized
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ScipyKrylov, ExecComp, NewtonSolver, \
-    ExplicitComponent, DefaultVector, NonlinearBlockGS, LinearRunOnce
+    ExplicitComponent, DefaultVector, NonlinearBlockGS, LinearRunOnce, DirectSolver
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.mpi import MPI
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray, TestImplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
-from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
+from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives, \
+     SellarDis1CS, SellarDis2CS
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompC, TgtCompF, TgtCompK
 from openmdao.test_suite.groups.parallel_groups import FanInSubbedIDVC
@@ -710,7 +711,7 @@ class TestGroupComplexStep(unittest.TestCase):
     def tearDown(self):
         # Global stuff seems to not get cleaned up if test fails.
         try:
-            self.prob.model._outputs._vector_info._under_complex_step = False
+            self.prob.model._outputs._under_complex_step = False
         except:
             pass
 
@@ -1079,10 +1080,6 @@ class TestGroupComplexStep(unittest.TestCase):
 
 class TestComponentComplexStep(unittest.TestCase):
 
-    def tearDown(self):
-        # Global stuff seems to not get cleaned up if test fails.
-        self.prob.model._outputs._vector_info._under_complex_step = False
-
     def test_implicit_component(self):
 
         class TestImplCompArrayDense(TestImplCompArray):
@@ -1183,7 +1180,7 @@ class TestComponentComplexStep(unittest.TestCase):
                 outputs['y1'][1][0] -= 6.67
                 outputs['y1'][1][1] /= 2.34
 
-                pass  # outputs['y1'] *= 1.0
+                outputs['y1'] *= 1.0
 
         prob = self.prob = Problem()
         model = prob.model = Group()
@@ -1203,6 +1200,160 @@ class TestComponentComplexStep(unittest.TestCase):
         assert_rel_error(self, derivs['comp.y1', 'px.x'][1][1], 3.0, 1e-6)
         assert_rel_error(self, derivs['comp.y1', 'px.x'][2][2], 1.0, 1e-6)
         assert_rel_error(self, derivs['comp.y1', 'px.x'][3][3], 1.0/2.34, 1e-6)
+
+    def test_sellar_comp_cs(self):
+        # Basic sellar test.
+
+        prob = self.prob = Problem()
+        model = prob.model = Group()
+
+        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+
+        model.add_subsystem('d1', SellarDis1CS(), promotes=['x', 'z', 'y1', 'y2'])
+        model.add_subsystem('d2', SellarDis2CS(), promotes=['z', 'y1', 'y2'])
+
+        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                z=np.array([0.0, 0.0]), x=0.0),
+                            promotes=['obj', 'x', 'z', 'y1', 'y2'])
+
+        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+
+        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.linear_solver = DirectSolver()
+
+        prob.setup(check=False)
+        prob.set_solver_print(level=0)
+        prob.run_model()
+
+        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
+        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+
+        wrt = ['z']
+        of = ['obj']
+
+        J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+
+        outs = prob.model.list_outputs(residuals=True, out_stream=None)
+        for j in range(len(outs)):
+            val = np.linalg.norm(outs[j][1]['resids'])
+            self.assertLess(val, 1e-8, msg="Check if CS cleans up after itself.")
+
+    def test_stepsizes_under_complex_step(self):
+        from openmdao.api import Problem, ExplicitComponent
+
+        class SimpleComp(ExplicitComponent):
+
+            def setup(self):
+                self.add_input('x', val=1.0)
+                self.add_output('y', val=1.0)
+
+                self.declare_partials(of='y', wrt='x', method='cs')
+                self.count = 0
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = 3.0*inputs['x']
+
+                if self.under_complex_step:
+
+                    # Local cs
+                    if self.count == 0 and inputs['x'].imag != 1.0e-40:
+                        msg = "Wrong stepsize for local CS"
+                        raise RuntimeError(msg)
+
+                    # Global cs with default setting.
+                    if self.count == 1 and inputs['x'].imag != 1.0e-40:
+                        msg = "Wrong stepsize for default global CS"
+                        raise RuntimeError(msg)
+
+                    # Global cs with user setting.
+                    if self.count == 3 and inputs['x'].imag != 1.0e-12:
+                        msg = "Wrong stepsize for user global CS"
+                        raise RuntimeError(msg)
+
+                    # Check partials cs with default setting forward.
+                    if self.count == 4 and inputs['x'].imag != 1.0e-40:
+                        msg = "Wrong stepsize for check partial default CS forward"
+                        raise RuntimeError(msg)
+
+                    # Check partials cs with default setting.
+                    if self.count == 5 and inputs['x'].imag != 1.0e-40:
+                        msg = "Wrong stepsize for check partial default CS"
+                        raise RuntimeError(msg)
+
+                    # Check partials cs with user setting forward.
+                    if self.count == 6 and inputs['x'].imag != 1.0e-40:
+                        msg = "Wrong stepsize for check partial user CS forward"
+                        raise RuntimeError(msg)
+
+                    # Check partials cs with user setting.
+                    if self.count == 7 and inputs['x'].imag != 1.0e-14:
+                        msg = "Wrong stepsize for check partial user CS"
+                        raise RuntimeError(msg)
+
+                    self.count += 1
+
+            def compute_partials(self, inputs, partials):
+                partials['y', 'x'] = 3.
+
+        prob = Problem()
+        prob.model = Group()
+        prob.model.add_subsystem('px', IndepVarComp('x', val=1.0))
+        prob.model.add_subsystem('comp', SimpleComp())
+        prob.model.connect('px.x', 'comp.x')
+
+        prob.model.add_design_var('px.x', lower=-100, upper=100)
+        prob.model.add_objective('comp.y')
+
+        prob.setup(force_alloc_complex=True)
+
+        prob.run_model()
+
+        prob.check_totals(method='cs', out_stream=None)
+
+        prob.check_totals(method='cs', step=1e-12, out_stream=None)
+
+        prob.check_partials(method='cs', out_stream=None)
+
+        prob.check_partials(method='cs', step=1e-14, out_stream=None)
+
+    def test_feature_under_complex_step(self):
+        from openmdao.api import Problem, ExplicitComponent
+
+        class SimpleComp(ExplicitComponent):
+
+            def setup(self):
+                self.add_input('x', val=1.0)
+                self.add_output('y', val=1.0)
+
+                self.declare_partials(of='y', wrt='x', method='cs')
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = 3.0*inputs['x']
+
+                if self.under_complex_step:
+                    print("Under complex step")
+                    print("x", inputs['x'])
+                    print("y", outputs['y'])
+
+
+        prob = Problem()
+        prob.model = Group()
+        prob.model.add_subsystem('px', IndepVarComp('x', val=1.0))
+        prob.model.add_subsystem('comp', SimpleComp())
+        prob.model.connect('px.x', 'comp.x')
+
+        prob.model.add_design_var('px.x', lower=-100, upper=100)
+        prob.model.add_objective('comp.y')
+
+        prob.setup(force_alloc_complex=True)
+
+        prob.run_model()
+
+        prob.compute_totals(of=['comp.y'], wrt=['px.x'])
 
 
 class ApproxTotalsFeature(unittest.TestCase):

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -971,9 +971,13 @@ class TestProblemCheckPartials(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             prob.check_partials()
 
-        self.assertEqual(str(cm.exception),
-                         "'foo' is not a valid form of finite difference; "
-                         "must be one of ['forward', 'backward', 'central']")
+        # The form options sometimes print out in different order.
+        msg = str(cm.exception)
+        self.assertTrue("'foo' is not a valid form of finite difference; "
+                         "must be one of [" in msg, 'error message not correct.')
+        self.assertTrue('forward' in msg, 'error message not correct.')
+        self.assertTrue('backward' in msg, 'error message not correct.')
+        self.assertTrue('central' in msg, 'error message not correct.')
 
         # check invalid step
         with self.assertRaises(ValueError) as cm:

--- a/openmdao/docs/features/core_features/working_with_derivatives/approximating_partials.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/approximating_partials.rst
@@ -52,3 +52,12 @@ Here is how to turn on complex step for all input/output pairs in the Sellar pro
 
 .. embed-code::
     openmdao.test_suite.components.sellar_feature.SellarDis2CS
+
+Sometimes you need to know when you are under a complex step so that your component can correctly handle complex inputs (e.g,
+in case you need to allocate intermediate arrays as complex.) All `Components` and `Groups` provide the attribute "under_complex_step"
+that you can use to tell if you are under a complex step. In the following example, we print out the incoming complex value when the
+"compute" method is called while computing this component's derivatives under complex step.
+
+.. embed-code::
+    openmdao.core.tests.test_approx_derivs.TestComponentComplexStep.test_feature_under_complex_step
+    :layout: code, output

--- a/openmdao/docs/features/core_features/working_with_derivatives/check_total_derivatives.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/check_total_derivatives.rst
@@ -59,6 +59,15 @@ step size to trigger the nonlinear Gauss-Seidel solver to try to converge after 
     openmdao.core.tests.test_problem.TestProblem.test_feature_check_totals_cs
     :layout: interleave
 
+Note that you need to set the argument "force_alloc_complex" to True when you call setup. This
+makes sure that the vectors allocate space to pass complex numbers. All systems also have an
+attribute "force_alloc_complex" that can be queried during `setup` in case you need to set up your
+`Component` or `Group` differently to accomodate complex step.
+
+.. embed-code::
+    openmdao.core.tests.test_problem.TestProblem.test_feature_check_totals_user_detect_forced
+    :layout: code, output
+
 ----
 
 Turn off standard output and just view the derivatives in the return:

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -225,20 +225,6 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         self.assertTrue(icount2 < icount1)
 
 
-# class TestScipyKrylovBICG(TestScipyKrylov):
-#     # This will run all of the gmres tests with the bicg solver.
-#
-#     linear_solver_name = 'bicg'
-#     linear_solver_class = krylov_factory('bicg')
-#
-#
-# class TestScipyKrylovBICGSTAB(TestScipyKrylov):
-#     # This will run all of the gmres tests with the bicgstab solver.
-#
-#     linear_solver_name = 'bicgstab'
-#     linear_solver_class = krylov_factory('bicgstab')
-
-
 class TestScipyKrylovFeature(unittest.TestCase):
 
     def test_feature_simple(self):

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -588,7 +588,7 @@ class TestNewton(unittest.TestCase):
             """ This version of Newton also counts how many times it linearizes"""
 
             def __init__(self, **kwargs):
-                super(DirectSolver, self).__init__(**kwargs)
+                super(CountDS, self).__init__(**kwargs)
                 self.lin_count = 0
 
             def _linearize(self):

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -98,6 +98,16 @@ class SellarDis1withDerivatives(SellarDis1):
         partials['y1', 'x'] = 1.0
 
 
+class SellarDis1CS(SellarDis1):
+    """
+    Component containing Discipline 1 -- complex step version.
+    """
+
+    def _do_declares(self):
+        # Analytic Derivs
+        self.declare_partials(of='*', wrt='*', method='cs')
+
+
 class SellarDis2(ExplicitComponent):
     """
     Component containing Discipline 2 -- no derivatives version.
@@ -175,6 +185,16 @@ class SellarDis2withDerivatives(SellarDis2):
 
         J['y2', 'y1'] = .5*y1**-.5
         J['y2', 'z'] = np.array([[1.0, 1.0]])
+
+
+class SellarDis2CS(SellarDis2):
+    """
+    Component containing Discipline 2 -- complex step version.
+    """
+
+    def _do_declares(self):
+        # Analytic Derivs
+        self.declare_partials(of='*', wrt='*', method='cs')
 
 
 class SellarNoDerivatives(Group):

--- a/openmdao/test_suite/test_examples/test_sellar_opt.py
+++ b/openmdao/test_suite/test_examples/test_sellar_opt.py
@@ -16,7 +16,6 @@ class TestSellarOpt(unittest.TestCase):
         prob = Problem()
         prob.model = SellarMDA()
 
-
         prob.driver = ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         # prob.driver.options['maxiter'] = 100

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -4,7 +4,9 @@ from __future__ import division
 
 from itertools import product, chain
 from six import iteritems, itervalues
+
 import numpy as np
+
 from openmdao.vectors.vector import INT_DTYPE
 from openmdao.vectors.transfer import Transfer
 from openmdao.utils.array_utils import convert_neg, _global2local_offsets
@@ -200,15 +202,9 @@ class DefaultTransfer(Transfer):
         out_inds = self._out_inds
 
         if mode == 'fwd':
-            do_complex = in_vec._vector_info._under_complex_step and out_vec._alloc_complex
 
             # this works whether the vecs have multi columns or not due to broadcasting
             in_vec._data[in_inds] = out_vec._data[out_inds]
-
-            # Imaginary transfer
-            # (for CS, so only need in fwd)
-            if do_complex:
-                in_vec._imag_data[in_inds] = out_vec._imag_data[out_inds]
 
         else:  # rev
             np.add.at(out_vec._data, out_inds, in_vec._data[in_inds])

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -87,7 +87,7 @@ class DefaultVector(Vector):
         iproc = self._iproc
         root_vec = self._root_vector
 
-        imag_data = None
+        cplx_data = None
         scaling = {}
         if self._do_scaling:
             scaling['phys'] = {}
@@ -99,13 +99,9 @@ class DefaultVector(Vector):
 
         data = root_vec._data[ind1:ind2]
 
-        # Extract view for imaginary part too
+        # Extract view for complex storage too.
         if self._alloc_complex:
-            if root_vec._alloc_complex:
-                imag_data = root_vec._imag_data[ind1:ind2]
-            else:
-                shape = root_vec._data[ind1:ind2].shape
-                imag_data = np.zeros(shape)
+            cplx_data = root_vec._cplx_data[ind1:ind2]
 
         if self._do_scaling:
             for typ in ('phys', 'norm'):
@@ -116,7 +112,7 @@ class DefaultVector(Vector):
                 else:
                     scaling[typ] = (rs0[ind1:ind2], root_scale[1][ind1:ind2])
 
-        return data, imag_data, scaling
+        return data, cplx_data, scaling
 
     def _initialize_data(self, root_vector):
         """
@@ -151,10 +147,10 @@ class DefaultVector(Vector):
 
             # Allocate imaginary for complex step
             if self._alloc_complex:
-                self._imag_data = deepcopy(self._data)
+                self._cplx_data = np.zeros(self._data.shape, dtype=np.complex)
 
         else:
-            self._data, self._imag_data, self._scaling = self._extract_data()
+            self._data, self._cplx_data, self._scaling = self._extract_data()
 
     def _initialize_views(self):
         """
@@ -169,6 +165,7 @@ class DefaultVector(Vector):
         kind = self._kind
         iproc = self._iproc
         ncol = self._ncol
+
         do_scaling = self._do_scaling
         if do_scaling:
             factors = system._scale_factors
@@ -178,8 +175,8 @@ class DefaultVector(Vector):
         self._views_flat = views_flat = {}
 
         alloc_complex = self._alloc_complex
-        self._imag_views = imag_views = {}
-        self._imag_views_flat = imag_views_flat = {}
+        self._cplx_views = cplx_views = {}
+        self._cplx_views_flat = cplx_views_flat = {}
 
         allprocs_abs2idx_t = system._var_allprocs_abs2idx[self._name]
         sizes_t = system._var_sizes[self._name][type_]
@@ -202,11 +199,11 @@ class DefaultVector(Vector):
             views[abs_name] = v
 
             if alloc_complex:
-                imag_views_flat[abs_name] = v = self._imag_data[ind1:ind2]
+                cplx_views_flat[abs_name] = v = self._cplx_data[ind1:ind2]
                 if shape != v.shape:
                     v = v.view()
                     v.shape = shape
-                imag_views[abs_name] = v
+                cplx_views[abs_name] = v
 
             if do_scaling:
                 for scaleto in ('phys', 'norm'):
@@ -224,8 +221,8 @@ class DefaultVector(Vector):
         """
         self._data = self._data.copy()
 
-        if self._vector_info._under_complex_step and self._imag_data is not None:
-            self._imag_data = self._imag_data.copy()
+        if self._under_complex_step and self._cplx_data is not None:
+            self._cplx_data = self._cplx_data.copy()
 
     def __iadd__(self, vec):
         """
@@ -242,8 +239,6 @@ class DefaultVector(Vector):
             self + vec
         """
         self._data += vec._data
-        if vec._alloc_complex and self._vector_info._under_complex_step:
-            self._imag_data += vec._imag_data
         return self
 
     def __isub__(self, vec):
@@ -261,8 +256,6 @@ class DefaultVector(Vector):
             self - vec
         """
         self._data -= vec._data
-        if vec._alloc_complex and self._vector_info._under_complex_step:
-            self._imag_data -= vec._imag_data
         return self
 
     def __imul__(self, val):
@@ -279,13 +272,7 @@ class DefaultVector(Vector):
         <Vector>
             self * val
         """
-        if self._vector_info._under_complex_step:
-            r_val = np.real(val)
-            i_val = np.imag(val)
-            self._data = r_val * self._data + i_val * self._imag_data
-            self._imag_data = r_val * self._imag_data + i_val * self._data
-        else:
-            self._data *= val
+        self._data *= val
         return self
 
     def add_scal_vec(self, val, vec):
@@ -299,13 +286,7 @@ class DefaultVector(Vector):
         vec : <Vector>
             this vector times val is added to self.
         """
-        if self._vector_info._under_complex_step:
-            r_val = np.real(val)
-            i_val = np.imag(val)
-            self._data += r_val * vec._data + i_val * vec._imag_data
-            self._imag_data += i_val * vec._data + r_val * vec._imag_data
-        else:
-            self._data += val * vec._data
+        self._data += val * vec._data
 
     def set_vec(self, vec):
         """
@@ -317,8 +298,6 @@ class DefaultVector(Vector):
             the vector whose values self is set to.
         """
         self._data[:] = vec._data
-        if self._vector_info._under_complex_step:
-            self._imag_data[:] = vec._imag_data
 
     def set_const(self, val):
         """
@@ -356,7 +335,7 @@ class DefaultVector(Vector):
         float
             norm of this vector.
         """
-        return np.sum(self._data**2) ** 0.5
+        return np.sum(self._data.real**2) ** 0.5
 
     def _enforce_bounds_vector(self, du, alpha, lower_bounds, upper_bounds):
         """

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -230,13 +230,43 @@ class PETScTransfer(DefaultTransfer):
             'fwd' or 'rev'.
         """
         if mode == 'fwd':
-            self._transfer.scatter(out_vec._petsc, in_vec._petsc, addv=False, mode=False)
 
-            # Imaginary transfer
-            # (for CS, so only need in fwd)
-            if in_vec._vector_info._under_complex_step and out_vec._alloc_complex:
-                self._transfer.scatter(out_vec._imag_petsc, in_vec._imag_petsc, addv=False,
-                                       mode=False)
+            in_petsc = in_vec._petsc
+            out_petsc = out_vec._petsc
+
+            # For Complex Step, need to disassemble real and imag parts, transfer them separately,
+            # then reassemble them.
+            if in_vec._under_complex_step and out_vec._alloc_complex:
+
+                # Real
+                in_petsc.array = in_vec._data.real
+                out_petsc.array = out_vec._data.real
+                self._transfer.scatter(out_petsc, in_petsc, addv=False, mode=False)
+
+                # Imaginary
+                in_petsc_imag = in_vec._imag_petsc
+                out_petsc_imag = out_vec._imag_petsc
+                in_petsc_imag.array = in_vec._data.imag
+                out_petsc_imag.array = out_vec._data.imag
+                self._transfer.scatter(out_petsc_imag, in_petsc_imag, addv=False, mode=False)
+
+                in_vec._data[:] = in_petsc.array + in_petsc_imag.array * 1j
+
+            else:
+
+                # Anything that has been allocated complex requires an additional step because
+                # the petsc vector does not directly reference the _data.
+
+                if in_vec._alloc_complex:
+                    in_petsc.array = in_vec._data
+
+                if out_vec._alloc_complex:
+                    out_petsc.array = out_vec._data
+
+                self._transfer.scatter(out_petsc, in_petsc, addv=False, mode=False)
+
+                if in_vec._alloc_complex:
+                    in_vec._data[:] = in_petsc.array
 
         else:  # rev
             self._transfer.scatter(in_vec._petsc, out_vec._petsc, addv=True, mode=True)
@@ -257,22 +287,32 @@ class PETScTransfer(DefaultTransfer):
         if mode == 'fwd':
             in_petsc = in_vec._petsc
             out_petsc = out_vec._petsc
-            for i in range(in_vec._ncol):
-                in_petsc.array = in_vec._data[:, i]
-                out_petsc.array = out_vec._data[:, i]
-                self._transfer.scatter(out_petsc, in_petsc, addv=False, mode=False)
-                in_vec._data[:, i] = in_petsc.array
 
-            # Imaginary transfer
-            # (for CS, so only need in fwd)
-            if in_vec._vector_info._under_complex_step and out_vec._alloc_complex:
-                in_petsc = in_vec._imag_petsc
-                out_petsc = out_vec._imag_petsc
+            # For Complex Step, need to disassemble real and imag parts, transfer them separately,
+            # then reassemble them.
+            if in_vec._under_complex_step and out_vec._alloc_complex:
+                in_petsc_imag = in_vec._imag_petsc
+                out_petsc_imag = out_vec._imag_petsc
                 for i in range(in_vec._ncol):
-                    in_petsc.array = in_vec._imag_data[:, i]
-                    out_petsc.array = out_vec._imag_data[:, i]
+
+                    # Real
+                    in_petsc.array = in_vec._data[:, i].real
+                    out_petsc.array = out_vec._data[:, i].real
                     self._transfer.scatter(out_petsc, in_petsc, addv=False, mode=False)
-                    in_vec._imag_data[:, i] = in_petsc.array
+
+                    # Imaginary
+                    in_petsc_imag.array = in_vec._data[:, i].imag
+                    out_petsc_imag.array = out_vec._data[:, i].imag
+                    self._transfer.scatter(out_petsc_imag, in_petsc_imag, addv=False, mode=False)
+
+                    in_vec._data[:, i] = in_petsc.array + in_petsc_imag.array * 1j
+
+            else:
+                for i in range(in_vec._ncol):
+                    in_petsc.array = in_vec._data[:, i]
+                    out_petsc.array = out_vec._data[:, i]
+                    self._transfer.scatter(out_petsc, in_petsc, addv=False, mode=False)
+                    in_vec._data[:, i] = in_petsc.array
 
         elif mode == 'rev':
             in_petsc = in_vec._petsc

--- a/openmdao/vectors/petsc_vector.py
+++ b/openmdao/vectors/petsc_vector.py
@@ -47,8 +47,12 @@ class PETScVector(DefaultVector):
         self._petsc = {}
         self._imag_petsc = {}
         data = self._data
+
         if self._ncol == 1:
-            self._petsc = PETSc.Vec().createWithArray(data, comm=self._system.comm)
+            if self._alloc_complex:
+                self._petsc = PETSc.Vec().createWithArray(data.copy(), comm=self._system.comm)
+            else:
+                self._petsc = PETSc.Vec().createWithArray(data, comm=self._system.comm)
         else:
             # for now the petsc array is only the size of one column and we do separate
             # transfers for each column.
@@ -60,7 +64,7 @@ class PETScVector(DefaultVector):
 
         # Allocate imaginary for complex step
         if self._alloc_complex:
-            data = self._imag_data
+            data = self._cplx_data.imag
             if self._ncol == 1:
                 self._imag_petsc = PETSc.Vec().createWithArray(data, comm=self._system.comm)
             else:
@@ -80,4 +84,4 @@ class PETScVector(DefaultVector):
         float
             norm of this vector.
         """
-        return self._system.comm.allreduce(np.sum(self._data**2)) ** 0.5
+        return self._system.comm.allreduce(np.sum(self._data.real**2)) ** 0.5

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -562,7 +562,7 @@ class Vector(object):
         print('-' * 35)
         print()
 
-    def set_complex_step_mode(self, flag):
+    def set_complex_step_mode(self, active):
         """
         Turn on or off complex stepping mode.
 
@@ -571,13 +571,13 @@ class Vector(object):
 
         Parameters
         ----------
-        flag : bool
+        active : bool
             Complex mode flag; set to True prior to commencing complex step.
         """
-        if flag:
+        if active:
             self._cplx_data[:] = self._data
 
         self._data, self._cplx_data = self._cplx_data, self._data
         self._views, self._cplx_views = self._cplx_views, self._views
         self._views_flat, self._cplx_views_flat = self._cplx_views_flat, self._views_flat
-        self._under_complex_step = flag
+        self._under_complex_step = active

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -22,23 +22,6 @@ else:
     INT_DTYPE = np.dtype(np.int32)
 
 
-class VectorInfo(object):
-    """
-    Communal object for storing some global information in the vectors.
-
-    Attributes
-    ----------
-    _under_complex_step : bool
-        When this is True, the vectors operate with complex numbers.
-    """
-
-    def __init__(self):
-        """
-        Initialize.
-        """
-        self._under_complex_step = False
-
-
 class Vector(object):
     """
     Base Vector class.
@@ -76,17 +59,15 @@ class Vector(object):
         If True, then space for the imaginary part is also allocated.
     _data : ndarray
         Actual allocated data.
-    _vector_info : <VectorInfo>
-        Object to store some global info, such as complex step state.
-    _imag_views : dict
-        Dictionary mapping absolute variable names to the ndarray views for the imaginary part.
-    _imag_views_flat : dict
-        Dictionary mapping absolute variable names to the flattened ndarray views for the imaginary
-        part.
-    _imag_data : ndarray
-        Actual allocated data for the imaginary part.
-    _complex_view_cache : {}
-        Temporary storage of complex views used by in-place numpy operations.
+    _cplx_data : ndarray
+        Actual allocated data under complex step.
+    _cplx_views : dict
+        Dictionary mapping absolute variable names to the ndarray views under complex step.
+    _cplx_views_flat : dict
+        Dictionary mapping absolute variable names to the flattened ndarray views under complex
+        step.
+    _under_complex_step : bool
+        When True, this vector is under complex step, and data is swapped with the complex data.
     _ncol : int
         Number of columns for multi-vectors.
     _icol : int or None
@@ -105,8 +86,6 @@ class Vector(object):
     read_only : bool
         When True, values in the vector cannot be changed via the user __setitem__ API.
     """
-
-    _vector_info = VectorInfo()
 
     cite = ""
 
@@ -157,11 +136,10 @@ class Vector(object):
 
         # Support for Complex Step
         self._alloc_complex = alloc_complex
-        if alloc_complex:
-            self._imag_data = None
-            self._imag_views = {}
-            self._complex_view_cache = {}
-            self._imag_views_flat = {}
+        self._cplx_data = None
+        self._cplx_views = {}
+        self._cplx_views_flat = {}
+        self._under_complex_step = False
 
         self._do_scaling = ((kind == 'input' and system._has_input_scaling) or
                             (kind == 'output' and system._has_output_scaling) or
@@ -307,25 +285,6 @@ class Vector(object):
         """
         abs_name = name2abs_name(self._system, name, self._names, self._typ)
         if abs_name is not None:
-            if self._vector_info._under_complex_step:
-                if self._typ == 'input':
-                    if self._icol is None:
-                        return self._views[abs_name] + 1j * self._imag_views[abs_name]
-                    else:
-                        return self._views[abs_name][:, self._icol] + \
-                            1j * self._imag_views[abs_name][:, self._icol]
-                else:
-                    if abs_name not in self._complex_view_cache:
-                        if self._icol is None:
-                            self._complex_view_cache[abs_name] = self._views[abs_name] + \
-                                1j * self._imag_views[abs_name]
-                        else:
-                            self._complex_view_cache[abs_name][:, self._icol] = \
-                                self._views[abs_name][:, self._icol] + \
-                                1j * self._imag_views[abs_name][:, self._icol]
-                            return self._complex_view_cache[abs_name][:, self._icol]
-                    return self._complex_view_cache[abs_name]
-
             if self._icol is None:
                 return self._views[abs_name]
             else:
@@ -363,18 +322,9 @@ class Vector(object):
                 raise ValueError("Incompatible shape for '%s': "
                                  "Expected %s but got %s." %
                                  (name, oldval.shape, value.shape))
-            if self._vector_info._under_complex_step:
 
-                # setitem overwrites anything you may have done with numpy indexing
-                try:
-                    del self._complex_view_cache[abs_name]
-                except KeyError:
-                    pass
+            self._views[abs_name][slc] = value
 
-                self._views[abs_name][slc] = value.real
-                self._imag_views[abs_name][slc] = value.imag
-            else:
-                self._views[abs_name][slc] = value
         else:
             msg = 'Variable name "{}" not found.'
             raise KeyError(msg.format(name))
@@ -599,15 +549,6 @@ class Vector(object):
         """
         pass
 
-    def _remove_complex_views(self):
-        """
-        Remove temporary complex view and migrate its values into real and imaginary views.
-        """
-        for abs_name, value in iteritems(self._complex_view_cache):
-            self._views[abs_name][:] = value.real
-            self._imag_views[abs_name][:] = value.imag
-        self._complex_view_cache = {}
-
     def print_variables(self):
         """
         Print the names and values of all variables in this vector, one per line.
@@ -620,3 +561,23 @@ class Vector(object):
             print(' ' * 3, prom_name, view)
         print('-' * 35)
         print()
+
+    def set_complex_step_mode(self, flag):
+        """
+        Turn on or off complex stepping mode.
+
+        When turned on, the default real ndarray is replaced with a complex ndarray and all
+        pointers are updated to point to it.
+
+        Parameters
+        ----------
+        flag : bool
+            Complex mode flag; set to True prior to commencing complex step.
+        """
+        if flag:
+            self._cplx_data[:] = self._data
+
+        self._data, self._cplx_data = self._cplx_data, self._data
+        self._views, self._cplx_views = self._cplx_views, self._views
+        self._views_flat, self._cplx_views_flat = self._cplx_views_flat, self._views_flat
+        self._under_complex_step = flag


### PR DESCRIPTION
1. Refactor Vectors to contain swappable real/complex arrays rather than a real and imaginary one.
  a. Implementation is much simpler at a possible cost of a little more average memory.
  b. Fixes a bug that would have otherwise required increased complexity in the Vectors
  c. Removes roadblock for complex step around newton solves.
2. Added a System attribute "under_complex_step" that the user can check to find out if he is in a complex step.
  a. Removed class attribute in Vector that used to contain under_complex_step.
3. Added a System attribute "force_alloc_complex" that the user can check to find out if the vector has been force into complex allocation.
4. Set default complex step stepsize to 1e-40.
5. Reworked how the step size is handled in check_totals and check_partials so that the correct default value is used.