### PR TITLE
P158798354 Change defaults and precedence for recording options in Drivers and Problems

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -153,7 +153,7 @@ class Driver(object):
         self.recording_options.declare('record_constraints', types=bool, default=True,
                                        desc='Set to True to record constraints at the '
                                             'driver level')
-        self.recording_options.declare('includes', types=list, default=['*'],
+        self.recording_options.declare('includes', types=list, default=[],
                                        desc='Patterns for variables to include in recording')
         self.recording_options.declare('excludes', types=list, default=[],
                                        desc='Patterns for vars to exclude in recording '

--- a/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
+++ b/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
@@ -103,7 +103,7 @@ class ExperimentalDriver(object):
         self.recording_options.declare('record_constraints', types=bool, default=True,
                                        desc='Set to True to record constraints at the \
                                        driver level')
-        self.recording_options.declare('includes', types=list, default=['*'],
+        self.recording_options.declare('includes', types=list, default=[],
                                        desc='Patterns for variables to include in recording')
         self.recording_options.declare('excludes', types=list, default=[],
                                        desc='Patterns for vars to exclude in recording '

--- a/openmdao/docs/features/recording/saving_data.rst
+++ b/openmdao/docs/features/recording/saving_data.rst
@@ -125,3 +125,14 @@ in the recorded case data:
 .. embed-code::
     openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_record_with_prefix
     :layout: interleave
+
+Recording Options Precedence
+----------------------------
+
+The recording options that determine what gets recorded can sometime be a little confusing. Here is an example
+that might help. The code shows how the `record_desvars` and `includes` variables interact.
+
+
+.. embed-code::
+    openmdao.recorders.tests.test_sqlite_reader.TestSqliteCaseReader.test_recording_option_precedence_driver_cases
+    :layout: interleave

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -914,6 +914,10 @@ class TestSqliteCaseReader(unittest.TestCase):
 
 
     def test_recording_option_precedence_driver_cases(self):
+        from openmdao.api import Problem, IndepVarComp, ExecComp, ScipyOptimizeDriver, \
+            SqliteRecorder, CaseReader
+        from openmdao.test_suite.components.paraboloid import Paraboloid
+
         prob = Problem()
         model = prob.model
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -937,7 +937,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         prob.driver.add_recorder(self.recorder)
         prob.driver.recording_options['record_desvars'] = True
-        prob.driver.recording_options['includes'] = []  # the new default according to this story
+        prob.driver.recording_options['includes'] = []
         prob.driver.recording_options['excludes'] = ['p2.y']
 
         prob.set_solver_print(0)
@@ -954,7 +954,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.recorder = SqliteRecorder(self.filename)
         prob.driver.add_recorder(self.recorder)
         prob.driver.recording_options['record_desvars'] = False
-        prob.driver.recording_options['includes'] = []  # the new default according to this story
+        prob.driver.recording_options['includes'] = []
 
         prob.setup()
         prob.run_driver()
@@ -968,7 +968,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.recorder = SqliteRecorder(self.filename)
         prob.driver.add_recorder(self.recorder)
         prob.driver.recording_options['record_desvars'] = True
-        prob.driver.recording_options['includes'] = ['*']  # the new default according to this story
+        prob.driver.recording_options['includes'] = ['*']
 
         prob.setup()
         prob.run_driver()
@@ -982,7 +982,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.recorder = SqliteRecorder(self.filename)
         prob.driver.add_recorder(self.recorder)
         prob.driver.recording_options['record_desvars'] = False
-        prob.driver.recording_options['includes'] = ['*']  # the new default according to this story
+        prob.driver.recording_options['includes'] = ['*']
 
         prob.setup()
         prob.run_driver()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -948,7 +948,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         # First case with record_desvars = True and includes = []
         cr = CaseReader(self.filename)
         case = cr.driver_cases.get_case(0)
-        self.assertEqual(list(case.outputs.keys()), ['x','f_xy', 'c'] )
+        self.assertEqual(sorted(case.outputs.keys()), ['c','f_xy', 'x'] )
 
         # Second case with record_desvars = False and includes = []
         self.recorder = SqliteRecorder(self.filename)
@@ -962,7 +962,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         cr = CaseReader(self.filename)
         case = cr.driver_cases.get_case(-1)
-        self.assertEqual(list(case.outputs.keys()), ['f_xy', 'c'])
+        self.assertEqual(sorted(case.outputs.keys()), ['c', 'f_xy'])
 
         # Third case with record_desvars = True and includes = ['*']
         self.recorder = SqliteRecorder(self.filename)
@@ -976,7 +976,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         cr = CaseReader(self.filename)
         case = cr.driver_cases.get_case(-1)
-        self.assertEqual(list(case.outputs.keys()), ['x', 'f_xy', 'c'])
+        self.assertEqual(sorted(case.outputs.keys()), ['c', 'f_xy', 'x'])
 
         # Fourth case with record_desvars = False and includes = ['*']
         self.recorder = SqliteRecorder(self.filename)
@@ -990,7 +990,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         cr = CaseReader(self.filename)
         case = cr.driver_cases.get_case(-1)
-        self.assertEqual(list(case.outputs.keys()), ['f_xy', 'c'])
+        self.assertEqual(sorted(case.outputs.keys()), ['c', 'f_xy'])
 
 
     def test_load_driver_cases(self):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -180,6 +180,7 @@ class TestSqliteRecorder(unittest.TestCase):
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True
         driver.recording_options['record_derivatives'] = True
+        driver.recording_options['includes'] = ['*']
         driver.add_recorder(self.recorder)
 
         prob.setup()
@@ -255,6 +256,7 @@ class TestSqliteRecorder(unittest.TestCase):
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True
         driver.recording_options['record_derivatives'] = True
+        driver.recording_options['includes'] = ['*']
         driver.add_recorder(self.recorder)
 
         prob.setup()
@@ -301,6 +303,7 @@ class TestSqliteRecorder(unittest.TestCase):
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True
         driver.recording_options['record_derivatives'] = True
+        driver.recording_options['includes'] = ['*']
         driver.add_recorder(self.recorder)
 
         prob.setup()
@@ -354,6 +357,7 @@ class TestSqliteRecorder(unittest.TestCase):
 
         driver = prob.driver = ScipyOptimizeDriver(disp=False, tol=1e-9)
         driver.add_recorder(self.recorder)
+        driver.recording_options['includes'] = ['*']
 
         prob.setup()
         prob.set_solver_print(0)
@@ -1418,7 +1422,6 @@ class TestSqliteRecorder(unittest.TestCase):
         #
 
         # Driver
-        driver.recording_options['includes'] = []
         driver.recording_options['record_metadata'] = True
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_responses'] = True
@@ -1458,6 +1461,11 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_objectives = {
             "obj_cmp.obj": prob['obj_cmp.obj']
         }
+        expected_constraints = {
+            "con_cmp1.con1": prob['con_cmp1.con1'],
+            "con_cmp2.con2": prob['con_cmp2.con2']
+        }
+
         expected_constraints = {
             "con_cmp1.con1": prob['con_cmp1.con1'],
             "con_cmp2.con2": prob['con_cmp2.con2']
@@ -2173,7 +2181,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         recorder = SqliteRecorder("cases.sql")
         prob.driver.add_recorder(recorder)
-
+        prob.driver.recording_options['includes'] = ['*']
         prob.setup()
 
         # set some initial guesses

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1466,11 +1466,6 @@ class TestSqliteRecorder(unittest.TestCase):
             "con_cmp2.con2": prob['con_cmp2.con2']
         }
 
-        expected_constraints = {
-            "con_cmp1.con1": prob['con_cmp1.con1'],
-            "con_cmp2.con2": prob['con_cmp2.con2']
-        }
-
         expected_outputs = expected_desvars
         expected_outputs.update(expected_objectives)
         expected_outputs.update(expected_constraints)


### PR DESCRIPTION
1. Default record_desvars, record_objectives, and record_constraints to True
2. Default Includes to empty
3. Make record_desvars, record_objectives, record_constraints not affect exclusion
4. Excludes should have precedence over all other options in Driver and Problem cases
5. Update docs to better explain recording options and precedence in Driver and Problem
6. Create tests for recording option precedence

#1, #3, and #4 were already done. 

#2 was only done for Drivers