### PR TITLE
 add deprecation for 'distributed' property

### DIFF
--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -16,64 +16,64 @@ from openmdao.utils.assert_utils import assert_rel_error
 
 _ufunc_test_data = {'abs': {'str': 'f=abs(x)',
                             'check_func': np.abs,
-                             'args': {'f': {'value': np.zeros(6)},
-                                      'x': {'value': np.random.random(6)}}},
+                            'args': {'f': {'value': np.zeros(6)},
+                                     'x': {'value': np.random.random(6)}}},
                     'acos': {'str': 'f=acos(x)',
-                               'check_func': np.arccos,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)-0.5}}},
+                             'check_func': np.arccos,
+                             'args': {'f': {'value': np.zeros(6)},
+                                      'x': {'value': np.random.random(6)-0.5}}},
                     'arccos': {'str': 'f=arccos(x)',
                                'check_func': np.arccos,
                                'args': {'f': {'value': np.zeros(6)},
                                         'x': {'value': np.random.random(6)-0.5}}},
                     'arccosh': {'str': 'f=arccosh(x)',
-                             'check_func': np.arccosh,
-                             'args': {'f': {'value': np.zeros(6)},
-                                      'x': {'value': 1.1+np.random.random(6)}}},
+                                'check_func': np.arccosh,
+                                'args': {'f': {'value': np.zeros(6)},
+                                         'x': {'value': 1.1+np.random.random(6)}}},
                     'acosh': {'str': 'f=acosh(x)',
-                             'check_func': np.arccosh,
-                             'args': {'f': {'value': np.zeros(6)},
-                                      'x': {'value': 1.1+np.random.random(6)}}},
+                              'check_func': np.arccosh,
+                              'args': {'f': {'value': np.zeros(6)},
+                                       'x': {'value': 1.1+np.random.random(6)}}},
                     'arange': {'str': 'f=arange(0,10,2)',
-                             'check_val': np.arange(0,10,2),
-                             'args': {'f': {'value': np.zeros(5)}}},
+                               'check_val': np.arange(0, 10, 2),
+                               'args': {'f': {'value': np.zeros(5)}}},
                     'arcsin': {'str': 'f=arcsin(x)',
                                'check_func': np.arcsin,
                                'args': {'f': {'value': np.zeros(6)},
                                         'x': {'value': np.random.random(6)-.5}}},
                     'arcsinh': {'str': 'f=arcsinh(x)',
-                               'check_func': np.arcsinh,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)}}},
+                                'check_func': np.arcsinh,
+                                'args': {'f': {'value': np.zeros(6)},
+                                         'x': {'value': np.random.random(6)}}},
                     'asinh': {'str': 'f=asinh(x)',
-                               'check_func': np.arcsinh,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)}}},
+                              'check_func': np.arcsinh,
+                              'args': {'f': {'value': np.zeros(6)},
+                                       'x': {'value': np.random.random(6)}}},
                     'asin': {'str': 'f=asin(x)',
-                               'check_func': np.arcsin,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)-.5}}},
+                             'check_func': np.arcsin,
+                             'args': {'f': {'value': np.zeros(6)},
+                                      'x': {'value': np.random.random(6)-.5}}},
                     'arctan': {'str': 'f=arctan(x)',
                                'check_func': np.arctan,
                                'args': {'f': {'value': np.zeros(6)},
                                         'x': {'value': np.random.random(6)}}},
                     'atan': {'str': 'f=atan(x)',
-                               'check_func': np.arctan,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)}}},
+                             'check_func': np.arctan,
+                             'args': {'f': {'value': np.zeros(6)},
+                                      'x': {'value': np.random.random(6)}}},
                     'cos': {'str': 'f=cos(x)',
-                               'check_func': np.cos,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)}}},
+                            'check_func': np.cos,
+                            'args': {'f': {'value': np.zeros(6)},
+                                     'x': {'value': np.random.random(6)}}},
                     'cosh': {'str': 'f=cosh(x)',
-                               'check_func': np.cosh,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)}}},
+                             'check_func': np.cosh,
+                             'args': {'f': {'value': np.zeros(6)},
+                                      'x': {'value': np.random.random(6)}}},
                     'dot': {'str': 'f=dot(x, y)',
-                               'check_func': np.dot,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)},
-                                        'y': {'value': np.random.random(6)}}},
+                            'check_func': np.dot,
+                            'args': {'f': {'value': np.zeros(6)},
+                                     'x': {'value': np.random.random(6)},
+                                     'y': {'value': np.random.random(6)}}},
                     'e': {'str': 'f=e',
                           'check_val': np.e,
                           'args': {'f': {'value': 0.0}}},
@@ -98,20 +98,20 @@ _ufunc_test_data = {'abs': {'str': 'f=abs(x)',
                                   'args': {'f': {'value': np.zeros(6)},
                                            'x': {'value': np.random.random(6)}}},
                     'fmax': {'str': 'f=fmax(x, y)',
-                            'check_func': np.fmax,
-                            'args': {'f': {'value': np.zeros(6)},
-                                     'x': {'value': np.random.random(6)},
-                                     'y': {'value': np.random.random(6)}}},
+                             'check_func': np.fmax,
+                             'args': {'f': {'value': np.zeros(6)},
+                                      'x': {'value': np.random.random(6)},
+                                      'y': {'value': np.random.random(6)}}},
                     'fmin': {'str': 'f=fmin(x, y)',
-                            'check_func': np.fmin,
-                            'args': {'f': {'value': np.zeros(6)},
-                                     'x': {'value': np.random.random(6)},
-                                     'y': {'value': np.random.random(6)}}},
+                             'check_func': np.fmin,
+                             'args': {'f': {'value': np.zeros(6)},
+                                      'x': {'value': np.random.random(6)},
+                                      'y': {'value': np.random.random(6)}}},
                     'inner': {'str': 'f=inner(x, y)',
-                               'check_func': np.inner,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)},
-                                        'y': {'value': np.random.random(6)}}},
+                              'check_func': np.inner,
+                              'args': {'f': {'value': np.zeros(6)},
+                                       'x': {'value': np.random.random(6)},
+                                       'y': {'value': np.random.random(6)}}},
                     'isinf': {'str': 'f=isinf(x)',
                               'check_func': np.isinf,
                               'args': {'f': {'value': np.zeros(3)},
@@ -121,30 +121,30 @@ _ufunc_test_data = {'abs': {'str': 'f=abs(x)',
                               'args': {'f': {'value': np.zeros(3)},
                                        'x': {'value': [0, np.nan, np.nan]}}},
                     'kron': {'str': 'f=kron(x, y)',
-                            'check_func': np.kron,
-                            'args': {'f': {'value': np.zeros(36)},
-                                     'x': {'value': np.random.random(6)},
-                                     'y': {'value': np.random.random(6)}}},
+                             'check_func': np.kron,
+                             'args': {'f': {'value': np.zeros(36)},
+                                      'x': {'value': np.random.random(6)},
+                                      'y': {'value': np.random.random(6)}}},
                     'linspace': {'str': 'f=linspace(0,10,50)',
-                                 'check_val': np.linspace(0,10,50),
+                                 'check_val': np.linspace(0, 10, 50),
                                  'args': {'f': {'value': np.zeros(50)}}},
                     'log': {'str': 'f=log(x)',
-                               'check_func': np.log,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)+0.1}}},
+                            'check_func': np.log,
+                            'args': {'f': {'value': np.zeros(6)},
+                                     'x': {'value': np.random.random(6)+0.1}}},
                     'log10': {'str': 'f=log10(x)',
-                               'check_func': np.log10,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)+0.1}}},
+                              'check_func': np.log10,
+                              'args': {'f': {'value': np.zeros(6)},
+                                       'x': {'value': np.random.random(6)+0.1}}},
                     'log1p': {'str': 'f=log1p(x)',
-                               'check_func': np.log1p,
-                               'args': {'f': {'value': np.zeros(6)},
-                                        'x': {'value': np.random.random(6)}}},
+                              'check_func': np.log1p,
+                              'args': {'f': {'value': np.zeros(6)},
+                                       'x': {'value': np.random.random(6)}}},
                     'matmul': {'str': 'f=matmul(x, y)',
                                'check_func': np.matmul,
-                               'args': {'f': {'value': np.zeros((3,1))},
-                                        'x': {'value': np.random.random((3,3))},
-                                        'y': {'value': np.random.random((3,1))}}},
+                               'args': {'f': {'value': np.zeros((3, 1))},
+                                        'x': {'value': np.random.random((3, 3))},
+                                        'y': {'value': np.random.random((3, 1))}}},
                     'maximum': {'str': 'f=maximum(x, y)',
                                 'check_func': np.maximum,
                                 'args': {'f': {'value': np.zeros(6)},
@@ -197,9 +197,9 @@ _ufunc_test_data = {'abs': {'str': 'f=abs(x)',
                                       'x': {'value': np.random.random(6)}}},
                     'tensordot': {'str': 'f=tensordot(x, y)',
                                   'check_func': np.tensordot,
-                                 'args': {'f': {'value': 0.0},
-                                          'x': {'value': np.random.random((6,6))},
-                                          'y': {'value': np.random.random((6,6))}}},
+                                  'args': {'f': {'value': 0.0},
+                                           'x': {'value': np.random.random((6, 6))},
+                                           'y': {'value': np.random.random((6, 6))}}},
                     'zeros': {'str': 'f=zeros(21)',
                               'check_val': np.zeros(21),
                               'args': {'f': {'value': np.zeros(21)}}}, }
@@ -221,15 +221,18 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C1: arg 'xx' in call to ExecComp() does not refer to any variable in the expressions ['y=x+1.']")
+                         "C1: arg 'xx' in call to ExecComp() does not refer to any variable "
+                         "in the expressions ['y=x+1.']")
 
     def test_bad_kwargs_meta(self):
         prob = Problem(model=Group())
-        prob.model.add_subsystem('C1', ExecComp('y=x+1.', x={'val': 2.0, 'low': 0.0, 'high': 10.0, 'units': 'ft'}))
+        prob.model.add_subsystem('C1', ExecComp('y=x+1.',
+                                                x={'val': 2, 'low': 0, 'high': 10, 'units': 'ft'}))
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C1: the following metadata names were not recognized for variable 'x': ['high', 'low', 'val']")
+                         "C1: the following metadata names were not recognized for "
+                         "variable 'x': ['high', 'low', 'val']")
 
     def test_name_collision_const(self):
         prob = Problem(model=Group())
@@ -237,7 +240,8 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C1: cannot assign to variable 'e' because it's already defined as an internal function or constant.")
+                         "C1: cannot assign to variable 'e' because it's already defined "
+                         "as an internal function or constant.")
 
     def test_name_collision_func(self):
         prob = Problem(model=Group())
@@ -245,7 +249,8 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C1: cannot assign to variable 'sin' because it's already defined as an internal function or constant.")
+                         "C1: cannot assign to variable 'sin' because it's already defined "
+                         "as an internal function or constant.")
 
     def test_func_as_rhs_var(self):
         prob = Problem(model=Group())
@@ -253,12 +258,13 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C1: cannot use 'sin' as a variable because it's already defined as an internal function.")
+                         "C1: cannot use 'sin' as a variable because it's already defined "
+                         "as an internal function.")
 
     def test_mixed_type(self):
         prob = Problem(model=Group())
         C1 = prob.model.add_subsystem('C1', ExecComp('y=sum(x)',
-                                                     x=np.arange(10,dtype=float)))
+                                                     x=np.arange(10, dtype=float)))
         prob.setup(check=False)
 
         # Conclude setup but don't run model.
@@ -343,7 +349,7 @@ class TestExecComp(unittest.TestCase):
     def test_array(self):
         prob = Problem(model=Group())
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x[1]',
-                                                     x=np.array([1.,2.,3.]),
+                                                     x=np.array([1., 2., 3.]),
                                                      y=0.0))
 
         prob.setup(check=False)
@@ -362,8 +368,8 @@ class TestExecComp(unittest.TestCase):
     def test_array_lhs(self):
         prob = Problem(model=Group())
         C1 = prob.model.add_subsystem('C1', ExecComp(['y[0]=x[1]', 'y[1]=x[0]'],
-                                                     x=np.array([1.,2.,3.]),
-                                                     y=np.array([0.,0.])))
+                                                     x=np.array([1., 2., 3.]),
+                                                     y=np.array([0., 0.])))
 
         prob.setup(check=False)
 
@@ -376,7 +382,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], np.array([2.,1.]), 0.00001)
+        assert_rel_error(self, C1._outputs['y'], np.array([2., 1.]), 0.00001)
 
     def test_simple_array_model(self):
         prob = Problem()
@@ -394,12 +400,12 @@ class TestExecComp(unittest.TestCase):
 
         data = prob.check_partials()
 
-        assert_rel_error(self, data['comp'][('y','x')]['abs error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['abs error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['abs error'][2], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['rel error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['rel error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['rel error'][2], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][0], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][1], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][2], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][0], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][1], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_simple_array_model2(self):
         prob = Problem()
@@ -407,7 +413,7 @@ class TestExecComp(unittest.TestCase):
         prob.model.add_subsystem('p1', IndepVarComp('x', np.ones([2])))
         prob.model.add_subsystem('comp', ExecComp('y = mat.dot(x)',
                                                   x=np.zeros((2,)), y=np.zeros((2,)),
-                                                  mat=np.array([[2.,7.],[5.,-3.]])))
+                                                  mat=np.array([[2., 7.], [5., -3.]])))
 
         prob.model.connect('p1.x', 'comp.x')
 
@@ -417,12 +423,12 @@ class TestExecComp(unittest.TestCase):
 
         data = prob.check_partials()
 
-        assert_rel_error(self, data['comp'][('y','x')]['abs error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['abs error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['abs error'][2], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['rel error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['rel error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y','x')]['rel error'][2], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][0], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][1], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][2], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][0], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][1], 0.0, 1e-5)
+        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_complex_step(self):
         prob = Problem(model=Group())
@@ -443,7 +449,7 @@ class TestExecComp(unittest.TestCase):
 
         C1._linearize()
 
-        assert_rel_error(self, C1._jacobian[('y','x')], [[2.0]], 0.00001)
+        assert_rel_error(self, C1._jacobian[('y', 'x')], [[2.0]], 0.00001)
 
     def test_complex_step2(self):
         prob = Problem(Group())
@@ -477,15 +483,15 @@ class TestExecComp(unittest.TestCase):
         # any positive C1.x should give a 2.0 derivative for dy/dx
         C1._inputs['x'] = 1.0e-10
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y','x'], [[2.0]], 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], [[2.0]], 0.00001)
 
         C1._inputs['x'] = -3.0
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y','x'], [[-2.0]], 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], [[-2.0]], 0.00001)
 
         C1._inputs['x'] = 0.0
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y','x'], [[2.0]], 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], [[2.0]], 0.00001)
 
     def test_abs_array_complex_step(self):
         prob = Problem(model=Group())
@@ -501,24 +507,24 @@ class TestExecComp(unittest.TestCase):
         # any positive C1.x should give a 2.0 derivative for dy/dx
         C1._inputs['x'] = np.ones(3)*1.0e-10
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y','x'], np.eye(3)*2.0, 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], np.eye(3)*2.0, 0.00001)
 
         C1._inputs['x'] = np.ones(3)*-3.0
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y','x'], np.eye(3)*-2.0, 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], np.eye(3)*-2.0, 0.00001)
 
         C1._inputs['x'] = np.zeros(3)
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y','x'], np.eye(3)*2.0, 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], np.eye(3)*2.0, 0.00001)
 
         C1._inputs['x'] = np.array([1.5, -0.6, 2.4])
         C1._linearize()
-        expect = np.zeros((3,3))
-        expect[0,0] = 2.0
-        expect[1,1] = -2.0
-        expect[2,2] = 2.0
+        expect = np.zeros((3, 3))
+        expect[0, 0] = 2.0
+        expect[1, 1] = -2.0
+        expect[2, 2] = 2.0
 
-        assert_rel_error(self, C1._jacobian['y','x'], expect, 0.00001)
+        assert_rel_error(self, C1._jacobian['y', 'x'], expect, 0.00001)
 
     def test_feature_simple(self):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
@@ -567,7 +573,7 @@ class TestExecComp(unittest.TestCase):
 
         model.add_subsystem('p', IndepVarComp('x', np.array([1., 2., 3.])))
         model.add_subsystem('comp', ExecComp('y=x[1]',
-                                             x=np.array([1.,2.,3.]),
+                                             x=np.array([1., 2., 3.]),
                                              y=0.0))
         model.connect('p.x', 'comp.x')
 
@@ -628,7 +634,7 @@ class TestExecComp(unittest.TestCase):
         model.add_subsystem('p1', IndepVarComp('x', 12.0, units='inch'))
         model.add_subsystem('p2', IndepVarComp('y', 1.0, units='ft'))
         model.add_subsystem('comp', ExecComp('z=x+y',
-                                             x={'value': 0.0, 'units':'inch'},
+                                             x={'value': 0.0, 'units': 'inch'},
                                              y={'value': 0.0, 'units': 'inch'},
                                              z={'value': 0.0, 'units': 'inch'}))
         model.connect('p1.x', 'comp.x')
@@ -641,10 +647,9 @@ class TestExecComp(unittest.TestCase):
 
         assert_rel_error(self, prob['comp.z'], 24.0, 0.00001)
 
-    @parameterized.expand(itertools.product(
-        [func_name for func_name in _expr_dict if not func_name.startswith('_')],
-    ), testcase_func_name=lambda f, n, p: 'test_exec_comp_value_' + '_'.join(a for a in p.args)
-    )
+    @parameterized.expand(itertools.product([
+        func_name for func_name in _expr_dict if not func_name.startswith('_')
+    ]), name_func=lambda f, n, p: 'test_exec_comp_value_' + '_'.join(a for a in p.args))
     def test_exec_comp_value(self, f):
         test_data = _ufunc_test_data[f]
 
@@ -670,19 +675,18 @@ class TestExecComp(unittest.TestCase):
             check_args = []
             try:
                 check_args.append(test_data['args']['x']['value'])
-            except:
+            except Exception:
                 pass
             try:
                 check_args.append(test_data['args']['y']['value'])
-            except:
+            except Exception:
                 pass
             check_args = tuple(check_args)
 
             expected = test_data['check_func'](*check_args)
         else:
-            expected =  test_data['check_val']
+            expected = test_data['check_val']
         np.testing.assert_almost_equal(prob['f'], expected)
-        #print('OK')
 
         if 'check_val' not in test_data:
             try:
@@ -690,10 +694,9 @@ class TestExecComp(unittest.TestCase):
             except TypeError as e:
                 print(f, 'does not support complex-step differentiation')
 
-    @parameterized.expand(itertools.product(
-        [func_name for func_name in _expr_dict if not func_name.startswith('_')],
-    ), testcase_func_name=lambda f, n, p: 'test_exec_comp_jac_' + '_'.join(a for a in p.args)
-    )
+    @parameterized.expand(itertools.product([
+        func_name for func_name in _expr_dict if not func_name.startswith('_')
+    ]), name_func=lambda f, n, p: 'test_exec_comp_jac_' + '_'.join(a for a in p.args))
     def test_exec_comp_jac(self, f):
 
         test_data = _ufunc_test_data[f]

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -106,6 +106,16 @@ class Component(System):
         self._approximated_partials = []
         self._declared_partial_checks = []
 
+    def _declare_options(self):
+        """
+        Declare options before kwargs are processed in the init method.
+        """
+        super(Component, self)._declare_options()
+
+        self.options.declare('distributed', False,
+                             desc='True if the component has variables that are distributed '
+                                  'across multiple processes.')
+
     @property
     def distributed(self):
         """
@@ -133,16 +143,6 @@ class Component(System):
         warn_deprecation("The 'distributed' property provides backwards compatibility "
                          "with OpenMDAO <= 2.4.0 ; use the 'distributed' option instead.")
         self.options['distributed'] = val
-
-    def _declare_options(self):
-        """
-        Declare options before kwargs are processed in the init method.
-        """
-        super(Component, self)._declare_options()
-
-        self.options.declare('distributed', False,
-                             desc='True if the component has variables that are distributed '
-                                  'across multiple processes.')
 
     def setup(self):
         """

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -126,7 +126,7 @@ class Component(System):
         Returns
         -------
         bool
-            reference to the 'distributed' property.
+            reference to the 'distributed' option.
         """
         warn_deprecation("The 'distributed' property provides backwards compatibility "
                          "with OpenMDAO <= 2.4.0 ; use the 'distributed' option instead.")
@@ -140,7 +140,7 @@ class Component(System):
         Parameters
         ----------
         val : bool
-            True if the component has variables that are distributed  across multiple processes.
+            True if the component has variables that are distributed across multiple processes.
         """
         warn_deprecation("The 'distributed' property provides backwards compatibility "
                          "with OpenMDAO <= 2.4.0 ; use the 'distributed' option instead.")

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -106,6 +106,34 @@ class Component(System):
         self._approximated_partials = []
         self._declared_partial_checks = []
 
+    @property
+    def distributed(self):
+        """
+        Provide 'distributed' property for backwards compatibility.
+
+        Returns
+        -------
+        bool
+            reference to the 'distributed' property.
+        """
+        warn_deprecation("The 'distributed' property provides backwards compatibility "
+                         "with OpenMDAO <= 2.4.0 ; use the 'distributed' option instead.")
+        return self.options['distributed']
+
+    @distributed.setter
+    def distributed(self, val):
+        """
+        Provide for setting of the 'distributed' property for backwards compatibility.
+
+        Parameters
+        ----------
+        val : bool
+            True if the component has variables that are distributed  across multiple processes.
+        """
+        warn_deprecation("The 'distributed' property provides backwards compatibility "
+                         "with OpenMDAO <= 2.4.0 ; use the 'distributed' option instead.")
+        self.options['distributed'] = val
+
     def _declare_options(self):
         """
         Declare options before kwargs are processed in the init method.

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -195,14 +195,14 @@ class Component(System):
         self._static_mode = True
 
         if self.options['distributed']:
-            if self._distributed_vector_class is None:
+            if self._distributed_vector_class is not None:
+                self._vector_class = self._distributed_vector_class
+            else:
                 warnings.warn("The 'distributed' option is set to True for Component %s, "
                               "but there is no distributed vector implementation (MPI/PETSc) "
                               "available. The default non-distributed vectors will be used."
                               % pathname)
                 self._vector_class = self._local_vector_class
-            else:
-                self._vector_class = self._distributed_vector_class
         else:
             self._vector_class = self._local_vector_class
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2,6 +2,8 @@
 
 from __future__ import division
 
+import warnings
+
 from collections import OrderedDict, Iterable
 from itertools import product
 from six import string_types, iteritems, itervalues
@@ -193,7 +195,14 @@ class Component(System):
         self._static_mode = True
 
         if self.options['distributed']:
-            self._vector_class = self._distributed_vector_class
+            if self._distributed_vector_class is None:
+                warnings.warn("The 'distributed' option is set to True for Component %s, "
+                              "but there is no distributed vector implementation (MPI/PETSc) "
+                              "available. The default non-distributed vectors will be used."
+                              % pathname)
+                self._vector_class = self._local_vector_class
+            else:
+                self._vector_class = self._distributed_vector_class
         else:
             self._vector_class = self._local_vector_class
 

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -12,8 +12,8 @@ from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.mpi import MPI
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray, TestImplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
-from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives, \
-     SellarDis1CS, SellarDis2CS
+from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, \
+    SellarDis2withDerivatives, SellarDis1CS, SellarDis2CS
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompC, TgtCompF, TgtCompK
 from openmdao.test_suite.groups.parallel_groups import FanInSubbedIDVC
@@ -712,11 +712,11 @@ class TestGroupComplexStep(unittest.TestCase):
         # Global stuff seems to not get cleaned up if test fails.
         try:
             self.prob.model._outputs._under_complex_step = False
-        except:
+        except Exception:
             pass
 
     @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
-                          testcase_func_name=lambda f, n, p:
+                          name_func=lambda f, n, p:
                           'test_paraboloid_'+'_'.join(title(a) for a in p.args))
     def test_paraboloid(self, vec_class):
 
@@ -747,7 +747,7 @@ class TestGroupComplexStep(unittest.TestCase):
         self.assertEqual(len(model._approx_schemes['cs']._exec_list), 2)
 
     @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
-                          testcase_func_name=lambda f, n, p:
+                          name_func=lambda f, n, p:
                           'test_paraboloid_subbed_'+'_'.join(title(a) for a in p.args))
     def test_paraboloid_subbed(self, vec_class):
 
@@ -783,8 +783,8 @@ class TestGroupComplexStep(unittest.TestCase):
         self.assertEqual(len(sub._approx_schemes['cs']._exec_list), 2)
 
     @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
-                          testcase_func_name=lambda f, n, p:
-                          'test_paraboloid_subbed_with_connections_'+'_'.join(title(a) for a in p.args))
+                          name_func=lambda f, n, p:
+                          'test_parab_subbed_with_connections_'+'_'.join(title(a) for a in p.args))
     def test_paraboloid_subbed_with_connections(self, vec_class):
 
         if not vec_class:
@@ -826,7 +826,7 @@ class TestGroupComplexStep(unittest.TestCase):
         self.assertEqual(len(sub._approx_schemes['cs']._exec_list), 6)
 
     @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
-                          testcase_func_name=lambda f, n, p:
+                          name_func=lambda f, n, p:
                           'test_arrray_comp_'+'_'.join(title(a) for a in p.args))
     def test_arrray_comp(self, vec_class):
 
@@ -864,7 +864,7 @@ class TestGroupComplexStep(unittest.TestCase):
         assert_rel_error(self, Jfd['comp.y2', 'p2.x2'], comp.JJ[2:4, 2:4], 1e-6)
 
     @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
-                          testcase_func_name=lambda f, n, p:
+                          name_func=lambda f, n, p:
                           'test_unit_conv_group_'+'_'.join(title(a) for a in p.args))
     def test_unit_conv_group(self, vec_class):
 
@@ -915,7 +915,7 @@ class TestGroupComplexStep(unittest.TestCase):
         assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
     @parameterized.expand(itertools.product([DefaultVector, PETScVector]),
-                          testcase_func_name=lambda f, n, p:
+                          name_func=lambda f, n, p:
                           'test_sellar_'+'_'.join(title(a) for a in p.args))
     def test_sellar(self, vec_class):
         # Basic sellar test.
@@ -1338,7 +1338,6 @@ class TestComponentComplexStep(unittest.TestCase):
                     print("Under complex step")
                     print("x", inputs['x'])
                     print("y", outputs['y'])
-
 
         prob = Problem()
         prob.model = Group()

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -322,7 +322,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as err:
             p.setup(check=False)
         self.assertEqual(str(err.exception),
-                         "comp1: 'promotes_outputs' failed to find any matches for the following names or patterns: ['xx'].")
+                         "comp1: 'promotes_outputs' failed to find any matches for "
+                         "the following names or patterns: ['xx'].")
 
     def test_group_renames_errors_bad_tuple(self):
         p = Problem()
@@ -333,7 +334,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as err:
             p.setup(check=False)
         self.assertEqual(str(err.exception),
-                         "when adding subsystem 'comp1', entry '('x', 'foo', 'bar')' is not a string or tuple of size 2")
+                         "when adding subsystem 'comp1', entry '('x', 'foo', 'bar')' "
+                         "is not a string or tuple of size 2")
 
     def test_group_promotes_multiple(self):
         """Promoting multiple variables."""
@@ -375,7 +377,8 @@ class TestGroup(unittest.TestCase):
                 dv.add_output('x', 1.0)
                 dv.add_output('z', np.array([5.0, 2.0]))
 
-                self.add_subsystem('d1', SellarDis2(), promotes_inputs=['y1'], promotes_outputs=['foo'])
+                self.add_subsystem('d1', SellarDis2(),
+                                   promotes_inputs=['y1'], promotes_outputs=['foo'])
                 self.add_subsystem('d2', SellarDis2())
 
         p = Problem()
@@ -384,7 +387,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as err:
             p.setup(check=False)
         self.assertEqual(str(err.exception),
-                         "d1: 'promotes_outputs' failed to find any matches for the following names or patterns: ['foo'].")
+                         "d1: 'promotes_outputs' failed to find any matches for "
+                         "the following names or patterns: ['foo'].")
 
     def test_group_nested_conn(self):
         """Example of adding subsystems and issuing connections with nested groups."""
@@ -429,7 +433,7 @@ class TestGroup(unittest.TestCase):
         p.set_solver_print(level=0)
         p.run_model()
 
-        self.assertEqual(p['group1.comp1.x'],  5.0)
+        self.assertEqual(p['group1.comp1.x'], 5.0)
         self.assertEqual(p['group1.comp2.b'], 10.0)
         self.assertEqual(p['group2.comp1.b'], 20.0)
         self.assertEqual(p['group2.comp2.b'], 40.0)
@@ -440,7 +444,7 @@ class TestGroup(unittest.TestCase):
         G1 = prob.model.add_subsystem('G1', Group())
         G1.add_subsystem("C1", ExecComp("y=2.0*x"), promotes=['y'])
         G1.add_subsystem("C2", ExecComp("y=2.0*x"), promotes=['y'])
-        msg = "Output name 'y' refers to multiple outputs: \['G1.C1.y', 'G1.C2.y'\]."
+        msg = r"Output name 'y' refers to multiple outputs: \['G1.C1.y', 'G1.C2.y'\]."
         with assertRaisesRegex(self, Exception, msg):
             prob.setup(check=False)
 
@@ -533,13 +537,13 @@ class TestGroup(unittest.TestCase):
         from openmdao.api import Problem, IndepVarComp, ExecComp
 
         p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', np.arange(12).reshape((4,3))))
-        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros((2,2))))
+        p.model.add_subsystem('indep', IndepVarComp('x', np.arange(12).reshape((4, 3))))
+        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros((2, 2))))
 
         # connect C1.x to entries (0,0), (-1,1), (2,1), (1,1) of indep.x
         p.model.connect('indep.x', 'C1.x',
-                        src_indices=[[(0,0), (-1,1)],
-                                     [(2,1), (1,1)]], flat_src_indices=False)
+                        src_indices=[[(0, 0), (-1, 1)],
+                                     [(2, 1), (1, 1)]], flat_src_indices=False)
 
         p.set_solver_print(level=0)
         p.setup()
@@ -558,7 +562,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C2: 'promotes_outputs' failed to find any matches for the following names or patterns: ['x*'].")
+                         "C2: 'promotes_outputs' failed to find any matches for "
+                         "the following names or patterns: ['x*'].")
 
     def test_promote_not_found2(self):
         p = Problem()
@@ -570,7 +575,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C2: 'promotes_inputs' failed to find any matches for the following names or patterns: ['xx'].")
+                         "C2: 'promotes_inputs' failed to find any matches for "
+                         "the following names or patterns: ['xx'].")
 
     def test_promote_not_found3(self):
         p = Problem()
@@ -582,7 +588,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "C2: 'promotes' failed to find any matches for the following names or patterns: ['xx'].")
+                         "C2: 'promotes' failed to find any matches for "
+                         "the following names or patterns: ['xx'].")
 
     def test_missing_promote_var(self):
         p = Problem()
@@ -596,7 +603,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "d1: 'promotes_inputs' failed to find any matches for the following names or patterns: ['foo'].")
+                         "d1: 'promotes_inputs' failed to find any matches for "
+                         "the following names or patterns: ['foo'].")
 
     def test_missing_promote_var2(self):
         p = Problem()
@@ -610,7 +618,8 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
         self.assertEqual(str(context.exception),
-                         "d1: 'promotes_outputs' failed to find any matches for the following names or patterns: ['bar', 'blammo'].")
+                         "d1: 'promotes_outputs' failed to find any matches for "
+                         "the following names or patterns: ['bar', 'blammo'].")
 
     def test_promote_src_indices(self):
         import numpy as np
@@ -667,9 +676,9 @@ class TestGroup(unittest.TestCase):
                 # as our input.  If we didn't set flat_src_indices to False,
                 # we could specify src_indices as a 1D array of indices into
                 # the flattened source.
-                self.add_input('x', np.ones((2,2)),
-                               src_indices=[[(0,0), (3,1)],
-                                            [(2,1), (1,1)]],
+                self.add_input('x', np.ones((2, 2)),
+                               src_indices=[[(0, 0), (3, 1)],
+                                            [(2, 1), (1, 1)]],
                                flat_src_indices=False)
                 self.add_output('y', 1.0)
 
@@ -681,7 +690,7 @@ class TestGroup(unittest.TestCase):
         # by promoting the following output and inputs to 'x', they will
         # be automatically connected
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape((4,3))),
+                              IndepVarComp('x', np.arange(12).reshape((4, 3))),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(),
                               promotes_inputs=['x'])
@@ -698,7 +707,7 @@ class TestGroup(unittest.TestCase):
     def test_promote_src_indices_nonflat_to_scalars(self):
         class MyComp(ExplicitComponent):
             def setup(self):
-                self.add_input('x', 1.0, src_indices=[(3,1)], shape=(1,))
+                self.add_input('x', 1.0, src_indices=[(3, 1)], shape=(1,))
                 self.add_output('y', 1.0)
 
             def compute(self, inputs, outputs):
@@ -707,7 +716,7 @@ class TestGroup(unittest.TestCase):
         p = Problem()
 
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape((4,3))),
+                              IndepVarComp('x', np.arange(12).reshape((4, 3))),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
@@ -720,7 +729,7 @@ class TestGroup(unittest.TestCase):
     def test_promote_src_indices_nonflat_error(self):
         class MyComp(ExplicitComponent):
             def setup(self):
-                self.add_input('x', 1.0, src_indices=[(3,1)])
+                self.add_input('x', 1.0, src_indices=[(3, 1)])
                 self.add_output('y', 1.0)
 
             def compute(self, inputs, outputs):
@@ -729,7 +738,7 @@ class TestGroup(unittest.TestCase):
         p = Problem()
 
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape((4,3))),
+                              IndepVarComp('x', np.arange(12).reshape((4, 3))),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
@@ -742,13 +751,12 @@ class TestGroup(unittest.TestCase):
                          "the input shape ambiguous.")
 
     @parameterized.expand(itertools.product(
-        [((4,3),  [(0,0), (3,1), (2,1), (1,1)]),
-         ((1,12), [(0,0), (0,10), (0,7), (0,4)]),
-         ((12,),  [0, 10, 7, 4]),
-         ((12,1), [(0,0), (10,0), (7,0), (4,0)])],
-        [(2,2), (4,), (4,1), (1,4)],
-        ), testcase_func_name=lambda f, n, p: 'test_promote_src_indices_'+'_'.join(str(a) for a in p.args)
-    )
+        [((4, 3),  [(0, 0), (3, 1), (2, 1), (1, 1)]),
+         ((1, 12), [(0, 0), (0, 10), (0, 7), (0, 4)]),
+         ((12,),   [0, 10, 7, 4]),
+         ((12, 1), [(0, 0), (10, 0), (7, 0), (4, 0)])],
+        [(2, 2), (4,), (4, 1), (1, 4)],
+    ), name_func=lambda f, n, p: 'test_promote_src_indices_'+'_'.join(str(a) for a in p.args))
     def test_promote_src_indices_param(self, src_info, tgt_shape):
         src_shape, idxvals = src_info
 
@@ -789,10 +797,11 @@ class TestGroup(unittest.TestCase):
         assert_rel_error(self, p['C1.y'], 21.)
 
     def test_set_order_feature(self):
-        from openmdao.api import Problem, IndepVarComp, NonlinearRunOnce
+        from openmdao.api import Problem, IndepVarComp
 
         class ReportOrderComp(ExplicitComponent):
             """Adds name to list."""
+
             def __init__(self, order_list):
                 super(ReportOrderComp, self).__init__()
                 self._order_list = order_list
@@ -881,7 +890,8 @@ class TestGroup(unittest.TestCase):
 
         self.assertEqual(str(cm.exception),
                          ": ['C3'] expected in subsystem order and not found.\n"
-                         ": subsystem(s) ['junk', 'junk2'] found in subsystem order but don't exist.")
+                         ": subsystem(s) ['junk', 'junk2'] found in subsystem order "
+                         "but don't exist.")
 
         # Dupes
         with self.assertRaises(ValueError) as cm:
@@ -941,8 +951,8 @@ class TestConnect(unittest.TestCase):
         sub = prob.model.add_subsystem('sub', Group())
 
         idv = sub.add_subsystem('src', IndepVarComp())
-        idv.add_output('x', np.arange(15).reshape((5,3)))  # array
-        idv.add_output('s', 3.)                            # scalar
+        idv.add_output('x', np.arange(15).reshape((5, 3)))  # array
+        idv.add_output('s', 3.)                             # scalar
 
         sub.add_subsystem('tgt', ExecComp('y = x'))
         sub.add_subsystem('cmp', ExecComp('z = x'))
@@ -1034,14 +1044,16 @@ class TestConnect(unittest.TestCase):
         prob.model.connect('px1.x1', 'src.x1')
         prob.model.connect('src.x2', 'tgt.x')
 
-        msg = "Output 'src.x2' with units of 'degC' is connected to input 'tgt.x' which has no units."
+        msg = "Output 'src.x2' with units of 'degC' is connected " \
+              "to input 'tgt.x' which has no units."
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             prob.setup(check=False)
             self.assertEqual(str(w[-1].message), msg)
 
     def test_connect_incompatible_units(self):
-        msg = "Output units of 'degC' for 'src.x2' are incompatible with input units of 'm' for 'tgt.x'."
+        msg = "Output units of 'degC' for 'src.x2' are incompatible " \
+              "with input units of 'm' for 'tgt.x'."
 
         prob = Problem(Group())
         prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0))
@@ -1098,31 +1110,38 @@ class TestConnect(unittest.TestCase):
 
     def test_mix_promotes_types(self):
         prob = Problem()
-        prob.model.add_subsystem('src', ExecComp(['y = 2 * x', 'y2 = 3 * x']), promotes=['x', 'y'], promotes_outputs=['y2'])
+        prob.model.add_subsystem('src', ExecComp(['y = 2 * x', 'y2 = 3 * x']),
+                                 promotes=['x', 'y'], promotes_outputs=['y2'])
 
         with self.assertRaises(RuntimeError) as context:
             prob.setup(check=False)
 
-        self.assertEqual(str(context.exception), "src: 'promotes' cannot be used at the same time as 'promotes_inputs' or 'promotes_outputs'.")
+        self.assertEqual(str(context.exception),
+                         "src: 'promotes' cannot be used at the same time as "
+                         "'promotes_inputs' or 'promotes_outputs'.")
 
     def test_mix_promotes_types2(self):
         prob = Problem()
-        prob.model.add_subsystem('src', ExecComp(['y = 2 * x', 'y2 = 3 * x2']), promotes=['x', 'y'], promotes_inputs=['x2'])
+        prob.model.add_subsystem('src', ExecComp(['y = 2 * x', 'y2 = 3 * x2']),
+                                 promotes=['x', 'y'], promotes_inputs=['x2'])
         with self.assertRaises(RuntimeError) as context:
             prob.setup(check=False)
 
-        self.assertEqual(str(context.exception), "src: 'promotes' cannot be used at the same time as 'promotes_inputs' or 'promotes_outputs'.")
+        self.assertEqual(str(context.exception),
+                         "src: 'promotes' cannot be used at the same time as "
+                         "'promotes_inputs' or 'promotes_outputs'.")
 
     def test_nested_nested_conn(self):
         prob = Problem()
         root = prob.model
 
-        p1 = root.add_subsystem('p', IndepVarComp('x', 1.0))
+        root.add_subsystem('p', IndepVarComp('x', 1.0))
+
         G1 = root.add_subsystem('G1', Group())
         par1 = G1.add_subsystem('par1', Group())
 
-        c2 = par1.add_subsystem('c2', ExecComp('y = x * 2.0'))
-        c4 = par1.add_subsystem('c4', ExecComp('y = x * 4.0'))
+        par1.add_subsystem('c2', ExecComp('y = x * 2.0'))
+        par1.add_subsystem('c4', ExecComp('y = x * 4.0'))
 
         prob.model.add_design_var('p.x')
         prob.model.add_constraint('G1.par1.c4.y', upper=0.0)
@@ -1146,14 +1165,14 @@ class TestConnect(unittest.TestCase):
 
     def test_bad_indices_shape(self):
         p = Problem()
-        p.model.add_subsystem('IV', IndepVarComp('x', np.arange(12).reshape((4,3))))
-        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros((2,2))))
+        p.model.add_subsystem('IV', IndepVarComp('x', np.arange(12).reshape((4, 3))))
+        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros((2, 2))))
 
         p.model.connect('IV.x', 'C1.x', src_indices=[(1, 1)])
 
-        msg = ("The source indices \[\[1 1\]\] do not specify a valid shape for "
-               "the connection 'IV.x' to 'C1.x'. The target "
-               "shape is \(2.*, 2.*\) but indices are \(1.*, 2.*\).")
+        msg = (r"The source indices \[\[1 1\]\] do not specify a valid shape for "
+               r"the connection 'IV.x' to 'C1.x'. The target "
+               r"shape is \(2.*, 2.*\) but indices are \(1.*, 2.*\).")
 
         with assertRaisesRegex(self, ValueError, msg):
             p.setup(check=False)
@@ -1190,37 +1209,43 @@ class TestConnect(unittest.TestCase):
             self.fail('Exception expected.')
 
     def test_src_indices_shape(self):
-        prob = src_indices_model(src_shape=(3,3), tgt_shape=(2,2),
-                                 src_indices=[[4,5],[7,8]],
-                                 flat_src_indices=True)
+        src_indices_model(src_shape=(3, 3), tgt_shape=(2, 2),
+                          src_indices=[[4, 5], [7, 8]],
+                          flat_src_indices=True)
 
     def test_src_indices_shape_bad_idx_flat(self):
         try:
-            prob = src_indices_model(src_shape=(3,3), tgt_shape=(2,2),
-                                     src_indices=[[4,5],[7,9]],
-                                     flat_src_indices=True)
+            src_indices_model(src_shape=(3, 3), tgt_shape=(2, 2),
+                              src_indices=[[4, 5], [7, 9]],
+                              flat_src_indices=True)
         except Exception as err:
-            self.assertEqual(str(err), "The source indices do not specify a valid index for the connection 'indeps.x' to 'C1.x'. Index '9' is out of range for a flat source of size 9.")
+            self.assertEqual(str(err), "The source indices do not specify a valid index "
+                                       "for the connection 'indeps.x' to 'C1.x'. "
+                                       "Index '9' is out of range for a flat source of size 9.")
         else:
             self.fail("Exception expected.")
 
     def test_src_indices_shape_bad_idx_flat_promotes(self):
         try:
-            prob = src_indices_model(src_shape=(3,3), tgt_shape=(2,2),
-                                     src_indices=[[4,5],[7,9]],
-                                     flat_src_indices=True, promotes=['x'])
+            src_indices_model(src_shape=(3, 3), tgt_shape=(2, 2),
+                              src_indices=[[4, 5], [7, 9]],
+                              flat_src_indices=True, promotes=['x'])
         except Exception as err:
-            self.assertEqual(str(err), "The source indices do not specify a valid index for the connection 'indeps.x' to 'C1.x'. Index '9' is out of range for a flat source of size 9.")
+            self.assertEqual(str(err), "The source indices do not specify a valid index "
+                                       "for the connection 'indeps.x' to 'C1.x'. "
+                                       "Index '9' is out of range for a flat source of size 9.")
         else:
             self.fail("Exception expected.")
 
     def test_src_indices_shape_bad_idx_flat_neg(self):
         try:
-            prob = src_indices_model(src_shape=(3,3), tgt_shape=(2,2),
-                                     src_indices=[[-10,5],[7,8]],
-                                     flat_src_indices=True)
+            src_indices_model(src_shape=(3, 3), tgt_shape=(2, 2),
+                              src_indices=[[-10, 5], [7, 8]],
+                              flat_src_indices=True)
         except Exception as err:
-            self.assertEqual(str(err), "The source indices do not specify a valid index for the connection 'indeps.x' to 'C1.x'. Index '-10' is out of range for a flat source of size 9.")
+            self.assertEqual(str(err), "The source indices do not specify a valid index "
+                                       "for the connection 'indeps.x' to 'C1.x'. "
+                                       "Index '-10' is out of range for a flat source of size 9.")
         else:
             self.fail("Exception expected.")
 

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -489,7 +489,7 @@ class TestJacobian(unittest.TestCase):
         G1.add_subsystem('C1', ExecComp('y=2.0*x*x'))
         G1.add_subsystem('C2', ExecComp('y=3.0*x*x'))
 
-        #prob.model.nonlinear_solver = NewtonSolver()
+        # prob.model.nonlinear_solver = NewtonSolver()
         prob.model.linear_solver = DirectSolver(assemble_jac=True)
 
         G1.linear_solver = DirectSolver(assemble_jac=True)

--- a/openmdao/test_suite/parametric_suite.py
+++ b/openmdao/test_suite/parametric_suite.py
@@ -70,8 +70,8 @@ def _test_suite(*args, **kwargs):
                         opts[arg] = arg_value
                 else:
                     # We're not asked to vary this parameter, so choose first item as default
-                    # Since we may use a generator (e.g. range), take the first value from the iterator
-                    # instead of indexing.
+                    # Since we may use a generator (e.g. range), take the first value from the
+                    # iterator instead of indexing.
                     for iter_val in default_val:
                         opts[arg] = (iter_val,)
                         break
@@ -106,14 +106,19 @@ def parametric_suite(*args, **kwargs):
     """
     Decorator used for testing a range of different options for a particular
     ParametericTestGroup. If args is present, must only be the value '*',
-    indicating running all available groups/parameters. Otherwise, use kwargs to set the options like so:
-    arg=value will specify that option,
-    arg='*' will vary over all default options,
-    arg=iterable will iterate over the given options.
-    Arguments that are not specified will have a reasonable default chosen."""
+    indicating running all available groups/parameters. Otherwise, use kwargs
+    to set the options like so:
+
+        arg=value will specify that option,
+        arg='*' will vary over all default options,
+        arg=iterable will iterate over the given options.
+
+    Arguments that are not specified will have a reasonable default chosen.
+    """
     run_by_default = kwargs.pop('run_by_default', False)
     test_cases = _test_suite(*args, **kwargs)
-    return parameterized.expand(test_cases, testcase_func_name=_test_name(run_by_default))
+    return parameterized.expand(test_cases, name_func=_test_name(run_by_default))
+
 
 # Needed for Nose
 parametric_suite.__test__ = False
@@ -141,6 +146,7 @@ class ParameterizedInstance(object):
     linear_solver_options : dict
         Options to pass into the constructor for `linear_solver_class`.
     """
+
     def __init__(self, group_type, **kwargs):
 
         self._group_type = group_type

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -68,9 +68,15 @@ def take_nth(rank, size, seq):
     while True:
         for proc in range(size):
             if rank == proc:
-                yield six.next(it)
+                try:
+                    yield six.next(it)
+                except StopIteration:
+                    return
             else:
-                six.next(it)
+                try:
+                    six.next(it)
+                except StopIteration:
+                    return
 
 
 def convert_neg(arr, dim):


### PR DESCRIPTION
Pivotal #160059310
Also: 
- Issue a warning instead of erroring out, if `distributed` is True but PETSc is not available
   (fall back to running non-distributed)
- cleaned up a deprecation in `parameterized` tests ('name_func' replaces 'testcase_func_name')
- changed a couple strings in tests to raw strings to address a PY3 warning
- linted test scripts that I touched (just line length and white space issues mainly)