### PR TITLE
add SCIPY var to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,11 @@ language: generic
 
 env:
   matrix:
-    - PY=2.7 NUMPY=1.12
-    - PY=2.7 NUMPY=1.13 PETSc=3.8.1
-    - PY=3.6 NUMPY=1.12
-    - PY=3.6 NUMPY=1.14 PETSc=3.8.1 UPLOAD_DOCS=1
-    - PY=3.7 NUMPY=1.15 PETSc=3.9.1
+    - PY=2.7 NUMPY=1.12 SCIPY=1.1
+    - PY=2.7 NUMPY=1.13 SCIPY=1.1 PETSc=3.8.1
+    - PY=3.6 NUMPY=1.12 SCIPY=1.1
+    - PY=3.6 NUMPY=1.14 SCIPY=1.0.1 PETSc=3.8.1 UPLOAD_DOCS=1
+    - PY=3.7 NUMPY=1.15 SCIPY=1.1 PETSc=3.9.1
 
 git:
   depth: 99999
@@ -90,7 +90,7 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy>=1.0 cython swig nose sphinx mock;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig nose sphinx mock;
 
     pip install --upgrade pip;
     pip install redbaron;


### PR DESCRIPTION
- use SciPy version 1.0.1 for the doc build until deprecation is  addressed by Pivotal #160492003 (scipy 1.1 introduces a deprecation causing noisy output)