### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 # exec this file to set __version__
 exec(open('openmdao/__init__.py').read())


### PR DESCRIPTION
install_requires and entry_points are actually attributes of setuptools, so installing with "setup.py install" won't work correctly without the change.