### PR TITLE
Newton feature doc update.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,4 @@ install:
   - conda list
 
 test_script:
-  - testflo . -n 1
+  - testflo . -vs -n 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,4 @@ install:
   - conda list
 
 test_script:
-  - testflo . -vs -n 1
+  - testflo . -n 1

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -253,8 +253,6 @@ class NOMPITests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             p.setup(check=False)
 
-        print(w[0].message)
-        print(w[1].message)
         self.assertEqual(len(w), 1)
         self.assertTrue(issubclass(w[0].category, UserWarning))
         self.assertEqual(str(w[0].message),

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -253,7 +253,6 @@ class NOMPITests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             p.setup(check=False)
 
-        self.assertEqual(len(w), 1)
         self.assertTrue(issubclass(w[0].category, UserWarning))
         self.assertEqual(str(w[0].message),
                          "The 'distributed' option is set to True for Component C2, "
@@ -514,7 +513,6 @@ class DeprecatedMPITests(unittest.TestCase):
             p.setup(check=False)
 
         if PETScVector is None:
-            self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[0].category, UserWarning))
             self.assertEqual(str(w[0].message),
                              "The 'distributed' option is set to True for Component C2, "

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -253,7 +253,8 @@ class NOMPITests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             p.setup(check=False)
 
-        print(w)
+        print(w[0].message)
+        print(w[1].message)
         self.assertEqual(len(w), 1)
         self.assertTrue(issubclass(w[0].category, UserWarning))
         self.assertEqual(str(w[0].message),

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -253,6 +253,7 @@ class NOMPITests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             p.setup(check=False)
 
+        print(w)
         self.assertEqual(len(w), 1)
         self.assertTrue(issubclass(w[0].category, UserWarning))
         self.assertEqual(str(w[0].message),

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/newton.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/newton.rst
@@ -126,12 +126,16 @@ By default, NewtonSolver does not perform a line search. We will show how to spe
 let's set up a problem that has implicit bounds on one of its states.
 
 .. embed-code::
-    openmdao.test_suite.components.implicit_newton_linesearch.ImplCompTwoStates
+    openmdao.solvers.linesearch.tests.test_backtracking.CompAtan
 
-In this component, the state "z" is only valid between 1.5 and 2.5, while the other state is valid
-everywhere. You can verify that if NewtonSolver is used with no backtracking specified, the solution
-violates the bounds on "z".  Here, we specify :ref:`ArmijoGoldsteinLS <openmdao.solvers.linesearch.backtracking.py>`
-as our line search algorithm, and we get a solution on the lower bounds for "z".
+This equation poses a challenge because a guess that is far from the solution yields large
+gradients and the solution will diverge. Additionally, the jacobian becomes singular at y = 20. To address
+both of these problems, a lower and upper bound are added on y so that a solver with a BoundsEnforceLS does not
+allow it to stray into problematic regions. Without the linsearch, Newton is unable to solve this problem unless you start
+very close to the solution.
+
+Here, we specify :ref:`BoundsEnforceLS <openmdao.solvers.linesearch.backtracking.py>`
+as our line search algorithm, and we get the expected solution for "y".
 
 .. embed-code::
     openmdao.solvers.linesearch.tests.test_backtracking.TestFeatureLineSearch.test_feature_specification

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -2,6 +2,7 @@
 
 import sys
 import unittest
+from math import atan
 
 from six.moves import cStringIO as StringIO
 from six.moves import range
@@ -661,32 +662,74 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
 
+class CompAtan(ImplicitComponent):
+    """
+    A simple implicit component with the following equation:
+
+    F(x, y) = 33.0 * atan(y-20)**2 + x
+
+    x is an input, y is the state to be solved.
+    for x = -100, y should be 19.68734033
+
+    This equation poses a challenge because a guess that is far from the solution yields large
+    gradients and divergence. Additionally, the jacobian becomes singular at y = 20. To address
+    this, a lower and upper bound are added on y so that a solver with a BoundsEnforceLS does not
+    allow it to stray into problematic regions.
+    """
+
+    def setup(self):
+        self.add_input('x', 1.0)
+        self.add_output('y', 1.0, lower=1.0, upper=19.9)
+
+        self.declare_partials(of='y', wrt='x')
+        self.declare_partials(of='y', wrt='y')
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        x = inputs['x']
+        y = outputs['y']
+
+        residuals['y'] = (33.0 * atan(y-20.0))**2 + x
+
+    def linearize(self, inputs, outputs, jacobian):
+        x = inputs['x']
+        y = outputs['y']
+
+        jacobian['y', 'y'] = 2178.0*atan(y-20.0) / (y**2 - 40.0*y + 401.0)
+        jacobian['y', 'x'] = 1.0
+
+
 class TestFeatureLineSearch(unittest.TestCase):
 
     def test_feature_specification(self):
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, ArmijoGoldsteinLS
-        from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStates
+        from openmdao.api import Problem, IndepVarComp, NewtonSolver, BoundsEnforceLS
+        from openmdao.api import DirectSolver
+        from openmdao.solvers.linesearch.tests.test_backtracking import CompAtan
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', 1.0))
-        top.model.add_subsystem('comp', ImplCompTwoStates())
-        top.model.connect('px.x', 'comp.x')
+        prob = Problem()
+        model = prob.model
 
-        top.model.nonlinear_solver = NewtonSolver()
-        top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        model.add_subsystem('px', IndepVarComp('x', -100.0))
+        model.add_subsystem('comp', CompAtan())
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS()
-        ls.options['maxiter'] = 10
+        model.connect('px.x', 'comp.x')
 
-        top.setup(check=False)
+        prob.setup()
 
-        top['px.x'] = 2.0
-        top['comp.y'] = 0.0
-        top['comp.z'] = 1.6
-        top.run_model()
-        assert_rel_error(self, top['comp.z'], 1.5, 1e-8)
+        prob['comp.y'] = 12.0
+
+        # You can change the NewtonSolver settings after setup is called
+        newton = prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.linear_solver = DirectSolver()
+        newton.options['iprint'] = 2
+        newton.options['rtol'] = 1e-8
+        newton.options['maxiter'] = 75
+        newton.options['solve_subsystems'] = True
+
+        newton.linesearch = BoundsEnforceLS()
+        newton.linesearch.options['iprint'] = 2
+        prob.run_model()
+
+        assert_rel_error(self, prob['comp.y'], 19.68734033, 1e-6)
 
     def test_feature_boundsenforcels_basic(self):
         import numpy as np

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -715,6 +715,7 @@ class TestFeatureLineSearch(unittest.TestCase):
 
         prob.setup()
 
+        # Initial value for the state:
         prob['comp.y'] = 12.0
 
         # You can change the NewtonSolver settings after setup is called
@@ -722,11 +723,11 @@ class TestFeatureLineSearch(unittest.TestCase):
         prob.model.linear_solver = DirectSolver()
         newton.options['iprint'] = 2
         newton.options['rtol'] = 1e-8
-        newton.options['maxiter'] = 75
         newton.options['solve_subsystems'] = True
 
         newton.linesearch = BoundsEnforceLS()
         newton.linesearch.options['iprint'] = 2
+
         prob.run_model()
 
         assert_rel_error(self, prob['comp.y'], 19.68734033, 1e-6)

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -823,7 +823,7 @@ class TestNewtonFeatures(unittest.TestCase):
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = DirectSolver()
 
         model.nonlinear_solver = NewtonSolver()
 
@@ -856,7 +856,7 @@ class TestNewtonFeatures(unittest.TestCase):
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = DirectSolver()
 
         nlgbs = model.nonlinear_solver = NewtonSolver()
         nlgbs.options['maxiter'] = 2
@@ -890,7 +890,7 @@ class TestNewtonFeatures(unittest.TestCase):
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = DirectSolver()
 
         nlgbs = model.nonlinear_solver = NewtonSolver()
         nlgbs.options['rtol'] = 1e-3
@@ -924,7 +924,7 @@ class TestNewtonFeatures(unittest.TestCase):
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = DirectSolver()
 
         nlgbs = model.nonlinear_solver = NewtonSolver()
         nlgbs.options['atol'] = 1e-4
@@ -1033,7 +1033,7 @@ class TestNewtonFeatures(unittest.TestCase):
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = DirectSolver()
 
         nlgbs = model.nonlinear_solver = NewtonSolver()
         nlgbs.options['maxiter'] = 1


### PR DESCRIPTION
1. For Newton feature tests, replaced LBGS with DirectSolver so that we won't get convergence failures from LBGS on first Newton iter. LGBS is not the best choice here.
2. For "slotting a linesearch" example, replaced Sellar with a new problem that Newton cant solve without a linesearch. BoundsEnforce works well on it.