### PR TITLE
bug in external code wrapper related to return codes

### DIFF
--- a/openmdao/utils/shell_proc.py
+++ b/openmdao/utils/shell_proc.py
@@ -258,7 +258,10 @@ class ShellProc(subprocess.Popen):
         error_msg = ''
         if return_code:
             if return_code > 0:
-                error_msg = ': %s' % os.strerror(return_code)
+                try:
+                    err_msg = os.strerror(return_code)
+                except OverflowError:
+                    err_msg = "Process exited with unknown return code {}".format(return_code)
             elif sys.platform != 'win32':
                 sig = -return_code
                 if sig < signal.NSIG:


### PR DESCRIPTION
npss (at least on windows) give some massive return code values. Not sure why it does that, but this breaks some of the error msg stuff in external_code comp: 

I was able to hack around it a bit with the following code in to modify: 
https://github.com/OpenMDAO/OpenMDAO/blob/master/openmdao/utils/shell_proc.py#L240

specificly, I added a try/except around os.strerror(return_code). 
I doubt my fix was actually correct, but it at least points to the right place to start. 

```    
def error_message(self, return_code):
        """
        Return error message for `return_code`.

        The error messages are derived from the operating system definitions.
        Some programs don't necessarily return exit codes conforming to these
        definitions.

        Parameters
        ----------
        return_code : int
            Return code from :meth:`poll`.

        Returns
        -------
        str
            Error Message string.
        """
        error_msg = ''
        if return_code:
            if return_code > 0:
                try: 
                   err_msg = os.strerror(return_code)
                except: 
                   err_msg = "process exited with unknown return code {}".format(return_code)

                error_msg = ': {}'.format(err_msg)
```

Here is a sample traceback from what the user was seeing: 
```
179, in compute
    super(LEAP_ExplicitWrap2, self).compute(inputs, outputs)
  File "C:\Users\rpthacke\AppData\Local\Continuum\anaconda3\lib\site-packages\openmdao\components\external_code_comp.py", line 295, in compute
    self._external_code_runner.run_component()
  File "C:\Users\rpthacke\AppData\Local\Continuum\anaconda3\lib\site-packages\openmdao\components\external_code_comp.py", line 144, in run_component
    return_code, error_msg = self._execute_local(command)
  File "C:\Users\rpthacke\AppData\Local\Continuum\anaconda3\lib\site-packages\openmdao\components\external_code_comp.py", line 214, in _execute_local
    comp._process.wait(comp.options['poll_delay'], comp.options['timeout'])
  File "C:\Users\rpthacke\AppData\Local\Continuum\anaconda3\lib\site-packages\openmdao\utils\shell_proc.py", line 235, in wait
    self.errormsg = self.error_message(return_code)
  File "C:\Users\rpthacke\AppData\Local\Continuum\anaconda3\lib\site-packages\openmdao\utils\shell_proc.py", line 261, in error_message
    error_msg = ': %s' % os.strerror(return_code)
OverflowError: Python int too large to convert to C long
```
