### PR TITLE
Fixed bug in global stack when nested Problems are used.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -18,7 +18,6 @@ from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.record_util import create_local_meta, check_path
 from openmdao.utils.general_utils import simple_warning
 from openmdao.utils.mpi import MPI
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.options_dictionary import OptionsDictionary
 import openmdao.utils.coloring as coloring_mod
 
@@ -236,6 +235,7 @@ class Driver(object):
             Pointer to the containing problem.
         """
         self._problem = problem
+        self._recording_iter = problem._recording_iter
         model = problem.model
         mode = problem._mode
 
@@ -732,7 +732,7 @@ class Driver(object):
             print(len(header) * '-' + '\n')
 
         if problem.model._owns_approx_jac:
-            recording_iteration.stack.append(('_compute_totals_approx', 0))
+            self._recording_iter.stack.append(('_compute_totals_approx', 0))
 
             try:
                 if total_jac is None:
@@ -743,7 +743,7 @@ class Driver(object):
                 else:
                     totals = total_jac.compute_totals_approx()
             finally:
-                recording_iteration.stack.pop()
+                self._recording_iter.stack.pop()
 
         else:
             if total_jac is None:
@@ -754,12 +754,12 @@ class Driver(object):
             if not total_jac.has_lin_cons:
                 self._total_jac = total_jac
 
-            recording_iteration.stack.append(('_compute_totals', 0))
+            self._recording_iter.stack.append(('_compute_totals', 0))
 
             try:
                 totals = total_jac.compute_totals()
             finally:
-                recording_iteration.stack.pop()
+                self._recording_iter.stack.pop()
 
         if self._rec_mgr._recorders and self.recording_options['record_derivatives']:
             metadata = create_local_meta(self._get_name())
@@ -1029,7 +1029,7 @@ class Driver(object):
 
         if not MPI or MPI.COMM_WORLD.rank == 0:
             header = 'Driver debug print for iter coord: {}'.format(
-                recording_iteration.get_formatted_iteration_coordinate())
+                self._recording_iter.get_formatted_iteration_coordinate())
             print(header)
             print(len(header) * '-')
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -399,6 +399,7 @@ class Group(System):
             subsys.force_alloc_complex = self.force_alloc_complex
             subsys._use_derivatives = self._use_derivatives
             subsys._solver_info = self._solver_info
+            subsys._recording_iter = self._recording_iter
 
             if self.pathname:
                 subsys._setup_procs('.'.join((self.pathname, subsys.name)), sub_comm, mode)

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -398,6 +398,7 @@ class Group(System):
             subsys._distributed_vector_class = self._distributed_vector_class
             subsys.force_alloc_complex = self.force_alloc_complex
             subsys._use_derivatives = self._use_derivatives
+            subsys._solver_info = self._solver_info
 
             if self.pathname:
                 subsys._setup_procs('.'.join((self.pathname, subsys.name)), sub_comm, mode)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -19,6 +19,7 @@ from openmdao.approximation_schemes.complex_step import ComplexStep, DEFAULT_CS_
 from openmdao.approximation_schemes.finite_difference import FiniteDifference, DEFAULT_FD_OPTIONS
 from openmdao.core.component import Component
 from openmdao.core.driver import Driver
+from openmdao.solvers.solver import SolverInfo
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.group import Group
 from openmdao.core.group import System
@@ -809,6 +810,9 @@ class Problem(object):
             raise ValueError(msg)
 
         self._mode = self._orig_mode = mode
+
+        # this will be shared by all Solvers in the model
+        model._solver_info = SolverInfo()
 
         model_comm = self.driver._setup_comm(comm)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -26,7 +26,7 @@ from openmdao.core.group import System
 from openmdao.core.indepvarcomp import IndepVarComp
 from openmdao.core.total_jac import _TotalJacInfo
 from openmdao.error_checking.check_config import check_config
-from openmdao.recorders.recording_iteration_stack import recording_iteration
+from openmdao.recorders.recording_iteration_stack import _RecIteration
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.utils.record_util import create_local_meta, check_path
 from openmdao.utils.general_utils import warn_deprecation, ContainsAll, pad_name, simple_warning
@@ -161,8 +161,6 @@ class Problem(object):
         self._solver_print_cache = []
 
         self._mode = None  # mode is assigned in setup()
-
-        recording_iteration.stack = []
 
         self._initial_condition_cache = {}
 
@@ -512,9 +510,9 @@ class Problem(object):
         if case_prefix:
             if not isinstance(case_prefix, str):
                 raise TypeError("The 'case_prefix' argument should be a string.")
-            recording_iteration.prefix = case_prefix
+            self._recording_iter.prefix = case_prefix
         else:
-            recording_iteration.prefix = None
+            self._recording_iter.prefix = None
 
         if self.model.iter_count > 0 and reset_iter_counts:
             self.driver.iter_count = 0
@@ -547,9 +545,9 @@ class Problem(object):
         if case_prefix:
             if not isinstance(case_prefix, str):
                 raise TypeError("The 'case_prefix' argument should be a string.")
-            recording_iteration.prefix = case_prefix
+            self._recording_iter.prefix = case_prefix
         else:
-            recording_iteration.prefix = None
+            self._recording_iter.prefix = None
 
         if self.model.iter_count > 0 and reset_iter_counts:
             self.driver.iter_count = 0
@@ -813,6 +811,8 @@ class Problem(object):
 
         # this will be shared by all Solvers in the model
         model._solver_info = SolverInfo()
+        self._recording_iter = _RecIteration()
+        model._recording_iter = self._recording_iter
 
         model_comm = self.driver._setup_comm(comm)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -16,7 +16,6 @@ from openmdao.jacobians.assembled_jacobian import DenseJacobian, CSCJacobian
 from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, warn_deprecation, ContainsAll
 from openmdao.recorders.recording_manager import RecordingManager
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.vectors.vector import Vector, INT_DTYPE
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
@@ -2829,7 +2828,7 @@ class System(object):
             metadata = create_local_meta(self.pathname)
 
             # Get the data to record
-            stack_top = recording_iteration.stack[-1][0]
+            stack_top = self._recording_iter.stack[-1][0]
             method = stack_top.split('.')[-1]
 
             if method not in ['_apply_linear', '_apply_nonlinear', '_solve_linear',

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -148,6 +148,8 @@ class System(object):
         Nonlinear solver to be used for solve_nonlinear.
     _linear_solver : <LinearSolver>
         Linear solver to be used for solve_linear; not the Newton system.
+    _solver_info : SolverInfo
+        A stack-like object shared by all Solvers in the model.
     _approx_schemes : OrderedDict
         A mapping of approximation types to the associated ApproximationScheme.
     _jacobian : <Jacobian>

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -18,7 +18,6 @@ from openmdao.test_suite.components.sellar import SellarDerivatives, \
     SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.groups.parallel_groups import FanOutGrouped, FanInGrouped
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 
 
 if MPI:
@@ -680,7 +679,6 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         from openmdao.api import Problem
         from openmdao.core.tests.test_parallel_derivatives import PartialDependGroup
 
-        recording_iteration.stack = []
         size = 4
 
         of = ['ParallelGroup1.Con1.y', 'ParallelGroup1.Con2.y']
@@ -697,8 +695,6 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
 
         assert_rel_error(self, J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
         assert_rel_error(self, J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
-
-        recording_iteration.stack = []
 
         # now run in rev mode and compare times for deriv calculation
         p = Problem(model=PartialDependGroup())

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -10,7 +10,7 @@ import numpy as np
 from openmdao.core.group import get_relevant_vars
 from openmdao.core.driver import Driver
 from openmdao.api import Problem, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, \
-    ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent
+    ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent, NonlinearRunOnce
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
@@ -1538,6 +1538,33 @@ class TestProblem(unittest.TestCase):
                                           'vectorize_derivs',
                                           'cache_linear_solution'],
                                )
+
+class NestedProblemTestCase(unittest.TestCase):
+
+    def test_nested_prob(self):
+
+        class _ProblemSolver(NonlinearRunOnce):
+            def solve(self):
+                # create a sill subproblem and run it to test for global solver_info bug
+                p = Problem()
+                p.model.add_subsystem('indep', IndepVarComp('x', 1.0))
+                p.model.add_subsystem('comp', ExecComp('y=2*x'))
+                p.model.connect('indep.x', 'comp.x')
+                p.setup()
+                p.run_model()
+
+                return super(_ProblemSolver, self).solve()
+
+        p = Problem()
+        p.model.add_subsystem('indep', IndepVarComp('x', 1.0))
+        G = p.model.add_subsystem('G', Group())
+        G.add_subsystem('comp', ExecComp('y=2*x'))
+        G.nonlinear_solver = _ProblemSolver()
+        p.model.connect('indep.x', 'G.comp.x')
+        p.setup()
+        p.run_model()
+
+
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1545,7 +1545,7 @@ class NestedProblemTestCase(unittest.TestCase):
 
         class _ProblemSolver(NonlinearRunOnce):
             def solve(self):
-                # create a sill subproblem and run it to test for global solver_info bug
+                # create a simple subproblem and run it to test for global solver_info bug
                 p = Problem()
                 p.model.add_subsystem('indep', IndepVarComp('x', 1.0))
                 p.model.add_subsystem('comp', ExecComp('y=2*x'))

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -21,7 +21,6 @@ except ImportError:
     PETSc = None
 
 from openmdao.vectors.vector import INT_DTYPE
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.general_utils import ContainsAll, simple_warning
 from openmdao.utils.record_util import create_local_meta
 from openmdao.utils.mpi import MPI
@@ -122,6 +121,7 @@ class _TotalJacInfo(object):
         self.responses = responses = driver._responses
         self.debug_print = debug_print
         self.par_deriv = {}
+        self._recording_iter = driver._recording_iter
 
         if not model._use_derivatives:
             raise RuntimeError("Derivative support has been turned off but compute_totals "
@@ -1486,7 +1486,7 @@ class _TotalJacInfo(object):
         metadata : dict
             Dictionary containing execution metadata.
         """
-        recording_iteration.stack.append((requester._get_name(), requester.iter_count))
+        self._recording_iter.stack.append((requester._get_name(), requester.iter_count))
 
         try:
             totals = self._get_dict_J(self.J, self.wrt, self.prom_wrt, self.of, self.prom_of,
@@ -1494,7 +1494,7 @@ class _TotalJacInfo(object):
             requester._rec_mgr.record_derivatives(requester, totals, metadata)
 
         finally:
-            recording_iteration.stack.pop()
+            self._recording_iter.stack.pop()
 
 
 def _get_subjac(jac_meta, prom_out, prom_in, of_idx, wrt_idx):

--- a/openmdao/recorders/base_recorder.py
+++ b/openmdao/recorders/base_recorder.py
@@ -7,7 +7,6 @@ from openmdao.core.system import System
 from openmdao.core.driver import Driver
 from openmdao.solvers.solver import Solver
 from openmdao.core.problem import Problem
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import check_path
@@ -169,7 +168,8 @@ class BaseRecorder(object):
 
         self._counter += 1
 
-        self._iteration_coordinate = recording_iteration.get_formatted_iteration_coordinate()
+        self._iteration_coordinate = \
+            recording_requester._recording_iter.get_formatted_iteration_coordinate()
 
         if isinstance(recording_requester, Driver):
             self.record_iteration_driver(recording_requester, data, metadata)
@@ -261,7 +261,8 @@ class BaseRecorder(object):
             if MPI and MPI.COMM_WORLD.rank > 0:
                 raise RuntimeError("Non-parallel recorders should not be recording on ranks > 0")
 
-        self._iteration_coordinate = recording_iteration.get_formatted_iteration_coordinate()
+        self._iteration_coordinate = \
+            recording_requester._recording_iter.get_formatted_iteration_coordinate()
 
         self.record_derivatives_driver(recording_requester, data, metadata)
 

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -67,9 +67,6 @@ class _RecIteration(object):
         return prefix + separator.join(coord_list)
 
 
-recording_iteration = _RecIteration()
-
-
 class Recording(object):
     """
     A class that acts as a context manager.
@@ -109,6 +106,7 @@ class Recording(object):
         self.name = name
         self.iter_count = iter_count
         self.recording_requester = recording_requester
+        self.stack = self.recording_requester._recording_iter.stack
         self.abs = 0
         self.rel = 0
 
@@ -124,7 +122,7 @@ class Recording(object):
         self : object
             self
         """
-        recording_iteration.stack.append((self.name, self.iter_count))
+        self.stack.append((self.name, self.iter_count))
         return self
 
     def __exit__(self, *args):
@@ -139,7 +137,7 @@ class Recording(object):
         # Determine if recording is justified.
         do_recording = True
 
-        for stack_item in recording_iteration.stack:
+        for stack_item in self.stack:
             if stack_item[0] in ('_run_apply', '_compute_totals'):
                 do_recording = False
                 break
@@ -150,9 +148,9 @@ class Recording(object):
             else:
                 self.recording_requester.record_iteration()
 
-        self.recording_requester = None
-
         # Enable the following line for stack debugging.
         # print_recording_iteration_stack()
 
-        recording_iteration.stack.pop()
+        self.stack.pop()
+
+        self.recording_requester = None

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -82,6 +82,8 @@ class Recording(object):
         Current counter of iterations completed.
     recording_requester : object
         The object that wants to be recorded.
+    stack : list
+        Stack containing names and iteration counts.
     abs : float
         Absolute error.
     rel : float
@@ -106,7 +108,7 @@ class Recording(object):
         self.name = name
         self.iter_count = iter_count
         self.recording_requester = recording_requester
-        self.stack = self.recording_requester._recording_iter.stack
+        self.stack = recording_requester._recording_iter.stack
         self.abs = 0
         self.rel = 0
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -17,7 +17,6 @@ from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearRunOnc
 from openmdao.recorders.sqlite_recorder import SqliteRecorder, format_version
 from openmdao.recorders.case_reader import CaseReader
 from openmdao.recorders.sqlite_reader import SqliteCaseReader
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 from openmdao.core.tests.test_units import SpeedComp
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArray
 from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -35,8 +34,6 @@ if OPTIMIZER:
 class TestSqliteCaseReader(unittest.TestCase):
 
     def setUp(self):
-        recording_iteration.stack = []  # reset to avoid problems from earlier tests
-
         self.orig_dir = os.getcwd()
         self.temp_dir = mkdtemp()
         os.chdir(self.temp_dir)
@@ -1409,7 +1406,6 @@ def _assert_model_matches_case(case, system):
 class TestSqliteCaseReaderLegacy(unittest.TestCase):
 
     def setUp(self):
-        recording_iteration.stack = []  # reset to avoid problems from earlier tests
         self.dir = mkdtemp()
         self.original_path = os.getcwd()
         os.chdir(self.dir)

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -15,7 +15,6 @@ from openmdao.api import Problem, Group, IndepVarComp, ExecComp, SqliteRecorder,
     BoundsEnforceLS, ArmijoGoldsteinLS, CaseReader, PETScVector, AnalysisError
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.recorders.recording_iteration_stack import recording_iteration
 
 from openmdao.test_suite.components.ae_tests import AEComp
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDerivativesGrouped, \
@@ -61,8 +60,6 @@ class ParaboloidProblem(Problem):
 class TestSqliteRecorder(unittest.TestCase):
 
     def setUp(self):
-        recording_iteration.stack = []  # reset to avoid problems from earlier tests
-
         self.orig_dir = os.getcwd()
         self.temp_dir = mkdtemp()
         os.chdir(self.temp_dir)
@@ -966,7 +963,7 @@ class TestSqliteRecorder(unittest.TestCase):
         except AnalysisError:
             pass
 
-        self.assertTrue(len(recording_iteration.stack) == 0)
+        self.assertTrue(len(prob._recording_iter.stack) == 0)
 
     def test_record_solver_nonlinear_block_gs(self):
         prob = SellarProblem(linear_solver=LinearBlockGS, nonlinear_solver=NonlinearBlockGS)

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 import numpy as np
 
 from openmdao.solvers.solver import NonlinearSolver
-from openmdao.recorders.recording_iteration_stack import Recording, recording_iteration
+from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.general_utils import warn_deprecation
 
 
@@ -136,7 +136,7 @@ class NewtonSolver(NonlinearSolver):
         """
         Run the apply_nonlinear method on the system.
         """
-        recording_iteration.stack.append(('_run_apply', 0))
+        self._recording_iter.stack.append(('_run_apply', 0))
 
         system = self._system
 
@@ -147,7 +147,7 @@ class NewtonSolver(NonlinearSolver):
         try:
             system._apply_nonlinear()
         finally:
-            recording_iteration.stack.pop()
+            self._recording_iter.stack.pop()
 
         # Enable local fd
         system._owns_approx_jac = approx_status

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -141,11 +141,12 @@ class Solver(object):
         Dict of list of var names to record
     _norm0: float
         Normalization factor
+    _solver_info : SolverInfo
+        A stack-like object shared by all Solvers in the model.
     """
 
     # Object to store some formatting for iprint that is shared across all solvers.
     SOLVER = 'base_solver'
-    _solver_info = SolverInfo()
 
     def __init__(self, **kwargs):
         """
@@ -161,6 +162,7 @@ class Solver(object):
         self._vec_names = None
         self._mode = 'fwd'
         self._iter_count = 0
+        self._solver_info = None
 
         # Solver options
         self.options = OptionsDictionary()
@@ -254,6 +256,7 @@ class Solver(object):
         """
         self._system = system
         self._depth = depth
+        self._solver_info = system._solver_info
 
         if isinstance(self, LinearSolver) and not system._use_derivatives:
             return


### PR DESCRIPTION
We had 2 global stacks (recording iteration stack and solver info stack) that have been made instance attributes of Problem (and passed down to Systems/Solvers/Drivers) so each nested Problem will have its own copy.