### PR TITLE
Duplicate support declaration for integer design variables

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -164,8 +164,6 @@ class Driver(object):
         self.supports.declare('active_set', types=bool, default=False)
         self.supports.declare('simultaneous_derivatives', types=bool, default=False)
         self.supports.declare('total_jac_sparsity', types=bool, default=False)
-        # TODO, support these in OpenMDAO
-        self.supports.declare('integer_design_vars', types=bool, default=False)
 
         self.iter_count = 0
         self._model_viewer_data = None


### PR DESCRIPTION
In `Driver` the support for integer design variables was declared twice. Deleted the duplicate.