### PR TITLE
New "trust-constr" optimizer in the ScipyOptimizeDriver

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -595,10 +595,10 @@ class ScipyOptimizeDriver(Driver):
 
 def signature_extender(fcn, extra_args):
     """
-    A closure function, which appends extra arguments to the original function call.
-    The first argument is the design vector.
-    The possible extra arguments from the callback of :func:`scipy.optimize.minimize` are not
-    passed to the function.
+    Closure function, which appends extra arguments to the original function call.
+
+    The first argument is the design vector. The possible extra arguments from the callback
+    of :func:`scipy.optimize.minimize` are not passed to the function.
 
     Some algorithms take a sequence of :class:`~scipy.optimize.NonlinearConstraint` as input
     for the constraints. For this class it is not possible to pass additional arguments.

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -11,6 +11,7 @@ from six.moves import range
 
 import numpy as np
 from scipy.optimize import minimize
+from scipy import __version__ as scipy_version
 
 import openmdao
 from openmdao.core.driver import Driver, RecordingDebugging
@@ -20,6 +21,9 @@ import openmdao.utils.coloring as coloring_mod
 
 _optimizers = ['Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',
                'TNC', 'COBYLA', 'SLSQP', 'trust-constr']
+if scipy_version == '1.1.0':
+    _optimizers.append('trust-constr')
+
 _gradient_optimizers = ['CG', 'BFGS', 'Newton-CG', 'L-BFGS-B', 'TNC',
                         'SLSQP', 'dogleg', 'trust-ncg', 'trust-constr']
 _hessian_optimizers = ['trust-constr', 'trust-ncg']
@@ -279,7 +283,12 @@ class ScipyOptimizeDriver(Driver):
 
                 # In scipy constraint optimizers take constraints in two separate formats
                 if opt in ['trust-constr']:  # Type of constraints is list of NonlinearConstraint
-                    from scipy.optimize import NonlinearConstraint
+                    try:
+                        from scipy.optimize import NonlinearConstraint
+                    except ImportError:
+                        msg = ('The "trust-constr" optimizer is supported for SciPy 1.1.0 and'
+                               'above. The installed version is {}')
+                        raise ImportError(msg.format(scipy_version))
 
                     if equals is not None:
                         lb = ub = equals

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -105,7 +105,6 @@ class ScipyOptimizeDriver(Driver):
         self.opt_settings = OrderedDict()
 
         self.result = None
-        self.fail = 0
         self._grad_cache = None
         self._con_cache = None
         self._con_idx = {}

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -23,6 +23,7 @@ _optimizers = ['Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',
 _gradient_optimizers = ['CG', 'BFGS', 'Newton-CG', 'L-BFGS-B', 'TNC',
                         'SLSQP', 'dogleg', 'trust-ncg', 'trust-constr']
 _hessian_optimizers = ['trust-constr', 'trust-ncg']
+# TODO, add 'trust-constr' to bounds optimizers, when SciPy issue #9043 is resolved
 _bounds_optimizers = ['L-BFGS-B', 'TNC', 'SLSQP']
 _constraint_optimizers = ['COBYLA', 'SLSQP', 'trust-constr']
 _constraint_grad_optimizers = ['SLSQP']

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -608,7 +608,7 @@ def signature_extender(fcn, extra_args):
     ----------
     fcn : callable
         Function, which takes the design vector as the first argument.
-    extra_args: tuple or list
+    extra_args : tuple or list
         Extra arguments for the function
 
     Returns

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -27,7 +27,7 @@ _hessian_optimizers = ['trust-constr', 'trust-ncg']
 _bounds_optimizers = ['L-BFGS-B', 'TNC', 'SLSQP']
 _constraint_optimizers = ['COBYLA', 'SLSQP', 'trust-constr']
 _constraint_grad_optimizers = ['SLSQP']
-_eq_constraint_optimizers = ['SLSQP', 'trust', 'trust-constr']
+_eq_constraint_optimizers = ['SLSQP', 'trust-constr']
 
 # These require Hessian or Hessian-vector product, so they are not supported
 # right now.

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1009,6 +1009,46 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_rel_error(self, prob['c'], 1.0, 1e-2)
 
+    # TODO, add bounds test, when SciPy issue #9043 is resolved
+    # def test_trust_constr_bounds(self):
+    #     class Rosenbrock(ExplicitComponent):
+    #
+    #         def __init__(self, problem):
+    #             super(Rosenbrock, self).__init__()
+    #             self.problem = problem
+    #             self.counter = 0
+    #
+    #         def setup(self):
+    #             self.add_input('x', np.array([1.5, 1.5]))
+    #             self.add_output('f', 0.0)
+    #             self.declare_partials('f', 'x', method='fd', form='central', step=1e-4)
+    #
+    #         def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+    #             x = inputs['x']
+    #             outputs['f'] = sum(x ** 2)
+    #
+    #     x0 = np.array([-3., -3.])
+    #
+    #     prob = Problem()
+    #     indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+    #     indeps.add_output('x', list(x0))
+    #
+    #     prob.model.add_subsystem('sphere', Rosenbrock(problem=prob), promotes=['*'])
+    #     prob.driver = ScipyOptimizeDriver()
+    #     prob.driver.options['optimizer'] = 'trust-constr'
+    #     prob.driver.options['tol'] = 1e-5
+    #     prob.driver.options['maxiter'] = 2000
+    #     prob.driver.options['disp'] = False
+    #
+    #     prob.model.add_design_var('x', lower=np.array([-4., -4.]), upper=np.array([-1, -1.5]))
+    #     prob.model.add_objective('f')
+    #
+    #     prob.setup()
+    #     prob.run_driver()
+    #
+    #     assert_rel_error(self, prob['x'][0], -1, 1e-2)
+    #     assert_rel_error(self, prob['x'][1], -1.5, 1e-2)
+
     def test_simple_paraboloid_lower_linear(self):
 
         prob = Problem()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -873,7 +873,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
         assert_rel_error(self, prob['x'], 0.0, 1e-3)
 
-    def test_rosen_trust_constr(self):
+    def test_trust_constr(self):
 
         def rosenbrock(x):
             x_0 = x[:-1]
@@ -907,18 +907,107 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.driver = ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'trust-constr'
         prob.driver.options['tol'] = 1e-5
-        prob.driver.options['maxiter'] = 1000
+        prob.driver.options['maxiter'] = 2000
+        prob.driver.options['disp'] = True
 
         prob.model.add_design_var('x')
         prob.model.add_objective('f', scaler=rosenbrock(x0))
-        prob.model.add_constraint('c', upper=10)
+        prob.model.add_constraint('c', lower=0, upper=10)  # Double sided
 
         prob.setup()
         prob.run_driver()
 
-        # TODO lower tolerances, when there will be a user option for 'xtol' for this optimizer
-        assert_rel_error(self, prob['x'][0], 1., 1e-2)
+        assert_rel_error(self, prob['x'][0], 1., 2e-2)
         assert_rel_error(self, prob['f'], 0., 1e-2)
+        self.assertTrue(prob['c'] < 10)
+        self.assertTrue(prob['c'] > 0)
+
+    def test_trust_constr_equality_con(self):
+
+        def rosenbrock(x):
+            x_0 = x[:-1]
+            x_1 = x[1:]
+            return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
+
+        class Rosenbrock(ExplicitComponent):
+
+            def __init__(self, problem):
+                super(Rosenbrock, self).__init__()
+                self.problem = problem
+                self.counter = 0
+
+            def setup(self):
+                self.add_input('x', np.array([1.5, 1.5, 1.5]))
+                self.add_output('f', 0.0)
+                self.declare_partials('f', 'x', method='fd', form='central', step=1e-4)
+
+            def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+                x = inputs['x']
+                outputs['f'] = rosenbrock(x)
+
+        x0 = np.array([0.5, 0.8, 1.4])
+
+        prob = Problem()
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps.add_output('x', list(x0))
+
+        prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
+        prob.driver = ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'trust-constr'
+        prob.driver.options['tol'] = 1e-5
+        prob.driver.options['maxiter'] = 2000
+        prob.driver.options['disp'] = True
+
+        prob.model.add_design_var('x')
+        prob.model.add_objective('f', scaler=rosenbrock(x0))
+        prob.model.add_constraint('c', equals=1.)
+
+        prob.setup()
+        prob.run_driver()
+
+        assert_rel_error(self, prob['c'], 1., 1e-3)
+
+    def test_trust_constr_inequality_con(self):
+
+        class Rosenbrock(ExplicitComponent):
+
+            def __init__(self, problem):
+                super(Rosenbrock, self).__init__()
+                self.problem = problem
+                self.counter = 0
+
+            def setup(self):
+                self.add_input('x', np.array([1.5, 1.5]))
+                self.add_output('f', 0.0)
+                self.declare_partials('f', 'x', method='fd', form='central', step=1e-4)
+
+            def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+                x = inputs['x']
+                outputs['f'] = sum(x**2)
+
+        x0 = np.array([1.2, 1.5])
+
+        prob = Problem()
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps.add_output('x', list(x0))
+
+        prob.model.add_subsystem('sphere', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
+        prob.driver = ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'trust-constr'
+        prob.driver.options['tol'] = 1e-5
+        prob.driver.options['maxiter'] = 2000
+        prob.driver.options['disp'] = True
+
+        prob.model.add_design_var('x')
+        prob.model.add_objective('f')
+        prob.model.add_constraint('c', lower=1.0)
+
+        prob.setup()
+        prob.run_driver()
+
+        assert_rel_error(self, prob['c'], 1.0, 1e-2)
 
     def test_simple_paraboloid_lower_linear(self):
 

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -908,7 +908,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.driver.options['optimizer'] = 'trust-constr'
         prob.driver.options['tol'] = 1e-5
         prob.driver.options['maxiter'] = 2000
-        prob.driver.options['disp'] = True
+        prob.driver.options['disp'] = False
 
         prob.model.add_design_var('x')
         prob.model.add_objective('f', scaler=rosenbrock(x0))
@@ -957,7 +957,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.driver.options['optimizer'] = 'trust-constr'
         prob.driver.options['tol'] = 1e-5
         prob.driver.options['maxiter'] = 2000
-        prob.driver.options['disp'] = True
+        prob.driver.options['disp'] = False
 
         prob.model.add_design_var('x')
         prob.model.add_objective('f', scaler=rosenbrock(x0))
@@ -998,7 +998,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.driver.options['optimizer'] = 'trust-constr'
         prob.driver.options['tol'] = 1e-5
         prob.driver.options['maxiter'] = 2000
-        prob.driver.options['disp'] = True
+        prob.driver.options['disp'] = False
 
         prob.model.add_design_var('x')
         prob.model.add_objective('f')

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -3,8 +3,10 @@
 import unittest
 import sys
 import warnings
+from distutils.version import LooseVersion
 
 import numpy as np
+from scipy import __version__ as scipy_version
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ScipyOptimizeDriver, \
     ScipyOptimizer, ExplicitComponent, DirectSolver, NonlinearBlockGS
@@ -873,6 +875,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
         assert_rel_error(self, prob['x'], 0.0, 1e-3)
 
+    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+                         "scipy >= 1.1 is required.")
     def test_trust_constr(self):
 
         def rosenbrock(x):
@@ -922,6 +926,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
+    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+                         "scipy >= 1.1 is required.")
     def test_trust_constr_equality_con(self):
 
         def rosenbrock(x):
@@ -968,6 +974,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_rel_error(self, prob['c'], 1., 1e-3)
 
+    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+                         "scipy >= 1.1 is required.")
     def test_trust_constr_inequality_con(self):
 
         class Rosenbrock(ExplicitComponent):

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -873,6 +873,53 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
         assert_rel_error(self, prob['x'], 0.0, 1e-3)
 
+    def test_rosen_trust_constr(self):
+
+        def rosenbrock(x):
+            x_0 = x[:-1]
+            x_1 = x[1:]
+            return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
+
+        class Rosenbrock(ExplicitComponent):
+
+            def __init__(self, problem):
+                super(Rosenbrock, self).__init__()
+                self.problem = problem
+                self.counter = 0
+
+            def setup(self):
+                self.add_input('x', np.array([1.5, 1.5, 1.5]))
+                self.add_output('f', 0.0)
+                self.declare_partials('f', 'x', method='fd', form='central', step=1e-4)
+
+            def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+                x = inputs['x']
+                outputs['f'] = rosenbrock(x)
+
+        x0 = np.array([0.5, 0.8, 1.4])
+
+        prob = Problem()
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps.add_output('x', list(x0))
+
+        prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
+        prob.driver = ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'trust-constr'
+        prob.driver.options['tol'] = 1e-5
+        prob.driver.options['maxiter'] = 1000
+
+        prob.model.add_design_var('x')
+        prob.model.add_objective('f', scaler=rosenbrock(x0))
+        prob.model.add_constraint('c', upper=10)
+
+        prob.setup()
+        prob.run_driver()
+
+        # TODO lower tolerances, when there will be a user option for 'xtol' for this optimizer
+        assert_rel_error(self, prob['x'][0], 1., 1e-2)
+        assert_rel_error(self, prob['f'], 0., 1e-2)
+
     def test_simple_paraboloid_lower_linear(self):
 
         prob = Problem()


### PR DESCRIPTION
Added "trust-constr" optimizer to the supported optimizers. 
Implemented a new type of constraint input in `run()` for `scipy.optimize.minimize`, because this algorithm does not support the dictionary format to pass the constraints.
Added tests with equality, inequality and double-sided constraints.

Bounds are not supported yet, because there are unresolved issues with the bounds of the "trust-constr" in SciPy.

Added exception handling to the "fail" attribute of the driver, because apparently  not all optimizers return a success flag in `OptimizeResult`.