### PR TITLE
new declaration of two extra COBYLA options in ScipyOptimizeDriver dr…

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -220,10 +220,10 @@ class ScipyOptimizeDriver(Driver):
         # maxiter and disp get passsed into scipy with all the other options.
         self.opt_settings['maxiter'] = self.options['maxiter']
         self.opt_settings['disp'] = self.options['disp']
+        # COBYLA specific options passed into scipy
         if opt == 'COBYLA':
             self.opt_settings['rhobeg'] = self.options['initstep']
             self.opt_settings['catol'] = self.options['catol_cob']
-
 
         # Size Problem
         nparam = 0

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -134,6 +134,10 @@ class ScipyOptimizeDriver(Driver):
         self.options.declare('dynamic_derivs_repeats', default=3, types=int,
                              desc='Number of compute_totals calls during dynamic computation of '
                                   'simultaneous derivative coloring')
+        self.options.declare('initstep', default=1., types=float,
+                             desc='COBYLA: Reasonable initial changes to the variables')
+        self.options.declare('catol_cob', default=0.0002, types=float,
+                             desc='COBYLA: Tolerance (absolute) for constraint violations')
 
     def _get_name(self):
         """
@@ -216,6 +220,10 @@ class ScipyOptimizeDriver(Driver):
         # maxiter and disp get passsed into scipy with all the other options.
         self.opt_settings['maxiter'] = self.options['maxiter']
         self.opt_settings['disp'] = self.options['disp']
+        if opt == 'COBYLA':
+            self.opt_settings['rhobeg'] = self.options['initstep']
+            self.opt_settings['catol'] = self.options['catol_cob']
+
 
         # Size Problem
         nparam = 0


### PR DESCRIPTION
ScipyOptimize-COBYLA's default first perturbation step for design variables is 1. This is enforced even though the values are outside upper and lower bounds. COBYLA has an option ''rhobeg'' to adjust this. 
I added this and constraint tolerance options to the ScipyOptimizeDriver driver class. So that these are accessible from the "highest level" in the hierarchy i.e. prob.driver.options['initstep'] = 0.1 etc.