### PR TITLE
a couple doc fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ environment:
       PY: 3.6
       NUMPY: 1.14
       SCIPY: 1.0.1
-      PETSc: 3.8.1
+      PETSc: 3.9.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PY: 2.7

--- a/openmdao/docs/_exts/embed_shell_cmd.py
+++ b/openmdao/docs/_exts/embed_shell_cmd.py
@@ -132,7 +132,7 @@ class EmbedShellCmdDirective(Directive):
                   .format(cmdstr, err.output.decode('utf-8'))
             raise self.directive_error(2, msg)
         except Exception as err:
-            msg = "Running of embedded shell command '{}' in docs failed. Output was: {}" \
+            msg = "Running of embedded shell command '{}' in docs failed. Output was: \n{}" \
                   .format(cmdstr, err)
             raise self.directive_error(2, msg)
         finally:

--- a/openmdao/docs/_exts/embed_shell_cmd.py
+++ b/openmdao/docs/_exts/embed_shell_cmd.py
@@ -128,10 +128,13 @@ class EmbedShellCmdDirective(Directive):
             # Failed cases raised as a Directive warning (level 2 in docutils).
             # This way, the sphinx build does not terminate if, for example, you are building on
             # an environment where mpi or pyoptsparse are missing.
-            msg = "Running of embedded shell command '{}' in docs failed. " + \
-                  "Output was: \n{}".format(cmdstr, err.output.decode('utf-8'))
+            msg = "Running of embedded shell command '{}' in docs failed. Output was: \n{}" \
+                  .format(cmdstr, err.output.decode('utf-8'))
             raise self.directive_error(2, msg)
-
+        except Exception as err:
+            msg = "Running of embedded shell command '{}' in docs failed. Output was: {}" \
+                  .format(cmdstr, err)
+            raise self.directive_error(2, msg)
         finally:
             os.chdir(startdir)
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1137,6 +1137,10 @@ class TestParallelDOE(unittest.TestCase):
 class TestDOEDriverFeature(unittest.TestCase):
 
     def setUp(self):
+        import os
+        import shutil
+        import tempfile
+
         self.startdir = os.getcwd()
         self.tempdir = tempfile.mkdtemp(prefix='TestDOEDriverFeature-')
         os.chdir(self.tempdir)
@@ -1332,6 +1336,11 @@ class TestParallelDOEFeature(unittest.TestCase):
     N_PROCS = 2
 
     def setUp(self):
+        import os
+        import shutil
+        import tempfile
+
+        from mpi4py import MPI
         rank = MPI.COMM_WORLD.rank
 
         expected = {
@@ -1417,8 +1426,7 @@ class TestParallelDOEFeature(unittest.TestCase):
             outputs = cr.get_case(cases[n]).outputs
             values.append((outputs['x'], outputs['y'], outputs['f_xy']))
 
-        self.assertEqual("\n"+"\n".join(["x: %5.2f, y: %5.2f, f_xy: %6.2f" % (x, y, f_xy)
-                                         for x, y, f_xy in values]),
+        self.assertEqual("\n"+"\n".join(["x: %5.2f, y: %5.2f, f_xy: %6.2f" % (x, y, f_xy) for x, y, f_xy in values]),
                          self.expect_text)
 
 
@@ -1428,6 +1436,11 @@ class TestParallelDOEFeature2(unittest.TestCase):
     N_PROCS = 4
 
     def setUp(self):
+        import os
+        import shutil
+        import tempfile
+
+        from mpi4py import MPI
         rank = MPI.COMM_WORLD.rank
 
         expected = {


### PR DESCRIPTION
Pivotal #161790419: Doc build fails if no MPI installed
    - add general exception handling to docs `embed-shell-cmd`
Pivotal #161792692: Problem in documentation with features/building_blocks/drivers/doe_driver.rst
    - rejoin split line that `embed-code` could not parse
    - add imports in setUp so that the embed will work in the future without module imports