### PR TITLE
Update Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ openmdao/docs/_srcdocs/index.rst
 openmdao/docs/tags/
 *.out
 doc_plot_*
+coloring.json
+connections.html
+rank*.dat

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ openmdao/docs/_srcdocs/usr/
 openmdao/docs/_srcdocs/dev/
 openmdao/docs/_srcdocs/packages/
 openmdao/docs/_srcdocs/index.rst
-*testflo_report.out
 openmdao/docs/tags/
 *.out
 doc_plot_*

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,9 +92,10 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
+    pip install git+https://github.com/swryan/coveralls-python@work;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,9 @@ install:
     conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
+    # Install customized packages
     pip install git+https://github.com/swryan/coveralls-python@work;
+    pip install git+https://github.com/OpenMDAO/testflo.git;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,45 +79,59 @@ install:
 
 # if we don't have a cached conda environment then build one, otherwise just activate the cached one
 - if [ "$CACHED_ENV" ]; then
-    echo "Using cached environment..."
+    echo ">>> Using cached environment";
     export PATH=$HOME/miniconda/bin:$PATH;
     source $HOME/miniconda/bin/activate PY$PY;
   else
-    echo "Building python environment...";
+    echo ">>> Building python environment";
+    echo " >> Installing conda";
+    echo "  > Downloading miniconda";
     wget "https://repo.continuum.io/miniconda/Miniconda${PY:0:1}-4.5.11-Linux-x86_64.sh" -O miniconda.sh;
     chmod +x miniconda.sh;
+    echo "  > Installing miniconda";
     ./miniconda.sh -b  -p $HOME/miniconda;
     export PATH=$HOME/miniconda/bin:$PATH;
 
+    echo " >> Creating conda environment";
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
+    echo " >> Installing non-pure Python dependencies from conda";
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig;
 
     pip install --upgrade pip;
+
+    echo " >> Installing forked python packages";
     pip install git+https://github.com/swryan/coveralls-python@work;
     pip install git+https://github.com/OpenMDAO/testflo.git;
 
+    echo " >> Installing pyOptSparse";
+    echo "  > Cloning pyOptSparse from OpenMDAO's fork";
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
 
     if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
       cd pyoptsparse/pySNOPT;
+      echo "  > Secure copying SNOPT over SSH";
       scp -r "$SNOPT_LOCATION" .;
       cd ../..;
     fi
 
+    echo "  > Install pyOptSparse";
     python setup.py install;
     cd ..;
 
     if [ "$PETSc" ]; then
-      pip install mpi4py petsc4py==$PETSc;
+      echo " >> Installing parallel processing dependencies";
+      pip install mpi4py;
+      pip install petsc4py==$PETSc;
     fi
   fi
 
 # install OpenMDAO and its development and documentation dependencies
 # NOTE: not using -e on purpose here, to catch packaging errors
-- pip install .[develop,docs];
+- echo ">>> Installing OpenMDAO";
+  pip install .[develop,docs];
 
 # display summary of installed packages and their versions
 - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,7 @@ install:
 # install OpenMDAO and its development and documentation dependencies
 # NOTE: not using -e on purpose here, to catch packaging errors
 - echo ">>> Installing OpenMDAO";
-  pip install .[develop,docs];
+  pip install .[all];
 
 # display summary of installed packages and their versions
 - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,8 @@ install:
       cd ../..;
     fi
 
-    # Install OpenMDAO with testing and documentation dependencies
-    pip install .[develop,docs];
+    # install pyOptSparse
+    python setup.py install;
     cd ..;
 
     if [ "$PETSc" ]; then
@@ -114,8 +114,9 @@ install:
     fi
   fi
 
-# install OpenMDAO (Not using -e on purpose here, to catch pkging errors)
-- pip install .;
+# install OpenMDAO and its development and documentation dependencies
+# NOTE: not using -e on purpose here, to catch packaging errors
+- pip install .[develop,docs];
 
 # display summary of installed packages and their versions
 - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,6 @@ install:
     conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
-    # Install customized packages
     pip install git+https://github.com/swryan/coveralls-python@work;
     pip install git+https://github.com/OpenMDAO/testflo.git;
 
@@ -108,7 +107,6 @@ install:
       cd ../..;
     fi
 
-    # install pyOptSparse
     python setup.py install;
     cd ..;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,13 +92,10 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig nose sphinx mock;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig;
 
     pip install --upgrade pip;
-    pip install redbaron;
-    pip install git+https://github.com/OpenMDAO/testflo.git;
-    pip install coverage;
-    pip install git+https://github.com/swryan/coveralls-python@work;
+    pip install coveralls;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
@@ -109,14 +106,13 @@ install:
       cd ../..;
     fi
 
-    python setup.py install;
+    # Install OpenMDAO with developer and documentation dependencies
+    pip install .[develop,docs];
     cd ..;
 
     if [ "$PETSc" ]; then
       pip install mpi4py petsc4py==$PETSc;
     fi
-
-    conda install --yes matplotlib;
   fi
 
 # install OpenMDAO (Not using -e on purpose here, to catch pkging errors)

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,7 +95,6 @@ install:
     conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig;
 
     pip install --upgrade pip;
-    pip install coveralls;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
@@ -106,7 +105,7 @@ install:
       cd ../..;
     fi
 
-    # Install OpenMDAO with developer and documentation dependencies
+    # Install OpenMDAO with testing and documentation dependencies
     pip install .[develop,docs];
     cd ..;
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![Coveralls Badge][13]][14]
 
 # [OpenMDAO 2][0]
-*This version of **OpenMDAO** is in Development Status **[BETA](15)**.*
+*This version of **OpenMDAO** is in Development Status **[BETA][15]**.*
 
 ## Documentation
 Documentation for the latest version can be found [here][2].
 
 Documentation archives for prior versions can be found [here][3].
 
-## Important Note
+## Important Notice
 While the API is MOSTLY stable, the **OpenMDAO** development team reserves the
 right to update it and other elements of the code as needed.
 
@@ -48,11 +48,11 @@ Here is a list of things that have not yet been developed in 2.x:
 WebRecorder are currently supported)
 
 ## Install OpenMDAO 2
-You have two means for installing OpenMDAO, from the Python Package Index (PyPI)
-or from a clone of the [GitHub repository][4].
+You have two options for installing **OpenMDAO**, (1) from the
+[Python Package Index (PyPI)][1], and (2) from the [GitHub repository][4].
 
-**OpenMDAO** includes two optional set of dependencies, one for installing
-the developer tools (e.g., testing, coverage) and one for building the
+**OpenMDAO** includes two optional sets of dependencies, one for installing
+the developer tools (e.g., testing, coverage), and one for building the
 documentation.
 
 ### Install from [PyPI][1]
@@ -82,7 +82,7 @@ make to the source code will be reflected when you import **OpenMDAO** in
 Users are encourage to run the unit tests to ensure **OpenMDAO** is performing
 correctly.  In order to do so, you must install the testing dependencies.
 
-1. Install OpenMDAO and its testing dependencies:
+1. Install **OpenMDAO** and its testing dependencies:
 
     > `pip install openmdao[develop]`
 
@@ -125,7 +125,7 @@ you can install [Anaconda](https://www.anaconda.com/download/) and install
     > Follow the [instructions](#install-from-a-cloned-repository) for
     installing **OpenMDAO** from a cloned repository.
 
-2. Install the OpenMDAO and the documentation making dependencies:
+2. Install **OpenMDAO** and the dependencies required to build the documentation :
     > `pip install OpenMDAO[docs]`
 
 3. Change to the docs directory:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # OpenMDAO Versions
 > **PLEASE NOTE**: Until recently, this repository was named **OpenMDAO/blue**. 
 If you had cloned that repository, please update your repository name and 
-remotes to reflect these changes. You can find instructions [here][7].
+remotes to reflect these changes. You can find instructions [here][8].
 
 The **OpenMDAO 2.x.y** code has taken the name **OpenMDAO**, and is maintained 
 [here][4]. To install the latest release, run `pip install --update openmdao`.
@@ -15,8 +15,7 @@ The **OpenMDAO 1.7.4** code repository is now named **OpenMDAO1**, and has moved
 `openmdao<2` are required). 
 
 The legacy **OpenMDAO v0.x** (versions 0.13.0 and older) of the 
-**OpenMDAO-Framework** are [here][8].
-
+**OpenMDAO-Framework** are [here][6].
 
 # OpenMDAO 2
 This is an ALPHA version of **OpenMDAO 2**.
@@ -31,11 +30,9 @@ While the API is MOSTLY stable, we reserve the right to change things as needed.
 We will be making frequent updates to this code. If you’re going to try it,
 make sure you pull these updates often.
 
-
 ## Features of OpenMDAO 1.7.4 Not Yet in 2.x.y
-
-Be aware that this is an Alpha.
-Not all the features of 1.7.4 exist in 2.x.y yet.
+Be aware that this new version of **OpenMDAO** is in beta and not all the
+features of 1.7.4 are currently available.
 
 Here is a list of things that have not yet been developed in 2.x:
 
@@ -50,7 +47,7 @@ WebRecorder are currently supported)
 
 # Installation Instructions
 You have two means for installing OpenMDAO, from the Python Package Index (PyPI)
-or from a clone of the [GitHub repository](https://github.com/OpenMDAO/OpenMDAO).
+or from a clone of the [GitHub repository][4].
 ### Install from [PyPI][1]
 This is the easist way to install **OpenMDAO**.
 > `pip install openmdao`
@@ -103,19 +100,19 @@ docs.
 # Testing Instructions
 1. Install OpenMDAO and its testing dependencies:
 
-    >`pip install openmdao[develop]`
+    > `pip install openmdao[develop]`
 
 2. Run tests:
 
     > `testflo openmdao -n 1`
 
-3. If everything works correctly, you should see a message that there 
-were no failures.  If you see failures, you are encouraged to report
-it as an [issue][6].  If so, please make sure you include your system spec,
+3. If everything works correctly, you should see a message stating that there 
+were zero failures.  If you see failures, you are encouraged to report
+it as an [issue][7].  If so, please make sure you include your system spec,
 and include the error message.
 
-    > If tests fail, please include your system information, you can obtain that
-    by running the following commands in *python* and copying the results 
+    > If tests fail, please include your system information, you can obtain
+    that by running the following commands in *python* and copying the results 
     produced by the last line.
     ```python
     >>> import platform
@@ -128,18 +125,23 @@ and include the error message.
     ```python
     (('Windows', '10.0.17134'),
      ('AMD64', 'Intel64 Family 6 Model 94 Stepping 3, GenuineIntel'),
-      '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) [MSC v.1900 64 bit (AMD64)]')
+     '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) ...')
     ```
 
 
-[1]: https://pypi.org/project/openmdao/ "PyPI"
+[1]: https://pypi.org/project/openmdao/ "OpenMDAO @PyPI"
+
 [2]: http://openmdao.org/twodocs/versions/latest "Latest Docs"
-[3]: http://openmdao.org/twodocs "Archived Docts"
+[3]: http://openmdao.org/twodocs "Archived Docs"
+
 [4]: https://github.com/OpenMDAO/OpenMDAO "OpenMDAO Git Repo"
 [5]: https://github.com/OpenMDAO/OpenMDAO1 "OpenMDAO 1.x Git Repo"
-[6]: https://github.com/OpenMDAO/OpenMDAO/issues/new "Make New Issue"
-[7]: https://help.github.com/articles/changing-a-remote-s-url/ "Remote URL Update"
-[8]: https://github.com/OpenMDAO/OpenMDAO-Framework "OpenMDAO Framework Git Repo"
+[6]: https://github.com/OpenMDAO/OpenMDAO-Framework "OpenMDAO Framework Git Repo"
+
+[7]: https://github.com/OpenMDAO/OpenMDAO/issues/new "Make New OpenMDAO Issue"
+
+[8]: https://help.github.com/articles/changing-a-remote-s-url/ "Update Git Remote URL"
+
 [9]: https://travis-ci.org/OpenMDAO/OpenMDAO.svg?branch=master "TravisCI Badge"
 [10]: https://travis-ci.org/OpenMDAO/OpenMDAO "OpenMDAO @TravisCI"
 [11]: https://ci.appveyor.com/api/projects/status/33kct0irhbgcg8m1?svg=true "Build Badge"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,28 @@
-[![Build Status][9]][10]
-[![Build status][11]][12]
-[![Coverage Status][13]][14]
+[![TravisCI Badge][9]][10]
+[![AppVeyor Badge][11]][12]
+[![Coveralls Badge][13]][14]
 
-# OpenMDAO Versions
+# [OpenMDAO 2][0]
+*This version of **OpenMDAO** is in Development Status **[BETA](15)**.*
+
+## Documentation
+Documentation for the latest version can be found [here][2].
+
+Documentation archives for prior versions can be found [here][3].
+
+## Important Note
+While the API is MOSTLY stable, the **OpenMDAO** development team reserves the
+right to update it and other elements of the code as needed.
+
+The team will be making frequent updates to the source code, so users are
+encouraged to regularly pull for updates.
+
+### OpenMDAO Versions
 > **PLEASE NOTE**: Until recently, this repository was named **OpenMDAO/blue**. 
-If you had cloned that repository, please update your repository name and 
+If you had cloned that repository, please update your repository name and
 remotes to reflect these changes. You can find instructions [here][8].
 
-The **OpenMDAO 2.x.y** code has taken the name **OpenMDAO**, and is maintained 
+The **OpenMDAO 2.x.y** code has taken the name **OpenMDAO**, and is maintained
 [here][4]. To install the latest release, run `pip install --update openmdao`.
 
 The **OpenMDAO 1.7.4** code repository is now named **OpenMDAO1**, and has moved
@@ -17,22 +32,9 @@ The **OpenMDAO 1.7.4** code repository is now named **OpenMDAO1**, and has moved
 The legacy **OpenMDAO v0.x** (versions 0.13.0 and older) of the 
 **OpenMDAO-Framework** are [here][6].
 
-# OpenMDAO 2
-This is an ALPHA version of **OpenMDAO 2**.
-
-The latest docs can be found [here][2].
-
-Archived versions of the docs can be found [here][3].
-
-## Important Note
-While the API is MOSTLY stable, we reserve the right to change things as needed.
-
-We will be making frequent updates to this code. If you’re going to try it,
-make sure you pull these updates often.
-
-## Features of OpenMDAO 1.7.4 Not Yet in 2.x.y
-Be aware that this new version of **OpenMDAO** is in beta and not all the
-features of 1.7.4 are currently available.
+### Missing Features from OpenMDAO 1.7.4
+Be aware that this new version of **OpenMDAO** is in Development Status **BETA**
+and not all the features of 1.7.4 are currently available.
 
 Here is a list of things that have not yet been developed in 2.x:
 
@@ -45,11 +47,16 @@ Here is a list of things that have not yet been developed in 2.x:
 * CaseRecording using CSV, HDF5, and dump recorders (SqliteRecorder and 
 WebRecorder are currently supported)
 
-# Installation Instructions
+## Install OpenMDAO 2
 You have two means for installing OpenMDAO, from the Python Package Index (PyPI)
 or from a clone of the [GitHub repository][4].
+
+**OpenMDAO** includes two optional set of dependencies, one for installing
+the developer tools (e.g., testing, coverage) and one for building the
+documentation.
+
 ### Install from [PyPI][1]
-This is the easist way to install **OpenMDAO**.
+This is the easiest way to install **OpenMDAO**.
 > `pip install openmdao`
 
 To install the testing dependencies, run:
@@ -66,41 +73,22 @@ This includes the packages necessary for running **OpenMDAO**'s tests.
 > `pip install OpenMDAO[develop]`
 
 If you would like to make changes to **OpenMDAO** it is recommended you
-install it in *editable* mode (i.e., development mode).
+install it in *[editable][16]* mode (i.e., development mode) so any changes you
+make to the source code will be reflected when you import **OpenMDAO** in
+*Python*.
 > `pip install -e OpenMDAO[develop]`
 
-If you are planning to change the Developer mode will allow you to make changes
-to the OpenMDAO code
+## Test OpenMDAO 2
+Users are encourage to run the unit tests to ensure **OpenMDAO** is performing
+correctly.  In order to do so, you must install the testing dependencies.
 
-#### Install the documentation making dependencies
-> `pip install OpenMDAO[docs]`
-
-# Documentation Building Instructions
-> Make sure you followed the [instructions](#install-from-a-cloned-repository)
-for installing **OpenMDAO** from a cloned repository, and the 
-[instructions](#install-the-documentation-making-dependencies) for installing 
-the documentation making dependencies
-
-> You will need **make** to build the documentation.  If you are using Windows,
-you can install [Anaconda](https://www.anaconda.com/download/) and install 
-**make** by running: `conda install make`.
-
-Change to the docs directory:
-
-> `cd OpenMDAO/openmdao/docs`
->
-> `make clean; make all`
-
-This will build the docs into `openmdao/docs/_build/html`.
-
-Then, just open  `openmdao/docs/_build/html/index.html` in a browser see the 
-docs.
-
-
-# Testing Instructions
 1. Install OpenMDAO and its testing dependencies:
 
     > `pip install openmdao[develop]`
+
+    > Alternatively, you can clone the repository, as explained
+    [here](#install-from-a-cloned-repository), and install the development
+    dependencies as described [here](#install-the-developer-dependencies).
 
 2. Run tests:
 
@@ -112,7 +100,7 @@ it as an [issue][7].  If so, please make sure you include your system spec,
 and include the error message.
 
     > If tests fail, please include your system information, you can obtain
-    that by running the following commands in *python* and copying the results 
+    that by running the following commands in *python* and copying the results
     produced by the last line.
     ```python
     >>> import platform
@@ -128,7 +116,30 @@ and include the error message.
      '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) ...')
     ```
 
+## Build the Documentation for OpenMDAO 2
+> You will need **make** to build the documentation.  If you are using Windows,
+you can install [Anaconda](https://www.anaconda.com/download/) and install
+**make** by running: `conda install make`.
 
+1. Make sure you have cloned the repository with the source code:
+    > Follow the [instructions](#install-from-a-cloned-repository) for
+    installing **OpenMDAO** from a cloned repository.
+
+2. Install the OpenMDAO and the documentation making dependencies:
+    > `pip install OpenMDAO[docs]`
+
+3. Change to the docs directory:
+    > `cd OpenMDAO/openmdao/docs`
+
+4. Run the command to auto-generate the documentation.
+    > `make clean; make all`
+
+This will build the docs into `openmdao/docs/_build/html`.  You can browse the
+documentation by opening `openmdao/docs/_build/html/index.html` with your web
+browser.
+
+
+[0]: http://openmdao.org/ "OpenMDAO"
 [1]: https://pypi.org/project/openmdao/ "OpenMDAO @PyPI"
 
 [2]: http://openmdao.org/twodocs/versions/latest "Latest Docs"
@@ -148,3 +159,7 @@ and include the error message.
 [12]: https://ci.appveyor.com/project/OpenMDAO/blue/branch/master "OpenMDAO @AppVeyor"
 [13]: https://coveralls.io/repos/github/OpenMDAO/OpenMDAO/badge.svg?branch=master "Coverage Badge"
 [14]: https://coveralls.io/github/OpenMDAO/OpenMDAO?branch=master "OpenMDAO @Coveralls"
+
+[15]: https://en.wikipedia.org/wiki/Software_release_life_cycle#Beta "Wikipedia Beta"
+
+[16]: https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode "Pip Editable Mode"

--- a/README.md
+++ b/README.md
@@ -103,11 +103,9 @@ and include the error message.
     that by running the following commands in *python* and copying the results
     produced by the last line.
     ```python
-    >>> import platform
-    >>> import sys
-    >>>
-    >>> info = platform.uname()
-    >>> (info.system, info.version), (info.machine, info.processor), sys.version
+    import platform, sys
+    info = platform.uname()
+    (info.system, info.version), (info.machine, info.processor), sys.version
     ```
     > Which should produce a result similar to:
     ```python

--- a/README.md
+++ b/README.md
@@ -1,51 +1,38 @@
+[![Build Status][9]][10]
+[![Build status][11]][12]
+[![Coverage Status][13]][14]
 
-[![Build Status](https://travis-ci.org/OpenMDAO/OpenMDAO.svg?branch=master)](https://travis-ci.org/OpenMDAO/OpenMDAO)   [![Build status](https://ci.appveyor.com/api/projects/status/33kct0irhbgcg8m1?svg=true
-)](https://ci.appveyor.com/project/OpenMDAO/blue/branch/master)  [![Coverage Status](https://coveralls.io/repos/github/OpenMDAO/OpenMDAO/badge.svg?branch=master)](https://coveralls.io/github/OpenMDAO/OpenMDAO?branch=master)
+# OpenMDAO Versions
+> **PLEASE NOTE**: Until recently, this repository was named **OpenMDAO/blue**. 
+If you had cloned that repository, please update your repository name and 
+remotes to reflect these changes. You can find instructions [here][7].
 
+The **OpenMDAO 2.x.y** code has taken the name **OpenMDAO**, and is maintained 
+[here][4]. To install the latest release, run `pip install --update openmdao`.
 
+The **OpenMDAO 1.7.4** code repository is now named **OpenMDAO1**, and has moved
+[here][5]. To install it, run: `pip install "openmdao<2"` (the quotes around 
+`openmdao<2` are required). 
 
-
-OpenMDAO Naming/Legacy OpenMDAO
--------------------------------
-
-PLEASE NOTE: Until recently, this repository was named OpenMDAO/blue. If you had cloned that repository, please update
-your repository name and remotes to reflect these changes.
-
-The OpenMDAO 1.7.4 codebase repo has been renamed to OpenMDAO1, and it resides
-at https://github.com/OpenMDAO/OpenMDAO1
-
-The OpenMDAO 2.x.y code has taken the name OpenMDAO,
-and it resides at https://github.com/OpenMDAO/OpenMDAO.
-
-Installation of 2.x.y code will now work with `pip install openmdao`.
-Installation of 1.7.4 code will now only work with a version specifier: `pip install openmdao==1.7.4`
-
-To use the OpenMDAO v0.x legacy version
- (versions 0.13.0 and older) of the OpenMDAO-Framework, go here:
-https://github.com/OpenMDAO/OpenMDAO-Framework
+The legacy **OpenMDAO v0.x** (versions 0.13.0 and older) of the 
+**OpenMDAO-Framework** are [here][8].
 
 
-OpenMDAO 2
---------------
+# OpenMDAO 2
+This is an ALPHA version of **OpenMDAO 2**.
 
-This is an ALPHA version of OpenMDAO 2
+The latest docs can be found [here][2].
 
-Our latest docs are available at [http://openmdao.org/twodocs/versions/latest](http://openmdao.org/twodocs/versions/latest)
-Our archived 2 docs are available at [http://openmdao.org/twodocs](http://openmdao.org/twodocs)
+Archived versions of the docs can be found [here][3].
 
-
-
-Important Note:
----------------
-
+## Important Note
 While the API is MOSTLY stable, we reserve the right to change things as needed.
 
 We will be making frequent updates to this code. If you’re going to try it,
 make sure you pull these updates often.
 
 
-Features of OpenMDAO 1.7.4 Not Yet in 2.x.y
--------------------------------------------
+## Features of OpenMDAO 1.7.4 Not Yet in 2.x.y
 
 Be aware that this is an Alpha.
 Not all the features of 1.7.4 exist in 2.x.y yet.
@@ -58,41 +45,104 @@ Here is a list of things that have not yet been developed in 2.x:
 * File variables
 * Active-set constraint calculation disabling
 * Brent Solver
-* CaseRecording using CSV, HDF5, and dump recorders (SqliteRecorder and WebRecorder are currently supported)
+* CaseRecording using CSV, HDF5, and dump recorders (SqliteRecorder and 
+WebRecorder are currently supported)
 
-Installation Instructions:
---------------------------
-Option 1: Install from pypi:
+# Installation Instructions
+You have two means for installing OpenMDAO, from the Python Package Index (PyPI)
+or from a clone of the [GitHub repository](https://github.com/OpenMDAO/OpenMDAO).
+### Install from [PyPI][1]
+This is the easist way to install **OpenMDAO**.
+> `pip install openmdao`
 
-`pip install openmdao`
+To install the testing dependencies, run:
+> `pip install openmdao[develop]`
 
-Option 2: Use git to clone the repository:
+### Install from a Cloned Repository
+This allows you to install **OpenMDAO** from a local copy of the source code.
+> `git clone http://github.com/OpenMDAO/OpenMDAO`
+>
+> `pip install OpenMDAO`
 
-`git clone http://github.com/OpenMDAO/OpenMDAO`
+#### Install the Developer Dependencies
+This includes the packages necessary for running **OpenMDAO**'s tests.  
+> `pip install OpenMDAO[develop]`
 
-Then use pip to install openmdao locally:
+If you would like to make changes to **OpenMDAO** it is recommended you
+install it in *editable* mode (i.e., development mode).
+> `pip install -e OpenMDAO[develop]`
 
-`cd OpenMDAO`
+If you are planning to change the Developer mode will allow you to make changes
+to the OpenMDAO code
 
-`pip install .`
+#### Install the documentation making dependencies
+> `pip install OpenMDAO[docs]`
 
-To install the developer dependencies (in development mode):
+# Documentation Building Instructions
+> Make sure you followed the [instructions](#install-from-a-cloned-repository)
+for installing **OpenMDAO** from a cloned repository, and the 
+[instructions](#install-the-documentation-making-dependencies) for installing 
+the documentation making dependencies
 
-`pip install -e .[develop]`
+> You will need **make** to build the documentation.  If you are using Windows,
+you can install [Anaconda](https://www.anaconda.com/download/) and install 
+**make** by running: `conda install make`.
 
-To install the documentation making dependencies:
+Change to the docs directory:
 
-`pip install .[docs]`
-
-Documentation Building Instructions:
-------------------------------------
-
-If you've cloned the repository and installed the documentation dependencies, change to the docs directory:
-
-`cd openmdao/docs`
-
-`make clean; make all`
+> `cd OpenMDAO/openmdao/docs`
+>
+> `make clean; make all`
 
 This will build the docs into `openmdao/docs/_build/html`.
 
-Then, just open  `openmdao/docs/_build/html/index.html` in a browser to begin.
+Then, just open  `openmdao/docs/_build/html/index.html` in a browser see the 
+docs.
+
+
+# Testing Instructions
+1. Install OpenMDAO and its testing dependencies:
+
+    >`pip install openmdao[develop]`
+
+2. Run tests:
+
+    > `testflo openmdao -n 1`
+
+3. If everything works correctly, you should see a message that there 
+were no failures.  If you see failures, you are encouraged to report
+it as an [issue][6].  If so, please make sure you include your system spec,
+and include the error message.
+
+    > If tests fail, please include your system information, you can obtain that
+    by running the following commands in *python* and copying the results 
+    produced by the last line.
+    ```python
+    >>> import platform
+    >>> import sys
+    >>>
+    >>> info = platform.uname()
+    >>> (info.system, info.version), (info.machine, info.processor), sys.version
+    ```
+    > Which should produce a result similar to:
+    ```python
+    (('Windows', '10.0.17134'),
+     ('AMD64', 'Intel64 Family 6 Model 94 Stepping 3, GenuineIntel'),
+      '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) [MSC v.1900 64 bit (AMD64)]')
+    ```
+
+
+[1]: https://pypi.org/project/openmdao/ "PyPI"
+[2]: http://openmdao.org/twodocs/versions/latest "Latest Docs"
+[3]: http://openmdao.org/twodocs "Archived Docts"
+[4]: https://github.com/OpenMDAO/OpenMDAO "OpenMDAO Git Repo"
+[5]: https://github.com/OpenMDAO/OpenMDAO1 "OpenMDAO 1.x Git Repo"
+[6]: https://github.com/OpenMDAO/OpenMDAO/issues/new "Make New Issue"
+[7]: https://help.github.com/articles/changing-a-remote-s-url/ "Remote URL Update"
+[8]: https://github.com/OpenMDAO/OpenMDAO-Framework "OpenMDAO Framework Git Repo"
+[9]: https://travis-ci.org/OpenMDAO/OpenMDAO.svg?branch=master "TravisCI Badge"
+[10]: https://travis-ci.org/OpenMDAO/OpenMDAO "OpenMDAO @TravisCI"
+[11]: https://ci.appveyor.com/api/projects/status/33kct0irhbgcg8m1?svg=true "Build Badge"
+[12]: https://ci.appveyor.com/project/OpenMDAO/blue/branch/master "OpenMDAO @AppVeyor"
+[13]: https://coveralls.io/repos/github/OpenMDAO/OpenMDAO/badge.svg?branch=master "Coverage Badge"
+[14]: https://coveralls.io/github/OpenMDAO/OpenMDAO?branch=master "OpenMDAO @Coveralls"

--- a/README.md
+++ b/README.md
@@ -66,22 +66,28 @@ Option 1: Install from pypi:
 
 `pip install openmdao`
 
-
 Option 2: Use git to clone the repository:
 
 `git clone http://github.com/OpenMDAO/OpenMDAO`
 
- Then use pip to install openmdao locally:
+Then use pip to install openmdao locally:
 
 `cd OpenMDAO`
 
 `pip install .`
 
+To install the developer dependencies (in development mode):
+
+`pip install -e .[develop]`
+
+To install the documentation making dependencies:
+
+`pip install .[docs]`
 
 Documentation Building Instructions:
 ------------------------------------
 
-If you've cloned the repository, change to the docs directory:
+If you've cloned the repository and installed the documentation dependencies, change to the docs directory:
 
 `cd openmdao/docs`
 

--- a/README.md
+++ b/README.md
@@ -51,32 +51,39 @@ WebRecorder are currently supported)
 You have two options for installing **OpenMDAO**, (1) from the
 [Python Package Index (PyPI)][1], and (2) from the [GitHub repository][4].
 
-**OpenMDAO** includes two optional sets of dependencies, one for installing
-the developer tools (e.g., testing, coverage), and one for building the
-documentation.
+**OpenMDAO** includes two optional sets of dependencies, `develop` for
+installing the developer tools (e.g., testing, coverage), and `docs` for
+building the documentation.  A third option, `all` combines these two sets.
 
 ### Install from [PyPI][1]
-This is the easiest way to install **OpenMDAO**.
-> `pip install openmdao`
+This is the easiest way to install **OpenMDAO**. To install only the runtime
+dependencies:
 
-To install the testing dependencies, run:
-> `pip install openmdao[develop]`
+    pip install openmdao
+
+To install all the optional dependencies:
+
+    pip install openmdao[all]
 
 ### Install from a Cloned Repository
 This allows you to install **OpenMDAO** from a local copy of the source code.
-> `git clone http://github.com/OpenMDAO/OpenMDAO`
->
-> `pip install OpenMDAO`
+
+    git clone http://github.com/OpenMDAO/OpenMDAO
+    pip install OpenMDAO
 
 #### Install the Developer Dependencies
-This includes the packages necessary for running **OpenMDAO**'s tests.  
-> `pip install OpenMDAO[develop]`
+If you want to modify **OpenMDAO**, you may want to install the packages
+necessary for running **OpenMDAO**'s tests and documentation generator.  You
+can install them explicitly by running:
+
+    pip install OpenMDAO[all]
 
 If you would like to make changes to **OpenMDAO** it is recommended you
-install it in *[editable][16]* mode (i.e., development mode) so any changes you
-make to the source code will be reflected when you import **OpenMDAO** in
-*Python*.
-> `pip install -e OpenMDAO[develop]`
+install it in *[editable][16]* mode (i.e., development mode) by adding the `-e`
+flag when calling `pip`, this way any changes you make to the source code will
+be included when you import **OpenMDAO** in *Python*.
+
+    pip install -e OpenMDAO[test]
 
 ## Test OpenMDAO 2
 Users are encourage to run the unit tests to ensure **OpenMDAO** is performing
@@ -84,7 +91,7 @@ correctly.  In order to do so, you must install the testing dependencies.
 
 1. Install **OpenMDAO** and its testing dependencies:
 
-    > `pip install openmdao[develop]`
+    `pip install openmdao[test]`
 
     > Alternatively, you can clone the repository, as explained
     [here](#install-from-a-cloned-repository), and install the development
@@ -92,27 +99,27 @@ correctly.  In order to do so, you must install the testing dependencies.
 
 2. Run tests:
 
-    > `testflo openmdao -n 1`
+    `testflo openmdao -n 1`
 
 3. If everything works correctly, you should see a message stating that there 
-were zero failures.  If you see failures, you are encouraged to report
-it as an [issue][7].  If so, please make sure you include your system spec,
+were zero failures.  If the tests produce failures, you are encouraged to report
+them as an [issue][7].  If so, please make sure you include your system spec,
 and include the error message.
 
     > If tests fail, please include your system information, you can obtain
     that by running the following commands in *python* and copying the results
     produced by the last line.
-    ```python
-    import platform, sys
-    info = platform.uname()
-    (info.system, info.version), (info.machine, info.processor), sys.version
-    ```
+
+        import platform, sys
+
+        info = platform.uname()
+        (info.system, info.version), (info.machine, info.processor), sys.version
+
     > Which should produce a result similar to:
-    ```python
-    (('Windows', '10.0.17134'),
-     ('AMD64', 'Intel64 Family 6 Model 94 Stepping 3, GenuineIntel'),
-     '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) ...')
-    ```
+
+        (('Windows', '10.0.17134'),
+         ('AMD64', 'Intel64 Family 6 Model 94 Stepping 3, GenuineIntel'),
+         '3.6.6 | packaged by conda-forge | (default, Jul 26 2018, 11:48:23) ...')
 
 ## Build the Documentation for OpenMDAO 2
 > You will need **make** to build the documentation.  If you are using Windows,
@@ -123,14 +130,18 @@ you can install [Anaconda](https://www.anaconda.com/download/) and install
     > Follow the [instructions](#install-from-a-cloned-repository) for
     installing **OpenMDAO** from a cloned repository.
 
-2. Install **OpenMDAO** and the dependencies required to build the documentation :
-    > `pip install OpenMDAO[docs]`
+2. Install **OpenMDAO** and the dependencies required to build the
+   documentation:
+
+    `pip install OpenMDAO[docs]`
 
 3. Change to the docs directory:
-    > `cd OpenMDAO/openmdao/docs`
+
+    `cd OpenMDAO/openmdao/docs`
 
 4. Run the command to auto-generate the documentation.
-    > `make clean; make all`
+
+    `make clean; make all`
 
 This will build the docs into `openmdao/docs/_build/html`.  You can browse the
 documentation by opening `openmdao/docs/_build/html/index.html` with your web

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -90,6 +90,7 @@ install:
     conda install --yes matplotlib;
 
     pip install .[develop];
+    pip install .[docs];
     conda list;
 
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
@@ -100,6 +101,7 @@ install:
 - cmd: pip install testflo
 - cmd: cd C:\projects\blue*
 - cmd: pip install -e .[develop]
+- cmd: pip install -e .[docs]
 - cmd: conda list
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,9 @@ install:
     conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
+    # Install customized packages
     pip install git+https://github.com/swryan/coveralls-python@work;
+    pip install git+https://github.com/OpenMDAO/testflo.git;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,13 +64,9 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig nose sphinx mock;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig
 
     pip install --upgrade pip;
-    pip install redbaron;
-    pip install git+https://github.com/OpenMDAO/testflo.git;
-    pip install coverage;
-    pip install git+https://github.com/swryan/coveralls-python@work;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
@@ -81,27 +77,21 @@ install:
       cd ../..;
     fi
 
-    python setup.py install;
+    pip install .[develop,docs];
     cd ..;
 
     pip install mpi4py;
     pip install petsc4py==$PETSc;
 
-    conda install --yes matplotlib;
-
-    pip install .[develop];
-    pip install .[docs];
     conda list;
 
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
 - cmd: conda update conda
-- cmd: conda install python=%PYTHON% numpy scipy=1.0.1 mkl==2018.0.2 nose sphinx mock pip --quiet
+- cmd: conda install python=%PYTHON% numpy scipy=1.0.1 mkl==2018.0.2 pip --quiet
 - cmd: pip install matplotlib
-- cmd: pip install testflo
 - cmd: cd C:\projects\blue*
-- cmd: pip install -e .[develop]
-- cmd: pip install -e .[docs]
+- cmd: pip install -e .[develop,docs]
 - cmd: conda list
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,28 +1,36 @@
 build: off
 
-image:
-- Ubuntu
-- Visual Studio 2015
-
 environment:
-  PY:
-    - 2.7
-    - 3.6
-    - 3.7
-  NUMPY:
-    - 1.15
-  SCIPY:
-    - 1.1
-  PETSc4PY:
-    - null
-    - 3.10
   matrix:
-    exclude:
-      - image: Visual Studio 2015
-        PETSc4PY: 3.10
-      - image: Ubuntu
-        PETSc4PY: null
-    fast_finish: true
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      PYTHON: 3.7
+      NUMPY: 1.15
+      SCIPY: 1.0.1
+      PETSc: 3.9.1
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      PYTHON: 3.6
+      NUMPY: 1.14
+      SCIPY: 1.0.1
+      PETSc: 3.9.1
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      PYTHON: 2.7
+      NUMPY: 1.14
+      SCIPY: 1.0.1
+      PETSc: 3.9.1
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PYTHON: 2.7
+      MKL: 2018.0.2  # Math Kernel Library
+      NUMPY: 1.14
+      SCIPY: 1.0.1
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      PYTHON: 3.6
+      MKL: 2018.0.2  # Math Kernel Library
+      NUMPY: 1.14
+      SCIPY: 1.0.1
 
   encrypted_74d70a284b7d_key:
     secure: 7u/kPupG0BmwqAJOLeyGMPakwj3lqukKHXsxEP4+6aX+Huu8VH2ZkDNq6GYlaw6HGJHi2JTAal9VDgOpZc9RMlweOrXJiNFWS3Iu0chy+L4=
@@ -52,52 +60,44 @@ install:
     sudo apt-get -y install openmpi-bin;
 
     echo "Building python environment...";
-    wget "https://repo.continuum.io/miniconda/Miniconda${PY:0:1}-4.5.11-Linux-x86_64.sh" -O miniconda.sh;
+    wget "https://repo.continuum.io/miniconda/Miniconda${PYTHON:0:1}-4.5.11-Linux-x86_64.sh" -O miniconda.sh;
     chmod +x miniconda.sh;
     ./miniconda.sh -b  -p $HOME/miniconda;
     export PATH=$HOME/miniconda/bin:$PATH;
 
-    conda create --yes -n PY$PY python=$PY;
-    source $HOME/miniconda/bin/activate PY$PY;
+    conda create --yes -n PY$PYTHON python=$PYTHON;
+    source $HOME/miniconda/bin/activate PY$PYTHON;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
-
-    echo "Installing forked python packages";
     pip install git+https://github.com/swryan/coveralls-python@work;
     pip install git+https://github.com/OpenMDAO/testflo.git;
 
-    echo "Cloning pyOptSparse source code from OpenMDAO's fork"
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
 
-    if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
+    if [ "$SNOPT_LOCATION" ] && [ "${PYTHON:0:1}" = "3" ]; then
       cd pyoptsparse/pySNOPT;
-      echo "Secure copying Sparse Nonlinear OPTimizer over SSH"
       scp -r "$SNOPT_LOCATION" ./source;
       cd ../..;
     fi
 
-    echo "Building pyOptSparse"
     python setup.py install;
     cd ..;
 
-    if [ "PETSc4PY" ]; then
-      echo "Installing parallel computing dependencies"
+    if [ "$PETSc" ]; then
       pip install mpi4py petsc4py==$PETSc;
     fi
 
-    echo "Installing OpenMDAO"
     pip install .[develop,docs];
     conda list;
 
-# Set conda path based on Python version
-- cmd: if %PY% GTR 3 (set CONDA="C:\\Miniconda3%PY:~2%-x64") else (set CONDA="C:\\Miniconda-x64")
+- cmd: if %PYTHON% GTR 3 (set CONDA="C:\\Miniconda3%PYTHON:~2%-x64") else (set CONDA="C:\\Miniconda-x64")
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
 - cmd: conda update conda
-- cmd: conda install python=%PY% make numpy=%NUMPY% pip scipy=%SCIPY% --quiet
+- cmd: conda install python=%PYTHON% numpy=%NUMPY% scipy=%SCIPI% mkl==%MKL% pip --quiet
 - cmd: cd C:\projects\blue*
 - cmd: pip install -e .[develop,docs]
 - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,32 +1,28 @@
 build: off
 
+image:
+- Ubuntu
+- Visual Studio 2015
+
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      PY: 3.7
-      NUMPY: 1.15
-      SCIPY: 1.0.1
-      PETSc: 3.9.1
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      PY: 3.6
-      NUMPY: 1.14
-      SCIPY: 1.0.1
-      PETSc: 3.9.1
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
-      PY: 2.7
-      NUMPY: 1.14
-      SCIPY: 1.0.1
-      PETSc: 3.9.1
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PYTHON: 2.7
-      CONDA: "C:\\Miniconda-x64"
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      PYTHON: 3.6
-      CONDA: "C:\\Miniconda36-x64"
+    PY:
+      - 2.7
+      - 3.6
+      - 3.7
+    NUMPY:
+      - 1.15
+    SCIPY:
+      - 1.1
+    PETSc4PY:
+      - null
+      - 3.10
+    exclude:
+      - image: Visual Studio 2015
+        PETSc4PY: 3.10
+      - image: Ubuntu
+        PETSc4PY: null
+    fast_finish: true
 
   encrypted_74d70a284b7d_key:
     secure: 7u/kPupG0BmwqAJOLeyGMPakwj3lqukKHXsxEP4+6aX+Huu8VH2ZkDNq6GYlaw6HGJHi2JTAal9VDgOpZc9RMlweOrXJiNFWS3Iu0chy+L4=
@@ -64,36 +60,44 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig;
 
     pip install --upgrade pip;
+
+    echo "Installing forked python packages";
     pip install git+https://github.com/swryan/coveralls-python@work;
     pip install git+https://github.com/OpenMDAO/testflo.git;
 
+    echo "Cloning pyOptSparse source code from OpenMDAO's fork"
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
 
     if [ "$SNOPT_LOCATION" ] && [ "${PY:0:1}" = "3" ]; then
       cd pyoptsparse/pySNOPT;
+      echo "Secure copying Sparse Nonlinear OPTimizer over SSH"
       scp -r "$SNOPT_LOCATION" ./source;
       cd ../..;
     fi
 
+    echo "Building pyOptSparse"
     python setup.py install;
     cd ..;
 
-    if [ "$PETSc" ]; then
+    if [ "PETSc4PY" ]; then
+      echo "Installing parallel computing dependencies"
       pip install mpi4py petsc4py==$PETSc;
     fi
 
+    echo "Installing OpenMDAO"
     pip install .[develop,docs];
     conda list;
 
+# Set conda path based on Python version
+- cmd: if %PY% GTR 3 (set CONDA="C:\\Miniconda3%PY:~2%-x64") else (set CONDA="C:\\Miniconda-x64")
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
 - cmd: conda update conda
-- cmd: conda install python=%PYTHON% numpy scipy=1.0.1 mkl==2018.0.2 pip --quiet
-- cmd: pip install matplotlib
+- cmd: conda install python=%PY% make numpy=%NUMPY% pip scipy=%SCIPY% --quiet
 - cmd: cd C:\projects\blue*
 - cmd: pip install -e .[develop,docs]
 - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,7 +89,7 @@ install:
 
     conda install --yes matplotlib;
 
-    pip install .;
+    pip install .[develop];
     conda list;
 
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
@@ -99,7 +99,7 @@ install:
 - cmd: pip install matplotlib
 - cmd: pip install testflo
 - cmd: cd C:\projects\blue*
-- cmd: pip install -e .
+- cmd: pip install -e .[develop]
 - cmd: conda list
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -104,7 +104,7 @@ install:
     fi
 
     echo ">>> Installing OpenMDAO";
-    pip install .[develop,docs];
+    pip install .[all];
     conda list;
 
 - cmd: if %PYTHON% GTR 3 (set CONDA="C:\\Miniconda3%PYTHON:~2%-x64") else (set CONDA="C:\\Miniconda-x64")
@@ -113,7 +113,7 @@ install:
 - cmd: conda update conda
 - cmd: conda install python=%PYTHON% numpy=%NUMPY% scipy=%SCIPY% pip --quiet
 - cmd: cd C:\projects\blue*
-- cmd: pip install -e .[develop,docs]
+- cmd: pip install -e .[all]
 - cmd: conda list
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,9 +64,10 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig;
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
+    pip install git+https://github.com/swryan/coveralls-python@work;
 
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
@@ -84,6 +85,7 @@ install:
       pip install mpi4py petsc4py==$PETSc;
     fi
 
+    pip install .[develop,docs];
     conda list;
 
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -64,7 +64,7 @@ install:
     conda create --yes -n PY$PY python=$PY;
     source $HOME/miniconda/bin/activate PY$PY;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig
+    conda install --yes numpy=$NUMPY scipy=$SCIPY coveralls cython matplotlib swig;
 
     pip install --upgrade pip;
 
@@ -80,8 +80,9 @@ install:
     pip install .[develop,docs];
     cd ..;
 
-    pip install mpi4py;
-    pip install petsc4py==$PETSc;
+    if [ "$PETSc" ]; then
+      pip install mpi4py petsc4py==$PETSc;
+    fi
 
     conda list;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ install:
       cd ../..;
     fi
 
-    pip install .[develop,docs];
+    python setup.py install;
     cd ..;
 
     if [ "$PETSc" ]; then

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,11 @@ environment:
       PYTHON: 3.6
       NUMPY: 1.14
       SCIPY: 1.0.1
-      PETSc: 3.9.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PYTHON: 2.7
       NUMPY: 1.14
       SCIPY: 1.0.1
-      PETSc: 3.9.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PYTHON: 2.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,37 +59,51 @@ install:
     sudo apt-get -y install libopenmpi-dev;
     sudo apt-get -y install openmpi-bin;
 
-    echo "Building python environment...";
+    echo ">>> Building python environment";
+    echo " >> Installing conda";
+    echo "  > Downloading miniconda";
     wget "https://repo.continuum.io/miniconda/Miniconda${PYTHON:0:1}-4.5.11-Linux-x86_64.sh" -O miniconda.sh;
     chmod +x miniconda.sh;
+    echo "  > Installing miniconda";
     ./miniconda.sh -b  -p $HOME/miniconda;
     export PATH=$HOME/miniconda/bin:$PATH;
 
+    echo " >> Creating conda environment";
     conda create --yes -n PY$PYTHON python=$PYTHON;
     source $HOME/miniconda/bin/activate PY$PYTHON;
 
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
+    echo " >> Installing non-pure Python dependencies from conda";
+    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig;
 
     pip install --upgrade pip;
+
+    echo " >> Installing forked python packages";
     pip install git+https://github.com/swryan/coveralls-python@work;
     pip install git+https://github.com/OpenMDAO/testflo.git;
 
+    echo " >> Installing pyOptSparse";
+    echo "  > Cloning pyOptSparse from OpenMDAO's fork";
     git clone https://github.com/OpenMDAO/pyoptsparse.git;
     cd pyoptsparse;
 
     if [ "$SNOPT_LOCATION" ] && [ "${PYTHON:0:1}" = "3" ]; then
       cd pyoptsparse/pySNOPT;
+      echo "  > Secure copying SNOPT over SSH";
       scp -r "$SNOPT_LOCATION" ./source;
       cd ../..;
     fi
 
+    echo "  > Install pyOptSparse";
     python setup.py install;
     cd ..;
 
     if [ "$PETSc" ]; then
-      pip install mpi4py petsc4py==$PETSc;
+      echo " >> Installing parallel processing dependencies";
+      pip install mpi4py;
+      pip install petsc4py==$PETSc;
     fi
 
+    echo ">>> Installing OpenMDAO";
     pip install .[develop,docs];
     conda list;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,17 +18,17 @@ environment:
       PYTHON: 2.7
       NUMPY: 1.15
       SCIPY: 1.0.1
-      PETSc: 3.9.1
+      # PETSc: 3.9.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PYTHON: 2.7
-      MKL: 2018.0.2  # Math Kernel Library
+      # MKL: 2018.0.2  # Math Kernel Library
       NUMPY: 1.15
       SCIPY: 1.0.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PYTHON: 3.6
-      MKL: 2018.0.2  # Math Kernel Library
+      # MKL: 2018.0.2  # Math Kernel Library
       NUMPY: 1.15
       SCIPY: 1.0.1
 
@@ -111,7 +111,7 @@ install:
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
 - cmd: conda update conda
-- cmd: conda install python=%PYTHON% numpy=%NUMPY% scipy=%SCIPI% mkl==%MKL% pip --quiet
+- cmd: conda install python=%PYTHON% numpy=%NUMPY% scipy=%SCIPY% pip --quiet
 - cmd: cd C:\projects\blue*
 - cmd: pip install -e .[develop,docs]
 - cmd: conda list

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,18 +5,18 @@ image:
 - Visual Studio 2015
 
 environment:
+  PY:
+    - 2.7
+    - 3.6
+    - 3.7
+  NUMPY:
+    - 1.15
+  SCIPY:
+    - 1.1
+  PETSc4PY:
+    - null
+    - 3.10
   matrix:
-    PY:
-      - 2.7
-      - 3.6
-      - 3.7
-    NUMPY:
-      - 1.15
-    SCIPY:
-      - 1.1
-    PETSc4PY:
-      - null
-      - 3.10
     exclude:
       - image: Visual Studio 2015
         PETSc4PY: 3.10

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,24 +10,26 @@ environment:
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PYTHON: 3.6
-      NUMPY: 1.14
+      NUMPY: 1.15
       SCIPY: 1.0.1
+      PETSc: 3.9.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PYTHON: 2.7
-      NUMPY: 1.14
+      NUMPY: 1.15
       SCIPY: 1.0.1
+      PETSc: 3.9.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PYTHON: 2.7
       MKL: 2018.0.2  # Math Kernel Library
-      NUMPY: 1.14
+      NUMPY: 1.15
       SCIPY: 1.0.1
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       PYTHON: 3.6
       MKL: 2018.0.2  # Math Kernel Library
-      NUMPY: 1.14
+      NUMPY: 1.15
       SCIPY: 1.0.1
 
   encrypted_74d70a284b7d_key:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -67,7 +67,6 @@ install:
     conda install --yes numpy=$NUMPY scipy=$SCIPY cython matplotlib swig;
 
     pip install --upgrade pip;
-    # Install customized packages
     pip install git+https://github.com/swryan/coveralls-python@work;
     pip install git+https://github.com/OpenMDAO/testflo.git;
 

--- a/openmdao/docs/conf.py
+++ b/openmdao/docs/conf.py
@@ -4,9 +4,7 @@
 import sys
 import os
 import importlib
-import textwrap
 
-from numpydoc.docscrape import NumpyDocString, Reader
 from mock import Mock
 
 from openmdao.docs.config_params import MOCK_MODULES
@@ -18,7 +16,7 @@ for mod_name in MOCK_MODULES:
     try:
         importlib.import_module(mod_name)
     except ImportError:
-        sys.modules[mod_name]=Mock()
+        sys.modules[mod_name] = Mock()
 
 # start off running the monkeypatch to keep options/parameters
 # usable in docstring for autodoc.

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -317,9 +317,9 @@ def set_pyoptsparse_opt(optname, fallback=True):
     if force:
         optname = force
 
+    from mock import Mock
     try:
         from pyoptsparse import OPT
-        from mock import Mock
 
         try:
             opt = OPT(optname)

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -7,7 +7,6 @@ import re
 import sys
 import warnings
 import unittest
-from mock import Mock
 from fnmatch import fnmatchcase
 from six import string_types, PY2
 from six.moves import range, cStringIO as StringIO
@@ -320,6 +319,8 @@ def set_pyoptsparse_opt(optname, fallback=True):
 
     try:
         from pyoptsparse import OPT
+        from mock import Mock
+
         try:
             opt = OPT(optname)
             OPTIMIZER = optname

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,13 @@
+import re
+
 from setuptools import setup
 
-# exec this file to set __version__
-exec(open('openmdao/__init__.py').read())
+
+__version__ = re.findall(
+    r"""__version__ = ["']+([0-9\.]*)["']+""",
+    open('openmdao/__init__.py').read(),
+)[0]
+
 
 setup(
     name='openmdao',
@@ -89,22 +95,12 @@ setup(
         'openmdao': ['*/tests/*.py', '*/*/tests/*.py', '*/*/*/tests/*.py']
     },
     install_requires=[
-        'six',
-        'numpydoc',
-        'scipy',
-        'sqlitedict',
-        'pycodestyle==2.3.1',
-        'pydocstyle==2.0.0',
-        'testflo',
-        'parameterized',
-        'pyparsing',
         'networkx>=2.0',
-        'sphinx',
-        'redbaron',
-        'mock',
-        'requests_mock',
-        'tornado',
-        'pyDOE2'
+        'numpy',
+        'pyDOE2',
+        'pyparsing',
+        'scipy',
+        'six',
     ],
     # scripts=['bin/om-pylint.sh']
     entry_points="""
@@ -113,5 +109,22 @@ setup(
     webview=openmdao.devtools.webview:webview_argv
     run_test=openmdao.devtools.run_test:run_test
     openmdao=openmdao.utils.om:openmdao_cmd
-    """
+    """,
+    extras_require={
+        'develop': [
+            'coverage',
+            'parameterized',
+            'pycodestyle==2.3.1',
+            'pydocstyle==2.0.0',
+            'testflo',
+        ],
+        'docs': [
+            'matplotlib',
+            'mock',
+            'numpydoc',
+            'redbaron',
+            'sphinx',
+            'tornado',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ optional_dependencies = {
     ],
     'test': [
         'coverage',
+        'mock',
         'parameterized',
         'pycodestyle==2.3.1',
         'pydocstyle==2.0.0',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,32 @@ __version__ = re.findall(
 )[0]
 
 
+optional_dependencies = {
+    'docs': [
+        'matplotlib',
+        'mock',
+        'numpydoc',
+        'redbaron',
+        'sphinx',
+        'tornado',
+    ],
+    'test': [
+        'coverage',
+        'parameterized',
+        'pycodestyle==2.3.1',
+        'pydocstyle==2.0.0',
+        'testflo',
+    ],
+}
+
+# Add an optional dependency that concatenates all others
+optional_dependencies['all'] = sorted([
+    dependency
+    for dependencies in optional_dependencies.values()
+    for dependency in dependencies
+])
+
+
 setup(
     name='openmdao',
     version=__version__,
@@ -110,21 +136,5 @@ setup(
     run_test=openmdao.devtools.run_test:run_test
     openmdao=openmdao.utils.om:openmdao_cmd
     """,
-    extras_require={
-        'develop': [
-            'coverage',
-            'parameterized',
-            'pycodestyle==2.3.1',
-            'pydocstyle==2.0.0',
-            'testflo',
-        ],
-        'docs': [
-            'matplotlib',
-            'mock',
-            'numpydoc',
-            'redbaron',
-            'sphinx',
-            'tornado',
-        ],
-    },
+    extras_require=optional_dependencies,
 )


### PR DESCRIPTION
This pull request is to help with building a conda recipe for **OpenMDAO** that removes the current dependencies that are not required for running **OpenMDAO** and provides them as `extras` that can be installed only if needed.

* Broke apart dependencies not necessary for running **OpenMDAO** into `develop` and `docs` in `setup.py`.
* Rewrote `README.md` and added instructions for installing the new optional dependencies and for testing a local install of **OpenMDAO**.
* Removed `exec` call for defining `__version__` in `setup.py`.
* Removed unnecessary imports in `conf.py`.
* Added missing auto-generated files to `.gitignore`.
* Updated `appveyor.yml` and `.travis.yml` to install optional dependencies and cleaned their installation scripts to make them more concise and consistent.