### PR TITLE
implement utility function for asserting a warning in unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 
     pip install --upgrade pip;
     pip install redbaron;
-    pip install git+https://github.com/OpenMDAO/testflo.git;
+    pip install git+https://github.com/swryan/testflo.git@test;
     pip install coverage;
     pip install git+https://github.com/swryan/coveralls-python@work;
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ install:
 
     pip install --upgrade pip;
     pip install redbaron;
-    pip install git+https://github.com/swryan/testflo.git@test;
+    pip install git+https://github.com/OpenMDAO/testflo.git;
     pip install coverage;
     pip install git+https://github.com/swryan/coveralls-python@work;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
 
     pip install --upgrade pip;
     pip install redbaron;
-    pip install git+https://github.com/swryan/testflo.git@test;
+    pip install git+https://github.com/OpenMDAO/testflo.git;
     pip install coverage;
     pip install git+https://github.com/swryan/coveralls-python@work;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,7 +68,7 @@ install:
 
     pip install --upgrade pip;
     pip install redbaron;
-    pip install git+https://github.com/OpenMDAO/testflo.git;
+    pip install git+https://github.com/swryan/testflo.git@test;
     pip install coverage;
     pip install git+https://github.com/swryan/coveralls-python@work;
 

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -12,7 +12,7 @@ from scipy.optimize import fsolve
 from openmdao.api import Problem, ExternalCodeComp, AnalysisError
 from openmdao.components.external_code_comp import STDOUT
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 DIRECTORY = os.path.dirname((os.path.abspath(__file__)))
 
@@ -516,7 +516,6 @@ class TestExternalCodeCompFeature(unittest.TestCase):
 # to ensure we get the warning and the correct answer.
 # self-contained, to be removed when class name goes away.
 from openmdao.api import ExternalCode
-import warnings
 
 
 class DeprecatedExternalCodeForTesting(ExternalCode):
@@ -533,13 +532,10 @@ class TestDeprecatedExternalCode(unittest.TestCase):
         shutil.copy(os.path.join(DIRECTORY, 'extcode_example.py'),
                     os.path.join(self.tempdir, 'extcode_example.py'))
 
-        with warnings.catch_warnings(record=True) as w:
-            self.extcode = DeprecatedExternalCodeForTesting()
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
         msg = "'ExternalCode' has been deprecated. Use 'ExternalCodeComp' instead."
-        self.assertEqual(str(w[0].message), msg)
+
+        with assert_warning(DeprecationWarning, msg):
+            self.extcode = DeprecatedExternalCodeForTesting()
 
         self.prob = Problem()
 

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -10,7 +10,7 @@ from openmdao.api import Problem, IndepVarComp, Group, ExecComp, ScipyOptimizeDr
 from openmdao.components.ks_comp import KSComp
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_stress import MultipointBeamGroup
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
 class TestKSFunction(unittest.TestCase):
@@ -138,7 +138,6 @@ class TestKSFunction(unittest.TestCase):
         # to ensure we get the warning and the correct answer.
         # self-contained, to be removed when class name goes away.
         from openmdao.components.ks_comp import KSComponent  # deprecated
-        import warnings
 
         prob = Problem()
         prob.model = model = Group()
@@ -146,12 +145,10 @@ class TestKSFunction(unittest.TestCase):
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2,))))
         model.add_subsystem('comp', DoubleArrayComp())
 
-        with warnings.catch_warnings(record=True) as w:
-            model.add_subsystem('ks', KSComponent(width=2))
+        msg = "'KSComponent' has been deprecated. Use 'KSComp' instead."
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "'KSComponent' has been deprecated. Use 'KSComp' instead.")
+        with assert_warning(DeprecationWarning, msg):
+            model.add_subsystem('ks', KSComponent(width=2))
 
         model.connect('px.x', 'comp.x1')
         model.connect('comp.y2', 'ks.g')

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -10,7 +10,8 @@ from openmdao.core.problem import Problem
 from openmdao.core.group import Group
 from openmdao.core.indepvarcomp import IndepVarComp
 from openmdao.core.analysis_error import AnalysisError
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+
 import numpy as np
 import unittest
 
@@ -1264,15 +1265,11 @@ class TestMetaModelStructuredCompMapFeature(unittest.TestCase):
         import numpy as np
         from openmdao.api import Group, Problem, IndepVarComp
         from openmdao.components.meta_model_structured_comp import MetaModelStructured  # deprecated
-        import warnings
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'MetaModelStructured' has been deprecated. Use 'MetaModelStructuredComp' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             xor_interp = MetaModelStructured(method='slinear')
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "'MetaModelStructured' has been deprecated. Use "
-                                            "'MetaModelStructuredComp' instead.")
 
         # set up inputs and outputs
         xor_interp.add_input('x', 0.0, training_data=np.array([0.0, 1.0]), units=None)

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -4,13 +4,11 @@ Unit tests for the unstructured metamodel component.
 from math import sin
 import numpy as np
 import unittest
-import warnings
 
 from openmdao.api import Group, Problem, MetaModelUnStructuredComp, IndepVarComp, ResponseSurface, \
     FloatKrigingSurrogate, KrigingSurrogate, ScipyOptimizeDriver, SurrogateModel, NearestNeighbor
 
-from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.utils.general_utils import reset_warning_registry
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.utils.logger_utils import TestLogger
 
 class MetaModelTestCase(unittest.TestCase):
@@ -746,15 +744,11 @@ class MetaModelTestCase(unittest.TestCase):
         # to ensure we get the warning and the correct answer.
         # self-contained, to be removed when class name goes away.
         from openmdao.components.meta_model_unstructured_comp import MetaModelUnStructured  # deprecated
-        import warnings
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'MetaModelUnStructured' has been deprecated. Use 'MetaModelUnStructuredComp' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm = MetaModelUnStructured()
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "'MetaModelUnStructured' has been deprecated. Use "
-                                            "'MetaModelUnStructuredComp' instead.")
 
         mm.add_input('x1', 0.)
         mm.add_input('x2', 0.)
@@ -762,14 +756,12 @@ class MetaModelTestCase(unittest.TestCase):
         mm.add_output('y1', 0.)
         mm.add_output('y2', 0., surrogate=FloatKrigingSurrogate())
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The 'default_surrogate' attribute provides backwards compatibility " \
+              "with earlier version of OpenMDAO; use options['default_surrogate'] " \
+              "instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm.default_surrogate = ResponseSurface()
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'default_surrogate' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use options['default_surrogate'] "
-                         "instead.")
 
         # add metamodel to a problem
         prob = Problem(model=Group())
@@ -784,16 +776,14 @@ class MetaModelTestCase(unittest.TestCase):
         self.assertTrue(isinstance(surrogate, FloatKrigingSurrogate))
 
         # populate training data
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The 'metadata' attribute provides backwards compatibility " \
+              "with earlier version of OpenMDAO; use 'options' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm.metadata['train:x1'] = [1.0, 2.0, 3.0]
             mm.metadata['train:x2'] = [1.0, 3.0, 4.0]
             mm.metadata['train:y1'] = [3.0, 2.0, 1.0]
             mm.metadata['train:y2'] = [1.0, 4.0, 7.0]
-        self.assertEqual(len(w), 4)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'metadata' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use 'options' instead.")
 
         # run problem for provided data point and check prediction
         prob['mm.x1'] = 2.0
@@ -815,14 +805,12 @@ class MetaModelTestCase(unittest.TestCase):
         assert_rel_error(self, prob['mm.y1'], 1.5934, .001)
 
         # change default surrogate, re-setup and check that metamodel re-trains
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The 'default_surrogate' attribute provides backwards compatibility with " \
+              "earlier version of OpenMDAO; use options['default_surrogate'] instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm.default_surrogate = FloatKrigingSurrogate()
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'default_surrogate' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use options['default_surrogate'] "
-                         "instead.")
+
         prob.setup(check=False)
 
         surrogate = mm._metadata('y1').get('surrogate')
@@ -841,15 +829,11 @@ class MetaModelTestCase(unittest.TestCase):
         # to ensure we get the warning and the correct answer.
         # self-contained, to be removed when class name goes away.
         from openmdao.components.meta_model_unstructured_comp import MetaModel  # deprecated
-        import warnings
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'MetaModel' has been deprecated. Use 'MetaModelUnStructuredComp' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm = MetaModel()
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "'MetaModel' has been deprecated. Use "
-                         "'MetaModelUnStructuredComp' instead.")
 
         mm.add_input('x1', 0.)
         mm.add_input('x2', 0.)
@@ -857,14 +841,11 @@ class MetaModelTestCase(unittest.TestCase):
         mm.add_output('y1', 0.)
         mm.add_output('y2', 0., surrogate=FloatKrigingSurrogate())
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The 'default_surrogate' attribute provides backwards compatibility with " \
+              "earlier version of OpenMDAO; use options['default_surrogate'] instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm.default_surrogate = ResponseSurface()
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'default_surrogate' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use options['default_surrogate'] "
-                         "instead.")
 
         # add metamodel to a problem
         prob = Problem(model=Group())
@@ -879,16 +860,14 @@ class MetaModelTestCase(unittest.TestCase):
         self.assertTrue(isinstance(surrogate, FloatKrigingSurrogate))
 
         # populate training data
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The 'metadata' attribute provides backwards compatibility " \
+              "with earlier version of OpenMDAO; use 'options' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm.metadata['train:x1'] = [1.0, 2.0, 3.0]
             mm.metadata['train:x2'] = [1.0, 3.0, 4.0]
             mm.metadata['train:y1'] = [3.0, 2.0, 1.0]
             mm.metadata['train:y2'] = [1.0, 4.0, 7.0]
-        self.assertEqual(len(w), 4)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'metadata' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use 'options' instead.")
 
         # run problem for provided data point and check prediction
         prob['mm.x1'] = 2.0
@@ -910,14 +889,12 @@ class MetaModelTestCase(unittest.TestCase):
         assert_rel_error(self, prob['mm.y1'], 1.5934, .001)
 
         # change default surrogate, re-setup and check that metamodel re-trains
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The 'default_surrogate' attribute provides backwards compatibility with " \
+              "earlier version of OpenMDAO; use options['default_surrogate'] instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm.default_surrogate = FloatKrigingSurrogate()
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'default_surrogate' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use options['default_surrogate'] "
-                         "instead.")
+
         prob.setup(check=False)
 
         surrogate = mm._metadata('y1').get('surrogate')
@@ -1005,16 +982,16 @@ class MetaModelTestCase(unittest.TestCase):
 
         # Test with user not explicitly setting fd
         trig = Trig()
-        with warnings.catch_warnings(record=True) as w:
-            with reset_warning_registry():
-                prob = no_surrogate_test_setup(trig)
-        self.assertTrue(issubclass(w[0].category, RuntimeWarning))
-        expected_msg = "Because the MetaModelUnStructuredComp 'trig' uses a surrogate which does not define a linearize method,\n" \
-        "OpenMDAO will use finite differences to compute derivatives. Some of the derivatives will be computed\n" \
-        "using default finite difference options because they were not explicitly declared.\n" \
-        "The derivatives computed using the defaults are:\n" \
-        "    trig.sin_x, trig.x\n"
-        self.assertEqual(expected_msg, str(w[0].message))
+
+        msg = "Because the MetaModelUnStructuredComp 'trig' uses a surrogate which does not define a linearize method,\n" \
+              "OpenMDAO will use finite differences to compute derivatives. Some of the derivatives will be computed\n" \
+              "using default finite difference options because they were not explicitly declared.\n" \
+              "The derivatives computed using the defaults are:\n" \
+              "    trig.sin_x, trig.x\n"
+
+        with assert_warning(RuntimeWarning, msg):
+            prob = no_surrogate_test_setup(trig)
+
         J = prob.compute_totals(of=['trig.sin_x'], wrt=['indep.x'])
         deriv_using_fd = J[('trig.sin_x', 'indep.x')]
         assert_rel_error(self, deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
@@ -1076,15 +1053,15 @@ class MetaModelTestCase(unittest.TestCase):
         prob['indep.x1'] = 5.0
         prob['indep.x2'] = 5.0
         trig.train = False
-        with warnings.catch_warnings(record=True) as w:
+
+        msg = "Because the MetaModelUnStructuredComp 'trig' uses a surrogate which does not define a linearize method,\n" \
+              "OpenMDAO will use finite differences to compute derivatives. Some of the derivatives will be computed\n" \
+              "using default finite difference options because they were not explicitly declared.\n" \
+              "The derivatives computed using the defaults are:\n" \
+              "    trig.sin_x, trig.x2\n"
+
+        with assert_warning(RuntimeWarning, msg):
             prob.run_model()
-        self.assertTrue(issubclass(w[0].category, RuntimeWarning))
-        expected_msg = "Because the MetaModelUnStructuredComp 'trig' uses a surrogate which does not define a linearize method,\n" \
-        "OpenMDAO will use finite differences to compute derivatives. Some of the derivatives will be computed\n" \
-        "using default finite difference options because they were not explicitly declared.\n" \
-        "The derivatives computed using the defaults are:\n" \
-        "    trig.sin_x, trig.x2\n"
-        self.assertEqual(expected_msg, str(w[0].message))
 
         self.assertEqual('fd', trig._subjacs_info[('trig.sin_x', 'trig.x1')]['method'])
         self.assertEqual('backward', trig._subjacs_info[('trig.sin_x', 'trig.x1')]['form'])

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -3,7 +3,7 @@ import unittest
 
 from openmdao.api import Group, Problem, MultiFiMetaModelUnStructuredComp, MultiFiSurrogateModel, \
      MultiFiCoKrigingSurrogate
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
 class MockSurrogate(MultiFiSurrogateModel):
@@ -351,15 +351,11 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
         # to ensure we get the warning and the correct answer.
         # self-contained, to be removed when class name goes away.
         from openmdao.components.multifi_meta_model_unstructured_comp import MultiFiMetaModelUnStructured  # deprecated
-        import warnings
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'MultiFiMetaModelUnStructured' has been deprecated. Use 'MultiFiMetaModelUnStructuredComp' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm = MultiFiMetaModelUnStructured(nfi=3)
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "'MultiFiMetaModelUnStructured' has been deprecated. Use "
-                                            "'MultiFiMetaModelUnStructuredComp' instead.")
 
         mm.add_input('x', 0.)
         mm.add_output('y', 0.)
@@ -380,15 +376,11 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
         # to ensure we get the warning and the correct answer.
         # self-contained, to be removed when class name goes away.
         from openmdao.components.multifi_meta_model_unstructured_comp import MultiFiMetaModel  # deprecated
-        import warnings
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'MultiFiMetaModel' component has been deprecated. Use 'MultiFiMetaModelUnStructuredComp' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             mm = MultiFiMetaModel(nfi=3)
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "'MultiFiMetaModel' component has been deprecated. Use "
-                                            "'MultiFiMetaModelUnStructuredComp' instead.")
 
         mm.add_input('x', 0.)
         mm.add_output('y', 0.)

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -2,8 +2,8 @@
 
 import sys
 import unittest
-import warnings
 import copy
+
 from six import assertRaisesRegex, StringIO, assertRegex
 
 import numpy as np

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -6,14 +6,13 @@ from six import assertRaisesRegex
 from six.moves import range
 
 import itertools
-import warnings
 
 import numpy as np
 from parameterized import parameterized
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent, \
     NonlinearRunOnce, NonLinearRunOnce
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.test_suite.components.sellar import SellarDis2
 
 
@@ -96,13 +95,11 @@ class TestGroup(unittest.TestCase):
         p = Problem()
         p.model.add_subsystem('indep', IndepVarComp('x', 5.0))
         p.model.add_subsystem('comp', ExecComp('b=2*a'))
-        with warnings.catch_warnings(record=True) as w:
-            p.model.nonlinear_solver = NonLinearRunOnce()
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "NonLinearRunOnce is deprecated.  Use NonlinearRunOnce instead.")
+        msg = "NonLinearRunOnce is deprecated.  Use NonlinearRunOnce instead."
+
+        with assert_warning(DeprecationWarning, msg):
+            p.model.nonlinear_solver = NonLinearRunOnce()
 
     def test_group_simple(self):
         from openmdao.api import ExecComp, Problem
@@ -119,14 +116,11 @@ class TestGroup(unittest.TestCase):
         model = Group()
         ecomp = ExecComp('b=2.0*a', a=3.0, b=6.0)
 
-        with warnings.catch_warnings(record=True) as w:
-            comp1 = model.add('comp1', ecomp)
+        msg = "The 'add' method provides backwards compatibility with OpenMDAO <= 1.x ; " \
+              "use 'add_subsystem' instead."
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'add' method provides backwards compatibility "
-                         "with OpenMDAO <= 1.x ; use 'add_subsystem' instead.")
+        with assert_warning(DeprecationWarning, msg):
+            comp1 = model.add('comp1', ecomp)
 
         self.assertTrue(ecomp is comp1)
 
@@ -1046,10 +1040,9 @@ class TestConnect(unittest.TestCase):
 
         msg = "Output 'src.x2' with units of 'degC' is connected " \
               "to input 'tgt.x' which has no units."
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+
+        with assert_warning(UserWarning, msg):
             prob.setup(check=False)
-            self.assertEqual(str(w[-1].message), msg)
 
     def test_connect_incompatible_units(self):
         msg = "Output units of 'degC' for 'src.x2' are incompatible " \
@@ -1074,15 +1067,14 @@ class TestConnect(unittest.TestCase):
 
         prob.model.connect('px1.x1', 'src.x1')
         prob.model.connect('src.x2', 'tgt.x')
+
         prob.set_solver_print(level=0)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            prob.setup(check=False)
+        msg = "Input 'tgt.x' with units of 'degC' is " \
+              "connected to output 'src.x2' which has no units."
 
-            self.assertEqual(str(w[-1].message),
-                             "Input 'tgt.x' with units of 'degC' is "
-                             "connected to output 'src.x2' which has no units.")
+        with assert_warning(UserWarning, msg):
+            prob.setup(check=False)
 
         prob.run_model()
 
@@ -1096,13 +1088,11 @@ class TestConnect(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            prob.setup(check=False)
+        msg = "Input 'tgt.y' with units of 'degC' is " \
+              "connected to output 'src.y' which has no units."
 
-            self.assertEqual(str(w[-1].message),
-                             "Input 'tgt.y' with units of 'degC' is "
-                             "connected to output 'src.y' which has no units.")
+        with assert_warning(UserWarning, msg):
+            prob.setup(check=False)
 
         prob.run_model()
 

--- a/openmdao/core/tests/test_parallel_fd.py
+++ b/openmdao/core/tests/test_parallel_fd.py
@@ -4,13 +4,13 @@ from __future__ import print_function
 import time
 import numpy as np
 import unittest
-import warnings
 TestCase = unittest.TestCase
+
 from six import iterkeys
 
 from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, ExplicitComponent, ExecComp, DirectSolver
 from openmdao.utils.mpi import MPI
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.test_suite.parametric_suite import parametric_suite
 from openmdao.test_suite.components.matmultcomp import MatMultComp
 
@@ -466,22 +466,16 @@ class ParFDWarningsTestCase(unittest.TestCase):
         self.mat = np.random.random(5 * size).reshape((5, size)) - 0.5
 
     def test_total_no_mpi(self):
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'': MPI is not active but num_par_fd = 3. No parallel finite difference will be performed."
+
+        with assert_warning(UserWarning, msg):
             _setup_problem(self.mat, total_method='fd', total_num_par_fd = 3, approx_totals=True)
 
-        self.assertEqual(len(w), 1)
-        self.assertEqual(str(w[0].message),
-                         "'': MPI is not active but num_par_fd = 3. No parallel finite difference will be performed.")
-
     def test_partial_no_mpi(self):
-        with warnings.catch_warnings(record=True) as w:
+        msg = "'comp': MPI is not active but num_par_fd = 3. No parallel finite difference will be performed."
+
+        with assert_warning(UserWarning, msg):
             _setup_problem(self.mat, partial_method='fd', partial_num_par_fd = 3)
-
-        self.assertEqual(len(w), 1)
-        self.assertEqual(str(w[0].message),
-                         "'comp': MPI is not active but num_par_fd = 3. No parallel finite difference will be performed.")
-
-
 
 
 @unittest.skipUnless(PETScVector, "PETSc is required.")

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2,7 +2,7 @@
 
 import sys
 import unittest
-import warnings
+
 from six import assertRaisesRegex, StringIO, assertRegex
 
 import numpy as np
@@ -11,7 +11,7 @@ from openmdao.core.group import get_relevant_vars
 from openmdao.core.driver import Driver
 from openmdao.api import Problem, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, \
     ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent, NonlinearRunOnce
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
 
@@ -990,15 +990,12 @@ class TestProblem(unittest.TestCase):
 
         prob.setup(mode='fwd')
 
-        with warnings.catch_warnings(record=True) as w:
-            prob.final_setup()
+        msg = "Inefficient choice of derivative mode.  " \
+              "You chose 'fwd' for a problem with 99 design variables and 10 " \
+              "response variables (objectives and nonlinear constraints)."
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, RuntimeWarning))
-        self.assertEqual(str(w[0].message),
-                         "Inefficient choice of derivative mode.  "
-                         "You chose 'fwd' for a problem with 99 design variables and 10 "
-                         "response variables (objectives and nonlinear constraints).")
+        with assert_warning(RuntimeWarning, msg):
+            prob.final_setup()
 
     def test_setup_bad_mode_direction_rev(self):
 
@@ -1015,15 +1012,12 @@ class TestProblem(unittest.TestCase):
 
         prob.setup(mode='rev')
 
-        with warnings.catch_warnings(record=True) as w:
-            prob.final_setup()
+        msg = "Inefficient choice of derivative mode.  " \
+              "You chose 'rev' for a problem with 10 design variables and 20 " \
+              "response variables (objectives and nonlinear constraints)."
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, RuntimeWarning))
-        self.assertEqual(str(w[0].message),
-                         "Inefficient choice of derivative mode.  "
-                         "You chose 'rev' for a problem with 10 design variables and 20 "
-                         "response variables (objectives and nonlinear constraints).")
+        with assert_warning(RuntimeWarning, msg):
+            prob.final_setup()
 
     def test_run_before_setup(self):
         # Test error message when running before setup.
@@ -1072,25 +1066,16 @@ class TestProblem(unittest.TestCase):
     def test_root_deprecated(self):
         # testing the root property
         msg = "The 'root' property provides backwards compatibility " \
-            + "with OpenMDAO <= 1.x ; use 'model' instead."
+              "with OpenMDAO <= 1.x ; use 'model' instead."
 
         prob = Problem()
 
-        # check deprecation on setter
-        with warnings.catch_warnings(record=True) as w:
+        # check deprecation on setter & getter
+        with assert_warning(DeprecationWarning, msg):
             prob.root = Group()
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), msg)
-
-        # check deprecation on getter
-        with warnings.catch_warnings(record=True) as w:
+        with assert_warning(DeprecationWarning, msg):
             prob.root
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), msg)
 
         # testing the root kwarg
         with self.assertRaises(ValueError) as cm:
@@ -1100,11 +1085,11 @@ class TestProblem(unittest.TestCase):
                          "Cannot specify both 'root' and 'model'. "
                          "'root' has been deprecated, please use 'model'.")
 
-        with warnings.catch_warnings(record=True) as w:
-            prob = Problem(root=Group())
+        msg = "The 'root' argument provides backwards " \
+              "compatibility with OpenMDAO <= 1.x ; use 'model' instead."
 
-        self.assertEqual(str(w[0].message), "The 'root' argument provides backwards "
-                         "compatibility with OpenMDAO <= 1.x ; use 'model' instead.")
+        with assert_warning(DeprecationWarning, msg):
+            prob = Problem(root=Group())
 
     def test_args(self):
         # defaults

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -3,12 +3,10 @@
 import unittest
 from six import assertRaisesRegex
 
-import warnings
-
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
 class TestSystem(unittest.TestCase):
@@ -213,47 +211,27 @@ class TestSystem(unittest.TestCase):
 
         model = Group()
 
-        # check nl_solver setter
-        with warnings.catch_warnings(record=True) as w:
+        # check nl_solver setter & getter
+        msg = "The 'nl_solver' attribute provides backwards compatibility " \
+              "with OpenMDAO 1.x ; use 'nonlinear_solver' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             model.nl_solver = DummySolver()
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'nl_solver' attribute provides backwards compatibility "
-                         "with OpenMDAO 1.x ; use 'nonlinear_solver' instead.")
-
-        # check nl_solver getter
-        with warnings.catch_warnings(record=True) as w:
+        with assert_warning(DeprecationWarning, msg):
             solver = model.nl_solver
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'nl_solver' attribute provides backwards compatibility "
-                         "with OpenMDAO 1.x ; use 'nonlinear_solver' instead.")
 
         self.assertTrue(isinstance(solver, DummySolver))
 
-        # check ln_solver setter
-        with warnings.catch_warnings(record=True) as w:
+        # check ln_solver setter & getter
+        msg = "The 'ln_solver' attribute provides backwards compatibility " \
+              "with OpenMDAO 1.x ; use 'linear_solver' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             model.ln_solver = DummySolver()
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'ln_solver' attribute provides backwards compatibility "
-                         "with OpenMDAO 1.x ; use 'linear_solver' instead.")
-
-        # check ln_solver getter
-        with warnings.catch_warnings(record=True) as w:
+        with assert_warning(DeprecationWarning, msg):
             solver = model.ln_solver
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'ln_solver' attribute provides backwards compatibility "
-                         "with OpenMDAO 1.x ; use 'linear_solver' instead.")
 
         self.assertTrue(isinstance(solver, DummySolver))
 
@@ -265,14 +243,11 @@ class TestSystem(unittest.TestCase):
         prob.model.add_subsystem('inputs', IndepVarComp('x', shape=3))
         prob.model.add_subsystem('double', VectorDoublingComp())
 
-        with warnings.catch_warnings(record=True) as w:
-            prob.model.double.metadata['size'] = 3
+        msg = "The 'metadata' attribute provides backwards compatibility " \
+              "with earlier version of OpenMDAO; use 'options' instead."
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message),
-                         "The 'metadata' attribute provides backwards compatibility "
-                         "with earlier version of OpenMDAO; use 'options' instead.")
+        with assert_warning(DeprecationWarning, msg):
+            prob.model.double.metadata['size'] = 3
 
         prob.model.connect('inputs.x', 'double.x')
         prob.setup()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -2,7 +2,7 @@
 
 import unittest
 import sys
-import warnings
+
 from distutils.version import LooseVersion
 
 import numpy as np
@@ -10,7 +10,7 @@ from scipy import __version__ as scipy_version
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ScipyOptimizeDriver, \
     ScipyOptimizer, ExplicitComponent, DirectSolver, NonlinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.utils.general_utils import run_driver
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -24,15 +24,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_scipyoptimizer_deprecation(self):
 
         msg = "'ScipyOptimizer' provides backwards compatibility " \
-            + "with OpenMDAO <= 2.2 ; use 'ScipyOptimizeDriver' instead."
+              "with OpenMDAO <= 2.2 ; use 'ScipyOptimizeDriver' instead."
 
-        # check deprecation on getter
-        with warnings.catch_warnings(record=True) as w:
-            driver = ScipyOptimizer()
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), msg)
+        with assert_warning(DeprecationWarning, msg):
+            ScipyOptimizer()
 
     def test_compute_totals_basic_return_array(self):
         # Make sure 'array' return_format works.

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import errno
 import os
 import unittest
-import warnings
 
 from shutil import rmtree
 from tempfile import mkdtemp, mkstemp
@@ -23,9 +22,8 @@ from openmdao.test_suite.components.expl_comp_array import TestExplCompArray
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
     SellarDis1withDerivatives, SellarDis2withDerivatives, SellarProblem
-from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.utils.general_utils import determine_adder_scaler
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.general_utils import set_pyoptsparse_opt, determine_adder_scaler
 
 from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov
 from openmdao.solvers.nonlinear.newton import NewtonSolver
@@ -1347,7 +1345,11 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob = Problem(model)
         prob.setup()
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "Trying to record options which cannot be pickled on system with name: subs. " \
+              "Use the 'options_excludes' recording option on system objects to avoid " \
+              "attempting to record options which cannot be pickled. Skipping recording " \
+              "options for this system."
+        with assert_warning(RuntimeWarning, msg):
             prob.run_model()
 
         prob.cleanup()
@@ -1356,10 +1358,6 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # no options should have been recorded for d1
         self.assertEqual(len(subs_options._dict), 0)
-
-        # make sure we got the warning we expected
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, RuntimeWarning))
 
     def test_pre_load(self):
         prob = SellarProblem()

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -4,12 +4,10 @@ from __future__ import division, print_function
 
 from six import iteritems
 import unittest
-import warnings
 
 import numpy as np
 
 from openmdao.api import Group, IndepVarComp, Problem, ExecComp, NonlinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.solvers.linear.linear_block_gs import LinearBlockGS
 from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov, ScipyIterativeSolver
 from openmdao.solvers.nonlinear.newton import NewtonSolver
@@ -18,6 +16,7 @@ from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDe
 from openmdao.test_suite.components.misc_components import Comp4LinearCacheTest
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
 # use this to fake out the TestImplicitGroup so it'll use the solver we want.
@@ -45,12 +44,10 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
 
         # use ScipyIterativeSolver here to check for deprecation warning and verify that the deprecated
         # class still gets the right answer without duplicating this test.
-        with warnings.catch_warnings(record=True) as w:
-            group = TestImplicitGroup(lnSolverClass=lambda : ScipyIterativeSolver(solver=self.linear_solver_name))
+        msg = "ScipyIterativeSolver is deprecated.  Use ScipyKrylov instead."
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), "ScipyIterativeSolver is deprecated.  Use ScipyKrylov instead.")
+        with assert_warning(DeprecationWarning, msg):
+            group = TestImplicitGroup(lnSolverClass=lambda : ScipyIterativeSolver(solver=self.linear_solver_name))
 
         p = Problem(group)
         p.setup(check=False)
@@ -151,21 +148,12 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         msg = "The 'preconditioner' property provides backwards compatibility " \
             + "with OpenMDAO <= 1.x ; use 'precon' instead."
 
-        # check deprecation on setter
-        with warnings.catch_warnings(record=True) as w:
+        # check deprecation on setter & getter
+        with assert_warning(DeprecationWarning, msg):
             group.linear_solver.preconditioner = LinearBlockGS()
 
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), msg)
-
-        # check deprecation on getter
-        with warnings.catch_warnings(record=True) as w:
+        with assert_warning(DeprecationWarning, msg):
             group.linear_solver.preconditioner
-
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-        self.assertEqual(str(w[0].message), msg)
 
     def test_linear_solution_cache(self):
         # Test derivatives across a converged Sellar model. When caching

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 from six import iteritems
 
 import unittest
-import warnings
 
 import numpy as np
 
@@ -14,7 +13,7 @@ from openmdao.solvers.nonlinear.broyden import BroydenSolver
 from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStates
 from openmdao.test_suite.components.sellar import SellarStateConnection, SellarDerivatives, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
 class VectorEquation(ImplicitComponent):
@@ -281,14 +280,11 @@ class TestBryoden(unittest.TestCase):
 
         prob.setup(check=False)
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The following states are not covered by a solver, and may have been " \
+              "omitted from the BroydenSolver 'state_vars': mixed.x3, mixed.x45"
+
+        with assert_warning(UserWarning, msg):
             prob.run_model()
-
-        self.assertEqual(len(w), 1)
-
-        msg = "The following states are not covered by a solver, and may have been omitted from the BroydenSolver 'state_vars': mixed.x3, mixed.x45"
-
-        self.assertEqual(str(w[0].message), msg)
 
         # Try again with promoted names.
         prob = Problem()
@@ -306,14 +302,11 @@ class TestBryoden(unittest.TestCase):
 
         prob.setup(check=False)
 
-        with warnings.catch_warnings(record=True) as w:
+        msg = "The following states are not covered by a solver, and may have been " \
+              "omitted from the BroydenSolver 'state_vars': x3, x45"
+
+        with assert_warning(UserWarning, msg):
             prob.run_model()
-
-        self.assertEqual(len(w), 1)
-
-        msg = "The following states are not covered by a solver, and may have been omitted from the BroydenSolver 'state_vars': x3, x45"
-
-        self.assertEqual(str(w[0].message), msg)
 
     def test_mixed_promoted_vars(self):
         # Testing Broyden on a 5 state case split among 3 vars.

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -1,13 +1,13 @@
 """Test the Newton nonlinear solver. """
 
 import unittest
-import warnings
+
 import numpy as np
 
 from openmdao.api import Group, Problem, IndepVarComp, LinearBlockGS, \
     NewtonSolver, ExecComp, ScipyKrylov, ImplicitComponent, \
     DirectSolver, AnalysisError
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.test_suite.components.double_sellar import DoubleSellar, DoubleSellarImplicit, \
      SubSellar
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
@@ -91,16 +91,14 @@ class TestNewton(unittest.TestCase):
         top.model.nonlinear_solver.options['maxiter'] = 10
         top.model.linear_solver = ScipyKrylov()
 
-        msg = "The 'line_search' attribute provides backwards compatibility with OpenMDAO 1.x ; use 'linesearch' instead."
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            top.model.nonlinear_solver.line_search = ArmijoGoldsteinLS(bound_enforcement='vector')
-            self.assertEqual(str(w[-1].message), msg)
+        msg = "The 'line_search' attribute provides backwards compatibility with OpenMDAO 1.x ; " \
+              "use 'linesearch' instead."
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with assert_warning(DeprecationWarning, msg):
+            top.model.nonlinear_solver.line_search = ArmijoGoldsteinLS(bound_enforcement='vector')
+
+        with assert_warning(DeprecationWarning, msg):
             ls = top.model.nonlinear_solver.line_search
-            self.assertEqual(str(w[-1].message), msg)
 
         ls.options['maxiter'] = 10
         ls.options['alpha'] = 1.0

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -184,7 +184,7 @@ class TestNonlinearSolversBugFixes(unittest.TestCase):
     unrelated to the tests in that test object, and doesn't need all the setup/teardown tempfile
     creation and deletion.
     """
-    N_PROCS = 1
+    ISOLATED = True
 
     def test_debug_after_raised_error(self):
         prob = Problem()

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -178,13 +178,26 @@ class TestNonlinearSolvers(unittest.TestCase):
             self.assertEqual(f.read(), self.expected_data)
 
 
-class TestNonlinearSolversBugFixes(unittest.TestCase):
+class TestNonlinearSolversIsolated(unittest.TestCase):
     """
-    Got some odd intermittent failures with this, so moved it to a separate test object. It is
-    unrelated to the tests in that test object, and doesn't need all the setup/teardown tempfile
-    creation and deletion.
+    This test needs to run isolated to preclude interactions in the underlying
+    `warnings` module that is used to raise the singular entry error.
     """
     ISOLATED = True
+
+    def setUp(self):
+        # perform test in temporary directory
+        self.startdir = os.getcwd()
+        self.tempdir = tempfile.mkdtemp(prefix='test_solver')
+        os.chdir(self.tempdir)
+
+    def tearDown(self):
+        # clean up the temporary directory
+        os.chdir(self.startdir)
+        try:
+            shutil.rmtree(self.tempdir)
+        except OSError:
+            pass
 
     def test_debug_after_raised_error(self):
         prob = Problem()

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -184,6 +184,8 @@ class TestNonlinearSolversBugFixes(unittest.TestCase):
     unrelated to the tests in that test object, and doesn't need all the setup/teardown tempfile
     creation and deletion.
     """
+    N_PROCS = 1
+
     def test_debug_after_raised_error(self):
         prob = Problem()
         model = prob.model

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -142,6 +142,7 @@ class TestNonlinearSolvers(unittest.TestCase):
     def test_solver_debug_print_feature(self):
         from openmdao.api import Problem, IndepVarComp, NewtonSolver
         from openmdao.test_suite.test_examples.test_circuit_analysis import Circuit
+        from openmdao.utils.general_utils import printoptions
 
         p = Problem()
         model = p.model
@@ -225,11 +226,12 @@ class TestNonlinearSolversBugFixes(unittest.TestCase):
 
         output = strout.getvalue()
         target = "'thrust_equilibrium_group.thrust_bal.thrust'"
-        self.assertTrue( target in output, msg=target + "NOT FOUND IN" + output)
+        self.assertTrue(target in output, msg=target + "NOT FOUND IN" + output)
 
         # Make sure exception is unchanged.
         expected_msg = "Singular entry found in 'thrust_equilibrium_group' for column associated with state/residual 'thrust'."
         self.assertEqual(expected_msg, str(cm.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -6,10 +6,11 @@ from math import isnan
 from six import raise_from
 from six.moves import zip
 
-from contextlib import contextmanager
-
 import warnings
 import unittest
+
+from contextlib import contextmanager
+from functools import wraps
 
 from openmdao.core.component import Component
 from openmdao.core.group import Group
@@ -44,8 +45,6 @@ def assert_warning(category, msg):
             break
     else:
         raise AssertionError("Did not see expected %s: %s" % (category.__name__, msg))
-
-from functools import wraps
 
 
 def assert_check_partials(data, atol=1e-6, rtol=1e-6):

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -1,6 +1,9 @@
 from openmdao.api import OptionsDictionary
+
 import unittest
-import warnings
+
+from openmdao.utils.assert_utils import assert_warning
+
 from six import PY3, assertRegex
 
 from openmdao.core.explicitcomponent import ExplicitComponent
@@ -121,11 +124,10 @@ class TestOptionsDict(unittest.TestCase):
 
     def test_isvalid_deprecated_type(self):
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        msg = "In declaration of option 'even_test' the '_type' arg is deprecated.  Use 'types' instead."
+
+        with assert_warning(DeprecationWarning, msg):
             self.dict.declare('even_test', type_=int, check_valid=check_even)
-            self.assertEqual(len(w), 1)
-            self.assertEqual(str(w[-1].message), "In declaration of option 'even_test' the '_type' arg is deprecated.  Use 'types' instead.")
 
         self.dict['even_test'] = 2
         self.dict['even_test'] = 4


### PR DESCRIPTION
Pivotal #161510396: When testing, do not make assertions on the number of warnings. Just check for the warning you expect