### PR TITLE
ScipyOptimizeDriver Hessian as user option

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -356,8 +356,11 @@ class ScipyOptimizeDriver(Driver):
             jac = None
 
         if opt in _hessian_optimizers:
-            from scipy.optimize import BFGS  # FIXME temporary, should be option. (P.O.)
-            hess = BFGS()
+            if 'hess' in self.opt_settings:
+                hess = self.opt_settings.pop('hess')
+            else:
+                from scipy.optimize import BFGS  # FIXME temporary, should be option. (P.O.)
+                hess = BFGS()
         else:
             hess = None
 

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -463,6 +463,28 @@ class ScipyOptimizeDriver(Driver):
         return f_new
 
     def _con_val_func(self, x_new, name, dbl, idx):
+        """
+        Return the value of the constraint function requested in args.
+
+        The lower or upper bound is **not** subtracted from the value. Used for optimizers,
+        which take the bounds of the constraints (e.g. trust-constr)
+        
+        Parameters
+        ----------
+        x_new : ndarray
+            Array containing parameter values at new design point.
+        name : string
+            Name of the constraint to be evaluated.
+        dbl : bool
+            True if double sided constraint.
+        idx : float
+            Contains index into the constraint array.
+
+        Returns
+        -------
+        float
+            Value of the constraint function.
+        """
         return self._con_cache[name][idx]
 
     def _confunc(self, x_new, name, dbl, idx):

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -180,7 +180,6 @@ class ScipyOptimizeDriver(Driver):
         # Since COBYLA does not support bounds, we
         #   need to add to the _cons metadata for any bounds that
         #   need to be translated into a constraint
-        # if (opt in _constraint_optimizers) and (opt not in _bounds_optimizers):
         if opt == 'COBYLA':
             for name, meta in iteritems(self._designvars):
                 lower = meta['lower']
@@ -195,6 +194,7 @@ class ScipyOptimizeDriver(Driver):
                     d['adder'] = None
                     d['scaler'] = None
                     d['size'] = meta['size']
+                    d['linear'] = True
                     self._cons[name] = d
 
     def run(self):
@@ -275,10 +275,6 @@ class ScipyOptimizeDriver(Driver):
                 upper = meta['upper']
                 lower = meta['lower']
                 equals = meta['equals']
-                try:
-                    print('name&meta', name, meta['linear'])
-                except KeyError:
-                    print('name&meta', name, meta)
                 if 'linear' in meta and meta['linear']:
                     lincons.append(name)
                     self._con_idx[name] = lin_i

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -115,6 +115,8 @@ class ScipyOptimizeDriver(Driver):
         self._con_cache = None
         self._con_idx = {}
         self._obj_and_nlcons = None
+        self._dvlist = None
+        self._lincongrad_cache = None
         self.fail = False
         self.iter_count = 0
         self._exc_info = None
@@ -178,6 +180,7 @@ class ScipyOptimizeDriver(Driver):
         # Since COBYLA does not support bounds, we
         #   need to add to the _cons metadata for any bounds that
         #   need to be translated into a constraint
+        # if (opt in _constraint_optimizers) and (opt not in _bounds_optimizers):
         if opt == 'COBYLA':
             for name, meta in iteritems(self._designvars):
                 lower = meta['lower']
@@ -272,6 +275,10 @@ class ScipyOptimizeDriver(Driver):
                 upper = meta['upper']
                 lower = meta['lower']
                 equals = meta['equals']
+                try:
+                    print('name&meta', name, meta['linear'])
+                except KeyError:
+                    print('name&meta', name, meta)
                 if 'linear' in meta and meta['linear']:
                     lincons.append(name)
                     self._con_idx[name] = lin_i
@@ -297,7 +304,7 @@ class ScipyOptimizeDriver(Driver):
                         ub = upper
                     # Loop over every index separately,
                     # because scipy calls each constraint by index.
-                    for j in range(0, size):
+                    for j in range(size):
                         # Double-sided constraints are accepted by the algorithm
                         args = [name, False, j]
                         # TODO linear constraint if meta['linear']
@@ -309,7 +316,7 @@ class ScipyOptimizeDriver(Driver):
                 else:  # Type of constraints is list of dict
                     # Loop over every index separately,
                     # because scipy calls each constraint by index.
-                    for j in range(0, size):
+                    for j in range(size):
                         con_dict = {}
                         if meta['equals'] is not None:
                             con_dict['type'] = 'eq'

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -82,6 +82,10 @@ class ScipyOptimizeDriver(Driver):
     _obj_and_nlcons : list
         List of objective + nonlinear constraints. Used to compute total derivatives
         for all except linear constraints.
+    _dvlist : list
+        Copy of _designvars.
+    _lincongrad_cache : np.ndarray
+        Pre-calculated gradients of linear constraints.
     """
 
     def __init__(self, **kwargs):
@@ -355,6 +359,7 @@ class ScipyOptimizeDriver(Driver):
         else:
             jac = None
 
+        # Hessian calculation method for optimizers, which require it
         if opt in _hessian_optimizers:
             if 'hess' in self.opt_settings:
                 hess = self.opt_settings.pop('hess')
@@ -468,7 +473,7 @@ class ScipyOptimizeDriver(Driver):
 
         The lower or upper bound is **not** subtracted from the value. Used for optimizers,
         which take the bounds of the constraints (e.g. trust-constr)
-        
+
         Parameters
         ----------
         x_new : ndarray

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -359,7 +359,8 @@ class ScipyOptimizeDriver(Driver):
             if 'hess' in self.opt_settings:
                 hess = self.opt_settings.pop('hess')
             else:
-                from scipy.optimize import BFGS  # FIXME temporary, should be option. (P.O.)
+                # Defaults to BFGS, if not in opt_settings
+                from scipy.optimize import BFGS
                 hess = BFGS()
         else:
             hess = None
@@ -445,7 +446,7 @@ class ScipyOptimizeDriver(Driver):
                 model._solve_nonlinear()
 
             # Get the objective function evaluations
-            for name, obj in iteritems(self.get_objective_values()):
+            for obj in itervalues(self.get_objective_values()):
                 f_new = obj
                 break
 

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -30,7 +30,7 @@ _hessian_optimizers = ['trust-constr', 'trust-ncg']
 # TODO, add 'trust-constr' to bounds optimizers, when SciPy issue #9043 is resolved
 _bounds_optimizers = ['L-BFGS-B', 'TNC', 'SLSQP']
 _constraint_optimizers = ['COBYLA', 'SLSQP', 'trust-constr']
-_constraint_grad_optimizers = ['SLSQP']
+_constraint_grad_optimizers = ['SLSQP', 'trust-constr']
 _eq_constraint_optimizers = ['SLSQP', 'trust-constr']
 
 # These require Hessian or Hessian-vector product, so they are not supported

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -903,20 +903,74 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         x0 = np.array([1.2, 0.8, 1.3])
 
         prob = Problem()
+        model = prob.model
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
         indeps.add_output('x', list(x0))
 
         prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
         prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
-        prob.driver.options['optimizer'] = 'trust-constr'
-        prob.driver.options['tol'] = 1e-8
-        prob.driver.options['maxiter'] = 2000
-        prob.driver.options['disp'] = False
+        prob.driver = driver = ScipyOptimizeDriver()
+        driver.options['optimizer'] = 'trust-constr'
+        driver.options['tol'] = 1e-8
+        driver.options['maxiter'] = 2000
+        driver.options['disp'] = False
 
-        prob.model.add_design_var('x')
-        prob.model.add_objective('f', scaler=1/rosenbrock(x0))
-        prob.model.add_constraint('c', lower=0, upper=10)  # Double sided
+        model.add_design_var('x')
+        model.add_objective('f', scaler=1/rosenbrock(x0))
+        model.add_constraint('c', lower=0, upper=10)  # Double sided
+
+        prob.setup()
+        prob.run_driver()
+
+        assert_rel_error(self, prob['x'], np.ones(3), 2e-2)
+        assert_rel_error(self, prob['f'], 0., 1e-2)
+        self.assertTrue(prob['c'] < 10)
+        self.assertTrue(prob['c'] > 0)
+
+    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+                         "scipy >= 1.1 is required.")
+    def test_trust_constr_hess_option(self):
+
+        def rosenbrock(x):
+            x_0 = x[:-1]
+            x_1 = x[1:]
+            return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
+
+        class Rosenbrock(ExplicitComponent):
+
+            def __init__(self, problem):
+                super(Rosenbrock, self).__init__()
+                self.problem = problem
+                self.counter = 0
+
+            def setup(self):
+                self.add_input('x', np.array([1.5, 1.5, 1.5]))
+                self.add_output('f', 0.0)
+                self.declare_partials('f', 'x', method='fd', form='central', step=1e-2)
+
+            def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+                x = inputs['x']
+                outputs['f'] = rosenbrock(x)
+
+        x0 = np.array([1.2, 0.8, 1.3])
+
+        prob = Problem()
+        model = prob.model
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps.add_output('x', list(x0))
+
+        prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
+        prob.driver = driver = ScipyOptimizeDriver()
+        driver.options['optimizer'] = 'trust-constr'
+        driver.options['tol'] = 1e-8
+        driver.options['maxiter'] = 2000
+        driver.options['disp'] = False
+        driver.opt_settings['hess'] = '2-point'
+
+        model.add_design_var('x')
+        model.add_objective('f', scaler=1/rosenbrock(x0))
+        model.add_constraint('c', lower=0, upper=10)  # Double sided
 
         prob.setup()
         prob.run_driver()
@@ -954,25 +1008,28 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         x0 = np.array([0.5, 0.8, 1.4])
 
         prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        model = prob.model
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob))
         indeps.add_output('x', list(x0))
 
-        prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
-        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
-        prob.driver.options['optimizer'] = 'trust-constr'
-        prob.driver.options['tol'] = 1e-5
-        prob.driver.options['maxiter'] = 2000
-        prob.driver.options['disp'] = False
+        model.add_subsystem('rosen', Rosenbrock(problem=prob))
+        model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)))
+        model.connect('indeps.x', 'rosen.x')
+        model.connect('indeps.x', 'con.x')
+        prob.driver = driver = ScipyOptimizeDriver()
+        driver.options['optimizer'] = 'trust-constr'
+        driver.options['tol'] = 1e-5
+        driver.options['maxiter'] = 2000
+        driver.options['disp'] = False
 
-        prob.model.add_design_var('x')
-        prob.model.add_objective('f', scaler=1/rosenbrock(x0))
-        prob.model.add_constraint('c', equals=1.)
+        model.add_design_var('indeps.x')
+        model.add_objective('rosen.f', scaler=1/rosenbrock(x0))
+        model.add_constraint('con.c', equals=1.)
 
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['c'], 1., 1e-3)
+        assert_rel_error(self, prob['con.c'], 1., 1e-3)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
                          "scipy >= 1.1 is required.")

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -894,13 +894,13 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
                 self.add_output('f', 0.0)
-                self.declare_partials('f', 'x', method='fd', form='central', step=1e-4)
+                self.declare_partials('f', 'x', method='fd', form='central', step=1e-2)
 
             def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
                 x = inputs['x']
                 outputs['f'] = rosenbrock(x)
 
-        x0 = np.array([0.5, 0.8, 1.4])
+        x0 = np.array([1.2, 0.8, 1.3])
 
         prob = Problem()
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
@@ -910,18 +910,18 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
         prob.driver = ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'trust-constr'
-        prob.driver.options['tol'] = 1e-5
+        prob.driver.options['tol'] = 1e-8
         prob.driver.options['maxiter'] = 2000
         prob.driver.options['disp'] = False
 
         prob.model.add_design_var('x')
-        prob.model.add_objective('f', scaler=rosenbrock(x0))
+        prob.model.add_objective('f', scaler=1/rosenbrock(x0))
         prob.model.add_constraint('c', lower=0, upper=10)  # Double sided
 
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'][0], 1., 2e-2)
+        assert_rel_error(self, prob['x'], np.ones(3), 2e-2)
         assert_rel_error(self, prob['f'], 0., 1e-2)
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
@@ -966,7 +966,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.driver.options['disp'] = False
 
         prob.model.add_design_var('x')
-        prob.model.add_objective('f', scaler=rosenbrock(x0))
+        prob.model.add_objective('f', scaler=1/rosenbrock(x0))
         prob.model.add_constraint('c', equals=1.)
 
         prob.setup()
@@ -978,10 +978,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                          "scipy >= 1.1 is required.")
     def test_trust_constr_inequality_con(self):
 
-        class Rosenbrock(ExplicitComponent):
+        class Sphere(ExplicitComponent):
 
             def __init__(self, problem):
-                super(Rosenbrock, self).__init__()
+                super(Sphere, self).__init__()
                 self.problem = problem
                 self.counter = 0
 
@@ -1000,7 +1000,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
         indeps.add_output('x', list(x0))
 
-        prob.model.add_subsystem('sphere', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('sphere', Sphere(problem=prob), promotes=['*'])
         prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
         prob.driver = ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'trust-constr'

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -879,11 +879,6 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         class Rosenbrock(ExplicitComponent):
 
-            def __init__(self, problem):
-                super(Rosenbrock, self).__init__()
-                self.problem = problem
-                self.counter = 0
-
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
                 self.add_output('f', 0.0)
@@ -897,10 +892,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob = Problem()
         model = prob.model
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
-        prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('rosen', Rosenbrock(), promotes=['*'])
         prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
         prob.driver = driver = ScipyOptimizeDriver()
         driver.options['optimizer'] = 'trust-constr'
@@ -931,11 +926,6 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         class Rosenbrock(ExplicitComponent):
 
-            def __init__(self, problem):
-                super(Rosenbrock, self).__init__()
-                self.problem = problem
-                self.counter = 0
-
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
                 self.add_output('f', 0.0)
@@ -949,10 +939,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob = Problem()
         model = prob.model
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
-        prob.model.add_subsystem('rosen', Rosenbrock(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('rosen', Rosenbrock(), promotes=['*'])
         prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
         prob.driver = driver = ScipyOptimizeDriver()
         driver.options['optimizer'] = 'trust-constr'
@@ -984,11 +974,6 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         class Rosenbrock(ExplicitComponent):
 
-            def __init__(self, problem):
-                super(Rosenbrock, self).__init__()
-                self.problem = problem
-                self.counter = 0
-
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
                 self.add_output('f', 0.0)
@@ -1002,10 +987,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob = Problem()
         model = prob.model
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob))
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
         indeps.add_output('x', list(x0))
 
-        model.add_subsystem('rosen', Rosenbrock(problem=prob))
+        model.add_subsystem('rosen', Rosenbrock())
         model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)))
         model.connect('indeps.x', 'rosen.x')
         model.connect('indeps.x', 'con.x')
@@ -1030,11 +1015,6 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         class Sphere(ExplicitComponent):
 
-            def __init__(self, problem):
-                super(Sphere, self).__init__()
-                self.problem = problem
-                self.counter = 0
-
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5]))
                 self.add_output('f', 0.0)
@@ -1047,10 +1027,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         x0 = np.array([1.2, 1.5])
 
         prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
-        prob.model.add_subsystem('sphere', Sphere(problem=prob), promotes=['*'])
+        prob.model.add_subsystem('sphere', Sphere(), promotes=['*'])
         prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
         prob.driver = ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'trust-constr'
@@ -1071,11 +1051,6 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     # def test_trust_constr_bounds(self):
     #     class Rosenbrock(ExplicitComponent):
     #
-    #         def __init__(self, problem):
-    #             super(Rosenbrock, self).__init__()
-    #             self.problem = problem
-    #             self.counter = 0
-    #
     #         def setup(self):
     #             self.add_input('x', np.array([1.5, 1.5]))
     #             self.add_output('f', 0.0)
@@ -1088,10 +1063,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     #     x0 = np.array([-3., -3.])
     #
     #     prob = Problem()
-    #     indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+    #     indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
     #     indeps.add_output('x', list(x0))
     #
-    #     prob.model.add_subsystem('sphere', Rosenbrock(problem=prob), promotes=['*'])
+    #     prob.model.add_subsystem('sphere', Rosenbrock(), promotes=['*'])
     #     prob.driver = ScipyOptimizeDriver()
     #     prob.driver.options['optimizer'] = 'trust-constr'
     #     prob.driver.options['tol'] = 1e-5


### PR DESCRIPTION
* Hessian calculation method can be a user option (with `opt_settings`) for optimizers which support this.
* Test added for setting the Hessian approximation with `opt_settings`
* Put some attributes into the `__init__`, which where not initialized
* Added 'linear' to COBYLA's bound constraints, this key was missing. It did not result in an error only, because COBYLA is not a gradient optimizer (but this feature to turn bounds into constraints could be reused to any optimizer, which supports constraints but not bounds)
* Some minor fixes in the tests and in the driver
* Some docs to the previous 'trust-constr' PR.