### PR TITLE
Three Solver-related Stories.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -674,10 +674,10 @@ class Driver(object):
             Failure flag; True if failed to converge, False is successful.
         """
         with RecordingDebugging(self._get_name(), self.iter_count, self):
-            failure_flag, _, _ = self._problem.model._solve_nonlinear()
+            self._problem.model._solve_nonlinear()
 
         self.iter_count += 1
-        return failure_flag
+        return False
 
     def _compute_totals(self, of=None, wrt=None, return_format='flat_dict', global_names=True):
         """

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -192,15 +192,6 @@ class ExplicitComponent(Component):
     def _solve_nonlinear(self):
         """
         Compute outputs. The model is assumed to be in a scaled state.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         super(ExplicitComponent, self)._solve_nonlinear()
 
@@ -210,14 +201,12 @@ class ExplicitComponent(Component):
                 self._inputs.read_only = True
                 try:
                     if self._discrete_inputs or self._discrete_outputs:
-                        failed = self.compute(self._inputs, self._outputs, self._discrete_inputs,
-                                              self._discrete_outputs)
+                        self.compute(self._inputs, self._outputs, self._discrete_inputs,
+                                     self._discrete_outputs)
                     else:
-                        failed = self.compute(self._inputs, self._outputs)
+                        self.compute(self._inputs, self._outputs)
                 finally:
                     self._inputs.read_only = False
-
-        return bool(failed), 0., 0.
 
     def _apply_linear(self, jac, vec_names, rel_systems, mode, scope_out=None, scope_in=None):
         """
@@ -304,14 +293,6 @@ class ExplicitComponent(Component):
         rel_systems : set of str
             Set of names of relevant systems based on the current linear solve.
 
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         for vec_name in vec_names:
             if vec_name in self._rel_vec_names:
@@ -339,8 +320,6 @@ class ExplicitComponent(Component):
 
                     # ExplicitComponent jacobian defined with -1 on diagonal.
                     d_residuals *= -1.0
-
-        return False, 0., 0.
 
     def _linearize(self, jac=None, sub_do_ln=False):
         """
@@ -389,11 +368,6 @@ class ExplicitComponent(Component):
             If not None, dict containing discrete input values.
         discrete_outputs : dict or None
             If not None, dict containing discrete output values.
-
-        Returns
-        -------
-        bool or None
-            None or False if run successfully; True if there was a failure.
         """
         pass
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1571,24 +1571,13 @@ class Group(System):
     def _solve_nonlinear(self):
         """
         Compute outputs. The model is assumed to be in a scaled state.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         super(Group, self)._solve_nonlinear()
 
         name = self.pathname if self.pathname else 'root'
 
         with Recording(name + '._solve_nonlinear', self.iter_count, self):
-            result = self._nonlinear_solver.solve()
-
-        return result
+            self._nonlinear_solver.solve()
 
     def _guess_nonlinear(self):
         """
@@ -1670,21 +1659,10 @@ class Group(System):
             'fwd' or 'rev'.
         rel_systems : set of str
             Set of names of relevant systems based on the current linear solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         vec_names = [v for v in vec_names if v in self._rel_vec_names]
 
-        result = self._linear_solver.solve(vec_names, mode, rel_systems)
-
-        return result
+        self._linear_solver.solve(vec_names, mode, rel_systems)
 
     def _linearize(self, jac, sub_do_ln=True):
         """

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -84,15 +84,6 @@ class ImplicitComponent(Component):
     def _solve_nonlinear(self):
         """
         Compute outputs. The model is assumed to be in a scaled state.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         # Reconfigure if needed.
         super(ImplicitComponent, self)._solve_nonlinear()
@@ -102,25 +93,17 @@ class ImplicitComponent(Component):
         try:
             if self._nonlinear_solver is not None:
                 with Recording(self.pathname + '._solve_nonlinear', self.iter_count, self):
-                    result = self._nonlinear_solver.solve()
+                    self._nonlinear_solver.solve()
             else:
                 with self._unscaled_context(outputs=[self._outputs]):
                     with Recording(self.pathname + '._solve_nonlinear', self.iter_count, self):
                         if self._discrete_inputs or self._discrete_outputs:
-                            result = self.solve_nonlinear(self._inputs, self._outputs,
-                                                          self._discrete_inputs,
-                                                          self._discrete_outputs)
+                            self.solve_nonlinear(self._inputs, self._outputs,
+                                                 self._discrete_inputs, self._discrete_outputs)
                         else:
-                            result = self.solve_nonlinear(self._inputs, self._outputs)
+                            self.solve_nonlinear(self._inputs, self._outputs)
         finally:
             self._inputs.read_only = False
-
-        if result is None:
-            return False, 0., 0.
-        elif type(result) is bool:
-            return result, 0., 0.
-        else:
-            return result
 
     def _guess_nonlinear(self):
         """
@@ -220,24 +203,12 @@ class ImplicitComponent(Component):
             'fwd' or 'rev'.
         rel_systems : set of str
             Set of names of relevant systems based on the current linear solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         if self._linear_solver is not None:
-            result = self._linear_solver.solve(vec_names, mode, rel_systems)
-            return result
+            self._linear_solver.solve(vec_names, mode, rel_systems)
 
         else:
             failed = False
-            abs_errors = [0.0]
-            rel_errors = [0.0]
             for vec_name in vec_names:
                 if vec_name not in self._rel_vec_names:
                     continue
@@ -254,36 +225,21 @@ class ImplicitComponent(Component):
                     try:
                         if d_outputs._ncol > 1:
                             if self.has_solve_multi_linear:
-                                result = self.solve_multi_linear(d_outputs, d_residuals, mode)
+                                self.solve_multi_linear(d_outputs, d_residuals, mode)
                             else:
                                 for i in range(d_outputs._ncol):
                                     # need to make the multivecs look like regular single vecs
                                     # since the component doesn't know about multivecs.
                                     d_outputs._icol = i
                                     d_residuals._icol = i
-                                    result = self.solve_linear(d_outputs, d_residuals, mode)
-                                    if isinstance(result, bool):
-                                        failed |= result
-                                    elif result is not None:
-                                        failed = failed or result[0]
-                                        abs_errors.append(result[1])
-                                        rel_errors.append(result[2])
+                                    self.solve_linear(d_outputs, d_residuals, mode)
 
                                 d_outputs._icol = None
                                 d_residuals._icol = None
                         else:
-                            result = self.solve_linear(d_outputs, d_residuals, mode)
+                            self.solve_linear(d_outputs, d_residuals, mode)
                     finally:
                         d_outputs.read_only = d_residuals.read_only = False
-
-                if isinstance(result, bool):
-                    failed |= result
-                elif result is not None:
-                    failed = failed or result[0]
-                    abs_errors.append(result[1])
-                    rel_errors.append(result[2])
-
-            return failed, np.linalg.norm(abs_errors), np.linalg.norm(rel_errors)
 
     def _linearize(self, jac=None, sub_do_ln=True):
         """
@@ -342,11 +298,6 @@ class ImplicitComponent(Component):
             unscaled, dimensional input variables read via inputs[key]
         outputs : Vector
             unscaled, dimensional output variables read via outputs[key]
-
-        Returns
-        -------
-        None or bool or (bool, float, float)
-            The bool is the failure flag; and the two floats are absolute and relative error.
         """
         pass
 
@@ -416,18 +367,11 @@ class ImplicitComponent(Component):
             unscaled, dimensional quantities read via d_residuals[key]
         mode : str
             either 'fwd' or 'rev'
-
-        Returns
-        -------
-        None or bool or (bool, float, float)
-            The bool is the failure flag; and the two floats are absolute and relative error.
         """
         if mode == 'fwd':
             d_outputs.set_vec(d_residuals)
         else:  # rev
             d_residuals.set_vec(d_outputs)
-
-        return False, 0., 0.
 
     def linearize(self, inputs, outputs, jacobian):
         """

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -517,7 +517,7 @@ class Problem(object):
 
         self.final_setup()
         self.model._clear_iprint()
-        return self.model.run_solve_nonlinear()
+        self.model.run_solve_nonlinear()
 
     def run_driver(self, case_prefix=None, reset_iter_counts=True):
         """
@@ -558,20 +558,11 @@ class Problem(object):
     def run_once(self):
         """
         Backward compatible call for run_model.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         warn_deprecation("The 'run_once' method provides backwards compatibility with "
                          "OpenMDAO <= 1.x ; use 'run_model' instead.")
 
-        return self.run_model()
+        self.run_model()
 
     def run(self):
         """

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -491,15 +491,6 @@ class Problem(object):
 
         reset_iter_counts : bool
             If True and model has been run previously, reset all iteration counters.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         if self._mode is None:
             raise RuntimeError("The `setup` method must be called before `run_model`.")

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2600,19 +2600,9 @@ class System(object):
 
         This calls _solve_nonlinear, but with the model assumed to be in an unscaled state.
 
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         with self._scaled_context_all():
-            result = self._solve_nonlinear()
-
-        return result
+            self._solve_nonlinear()
 
     def run_apply_linear(self, vec_names, mode, scope_out=None, scope_in=None):
         """
@@ -2648,20 +2638,9 @@ class System(object):
             list of names of the right-hand-side vectors.
         mode : str
             'fwd' or 'rev'.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         with self._scaled_context_all():
-            result = self._solve_linear(vec_names, mode, ContainsAll())
-
-        return result
+            self._solve_linear(vec_names, mode, ContainsAll())
 
     def run_linearize(self, sub_do_ln=True):
         """
@@ -2690,19 +2669,9 @@ class System(object):
         """
         Compute outputs. The model is assumed to be in a scaled state.
 
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            Relative error.
-        float
-            Absolute error.
         """
         # Reconfigure if needed.
         self._check_reconf()
-
-        return False, 0., 0.
 
     def check_config(self, logger):
         """
@@ -2750,15 +2719,6 @@ class System(object):
             'fwd' or 'rev'.
         rel_systems : set of str
             Set of names of relevant systems based on the current linear solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            relative error.
-        float
-            absolute error.
         """
         pass
 

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1000,70 +1000,70 @@ def _get_mat(rows, cols):
         return np.random.random(rows * cols).reshape((rows, cols)) - 0.5
 
 
-#@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
-#class MatMultMultipointTestCase(unittest.TestCase):
-    #N_PROCS = 4
+@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
+class MatMultMultipointTestCase(unittest.TestCase):
+    N_PROCS = 4
 
-    #def test_multipoint_with_coloring(self):
-        #size = 10
-        #num_pts = self.N_PROCS
+    def test_multipoint_with_coloring(self):
+        size = 10
+        num_pts = self.N_PROCS
 
-        #np.random.seed(11)
+        np.random.seed(11)
 
-        #p = Problem()
-        #p.driver = pyOptSparseDriver()
-        #p.driver.options['optimizer'] = OPTIMIZER
-        #p.driver.options['dynamic_simul_derivs'] = True
-        #if OPTIMIZER == 'SNOPT':
-            #p.driver.opt_settings['Major iterations limit'] = 100
-            #p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-            #p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-            #p.driver.opt_settings['iSumm'] = 6
+        p = Problem()
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = OPTIMIZER
+        p.driver.options['dynamic_simul_derivs'] = True
+        if OPTIMIZER == 'SNOPT':
+            p.driver.opt_settings['Major iterations limit'] = 100
+            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+            p.driver.opt_settings['iSumm'] = 6
 
-        #model = p.model
-        #for i in range(num_pts):
-            #model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
-            #model.add_design_var('indep%d.x' % i)
+        model = p.model
+        for i in range(num_pts):
+            model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
+            model.add_design_var('indep%d.x' % i)
 
-        #par1 = model.add_subsystem('par1', ParallelGroup())
-        #for i in range(num_pts):
-            #mat = _get_mat(5, size)
-            #par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
-            #model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
+        par1 = model.add_subsystem('par1', ParallelGroup())
+        for i in range(num_pts):
+            mat = _get_mat(5, size)
+            par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
+            model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
 
-        #par2 = model.add_subsystem('par2', ParallelGroup())
-        #for i in range(num_pts):
-            #mat = _get_mat(size, 5)
-            #par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
-            #model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
-            #par2.add_constraint('comp%d.y' % i, lower=-1.)
+        par2 = model.add_subsystem('par2', ParallelGroup())
+        for i in range(num_pts):
+            mat = _get_mat(size, 5)
+            par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
+            model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
+            par2.add_constraint('comp%d.y' % i, lower=-1.)
 
-            #model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
-            #model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
+            model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
+            model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
 
-        #model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
+        model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
 
-        #for i in range(num_pts):
-            #model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
+        for i in range(num_pts):
+            model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
 
-        #model.add_objective('obj.y')
+        model.add_objective('obj.y')
 
-        #p.setup()
+        p.setup()
 
-        #p.run_driver()
+        p.run_driver()
 
-        #J = p.compute_totals()
+        J = p.compute_totals()
 
-        #for i in range(num_pts):
-            #vname = 'par2.comp%d.A' % i
-            #if vname in model._var_abs_names['input']:
-                #norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
-                                      #getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
-                #self.assertLess(norm, 1.e-7)
-            #elif vname not in model._var_allprocs_abs_names['input']:
-                #self.fail("Can't find variable par2.comp%d.A" % i)
+        for i in range(num_pts):
+            vname = 'par2.comp%d.A' % i
+            if vname in model._var_abs_names['input']:
+                norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
+                                      getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
+                self.assertLess(norm, 1.e-7)
+            elif vname not in model._var_allprocs_abs_names['input']:
+                self.fail("Can't find variable par2.comp%d.A" % i)
 
-        ## print("final obj:", p['obj.y'])
+        # print("final obj:", p['obj.y'])
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1000,70 +1000,70 @@ def _get_mat(rows, cols):
         return np.random.random(rows * cols).reshape((rows, cols)) - 0.5
 
 
-@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
-class MatMultMultipointTestCase(unittest.TestCase):
-    N_PROCS = 4
+#@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
+#class MatMultMultipointTestCase(unittest.TestCase):
+    #N_PROCS = 4
 
-    def test_multipoint_with_coloring(self):
-        size = 10
-        num_pts = self.N_PROCS
+    #def test_multipoint_with_coloring(self):
+        #size = 10
+        #num_pts = self.N_PROCS
 
-        np.random.seed(11)
+        #np.random.seed(11)
 
-        p = Problem()
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = OPTIMIZER
-        p.driver.options['dynamic_simul_derivs'] = True
-        if OPTIMIZER == 'SNOPT':
-            p.driver.opt_settings['Major iterations limit'] = 100
-            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-            p.driver.opt_settings['iSumm'] = 6
+        #p = Problem()
+        #p.driver = pyOptSparseDriver()
+        #p.driver.options['optimizer'] = OPTIMIZER
+        #p.driver.options['dynamic_simul_derivs'] = True
+        #if OPTIMIZER == 'SNOPT':
+            #p.driver.opt_settings['Major iterations limit'] = 100
+            #p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            #p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+            #p.driver.opt_settings['iSumm'] = 6
 
-        model = p.model
-        for i in range(num_pts):
-            model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
-            model.add_design_var('indep%d.x' % i)
+        #model = p.model
+        #for i in range(num_pts):
+            #model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
+            #model.add_design_var('indep%d.x' % i)
 
-        par1 = model.add_subsystem('par1', ParallelGroup())
-        for i in range(num_pts):
-            mat = _get_mat(5, size)
-            par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
-            model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
+        #par1 = model.add_subsystem('par1', ParallelGroup())
+        #for i in range(num_pts):
+            #mat = _get_mat(5, size)
+            #par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
+            #model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
 
-        par2 = model.add_subsystem('par2', ParallelGroup())
-        for i in range(num_pts):
-            mat = _get_mat(size, 5)
-            par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
-            model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
-            par2.add_constraint('comp%d.y' % i, lower=-1.)
+        #par2 = model.add_subsystem('par2', ParallelGroup())
+        #for i in range(num_pts):
+            #mat = _get_mat(size, 5)
+            #par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
+            #model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
+            #par2.add_constraint('comp%d.y' % i, lower=-1.)
 
-            model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
-            model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
+            #model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
+            #model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
 
-        model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
+        #model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
 
-        for i in range(num_pts):
-            model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
+        #for i in range(num_pts):
+            #model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
 
-        model.add_objective('obj.y')
+        #model.add_objective('obj.y')
 
-        p.setup()
+        #p.setup()
 
-        p.run_driver()
+        #p.run_driver()
 
-        J = p.compute_totals()
+        #J = p.compute_totals()
 
-        for i in range(num_pts):
-            vname = 'par2.comp%d.A' % i
-            if vname in model._var_abs_names['input']:
-                norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
-                                      getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
-                self.assertLess(norm, 1.e-7)
-            elif vname not in model._var_allprocs_abs_names['input']:
-                self.fail("Can't find variable par2.comp%d.A" % i)
+        #for i in range(num_pts):
+            #vname = 'par2.comp%d.A' % i
+            #if vname in model._var_abs_names['input']:
+                #norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
+                                      #getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
+                #self.assertLess(norm, 1.e-7)
+            #elif vname not in model._var_allprocs_abs_names['input']:
+                #self.fail("Can't find variable par2.comp%d.A" % i)
 
-        # print("final obj:", p['obj.y'])
+        ## print("final obj:", p['obj.y'])
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_reconf_connections.py
+++ b/openmdao/core/tests/test_reconf_connections.py
@@ -227,8 +227,7 @@ class TestReconfConnections(unittest.TestCase):
         self.assertEqual(len(p['c3.y']), 1)
 
         # Run the model again, which will trigger reconfiguration; counter = 2, size of y = 2
-        fail, _, _ = p.run_model()
-        self.assertFalse(fail)
+        p.run_model()
         self.assertEqual(len(p['c3.y']), 2)
         self.assertEqual(len(p['c2.y']), 2)
 

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -290,10 +290,9 @@ class TestScaling(unittest.TestCase):
             prob.set_solver_print(level=0)
 
             prob.setup(check=False)
-            result = prob.run_model()
+            prob.run_model()
 
-            success = not result[0]
-            return success
+            return np.linalg.norm(prob.model._residuals._data) < 1e-5
 
         # ---------------------------
         # coeffs: r1, r2, c1, c2

--- a/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
+++ b/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
@@ -531,10 +531,10 @@ class ExperimentalDriver(object):
             Failure flag; True if failed to converge, False is successful.
         """
         with Recording(self._get_name(), self.iter_count, self) as rec:
-            failure_flag = self._problem.model._solve_nonlinear()
+            self._problem.model._solve_nonlinear()
 
         self.iter_count += 1
-        return failure_flag
+        return False
 
     def _dict2array_jac(self, derivs):
         osize = 0

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -191,8 +191,8 @@ class DOEDriver(Driver):
 
         with RecordingDebugging(self._name, self.iter_count, self) as rec:
             try:
-                failure_flag, _, _ = self._problem.model._solve_nonlinear()
-                metadata['success'] = not failure_flag
+                self._problem.model._solve_nonlinear()
+                metadata['success'] = 1
                 metadata['msg'] = ''
             except AnalysisError:
                 metadata['success'] = 0

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -63,9 +63,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup(check=False, mode='rev')
 
-        failed, rel_err, abs_err = prob.run_model()
-
-        self.assertFalse(failed, "Optimization failed.")
+        prob.run_model()
 
         of = ['f_xy']
         wrt = ['x', 'y']

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -90,6 +90,12 @@ def format_singular_csc_error(system, matrix):
         # There is a nan in the matrix.
         return(format_nan_error(system, dense))
     elif zero_cols.size <= zero_rows.size:
+
+        if zero_rows.size == 0:
+            # Underdetermined: duplicate columns or rows.
+            msg = "Identical rows or columns found in jacobian. Problem is underdetermined."
+            return msg
+
         loc_txt = "row"
         loc = zero_rows[0]
     else:

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -364,15 +364,6 @@ class DirectSolver(LinearSolver):
             'fwd' or 'rev'.
         rel_systems : set of str
             Names of systems relevant to the current solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         if len(vec_names) > 1:
             raise RuntimeError("DirectSolvers with multiple right-hand-sides are not supported.")
@@ -413,5 +404,3 @@ class DirectSolver(LinearSolver):
             # MVP-generated jacobians are scaled.
             else:
                 x_vec._data[:] = scipy.linalg.lu_solve(self._lup, b_vec._data, trans=trans_lu)
-
-        return False, 0., 0.

--- a/openmdao/solvers/linear/linear_runonce.py
+++ b/openmdao/solvers/linear/linear_runonce.py
@@ -24,13 +24,6 @@ class LinearRunOnce(LinearBlockGS):
             'fwd' or 'rev'.
         rel_systems : set of str
             Names of systems relevant to the current solve.
-
-        Returns
-        -------
-        float
-            Initial error.
-        float
-            Error at the first iteration.
         """
         self._vec_names = vec_names
         self._mode = mode
@@ -49,8 +42,6 @@ class LinearRunOnce(LinearBlockGS):
 
         # Single iteration of GS
         self._iter_execute()
-
-        return False, 0.0, 0.0
 
     def _declare_options(self):
         """

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -332,15 +332,6 @@ class PETScKrylov(LinearSolver):
             Derivative mode, can be 'fwd' or 'rev'.
         rel_systems : set of str
             Names of systems relevant to the current solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         self._vec_names = vec_names
         self._rel_systems = rel_systems
@@ -387,8 +378,6 @@ class PETScKrylov(LinearSolver):
             x_vec._data[:] = sol_array
 
             sol_petsc_vec = rhs_petsc_vec = None
-
-        return False, 0., 0.
 
     def apply(self, mat, in_vec, result):
         """

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -192,15 +192,6 @@ class ScipyKrylov(LinearSolver):
             'fwd' or 'rev'.
         rel_systems : set of str
             Names of systems relevant to the current solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         self._vec_names = vec_names
         self._rel_systems = rel_systems
@@ -257,10 +248,6 @@ class ScipyKrylov(LinearSolver):
 
             fail |= (info != 0)
             x_vec._data[:] = x
-
-        # TODO: implement this properly
-
-        return fail, 0., 0.
 
     def _apply_precon(self, in_vec):
         """

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -519,6 +519,72 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         self.assertEqual(expected_msg, str(cm.exception))
 
+    def test_raise_error_on_underdetermined(self):
+
+        class DCgenerator(ImplicitComponent):
+
+            def setup(self):
+                self.add_input('V_bus', val=1.0)
+                self.add_input('V_out', val=1.0)
+
+                self.add_output('I_out', val=-2.0)
+                self.add_output('P_out', val=-2.0)
+
+                self.declare_partials('I_out', 'V_bus', val=1.0)
+                self.declare_partials('I_out', 'V_out', val=-1.0)
+                self.declare_partials('P_out', ['V_out', 'I_out'])
+                self.declare_partials('P_out', 'P_out', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, resids):
+                resids['I_out'] = inputs['V_bus'] - inputs['V_out']
+                resids['P_out'] = inputs['V_out'] * outputs['I_out'] - outputs['P_out']
+
+            def linearize(self, inputs, outputs, J):
+                J['P_out', 'V_out'] = outputs['I_out']
+                J['P_out', 'I_out'] = inputs['V_out']
+
+        class RectifierCalcs(ImplicitComponent):
+
+            def setup(self):
+                self.add_input('P_out', val=1.0)
+
+                self.add_output('P_in', val=1.0)
+                self.add_output('V_out', val=1.0)
+                self.add_output('Q_in', val=1.0)
+
+                self.declare_partials('P_in', 'P_out', val=1.0)
+                self.declare_partials('P_in', 'P_in', val=-1.0)
+                self.declare_partials('V_out', 'V_out', val=-1.0)
+                self.declare_partials('Q_in', 'P_in', val=1.0)
+                self.declare_partials('Q_in', 'Q_in', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, resids):
+                resids['P_in'] = inputs['P_out'] - outputs['P_in']
+                resids['V_out'] = 1.0 - outputs['V_out']
+                resids['Q_in'] = outputs['P_in'] - outputs['Q_in']
+
+        class Rectifier(Group):
+
+            def setup(self):
+                self.add_subsystem('gen', DCgenerator(), promotes=[('V_bus', 'Vm_dc'), 'P_out'])
+
+                self.add_subsystem('calcs', RectifierCalcs(), promotes=['P_out', ('V_out', 'Vm_dc')])
+
+                self.nonlinear_solver = NewtonSolver()
+                self.linear_solver = DirectSolver(assemble_jac=True)
+
+        prob = Problem(model=Rectifier())
+
+        prob.setup(check=False)
+        prob.set_solver_print(level=2)
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.run_model()
+
+        expected_msg = "Identical rows or columns found in jacobian. Problem is underdetermined."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
 
 class TestDirectSolverFeature(unittest.TestCase):
 

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -519,7 +519,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         self.assertEqual(expected_msg, str(cm.exception))
 
-    def test_raise_error_on_underdetermined(self):
+    def test_raise_error_on_underdetermined_csc(self):
 
         class DCgenerator(ImplicitComponent):
 

--- a/openmdao/solvers/linear/tests/test_user_defined.py
+++ b/openmdao/solvers/linear/tests/test_user_defined.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     PETScVector = None
 
+
 class DistribStateImplicit(ImplicitComponent):
 
     def setup(self):
@@ -108,19 +109,12 @@ class DistribStateImplicit(ImplicitComponent):
             unscaled, dimensional quantities read via d_residuals[key]
         mode : str
             either 'fwd' or 'rev'
-
-        Returns
-        -------
-        None or bool or (bool, float, float)
-            The bool is the failure flag; and the two floats are absolute and relative error.
         """
         # Note: we are just preconditioning with Identity as a proof of concept.
         if mode == 'fwd':
             d_outputs.set_vec(d_residuals)
         elif mode == 'rev':
             d_residuals.set_vec(d_outputs)
-
-        return False, 0., 0.
 
 
 @unittest.skipUnless(PETScVector, "PETSc is required.")
@@ -150,7 +144,6 @@ class TestUserDefinedSolver(unittest.TestCase):
         def custom_method(d_outputs, d_residuals, mode):
             if d_outputs['out_var'][0] != -12.0:
                 raise ValueError('This value should be unscaled.')
-            return False, 0, 0
 
 
         class ScaledComp(ImplicitComponent):
@@ -288,19 +281,12 @@ class TestUserDefinedSolver(unittest.TestCase):
                     unscaled, dimensional quantities read via d_residuals[key]
                 mode : str
                     either 'fwd' or 'rev'
-
-                Returns
-                -------
-                None or bool or (bool, float, float)
-                    The bool is the failure flag; and the two floats are absolute and relative error.
                 """
                 # Note: we are just preconditioning with Identity as a proof of concept.
                 if mode == 'fwd':
                     d_outputs.set_vec(d_residuals)
                 elif mode == 'rev':
                     d_residuals.set_vec(d_outputs)
-
-                return False, 0., 0.
 
         prob = Problem()
 

--- a/openmdao/solvers/linear/user_defined.py
+++ b/openmdao/solvers/linear/user_defined.py
@@ -78,6 +78,4 @@ class LinearUserDefined(LinearSolver):
 
             # run custom solver
             with system._unscaled_context(outputs=[d_outputs], residuals=[d_resids]):
-                fail, abs_error, rel_error = solve(d_outputs, d_resids, mode)
-
-        return fail, abs_error, rel_error
+                solve(d_outputs, d_resids, mode)

--- a/openmdao/solvers/linear/user_defined.py
+++ b/openmdao/solvers/linear/user_defined.py
@@ -48,15 +48,6 @@ class LinearUserDefined(LinearSolver):
             Derivative mode, can be 'fwd' or 'rev'.
         rel_systems : set of str
             Set of names of relevant systems based on the current linear solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         self._vec_names = vec_names
         self._rel_systems = rel_systems

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -96,15 +96,6 @@ class BoundsEnforceLS(NonlinearSolver):
     def _run_iterator(self):
         """
         Run the iterative solver.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         self._iter_count = 0
         system = self._system
@@ -141,9 +132,6 @@ class BoundsEnforceLS(NonlinearSolver):
             rec.rel = norm / norm0
 
         self._mpi_print(self._iter_count, norm, norm / norm0)
-
-        fail = (np.isinf(norm) or np.isnan(norm))
-        return fail, norm, norm / norm0
 
 
 class ArmijoGoldsteinLS(NonlinearSolver):
@@ -302,15 +290,6 @@ class ArmijoGoldsteinLS(NonlinearSolver):
     def _run_iterator(self):
         """
         Run the iterative solver.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         maxiter = self.options['maxiter']
         atol = self.options['atol']
@@ -358,8 +337,3 @@ class ArmijoGoldsteinLS(NonlinearSolver):
                         reraise(*exc)
 
             self._mpi_print(self._iter_count, norm, norm / norm0)
-
-        fail = (np.isinf(norm) or np.isnan(norm) or
-                (norm > atol and norm / norm0 > rtol))
-
-        return fail, norm, norm / norm0

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -4,7 +4,6 @@ Define the BroydenSolver class.
 Based on implementation in Scipy via OpenMDAO 0.8x with improvements based on NPSS solver.
 """
 from __future__ import print_function
-from copy import deepcopy
 import warnings
 from six.moves import range
 
@@ -283,8 +282,8 @@ class BroydenSolver(NonlinearSolver):
         """
         system = self._system
         if self.options['debug_print']:
-            self._err_cache['inputs'] = deepcopy(self._system._inputs)
-            self._err_cache['outputs'] = deepcopy(self._system._outputs)
+            self._err_cache['inputs'] = self._system._inputs._copy_views()
+            self._err_cache['outputs'] = self._system._outputs._copy_views()
 
         # Convert local storage if we are under complex step.
         if system.under_complex_step:

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -2,8 +2,6 @@
 
 from __future__ import print_function
 
-from copy import deepcopy
-
 import numpy as np
 
 from openmdao.solvers.solver import NonlinearSolver
@@ -186,8 +184,8 @@ class NewtonSolver(NonlinearSolver):
             error at the first iteration.
         """
         if self.options['debug_print']:
-            self._err_cache['inputs'] = deepcopy(self._system._inputs)
-            self._err_cache['outputs'] = deepcopy(self._system._outputs)
+            self._err_cache['inputs'] = self._system._inputs._copy_views()
+            self._err_cache['outputs'] = self._system._outputs._copy_views()
 
         system = self._system
 

--- a/openmdao/solvers/nonlinear/nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/nonlinear_runonce.py
@@ -21,15 +21,6 @@ class NonlinearRunOnce(NonlinearSolver):
     def solve(self):
         """
         Run the solver.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         system = self._system
 
@@ -52,8 +43,6 @@ class NonlinearRunOnce(NonlinearSolver):
                     system._check_reconf_update()
             rec.abs = 0.0
             rec.rel = 0.0
-
-        return False, 0.0, 0.0
 
     def _declare_options(self):
         """

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -606,10 +606,10 @@ class NonlinearSolver(Solver):
             coord = self._recording_iter.get_formatted_iteration_coordinate()
 
             out_str = "\n# Inputs and outputs at start of iteration '%s':\n" % coord
-            for vec_type, vec in iteritems(self._err_cache):
+            for vec_type, views in iteritems(self._err_cache):
                 out_str += '\n'
-                out_str += '# %s %ss\n' % (vec._name, vec._typ)
-                out_str += pprint.pformat(vec._views)
+                out_str += '# nonlinear %s\n' % vec_type
+                out_str += pprint.pformat(views)
                 out_str += '\n'
 
             print(out_str)

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -11,8 +11,6 @@ import sys
 
 import numpy as np
 
-from copy import deepcopy
-
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.recorders.recording_manager import RecordingManager
@@ -661,8 +659,8 @@ class NonlinearSolver(Solver):
             error at the first iteration.
         """
         if self.options['debug_print']:
-            self._err_cache['inputs'] = deepcopy(self._system._inputs)
-            self._err_cache['outputs'] = deepcopy(self._system._outputs)
+            self._err_cache['inputs'] = self._system._inputs._copy_views()
+            self._err_cache['outputs'] = self._system._outputs._copy_views()
 
         if self.options['maxiter'] > 0:
             self._run_apply()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -344,15 +344,6 @@ class Solver(object):
     def _run_iterator(self):
         """
         Run the iterative solver.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         maxiter = self.options['maxiter']
         atol = self.options['atol']
@@ -404,8 +395,6 @@ class Solver(object):
                 print(prefix + ' Converged in {} iterations'.format(self._iter_count))
             elif iprint == 2:
                 print(prefix + ' Converged')
-
-        return fail, norm, norm / norm0
 
     def _iter_initialize(self):
         """
@@ -604,25 +593,20 @@ class NonlinearSolver(Solver):
     def solve(self):
         """
         Run the solver.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            absolute error.
-        float
-            relative error.
         """
         raised = False
         try:
-            fail, abs_err, rel_err = self._run_iterator()
-        except Exception:
-            fail = True
+            self._run_iterator()
+
+        except AnalysisError:
             raised = True
             exc = sys.exc_info()
 
-        if fail and self.options['debug_print']:
+        except Exception:
+            raised = True
+            exc = sys.exc_info()
+
+        if raised and self.options['debug_print']:
             coord = self._recording_iter.get_formatted_iteration_coordinate()
 
             out_str = "\n# Inputs and outputs at start of iteration '%s':\n" % coord
@@ -644,8 +628,6 @@ class NonlinearSolver(Solver):
 
         if raised:
             reraise(*exc)
-
-        return fail, abs_err, rel_err
 
     def _iter_initialize(self):
         """
@@ -795,20 +777,11 @@ class LinearSolver(Solver):
             'fwd' or 'rev'.
         rel_systems : set of str
             Set of names of relevant systems based on the current linear solve.
-
-        Returns
-        -------
-        boolean
-            Failure flag; True if failed to converge, False is successful.
-        float
-            initial error.
-        float
-            error at the first iteration.
         """
         self._vec_names = vec_names
         self._rel_systems = rel_systems
         self._mode = mode
-        return self._run_iterator()
+        self._run_iterator()
 
     def _iter_initialize(self):
         """

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -598,10 +598,6 @@ class NonlinearSolver(Solver):
         try:
             self._run_iterator()
 
-        except AnalysisError:
-            raised = True
-            exc = sys.exc_info()
-
         except Exception:
             raised = True
             exc = sys.exc_info()

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -15,7 +15,7 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from openmdao.api import Problem, IndepVarComp, ExecComp, Group, BalanceComp
+from openmdao.api import Problem, IndepVarComp, ExecComp, Group, BalanceComp, AnalysisError
 
 from openmdao.solvers.linear.direct import DirectSolver
 from openmdao.solvers.nonlinear.broyden import BroydenSolver
@@ -105,6 +105,7 @@ class TestNonlinearSolvers(unittest.TestCase):
         nl = model.circuit.nonlinear_solver = solver()
 
         nl.options['debug_print'] = True
+        nl.options['err_on_maxiter'] = True
 
         # suppress solver output for test
         nl.options['iprint'] = model.circuit.linear_solver.options['iprint'] = -1
@@ -126,7 +127,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         with printoptions(**opts):
             # run the model and check for expected output file
-            output = run_model(p)
+            output = run_model(p, allow_exception=True)
 
         expected_output = '\n'.join([
             self.expected_data,
@@ -140,7 +141,7 @@ class TestNonlinearSolvers(unittest.TestCase):
             self.assertEqual(f.read(), self.expected_data)
 
     def test_solver_debug_print_feature(self):
-        from openmdao.api import Problem, IndepVarComp, NewtonSolver
+        from openmdao.api import Problem, IndepVarComp, NewtonSolver, AnalysisError
         from openmdao.test_suite.test_examples.test_circuit_analysis import Circuit
 
         p = Problem()
@@ -159,6 +160,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         nl.options['iprint'] = 2
         nl.options['debug_print'] = True
+        nl.options['err_on_maxiter'] = True
 
         # set some poor initial guesses so that we don't converge
         p['circuit.n1.V'] = 10.
@@ -171,7 +173,10 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         with printoptions(**opts):
             # run the model
-            p.run_model()
+            try:
+                p.run_model()
+            except AnalysisError:
+                pass
 
         with open('rank0_root_0_NLRunOnce_0_circuit_0.dat', 'r') as f:
             self.assertEqual(f.read(), self.expected_data)

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -129,7 +129,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         with printoptions(**opts):
             # run the model and check for expected output file
-            output = run_model(p, allow_exception=True)
+            output = run_model(p, ignore_exception=True)
 
         expected_output = '\n'.join([
             self.expected_data,

--- a/openmdao/test_suite/components/ae_tests.py
+++ b/openmdao/test_suite/components/ae_tests.py
@@ -33,7 +33,7 @@ class AEDriver(Driver):
         Just handle it and return an error state.
         """
         try:
-            failure_flag, _, _ = self._problem.model._solve_nonlinear()
+            self._problem.model._solve_nonlinear()
         except AnalysisError:
             return True
 

--- a/openmdao/test_suite/parametric_suite.py
+++ b/openmdao/test_suite/parametric_suite.py
@@ -214,9 +214,7 @@ class ParameterizedInstance(object):
 
         prob.setup(check=check, local_vector_class=vec_class)
 
-        fail, rele, abse = prob.run_model()
-        if fail:
-            raise RuntimeError('Problem run failed: re %f ; ae %f' % (rele, abse))
+        prob.run_model()
 
     def compute_totals(self, mode='fwd'):
         """
@@ -236,9 +234,7 @@ class ParameterizedInstance(object):
 
         if problem._mode != mode:
             problem.setup(check=False, mode=mode)
-            fail, rele, abse = problem.run_model()
-            if fail:
-                raise RuntimeError('Problem run failed: re %f ; ae %f' % (rele, abse))
+            problem.run_model()
 
         root = problem.model
         of = root.total_of

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -506,7 +506,7 @@ def pad_name(name, pad_num=10, quotes=False):
             return '{0}'.format(name)
 
 
-def run_model(prob, allow_exception=False):
+def run_model(prob, ignore_exception=False):
     """
     Call `run_model` on problem and capture output.
 
@@ -514,8 +514,8 @@ def run_model(prob, allow_exception=False):
     ----------
     prob : Problem
         an instance of Problem
-    allow_exception : bool
-        Set to True to allow an exception of any kind.
+    ignore_exception : bool
+        Set to True to ignore an exception of any kind.
 
     Returns
     -------
@@ -529,7 +529,7 @@ def run_model(prob, allow_exception=False):
     try:
         prob.run_model()
     except Exception:
-        if not allow_exception:
+        if not ignore_exception:
             exc = sys.exc_info()
             reraise(*exc)
     finally:

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -502,7 +502,7 @@ def pad_name(name, pad_num=10, quotes=False):
             return '{0}'.format(name)
 
 
-def run_model(prob):
+def run_model(prob, allow_exception=False):
     """
     Call `run_model` on problem and capture output.
 
@@ -510,6 +510,8 @@ def run_model(prob):
     ----------
     prob : Problem
         an instance of Problem
+    allow_exception : bool
+        Set to True to allow an exception of any kind.
 
     Returns
     -------
@@ -522,6 +524,10 @@ def run_model(prob):
     sys.stdout = strout
     try:
         prob.run_model()
+    except Exception:
+        if not allow_exception:
+            exc = sys.exc_info()
+            reraise(*exc)
     finally:
         sys.stdout = stdout
 

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -1,9 +1,10 @@
 """Define the base Vector and Transfer classes."""
 from __future__ import division, print_function
 
+from six import iteritems, PY3
+from copy import deepcopy
 import os
 import numpy as np
-from six import iteritems, PY3
 
 from openmdao.utils.name_maps import name2abs_name
 
@@ -215,17 +216,17 @@ class Vector(object):
 
     def _copy_views(self):
         """
-        Return a lightweight object containing the views.
-         Returns
+        Return a lightweight copy containing just the views.
+
+        Returns
         -------
-        <Object>
-            Object containing _name, _typ, and _views.
+        <Vector>
+            Vector containing _name, _typ, and _views.
         """
         vec_cp = self.__class__(self._name, self._kind, self._system, self._root_vector,
                                 alloc_complex=self._alloc_complex, ncol=self._ncol)
         vec_cp._system = None
         vec_cp._typ = self._typ
-        vec_cp._name = self._name
         vec_cp._views = deepcopy(self._views)
         return vec_cp
 

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -216,19 +216,14 @@ class Vector(object):
 
     def _copy_views(self):
         """
-        Return a lightweight copy containing just the views.
+        Return a dictionary containing just the views.
 
         Returns
         -------
-        <Vector>
-            Vector containing _name, _typ, and _views.
+        dict
+            Dictionary containing the _views.
         """
-        vec_cp = self.__class__(self._name, self._kind, self._system, self._root_vector,
-                                alloc_complex=self._alloc_complex, ncol=self._ncol)
-        vec_cp._system = None
-        vec_cp._typ = self._typ
-        vec_cp._views = deepcopy(self._views)
-        return vec_cp
+        return deepcopy(self._views)
 
     def keys(self):
         """

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -213,6 +213,22 @@ class Vector(object):
             vec._initialize_views()
         return vec
 
+    def _copy_views(self):
+        """
+        Return a lightweight object containing the views.
+         Returns
+        -------
+        <Object>
+            Object containing _name, _typ, and _views.
+        """
+        vec_cp = self.__class__(self._name, self._kind, self._system, self._root_vector,
+                                alloc_complex=self._alloc_complex, ncol=self._ncol)
+        vec_cp._system = None
+        vec_cp._typ = self._typ
+        vec_cp._name = self._name
+        vec_cp._views = deepcopy(self._views)
+        return vec_cp
+
     def keys(self):
         """
         Return variable names of variables contained in this vector (relative names).


### PR DESCRIPTION
1. Removed the return values (fail, abs rel) from the entire openmdao solve/solve_*/run_* hierarchy; AnalysisError should be used to detect and act on errors.
2. Replaced vector deepcopy in the debug printing with a lightweight copy that only deepcopies the views.
3. Added an error message for DirectSolver with csc assembled jacobian for when there a row or column in the matrix is a linear  combination of other rows/cols.