### PR TITLE
remove tornado from 'docs' dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ optional_dependencies = {
         'numpydoc',
         'redbaron',
         'sphinx',
-        'tornado',
     ],
     'test': [
         'coverage',


### PR DESCRIPTION
Pivotal #162013259

`tornado` is only used by the `iprof` command line tool and the user is prompted to install it if it is not already installed when the command is used