### PR TITLE
update travis & appveyor scripts to install `testflo>=1.3.3` from `pypi` (via `setup.py`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,6 @@ install:
 
     echo " >> Installing forked python packages";
     pip install git+https://github.com/swryan/coveralls-python@work;
-    pip install git+https://github.com/OpenMDAO/testflo.git;
 
     echo " >> Installing pyOptSparse";
     echo "  > Cloning pyOptSparse from OpenMDAO's fork";

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -79,7 +79,6 @@ install:
 
     echo " >> Installing forked python packages";
     pip install git+https://github.com/swryan/coveralls-python@work;
-    pip install git+https://github.com/OpenMDAO/testflo.git;
 
     echo " >> Installing pyOptSparse";
     echo "  > Cloning pyOptSparse from OpenMDAO's fork";
@@ -112,7 +111,6 @@ install:
 - cmd: conda config --set always_yes yes
 - cmd: conda update conda
 - cmd: conda install python=%PYTHON% numpy=%NUMPY% scipy=%SCIPY% pip --quiet
-- cmd: pip install git+https://github.com/OpenMDAO/testflo.git
 - cmd: cd C:\projects\blue*
 - cmd: pip install -e .[all]
 - cmd: conda list

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ optional_dependencies = {
         'parameterized',
         'pycodestyle==2.3.1',
         'pydocstyle==2.0.0',
-        'testflo>=1.3.2',
+        'testflo>=1.3.3',
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ optional_dependencies = {
         'parameterized',
         'pycodestyle==2.3.1',
         'pydocstyle==2.0.0',
-        'testflo',
+        'testflo>=1.3.2',
     ],
 }
 


### PR DESCRIPTION
Previously, the scripts were installing `testflo` from `github` to pick up the latest version.
This is no longer necessary since the latest version has been published to `pypi`.