### PR TITLE
NonlinearBlockGS overhaul

### DIFF
--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1003,70 +1003,70 @@ def _get_mat(rows, cols):
         return np.random.random(rows * cols).reshape((rows, cols)) - 0.5
 
 
-#@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
-#class MatMultMultipointTestCase(unittest.TestCase):
-    #N_PROCS = 4
+@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
+class MatMultMultipointTestCase(unittest.TestCase):
+    N_PROCS = 4
 
-    #def test_multipoint_with_coloring(self):
-        #size = 10
-        #num_pts = self.N_PROCS
+    def test_multipoint_with_coloring(self):
+        size = 10
+        num_pts = self.N_PROCS
 
-        #np.random.seed(11)
+        np.random.seed(11)
 
-        #p = Problem()
-        #p.driver = pyOptSparseDriver()
-        #p.driver.options['optimizer'] = OPTIMIZER
-        #p.driver.options['dynamic_simul_derivs'] = True
-        #if OPTIMIZER == 'SNOPT':
-            #p.driver.opt_settings['Major iterations limit'] = 100
-            #p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-            #p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-            #p.driver.opt_settings['iSumm'] = 6
+        p = Problem()
+        p.driver = pyOptSparseDriver()
+        p.driver.options['optimizer'] = OPTIMIZER
+        p.driver.options['dynamic_simul_derivs'] = True
+        if OPTIMIZER == 'SNOPT':
+            p.driver.opt_settings['Major iterations limit'] = 100
+            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+            p.driver.opt_settings['iSumm'] = 6
 
-        #model = p.model
-        #for i in range(num_pts):
-            #model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
-            #model.add_design_var('indep%d.x' % i)
+        model = p.model
+        for i in range(num_pts):
+            model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
+            model.add_design_var('indep%d.x' % i)
 
-        #par1 = model.add_subsystem('par1', ParallelGroup())
-        #for i in range(num_pts):
-            #mat = _get_mat(5, size)
-            #par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
-            #model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
+        par1 = model.add_subsystem('par1', ParallelGroup())
+        for i in range(num_pts):
+            mat = _get_mat(5, size)
+            par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
+            model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
 
-        #par2 = model.add_subsystem('par2', ParallelGroup())
-        #for i in range(num_pts):
-            #mat = _get_mat(size, 5)
-            #par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
-            #model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
-            #par2.add_constraint('comp%d.y' % i, lower=-1.)
+        par2 = model.add_subsystem('par2', ParallelGroup())
+        for i in range(num_pts):
+            mat = _get_mat(size, 5)
+            par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
+            model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
+            par2.add_constraint('comp%d.y' % i, lower=-1.)
 
-            #model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
-            #model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
+            model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
+            model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
 
-        #model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
+        model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
 
-        #for i in range(num_pts):
-            #model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
+        for i in range(num_pts):
+            model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
 
-        #model.add_objective('obj.y')
+        model.add_objective('obj.y')
 
-        #p.setup()
+        p.setup()
 
-        #p.run_driver()
+        p.run_driver()
 
-        #J = p.compute_totals()
+        J = p.compute_totals()
 
-        #for i in range(num_pts):
-            #vname = 'par2.comp%d.A' % i
-            #if vname in model._var_abs_names['input']:
-                #norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
-                                      #getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
-                #self.assertLess(norm, 1.e-7)
-            #elif vname not in model._var_allprocs_abs_names['input']:
-                #self.fail("Can't find variable par2.comp%d.A" % i)
+        for i in range(num_pts):
+            vname = 'par2.comp%d.A' % i
+            if vname in model._var_abs_names['input']:
+                norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
+                                      getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
+                self.assertLess(norm, 1.e-7)
+            elif vname not in model._var_allprocs_abs_names['input']:
+                self.fail("Can't find variable par2.comp%d.A" % i)
 
-        ## print("final obj:", p['obj.y'])
+        # print("final obj:", p['obj.y'])
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1003,70 +1003,70 @@ def _get_mat(rows, cols):
         return np.random.random(rows * cols).reshape((rows, cols)) - 0.5
 
 
-@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
-class MatMultMultipointTestCase(unittest.TestCase):
-    N_PROCS = 4
+#@unittest.skipUnless(PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
+#class MatMultMultipointTestCase(unittest.TestCase):
+    #N_PROCS = 4
 
-    def test_multipoint_with_coloring(self):
-        size = 10
-        num_pts = self.N_PROCS
+    #def test_multipoint_with_coloring(self):
+        #size = 10
+        #num_pts = self.N_PROCS
 
-        np.random.seed(11)
+        #np.random.seed(11)
 
-        p = Problem()
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = OPTIMIZER
-        p.driver.options['dynamic_simul_derivs'] = True
-        if OPTIMIZER == 'SNOPT':
-            p.driver.opt_settings['Major iterations limit'] = 100
-            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-            p.driver.opt_settings['iSumm'] = 6
+        #p = Problem()
+        #p.driver = pyOptSparseDriver()
+        #p.driver.options['optimizer'] = OPTIMIZER
+        #p.driver.options['dynamic_simul_derivs'] = True
+        #if OPTIMIZER == 'SNOPT':
+            #p.driver.opt_settings['Major iterations limit'] = 100
+            #p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            #p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+            #p.driver.opt_settings['iSumm'] = 6
 
-        model = p.model
-        for i in range(num_pts):
-            model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
-            model.add_design_var('indep%d.x' % i)
+        #model = p.model
+        #for i in range(num_pts):
+            #model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
+            #model.add_design_var('indep%d.x' % i)
 
-        par1 = model.add_subsystem('par1', ParallelGroup())
-        for i in range(num_pts):
-            mat = _get_mat(5, size)
-            par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
-            model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
+        #par1 = model.add_subsystem('par1', ParallelGroup())
+        #for i in range(num_pts):
+            #mat = _get_mat(5, size)
+            #par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
+            #model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
 
-        par2 = model.add_subsystem('par2', ParallelGroup())
-        for i in range(num_pts):
-            mat = _get_mat(size, 5)
-            par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
-            model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
-            par2.add_constraint('comp%d.y' % i, lower=-1.)
+        #par2 = model.add_subsystem('par2', ParallelGroup())
+        #for i in range(num_pts):
+            #mat = _get_mat(size, 5)
+            #par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
+            #model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
+            #par2.add_constraint('comp%d.y' % i, lower=-1.)
 
-            model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
-            model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
+            #model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
+            #model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
 
-        model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
+        #model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
 
-        for i in range(num_pts):
-            model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
+        #for i in range(num_pts):
+            #model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
 
-        model.add_objective('obj.y')
+        #model.add_objective('obj.y')
 
-        p.setup()
+        #p.setup()
 
-        p.run_driver()
+        #p.run_driver()
 
-        J = p.compute_totals()
+        #J = p.compute_totals()
 
-        for i in range(num_pts):
-            vname = 'par2.comp%d.A' % i
-            if vname in model._var_abs_names['input']:
-                norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
-                                      getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
-                self.assertLess(norm, 1.e-7)
-            elif vname not in model._var_allprocs_abs_names['input']:
-                self.fail("Can't find variable par2.comp%d.A" % i)
+        #for i in range(num_pts):
+            #vname = 'par2.comp%d.A' % i
+            #if vname in model._var_abs_names['input']:
+                #norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
+                                      #getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
+                #self.assertLess(norm, 1.e-7)
+            #elif vname not in model._var_allprocs_abs_names['input']:
+                #self.fail("Can't find variable par2.comp%d.A" % i)
 
-        # print("final obj:", p['obj.y'])
+        ## print("final obj:", p['obj.y'])
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -372,6 +372,7 @@ class TestScaling(unittest.TestCase):
 
         model.nonlinear_solver = NonlinearBlockGS()
         model.nonlinear_solver.options['maxiter'] = 1
+        model.nonlinear_solver.options['use_apply_nonlinear'] = True
 
         prob.set_solver_print(level=0)
 
@@ -410,6 +411,7 @@ class TestScaling(unittest.TestCase):
 
         model.nonlinear_solver = NonlinearBlockGS()
         model.nonlinear_solver.options['maxiter'] = 1
+        model.nonlinear_solver.options['use_apply_nonlinear'] = True
 
         prob.set_solver_print(level=0)
 
@@ -444,6 +446,7 @@ class TestScaling(unittest.TestCase):
 
         model.nonlinear_solver = NonlinearBlockGS()
         model.nonlinear_solver.options['maxiter'] = 1
+        model.nonlinear_solver.options['use_apply_nonlinear'] = True
 
         prob.set_solver_print(level=0)
 
@@ -480,6 +483,7 @@ class TestScaling(unittest.TestCase):
 
         model.nonlinear_solver = NonlinearBlockGS()
         model.nonlinear_solver.options['maxiter'] = 1
+        model.nonlinear_solver.options['use_apply_nonlinear'] = True
 
         prob.set_solver_print(level=0)
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/newton.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/newton.rst
@@ -45,8 +45,8 @@ NewtonSolver Option Examples
 **atol**
 
   Here, we set the absolute tolerance to a looser value that will trigger an earlier termination. After
-  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on implicit
-  components and `evaluate` on explicit components. If this norm value is lower than the absolute
+  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on all of the components.
+  If this norm value is lower than the absolute
   tolerance `atol`, the iteration will terminate.
 
   .. embed-code::
@@ -56,8 +56,8 @@ NewtonSolver Option Examples
 **rtol**
 
   Here, we set the relative tolerance to a looser value that will trigger an earlier termination. After
-  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on implicit
-  components and `evaluate` on explicit components. If the ratio of the currently calculated norm to the
+  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on all of the components.
+  If the ratio of the currently calculated norm to the
   initial residual norm is lower than the relative tolerance `rtol`, the iteration will terminate.
 
   .. embed-code::

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -46,8 +46,8 @@ The relaxation is turned off by default, but it may help convergence for more ti
 
 .. _optimization: http://mdolab.engin.umich.edu/content/scalable-parallel-approach-aeroelastic-analysis-and-derivative
 
-Norm Calculation
------------------
+Residual Calculation
+--------------------
 The `Unified Derivatives Equations` are formulated so that explicit equations (via `ExplicitComponent`) are also expressed
 as implicit relationships, and their residual is also calculated in "apply_linear", which runs the component a second time and
 saves the difference in the output vector as the residual. However, this would require an extra call to `execute`, which is

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -50,7 +50,7 @@ Residual Calculation
 --------------------
 The `Unified Derivatives Equations` are formulated so that explicit equations (via `ExplicitComponent`) are also expressed
 as implicit relationships, and their residual is also calculated in "apply_linear", which runs the component a second time and
-saves the difference in the output vector as the residual. However, this would require an extra call to `execute`, which is
+saves the difference in the output vector as the residual. However, this would require an extra call to `compute`, which is
 inefficient for slower components. To elimimate the inefficiency of running the model twice every iteration the NonlinearBlockGS
 driver saves a copy of the output vector and uses that to calculate the residual without rerunning the model. This does require
 a little more memory, so if you are solving a model where memory is more of a concern than execution time, you can set the

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -46,6 +46,17 @@ The relaxation is turned off by default, but it may help convergence for more ti
 
 .. _optimization: http://mdolab.engin.umich.edu/content/scalable-parallel-approach-aeroelastic-analysis-and-derivative
 
+Norm Calculation
+-----------------
+The `Unified Derivatives Equations` are formulated so that explicit equations (via `ExplicitComponent`) are also expressed
+as implicit relationships, and their residual is also calculated in "apply_linear", which runs the component a second time and
+saves the difference in the output vector as the residual. However, this would require an extra call to `execute`, which is
+inefficient for slower components. To elimimate the inefficiency of running the model twice every iteration the NonlinearBlockGS
+driver saves a copy of the output vector and uses that to calculate the residual without rerunning the model. This does require
+a little more memory, so if you are solving a model where memory is more of a concern than execution time, you can set the
+"use_apply_nonlinear" option to True to use thhe original formulation that calls "apply_linear" on the subsystem.
+
+
 NonlinearBlockGS Option Examples
 --------------------------------
 
@@ -62,9 +73,11 @@ NonlinearBlockGS Option Examples
 **atol**
 
   Here, we set the absolute tolerance to a looser value that will trigger an earlier termination. After
-  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on implicit
-  components and `evaluate` on explicit components. If this norm value is lower than the absolute
-  tolerance `atol`, the iteration will terminate.
+  each iteration, the norm of the residuals is calculated one of two ways. If the "use_apply_linear" option
+  is set to False (its default), then the norm is calculated by subtracting a cached previous value of the
+  outputs from the current value.  If "use_apply_linear" is True, then the norm is calculated by calling
+  apply_linear on all of the subsystems. In this case, `ExplicitComponents` are executed a second time.
+  If this norm value is lower than the absolute tolerance `atol`, the iteration will terminate.
 
   .. embed-code::
       openmdao.solvers.nonlinear.tests.test_nonlinear_block_gs.TestNLBGaussSeidel.test_feature_atol
@@ -73,9 +86,12 @@ NonlinearBlockGS Option Examples
 **rtol**
 
   Here, we set the relative tolerance to a looser value that will trigger an earlier termination. After
-  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on implicit
-  components and `evaluate` on explicit components. If the ratio of the currently calculated norm to the
-  initial residual norm is lower than the relative tolerance `rtol`, the iteration will terminate.
+  each iteration, the norm of the residuals is calculated one of two ways. If the "use_apply_linear" option
+  is set to False (its default), then the norm is calculated by subtracting a cached previous value of the
+  outputs from the current value.  If "use_apply_linear" is True, then the norm is calculated by calling
+  apply_linear on all of the subsystems. In this case, `ExplicitComponents` are executed a second time.
+  If the ratio of the currently calculated norm to the initial residual norm is lower than the relative tolerance
+  `rtol`, the iteration will terminate.
 
   .. embed-code::
       openmdao.solvers.nonlinear.tests.test_nonlinear_block_gs.TestNLBGaussSeidel.test_feature_rtol

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -54,7 +54,7 @@ saves the difference in the output vector as the residual. However, this would r
 inefficient for slower components. To elimimate the inefficiency of running the model twice every iteration the NonlinearBlockGS
 driver saves a copy of the output vector and uses that to calculate the residual without rerunning the model. This does require
 a little more memory, so if you are solving a model where memory is more of a concern than execution time, you can set the
-"use_apply_nonlinear" option to True to use thhe original formulation that calls "apply_linear" on the subsystem.
+"use_apply_nonlinear" option to True to use the original formulation that calls "apply_linear" on the subsystem.
 
 
 NonlinearBlockGS Option Examples

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_jac.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_jac.rst
@@ -54,8 +54,8 @@ NonlinearBlockJac Option Examples
 **atol**
 
   Here, we set the absolute tolerance to a looser value that will trigger an earlier termination. After
-  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on implicit
-  components and `evaluate` on explicit components. If this norm value is lower than the absolute
+  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on all of the components.
+  If this norm value is lower than the absolute
   tolerance `atol`, the iteration will terminate.
 
   .. embed-code::
@@ -65,8 +65,8 @@ NonlinearBlockJac Option Examples
 **rtol**
 
   Here, we set the relative tolerance to a looser value that will trigger an earlier termination. After
-  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on implicit
-  components and `evaluate` on explicit components. If the ratio of the currently calculated norm to the
+  each iteration, the norm of the residuals is calculated by calling `apply_nonlinear` on all of the components.
+  If the ratio of the currently calculated norm to the
   initial residual norm is lower than the relative tolerance `rtol`, the iteration will terminate.
 
   .. embed-code::

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -235,6 +235,8 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         prob.setup()
 
+        model.nonlinear_solver.options['use_apply_nonlinear'] = True
+
         model.d1.add_recorder(self.recorder)  # SellarDis1withDerivatives (an ExplicitComp)
         model.obj_cmp.add_recorder(self.recorder)  # an ExecComp
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -374,10 +374,10 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.assertEqual(cr._input2meta['obj_cmp.y1']['explicit'], True)
         self.assertEqual(cr._input2meta['obj_cmp.y2']['explicit'], True)
 
-        self.assertEqual(cr._output2meta['x']['lower'], -1000)
-        self.assertEqual(cr._output2meta['x']['upper'], 1000)
-        self.assertEqual(cr._output2meta['y2']['upper'], None)
-        self.assertEqual(cr._output2meta['y2']['lower'], None)
+        self.assertEqual(cr._output2meta['x']['lower'], -1000.)
+        self.assertEqual(cr._output2meta['x']['upper'], 1000.)
+        self.assertEqual(cr._output2meta['y2']['upper'], 1000.)
+        self.assertEqual(cr._output2meta['y2']['lower'], -1000.)
 
     def test_reading_solver_metadata(self):
         prob = SellarProblem(linear_solver=LinearBlockGS())
@@ -954,7 +954,8 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         expected_outputs = {
             'd1.y1': {
-                'lower': None,
+                'lower': -1000.,
+                'upper': 1000.,
                 'ref': 1.0,
                 'resids': [1.318e-10],
                 'shape': (1,),

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -377,7 +377,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.assertEqual(cr._output2meta['x']['lower'], -1000.)
         self.assertEqual(cr._output2meta['x']['upper'], 1000.)
         self.assertEqual(cr._output2meta['y2']['upper'], 1000.)
-        self.assertEqual(cr._output2meta['y2']['lower'], -1000.)
+        self.assertEqual(cr._output2meta['y2']['lower'], 0.1)
 
     def test_reading_solver_metadata(self):
         prob = SellarProblem(linear_solver=LinearBlockGS())
@@ -954,7 +954,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         expected_outputs = {
             'd1.y1': {
-                'lower': -1000.,
+                'lower': 0.1,
                 'upper': 1000.,
                 'ref': 1.0,
                 'resids': [1.318e-10],

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -554,6 +554,8 @@ class TestSqliteRecorder(unittest.TestCase):
         model.recording_options['record_metadata'] = True
         model.add_recorder(self.recorder)
 
+        model.nonlinear_solver.options['use_apply_nonlinear'] = True
+
         d1 = model.d1  # SellarDis1withDerivatives, an ExplicitComp
         d1.recording_options['record_inputs'] = True
         d1.recording_options['record_outputs'] = True
@@ -713,6 +715,8 @@ class TestSqliteRecorder(unittest.TestCase):
         model.recording_options['record_metadata'] = True
         model.add_recorder(self.recorder)
 
+        model.mda.nonlinear_solver.options['use_apply_nonlinear'] = True
+
         pz = model.pz  # IndepVarComp which is an ExplicitComponent
         pz.recording_options['record_inputs'] = True
         pz.recording_options['record_outputs'] = True
@@ -778,6 +782,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
 
         nl = prob.model.nonlinear_solver
+        nl.options['use_apply_nonlinear'] = True
         nl.recording_options['record_abs_error'] = True
         nl.recording_options['record_rel_error'] = True
         nl.recording_options['record_solver_residuals'] = True
@@ -961,6 +966,7 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.model.nonlinear_solver.add_recorder(self.recorder)
         prob.model.nonlinear_solver.recording_options['record_solver_residuals'] = True
+        prob.model.nonlinear_solver.options['use_apply_nonlinear'] = True
 
         prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
@@ -1354,6 +1360,8 @@ class TestSqliteRecorder(unittest.TestCase):
         # Need to do recursive adding of recorders AFTER setup
         prob.model.add_recorder(self.recorder, recurse=True)
 
+        prob.model.mda.nonlinear_solver.options['use_apply_nonlinear'] = True
+
         prob.run_model()
         prob.cleanup()
 
@@ -1386,6 +1394,8 @@ class TestSqliteRecorder(unittest.TestCase):
     def test_record_system_with_prefix(self):
         prob = SellarProblem(SellarDerivativesGrouped, nonlinear_solver=NonlinearRunOnce)
         prob.setup(mode='rev')
+
+        prob.model.mda.nonlinear_solver.options['use_apply_nonlinear'] = True
 
         prob.model.add_recorder(self.recorder, recurse=True)
 
@@ -1848,6 +1858,8 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         obj_cmp.recording_options['includes'] = ['*']
         obj_cmp.recording_options['excludes'] = ['obj_cmp.x']
 
+        prob.model.nonlinear_solver.options['use_apply_nonlinear'] = True
+
         prob.run_model()
         prob.cleanup()
 
@@ -1918,6 +1930,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         solver = prob.model.nonlinear_solver
         solver.add_recorder(recorder)
         solver.recording_options['record_abs_error'] = True
+        solver.options['use_apply_nonlinear'] = True
 
         prob.run_model()
         prob.cleanup()

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -106,9 +106,9 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         model.nonlinear_solver.options['maxiter'] = 5
         model.linear_solver = ScipyKrylov()
         model.linear_solver.precon = self.linear_solver_class()
+        model.linear_solver.precon.options['maxiter'] = 100
 
         prob.setup(check=False)
-        prob.set_solver_print(level=0)
 
         prob.run_model()
         res = model._residuals.get_norm()

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -110,6 +110,8 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
 
         prob.setup(check=False)
 
+        prob['d1.y1'] = 4.0
+        prob.set_solver_print()
         prob.run_model()
         res = model._residuals.get_norm()
 

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -8,7 +8,7 @@ import numpy as np
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.api import LinearBlockGS, Problem, Group, ImplicitComponent, IndepVarComp, \
-    DirectSolver, NewtonSolver, ScipyKrylov, ExecComp, NonlinearBlockGS
+    DirectSolver, NewtonSolver, ScipyKrylov, ExecComp, NonlinearBlockGS, BoundsEnforceLS
 from openmdao.test_suite.components.sellar import SellarImplicitDis1, SellarImplicitDis2, \
     SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
@@ -104,9 +104,9 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
 
         model.nonlinear_solver = NewtonSolver()
         model.nonlinear_solver.options['maxiter'] = 5
+        model.nonlinear_solver.linesearch = BoundsEnforceLS()
         model.linear_solver = ScipyKrylov()
         model.linear_solver.precon = self.linear_solver_class()
-        model.linear_solver.precon.options['maxiter'] = 100
 
         prob.setup(check=False)
 

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -382,7 +382,7 @@ class TestScipyKrylovFeature(unittest.TestCase):
         model.linear_solver = ScipyKrylov()
 
         model.linear_solver.precon = LinearBlockGS()
-        model.linear_solver.precon.options['maxiter'] = 2
+        model.linear_solver.precon.options['maxiter'] = 10
 
         prob.setup()
         prob.run_model()

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -7,7 +7,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, Problem, ExecComp, NonlinearBlockGS
+from openmdao.api import Group, IndepVarComp, Problem, ExecComp, NonlinearBlockGS, BoundsEnforceLS
 from openmdao.solvers.linear.linear_block_gs import LinearBlockGS
 from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov, ScipyIterativeSolver
 from openmdao.solvers.nonlinear.newton import NewtonSolver
@@ -379,10 +379,11 @@ class TestScipyKrylovFeature(unittest.TestCase):
         model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
         model.nonlinear_solver = NewtonSolver()
+        model.nonlinear_solver.linesearch = BoundsEnforceLS()
         model.linear_solver = ScipyKrylov()
 
         model.linear_solver.precon = LinearBlockGS()
-        model.linear_solver.precon.options['maxiter'] = 10
+        model.linear_solver.precon.options['maxiter'] = 2
 
         prob.setup()
         prob.run_model()

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -103,11 +103,13 @@ class TestNonlinearSolvers(unittest.TestCase):
         model.connect('ground.V', 'circuit.Vg')
 
         p.setup()
-
         nl = model.circuit.nonlinear_solver = solver()
 
         nl.options['debug_print'] = True
         nl.options['err_on_maxiter'] = True
+
+        if name == 'NonlinearBlockGS':
+            nl.options['use_apply_nonlinear'] = True
 
         # suppress solver output for test
         nl.options['iprint'] = model.circuit.linear_solver.options['iprint'] = -1

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -182,6 +182,8 @@ class SellarDis2withDerivatives(SellarDis2):
         y1 = inputs['y1']
         if y1.real < 0.0:
             y1 *= -1
+        if y1.real < 1e-8:
+            y1 = 1e-8
 
         J['y2', 'y1'] = .5*y1**-.5
         J['y2', 'z'] = np.array([[1.0, 1.0]])
@@ -606,6 +608,8 @@ class SellarImplicitDis2(ImplicitComponent):
         y1 = inputs['y1']
         if y1.real < 0.0:
             y1 *= -1
+        if y1.real < 1e-8:
+            y1 = 1e-8
 
         J['y2', 'y1'] = -.5*y1**-.5
         J['y2', 'z'] = -np.array([[1.0, 1.0]])

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -56,7 +56,7 @@ class SellarDis1(ExplicitComponent):
         self.add_input('y2', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y1', val=1.0, lower=-1000., upper=1000., units=units, ref=ref)
+        self.add_output('y1', val=1.0, lower=0.1, upper=1000., units=units, ref=ref)
 
         self._do_declares()
 
@@ -137,7 +137,7 @@ class SellarDis2(ExplicitComponent):
         self.add_input('y1', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y2', val=1.0, lower=-1000., upper=1000., units=units, ref=ref)
+        self.add_output('y2', val=1.0, lower=0.1, upper=1000., units=units, ref=ref)
 
         self._do_declares()
 
@@ -517,7 +517,7 @@ class SellarImplicitDis1(ImplicitComponent):
         self.add_input('y2', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y1', val=1.0, lower=-1000, upper=1000, units=units, ref=ref)
+        self.add_output('y1', val=1.0, lower=-0.1, upper=1000, units=units, ref=ref)
 
         # Derivatives
         self.declare_partials('*', '*')
@@ -576,7 +576,7 @@ class SellarImplicitDis2(ImplicitComponent):
         self.add_input('y1', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y2', val=1.0, lower=-1000., upper=1000., units=units, ref=ref)
+        self.add_output('y2', val=1.0, lower=0.1, upper=1000., units=units, ref=ref)
 
         # Derivatives
         self.declare_partials('*', '*')

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -56,7 +56,7 @@ class SellarDis1(ExplicitComponent):
         self.add_input('y2', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y1', val=1.0, units=units, ref=ref)
+        self.add_output('y1', val=1.0, lower=-1000., upper=1000., units=units, ref=ref)
 
         self._do_declares()
 
@@ -137,7 +137,7 @@ class SellarDis2(ExplicitComponent):
         self.add_input('y1', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y2', val=1.0, units=units, ref=ref)
+        self.add_output('y2', val=1.0, lower=-1000., upper=1000., units=units, ref=ref)
 
         self._do_declares()
 
@@ -515,7 +515,7 @@ class SellarImplicitDis1(ImplicitComponent):
         self.add_input('y2', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y1', val=1.0, units=units, ref=ref)
+        self.add_output('y1', val=1.0, lower=-1000, upper=1000, units=units, ref=ref)
 
         # Derivatives
         self.declare_partials('*', '*')
@@ -574,7 +574,7 @@ class SellarImplicitDis2(ImplicitComponent):
         self.add_input('y1', val=1.0, units=units)
 
         # Coupling output
-        self.add_output('y2', val=1.0, units=units, ref=ref)
+        self.add_output('y2', val=1.0, lower=-1000., upper=1000., units=units, ref=ref)
 
         # Derivatives
         self.declare_partials('*', '*')

--- a/openmdao/test_suite/tests/test_feature_sellar.py
+++ b/openmdao/test_suite/tests/test_feature_sellar.py
@@ -29,6 +29,7 @@ class TestSellarFeature(unittest.TestCase):
         prob.model = SellarMDALinearSolver()
 
         prob.setup(check=False)
+        prob.model.cycle.nonlinear_solver.options['use_apply_nonlinear'] = True
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)


### PR DESCRIPTION
1. Modification to nlbgs solver so that the residual is calculated by caching the outputs vector from the previous iteration instead of running the model a second time per iteration. This is computationally much more efficient, but uses a little more memory. The old behavior can be retained if desired by setting `use_apply_nonlinear` to True.
2.  Modified the aitken implementation so that it uses ndarrays instead of cloning the openmdao vector. Also, the caching between iterations has been reduced to the minimal necessary.