### PR TITLE
fix problem with case recording

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -273,9 +273,6 @@ class Driver(object):
         self._remote_responses = self._remote_cons.copy()
         self._remote_responses.update(self._remote_objs)
 
-        # set up case recording
-        self._setup_recording()
-
         # set up simultaneous deriv coloring
         if (coloring_mod._use_sparsity and self._simul_coloring_info and
                 self.supports['simultaneous_derivatives']):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -305,7 +305,6 @@ class Driver(object):
         mydesvars = myobjectives = myconstraints = set()
 
         if recording_options['record_desvars']:
-            print('recording desvars', recording_options['record_desvars'])
             if MPI:
                 mydesvars = [n for n in all_desvars if rrank == rowned[n]]
             else:
@@ -328,10 +327,6 @@ class Driver(object):
             'obj': myobjectives,
             'con': myconstraints
         }
-
-        if recording_options is self.recording_options:
-            from pprint import pprint
-            pprint(filtered_vars_to_record)
 
         # responses (if in options)
         if 'record_responses' in recording_options:
@@ -379,15 +374,13 @@ class Driver(object):
                         for d in all_vars[:-1]:
                             myoutputs.update(d)
 
-                    # de-duplicate
-                    myoutputs = myoutputs.difference(all_desvars, all_objectives, all_constraints)
+                # de-duplicate
+                myoutputs = myoutputs.difference(all_desvars, all_objectives, all_constraints)
 
+                if MPI:
                     myoutputs = [n for n in myoutputs if rrank == rowned[n]]
 
             filtered_vars_to_record['sys'] = myoutputs
-
-        if recording_options is self.recording_options:
-            pprint(filtered_vars_to_record)
 
         return filtered_vars_to_record
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -281,6 +281,16 @@ class Driver(object):
     def _get_vars_to_record(self, recording_options):
         """
         Get variables to record based on recording options.
+
+        Parameters
+        ----------
+        recording_options : <OptionsDictionary>
+            Dictionary with recording options.
+
+        Returns
+        -------
+        dict
+           Dictionary containing lists of variables to record.
         """
         problem = self._problem
         model = problem.model

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -318,19 +318,19 @@ class Driver(object):
             if MPI:
                 mydesvars = [n for n in all_desvars if rrank == rowned[n]]
             else:
-                mydesvars = all_desvars
+                mydesvars = list(all_desvars)
 
         if recording_options['record_objectives']:
             if MPI:
                 myobjectives = [n for n in all_objectives if rrank == rowned[n]]
             else:
-                myobjectives = all_objectives
+                myobjectives = list(all_objectives)
 
         if recording_options['record_constraints']:
             if MPI:
                 myconstraints = [n for n in all_constraints if rrank == rowned[n]]
             else:
-                myconstraints = all_constraints
+                myconstraints = list(all_constraints)
 
         filtered_vars_to_record = {
             'des': mydesvars,
@@ -348,7 +348,7 @@ class Driver(object):
                 if MPI:
                     myresponses = [n for n in myresponses if rrank == rowned[n]]
 
-            filtered_vars_to_record['res'] = myresponses
+            filtered_vars_to_record['res'] = list(myresponses)
 
         # inputs (if in options)
         if 'record_inputs' in recording_options:
@@ -365,9 +365,9 @@ class Driver(object):
                         for d in all_vars[:-1]:
                             myinputs.update(d)
 
-                    myinputs = set([n for n in myinputs if rrank == rowned[n]])
+                    myinputs = [n for n in myinputs if rrank == rowned[n]]
 
-            filtered_vars_to_record['in'] = myinputs
+            filtered_vars_to_record['in'] = list(myinputs)
 
         # system outputs (if the options being processed are for the driver itself)
         if recording_options is self.recording_options:
@@ -390,7 +390,7 @@ class Driver(object):
                 if MPI:
                     myoutputs = [n for n in myoutputs if rrank == rowned[n]]
 
-            filtered_vars_to_record['sys'] = myoutputs
+            filtered_vars_to_record['sys'] = list(myoutputs)
 
         return filtered_vars_to_record
 
@@ -401,8 +401,6 @@ class Driver(object):
         self._filtered_vars_to_record = self._get_vars_to_record(self.recording_options)
 
         self._rec_mgr.startup(self)
-
-        print(self.__class__.__name__, 'recorders:', self._rec_mgr._recorders)
 
         # record the system metadata to the recorders attached to this Driver
         if self.recording_options['record_model_metadata']:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -841,7 +841,7 @@ class Problem(object):
                            "(objectives and nonlinear constraints)." %
                            (mode, desvar_size, response_size), RuntimeWarning)
 
-        # we only want to set up recording once
+        # we only want to set up recording once, after problem setup
         if self._setup_status == 1:
             driver._setup_recording()
             self._setup_recording()

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -95,9 +95,8 @@ class RecordingManager(object):
             # TODO Eventually, we think we can get rid of this next check. But to be safe,
             #       we are leaving it in there.
             if not model.is_active():
-                raise RuntimeError(
-                    "RecordingManager.startup should never be called when "
-                    "running in parallel on an inactive System")
+                raise RuntimeError("RecordingManager.startup should never be called when "
+                                   "running in parallel on an inactive System")
 
         for recorder in self._recorders:
             # Each of the recorders determines its self._filtered_* list of vars

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -494,7 +494,7 @@ def _get_bool_jac(prob, repeats=3, tol=1e-15, orders=5, setup=False, run_model=F
         prob.setup(mode=prob._mode)
 
     if run_model:
-        prob.run_model()
+        prob.run_model(reset_iter_counts=False)
 
     wrt = list(prob.driver._designvars)
 


### PR DESCRIPTION
Pivotal #162598121 : problem with case recording from SNOPT/pyoptsparse

Calling `final_setup` multiple times (due to calling `run_model` during coloring) meant recording setup was called multiple times, resetting counters and creating duplicate iteration coordinates, etc.  This change ensures that recording setup is called only once after problem setup and that coloring does not reset the iteration counter.

I've also consolidated some duplicate code that existed in both `Problem` and `Driver`.
