### PR TITLE
add shape & prom_name args to list_inputs

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2355,7 +2355,9 @@ class System(object):
 
     def list_inputs(self,
                     values=True,
+                    prom_name=False,
                     units=False,
+                    shape=False,
                     hierarchical=True,
                     print_arrays=False,
                     out_stream=_DEFAULT_OUT_STREAM):
@@ -2370,8 +2372,13 @@ class System(object):
         ----------
         values : bool, optional
             When True, display/return input values. Default is True.
+        prom_name : bool, optional
+            When True, display/return the promoted name of the variable.
+            Default is False.
         units : bool, optional
             When True, display/return units. Default is False.
+        shape : bool, optional
+            When True, display/return the shape of the value. Default is False.
         hierarchical : bool, optional
             When True, human readable output shows variables in hierarchical format.
         print_arrays : bool, optional
@@ -2399,8 +2406,12 @@ class System(object):
             outs = {}
             if values:
                 outs['value'] = val
+            if prom_name:
+                outs['prom_name'] = self._var_abs2prom['input'][name]
             if units:
                 outs['units'] = meta[name]['units']
+            if shape:
+                outs['shape'] = val.shape
             inputs.append((name, outs))
 
         if out_stream is _DEFAULT_OUT_STREAM:

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -183,24 +183,28 @@ class ExplCompTestCase(unittest.TestCase):
         # list_inputs tests
         # Can't do exact equality here because units cause comp.y to be slightly different than 12.0
         stream = cStringIO()
-        inputs = prob.model.list_inputs(units=True, out_stream=stream)
+        inputs = prob.model.list_inputs(units=True, shape=True, out_stream=stream)
         tol = 1e-7
         for actual, expected in zip(sorted(inputs), [
-            ('comp.x', {'value': [12.], 'units': 'inch'}),
-            ('comp.y', {'value': [12.], 'units': 'inch'})
+            ('comp.x', {'value': [12.], 'shape': (1,), 'units': 'inch'}),
+            ('comp.y', {'value': [12.], 'shape': (1,), 'units': 'inch'})
         ]):
             self.assertEqual(expected[0], actual[0])
             self.assertEqual(expected[1]['units'], actual[1]['units'])
+            self.assertEqual(expected[1]['shape'], actual[1]['shape'])
             assert_rel_error(self, expected[1]['value'], actual[1]['value'], tol)
 
         text = stream.getvalue()
+
         self.assertEqual(1, text.count("Input(s) in 'model'"))
         self.assertEqual(1, text.count('varname'))
         self.assertEqual(1, text.count('value'))
+        self.assertEqual(1, text.count('shape'))
         self.assertEqual(1, text.count('top'))
         self.assertEqual(1, text.count('  comp'))
         self.assertEqual(1, text.count('    x'))
         self.assertEqual(1, text.count('    y'))
+
         num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
         self.assertEqual(8, num_non_empty_lines)
 

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -189,6 +189,25 @@ class ImplicitCompTestCase(unittest.TestCase):
         self.assertEqual(text.count('comp3.'), 3)
         self.assertEqual(text.count('value'), 1)
 
+    def test_list_inputs_prom_name(self):
+        self.prob.run_model()
+
+        stream = cStringIO()
+        states = self.prob.model.list_inputs(prom_name=True, shape=True, hierarchical=True,
+                                             out_stream=stream)
+
+        text = stream.getvalue()
+
+        self.assertEqual(text.count('comp2.a'), 1)
+        self.assertEqual(text.count('comp2.b'), 1)
+        self.assertEqual(text.count('comp2.c'), 1)
+        self.assertEqual(text.count('comp3.a'), 1)
+        self.assertEqual(text.count('comp3.b'), 1)
+        self.assertEqual(text.count('comp3.c'), 1)
+
+        num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
+        self.assertEqual(num_non_empty_lines, 13)
+
     def test_list_explicit_outputs(self):
         self.prob.run_model()
 

--- a/openmdao/utils/write_outputs.py
+++ b/openmdao/utils/write_outputs.py
@@ -71,7 +71,7 @@ def write_outputs(in_or_out, comp_type, dict_of_outputs, hierarchical, print_arr
     # Need an ordered list of possible output values for the two cases: inputs and outputs
     #  so that we do the column output in the correct order
     if in_or_out == 'input':
-        out_types = ('value', 'units',)
+        out_types = ('value', 'units', 'shape', 'prom_name')
     else:
         out_types = ('value', 'resids', 'units', 'shape', 'lower', 'upper', 'ref',
                      'ref0', 'res_ref', 'prom_name')


### PR DESCRIPTION
Pivotal #163328616 : list_inputs should accommodate the shape argument
Pivotal #163309134 : user can request a listing of promoted name when calling list_inputs on a system. 