### PR TITLE
ScipyOptimizeDriver new-style bounds

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -274,8 +274,14 @@ class ScipyOptimizeDriver(Driver):
         if use_bounds and (opt in _supports_new_style) and _use_new_style:
             # For 'trust-constr' it is better to use the new type bounds, because it seems to work
             # better (for the current examples in the tests) with the "keep_feasible" option
-            from scipy.optimize import Bounds
-            from scipy.optimize._constraints import old_bound_to_new
+            try:
+                from scipy.optimize import Bounds
+                from scipy.optimize._constraints import old_bound_to_new
+            except ImportError:
+                msg = ('The "trust-constr" optimizer is supported for SciPy 1.1.0 and above. '
+                       'The installed version is {}')
+                raise ImportError(msg.format(scipy_version))
+
             lower, upper = old_bound_to_new(bounds)
             keep_feasible = self.opt_settings.get('keep_feasible_bounds', True)
             bounds = Bounds(lb=lower, ub=upper, keep_feasible=keep_feasible)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1047,7 +1047,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_rel_error(self, prob['c'], 1.0, 1e-2)
 
-    # TODO, add bounds test, when SciPy issue #9043 is resolved
+    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
+                         "scipy >= 1.2 is required.")
     def test_trust_constr_bounds(self):
         class Rosenbrock(ExplicitComponent):
 


### PR DESCRIPTION
Implemented "new-style" bounds (which are `Bounds` objects instead of tuples). This is useful for the "trust-constr" optimizer, because it has an additional option to keep the bounds feasible. 
Now the test for the bounded "trust-constr" problem from PR  #800 works.