### PR TITLE
Problem viewer toolbar

### DIFF
--- a/openmdao/devtools/html_utils.py
+++ b/openmdao/devtools/html_utils.py
@@ -16,13 +16,14 @@ def head_and_body(head, body, attrs=None):
     return doc_type + '\n' + index
 
 
-def write_tags(tag, content='', attrs=None, cls=None, new_lines=False, indent=0):
+def write_tags(tag, content='', attrs=None, cls=None, new_lines=False, indent=0, **kwargs):
     # Writes an HTML tag with element content and element attributes (given as a dictionary)
     line_sep = '\n' if new_lines else ''
     spaces = ' ' * indent
     template = '{spaces}<{tag} {attributes}>{ls}{content}{ls}</{tag}>\n'
     if attrs is None:
         attrs = {}
+    attrs.update(kwargs)
     if cls is not None:
         attrs['class'] = cls
     attrs = ' '.join(['{}="{}"'.format(k, v) for k, v in iteritems(attrs)])
@@ -31,26 +32,27 @@ def write_tags(tag, content='', attrs=None, cls=None, new_lines=False, indent=0)
     return template.format(tag=tag, content=content, attributes=attrs, ls=line_sep, spaces=spaces)
 
 
-def write_div(content='', attrs=None, cls=None, indent=0):
-    return write_tags('div', content=content, attrs=attrs, cls=cls, new_lines=False, indent=indent)
+def write_div(content='', attrs=None, cls=None, indent=0, **kwargs):
+    return write_tags('div', content=content, attrs=attrs, cls=cls, new_lines=False,
+                      indent=indent, **kwargs)
 
 
-def write_style(content='', attrs=None, indent=0):
+def write_style(content='', attrs=None, indent=0, **kwargs):
     default = {'type': "text/css"}
     if attrs is None:
         attrs = default
     else:
         attrs = default.update(attrs)
-    return write_tags('style', content, attrs=attrs, new_lines=True, indent=indent)
+    return write_tags('style', content, attrs=attrs, new_lines=True, indent=indent, **kwargs)
 
 
-def write_script(content='', attrs=None, indent=0):
+def write_script(content='', attrs=None, indent=0, **kwargs):
     default = {'type': "text/javascript"}
     if attrs is None:
         attrs = default
     else:
         attrs = default.update(attrs)
-    return write_tags('script', content, attrs=attrs, new_lines=True, indent=indent)
+    return write_tags('script', content, attrs=attrs, new_lines=True, indent=indent, **kwargs)
 
 
 def read_files(filenames, directory, extension):
@@ -64,17 +66,17 @@ def read_files(filenames, directory, extension):
 # Viewer API
 
 
-def add_button(title, content='', button_id=None, indent=0):
+def add_button(title, content='', button_id=None, indent=0, **kwargs):
     i = write_tags(tag='i', attrs={'class': content})
     attrs = {'title': title}
     if button_id:
         attrs['id'] = button_id
     return write_tags('button', cls="myButton", content=i, attrs=attrs,
-                      new_lines=True, indent=indent)
+                      new_lines=True, indent=indent, **kwargs)
 
 
 def add_dropdown(title, id_naming=None, options=None, button_content='', header=None,
-                 dropdown_id=None, indent=0):
+                 dropdown_id=None, indent=0, **kwargs):
     button = add_button(title=title, content=button_content)
     if header is not None:
         items = write_tags(tag='span', cls="fakeLink", content=header)
@@ -92,7 +94,7 @@ def add_dropdown(title, id_naming=None, options=None, button_content='', header=
     menu = write_div(content=items, attrs=attrs)
 
     content = [button, menu]
-    return write_div(content=content, cls='dropdown', indent=indent)
+    return write_div(content=content, cls='dropdown', indent=indent, **kwargs)
 
 
 class ButtonGroup(object):
@@ -102,15 +104,15 @@ class ButtonGroup(object):
         self.items = []
         self.indent = indent
 
-    def add_button(self, title, content='', button_id=None):
-        button = add_button(title, content=content, button_id=button_id, indent=self.indent+4)
+    def add_button(self, title, content='', button_id=None, **kwargs):
+        button = add_button(title, content=content, button_id=button_id, indent=self.indent+4, **kwargs)
         self.items.append(button)
 
     def add_dropdown(self, title, id_naming=None, options=None, button_content='', header=None,
-                     dropdown_id=None):
+                     dropdown_id=None, **kwargs):
         dropdown = add_dropdown(self, title=title, id_naming=id_naming, options=options,
                                 button_content=button_content, header=header,
-                                dropdown_id=dropdown_id, indent=self.indent+4)
+                                dropdown_id=dropdown_id, indent=self.indent+4, **kwargs)
         self.items.append(dropdown)
 
     def write(self):

--- a/openmdao/devtools/html_utils.py
+++ b/openmdao/devtools/html_utils.py
@@ -1,7 +1,6 @@
 """
 Functions to write HTML elements.
 """
-
 import os
 
 from six import iteritems
@@ -25,6 +24,8 @@ def write_tags(tag, content='', attrs=None, new_lines=False, indent=0):
     if attrs is None:
         attrs = {}
     attrs = ' '.join(['{}="{}"'.format(k, v) for k, v in iteritems(attrs)])
+    if isinstance(content, list):  # Convert iterable to string
+        content = '\n'.join(content)
     return template.format(tag=tag, content=content, attributes=attrs, ls=line_sep, spaces=spaces)
 
 
@@ -61,10 +62,18 @@ def read_files(filenames, directory, extension):
 # Viewer API
 
 
-def add_button(title, content='', indent=0):
+def add_button(title, content='', button_id=None, indent=0):
     i = write_tags(tag='i', attrs={'class': content})
+    attrs = {'class': "myButton", 'title': title}
+    if button_id:
+        attrs['id'] = button_id
     return write_tags('button', content=i, attrs={'class': "myButton", 'title': title},
                       new_lines=True, indent=indent)
+
+
+def add_button_group(buttons):
+    button_elems = [add_button(**b) for b in buttons]
+    return write_div(attrs={'class': "button-group"}, content=button_elems)
 
 
 def add_dropdown(title, id_naming=None, options=None, button_content='', header=None,
@@ -85,5 +94,5 @@ def add_dropdown(title, id_naming=None, options=None, button_content='', header=
         attrs['id'] = dropdown_id
     menu = write_div(content=items, attrs=attrs)
 
-    content = '\n'.join([button, menu])
+    content = [button, menu]
     return write_div(content=content, attrs={'class': 'dropdown'}, indent=indent)

--- a/openmdao/devtools/html_utils.py
+++ b/openmdao/devtools/html_utils.py
@@ -17,7 +17,7 @@ def head_and_body(head, body, attrs=None):
     return doc_type + '\n' + index
 
 
-def write_tags(tag, content, attrs=None, new_lines=False, indent=0):
+def write_tags(tag, content='', attrs=None, new_lines=False, indent=0):
     # Writes an HTML tag with element content and element attributes (given as a dictionary)
     line_sep = '\n' if new_lines else ''
     spaces = ' ' * indent
@@ -57,3 +57,33 @@ def read_files(filenames, directory, extension):
         with open(os.path.join(directory, '.'.join([name, extension])), "r") as f:
             libs[name] = f.read()
     return libs
+
+# Viewer API
+
+
+def add_button(title, content='', indent=0):
+    i = write_tags(tag='i', attrs={'class': content})
+    return write_tags('button', content=i, attrs={'class': "myButton", 'title': title},
+                      new_lines=True, indent=indent)
+
+
+def add_dropdown(title, id_naming=None, options=None, button_content='', header=None,
+                 dropdown_id=None, indent=0):
+    button = add_button(title=title, content=button_content)
+    if header is not None:
+        items = write_tags(tag='span', attrs={'class': "fakeLink"}, content=header)
+    else:
+        items = ''
+
+    if options is not None:
+        for option in options:
+            idx = "{}{}".format(id_naming, option)
+            items += write_tags(tag='span', attrs={'class': "fakeLink", 'id': idx}, content=option)
+
+    attrs = {'class': 'dropdown-content'}
+    if dropdown_id is not None:
+        attrs['id'] = dropdown_id
+    menu = write_div(content=items, attrs=attrs)
+
+    content = '\n'.join([button, menu])
+    return write_div(content=content, attrs={'class': 'dropdown'}, indent=indent)

--- a/openmdao/devtools/html_utils.py
+++ b/openmdao/devtools/html_utils.py
@@ -9,6 +9,22 @@ _IND = 4  # indentation (spaces)
 
 
 def head_and_body(head, body, attrs=None):
+    """
+    Makes an html element from a head and body.
+
+    Parameters
+    ----------
+    head : str
+        Head of HTML.
+    body : str
+        Body of the HTML
+    attrs : dict or None
+        Attributes of the html element.
+        Defaults to None.
+    Returns
+    -------
+        str
+    """
     # Wraps the head and body in tags
     doc_type = '<!doctype html>'
     head_elem = write_tags(tag='head', content=head, new_lines=True)
@@ -43,10 +59,6 @@ def write_tags(tag, content='', attrs=None, cls=None, uid=None, new_lines=False,
     kwargs
         Alternative way to add element attributes. Use with attention, can overwrite some in-built
         python names as "class" or "id" if misused.
-
-    Returns
-    -------
-
     """
     # Writes an HTML tag with element content and element attributes (given as a dictionary)
     line_sep = '\n' if new_lines else ''
@@ -111,7 +123,8 @@ def write_script(content='', attrs=None, indent=0, **kwargs):
     return write_tags('script', content, attrs=attrs, new_lines=True, indent=indent, **kwargs)
 
 
-def _p(content):
+def write_paragraph(content):
+    # Write a paragraph
     return write_tags(tag='p', content=content)
 
 
@@ -155,18 +168,52 @@ def add_dropdown(title, id_naming=None, options=None, button_content='', header=
 
 
 def add_help(txt, header='Instructions', footer=''):
+    """
+    Add a popup help.
+
+    Parameters
+    ----------
+    txt : str
+        Help message/instructions.
+    header : str
+        Message header.
+    footer : str
+        Additional info.
+
+    Returns
+    -------
+        str
+    """
     header_txt = write_tags(tag='span', cls='close', content='&times;', uid="idSpanModalClose")
     header_txt += header
     head = write_div(content=header_txt, cls="modal-header")
     foot = write_div(content=footer, cls="modal-footer")
-    body = write_div(content=_p(txt), cls="modal-body")
+    body = write_div(content=write_paragraph(txt), cls="modal-body")
     modal_content = write_div(content=[head, body, foot], cls="modal-content")
     return write_div(content=modal_content, cls="modal", uid="myModal")
 
 
-def add_title(txt):
-    title = write_tags(tag='h1', content=txt)
-    return write_div(content=title, uid="maintitle", attrs={'style': "text-align: center"})
+def add_title(txt, heading='h1', align='center'):
+    """
+    Add a title heading.
+
+    Parameters
+    ----------
+    txt : str
+        Title text.
+    heading : str
+        Heading. Options are "h1" to "h6".
+        Defaults to "h1"
+    align : str
+        Defaults to "center"
+
+    Returns
+    -------
+        str
+    """
+    title = write_tags(tag=heading, content=txt)
+    style = "text-align: {}".format(align)
+    return write_div(content=title, uid="maintitle", attrs={'style': style})
 
 
 class UIElement(object):
@@ -197,6 +244,7 @@ class ButtonGroup(UIElement):
             ID.
         kwargs : dict
             Attributes passed to the button element.
+
         Returns
         -------
             str
@@ -232,6 +280,10 @@ class ButtonGroup(UIElement):
             Defaults to None.
         kwargs : dict
             Attributes passed to the dropdown element.
+
+        Returns
+        -------
+            str
         """
         dropdown = add_dropdown(title=title, id_naming=id_naming, options=options,
                                 button_content=button_content, header=header,

--- a/openmdao/devtools/html_utils.py
+++ b/openmdao/devtools/html_utils.py
@@ -71,11 +71,6 @@ def add_button(title, content='', button_id=None, indent=0):
                       new_lines=True, indent=indent)
 
 
-def add_button_group(buttons):
-    button_elems = [add_button(**b) for b in buttons]
-    return write_div(attrs={'class': "button-group"}, content=button_elems)
-
-
 def add_dropdown(title, id_naming=None, options=None, button_content='', header=None,
                  dropdown_id=None, indent=0):
     button = add_button(title=title, content=button_content)
@@ -96,3 +91,24 @@ def add_dropdown(title, id_naming=None, options=None, button_content='', header=
 
     content = [button, menu]
     return write_div(content=content, attrs={'class': 'dropdown'}, indent=indent)
+
+
+class ButtonGroup(object):
+
+    def __init__(self, indent=0):
+        self.items = []
+        self.indent = indent
+
+    def add_button(self, title, content='', button_id=None):
+        button = add_button(title, content=content, button_id=button_id, indent=self.indent+4)
+        self.items.append(button)
+
+    def add_dropdown(self, title, id_naming=None, options=None, button_content='', header=None,
+                     dropdown_id=None):
+        dropdown = add_dropdown(self, title=title, id_naming=id_naming, options=options,
+                                button_content=button_content, header=header,
+                                dropdown_id=dropdown_id, indent=self.indent+4)
+        self.items.append(dropdown)
+
+    def write(self):
+        return '\n\n'.join(self.items)

--- a/openmdao/devtools/html_utils.py
+++ b/openmdao/devtools/html_utils.py
@@ -16,21 +16,23 @@ def head_and_body(head, body, attrs=None):
     return doc_type + '\n' + index
 
 
-def write_tags(tag, content='', attrs=None, new_lines=False, indent=0):
+def write_tags(tag, content='', attrs=None, cls=None, new_lines=False, indent=0):
     # Writes an HTML tag with element content and element attributes (given as a dictionary)
     line_sep = '\n' if new_lines else ''
     spaces = ' ' * indent
     template = '{spaces}<{tag} {attributes}>{ls}{content}{ls}</{tag}>\n'
     if attrs is None:
         attrs = {}
+    if cls is not None:
+        attrs['class'] = cls
     attrs = ' '.join(['{}="{}"'.format(k, v) for k, v in iteritems(attrs)])
     if isinstance(content, list):  # Convert iterable to string
         content = '\n'.join(content)
     return template.format(tag=tag, content=content, attributes=attrs, ls=line_sep, spaces=spaces)
 
 
-def write_div(content='', attrs=None, indent=0):
-    return write_tags('div', content, attrs, new_lines=False, indent=indent)
+def write_div(content='', attrs=None, cls=None, indent=0):
+    return write_tags('div', content=content, attrs=attrs, cls=cls, new_lines=False, indent=indent)
 
 
 def write_style(content='', attrs=None, indent=0):
@@ -64,10 +66,10 @@ def read_files(filenames, directory, extension):
 
 def add_button(title, content='', button_id=None, indent=0):
     i = write_tags(tag='i', attrs={'class': content})
-    attrs = {'class': "myButton", 'title': title}
+    attrs = {'title': title}
     if button_id:
         attrs['id'] = button_id
-    return write_tags('button', content=i, attrs={'class': "myButton", 'title': title},
+    return write_tags('button', cls="myButton", content=i, attrs=attrs,
                       new_lines=True, indent=indent)
 
 
@@ -75,14 +77,14 @@ def add_dropdown(title, id_naming=None, options=None, button_content='', header=
                  dropdown_id=None, indent=0):
     button = add_button(title=title, content=button_content)
     if header is not None:
-        items = write_tags(tag='span', attrs={'class': "fakeLink"}, content=header)
+        items = write_tags(tag='span', cls="fakeLink", content=header)
     else:
         items = ''
 
     if options is not None:
         for option in options:
             idx = "{}{}".format(id_naming, option)
-            items += write_tags(tag='span', attrs={'class': "fakeLink", 'id': idx}, content=option)
+            items += write_tags(tag='span', cls="fakeLink", attrs={'id': idx}, content=option)
 
     attrs = {'class': 'dropdown-content'}
     if dropdown_id is not None:
@@ -90,10 +92,11 @@ def add_dropdown(title, id_naming=None, options=None, button_content='', header=
     menu = write_div(content=items, attrs=attrs)
 
     content = [button, menu]
-    return write_div(content=content, attrs={'class': 'dropdown'}, indent=indent)
+    return write_div(content=content, cls='dropdown', indent=indent)
 
 
 class ButtonGroup(object):
+    """Button group, which consists of buttons and dropdowns."""
 
     def __init__(self, indent=0):
         self.items = []
@@ -111,4 +114,12 @@ class ButtonGroup(object):
         self.items.append(dropdown)
 
     def write(self):
-        return '\n\n'.join(self.items)
+        """
+        Outputs the HTML code.
+
+        Returns
+        -------
+            str
+        """
+        content = '\n\n'.join(self.items)
+        return write_div(content=content, cls="button-group")

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -291,19 +291,24 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
         encoded_font = str(base64.b64encode(f.read()).decode("ascii"))
 
     h = TemplateWriter(filename=os.path.join(vis_dir, "index.html"),
-                       title="OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.")
+                       # title="OpenMDAO Model Hierarchy and N<sup>2</sup> diagram."
+                       styles=styles)
 
-    # grab the index.html
-    with open(os.path.join(vis_dir, "index.html"), "r") as f:
-        index = f.read()
+    # # grab the index.html
+    # with open(os.path.join(vis_dir, "index.html"), "r") as f:
+    #     index = f.read()
 
-    # add the necessary HTML tags if we aren't embedding
-    if embeddable:
-        index = '\n\n'.join([style_elems, index])
-    else:
-        meta = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
-        head = '\n\n'.join([meta, style_elems])  # Write styles to head
-        index = head_and_body(head=head, body=index)
+
+    # # add the necessary HTML tags if we aren't embedding
+    # if embeddable:
+    #     index = '\n\n'.join([style_elems, index])
+    # else:
+    #     meta = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
+    #     head = '\n\n'.join([meta, style_elems])  # Write styles to head
+    #     index = head_and_body(head=head, body=index)
+
+    index = h.template
+
 
     # put all style and JS into index
     index = index.replace('{{fontello}}', encoded_font)

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -21,7 +21,8 @@ from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
-from openmdao.devtools.html_utils import head_and_body, write_style, read_files, write_script
+from openmdao.devtools.html_utils import head_and_body, write_style, read_files, write_script, \
+    add_dropdown
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.general_utils import warn_deprecation, simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db
@@ -309,6 +310,37 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
 
     index = index.replace('{{model_data}}', write_script(model_viewer_data, indent=4))
     index = index.replace('{{draw_potential_connections}}', str(draw_potential_connections).lower())
+
+    sizes = [8, 9, 10, 11, 12, 13, 14]
+    opts = ['{}px'.format(size) for size in sizes]
+    font_size_dropdown = add_dropdown(
+        "Font Size",
+        id_naming="idFontSize",
+        options=opts,
+        button_content="icon-text-height",
+        header="Font Size"
+    )
+    sizes = [600, 650, 700, 750, 800, 850, 900, 950, 1000, 2000, 3000, 4000]
+    opts = ['{}px'.format(size) for size in sizes]
+    vertical_size_dropdown = add_dropdown(
+        "Vertically Resize",
+        id_naming="idVerticalResize",
+        options=opts,
+        button_content="icon-resize-vertical",
+        header="Model Height"
+    )
+
+    collapse_depth_dropdown = add_dropdown(
+        "Collapse Depth",
+        button_content="icon-sort-number-up",
+        header="Collapse Depth",
+        dropdown_id="idCollapseDepthDiv"
+    )
+
+    # Dropdowns
+    index = index.replace('{{collapse_depth_dropdown}}', collapse_depth_dropdown)
+    index = index.replace('{{font_size_dropdown}}', font_size_dropdown)
+    index = index.replace('{{vertical_size_dropdown}}', vertical_size_dropdown)
 
     with open(outfile, 'w') as f:  # write output file
         f.write(index)

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -21,8 +21,7 @@ from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
-from openmdao.devtools.html_utils import head_and_body, write_style, read_files, write_script, \
-    Toolbar, add_help, add_title, TemplateWriter
+from openmdao.devtools.html_utils import read_files, write_script, DiagramWriter
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.general_utils import warn_deprecation, simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db
@@ -289,9 +288,9 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     with open(os.path.join(style_dir, "fontello.woff"), "rb") as f:
         encoded_font = str(base64.b64encode(f.read()).decode("ascii"))
 
-    h = TemplateWriter(filename=os.path.join(vis_dir, "index.html"),
-                       # title="OpenMDAO Model Hierarchy and N<sup>2</sup> diagram."
-                       styles=styles)
+    h = DiagramWriter(filename=os.path.join(vis_dir, "index.html"),
+                      title="OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.",
+                      styles=styles, embeddable=embeddable)
 
     # put all style and JS into index
     h.insert('{{fontello}}', encoded_font)
@@ -306,7 +305,7 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     h.insert('{{draw_potential_connections}}', str(draw_potential_connections).lower())
 
     # Toolbar
-    toolbar = Toolbar()
+    toolbar = h.toolbar
     group1 = toolbar.add_button_group()
     group1.add_button("Return To Root", button_id="returnToRootButtonId", disabled="disabled", content="icon-home")
     group1.add_button("Back", button_id="backButtonId", disabled="disabled", content="icon-left-big")
@@ -345,18 +344,14 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     group5 = toolbar.add_button_group()
     group5.add_button("Help", button_id="helpButtonId", content="icon-help")
 
+    # Help
     help_txt = ('Left clicking on a node in the partition tree will navigate to that node. '
                 'Right clicking on a node in the model hierarchy will collapse/uncollapse it. '
                 'A click on any element in the N^2 diagram will allow those arrows to persist.')
 
-    help = add_help(help_txt, footer="OpenMDAO Model Hierarchy and N^2 diagram")
+    h.add_help(help_txt, footer="OpenMDAO Model Hierarchy and N^2 diagram")
 
-    title = add_title("OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.")
-
-    h.insert('{{toolbar}}', toolbar.write())
-    h.insert('{{help}}', help)
-    h.insert('{{title}}', title)
-
+    # Write output file
     h.write(outfile)
 
     # open it up in the browser

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -22,7 +22,7 @@ from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.devtools.html_utils import head_and_body, write_style, read_files, write_script, \
-    add_dropdown, ButtonGroup, Toolbar
+    Toolbar, add_help, add_title, TemplateWriter
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.general_utils import warn_deprecation, simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db
@@ -290,6 +290,9 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     with open(os.path.join(style_dir, "fontello.woff"), "rb") as f:
         encoded_font = str(base64.b64encode(f.read()).decode("ascii"))
 
+    h = TemplateWriter(filename=os.path.join(vis_dir, "index.html"),
+                       title="OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.")
+
     # grab the index.html
     with open(os.path.join(vis_dir, "index.html"), "r") as f:
         index = f.read()
@@ -354,7 +357,17 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     group5 = toolbar.add_button_group()
     group5.add_button("Help", button_id="helpButtonId", content="icon-help")
 
+    help_txt = ('Left clicking on a node in the partition tree will navigate to that node. '
+                'Right clicking on a node in the model hierarchy will collapse/uncollapse it. '
+                'A click on any element in the N^2 diagram will allow those arrows to persist.')
+
+    help = add_help(help_txt, footer="OpenMDAO Model Hierarchy and N^2 diagram")
+
+    title = add_title("OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.")
+
     index = index.replace('{{toolbar}}', toolbar.write())
+    index = index.replace('{{help}}', help)
+    index = index.replace('{{title}}', title)
 
     with open(outfile, 'w') as f:  # write output file
         f.write(index)

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -314,31 +314,6 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     index = index.replace('{{model_data}}', write_script(model_viewer_data, indent=4))
     index = index.replace('{{draw_potential_connections}}', str(draw_potential_connections).lower())
 
-    sizes = [8, 9, 10, 11, 12, 13, 14]
-    opts = ['{}px'.format(size) for size in sizes]
-    font_size_dropdown = add_dropdown(
-        "Font Size",
-        id_naming="idFontSize",
-        options=opts,
-        button_content="icon-text-height",
-    )
-    sizes = [600, 650, 700, 750, 800, 850, 900, 950, 1000, 2000, 3000, 4000]
-    opts = ['{}px'.format(size) for size in sizes]
-    vertical_size_dropdown = add_dropdown(
-        "Vertically Resize",
-        id_naming="idVerticalResize",
-        options=opts,
-        button_content="icon-resize-vertical",
-        header="Model Height"
-    )
-
-    # collapse_depth_dropdown = add_dropdown(
-    #     "Collapse Depth",
-    #     button_content="icon-sort-number-up",
-    #     header="Collapse Depth",
-    #     dropdown_id="idCollapseDepthDiv"
-    # )
-
     # Toolbar
     toolbar = Toolbar()
     group1 = toolbar.add_button_group()

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -27,8 +27,11 @@ from openmdao.utils.general_utils import warn_deprecation, simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db
 from openmdao.utils.mpi import MPI
 
+# Toolbar settings
 _FONT_SIZES = [8, 9, 10, 11, 12, 13, 14]
 _MODEL_HEIGHTS = [600, 650, 700, 750, 800, 850, 900, 950, 1000, 2000, 3000, 4000]
+
+_IND = 4  # HTML indentation (spaces)
 
 
 def _get_tree_dict(system, component_execution_orders, component_execution_index, is_parallel=False):
@@ -296,41 +299,41 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     h.insert('{{fontello}}', encoded_font)
 
     for k, v in iteritems(lib_dct):
-        h.insert('{{{}_lib}}'.format(k), write_script(libs[v], indent=4))
+        h.insert('{{{}_lib}}'.format(k), write_script(libs[v], indent=_IND))
 
     for name, code in iteritems(srcs):
-        h.insert('{{{}_lib}}'.format(name.lower()), write_script(code, indent=4))
+        h.insert('{{{}_lib}}'.format(name.lower()), write_script(code, indent=_IND))
 
-    h.insert('{{model_data}}', write_script(model_viewer_data, indent=4))
+    h.insert('{{model_data}}', write_script(model_viewer_data, indent=_IND))
     h.insert('{{draw_potential_connections}}', str(draw_potential_connections).lower())
 
     # Toolbar
     toolbar = h.toolbar
     group1 = toolbar.add_button_group()
-    group1.add_button("Return To Root", button_id="returnToRootButtonId", disabled="disabled", content="icon-home")
-    group1.add_button("Back", button_id="backButtonId", disabled="disabled", content="icon-left-big")
-    group1.add_button("Forward", button_id="forwardButtonId", disabled="disabled", content="icon-right-big")
-    group1.add_button("Up One Level", button_id="upOneLevelButtonId", disabled="disabled", content="icon-up-big")
+    group1.add_button("Return To Root", uid="returnToRootButtonId", disabled="disabled", content="icon-home")
+    group1.add_button("Back", uid="backButtonId", disabled="disabled", content="icon-left-big")
+    group1.add_button("Forward", uid="forwardButtonId", disabled="disabled", content="icon-right-big")
+    group1.add_button("Up One Level", uid="upOneLevelButtonId", disabled="disabled", content="icon-up-big")
 
     group2 = toolbar.add_button_group()
-    group2.add_button("Uncollapse In View Only", button_id="uncollapseInViewButtonId",
+    group2.add_button("Uncollapse In View Only", uid="uncollapseInViewButtonId",
                       content="icon-resize-full")
-    group2.add_button("Uncollapse All", button_id="uncollapseAllButtonId",
+    group2.add_button("Uncollapse All", uid="uncollapseAllButtonId",
                       content="icon-resize-full bigger-font")
-    group2.add_button("Collapse Outputs In View Only", button_id="collapseInViewButtonId",
+    group2.add_button("Collapse Outputs In View Only", uid="collapseInViewButtonId",
                       content="icon-resize-small")
-    group2.add_button("Collapse All Outputs", button_id="collapseAllButtonId",
+    group2.add_button("Collapse All Outputs", uid="collapseAllButtonId",
                       content="icon-resize-small bigger-font")
     group2.add_dropdown("Collapse Depth", button_content="icon-sort-number-up",
-                        dropdown_id="idCollapseDepthDiv")
+                        uid="idCollapseDepthDiv")
 
     group3 = toolbar.add_button_group()
-    group3.add_button("Clear Arrows and Connections", button_id="clearArrowsAndConnectsButtonId",
+    group3.add_button("Clear Arrows and Connections", uid="clearArrowsAndConnectsButtonId",
                       content="icon-eraser")
-    group3.add_button("Show Path", button_id="showCurrentPathButtonId", content="icon-terminal")
-    group3.add_button("Show Legend", button_id="showLegendButtonId", content="icon-map-signs")
-    group3.add_button("Show Params", button_id="showParamsButtonId", content="icon-exchange")
-    group3.add_button("Toggle Solver Names", button_id="toggleSolverNamesButtonId", content="icon-minus")
+    group3.add_button("Show Path", uid="showCurrentPathButtonId", content="icon-terminal")
+    group3.add_button("Show Legend", uid="showLegendButtonId", content="icon-map-signs")
+    group3.add_button("Show Params", uid="showParamsButtonId", content="icon-exchange")
+    group3.add_button("Toggle Solver Names", uid="toggleSolverNamesButtonId", content="icon-minus")
     group3.add_dropdown("Font Size", id_naming="idFontSize", options=_FONT_SIZES,
                         option_formatter=lambda x: '{}px'.format(x),
                         button_content="icon-text-height")
@@ -339,10 +342,10 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
                         button_content="icon-resize-vertical", header="Model Height")
 
     group4 = toolbar.add_button_group()
-    group4.add_button("Save SVG", button_id="saveSvgButtonId", content="icon-floppy")
+    group4.add_button("Save SVG", uid="saveSvgButtonId", content="icon-floppy")
 
     group5 = toolbar.add_button_group()
-    group5.add_button("Help", button_id="helpButtonId", content="icon-help")
+    group5.add_button("Help", uid="helpButtonId", content="icon-help")
 
     # Help
     help_txt = ('Left clicking on a node in the partition tree will navigate to that node. '

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -285,7 +285,6 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     src_names = 'constants', 'draw', 'legend', 'modal', 'ptN2', 'search', 'svg'
     srcs = read_files(src_names, src_dir, 'js')
     styles = read_files(('awesomplete', 'partition_tree'), style_dir, 'css')
-    style_elems = '\n\n'.join([write_style(content=s) for s in itervalues(styles)])
 
     with open(os.path.join(style_dir, "fontello.woff"), "rb") as f:
         encoded_font = str(base64.b64encode(f.read()).decode("ascii"))
@@ -294,33 +293,17 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
                        # title="OpenMDAO Model Hierarchy and N<sup>2</sup> diagram."
                        styles=styles)
 
-    # # grab the index.html
-    # with open(os.path.join(vis_dir, "index.html"), "r") as f:
-    #     index = f.read()
-
-
-    # # add the necessary HTML tags if we aren't embedding
-    # if embeddable:
-    #     index = '\n\n'.join([style_elems, index])
-    # else:
-    #     meta = '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">'
-    #     head = '\n\n'.join([meta, style_elems])  # Write styles to head
-    #     index = head_and_body(head=head, body=index)
-
-    index = h.template
-
-
     # put all style and JS into index
-    index = index.replace('{{fontello}}', encoded_font)
+    h.insert('{{fontello}}', encoded_font)
 
     for k, v in iteritems(lib_dct):
-        index = index.replace('{{{}_lib}}'.format(k), write_script(libs[v], indent=4))
+        h.insert('{{{}_lib}}'.format(k), write_script(libs[v], indent=4))
 
     for name, code in iteritems(srcs):
-        index = index.replace('{{{}_lib}}'.format(name.lower()), write_script(code, indent=4))
+        h.insert('{{{}_lib}}'.format(name.lower()), write_script(code, indent=4))
 
-    index = index.replace('{{model_data}}', write_script(model_viewer_data, indent=4))
-    index = index.replace('{{draw_potential_connections}}', str(draw_potential_connections).lower())
+    h.insert('{{model_data}}', write_script(model_viewer_data, indent=4))
+    h.insert('{{draw_potential_connections}}', str(draw_potential_connections).lower())
 
     # Toolbar
     toolbar = Toolbar()
@@ -370,12 +353,11 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
 
     title = add_title("OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.")
 
-    index = index.replace('{{toolbar}}', toolbar.write())
-    index = index.replace('{{help}}', help)
-    index = index.replace('{{title}}', title)
+    h.insert('{{toolbar}}', toolbar.write())
+    h.insert('{{help}}', help)
+    h.insert('{{title}}', title)
 
-    with open(outfile, 'w') as f:  # write output file
-        f.write(index)
+    h.write(outfile)
 
     # open it up in the browser
     if show_browser:

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -22,11 +22,14 @@ from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.devtools.html_utils import head_and_body, write_style, read_files, write_script, \
-    add_dropdown, ButtonGroup
+    add_dropdown, ButtonGroup, Toolbar
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.general_utils import warn_deprecation, simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db
 from openmdao.utils.mpi import MPI
+
+_FONT_SIZES = [8, 9, 10, 11, 12, 13, 14]
+_MODEL_HEIGHTS = [600, 650, 700, 750, 800, 850, 900, 950, 1000, 2000, 3000, 4000]
 
 
 def _get_tree_dict(system, component_execution_orders, component_execution_index, is_parallel=False):
@@ -318,7 +321,6 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
         id_naming="idFontSize",
         options=opts,
         button_content="icon-text-height",
-        header="Font Size"
     )
     sizes = [600, 650, 700, 750, 800, 850, 900, 950, 1000, 2000, 3000, 4000]
     opts = ['{}px'.format(size) for size in sizes]
@@ -330,29 +332,54 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
         header="Model Height"
     )
 
-    collapse_depth_dropdown = add_dropdown(
-        "Collapse Depth",
-        button_content="icon-sort-number-up",
-        header="Collapse Depth",
-        dropdown_id="idCollapseDepthDiv"
-    )
+    # collapse_depth_dropdown = add_dropdown(
+    #     "Collapse Depth",
+    #     button_content="icon-sort-number-up",
+    #     header="Collapse Depth",
+    #     dropdown_id="idCollapseDepthDiv"
+    # )
 
-    # Dropdowns
-    index = index.replace('{{collapse_depth_dropdown}}', collapse_depth_dropdown)
-    index = index.replace('{{font_size_dropdown}}', font_size_dropdown)
-    index = index.replace('{{vertical_size_dropdown}}', vertical_size_dropdown)
+    # Toolbar
+    toolbar = Toolbar()
+    group1 = toolbar.add_button_group()
+    group1.add_button("Return To Root", button_id="returnToRootButtonId", disabled="disabled", content="icon-home")
+    group1.add_button("Back", button_id="backButtonId", disabled="disabled", content="icon-left-big")
+    group1.add_button("Forward", button_id="forwardButtonId", disabled="disabled", content="icon-right-big")
+    group1.add_button("Up One Level", button_id="upOneLevelButtonId", disabled="disabled", content="icon-up-big")
 
+    group2 = toolbar.add_button_group()
+    group2.add_button("Uncollapse In View Only", button_id="uncollapseInViewButtonId",
+                      content="icon-resize-full")
+    group2.add_button("Uncollapse All", button_id="uncollapseAllButtonId",
+                      content="icon-resize-full bigger-font")
+    group2.add_button("Collapse Outputs In View Only", button_id="collapseInViewButtonId",
+                      content="icon-resize-small")
+    group2.add_button("Collapse All Outputs", button_id="collapseAllButtonId",
+                      content="icon-resize-small bigger-font")
+    group2.add_dropdown("Collapse Depth", button_content="icon-sort-number-up",
+                        dropdown_id="idCollapseDepthDiv")
 
-    button_group1 = ButtonGroup()
-    button_group1.add_button(title="Return To Root", button_id="returnToRootButtonId",
-                             disabled="disabled")
-    button_group1.add_button(title="Back", button_id="backButtonId",
-                             disabled="disabled")
-    button_group1.add_button(title="Forward", button_id="forwardButtonId",
-                             disabled="disabled")
-    button_group1.add_button(title="Up One Level", button_id="upOneLevelButtonId",
-                             disabled="disabled")
-    index = index.replace('{{button_group1}}', button_group1.write())
+    group3 = toolbar.add_button_group()
+    group3.add_button("Clear Arrows and Connections", button_id="clearArrowsAndConnectsButtonId",
+                      content="icon-eraser")
+    group3.add_button("Show Path", button_id="showCurrentPathButtonId", content="icon-terminal")
+    group3.add_button("Show Legend", button_id="showLegendButtonId", content="icon-map-signs")
+    group3.add_button("Show Params", button_id="showParamsButtonId", content="icon-exchange")
+    group3.add_button("Toggle Solver Names", button_id="toggleSolverNamesButtonId", content="icon-minus")
+    group3.add_dropdown("Font Size", id_naming="idFontSize", options=_FONT_SIZES,
+                        option_formatter=lambda x: '{}px'.format(x),
+                        button_content="icon-text-height")
+    group3.add_dropdown("Vertically Resize", id_naming="idVerticalResize",
+                        options=_MODEL_HEIGHTS, option_formatter=lambda x: '{}px'.format(x),
+                        button_content="icon-resize-vertical", header="Model Height")
+
+    group4 = toolbar.add_button_group()
+    group4.add_button("Save SVG", button_id="saveSvgButtonId", content="icon-floppy")
+
+    group5 = toolbar.add_button_group()
+    group5.add_button("Help", button_id="helpButtonId", content="icon-help")
+
+    index = index.replace('{{toolbar}}', toolbar.write())
 
     with open(outfile, 'w') as f:  # write output file
         f.write(index)

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -22,7 +22,7 @@ from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.devtools.html_utils import head_and_body, write_style, read_files, write_script, \
-    add_dropdown
+    add_dropdown, ButtonGroup
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.general_utils import warn_deprecation, simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db
@@ -341,6 +341,18 @@ def view_model(data_source, outfile='n2.html', show_browser=True, embeddable=Fal
     index = index.replace('{{collapse_depth_dropdown}}', collapse_depth_dropdown)
     index = index.replace('{{font_size_dropdown}}', font_size_dropdown)
     index = index.replace('{{vertical_size_dropdown}}', vertical_size_dropdown)
+
+
+    button_group1 = ButtonGroup()
+    button_group1.add_button(title="Return To Root", button_id="returnToRootButtonId",
+                             disabled="disabled")
+    button_group1.add_button(title="Back", button_id="backButtonId",
+                             disabled="disabled")
+    button_group1.add_button(title="Forward", button_id="forwardButtonId",
+                             disabled="disabled")
+    button_group1.add_button(title="Up One Level", button_id="upOneLevelButtonId",
+                             disabled="disabled")
+    index = index.replace('{{button_group1}}', button_group1.write())
 
     with open(outfile, 'w') as f:  # write output file
         f.write(index)

--- a/openmdao/devtools/problem_viewer/visualization/index.html
+++ b/openmdao/devtools/problem_viewer/visualization/index.html
@@ -49,14 +49,7 @@
                         <button class="myButton" id="collapseAllButtonId" title="Collapse All Outputs">
                             <i class="icon-resize-small bigger-font"></i>
                         </button>
-                        <div class="dropdown">
-                            <button class="myButton" title="Collapse Depth">
-                                <i class="icon-sort-number-up"></i>
-                            </button>
-                            <div id="idCollapseDepthDiv" class="dropdown-content">
-                                <span class="fakeLink">Collapse Depth</span>
-                            </div>
-                        </div>
+                        {{collapse_depth_dropdown}}
                     </div>
                     <div class="button-group">
                         <button class="myButton" id="clearArrowsAndConnectsButtonId" title="Clear Arrows and Connections">
@@ -75,41 +68,8 @@
                             <i class="icon-minus"></i>
                         </button>
 
-                        <div class="dropdown">
-                            <button class="myButton" title="Font Size">
-                                <i class="icon-text-height"></i>
-                            </button>
-                            <div class="dropdown-content">
-                                <span class="fakeLink">Font Size</span>
-                                <span class="fakeLink" id="idFontSize8px">8px</span>
-                                <span class="fakeLink" id="idFontSize9px">9px</span>
-                                <span class="fakeLink" id="idFontSize10px">10px</span>
-                                <span class="fakeLink" id="idFontSize11px"><b>11px</b></span>
-                                <span class="fakeLink" id="idFontSize12px">12px</span>
-                                <span class="fakeLink" id="idFontSize13px">13px</span>
-                                <span class="fakeLink" id="idFontSize14px">14px</span>
-                            </div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="myButton" title="Vertically Resize">
-                                <i class="icon-resize-vertical"></i>
-                            </button>
-                            <div class="dropdown-content">
-                                <span class="fakeLink">Model Height</span>
-                                <span class="fakeLink" id="idVerticalResize600px"><b>600px</b></span>
-                                <span class="fakeLink" id="idVerticalResize650px">650px</span>
-                                <span class="fakeLink" id="idVerticalResize700px">700px</span>
-                                <span class="fakeLink" id="idVerticalResize750px">750px</span>
-                                <span class="fakeLink" id="idVerticalResize800px">800px</span>
-                                <span class="fakeLink" id="idVerticalResize850px">850px</span>
-                                <span class="fakeLink" id="idVerticalResize900px">900px</span>
-                                <span class="fakeLink" id="idVerticalResize950px">950px</span>
-                                <span class="fakeLink" id="idVerticalResize1000px">1000px</span>
-                                <span class="fakeLink" id="idVerticalResize2000px">2000px</span>
-                                <span class="fakeLink" id="idVerticalResize3000px">3000px</span>
-                                <span class="fakeLink" id="idVerticalResize4000px">4000px</span>
-                            </div>
-                        </div>
+                        {{font_size_dropdown}}
+                        {{vertical_size_dropdown}}
                     </div>
                     <div class="button-group">
                         <button class="myButton" id="saveSvgButtonId" title="Save SVG">

--- a/openmdao/devtools/problem_viewer/visualization/index.html
+++ b/openmdao/devtools/problem_viewer/visualization/index.html
@@ -50,6 +50,14 @@
                             <i class="icon-resize-small bigger-font"></i>
                         </button>
                         {{collapse_depth_dropdown}}
+                        <div class="dropdown">
+                            <button class="myButton" title="Collapse Depth">
+                                <i class="icon-sort-number-up"></i>
+                            </button>
+                            <div id="idCollapseDepthDiv" class="dropdown-content">
+                                <span class="fakeLink">Collapse Depth</span>
+                            </div>
+                        </div>
                     </div>
                     <div class="button-group">
                         <button class="myButton" id="clearArrowsAndConnectsButtonId" title="Clear Arrows and Connections">

--- a/openmdao/devtools/problem_viewer/visualization/index.html
+++ b/openmdao/devtools/problem_viewer/visualization/index.html
@@ -1,25 +1,8 @@
  <div id="all_pt_n2_content_div">
-        <div id="maintitle" style="text-align: center">
-            <h1>OpenMDAO Model Hierarchy and N<sup>2</sup> diagram.</h1>
-        </div>
+        {{title}}
         <div id="ptN2ContentDivId">
             <!-- The Modal -->
-            <div id="myModal" class="modal">
-                <!-- Modal content -->
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <span id="idSpanModalClose" class="close">×</span> Instructions
-                    </div>
-                    <div class="modal-body">
-                        <p>Left clicking on a node in the partition tree will navigate to that node. Right clicking on a node
-                            in the model hierarchy will collapse/uncollapse it. A click on any element in the N^2 diagram
-                            will allow those arrows to persist.</p>
-                    </div>
-                    <div class="modal-footer">
-                        OpenMDAO Model Hierarchy and N^2 diagram.
-                    </div>
-                </div>
-            </div>
+            {{help}}
             <div id="toolbarLoc">
                 {{toolbar}}
             </div>

--- a/openmdao/devtools/problem_viewer/visualization/index.html
+++ b/openmdao/devtools/problem_viewer/visualization/index.html
@@ -21,75 +21,7 @@
                 </div>
             </div>
             <div id="toolbarLoc">
-                <div class="toolbar" id="toolbarDiv">
-                    <div class="button-group">
-                        <button class="myButton" id="returnToRootButtonId" disabled="disabled" title="Return To Root">
-                            <i class="icon-home"></i>
-                        </button>
-                        <button class="myButton" id="backButtonId" disabled="disabled" title="Back">
-                            <i class="icon-left-big"></i>
-                        </button>
-                        <button class="myButton" id="forwardButtonId" disabled="disabled" title="Forward">
-                            <i class="icon-right-big"></i>
-                        </button>
-                        <button class="myButton" id="upOneLevelButtonId" disabled="disabled" title="Up One Level">
-                            <i class="icon-up-big"></i>
-                        </button>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="uncollapseInViewButtonId" title="Uncollapse In View Only">
-                            <i class="icon-resize-full"></i>
-                        </button>
-                        <button class="myButton" id="uncollapseAllButtonId" title="Uncollapse All">
-                            <i class="icon-resize-full bigger-font"></i>
-                        </button>
-                        <button class="myButton" id="collapseInViewButtonId" title="Collapse Outputs In View Only">
-                            <i class="icon-resize-small"></i>
-                        </button>
-                        <button class="myButton" id="collapseAllButtonId" title="Collapse All Outputs">
-                            <i class="icon-resize-small bigger-font"></i>
-                        </button>
-                        {{collapse_depth_dropdown}}
-                        <div class="dropdown">
-                            <button class="myButton" title="Collapse Depth">
-                                <i class="icon-sort-number-up"></i>
-                            </button>
-                            <div id="idCollapseDepthDiv" class="dropdown-content">
-                                <span class="fakeLink">Collapse Depth</span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="clearArrowsAndConnectsButtonId" title="Clear Arrows and Connections">
-                            <i class="icon-eraser"></i>
-                        </button>
-                        <button class="myButton" id="showCurrentPathButtonId" title="Show Path">
-                            <i class="icon-terminal"></i>
-                        </button>
-                        <button class="myButton" id="showLegendButtonId" title="Show Legend">
-                            <i class="icon-map-signs"></i>
-                        </button>
-                        <button class="myButton" id="showParamsButtonId" type="checkbox" title="Show Params">
-                            <i class="icon-exchange"></i>
-                        </button>
-                        <button class="myButton" id="toggleSolverNamesButtonId" type="checkbox" title="Toggle Solver Names">
-                            <i class="icon-minus"></i>
-                        </button>
-
-                        {{font_size_dropdown}}
-                        {{vertical_size_dropdown}}
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="saveSvgButtonId" title="Save SVG">
-                            <i class="icon-floppy"></i>
-                        </button>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="helpButtonId" title="Help">
-                            <i class="icon-help"></i>
-                        </button>
-                    </div>
-                </div>
+                {{toolbar}}
             </div>
             <div style="margin-top:5px;">
                 <input type="text" id="awesompleteId" size="80" />


### PR DESCRIPTION
The code for the problem viewer toolbar in the template file was replaced with a simple API. Aim was to make it easier to implement new features and to make it reusable for the XDSMjs viewer. No functional change in the problem viewer.