### PR TITLE
Resolving Issue #874 (GA driver bug with vector design variables)

### DIFF
--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -252,12 +252,11 @@ class SimpleGADriver(Driver):
                 # to pad additional values above the upper range, and adjust accordingly. Design
                 # points with values above the upper bound will be discarded by the GA.
                 log_range = np.log2(upper_bound[i:j] - lower_bound[i:j] + 1)
-                if log_range % 2 > 0:
-                    val = np.ceil(log_range)
-                    outer_bound[i:j] = upper_bound[i:j]
-                    upper_bound[i:j] = 2**np.ceil(log_range) - 1 + lower_bound[i:j]
-                else:
-                    val = log_range
+                val = log_range  # default case -- no padding required
+                mask = log_range % 2 > 0  # mask for vars requiring padding
+                val[mask] = np.ceil(log_range[mask])
+                outer_bound[i:j][mask] = upper_bound[i:j][mask]
+                upper_bound[i:j][mask] = 2**np.ceil(log_range[mask]) - 1 + lower_bound[i:j][mask]
 
             bits[i:j] = val
 

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -279,27 +279,30 @@ class TestSimpleGA(unittest.TestCase):
         np.testing.assert_array_almost_equal(gen[0], ga.encode(x[0], vlb, vub, bits))
         np.testing.assert_array_almost_equal(gen[1], ga.encode(x[1], vlb, vub, bits))
 
-    def test_vector_desvars(self):
+    def test_vector_desvars_multiobj(self):
         prob = Problem()
 
         indeps = prob.model.add_subsystem('indeps', IndepVarComp())
         indeps.add_output('x', 3)
         indeps.add_output('y', [4.0, -4])
 
-        prob.model.add_subsystem('paraboloid',
-                                 ExecComp('f = (x+5)**2 + (y[0]-3)**2 + (y[1]-1)**2 - 3',
+        prob.model.add_subsystem('paraboloid1',
+                                 ExecComp('f = (x+5)**2- 3'))
+        prob.model.add_subsystem('paraboloid2',
+                                 ExecComp('f = (y[0]-3)**2 + (y[1]-1)**2 - 3',
                                           y=[0, 0]))
-        prob.model.connect('indeps.x', 'paraboloid.x')
-        prob.model.connect('indeps.y', 'paraboloid.y')
+        prob.model.connect('indeps.x', 'paraboloid1.x')
+        prob.model.connect('indeps.y', 'paraboloid2.y')
 
         prob.driver = SimpleGADriver()
 
         prob.model.add_design_var('indeps.x', lower=-5, upper=5)
         prob.model.add_design_var('indeps.y', lower=[-10, 0], upper=[10, 3])
-        prob.model.add_objective('paraboloid.f')
+        prob.model.add_objective('paraboloid1.f')
+        prob.model.add_objective('paraboloid2.f')
         prob.setup()
         prob.run_driver()
-
+        
         np.testing.assert_array_almost_equal(prob['indeps.x'], -5)
         np.testing.assert_array_almost_equal(prob['indeps.y'], [3, 1])
 


### PR DESCRIPTION
My proposed patch for Issue #874

Two main changes:
- Switch the log_range logic to use masking so it can handle design variables that are vectors
- Added a new test for vector design variables