### PR TITLE
use current Ubuntu images for appveyor testing

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,19 +6,19 @@ branches:
 
 environment:
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PYTHON: 3.7
       NUMPY: 1.15
       SCIPY: 1.0.1
       PETSc: 3.9.1
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PYTHON: 3.6
       NUMPY: 1.15
       SCIPY: 1.0.1
       PETSc: 3.9.1
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       PYTHON: 2.7
       NUMPY: 1.15
       SCIPY: 1.0.1


### PR DESCRIPTION
Appveyor has "switched current Ubuntu builds to the same datacenter as previous"... 
Testing seems to indicate it is no longer necessary to use the `Previous` image.