### PR TITLE
XDSM model path bug fix

### DIFF
--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -264,7 +264,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         p.run_model()
 
         write_xdsm(p, 'xdsm_circuit2', out_format='pdf', quiet=QUIET, show_browser=False,
-                   recurse=True, model_path='G1', include_external_outputs=False)
+                   recurse=True, model_path='G2', include_external_outputs=False)
         self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit2', 'tex'])))
 
     def test_circuit_model_path_no_recurse(self):

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -24,6 +24,7 @@ except ImportError:
 DEBUG = False
 # Suppress pyXDSM console output
 QUIET = not DEBUG
+PYXDSM_OUT = 'pdf' if DEBUG else 'tex'
 
 
 @unittest.skipUnless(XDSM, "The pyXDSM package is required.")
@@ -59,10 +60,10 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='pdf', show_browser=False, quiet=QUIET)
+        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=False, quiet=QUIET)
 
         # Check if file was created
-        self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
     def test_pyxdsm_sellar_no_recurse(self):
         """Makes XDSM for the Sellar problem, with no recursion."""
@@ -81,11 +82,11 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='tex', show_browser=False, recurse=False,
+        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=False, recurse=False,
                    quiet=QUIET)
 
         # Check if file was created
-        self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
     def test_pyxdsm_sphere(self):
         """
@@ -126,10 +127,10 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='tex', show_browser=False)
+        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=False)
 
         # Check if file was created
-        self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
     def test_pyxdsm_identical_relative_names(self):
         class TimeComp(ExplicitComponent):
@@ -229,9 +230,9 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         p.run_model()
 
-        write_xdsm(p, 'xdsm_circuit', out_format='pdf', quiet=QUIET, show_browser=False,
+        write_xdsm(p, 'xdsm_circuit', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=False,
                    recurse=False)
-        self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit', 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit', PYXDSM_OUT])))
 
     def test_circuit_model_path_recurse(self):
 
@@ -262,9 +263,9 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         p.run_model()
 
-        write_xdsm(p, 'xdsm_circuit2', out_format='pdf', quiet=QUIET, show_browser=False,
+        write_xdsm(p, 'xdsm_circuit2', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=False,
                    recurse=True, model_path='G2', include_external_outputs=False)
-        self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit2', 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit2', PYXDSM_OUT])))
 
     def test_circuit_model_path_no_recurse(self):
 
@@ -295,9 +296,9 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         p.run_model()
 
-        write_xdsm(p, 'xdsm_circuit3', out_format='pdf', quiet=QUIET, show_browser=False,
+        write_xdsm(p, 'xdsm_circuit3', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=False,
                    recurse=False, model_path='G1')
-        self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit3', 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit3', PYXDSM_OUT])))
 
     def test_invalid_model_path(self):
 
@@ -329,14 +330,14 @@ class TestPyXDSMViewer(unittest.TestCase):
         p.run_model()
 
         with self.assertRaises(ValueError):
-            write_xdsm(p, 'xdsm_circuit3', out_format='pdf', quiet=QUIET, show_browser=False,
+            write_xdsm(p, 'xdsm_circuit3', out_format='tex', quiet=QUIET, show_browser=False,
                        recurse=False, model_path='G3')
 
     def test_pyxdsm_solver(self):
         from openmdao.api import NonlinearBlockGS
 
         filename = 'pyxdsm_solver'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         prob = Problem()
         prob.model = model = SellarNoDerivatives()
         model.nonlinear_solver = NonlinearBlockGS()
@@ -353,7 +354,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
     def test_pyxdsm_mda(self):
         filename = 'pyxdsm_mda'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         prob = Problem(model=SellarMDA())
         prob.setup(check=False)
         prob.final_setup()
@@ -366,7 +367,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
     def test_pyxdsm_mdf(self):
         filename = 'pyxdsm_mdf'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         prob = Problem(model=SellarMDA())
         model = prob.model
         prob.driver = ScipyOptimizeDriver()
@@ -417,7 +418,7 @@ class TestPyXDSMViewer(unittest.TestCase):
                                    promotes=['con2', 'y2'])
 
         filename = 'pyxdsm_parallel'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         prob = Problem(model=SellarMDA())
         model = prob.model
         prob.driver = ScipyOptimizeDriver()
@@ -440,7 +441,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
     def test_execcomp(self):
         filename = 'pyxdsm_execcomp'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         prob = Problem(model=Group())
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
@@ -460,7 +461,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
     def test_doe(self):
         filename = 'pyxdsm_doe'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         prob = Problem(model=Group())
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
@@ -483,7 +484,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         from openmdao.components.meta_model_structured_comp import MetaModelStructuredComp
 
         filename = 'pyxdsm_meta_model'
-        out_format = 'pdf'
+        out_format = PYXDSM_OUT
         model = Group()
         ivc = IndepVarComp()
 
@@ -533,19 +534,19 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='pdf', show_browser=False, quiet=QUIET,
+        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=False, quiet=QUIET,
                    output_side='right')
 
         # Check if file was created
-        self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
         filename = 'xdsm_outputs_side_mixed'
         # Write output
-        write_xdsm(prob, filename=filename, out_format='pdf', show_browser=False, quiet=QUIET,
+        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=False, quiet=QUIET,
                    output_side={'optimization': 'left', 'default': 'right'})
 
         # Check if file was created
-        self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
+        self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
 
 class TestXDSMjsViewer(unittest.TestCase):

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -233,7 +233,6 @@ class TestPyXDSMViewer(unittest.TestCase):
                    recurse=False)
         self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit', 'tex'])))
 
-    @unittest.expectedFailure
     def test_circuit_model_path_recurse(self):
 
         from openmdao.api import Problem, IndepVarComp

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -1007,12 +1007,13 @@ def _get_path(name, sep='.'):
     return name.rsplit(sep, 1)[0]
 
 
-def _make_rel_path(full_path, model_path):
+def _make_rel_path(full_path, model_path, sep='.'):
     # Path will be cut from this character. Length of model path + separator after it.
     # If path does not contain the model path, the full path will be returned.
     if model_path is not None:
-        first_char = len(model_path) + 1
-        if full_path.startswith(model_path):
+        path = model_path + sep  # Add separator character
+        first_char = len(path)
+        if full_path.startswith(path):
             return full_path[first_char:]
         else:
             return full_path
@@ -1074,7 +1075,7 @@ def _format_name(name):
     return name
 
 
-def _prune_connections(conns, model_path=None):
+def _prune_connections(conns, model_path=None, sep='.'):
     """
     Remove connections that don't involve components within model.
 
@@ -1082,8 +1083,12 @@ def _prune_connections(conns, model_path=None):
     ----------
     conns : list
         A list of connections from viewer_data
-    model_path : str or None
+    model_path : str or None, optional
         The path in model to the system to be transcribed to XDSM.
+        Defaults to None.
+    sep : str, optional
+        Separator character.
+        Defaults to '.'.
 
     Returns
     -------
@@ -1104,19 +1109,20 @@ def _prune_connections(conns, model_path=None):
     if model_path is None:
         return conns, external_inputs, external_outputs
     else:
+        path = model_path + sep  # Add separator character
         for conn in conns:
             src = conn['src']
             src_path = _make_rel_path(src, model_path=model_path)
             tgt = conn['tgt']
             tgt_path = _make_rel_path(tgt, model_path=model_path)
 
-            if src.startswith(model_path) and tgt.startswith(model_path):
+            if src.startswith(path) and tgt.startswith(path):
                 # Internal connections
                 internal_conns.append({'src': src_path, 'tgt': tgt_path})
-            elif not src.startswith(model_path) and tgt.startswith(model_path):
+            elif not src.startswith(path) and tgt.startswith(path):
                 # Externally connected input
                 external_inputs.append({'src': src_path, 'tgt': tgt_path})
-            elif src.startswith(model_path) and not tgt.startswith(model_path):
+            elif src.startswith(path) and not tgt.startswith(path):
                 # Externally connected output
                 external_outputs.append({'src': src_path, 'tgt': tgt_path})
         return internal_conns, external_inputs, external_outputs

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -1074,7 +1074,7 @@ def _format_name(name):
     return name
 
 
-def _prune_connections(conns, model_path=None, sep='.'):
+def _prune_connections(conns, model_path=None):
     """
     Remove connections that don't involve components within model.
 


### PR DESCRIPTION
The XDSM writer now works correctly if a model path is given.

This PR solves issue this issue: https://www.pivotaltracker.com/n/projects/1885757/stories/163920286

The tests were also rationalized a bit, to not create the PDF when it is not actually tested. Some similar tests, which used the same model were merged into one.