### PR TITLE
beam_optimization doc referred to a new N2

### DIFF
--- a/openmdao/docs/examples/beam_optimization/beam_optimization.rst
+++ b/openmdao/docs/examples/beam_optimization/beam_optimization.rst
@@ -34,7 +34,7 @@ Since our model contains a system of equations, we use the adjoint method to com
 The model is shown below.
 
 .. embed-n2::
-    ../test_suite/scripts/multipoint_beam_opt.py
+    ../test_suite/scripts/beam_opt.py
 
 
 Implementation: group


### PR DESCRIPTION
Maybe the solution should be different but the idea of this pull request is that I believe the N2 diagram in [this example](http://openmdao.org/twodocs/versions/latest/examples/beam_optimization/beam_optimization.html) does not match the text/code. The N2 shown in that link is the one that uses BsplinesComp   and multi_ point beam example. When one clicks the example it causes confusion as the N2 does not represent the problem given at the end of that page. 