### PR TITLE
XDSM from SQL

### DIFF
--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -65,7 +65,10 @@ class TestPyXDSMViewer(unittest.TestCase):
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
 
     def test_pyxdsm_case_reading(self):
-        """Makes XDSM for the Sellar problem"""
+        """
+        Writes a recorder file, and the XDSM writer makes the diagram based on the SQL file
+        and not the Problem instance.
+        """
         from openmdao.recorders.sqlite_recorder import SqliteRecorder
 
         filename = 'xdsm_from_sql'
@@ -87,10 +90,15 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(case_recording_filename, filename=filename, out_format='pdf', show_browser=False,
-                   quiet=QUIET)
+        msg = ('For SQL input the XDSM writer shows only the model hierarchy, '
+               'and the driver, design variables and responses are not part of the '
+               'diagram.')
+        with assert_warning(Warning, msg):
+            write_xdsm(case_recording_filename, filename=filename, out_format='tex',
+                       show_browser=False, quiet=QUIET)
 
         # Check if file was created
+        self.assertTrue(os.path.isfile(case_recording_filename))
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
 
     def test_pyxdsm_sellar_no_recurse(self):

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -64,6 +64,35 @@ class TestPyXDSMViewer(unittest.TestCase):
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
 
+    def test_pyxdsm_case_reading(self):
+        """Makes XDSM for the Sellar problem"""
+        from openmdao.recorders.sqlite_recorder import SqliteRecorder
+
+        filename = 'xdsm_from_sql'
+        case_recording_filename = filename + '.sql'
+
+        prob = Problem()
+        prob.model = model = SellarNoDerivatives()
+        model.add_design_var('z', lower=np.array([-10.0, 0.0]),
+                             upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
+        model.add_design_var('x', lower=0.0, upper=10.0)
+        model.add_objective('obj')
+        model.add_constraint('con1', equals=np.zeros(1))
+        model.add_constraint('con2', upper=0.0)
+
+        recorder = SqliteRecorder(case_recording_filename)
+        prob.driver.add_recorder(recorder)
+
+        prob.setup(check=False)
+        prob.final_setup()
+
+        # Write output
+        write_xdsm(case_recording_filename, filename=filename, out_format='pdf', show_browser=False,
+                   quiet=QUIET)
+
+        # Check if file was created
+        self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
+
     def test_pyxdsm_sellar_no_recurse(self):
         """Makes XDSM for the Sellar problem, with no recursion."""
 

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -575,8 +575,8 @@ def write_xdsm(problem, filename, model_path=None, recurse=True,
 
     Parameters
     ----------
-    problem : Problem
-        Problem
+    problem : Problem or str
+        The Problem or case recorder database containing the model or model data.
     filename : str
         Name of the output files (do not provide file extension)
     model_path : str or None
@@ -640,9 +640,15 @@ def write_xdsm(problem, filename, model_path=None, recurse=True,
         design_vars = _model.get_design_vars()
         responses = _model.get_responses()
     elif isinstance(problem, str):  # SQL file
+        # from openmdao.recorders.sqlite_reader import SqliteCaseReader
+        # reader = SqliteCaseReader(problem)
         driver = None
         design_vars = None
         responses = None
+        # TODO get design variables, responses and the driver name from the SQL file
+        warnings.warn('For SQL input the XDSM writer shows only the model hierarchy, '
+                      'and the driver, design variables and responses are not part of the '
+                      'diagram.')
     else:
         msg = 'write_xdsm() only accepts Problems, Groups or filenames, not "{}"'
         raise TypeError(msg.format(type(problem)))

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -24,6 +24,7 @@ import json
 import os
 import warnings
 
+import six
 from six import iteritems
 
 from openmdao.core.problem import Problem
@@ -1051,7 +1052,7 @@ def _convert_name(name, recurse=True, subs=None):
 def _format_name(name):
     # Replaces illegal characters in names for pyXDSM component and connection names
     # This does not effect the labels, only reference names TikZ
-    if isinstance(name, (str, unicode)):  # from an SQL reader the name will be in unicode
+    if isinstance(name, six.string_types):  # from an SQL reader the name will be in unicode
         for char in ('.', ' ', '-', '_', ':'):
             name = name.replace(char, '@')
     return name


### PR DESCRIPTION
The `write_xdsm()` function can take an SQL file as input to generate the diagram. 
Yet the driver, design variables and responses are not included. (Any easy way to get them from the SQL file or from an `SqliteCaseReader`?)

It also might make sense to change the name of the first argument from `problem` to `source_data` to make it consistent with the N^2 writer.