### PR TITLE
Driver name for recording

### DIFF
--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -385,7 +385,7 @@ class SimulColoringRecordingTestCase(unittest.TestCase):
 
         cr = CaseReader('cases.sql')
 
-        self.assertEqual(cr.list_cases(), ['rank0:SNOPT|%d' % i for i in range(p.driver.iter_count)])
+        self.assertEqual(cr.list_cases(), ['rank0:pyOptSparse_SNOPT|%d' % i for i in range(p.driver.iter_count)])
 
 
 class SimulColoringPyoptSparseRevTestCase(unittest.TestCase):

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -189,7 +189,7 @@ class DOEDriver(Driver):
                 if msg:
                     raise(ValueError(msg))
 
-        with RecordingDebugging(self._name, self.iter_count, self) as rec:
+        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
             try:
                 self.run_solve_nonlinear()
                 metadata['success'] = 1

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -191,6 +191,17 @@ class SimpleGADriver(Driver):
         self._concurrent_color = 0
         return comm
 
+    def _get_name(self):
+        """
+        Get name of current Driver.
+
+        Returns
+        -------
+        str
+            Name of current Driver.
+        """
+        return "SimpleGA"
+
     def run(self):
         """
         Execute the genetic algorithm.
@@ -275,8 +286,8 @@ class SimpleGADriver(Driver):
             val = desvar_new[i:j]
             self.set_design_var(name, val)
 
-        with RecordingDebugging('SimpleGA', self.iter_count, self) as rec:
-            self.run_solve_nonlinear()
+        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
+            model.run_solve_nonlinear()
             rec.abs = 0.0
             rec.rel = 0.0
         self.iter_count += 1
@@ -378,7 +389,7 @@ class SimpleGADriver(Driver):
         almost_inf = openmdao.INF_BOUND
 
         # Execute the model
-        with RecordingDebugging('SimpleGA', self.iter_count, self) as rec:
+        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
             self.iter_count += 1
             try:
                 self.run_solve_nonlinear()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -207,7 +207,7 @@ class pyOptSparseDriver(Driver):
         con_meta = self._cons
         model_ran = False
         if optimizer in run_required or np.any([con['linear'] for con in itervalues(self._cons)]):
-            with RecordingDebugging(optimizer, self.iter_count, self) as rec:
+            with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
                 # Initial Run
                 self.run_solve_nonlinear()
                 rec.abs = 0.0
@@ -371,8 +371,8 @@ class pyOptSparseDriver(Driver):
         for name in indep_list:
             self.set_design_var(name, dv_dict[name])
 
-        with RecordingDebugging(self.options['optimizer'], self.iter_count, self) as rec:
-            self.run_solve_nonlinear()
+        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
+            model.run_solve_nonlinear()
             rec.abs = 0.0
             rec.rel = 0.0
         self.iter_count += 1
@@ -425,7 +425,7 @@ class pyOptSparseDriver(Driver):
             # print(dv_dict)
 
             # Execute the model
-            with RecordingDebugging(self.options['optimizer'], self.iter_count, self) as rec:
+            with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
                 self.iter_count += 1
                 try:
                     self.run_solve_nonlinear()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -547,7 +547,7 @@ class pyOptSparseDriver(Driver):
         str
             The name of the current optimizer.
         """
-        return self.options['optimizer']
+        return "pyOptSparse_" + self.options['optimizer']
 
     def _get_ordered_nl_responses(self):
         """

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -240,8 +240,8 @@ class ScipyOptimizeDriver(Driver):
         self._total_jac = None
 
         # Initial Run
-        with RecordingDebugging(self.options['optimizer'], self.iter_count, self) as rec:
-            self.run_solve_nonlinear()
+        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
+            model.run_solve_nonlinear()
             self.iter_count += 1
 
         self._con_cache = self.get_constraint_values()
@@ -555,7 +555,7 @@ class ScipyOptimizeDriver(Driver):
                 self.set_design_var(name, x_new[i:i + size])
                 i += size
 
-            with RecordingDebugging(self.options['optimizer'], self.iter_count, self) as rec:
+            with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
                 self.iter_count += 1
                 self.run_solve_nonlinear()
 

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -178,7 +178,7 @@ class ScipyOptimizeDriver(Driver):
         str
             The name of the current optimizer.
         """
-        return self.options['optimizer']
+        return "ScipyOptimize_" + self.options['optimizer']
 
     def _setup_driver(self, problem):
         """

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -248,7 +248,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
             expected_outputs.update(expected_includes)
 
-            coordinate = [0, 'SLSQP', (driver.iter_count-1,)]
+            coordinate = [0, 'ScipyOptimize_SLSQP', (driver.iter_count-1,)]
 
             expected_data = ((coordinate, (t0, t1), expected_outputs, None),)
             assertDriverIterDataRecorded(self, expected_data, self.eps)

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -31,7 +31,7 @@ from openmdao.solvers.linesearch.backtracking import ArmijoGoldsteinLS
 from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStates
 
 # check that pyoptsparse is installed
-OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
+OPT, OPTIMIZER = set_pyoptsparse_opt('')
 if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
@@ -191,17 +191,17 @@ class TestSqliteCaseReader(unittest.TestCase):
         driver_cases = cr.list_cases('driver')
 
         self.assertEqual(driver_cases, [
-            'rank0:SLSQP|0', 'rank0:SLSQP|1', 'rank0:SLSQP|2',
-            'rank0:SLSQP|3', 'rank0:SLSQP|4', 'rank0:SLSQP|5',
-            'rank0:SLSQP|6'
+            'rank0:ScipyOptimize_SLSQP|0', 'rank0:ScipyOptimize_SLSQP|1', 'rank0:ScipyOptimize_SLSQP|2',
+            'rank0:ScipyOptimize_SLSQP|3', 'rank0:ScipyOptimize_SLSQP|4', 'rank0:ScipyOptimize_SLSQP|5',
+            'rank0:ScipyOptimize_SLSQP|6'
         ])
 
         # Test to see if the access by case keys works:
-        seventh_slsqp_iteration_case = cr.get_case('rank0:SLSQP|6')
+        seventh_slsqp_iteration_case = cr.get_case('rank0:ScipyOptimize_SLSQP|6')
         np.testing.assert_almost_equal(seventh_slsqp_iteration_case.outputs['z'],
                                        [1.97846296, -2.21388305e-13], decimal=2)
 
-        deriv_case = cr.get_case('rank0:SLSQP|4')
+        deriv_case = cr.get_case('rank0:ScipyOptimize_SLSQP|4')
         np.testing.assert_almost_equal(deriv_case.jacobian['obj', 'pz.z'],
                                        [[3.8178954, 1.73971323]], decimal=2)
 
@@ -220,7 +220,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # Test to see if the case keys (iteration coords) come back correctly
         for i, iter_coord in enumerate(driver_cases):
-            self.assertEqual(iter_coord, 'rank0:SLSQP|{}'.format(i))
+            self.assertEqual(iter_coord, 'rank0:ScipyOptimize_SLSQP|{}'.format(i))
 
     def test_reading_system_cases(self):
         prob = SellarProblem()
@@ -453,13 +453,13 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # check driver cases
         expected_coords = [
-            'rank0:SLSQP|0',
-            'rank0:SLSQP|1',
-            'rank0:SLSQP|2',
-            'rank0:SLSQP|3',
-            'rank0:SLSQP|4',
-            'rank0:SLSQP|5',
-            'rank0:SLSQP|6'
+            'rank0:pyOptSparse_SLSQP|0',
+            'rank0:pyOptSparse_SLSQP|1',
+            'rank0:pyOptSparse_SLSQP|2',
+            'rank0:pyOptSparse_SLSQP|3',
+            'rank0:pyOptSparse_SLSQP|4',
+            'rank0:pyOptSparse_SLSQP|5',
+            'rank0:pyOptSparse_SLSQP|6'
         ]
 
         last_counter = 0
@@ -472,27 +472,27 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # check driver cases with recursion, flat
         expected_coords = [
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0',
-            'rank0:SLSQP|0',
-            'rank0:SLSQP|1|root._solve_nonlinear|1|NLRunOnce|0',
-            'rank0:SLSQP|1|root._solve_nonlinear|1',
-            'rank0:SLSQP|1',
-            'rank0:SLSQP|2|root._solve_nonlinear|2|NLRunOnce|0',
-            'rank0:SLSQP|2|root._solve_nonlinear|2',
-            'rank0:SLSQP|2',
-            'rank0:SLSQP|3|root._solve_nonlinear|3|NLRunOnce|0',
-            'rank0:SLSQP|3|root._solve_nonlinear|3',
-            'rank0:SLSQP|3',
-            'rank0:SLSQP|4|root._solve_nonlinear|4|NLRunOnce|0',
-            'rank0:SLSQP|4|root._solve_nonlinear|4',
-            'rank0:SLSQP|4',
-            'rank0:SLSQP|5|root._solve_nonlinear|5|NLRunOnce|0',
-            'rank0:SLSQP|5|root._solve_nonlinear|5',
-            'rank0:SLSQP|5',
-            'rank0:SLSQP|6|root._solve_nonlinear|6|NLRunOnce|0',
-            'rank0:SLSQP|6|root._solve_nonlinear|6',
-            'rank0:SLSQP|6',
+            'rank0:pyOptSparse_SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|0|root._solve_nonlinear|0',
+            'rank0:pyOptSparse_SLSQP|0',
+            'rank0:pyOptSparse_SLSQP|1|root._solve_nonlinear|1|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|1|root._solve_nonlinear|1',
+            'rank0:pyOptSparse_SLSQP|1',
+            'rank0:pyOptSparse_SLSQP|2|root._solve_nonlinear|2|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|2|root._solve_nonlinear|2',
+            'rank0:pyOptSparse_SLSQP|2',
+            'rank0:pyOptSparse_SLSQP|3|root._solve_nonlinear|3|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|3|root._solve_nonlinear|3',
+            'rank0:pyOptSparse_SLSQP|3',
+            'rank0:pyOptSparse_SLSQP|4|root._solve_nonlinear|4|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|4|root._solve_nonlinear|4',
+            'rank0:pyOptSparse_SLSQP|4',
+            'rank0:pyOptSparse_SLSQP|5|root._solve_nonlinear|5|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|5|root._solve_nonlinear|5',
+            'rank0:pyOptSparse_SLSQP|5',
+            'rank0:pyOptSparse_SLSQP|6|root._solve_nonlinear|6|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|6|root._solve_nonlinear|6',
+            'rank0:pyOptSparse_SLSQP|6',
         ]
 
         last_counter = 0
@@ -509,13 +509,13 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # check child cases with recursion, flat
         expected_coords = [
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0',
-            'rank0:SLSQP|0|root._solve_nonlinear|0',
-            'rank0:SLSQP|0',
+            'rank0:pyOptSparse_SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0',
+            'rank0:pyOptSparse_SLSQP|0|root._solve_nonlinear|0',
+            'rank0:pyOptSparse_SLSQP|0',
         ]
 
         last_counter = 0
-        for i, c in enumerate(cr.get_cases('rank0:SLSQP|0', recurse=True, flat=True)):
+        for i, c in enumerate(cr.get_cases('rank0:pyOptSparse_SLSQP|0', recurse=True, flat=True)):
             self.assertEqual(c.iteration_coordinate, expected_coords[i])
             self.assertTrue(c.counter > last_counter)
             last_counter = c.counter
@@ -524,14 +524,14 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # check child cases with recursion, nested
         expected_coords = {
-            'rank0:SLSQP|0': {
-                'rank0:SLSQP|0|root._solve_nonlinear|0': {
-                    'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0': {}
+            'rank0:pyOptSparse_SLSQP|0': {
+                'rank0:pyOptSparse_SLSQP|0|root._solve_nonlinear|0': {
+                    'rank0:pyOptSparse_SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0': {}
                 },
             }
         }
 
-        cases = cr.get_cases('rank0:SLSQP|0', recurse=True, flat=False)
+        cases = cr.get_cases('rank0:pyOptSparse_SLSQP|0', recurse=True, flat=False)
 
         count = 0
         for case in cases:
@@ -564,7 +564,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         cr = CaseReader(self.filename)
 
-        parent_coord = 'rank0:SLSQP|2|root._solve_nonlinear|2'
+        parent_coord = 'rank0:ScipyOptimize_SLSQP|2|root._solve_nonlinear|2'
         coord = parent_coord + '|NLRunOnce|0'
 
         # user scenario: given a case (with coord), get all cases with same parent
@@ -639,7 +639,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         #
         # get a recursive list of child cases
         #
-        parent_coord = 'rank0:SLSQP|0|root._solve_nonlinear|0'
+        parent_coord = 'rank0:ScipyOptimize_SLSQP|0|root._solve_nonlinear|0'
 
         expected_coords = [
             parent_coord + '|NLRunOnce|0|mda._solve_nonlinear|0|NonlinearBlockGS|0',
@@ -671,11 +671,11 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # verify the coordinates of the returned cases are all there as expected
         expected_coord = {
-            'driver':                    r'rank0:SLSQP\|\d',
-            'root':                      r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d',
-            'root.nonlinear_solver':     r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0',
-            'root.mda':                  r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d',
-            'root.mda.nonlinear_solver': r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d\|NonlinearBlockGS\|\d',
+            'driver':                    r'rank0:ScipyOptimize_SLSQP\|\d',
+            'root':                      r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d',
+            'root.nonlinear_solver':     r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0',
+            'root.mda':                  r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d',
+            'root.mda.nonlinear_solver': r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d\|NonlinearBlockGS\|\d',
         }
         counter = 0
         mda_counter = 0
@@ -851,7 +851,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         #
         # get a recursive list of child cases
         #
-        parent_coord = 'rank0:SLSQP|0|root._solve_nonlinear|0'
+        parent_coord = 'rank0:ScipyOptimize_SLSQP|0|root._solve_nonlinear|0'
 
         expected_coords = [
             parent_coord + '|NLRunOnce|0|mda._solve_nonlinear|0|NonlinearBlockGS|0',
@@ -883,11 +883,11 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # verify the coordinates of the returned cases are as expected and that the cases are all there
         expected_coord = {
-            'driver':                    r'rank0:SLSQP\|\d',
-            'root':                      r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d',
-            'root.nonlinear_solver':     r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0',
-            'root.mda':                  r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d',
-            'root.mda.nonlinear_solver': r'rank0:SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d\|NonlinearBlockGS\|\d',
+            'driver':                    r'rank0:ScipyOptimize_SLSQP\|\d',
+            'root':                      r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d',
+            'root.nonlinear_solver':     r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0',
+            'root.mda':                  r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d',
+            'root.mda.nonlinear_solver': r'rank0:ScipyOptimize_SLSQP\|\d\|root._solve_nonlinear\|\d\|NLRunOnce\|0\|mda._solve_nonlinear\|\d\|NonlinearBlockGS\|\d',
         }
         counter = 0
         mda_counter = 0
@@ -1752,13 +1752,13 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         system_cases = cr.list_cases('root.pz', recurse=False)
         expected_cases = [
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|pz._solve_nonlinear|0',
-            'rank0:SLSQP|1|root._solve_nonlinear|1|NLRunOnce|0|pz._solve_nonlinear|1',
-            'rank0:SLSQP|2|root._solve_nonlinear|2|NLRunOnce|0|pz._solve_nonlinear|2',
-            'rank0:SLSQP|3|root._solve_nonlinear|3|NLRunOnce|0|pz._solve_nonlinear|3',
-            'rank0:SLSQP|4|root._solve_nonlinear|4|NLRunOnce|0|pz._solve_nonlinear|4',
-            'rank0:SLSQP|5|root._solve_nonlinear|5|NLRunOnce|0|pz._solve_nonlinear|5',
-            'rank0:SLSQP|6|root._solve_nonlinear|6|NLRunOnce|0|pz._solve_nonlinear|6'
+            'rank0:ScipyOptimize_SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0|pz._solve_nonlinear|0',
+            'rank0:ScipyOptimize_SLSQP|1|root._solve_nonlinear|1|NLRunOnce|0|pz._solve_nonlinear|1',
+            'rank0:ScipyOptimize_SLSQP|2|root._solve_nonlinear|2|NLRunOnce|0|pz._solve_nonlinear|2',
+            'rank0:ScipyOptimize_SLSQP|3|root._solve_nonlinear|3|NLRunOnce|0|pz._solve_nonlinear|3',
+            'rank0:ScipyOptimize_SLSQP|4|root._solve_nonlinear|4|NLRunOnce|0|pz._solve_nonlinear|4',
+            'rank0:ScipyOptimize_SLSQP|5|root._solve_nonlinear|5|NLRunOnce|0|pz._solve_nonlinear|5',
+            'rank0:ScipyOptimize_SLSQP|6|root._solve_nonlinear|6|NLRunOnce|0|pz._solve_nonlinear|6'
         ]
         self.assertEqual(len(system_cases), len(expected_cases))
         for i, coord in enumerate(system_cases):
@@ -1783,13 +1783,13 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         root_solver_cases = cr.list_cases('root.nonlinear_solver', recurse=False)
         expected_cases = [
-            'rank0:SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0',
-            'rank0:SLSQP|1|root._solve_nonlinear|1|NLRunOnce|0',
-            'rank0:SLSQP|2|root._solve_nonlinear|2|NLRunOnce|0',
-            'rank0:SLSQP|3|root._solve_nonlinear|3|NLRunOnce|0',
-            'rank0:SLSQP|4|root._solve_nonlinear|4|NLRunOnce|0',
-            'rank0:SLSQP|5|root._solve_nonlinear|5|NLRunOnce|0',
-            'rank0:SLSQP|6|root._solve_nonlinear|6|NLRunOnce|0'
+            'rank0:ScipyOptimize_SLSQP|0|root._solve_nonlinear|0|NLRunOnce|0',
+            'rank0:ScipyOptimize_SLSQP|1|root._solve_nonlinear|1|NLRunOnce|0',
+            'rank0:ScipyOptimize_SLSQP|2|root._solve_nonlinear|2|NLRunOnce|0',
+            'rank0:ScipyOptimize_SLSQP|3|root._solve_nonlinear|3|NLRunOnce|0',
+            'rank0:ScipyOptimize_SLSQP|4|root._solve_nonlinear|4|NLRunOnce|0',
+            'rank0:ScipyOptimize_SLSQP|5|root._solve_nonlinear|5|NLRunOnce|0',
+            'rank0:ScipyOptimize_SLSQP|6|root._solve_nonlinear|6|NLRunOnce|0'
         ]
         self.assertEqual(len(root_solver_cases), len(expected_cases))
         for i, coord in enumerate(root_solver_cases):
@@ -1852,13 +1852,13 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         driver_cases = cr.list_cases('driver', recurse=False)
         expected_cases = [
-            'rank0:SLSQP|0',
-            'rank0:SLSQP|1',
-            'rank0:SLSQP|2',
-            'rank0:SLSQP|3',
-            'rank0:SLSQP|4',
-            'rank0:SLSQP|5',
-            'rank0:SLSQP|6'
+            'rank0:ScipyOptimize_SLSQP|0',
+            'rank0:ScipyOptimize_SLSQP|1',
+            'rank0:ScipyOptimize_SLSQP|2',
+            'rank0:ScipyOptimize_SLSQP|3',
+            'rank0:ScipyOptimize_SLSQP|4',
+            'rank0:ScipyOptimize_SLSQP|5',
+            'rank0:ScipyOptimize_SLSQP|6'
         ]
         # check that there are multiple iterations and they have the expected coordinates
         self.assertTrue(len(driver_cases), len(expected_cases))
@@ -1909,7 +1909,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         all_driver_cases = cr.list_cases('driver', recurse=True, flat=True)
 
         expected_cases = driver_cases + \
-            [c for c in all_solver_cases if c.startswith('rank0:SLSQP')]
+            [c for c in all_solver_cases if c.startswith('rank0:ScipyOptimize_SLSQP')]
 
         self.assertEqual(len(all_driver_cases), len(expected_cases))
         for case in expected_cases:
@@ -2026,7 +2026,7 @@ class TestFeatureSqliteReader(unittest.TestCase):
         case_ids = cr.list_cases()
 
         self.assertEqual(len(case_ids), driver.iter_count)
-        self.assertEqual(case_ids, ['rank0:SLSQP|%d' % i for i in range(driver.iter_count)])
+        self.assertEqual(case_ids, ['rank0:ScipyOptimize_SLSQP|%d' % i for i in range(driver.iter_count)])
         self.assertEqual('', '')
 
         for case_id in case_ids:

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -185,7 +185,7 @@ class TestSqliteRecorder(unittest.TestCase):
         t0, t1 = run_driver(prob)
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (4, )]
+        coordinate = [0, 'ScipyOptimize_SLSQP', (4, )]
 
         expected_desvars = {"p1.x": [7.16706813], "p2.y": [-7.83293187]}
         expected_objectives = {"comp.f_xy": [-27.0833]}
@@ -261,7 +261,7 @@ class TestSqliteRecorder(unittest.TestCase):
         t0, t1 = run_driver(prob)
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (3, )]
+        coordinate = [0, 'pyOptSparse_SLSQP', (3, )]
 
         expected_desvars = {"p1.x": [7.16706813], "p2.y": [-7.83293187]}
         expected_objectives = {"comp.f_xy": [-27.0833]}
@@ -309,8 +309,8 @@ class TestSqliteRecorder(unittest.TestCase):
         run2_t0, run2_t1 = run_driver(prob, case_prefix='Run2')
         prob.cleanup()
 
-        run1_coord = [0, 'SLSQP', (4, )]  # 1st run, 5 iterations
-        run2_coord = [0, 'SLSQP', (0, )]  # 2nd run, 1 iteration
+        run1_coord = [0, 'ScipyOptimize_SLSQP', (4, )]  # 1st run, 5 iterations
+        run2_coord = [0, 'ScipyOptimize_SLSQP', (0, )]  # 2nd run, 1 iteration
 
         expected_desvars = {"p1.x": [7.16706813], "p2.y": [-7.83293187]}
         expected_objectives = {"comp.f_xy": [-27.0833]}
@@ -361,7 +361,7 @@ class TestSqliteRecorder(unittest.TestCase):
         t0, t1 = run_driver(prob)
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (3, )]
+        coordinate = [0, 'ScipyOptimize_SLSQP', (3, )]
 
         expected_desvars = {"p1.x": [7.16706813, ], "p2.y": [-7.83293187]}
         expected_objectives = {"comp.f_xy": [-27.0833]}
@@ -643,7 +643,7 @@ class TestSqliteRecorder(unittest.TestCase):
 
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (3, )]
+        coordinate = [0, 'ScipyOptimize_SLSQP', (3, )]
 
         expected_desvars = {"p1.x": prob["p1.x"]}
         expected_objectives = {"comp.f_xy": prob['comp.f_xy']}
@@ -686,7 +686,7 @@ class TestSqliteRecorder(unittest.TestCase):
         t0, t1 = run_driver(prob)
         prob.cleanup()
 
-        coordinate = [0, 'SLSQP', (3, )]
+        coordinate = [0, 'ScipyOptimize_SLSQP', (3, )]
 
         expected_desvars = {"p1.x": prob["p1.x"]}
         expected_objectives = {"comp.f_xy": prob['comp.f_xy']}
@@ -743,7 +743,7 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         coordinate = [
             0,
-            'SLSQP', (1, ),
+            'ScipyOptimize_SLSQP', (1, ),
             'root._solve_nonlinear', (1, ),
             'NLRunOnce', (0, ),
             'mda._solve_nonlinear', (1, ),
@@ -767,7 +767,7 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # check data for 'pz'
         #
-        coordinate = [0, 'SLSQP', (2, ), 'root._solve_nonlinear', (2, ), 'NLRunOnce', (0, ),
+        coordinate = [0, 'ScipyOptimize_SLSQP', (2, ), 'root._solve_nonlinear', (2, ), 'NLRunOnce', (0, ),
                       'pz._solve_nonlinear', (2, )]
 
         expected_inputs = None
@@ -1164,7 +1164,7 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # Driver recording test
         #
-        coordinate = [0, 'SLSQP', (6, )]
+        coordinate = [0, 'ScipyOptimize_SLSQP', (6, )]
 
         expected_desvars = {
             "pz.z": prob['pz.z'],
@@ -1188,7 +1188,7 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # System recording test
         #
-        coordinate = [0, 'SLSQP', (2, ), 'root._solve_nonlinear', (2, ), 'NLRunOnce', (0, ),
+        coordinate = [0, 'ScipyOptimize_SLSQP', (2, ), 'root._solve_nonlinear', (2, ), 'NLRunOnce', (0, ),
                       'pz._solve_nonlinear', (2, )]
 
         expected_inputs = None
@@ -1203,7 +1203,7 @@ class TestSqliteRecorder(unittest.TestCase):
         #
         # Solver recording test
         #
-        coordinate = [0, 'SLSQP', (6, ), 'root._solve_nonlinear', (6, ), 'NLRunOnce', (0, ),
+        coordinate = [0, 'ScipyOptimize_SLSQP', (6, ), 'root._solve_nonlinear', (6, ), 'NLRunOnce', (0, ),
                       'mda._solve_nonlinear', (6, ), 'NonlinearBlockGS', (4, )]
 
         expected_abs_error = 0.0,
@@ -1460,7 +1460,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         # Driver recording test
-        coordinate = [0, 'SLSQP', (6, )]
+        coordinate = [0, 'ScipyOptimize_SLSQP', (6, )]
 
         expected_desvars = {
             "pz.z": prob['pz.z'],
@@ -1720,7 +1720,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         cr = CaseReader(case_recorder_filename)
-        case = cr.get_case('rank0:SLSQP|4')
+        case = cr.get_case('rank0:ScipyOptimize_SLSQP|4')
 
         assert_rel_error(self, case.outputs['x'], 7.16666667, 1e-6)
         assert_rel_error(self, case.outputs['y'], -7.83333333, 1e-6)


### PR DESCRIPTION
This PR to use driver <code>_get_name</code> call consistently in RecordingDebugging creation and specify scipy or pyoptsparse prefix in corresponding driver names.