### PR TITLE
XDSM target name formatting bugfix

### DIFF
--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -830,7 +830,7 @@ def _write_xdsm(filename, viewer_data, driver=None, include_solver=False, cleanu
                 for tgt, conn_vars in iteritems(dct):
                     formatted_cons = format_block(conn_vars)
                     if (src in comp_names) and (tgt in comp_names):
-                        formatted_targets = [format_var_str(c, 'target') for c in formatted_cons]
+                        formatted_targets = format_block([format_var_str(c, 'target') for c in conn_vars])
                         # From solver to components (targets)
                         x.connect(solver_name, tgt, formatted_targets)
                         # From components to solver

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -1223,7 +1223,8 @@ def _format_block_string(var_names, stacking='vertical', **kwargs):
                         line = name
                 else:  # make new line
                     if stacking == 'max_chars':
-                        lines.append(line)
+                        if line:
+                            lines.append(line)
                         line = name
                         lengths = len(name)
                     else:  # 'cut_chars'


### PR DESCRIPTION
Small formatting error corrected. Bug was there only with `include_solver` option turned on.

Before
![image](https://user-images.githubusercontent.com/34424189/54788026-ede5a400-4c2d-11e9-95e3-49cd038fe5c0.png)

Now:
![image](https://user-images.githubusercontent.com/34424189/54789407-ad3c5980-4c32-11e9-93e8-a5ff66bf72ef.png)

