### PR TITLE
Improvements to two error messages.

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -798,7 +798,16 @@ class Component(System):
                 raise ValueError('If one of rows/cols is specified, then both must be specified')
 
             if rows is not None:
-                # check for repeated rows/cols indices
+
+                # First, check the length of rows and cols to catch this easy mistake and give a
+                # clear message.
+                if len(cols) != len(rows):
+                    msg = "{0}: declare_partials has been called with rows and cols, which" + \
+                          " should be arrays of equal length, but rows is length {1} while " + \
+                          "cols is length {2}."
+                    raise RuntimeError(msg.format(self.pathname, len(rows), len(cols)))
+
+                # Check for repeated rows/cols indices.
                 idxset = set(zip(rows, cols))
                 if len(rows) - len(idxset) > 0:
                     dups = [n for n, val in iteritems(Counter(zip(rows, cols))) if val > 1]

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -225,13 +225,13 @@ class TestJacobianFeatures(unittest.TestCase):
          'If one of rows/cols is specified, then both must be specified'),
         ({'of': 'f', 'wrt': 'z', 'cols': [0, 10]},
          'If one of rows/cols is specified, then both must be specified'),
-        ({'of': 'f', 'wrt': 'z', 'rows': [0], 'cols': [0, 3]},
-         'rows and cols must have the same shape, rows: \(1L?,\), cols: \(2L?,\)'),
         ({'of': 'f', 'wrt': 'z', 'rows': [0, 0, 0], 'cols': [0, 1, 3], 'val': [0, 1]},
          'If rows and cols are specified, val must be a scalar or have the same shape, '
          'val: \(2L?,\), rows/cols: \(3L?,\)'),
     ])
     def test_bad_sizes(self, partials_kwargs, error_msg):
+        # This tests various shape mismatches. Basic size mismatch is now tested earlier in the
+        # declare_partials call.
         comp = SimpleCompKwarg(partials_kwargs)
         problem = self.problem
         model = problem.model

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -93,8 +93,9 @@ def format_singular_csc_error(system, matrix):
 
         if zero_rows.size == 0:
             # Underdetermined: duplicate columns or rows.
-            msg = "Identical rows or columns found in jacobian. Problem is underdetermined."
-            return msg
+            msg = "Identical rows or columns found in jacobian in '{}'. Problem is " + \
+                  "underdetermined."
+            return msg.format(system.pathname)
 
         loc_txt = "row"
         loc = zero_rows[0]

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -576,15 +576,16 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                 self.nonlinear_solver = NewtonSolver()
                 self.linear_solver = DirectSolver()
 
-        prob = Problem(model=Rectifier())
+        prob = Problem()
+        prob.model.add_subsystem('sub', Rectifier())
 
         prob.setup(check=False)
-        prob.set_solver_print(level=2)
+        prob.set_solver_print(level=0)
 
         with self.assertRaises(RuntimeError) as cm:
             prob.run_model()
 
-        expected_msg = "Identical rows or columns found in jacobian. Problem is underdetermined."
+        expected_msg = "Identical rows or columns found in jacobian in 'sub'. Problem is underdetermined."
 
         self.assertEqual(expected_msg, str(cm.exception))
 


### PR DESCRIPTION
1. In declare_partials when rows and cols have different lengths.
2. In direct solver when the problem is underdetermined.