### PR TITLE
Fixed errors in dot and cross product documentation.

### DIFF
--- a/openmdao/components/cross_product_comp.py
+++ b/openmdao/components/cross_product_comp.py
@@ -9,7 +9,7 @@ from openmdao.core.explicitcomponent import ExplicitComponent
 
 class CrossProductComp(ExplicitComponent):
     """
-    Compute a vectorized dot product.
+    Compute a vectorized cross product.
 
     math::
         c = np.cross(a, b)
@@ -32,7 +32,7 @@ class CrossProductComp(ExplicitComponent):
         Declare options.
         """
         self.options.declare('vec_size', types=int, default=1,
-                             desc='The number of points at which the dot product is computed')
+                             desc='The number of points at which the cross product is computed')
         self.options.declare('a_name', types=string_types, default='a',
                              desc='The variable name for vector a.')
         self.options.declare('b_name', types=string_types, default='b',
@@ -85,7 +85,7 @@ class CrossProductComp(ExplicitComponent):
 
     def compute(self, inputs, outputs):
         """
-        Compute the dot product of inputs `a` and `b` using np.cross.
+        Compute the cross product of inputs `a` and `b` using np.cross.
 
         Parameters
         ----------

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -89,7 +89,7 @@ class ExecComp(ExplicitComponent):
         atan(x)                    Inverse tangent of x
         cos(x)                     Cosine of x
         cosh(x)                    Hyperbolic cosine of x
-        dot(x, y)                  Dot-product of x and y
+        dot(x, y)                  Dot product of x and y
         e                          Euler's number
         erf(x)                     Error function
         erfc(x)                    Complementary error function

--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -8,7 +8,7 @@ from openmdao.api import Problem, Group, IndepVarComp, CrossProductComp
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-class TestDotProductCompNx3(unittest.TestCase):
+class TestCrossProductCompNx3(unittest.TestCase):
 
     def setUp(self):
         self.n = 5
@@ -63,7 +63,7 @@ class TestDotProductCompNx3(unittest.TestCase):
                                                desired=cpd[comp][var, wrt]['J_fd'],
                                                decimal=6)
 
-class TestDotProductCompNx3x1(unittest.TestCase):
+class TestCrossProductCompNx3x1(unittest.TestCase):
 
     def setUp(self):
         self.nn = 5
@@ -118,7 +118,7 @@ class TestDotProductCompNx3x1(unittest.TestCase):
                                                desired=cpd[comp][var, wrt]['J_fd'],
                                                decimal=6)
 
-class TestDotProductCompNonVectorized(unittest.TestCase):
+class TestCrossProductCompNonVectorized(unittest.TestCase):
 
     def setUp(self):
         self.p = Problem(model=Group())

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -158,7 +158,7 @@ class TestForDocs(unittest.TestCase):
 
     def test(self):
         """
-        A simple example to compute power as the dot-product of force and velocity vectors
+        A simple example to compute power as the dot product of force and velocity vectors
         at 100 points simultaneously.
         """
         import numpy as np

--- a/openmdao/docs/features/building_blocks/components/cross_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/cross_product_comp.rst
@@ -5,7 +5,7 @@
 CrossProductComp
 ================
 
-`CrossProductComp` performs a cross-product between two 3-vector inputs.  It may be vectorized to provide the result at one or more points simultaneously.
+`CrossProductComp` performs a cross product between two 3-vector inputs.  It may be vectorized to provide the result at one or more points simultaneously.
 
 .. math::
 
@@ -34,7 +34,7 @@ and the output :math:`c`, as well as specifying their units.
 CrossProductComp Example
 ------------------------
 
-In the following example DotProductComp is used to compute torque as the
+In the following example CrossProductComp is used to compute torque as the
 cross product of force (:math:`F`) and radius (:math:`r`) at 100 points simultaneously.
 Note the use of `a_name`, `b_name`, and `c_name` to assign names to the inputs and outputs.
 Units are assigned using `a_units`, `b_units`, and `c_units`.

--- a/openmdao/docs/features/building_blocks/components/cross_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/cross_product_comp.rst
@@ -1,6 +1,10 @@
 
 .. _crossproductcomp_feature:
 
+.. meta::
+   :description: OpenMDAO Feature doc for CrossProductComp, which performs a cross product on two inputs
+   :keywords: cross product, CrossProductComp
+
 ================
 CrossProductComp
 ================

--- a/openmdao/docs/features/building_blocks/components/dot_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/dot_product_comp.rst
@@ -5,7 +5,7 @@
 DotProductComp
 **************
 
-`DotProductComp` performs a dot-product between two compatible inputs.  It may be vectorized to provide the result at one or more points simultaneously.
+`DotProductComp` performs a dot product between two compatible inputs.  It may be vectorized to provide the result at one or more points simultaneously.
 
 .. math::
 
@@ -37,6 +37,6 @@ Note that no internal checks are performed to ensure that `c_units` are consiste
 with `a_units` and `b_units`.
 
 .. embed-code::
-    openmdao.components.tests.test_cross_product_comp.TestForDocs.test
+    openmdao.components.tests.test_dot_product_comp.TestForDocs.test
 
 .. tags:: DotProductComp, Component

--- a/openmdao/docs/features/building_blocks/components/dot_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/dot_product_comp.rst
@@ -1,6 +1,10 @@
 
 .. _dotproductcomp_feature:
 
+.. meta::
+   :description: OpenMDAO Feature doc for DotProductComp, which performs a dot product on two inputs
+   :keywords: dot product, DotProductComp
+
 **************
 DotProductComp
 **************


### PR DESCRIPTION
1. Fixed some errors in the dot and cross product documentation.
2. Made an attempt at improving the search, but didn't succeed.  I left the two `meta` directives in, since they are good to have for google indexing, and maybe a custom html search scorer can use them.