### PR TITLE
XDSM solver hierarchy Vol. 2.

### DIFF
--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -497,16 +497,24 @@ else:
 
             for comp in self._comps:
                 label = comp['label']
+                # If the process steps are included in the labels
                 if self.add_component_indices:
                     i = i0 = comp.pop('index', None)
                     step = comp.pop('step', None)
+                    # For each closed loop inrement the process index by one
                     for loop in self._loop_ends:
                         if loop < i0:
                             i += 1
+                    # Step is not None for the driver and solvers, for these a different label
+                    # will be made showing the starting end and step and the index of the next step.
                     if step is not None:
                         i = self._make_loop_str(first=i, last=step, start_index=_START_INDEX)
+                    # Add the number
                     label = self.number_label(i, label, self.number_alignment)
+                # Convert from math mode to regular text
                 comp['label'] = self._textify(label)
+                # Now the label is finished.
+                # Now really add the system with the XDSM class' method
                 self.add_system(**comp)
 
             super(XDSMWriter, self).write(file_name=filename, build=build, cleanup=cleanup, **kwargs)

--- a/openmdao/devtools/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/devtools/xdsm_viewer/xdsm_writer.py
@@ -626,9 +626,9 @@ else:
                             proc[i+1:i+1+nr] = []
                             process_index = meta[process_name]['index']
                             meta[process_name]['steps'] += 1
-                            self.comps[process_index][2] = 'Changed label!'
+                            self.comps[process_index][2] = meta[process_name]['steps']
             process_steps = comp_names + [comp_names[0]]  # close the loop
-            meta[process_steps[0]]['steps'] = len(process_steps) - 2
+            meta[process_steps[0]]['steps'] = len(process_steps)
             print('META:::', meta)
             self.add_process(process_steps, arrow=_PROCESS_ARROWS)
 


### PR DESCRIPTION
Now the blocks have the correct process numbering in pyXDSM. This required to restructure a bit the `XDSMWriter` class, so the labels are added after the processes are added.

Now the numbering should be consistent for the two writers.

With XDSMjs...
![image](https://user-images.githubusercontent.com/34424189/55037185-2cf46a80-501d-11e9-8b02-a0f3d3319331.png)

... and with pyXDSM:
![image](https://user-images.githubusercontent.com/34424189/55037205-43022b00-501d-11e9-9b25-d7fe96c1faf3.png)
