### PR TITLE
User can pass shape as an argument to ExecComp, when all variables have the same shape 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,18 @@ branches:
 
 environment:
   matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PYTHON: 2.7
+      # MKL: 2018.0.2  # Math Kernel Library
+      NUMPY: 1.15
+      SCIPY: 1.0.1
+
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      PYTHON: 3.6
+      # MKL: 2018.0.2  # Math Kernel Library
+      NUMPY: 1.15
+      SCIPY: 1.0.1
+
     - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
       PYTHON: 3.7
       NUMPY: 1.15
@@ -23,18 +35,6 @@ environment:
       NUMPY: 1.15
       SCIPY: 1.0.1
       # PETSc: 3.9.1
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: 2.7
-      # MKL: 2018.0.2  # Math Kernel Library
-      NUMPY: 1.15
-      SCIPY: 1.0.1
-
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      PYTHON: 3.6
-      # MKL: 2018.0.2  # Math Kernel Library
-      NUMPY: 1.15
-      SCIPY: 1.0.1
 
   encrypted_74d70a284b7d_key:
     secure: 7u/kPupG0BmwqAJOLeyGMPakwj3lqukKHXsxEP4+6aX+Huu8VH2ZkDNq6GYlaw6HGJHi2JTAal9VDgOpZc9RMlweOrXJiNFWS3Iu0chy+L4=

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -93,7 +93,7 @@ class AddSubtractComp(ExplicitComponent):
         complex : Boolean
             Set True to enable complex math (e.g. for complex step verification)
         """
-        self.options.declare('complex', default=False,
+        self.options.declare('complex', types=bool, default=False,
                              desc="Allocate as complex (e.g. for complex-step verification)")
 
     def add_equation(self, output_name, input_names, vec_size=1, length=1, val=1.0,

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -22,6 +22,7 @@ _allowed_meta = {'value', 'shape', 'units', 'res_units', 'desc',
 # Names that are not allowed for input or output variables (keywords for options)
 _disallowed_names = {'vectorize', 'units', 'shape'}
 
+
 def array_idx_iter(shape):
     """
     Return an iterator over the indices into a n-dimensional array.
@@ -66,21 +67,23 @@ class ExecComp(ExplicitComponent):
             if option is 'units' and value is not None and not valid_units(value):
                 raise ValueError("The units '%s' are invalid." % value)
 
-
         self.options.declare('vectorize', types=bool, default=False,
                              desc='If True, treat all array/array partials as diagonal if both '
                                   'arrays have size > 1. All arrays with size > 1 must have the '
                                   'same flattened size or an exception will be raised.')
 
-        self.options.declare('units', types=str, allow_none=True, default=None, check_valid=check_option,
-                             desc='Units to be assigned to all variables in this component. Default is '
-                                  'None, which means units are provided for variables individually.')
+        self.options.declare('units', types=str, allow_none=True, default=None,
+                             desc='Units to be assigned to all variables in this component. '
+                                  'Default is None, which means units are provided for variables '
+                                  'individually.',
+                             check_valid=check_option)
 
         self.options.declare('shape', types=(int, tuple, list), allow_none=True, default=None,
-                             desc='Shape to be assigned to all variables in this component. Default is '
-                                  'None, which means shape is provided for variables individually.')
+                             desc='Shape to be assigned to all variables in this component. '
+                                  'Default is None, which means shape is provided for variables '
+                                  'individually.')
 
-    def __init__(self, exprs, **kwargs):
+    def __init__(self, exprs=[], **kwargs):
         r"""
         Create a <Component> using only an expression string.
 
@@ -210,6 +213,9 @@ class ExecComp(ExplicitComponent):
         """
         Set up variable name and metadata lists.
         """
+        if not self._exprs:
+            raise RuntimeError("%s: No valid expressions provided to ExecComp(): %s."
+                               % (self.pathname, self._exprs))
         outs = set()
         allvars = set()
         exprs = self._exprs

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -24,6 +24,20 @@ _disallowed_names = {'vectorize', 'units', 'shape'}
 
 
 def check_option(option, value):
+    """
+    Check option for validity.
+
+    Parameters
+    ----------
+    option : str
+        The name of the option
+    value : any
+        The value of the option
+
+    Raises
+    ------
+    ValueError
+    """
     if option is 'units' and value is not None and not valid_units(value):
         raise ValueError("The units '%s' are invalid." % value)
 

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -209,8 +209,7 @@ class ExecComp(ExplicitComponent):
         options = {}
         for name in _disallowed_names:
             if name in kwargs:
-                options[name] = kwargs[name]
-                kwargs.pop(name)
+                options[name] = kwargs.pop(name)
 
         super(ExecComp, self).__init__(**options)
 

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -23,6 +23,11 @@ _allowed_meta = {'value', 'shape', 'units', 'res_units', 'desc',
 _disallowed_names = {'vectorize', 'units', 'shape'}
 
 
+def check_option(option, value):
+    if option is 'units' and value is not None and not valid_units(value):
+        raise ValueError("The units '%s' are invalid." % value)
+
+
 def array_idx_iter(shape):
     """
     Return an iterator over the indices into a n-dimensional array.
@@ -63,10 +68,6 @@ class ExecComp(ExplicitComponent):
         """
         Declare options.
         """
-        def check_option(option, value):
-            if option is 'units' and value is not None and not valid_units(value):
-                raise ValueError("The units '%s' are invalid." % value)
-
         self.options.declare('vectorize', types=bool, default=False,
                              desc='If True, treat all array/array partials as diagonal if both '
                                   'arrays have size > 1. All arrays with size > 1 must have the '

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -278,13 +278,12 @@ class ExecComp(ExplicitComponent):
                     del kwargs2[arg]['value']
 
                 if 'shape' in val:
-                    shape = val['shape']
                     if arg not in init_vals:
-                        init_vals[arg] = np.ones(shape)
-                    elif shape != np.atleast_1d(init_vals[arg]).shape:
+                        init_vals[arg] = np.ones(val['shape'])
+                    elif np.atleast_1d(init_vals[arg]).shape != val['shape']:
                         raise RuntimeError("%s: shape of %s has been specified for variable "
                                            "'%s', but a value of shape %s has been provided." %
-                                           (self.pathname, str(shape), arg,
+                                           (self.pathname, str(val['shape']), arg,
                                             str(np.atleast_1d(init_vals[arg]).shape)))
                     del kwargs2[arg]['shape']
             else:

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -55,7 +55,7 @@ class ExternalCodeDelegate(object):
         comp.options.declare('external_output_files', [],
                              desc='List of output files that must exist after execution, '
                                   'otherwise an Exception is raised.')
-        comp.options.declare('fail_hard', True,
+        comp.options.declare('fail_hard', types=bool, default=True,
                              desc="If True, external code errors raise a 'hard' exception "
                                   "(RuntimeError), otherwise errors raise a 'soft' exception "
                                   "(AnalysisError).")

--- a/openmdao/components/ks_comp.py
+++ b/openmdao/components/ks_comp.py
@@ -140,7 +140,7 @@ class KSComp(ExplicitComponent):
         self.options.declare('width', types=int, default=1, desc='Width of constraint vector.')
         self.options.declare('vec_size', types=int, default=1,
                              desc='The number of rows to independently aggregate.')
-        self.options.declare('lower_flag', False,
+        self.options.declare('lower_flag', types=bool, default=False,
                              desc="Set to True to reverse sign of input constraints.")
         self.options.declare('rho', 50.0, desc="Constraint Aggregation Factor.")
         self.options.declare('upper', 0.0, desc="Upper bound for constraint, default is zero.")

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -399,8 +399,8 @@ class TestExecComp(unittest.TestCase):
                                                     units=2.0))
 
         self.assertEqual(str(cm.exception),
-                         "Value (2.0) of option 'units' has type of (<class 'float'>), "
-                         "but expected type (<class 'str'>).")
+                         "Value (2.0) of option 'units' has type 'float', "
+                         "but type 'str' was expected.")
 
     def test_units_varname_str(self):
         prob = Problem(model=Group())

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -390,7 +390,9 @@ class TestExecComp(unittest.TestCase):
                                                     y={'units': 'm'},
                                                     units=2.0))
 
-        self.assertEqual(str(cm.exception), "The units argument should be a str or None.")
+        self.assertEqual(str(cm.exception),
+                         "Value (2.0) of option 'units' has type of (<class 'float'>), "
+                         "but expected type (<class 'str'>).")
 
     def test_units_varname_str(self):
         prob = Problem(model=Group())

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -503,7 +503,7 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup()
 
-        self.assertEqual(str(context.exception).replace('1L,', '1,'),  # 1L on Windows
+        self.assertEqual(str(context.exception).replace('L,', ','),  # L on Windows
                          "comp: shape of (5,) has been specified for variable 'x', "
                          "but a value of shape (1,) has been provided.")
 
@@ -554,7 +554,7 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             p.setup()
 
-        self.assertEqual(str(context.exception).replace('1L,', '1,'),  # 1L on Windows
+        self.assertEqual(str(context.exception).replace('L,', ','),  # L on Windows
                          "comp: shape of (10,) has been specified for variable 'y', "
                          "but shape of (5,) has been specified for the entire component.")
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -113,7 +113,7 @@ class Component(System):
         """
         super(Component, self)._declare_options()
 
-        self.options.declare('distributed', False,
+        self.options.declare('distributed', types=bool, default=False,
                              desc='True if the component has variables that are distributed '
                                   'across multiple processes.')
 

--- a/openmdao/docs/features/building_blocks/components/exec_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/exec_comp.rst
@@ -11,6 +11,14 @@ represents a set of simple mathematical relationships between inputs and outputs
 automatically takes care of all of the component API methods, so you just need to instantiate
 it with an equation.
 
+ExecComp Options
+--------------------
+
+.. embed-options::
+    openmdao.components.exec_comp
+    ExecComp
+    options
+
 ExecComp Constructor
 --------------------
 
@@ -57,8 +65,8 @@ For more information about these metadata, see the documentation for the argumen
 
 - :meth:`add_output <openmdao.core.component.Component.add_output>`
 
-ExecComp Usage Examples
------------------------
+ExecComp Example: Simple
+------------------------
 
 For example, here is a simple component that takes the input and adds one to it.
 
@@ -66,13 +74,19 @@ For example, here is a simple component that takes the input and adds one to it.
     openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_simple
     :layout: interleave
 
+ExecComp Example: Multiple Outputs
+----------------------------------
+
 You can also create an ExecComp with multiple outputs by placing the expressions in a list.
 
 .. embed-code::
     openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_multi_output
     :layout: interleave
 
-You can also declare an ExecComp with arrays for inputs and outputs, but when you do, you must also
+ExecComp Example: Arrays
+------------------------
+
+You can declare an ExecComp with arrays for inputs and outputs, but when you do, you must also
 pass in a correctly-sized array as an argument to the ExecComp call. This can be the initial value
 in the case of unconnected inputs, or just an empty array with the correct size.
 
@@ -80,17 +94,8 @@ in the case of unconnected inputs, or just an empty array with the correct size.
     openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_array
     :layout: interleave
 
-If all of your ExecComp's array inputs and array outputs are the same size and happen to have
-diagonal partials, you can create a vectorized ExecComp by specifying a `vectorize=True` arg
-to `__init__`.  This will cause the ExecComp to solve for its partials by complex stepping
-all entries of an array input at once instead of looping over each entry individually.  Here's
-a simple example:
-
-
-.. embed-code::
-    openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_vectorize
-    :layout: interleave
-
+ExecComp Example: Math Functions
+--------------------------------
 
 Functions from the math library are available for use in the expression strings.
 
@@ -98,14 +103,39 @@ Functions from the math library are available for use in the expression strings.
     openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_math
     :layout: interleave
 
+ExecComp Example: Variable Properties
+-------------------------------------
 
-You can also declare options like 'units', 'upper', or 'lower' on the inputs and outputs. Here is an example
-where we declare all our inputs to be inches to trigger conversion from a variable expressed in feet in one
-connection source.
+You can also declare properties like 'units', 'upper', or 'lower' on the inputs and outputs. In this 
+example we declare all our inputs to be inches to trigger conversion from a variable expressed in feet
+in one connection source.
 
 .. embed-code::
     openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_metadata
     :layout: interleave
 
+ExecComp Example: Vectorized
+----------------------------
+
+If all of your ExecComp's array inputs and array outputs are the same size and happen to have
+diagonal partials, you can create a vectorized ExecComp by specifying a `vectorize=True` argument
+to `__init__` or via the component options. This will cause the ExecComp to solve for its partials 
+by complex stepping all entries of an array input at once instead of looping over each entry individually.
+
+.. embed-code::
+    openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_vectorize
+    :layout: interleave
+
+ExecComp Example: Options
+-------------------------
+
+Other options that can apply to all the variables in the component are variable shape and units.
+These can also be set as a keyword argument in the constructor or via the component options. In the 
+following example the variables all share the same shape, which is specified in the constructor, and
+common units that are specified by setting the option.
+
+.. embed-code::
+    openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_options
+    :layout: interleave
 
 .. tags:: ExecComp, Component, Examples

--- a/openmdao/docs/features/building_blocks/components/exec_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/exec_comp.rst
@@ -12,7 +12,7 @@ automatically takes care of all of the component API methods, so you just need t
 it with an equation.
 
 ExecComp Options
---------------------
+----------------
 
 .. embed-options::
     openmdao.components.exec_comp

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -73,7 +73,7 @@ class DOEDriver(Driver):
         """
         self.options.declare('generator', types=(DOEGenerator), default=DOEGenerator(),
                              desc='The case generator. If default, no cases are generated.')
-        self.options.declare('run_parallel', default=False,
+        self.options.declare('run_parallel', types=bool, default=False,
                              desc='Set to True to execute cases in parallel.')
         self.options.declare('procs_per_model', default=1, lower=1,
                              desc='Number of processors to give each model under MPI.')

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -100,7 +100,7 @@ class SimpleGADriver(Driver):
                              'every unspecified variable is assumed to be integer, and the number '
                              'of bits is calculated automatically. If you have a continuous var, '
                              'you should set a bits value as a key in this dictionary.')
-        self.options.declare('elitism', default=True,
+        self.options.declare('elitism', types=bool, default=True,
                              desc='If True, replace worst performing point with best from previous'
                              ' generation each iteration.')
         self.options.declare('max_gen', default=100,
@@ -108,7 +108,7 @@ class SimpleGADriver(Driver):
         self.options.declare('pop_size', default=0,
                              desc='Number of points in the GA. Set to 0 and it will be computed '
                              'as four times the number of bits.')
-        self.options.declare('run_parallel', default=False,
+        self.options.declare('run_parallel', types=bool, default=False,
                              desc='Set to True to execute the points in a generation in parallel.')
         self.options.declare('procs_per_model', default=1, lower=1,
                              desc='Number of processors to give each model under MPI.')

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -161,7 +161,7 @@ class ScipyOptimizeDriver(Driver):
                              'control, use solver-specific options.')
         self.options.declare('maxiter', 200, lower=0,
                              desc='Maximum number of iterations.')
-        self.options.declare('disp', True,
+        self.options.declare('disp', True, types=bool,
                              desc='Set to False to prevent printing of Scipy convergence messages')
         self.options.declare('dynamic_simul_derivs', default=False, types=bool,
                              desc='Compute simultaneous derivative coloring dynamically if True')

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1841,7 +1841,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
             "=============== ======= ================= ================ =========================================\n"
             "Option          Default Acceptable Values Acceptable Types Description                              \n"
             "=============== ======= ================= ================ =========================================\n"
-            "distributed     False   N/A               N/A              True if the component has variables that \n"
+            "distributed     False   [True, False]     ['bool']         True if the component has variables that \n"
             "                                                           are distributed across multiple processes\n"
             "                                                           .\n"
             "options value 1 1       N/A               N/A                                                       \n"

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -165,7 +165,7 @@ class DirectSolver(LinearSolver):
         """
         super(DirectSolver, self)._declare_options()
 
-        self.options.declare('err_on_singular', default=True,
+        self.options.declare('err_on_singular', types=bool, default=True,
                              desc="Raise an error if LU decomposition is singular.")
 
         # this solver does not iterate

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -105,7 +105,7 @@ class BroydenSolver(NonlinearSolver):
                              desc="Value to scale the starting Jacobian, which is Identity. This "
                                   "option does nothing if you compute the initial Jacobian "
                                   "instead.")
-        self.options.declare('compute_jacobian', default=True,
+        self.options.declare('compute_jacobian', types=bool, default=True,
                              desc="When True, compute an initial Jacobian, otherwise start "
                                   "with Identity scaled by alpha. Further Jacobians may also be "
                                   "computed depending on the other options.")
@@ -114,7 +114,7 @@ class BroydenSolver(NonlinearSolver):
                                   "convergence is considered a failure. The Jacobian will be "
                                   "regenerated once this condition has been reached a number of "
                                   "consecutive times as specified in max_converge_failures.")
-        self.options.declare('cs_reconverge', default=True,
+        self.options.declare('cs_reconverge', types=bool, default=True,
                              desc='When True, when this driver solves under a complex step, nudge '
                              'the Solution vector by a small amount so that it reconverges.')
         self.options.declare('diverge_limit', default=2.0,

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -71,7 +71,7 @@ class NewtonSolver(NonlinearSolver):
                              desc='Set to True to turn on sub-solvers (Hybrid Newton).')
         self.options.declare('max_sub_solves', types=int, default=10,
                              desc='Maximum number of subsystem solves.')
-        self.options.declare('cs_reconverge', default=True,
+        self.options.declare('cs_reconverge', types=bool, default=True,
                              desc='When True, when this driver solves under a complex step, nudge '
                              'the Solution vector by a small amount so that it reconverges.')
 

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -63,10 +63,10 @@ class NonlinearBlockGS(NonlinearSolver):
                              desc='lower limit for Aitken relaxation factor')
         self.options.declare('aitken_max_factor', default=1.5,
                              desc='upper limit for Aitken relaxation factor')
-        self.options.declare('cs_reconverge', default=True,
+        self.options.declare('cs_reconverge', types=bool, default=True,
                              desc='When True, when this driver solves under a complex step, nudge '
                              'the Solution vector by a small amount so that it reconverges.')
-        self.options.declare('use_apply_nonlinear', False,
+        self.options.declare('use_apply_nonlinear', types=bool, default=False,
                              desc="Set to True to always call apply_linear on the solver's system "
                              "after solve_nonlinear has been called.")
 

--- a/openmdao/surrogate_models/kriging.py
+++ b/openmdao/surrogate_models/kriging.py
@@ -77,7 +77,7 @@ class KrigingSurrogate(SurrogateModel):
         """
         Declare options before kwargs are processed in the init method.
         """
-        self.options.declare('eval_rmse', default=False,
+        self.options.declare('eval_rmse', types=bool, default=False,
                              desc="Flag indicating whether the Root Mean Squared Error (RMSE) "
                                   "should be computed. Set to False by default.")
 

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -211,11 +211,18 @@ class OptionsDictionary(object):
             # If only types is declared
             elif types is not None:
                 if not isinstance(value, types):
-                    vtype = type(value)
+                    vtype = type(value).__name__
+
                     if isinstance(value, string_types):
                         value = "'{}'".format(value)
-                    raise TypeError("Value ({}) of option '{}' has type of ({}), but "
-                                    "expected type ({}).".format(value, name, vtype, types))
+
+                    if isinstance(types, (tuple, list)):
+                        typs = tuple([type_.__name__ for type_ in types])
+                        raise TypeError("Value ({}) of option '{}' has type '{}', but one of "
+                                        "types {} was expected.".format(value, name, vtype, typs))
+                    else:
+                        raise TypeError("Value ({}) of option '{}' has type '{}', but type '{}' "
+                                        "was expected.".format(value, name, vtype, types.__name__))
 
             if upper is not None:
                 if value > upper:

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -79,7 +79,7 @@ class OptionsDictionary(object):
                 types = "N/A"
 
             elif types is not None:
-                if not isinstance(types, (tuple, list)):
+                if not isinstance(types, (set, tuple, list)):
                     types = (types,)
 
                 types = [type_.__name__ for type_ in types]
@@ -88,7 +88,7 @@ class OptionsDictionary(object):
                 values = "N/A"
 
             elif values is not None:
-                if not isinstance(values, (tuple, list)):
+                if not isinstance(values, (set, tuple, list)):
                     values = (values,)
 
                 values = [value for value in values]
@@ -216,7 +216,7 @@ class OptionsDictionary(object):
                     if isinstance(value, string_types):
                         value = "'{}'".format(value)
 
-                    if isinstance(types, (tuple, list)):
+                    if isinstance(types, (set, tuple, list)):
                         typs = tuple([type_.__name__ for type_ in types])
                         raise TypeError("Value ({}) of option '{}' has type '{}', but one of "
                                         "types {} was expected.".format(value, name, vtype, typs))
@@ -281,6 +281,7 @@ class OptionsDictionary(object):
         if values is not None and not isinstance(values, (set, list, tuple)):
             raise TypeError("In declaration of option '%s', the 'values' arg must be of type None,"
                             " list, or tuple - not %s." % (name, values))
+
         if types is not None and not isinstance(types, (type, set, list, tuple)):
             raise TypeError("In declaration of option '%s', the 'types' arg must be None, a type "
                             "or a tuple - not %s." % (name, types))
@@ -288,6 +289,9 @@ class OptionsDictionary(object):
         if types is not None and values is not None:
             raise RuntimeError("'types' and 'values' were both specified for option '%s'." %
                                name)
+
+        if types is bool:
+            values = (True, False)
 
         default_provided = default is not _undefined
 

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -4,7 +4,7 @@ import unittest
 
 from openmdao.utils.assert_utils import assert_warning
 
-from six import PY3, assertRegex
+from six import assertRegex
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 
@@ -69,7 +69,6 @@ class TestOptionsDict(unittest.TestCase):
             "==================================================================== ",
         ]))
 
-
     def test_type_checking(self):
         self.dict.declare('test', types=int, desc='Test integer value')
 
@@ -79,8 +78,26 @@ class TestOptionsDict(unittest.TestCase):
         with self.assertRaises(TypeError) as context:
             self.dict['test'] = ''
 
-        class_or_type = 'class' if PY3 else 'type'
-        expected_msg = "Value ('') of option 'test' has type of (<{} 'str'>), but expected type (<{} 'int'>).".format(class_or_type, class_or_type)
+        expected_msg = "Value ('') of option 'test' has type 'str', " \
+                       "but type 'int' was expected."
+        self.assertEqual(expected_msg, str(context.exception))
+
+        # multiple types are allowed
+        self.dict.declare('test_multi', types=(int, float), desc='Test multiple types')
+
+        self.dict['test_multi'] = 1
+        self.assertEqual(self.dict['test_multi'], 1)
+        self.assertEqual(type(self.dict['test_multi']), int)
+
+        self.dict['test_multi'] = 1.0
+        self.assertEqual(self.dict['test_multi'], 1.0)
+        self.assertEqual(type(self.dict['test_multi']), float)
+
+        with self.assertRaises(TypeError) as context:
+            self.dict['test_multi'] = ''
+
+        expected_msg = "Value ('') of option 'test_multi' has type 'str', " \
+                       "but one of types ('int', 'float') was expected."
         self.assertEqual(expected_msg, str(context.exception))
 
         # make sure bools work

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -39,7 +39,7 @@ class TestOptionsDict(unittest.TestCase):
             "Option    Default      Acceptable Values Acceptable Types      Description         ",
             "========= ============ ================= ===================== ====================",
             "comp      MyComp       N/A               ['ExplicitComponent']                     ",
-            "flag      False        N/A               ['bool']                                  ",
+            "flag      False        [True, False]     ['bool']                                  ",
             "long_desc **Required** N/A               ['str']               This description is ",
             "                                                               long and verbose, so",
             "                                                                it takes up multipl",
@@ -59,7 +59,7 @@ class TestOptionsDict(unittest.TestCase):
             "==================================================================== ",
             "comp      MyComp       N/A               ['ExplicitComponent']                      "
             "                                                                     ",
-            "flag      False        N/A               ['bool']                                   "
+            "flag      False        [True, False]     ['bool']                                   "
             "                                                                     ",
             "long_desc **Required** N/A               ['str']               This description is l"
             "ong and verbose, so it takes up multiple lines in the options table. ",

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -100,11 +100,14 @@ class TestOptionsDict(unittest.TestCase):
                        "but one of types ('int', 'float') was expected."
         self.assertEqual(expected_msg, str(context.exception))
 
-        # make sure bools work
+        # make sure bools work and allowed values are populated
         self.dict.declare('flag', default=False, types=bool)
         self.assertEqual(self.dict['flag'], False)
         self.dict['flag'] = True
         self.assertEqual(self.dict['flag'], True)
+
+        meta = self.dict._dict['flag']
+        self.assertEqual(meta['values'], (True, False))
 
     def test_allow_none(self):
         self.dict.declare('test', types=int, allow_none=True, desc='Test integer value')


### PR DESCRIPTION
shape, units and vectorize are now proper options to ExecComp

Also:
- Update options to properly show Available Values for bool types