### PR TITLE
fix mpi4py buffer issue in Group

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -5,6 +5,7 @@ from collections import Iterable, Counter, OrderedDict, defaultdict
 from itertools import product, chain
 from numbers import Number
 import inspect
+import copy
 
 from six import iteritems, string_types, itervalues
 from six.moves import range
@@ -713,7 +714,8 @@ class Group(System):
             for vec_name in self._lin_rel_vec_name_list:
                 sizes = self._var_sizes[vec_name]
                 for type_ in ['input', 'output']:
-                    self.comm.Allgather(sizes[type_][iproc, :], sizes[type_])
+                    sizes_in = copy.deepcopy(sizes[type_][iproc, :])
+                    self.comm.Allgather(sizes_in, sizes[type_])
 
             # compute owning ranks
             owns = self._owning_rank


### PR DESCRIPTION
This issue was reported here: https://stackoverflow.com/questions/48867052/got-mpi-errors-when-run-openmdao-v2-2-0-in-parallel and I had the same problem on our cluster, where the following error is raised:

    PMPI_Allgather(1026): Buffers must not be aliased

The issue appears to be that on newer versions of `MPI4py` it is not allowed to send and receive data in the same buffer. The easy fix is to deep copy the snd buffer, which seems to fix things. I've only tested this on one of our own workflows, and tried to run some of the test scripts you have made in parallel which now seem to work.