### PR TITLE
allow_pickle=True when loading recorder data 

### DIFF
--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -75,7 +75,7 @@ class DOEDriver(Driver):
                              desc='The case generator. If default, no cases are generated.')
         self.options.declare('run_parallel', types=bool, default=False,
                              desc='Set to True to execute cases in parallel.')
-        self.options.declare('procs_per_model', default=1, lower=1,
+        self.options.declare('procs_per_model', types=int, default=1, lower=1,
                              desc='Number of processors to give each model under MPI.')
 
     def _setup_comm(self, comm):

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -85,7 +85,7 @@ def blob_to_array(blob):
     """
     out = BytesIO(blob)
     out.seek(0)
-    return np.load(out)
+    return np.load(out, allow_pickle=True)
 
 
 class SqliteRecorder(CaseRecorder):


### PR DESCRIPTION
default changed in numpy 1.16.3:  https://github.com/numpy/numpy/releases/tag/v1.16.3
