### PR TITLE
vector component default outputs should not be zeros

### DIFF
--- a/openmdao/components/dot_product_comp.py
+++ b/openmdao/components/dot_product_comp.py
@@ -60,7 +60,7 @@ class DotProductComp(ExplicitComponent):
                        units=opts['b_units'])
 
         self.add_output(name=opts['c_name'],
-                        val=np.zeros(shape=(vec_size,)),
+                        shape=(vec_size,),
                         units=opts['c_units'])
 
         row_idxs = np.repeat(np.arange(vec_size), m)

--- a/openmdao/components/vector_magnitude_comp.py
+++ b/openmdao/components/vector_magnitude_comp.py
@@ -47,7 +47,7 @@ class VectorMagnitudeComp(ExplicitComponent):
                        units=opts['units'])
 
         self.add_output(name=opts['mag_name'],
-                        val=np.zeros(shape=(vec_size,)),
+                        shape=(vec_size,),
                         units=opts['units'])
 
         row_idxs = np.repeat(np.arange(vec_size), m)


### PR DESCRIPTION
dot product and vector magnitude components no longer specify np.zeros for default output