### PR TITLE
Better reporting of relative error when fd is zero during drivative checks.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1770,7 +1770,16 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
             derivative_info['magnitude'] = magnitude = MagnitudeTuple(fwd_norm, rev_norm, fd_norm)
 
             if fd_norm == 0.:
-                derivative_info['rel error'] = rel_err = ErrorTuple(nan, nan, nan)
+                if fwd_norm == 0.:
+                    derivative_info['rel error'] = rel_err = ErrorTuple(nan, nan, nan)
+
+                else:
+                    # If fd_norm is zero, let's use fwd_norm as the divisor for relative
+                    # check. That way we don't accidentally squelch a legitimate problem.
+                    derivative_info['rel error'] = rel_err = ErrorTuple(fwd_error / fwd_norm,
+                                                                        rev_error / fwd_norm,
+                                                                        fwd_rev_error / fwd_norm)
+
             else:
                 if totals:
                     derivative_info['rel error'] = rel_err = ErrorTuple(fwd_error / fd_norm,


### PR DESCRIPTION
During check_partials, if the norm of the fd value is zero for a deriv, we formerly reported the relative error as NaN. Now, we report (fd - fwd)/fwd if fd is zero.  This prevents some deriv errors (e.g., if you forget to assign an output in `compute`) from being ignored in `assert_check_partials` if atol was set to a high value.  This is needed because sometimes we tend to ignore the absolute check when a component has wide ranges of orders of magnitude.