### PR TITLE
add required versions for numpydoc and sphinx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,14 +13,14 @@ optional_dependencies = {
     'docs': [
         'matplotlib',
         'mock',
-        'numpydoc',
+        'numpydoc>=0.9.1',
         'redbaron',
-        'sphinx',
+        'sphinx>=1.8.5',
     ],
     'test': [
         'coverage',
         'parameterized',
-        'numpydoc',
+        'numpydoc>=0.9.1',
         'pycodestyle==2.3.1',
         'pydocstyle==2.0.0',
         'testflo>=1.3.4',


### PR DESCRIPTION
sphinx 1.8.5 (released Mar 10, 2019) is the last version before 2.0, which drops Python 2.7 support
numpydoc 0.9.1 (released Apr 23, 2019)  is the current version