### PR TITLE
Problem __getitem__ now does NOT try to retrieve remote variables.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -235,9 +235,9 @@ class Problem(object):
             if len(abs_names) == 1:
                 return abs_names[0]
             else:
-                raise RuntimeError("Using promoted name `{}' is ambiguous and matches unconnected "
-                                   "inputs %s. Use absolute name to "
-                                   "disambiguate.".format(name, abs_names))
+                raise KeyError("Using promoted name `{}' is ambiguous and matches unconnected "
+                               "inputs %s. Use absolute name to disambiguate.".format(name,
+                                                                                      abs_names))
 
         raise KeyError("Variable '{}' not found.".format(name))
 
@@ -260,7 +260,7 @@ class Problem(object):
 
         try:
             abs_name = self._get_var_abs_name(name)
-        except Exception:
+        except KeyError:
             sub = self.model._get_subsystem(name)
             if sub is None:  # either the sub is remote or there is no sub by that name
                 # TODO: raise exception if sub does not exist

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -567,19 +567,19 @@ class ProbRemoteTests(unittest.TestCase):
 
         # test that getitem from Problem on a distrib var raises an exception
         with self.assertRaises(Exception) as context:
-            ans = p['par.C2.invec']
+            ans = p.get_val('par.C2.invec', get_remote=True)
         self.assertEqual(str(context.exception),
                          "Retrieval of the full distributed variable 'par.C2.invec' is not supported.")
         with self.assertRaises(Exception) as context:
-            ans = p['par.C2.outvec']
+            ans = p.get_val('par.C2.outvec', get_remote=True)
         self.assertEqual(str(context.exception),
                          "Retrieval of the full distributed variable 'par.C2.outvec' is not supported.")
         with self.assertRaises(Exception) as context:
-            ans = p['par.C1.invec']
+            ans = p.get_val('par.C1.invec', get_remote=True)
         self.assertEqual(str(context.exception),
                          "Retrieval of the full distributed variable 'par.C1.invec' is not supported.")
         with self.assertRaises(Exception) as context:
-            ans = p['par.C1.outvec']
+            ans = p.get_val('par.C1.outvec', get_remote=True)
         self.assertEqual(str(context.exception),
                          "Retrieval of the full distributed variable 'par.C1.outvec' is not supported.")
 

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -37,8 +37,8 @@ class ProbRemoteTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        np.testing.assert_almost_equal(prob['group.comp1.f'], 42., decimal=5)
-        np.testing.assert_almost_equal(prob['group.comp2.g'], 10., decimal=5)
+        np.testing.assert_almost_equal(prob.get_val('group.comp1.f', get_remote=True), 42., decimal=5)
+        np.testing.assert_almost_equal(prob.get_val('group.comp2.g', get_remote=True), 10., decimal=5)
 
     def test_remote_var_access_prom(self):
         prob = Problem()

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -61,4 +61,50 @@ class ProbRemoteTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(prob['summ.z'], 9., decimal=5)
         np.testing.assert_almost_equal(prob['prod.z'], 20., decimal=5)
 
+    def test_is_local(self):
+        p = Problem()
+        p.model.add_subsystem('indep', IndepVarComp('x', 1.0))
+        par = p.model.add_subsystem('par', ParallelGroup())
+        par.add_subsystem('C1', ExecComp('y=2*x'))
+        par.add_subsystem('C2', ExecComp('y=3*x'))
+        p.model.connect('indep.x', ['par.C1.x', 'par.C2.x'])
+
+        with self.assertRaises(RuntimeError) as cm:
+            loc = p.is_local('indep.x')
+        self.assertEqual(str(cm.exception), "is_local('indep.x') was called before setup() completed.")
+
+        with self.assertRaises(RuntimeError) as cm:
+            loc = p.is_local('par.C1')
+        self.assertEqual(str(cm.exception), "is_local('par.C1') was called before setup() completed.")
+
+        with self.assertRaises(RuntimeError) as cm:
+            loc = p.is_local('par.C1.y')
+        self.assertEqual(str(cm.exception), "is_local('par.C1.y') was called before setup() completed.")
+
+        with self.assertRaises(RuntimeError) as cm:
+            loc = p.is_local('par.C1.x')
+        self.assertEqual(str(cm.exception), "is_local('par.C1.x') was called before setup() completed.")
+
+        p.setup()
+        p.final_setup()
+
+        self.assertTrue(p.is_local('indep'), 'indep should be local')
+        self.assertTrue(p.is_local('indep.x'), 'indep.x should be local')
+
+        if p.comm.rank == 0:
+            self.assertTrue(p.is_local('par.C1'), 'par.C1 should be local')
+            self.assertTrue(p.is_local('par.C1.x'), 'par.C1.x should be local')
+            self.assertTrue(p.is_local('par.C1.y'), 'par.C1.y should be local')
+
+            self.assertFalse(p.is_local('par.C2'), 'par.C1 should be remote')
+            self.assertFalse(p.is_local('par.C2.x'), 'par.C1.x should be remote')
+            self.assertFalse(p.is_local('par.C2.y'), 'par.C1.y should be remote')
+        else:
+            self.assertFalse(p.is_local('par.C1'), 'par.C1 should be remote')
+            self.assertFalse(p.is_local('par.C1.x'), 'par.C1.x should be remote')
+            self.assertFalse(p.is_local('par.C1.y'), 'par.C1.y should be remote')
+
+            self.assertTrue(p.is_local('par.C2'), 'par.C2 should be local')
+            self.assertTrue(p.is_local('par.C2.x'), 'par.C2.x should be local')
+            self.assertTrue(p.is_local('par.C2.y'), 'par.C2.y should be local')
 

--- a/openmdao/core/tests/test_reconf_parallel_group.py
+++ b/openmdao/core/tests/test_reconf_parallel_group.py
@@ -53,16 +53,15 @@ class Test(unittest.TestCase):
         prob['x0'] = 6.
         prob['x1'] = 4.
         prob.run_model()
-        assert_rel_error(self, prob['C1.z'], 8.0)
-        assert_rel_error(self, prob['C2.z'], 6.0)
+        assert_rel_error(self, prob.get_val('C1.z', get_remote=True), 8.0)
+        assert_rel_error(self, prob.get_val('C2.z', get_remote=True), 6.0)
 
         # Now, reconfigure so ReconfGroup is not parallel, and x0, x1 should be preserved
         prob.model.g.resetup('reconf')
         prob.model.resetup('update')
         prob.run_model()
-        assert_rel_error(self, prob['C1.z'], 8.0, 1e-8)
-        assert_rel_error(self, prob['C2.z'], 6.0, 1e-8)
-        print(prob['C1.z'], prob['C2.z'])
+        assert_rel_error(self, prob.get_val('C1.z', get_remote=True), 8.0, 1e-8)
+        assert_rel_error(self, prob.get_val('C2.z', get_remote=True), 6.0, 1e-8)
 
 
 if __name__ == '__main__':

--- a/openmdao/docs/features/core_features/running/set_get.rst
+++ b/openmdao/docs/features/core_features/running/set_get.rst
@@ -102,4 +102,38 @@ When dealing with arrays, you can set or get specific indices or index ranges by
     :layout: interleave
 
 
+Retrieving Remote Variables
+---------------------------
+
+If you're running under MPI, the `Problem.get_val` method also has a *get_remote* arg that allows
+you to get the value of a variable even if it's not local to the current MPI process.  For example,
+the code below will retrieve the value of `foo.bar.x` in all processes, whether the variable is
+local or not.
+
+
+.. code-block:: python
+
+    val = prob.get_val('foo.bar.x', get_remote=True)
+
+
+.. warning::
+
+    If `get_remote` is True, `get_val` makes a collective MPI call, so make sure to call it
+    in *all* ranks of the Problem's MPI communicator.  Otherwise, collective calls made
+    in different ranks will get out of sync and result in cryptic MPI errors.
+
+
+
+Testing if a Variable or System is Local
+----------------------------------------
+
+If you want to know if a given variable or system is local to the current process, the
+`Problem.is_local` method will tell you.  For example:
+
+.. code-block:: python
+
+    if prob.is_local('foo.bar.x'):
+        print("foo.bar.x is local!")
+
+
 .. tags:: SetGet


### PR DESCRIPTION
- added a 'get_remote' arg to Problem.get_val to allow the user to access the remote retrieval functionality if desired, but in a more explicit way.
- added an 'is_local' method to Problem that can be used to determine if any given variable or system is local.
- Problem.__setitem__ now prints a message saying the assignment is ignored if the specified variable is remote.