### PR TITLE
split up config checks into default and full lists

### DIFF
--- a/openmdao/docs/features/debugging/om_command.rst
+++ b/openmdao/docs/features/debugging/om_command.rst
@@ -47,10 +47,9 @@ openmdao check
 
 The :code:`openmdao check` command will perform a number of checks on a model and display
 errors, warnings, or informational messages describing what it finds. Some of the available
-checks are *hanging_inputs*, which lists any input variables that are not connected, and
-*cycles*, which will display any component dependency cycles or out-of-order executing components.
-By default, all checks will be done, unless you supply individual checks on the command line
-using *-c* args.  For example:
+checks are *unconnected_inputs*, which lists any input variables that are not connected, and
+*out_of_order*, which displays any systems that are being executed out-of-order.
+You can supply individual checks on the command line using *-c* args.  For example:
 
 
 .. embed-shell-cmd::
@@ -58,7 +57,8 @@ using *-c* args.  For example:
     :dir: ../test_suite/scripts
 
 
-To see the available checks, run the following command:
+Otherwise, a set of default checks will be done.
+To see lists of the available and default checks, run the following command:
 
 .. embed-shell-cmd::
     :cmd: openmdao check -h

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -45,7 +45,7 @@ def _check_cycles(group, infos=None):
 
 def _check_ubcs(group, warnings):
     """
-    Report any out of order Systems to the logger.
+    Report any 'used before calculated' Systems to the logger.
 
     Parameters
     ----------
@@ -64,7 +64,7 @@ def _check_ubcs(group, warnings):
         for s in cycle:
             cycle_idxs[s] = i
 
-    ubcs = _get_out_of_order_subs(group, group._conn_global_abs_in2out)
+    ubcs = _get_used_before_calc_subs(group, group._conn_global_abs_in2out)
 
     for tgt_system, src_systems in sorted(ubcs.items()):
         keep_srcs = []
@@ -124,7 +124,7 @@ def _check_ubcs_prob(prob, logger):
         logger.warning(''.join(warnings[:1] + sorted(warnings[1:])))
 
 
-def _get_out_of_order_subs(group, input_srcs):
+def _get_used_before_calc_subs(group, input_srcs):
     """
     Return Systems that are executed out of dataflow order.
 

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -16,9 +16,9 @@ from openmdao.utils.class_util import overrides_method
 from openmdao.utils.mpi import MPI
 
 
-def _check_dataflow(group, infos, warnings):
+def _check_cycles(group, infos=None):
     """
-    Report any cycles and out of order Systems to the logger.
+    Report any cycles to the logger.
 
     Parameters
     ----------
@@ -26,24 +26,43 @@ def _check_dataflow(group, infos, warnings):
         The Group being checked for dataflow issues
     infos : list
         List to collect informational messages.
-    warnings : list
-        List to collect warning messages.
+
+    Returns
+    -------
+    list
+        List of cycles, with subsystem names sorted in execution order.
     """
     graph = group.compute_sys_graph(comps_only=False)
     sccs = get_sccs_topo(graph)
     sub2i = {sub.name: i for i, sub in enumerate(group._subsystems_allprocs)}
     cycles = [sorted(s, key=lambda n: sub2i[n]) for s in sccs if len(s) > 1]
+
+    if cycles and infos is not None:
+        infos.append("   Group '%s' has the following cycles: %s\n" % (group.pathname, cycles))
+
+    return cycles
+
+
+def _check_ubcs(group, warnings):
+    """
+    Report any out of order Systems to the logger.
+
+    Parameters
+    ----------
+    group : <Group>
+        The Group being checked for dataflow issues
+    warnings : list
+        List to collect warning messages.
+    """
+    cycles = _check_cycles(group)
+
     cycle_idxs = {}
 
-    if cycles:
-        infos.append("   Group '%s' has the following cycles: %s\n" % (group.pathname, cycles))
-        for i, cycle in enumerate(cycles):
-            # keep track of cycles so we can detect when a system in
-            # one cycle is out of order with a system in a different cycle.
-            for s in cycle:
-                if group.pathname:
-                    s = '.'.join((group.pathname, s))
-                cycle_idxs[s] = i
+    for i, cycle in enumerate(cycles):
+        # keep track of cycles so we can detect when a system in
+        # one cycle is out of order with a system in a different cycle.
+        for s in cycle:
+            cycle_idxs[s] = i
 
     ubcs = _get_out_of_order_subs(group, group._conn_global_abs_in2out)
 
@@ -51,20 +70,43 @@ def _check_dataflow(group, infos, warnings):
         keep_srcs = []
 
         for src_system in src_systems:
-            if not (src_system in cycle_idxs and
-                    tgt_system in cycle_idxs and
-                    cycle_idxs[tgt_system] == cycle_idxs[src_system]):
+            if (src_system not in cycle_idxs or
+                    tgt_system not in cycle_idxs or
+                    cycle_idxs[tgt_system] != cycle_idxs[src_system]):
                 keep_srcs.append(src_system)
 
         if keep_srcs:
+            if group.pathname:
+                tgt_system = '.'.join((group.pathname, tgt_system))
+                keep_srcs = ['.'.join((group.pathname, n)) for n in keep_srcs]
             warnings.append("   System '%s' executes out-of-order with "
                             "respect to its source systems %s\n" %
                             (tgt_system, sorted(keep_srcs)))
 
 
-def _check_dataflow_prob(prob, logger):
+def _check_cycles_prob(prob, logger):
     """
-    Report any cycles and out of order Systems.
+    Report any cycles.
+
+    Parameters
+    ----------
+    prob : <Problem>
+        The Problem being checked for cycles.
+    logger : object
+        The object that manages logging output.
+
+    """
+    infos = ["The following groups contain cycles:\n"]
+    for group in prob.model.system_iter(include_self=True, recurse=True, typ=Group):
+        _check_cycles(group, infos)
+
+    if len(infos) > 1:
+        logger.info(''.join(infos[:1] + sorted(infos[1:])))
+
+
+def _check_ubcs_prob(prob, logger):
+    """
+    Report any out of order Systems.
 
     Parameters
     ----------
@@ -74,13 +116,9 @@ def _check_dataflow_prob(prob, logger):
         The object that manages logging output.
 
     """
-    infos = ["The following groups contain cycles:\n"]
     warnings = ["The following systems are executed out-of-order:\n"]
     for group in prob.model.system_iter(include_self=True, recurse=True, typ=Group):
-        _check_dataflow(group, infos, warnings)
-
-    if len(infos) > 1:
-        logger.info(''.join(infos[:1] + sorted(infos[1:])))
+        _check_ubcs(group, warnings)
 
     if len(warnings) > 1:
         logger.warning(''.join(warnings[:1] + sorted(warnings[1:])))
@@ -105,20 +143,19 @@ def _get_out_of_order_subs(group, input_srcs):
         A dict mapping names of target Systems to a set of names of their
         source Systems that execute after them.
     """
-    subsystems = group._subsystems_allprocs
-    sub2i = {sub.name: i for i, sub in enumerate(subsystems)}
+    sub2i = {sub.name: i for i, sub in enumerate(group._subsystems_allprocs)}
     glen = len(group.pathname.split('.')) if group.pathname else 0
 
     ubcs = defaultdict(set)
-    for in_abs, src_abs in iteritems(input_srcs):
+    for tgt_abs, src_abs in iteritems(input_srcs):
         if src_abs is not None:
-            iparts = in_abs.split('.')
+            iparts = tgt_abs.split('.')
             oparts = src_abs.split('.')
             src_sys = oparts[glen]
             tgt_sys = iparts[glen]
             if (src_sys in sub2i and tgt_sys in sub2i and
                     (sub2i[src_sys] > sub2i[tgt_sys])):
-                ubcs['.'.join(iparts[:glen + 1])].add('.'.join(oparts[:glen + 1]))
+                ubcs[tgt_sys].add(src_sys)
 
     return ubcs
 
@@ -416,19 +453,24 @@ def _check_explicitly_connected_promoted_inputs(problem, logger):
 
 # Dict of all checks by name, mapped to the corresponding function that performs the check
 # Each function must be of the form  f(problem, logger).
-_checks = {
-    'hanging_inputs': _check_hanging_inputs,
-    'cycles': _check_dataflow_prob,
+_default_checks = {
+    'out_of_order': _check_ubcs_prob,
     'system': _check_system_configs,
     'solvers': _check_solvers,
     'dup_inputs': _check_dup_comp_inputs,
     'missing_recorders': _check_missing_recorders,
     'comp_has_no_outputs': _check_comp_has_no_outputs,
-    'promoted_connected': _check_explicitly_connected_promoted_inputs,
 }
 
+_all_checks = _default_checks.copy()
+_all_checks.update({
+    'cycles': _check_cycles_prob,
+    'unconnected_inputs': _check_hanging_inputs,
+    'promotions': _check_explicitly_connected_promoted_inputs,
+})
 
-def check_config(problem, logger=None):
+
+def check_config(problem, logger=None, checks=None):
     """
     Perform optional error checks on a Problem.
 
@@ -438,11 +480,19 @@ def check_config(problem, logger=None):
         The Problem being checked.
     logger : object
         Logging object.
+    checks : list of str or None
+        List of specific checks to be performed.
     """
     logger = logger if logger else get_logger('check_config', use_format=True)
 
-    for c in sorted(_checks.keys()):
-        _checks[c](problem, logger)
+    if checks is None:
+        checks = sorted(_default_checks)
+
+    for c in checks:
+        if c not in _all_checks:
+            print("WARNING: '%s' is not a recognized check." % c)
+            continue
+        _all_checks[c](problem, logger)
 
 
 #
@@ -461,8 +511,9 @@ def _check_config_setup_parser(parser):
     parser.add_argument('file', nargs=1, help='Python file containing the model.')
     parser.add_argument('-o', action='store', dest='outfile', help='output file.')
     parser.add_argument('-c', action='append', dest='checks', default=[],
-                        help='Only perform specific check(s). Available checks are: %s. '
-                        'By default, will perform all checks.' % sorted(_checks.keys()))
+                        help='Only perform specific check(s). Default checks are: %s. '
+                        'Other available checks are: %s.' %
+                        (sorted(_default_checks), sorted(set(_all_checks) - set(_default_checks))))
 
 
 def _check_config_cmd(options):
@@ -488,10 +539,9 @@ def _check_config_cmd(options):
                 logger = get_logger('check_config', out_stream=outfile, use_format=True)
 
             if not options.checks:
-                options.checks = sorted(_checks.keys())
+                options.checks = sorted(_default_checks)
 
-            for c in options.checks:
-                _checks[c](prob, logger)
+            check_config(prob, logger, options.checks)
 
         exit()
 

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -10,7 +10,7 @@ from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitCompone
     LinearBlockGS, NonlinearBlockGS, SqliteRecorder
 
 from openmdao.utils.logger_utils import TestLogger
-from openmdao.error_checking.check_config import get_sccs_topo
+from openmdao.error_checking.check_config import get_sccs_topo, check_config
 
 
 class MyComp(ExecComp):
@@ -35,8 +35,9 @@ class TestCheckConfig(unittest.TestCase):
         G4.add_subsystem("C4", ExecComp('y=x*2.0+v'))
 
         testlogger = TestLogger()
-        p.setup(check=True, logger=testlogger)
+        p.setup(check=False, logger=testlogger)
         p.final_setup()
+        check_config(p, logger=testlogger, checks=['unconnected_inputs'])
 
         expected = (
             "The following inputs are not connected:\n"
@@ -75,8 +76,9 @@ class TestCheckConfig(unittest.TestCase):
         root.nonlinear_solver = NonlinearBlockGS()
 
         testlogger = TestLogger()
-        p.setup(check=True, logger=testlogger)
+        p.setup(check=False, logger=testlogger)
         p.final_setup()
+        check_config(p, logger=testlogger, checks=['cycles', 'out_of_order'])
 
         expected_info = (
             "The following groups contain cycles:\n"
@@ -121,8 +123,9 @@ class TestCheckConfig(unittest.TestCase):
         root.nonlinear_solver = NonlinearBlockGS()
 
         testlogger = TestLogger()
-        p.setup(check=True, logger=testlogger)
+        p.setup(check=False, logger=testlogger)
         p.final_setup()
+        check_config(p, logger=testlogger, checks=['cycles', 'out_of_order'])
 
         expected_info = (
             "The following groups contain cycles:\n"
@@ -218,6 +221,60 @@ class TestCheckConfig(unittest.TestCase):
         testlogger = TestLogger()
         p.setup(check=True, logger=testlogger)
         p.final_setup()
+
+        expected_warning_1 = (
+            "The following systems are executed out-of-order:\n"
+            "   System 'G1.C2' executes out-of-order with respect to its source systems ['G1.N3']\n"
+            "   System 'G1.C3' executes out-of-order with respect to its source systems ['G1.C11']\n"
+        )
+
+        self.assertTrue(testlogger.contains('warning', expected_warning_1))
+
+    def test_multi_cycles_non_default(self):
+        p = Problem()
+        root = p.model
+
+        root.add_subsystem("indep", IndepVarComp('x', 1.0))
+
+        def make_cycle(root, start, end):
+            # systems within a cycle will be declared out of order, but
+            # should not be reported since they're internal to a cycle.
+            for i in range(end, start-1, -1):
+                root.add_subsystem("C%d" % i, MyComp())
+
+            for i in range(start, end):
+                root.connect("C%d.y" % i, "C%d.a" % (i+1))
+            root.connect("C%d.y" % end, "C%d.a" % start)
+
+        G1 = root.add_subsystem('G1', Group())
+
+        make_cycle(G1, 1, 3)
+
+        G1.add_subsystem("N1", MyComp())
+
+        make_cycle(G1, 11, 13)
+
+        G1.add_subsystem("N2", MyComp())
+
+        make_cycle(G1, 21, 23)
+
+        G1.add_subsystem("N3", MyComp())
+
+        G1.connect("N1.z", "C12.b")
+        G1.connect("C13.z", "N2.b")
+        G1.connect("N2.z", "C21.b")
+        G1.connect("C23.z", "N3.b")
+        G1.connect("N3.z", "C2.b")
+        G1.connect("C11.z", "C3.b")
+
+        # set iterative solvers since we have cycles
+        root.linear_solver = LinearBlockGS()
+        root.nonlinear_solver = NonlinearBlockGS()
+
+        testlogger = TestLogger()
+        p.setup(check=False, logger=testlogger)
+        p.final_setup()
+        check_config(p, logger=testlogger, checks=['cycles', 'out_of_order', 'unconnected_inputs'])
 
         expected_info = (
             "The following groups contain cycles:\n"

--- a/openmdao/test_suite/scripts/circuit_with_unconnected_input.py
+++ b/openmdao/test_suite/scripts/circuit_with_unconnected_input.py
@@ -1,5 +1,5 @@
 from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-
+from openmdao.error_checking.check_config import check_config
 from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node
 
 class Circuit(Group):
@@ -40,7 +40,8 @@ model.add_design_var('ground.V')
 model.add_design_var('source.I')
 model.add_objective('circuit.D1.I')
 
-p.setup(check=True)
+p.setup()
+check_config(p, checks=['unconnected_inputs'])
 
 # set some initial guesses
 p['circuit.n1.V'] = 10.

--- a/openmdao/test_suite/test_examples/test_circuit_with_unconnected_input.py
+++ b/openmdao/test_suite/test_examples/test_circuit_with_unconnected_input.py
@@ -26,3 +26,7 @@ class TestCircuitWithUnconnectedInputScript(unittest.TestCase):
 
         self.assertTrue('The following inputs are not connected' in output,
                         msg="Should have gotten error about unconnected input")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Certain checks, like the promoted connected input check were resulting in lots of annoying output, so some checks were removed from the default list and won't happen now unless explicitly asked for using a -c option on the command line or using the `checks` arg passed to check_config.
Checks that are no longer performed by default are:
    - unconnected inputs
    - connected inputs promoted above their connection level
    - cycles