### PR TITLE
Change examples to use "import openmdao.api as om".

### DIFF
--- a/benchmark/benchmark_beam.py
+++ b/benchmark/benchmark_beam.py
@@ -3,7 +3,7 @@ This benchmark documents a performance problem with data transfers that needs to
 """
 import unittest
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
 
@@ -22,9 +22,9 @@ class BenchBeamNP1(unittest.TestCase):
         num_cp = 4
         num_load_cases = 32
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        prob = om.Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
+                                                    num_elements=num_elements, num_cp=num_cp,
+                                                    num_load_cases=num_load_cases))
 
         prob.setup()
 
@@ -46,9 +46,9 @@ class BenchBeamNP2(unittest.TestCase):
         num_cp = 4
         num_load_cases = 32
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        prob = om.Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
+                                                    num_elements=num_elements, num_cp=num_cp,
+                                                    num_load_cases=num_load_cases))
 
         prob.setup()
 
@@ -71,9 +71,9 @@ class BenchBeamNP4(unittest.TestCase):
         num_cp = 4
         num_load_cases = 32
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        prob = om.Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
+                                                    num_elements=num_elements, num_cp=num_cp,
+                                                    num_load_cases=num_load_cases))
 
         prob.setup()
 

--- a/benchmark/benchmark_manycomps.py
+++ b/benchmark/benchmark_manycomps.py
@@ -11,17 +11,17 @@ class BM(unittest.TestCase):
     def benchmark_100(self):
         p = om.Problem()
         create_dyncomps(p.model, 100, 10, 10, 5)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
     def benchmark_500(self):
         p = om.Problem()
         create_dyncomps(p.model, 500, 10, 10, 5)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
     def benchmark_1K(self):
         p = om.Problem()
         create_dyncomps(p.model, 1000, 10, 10, 5)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()

--- a/benchmark/benchmark_manycomps.py
+++ b/benchmark/benchmark_manycomps.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 from openmdao.test_suite.build4test import DynComp, create_dyncomps
 
 
@@ -9,19 +9,19 @@ class BM(unittest.TestCase):
     """Setup of models with lots of components"""
 
     def benchmark_100(self):
-        p = Problem()
+        p = om.Problem()
         create_dyncomps(p.model, 100, 10, 10, 5)
         p.setup(check=False)
         p.final_setup()
 
     def benchmark_500(self):
-        p = Problem()
+        p = om.Problem()
         create_dyncomps(p.model, 500, 10, 10, 5)
         p.setup(check=False)
         p.final_setup()
 
     def benchmark_1K(self):
-        p = Problem()
+        p = om.Problem()
         create_dyncomps(p.model, 1000, 10, 10, 5)
         p.setup(check=False)
         p.final_setup()

--- a/benchmark/benchmark_manyvars.py
+++ b/benchmark/benchmark_manyvars.py
@@ -1,12 +1,12 @@
 
 import unittest
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 from openmdao.test_suite.build4test import DynComp, create_dyncomps
 
 
 def _build_comp(np, no, ns=0):
-    prob = Problem()
+    prob = om.Problem()
     prob.model.add_subsystem("C1", DynComp(np, no, ns))
     return prob
 

--- a/benchmark/benchmark_manyvars.py
+++ b/benchmark/benchmark_manyvars.py
@@ -18,36 +18,36 @@ class BM(unittest.TestCase):
 
     def benchmark_1Kparams(self):
         prob = _build_comp(1000, 1)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
     def benchmark_2Kparams(self):
         prob = _build_comp(2000, 1)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
     def benchmark_1Kouts(self):
         prob = _build_comp(1, 1000)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
     def benchmark_2Kouts(self):
         prob = _build_comp(1, 2000)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
     def benchmark_1Kvars(self):
         prob = _build_comp(500, 500)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
     def benchmark_2Kvars(self):
         prob = _build_comp(1000, 1000)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
 
 if __name__ == '__main__':
     prob = _build_comp(1, 2000)
-    prob.setup(check=False)
+    prob.setup()
     prob.final_setup()

--- a/benchmark/benchmark_multipoint.py
+++ b/benchmark/benchmark_multipoint.py
@@ -1,13 +1,14 @@
 from __future__ import print_function
+import time
 import unittest
 from six.moves import range
+
 import numpy as np
 
-import time
-from openmdao.api import Problem, Group, ExplicitComponent, IndepVarComp, ExecComp
+import openmdao.api as om
 
 
-class Plus(ExplicitComponent):
+class Plus(om.ExplicitComponent):
     def __init__(self, adder):
         super(Plus, self).__init__()
         self.adder = float(adder)
@@ -19,7 +20,8 @@ class Plus(ExplicitComponent):
     def compute(self, inputs, outputs):
         outputs['f1'] = inputs['x'] + self.adder
 
-class Times(ExplicitComponent):
+
+class Times(om.ExplicitComponent):
     def __init__(self, scalar):
         super(Times, self).__init__()
         self.scalar = float(scalar)
@@ -31,7 +33,8 @@ class Times(ExplicitComponent):
     def compute(self, inputs, outputs):
         outputs['f2'] = inputs['f1'] + self.scalar
 
-class Point(Group):
+
+class Point(om.Group):
 
     def __init__(self, adder, scalar):
         super(Point, self).__init__()
@@ -42,7 +45,8 @@ class Point(Group):
         self.add_subsystem('plus', Plus(self.adder), promotes=['*'])
         self.add_subsystem('times', Times(self.scalar), promotes=['*'])
 
-class Summer(ExplicitComponent):
+
+class Summer(om.ExplicitComponent):
 
     def __init__(self, size):
         super(Summer, self).__init__()
@@ -60,7 +64,8 @@ class Summer(ExplicitComponent):
             tot += inputs['y%d'%i]
         outputs['total'] = tot
 
-class MultiPoint(Group):
+
+class MultiPoint(om.Group):
 
     def __init__(self, adders, scalars):
         super(MultiPoint, self).__init__()
@@ -78,6 +83,7 @@ class MultiPoint(Group):
 
         self.add_subsystem('aggregate', Summer(size))
 
+
 class BM(unittest.TestCase):
     """A few 'brute force' multipoint cases (1K, 2K, 5K)"""
 
@@ -87,7 +93,7 @@ class BM(unittest.TestCase):
         adders =  np.random.random(size)
         scalars = np.random.random(size)
 
-        prob = Problem(MultiPoint(adders, scalars))
+        prob = om.Problem(MultiPoint(adders, scalars))
         prob.setup(check=False)
 
         return prob

--- a/benchmark/benchmark_multipoint.py
+++ b/benchmark/benchmark_multipoint.py
@@ -94,7 +94,7 @@ class BM(unittest.TestCase):
         scalars = np.random.random(size)
 
         prob = om.Problem(MultiPoint(adders, scalars))
-        prob.setup(check=False)
+        prob.setup()
 
         return prob
 

--- a/benchmark/benchmark_parallel_GA.py
+++ b/benchmark/benchmark_parallel_GA.py
@@ -4,7 +4,7 @@ Benchmarks the parallel scaling for the GA driver.
 from time import time
 import unittest
 
-from openmdao.api import Problem, SimpleGADriver, IndepVarComp, Group
+import openmdao.api as om
 from openmdao.test_suite.components.exec_comp_for_test import ExecComp4Test
 
 
@@ -15,13 +15,13 @@ MAXGEN = 5
 POPSIZE = 40
 
 
-class GAGroup(Group):
+class GAGroup(om.Group):
 
     def setup(self):
 
-        self.add_subsystem('p1', IndepVarComp('x', 1.0))
-        self.add_subsystem('p2', IndepVarComp('y', 1.0))
-        self.add_subsystem('p3', IndepVarComp('z', 1.0))
+        self.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+        self.add_subsystem('p2', om.IndepVarComp('y', 1.0))
+        self.add_subsystem('p3', om.IndepVarComp('z', 1.0))
 
         self.add_subsystem('comp', ExecComp4Test(['f = x + y + z'], nl_delay=DELAY))
 
@@ -37,10 +37,10 @@ class BenchParGA1(unittest.TestCase):
 
     def benchmark_genetic_1(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = GAGroup()
 
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         driver.options['max_gen'] = MAXGEN
         driver.options['pop_size'] = POPSIZE
         driver.options['run_parallel'] = True
@@ -58,10 +58,10 @@ class BenchParGA2(unittest.TestCase):
 
     def benchmark_genetic_2(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = GAGroup()
 
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         driver.options['max_gen'] = MAXGEN
         driver.options['pop_size'] = POPSIZE
         driver.options['run_parallel'] = True
@@ -79,10 +79,10 @@ class BenchParGA4(unittest.TestCase):
 
     def benchmark_genetic_4(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = GAGroup()
 
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         driver.options['max_gen'] = MAXGEN
         driver.options['pop_size'] = POPSIZE
         driver.options['run_parallel'] = True

--- a/benchmark/benchmark_param_cycle.py
+++ b/benchmark/benchmark_param_cycle.py
@@ -1,13 +1,12 @@
 
 import unittest
 
-from openmdao.api import Problem, Group, NewtonSolver, ScipyKrylov, NonlinearBlockGS, \
-    LinearBlockGS, DirectSolver
+import openmdao.api as om
 from openmdao.test_suite.parametric_suite import ParameterizedInstance
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-def _build(solver_class=NewtonSolver, linear_solver_class=ScipyKrylov,
+def _build(solver_class=om.NewtonSolver, linear_solver_class=om.ScipyKrylov,
            solver_options=None, linear_solver_options=None, **options):
     suite = ParameterizedInstance('cycle', **options)
     suite.solver_class = solver_class
@@ -44,7 +43,7 @@ class BM(unittest.TestCase):
 
     def benchmark_comp200_var5_nlbs_lbgs(self):
         suite = _build(
-            solver_class=NonlinearBlockGS, linear_solver_class=LinearBlockGS,
+            solver_class=om.NonlinearBlockGS, linear_solver_class=om.LinearBlockGS,
             assembled_jac=False,
             jacobian_type='dense',
             connection_type='explicit',
@@ -58,7 +57,7 @@ class BM(unittest.TestCase):
 
     def benchmark_comp200_var5_newton_lings(self):
         suite = _build(
-            solver_class=NewtonSolver, linear_solver_class=LinearBlockGS,
+            solver_class=om.NewtonSolver, linear_solver_class=om.LinearBlockGS,
             solver_options={'maxiter': 20},
             linear_solver_options={'maxiter': 200, 'atol': 1e-10, 'rtol': 1e-10},
             assembled_jac=False,
@@ -74,7 +73,7 @@ class BM(unittest.TestCase):
 
     def benchmark_comp200_var5_newton_direct_assembled(self):
         suite = _build(
-            solver_class=NewtonSolver, linear_solver_class=DirectSolver,
+            solver_class=om.NewtonSolver, linear_solver_class=om.DirectSolver,
             linear_solver_options={},  # defaults not valid for DirectSolver
             assembled_jac=True,
             jacobian_type='dense',
@@ -89,7 +88,7 @@ class BM(unittest.TestCase):
 
     def benchmark_comp50_var5_newton_direct_assembled_fd(self):
         suite = _build(
-            solver_class=NewtonSolver, linear_solver_class=DirectSolver,
+            solver_class=om.NewtonSolver, linear_solver_class=om.DirectSolver,
             linear_solver_options={},  # defaults not valid for DirectSolver
             assembled_jac=True,
             jacobian_type='dense',

--- a/benchmark/benchmark_trees.py
+++ b/benchmark/benchmark_trees.py
@@ -12,19 +12,19 @@ class BM(unittest.TestCase):
         p = om.Problem()
         make_subtree(p.model, nsubgroups=2, levels=4, ncomps=10,
                      ninputs=10, noutputs=10, nconns=5)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
     def benchmark_L6_sub2_c10(self):
         p = om.Problem()
         make_subtree(p.model, nsubgroups=2, levels=6, ncomps=10,
                      ninputs=10, noutputs=10, nconns=5)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
     def benchmark_L7_sub2_c10(self):
         p = om.Problem()
         make_subtree(p.model, nsubgroups=2, levels=7, ncomps=10,
                      ninputs=10, noutputs=10, nconns=5)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()

--- a/benchmark/benchmark_trees.py
+++ b/benchmark/benchmark_trees.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from openmdao.api import Problem, Group
+import openmdao.api as om
 from openmdao.test_suite.build4test import DynComp, create_dyncomps, make_subtree
 
 
@@ -9,21 +9,21 @@ class BM(unittest.TestCase):
     """Setup of models with various tree structures"""
 
     def benchmark_L4_sub2_c10(self):
-        p = Problem()
+        p = om.Problem()
         make_subtree(p.model, nsubgroups=2, levels=4, ncomps=10,
                      ninputs=10, noutputs=10, nconns=5)
         p.setup(check=False)
         p.final_setup()
 
     def benchmark_L6_sub2_c10(self):
-        p = Problem()
+        p = om.Problem()
         make_subtree(p.model, nsubgroups=2, levels=6, ncomps=10,
                      ninputs=10, noutputs=10, nconns=5)
         p.setup(check=False)
         p.final_setup()
 
     def benchmark_L7_sub2_c10(self):
-        p = Problem()
+        p = om.Problem()
         make_subtree(p.model, nsubgroups=2, levels=7, ncomps=10,
                      ninputs=10, noutputs=10, nconns=5)
         p.setup(check=False)

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -1,9 +1,11 @@
-"""Definition of the Add/Subtract Component."""
-
+"""
+Definition of the Add/Subtract Component.
+"""
 import collections
+from six import string_types
+
 import numpy as np
 from scipy import sparse as sp
-from six import string_types
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -67,7 +67,7 @@ class BalanceComp(ImplicitComponent):
 
         .. code-block:: python
 
-            prob = Problem(model=Group())
+            prob = Problem()
             bal = BalanceComp()
             bal.add_balance('x', val=1.0)
             tgt = IndepVarComp(name='y_tgt', val=2)
@@ -88,7 +88,7 @@ class BalanceComp(ImplicitComponent):
 
         .. code-block:: python
 
-            prob = Problem(model=Group())
+            prob = Problem()
             bal = BalanceComp('x', val=1.0)
             tgt = IndepVarComp(name='y_tgt', val=2)
             exec_comp = ExecComp('y=x**2')

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -189,8 +189,8 @@ class ExecComp(ExplicitComponent):
         .. code-block:: python
 
             import numpy
-            from openmdao.api import ExecComp
-            excomp = ExecComp('y=sum(x)', x=numpy.ones(10,dtype=float))
+            import openmdao.api as om
+            excomp = om.ExecComp('y=sum(x)', x=numpy.ones(10,dtype=float))
 
         In this example, 'y' would be assumed to be the default type of float
         and would be given the default initial value of 1.0, while 'x' would be

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -4,16 +4,16 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
-from openmdao.components.add_subtract_comp import AddSubtractComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+
 
 class TestAddSubtractCompScalars(unittest.TestCase):
 
     def setUp(self):
         self.nn = 1
-        self.p = Problem(model=Group())
-        ivc = IndepVarComp()
+        self.p = om.Problem()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn,))
         ivc.add_output(name='b', shape=(self.nn,))
 
@@ -22,7 +22,7 @@ class TestAddSubtractCompScalars(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b'])
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -46,14 +46,15 @@ class TestAddSubtractCompScalars(unittest.TestCase):
         partials = self.p.check_partials(method='fd', out_stream=None)
         assert_check_partials(partials)
 
+
 class TestAddSubtractCompNx1(unittest.TestCase):
 
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn,))
         ivc.add_output(name='b', shape=(self.nn,))
 
@@ -62,7 +63,7 @@ class TestAddSubtractCompNx1(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b'],vec_size=self.nn)
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -92,9 +93,9 @@ class TestAddSubtractCompNx3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
         ivc.add_output(name='b', shape=(self.nn, 3))
 
@@ -103,7 +104,7 @@ class TestAddSubtractCompNx3(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b'],vec_size=self.nn,length=3)
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -127,14 +128,15 @@ class TestAddSubtractCompNx3(unittest.TestCase):
         partials = self.p.check_partials(method='fd', out_stream=None)
         assert_check_partials(partials)
 
+
 class TestAddSubtractMultipleInputs(unittest.TestCase):
 
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
         ivc.add_output(name='b', shape=(self.nn, 3))
         ivc.add_output(name='c', shape=(self.nn, 3))
@@ -144,7 +146,7 @@ class TestAddSubtractMultipleInputs(unittest.TestCase):
                                    promotes_outputs=['a', 'b','c'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b','input_c'],vec_size=self.nn,length=3)
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -171,14 +173,15 @@ class TestAddSubtractMultipleInputs(unittest.TestCase):
         partials = self.p.check_partials(method='fd', out_stream=None)
         assert_check_partials(partials)
 
+
 class TestAddSubtractScalingFactors(unittest.TestCase):
 
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
         ivc.add_output(name='b', shape=(self.nn, 3))
         ivc.add_output(name='c', shape=(self.nn, 3))
@@ -188,7 +191,7 @@ class TestAddSubtractScalingFactors(unittest.TestCase):
                                    promotes_outputs=['a', 'b','c'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b','input_c'],vec_size=self.nn,length=3,scaling_factors=[2.,1.,-1])
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -215,14 +218,15 @@ class TestAddSubtractScalingFactors(unittest.TestCase):
         partials = self.p.check_partials(method='fd', out_stream=None)
         assert_check_partials(partials)
 
+
 class TestAddSubtractUnits(unittest.TestCase):
 
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3),units='ft')
         ivc.add_output(name='b', shape=(self.nn, 3),units='m')
         ivc.add_output(name='c', shape=(self.nn, 3),units='m')
@@ -232,7 +236,7 @@ class TestAddSubtractUnits(unittest.TestCase):
                                    promotes_outputs=['a', 'b','c'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b','input_c'],vec_size=self.nn,length=3,units='ft')
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -260,13 +264,14 @@ class TestAddSubtractUnits(unittest.TestCase):
         partials = self.p.check_partials(method='fd', out_stream=None)
         assert_check_partials(partials)
 
+
 class TestWrongScalingFactorCount(unittest.TestCase):
 
     def setUp(self):
         self.nn = 5
-        self.p = Problem(model=Group())
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
         ivc.add_output(name='b', shape=(self.nn, 3))
         ivc.add_output(name='c', shape=(self.nn, 3))
@@ -276,7 +281,7 @@ class TestWrongScalingFactorCount(unittest.TestCase):
                                    promotes_outputs=['a', 'b','c'])
 
         adder=self.p.model.add_subsystem(name='add_subtract_comp',
-                                   subsys=AddSubtractComp())
+                                   subsys=om.AddSubtractComp())
         adder.add_equation('adder_output',['input_a','input_b','input_c'],vec_size=self.nn,length=3,scaling_factors=[1,-1])
 
         self.p.model.connect('a', 'add_subtract_comp.input_a')
@@ -287,34 +292,36 @@ class TestWrongScalingFactorCount(unittest.TestCase):
     def test_for_exception(self):
         self.assertRaises(ValueError,self.p.setup)
 
-class TestForDocs(unittest.TestCase):
+
+class TestFeature(unittest.TestCase):
 
     def test(self):
         """
         A simple example to compute the resultant force on an aircraft and demonstrate the AddSubtract component
         """
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, AddSubtractComp
-        from openmdao.utils.assert_utils import assert_rel_error
+
+        import openmdao.api as om
 
         n = 3
 
-        p = Problem(model=Group())
+        p = om.Problem()
 
-        ivc = IndepVarComp()
-        #the vector represents forces at 3 time points (rows) in 2 dimensional plane (cols)
-        ivc.add_output(name='thrust', shape=(n,2),units='kN')
-        ivc.add_output(name='drag', shape=(n,2),units='kN')
-        ivc.add_output(name='lift', shape=(n,2),units='kN')
-        ivc.add_output(name='weight', shape=(n,2),units='kN')
+        ivc = om.IndepVarComp()
+        # The vector represents forces at 3 time points (rows) in 2 dimensional plane (cols)
+        ivc.add_output(name='thrust', shape=(n, 2), units='kN')
+        ivc.add_output(name='drag', shape=(n, 2), units='kN')
+        ivc.add_output(name='lift', shape=(n, 2), units='kN')
+        ivc.add_output(name='weight', shape=(n, 2), units='kN')
         p.model.add_subsystem(name='ivc',
                               subsys=ivc,
                               promotes_outputs=['thrust', 'drag', 'lift', 'weight'])
 
-        #construct an adder/subtracter here. create a relationship through the add_equation method
-        adder = AddSubtractComp()
-        adder.add_equation('total_force',input_names=['thrust','drag','lift','weight'],vec_size=n,length=2, scaling_factors=[1,-1,1,-1], units='kN')
-        #note the scaling factors. we assume all forces are positive sign upstream
+        # Construct an adder/subtracter here. create a relationship through the add_equation method
+        adder = om.AddSubtractComp()
+        adder.add_equation('total_force', input_names=['thrust', 'drag', 'lift', 'weight'],
+                           vec_size=n, length=2, scaling_factors=[1, -1, 1, -1], units='kN')
+        # Note the scaling factors. we assume all forces are positive sign upstream
 
         p.model.add_subsystem(name='totalforcecomp', subsys=adder)
 
@@ -325,18 +332,18 @@ class TestForDocs(unittest.TestCase):
 
         p.setup()
 
-        #set thrust to exceed drag, weight to equal lift for this scenario
-        p['thrust'][:,0] = [500, 600, 700]
-        p['drag'][:,0] = [400, 400, 400]
-        p['weight'][:,1] = [1000, 1001, 1002]
-        p['lift'][:,1] = [1000, 1000, 1000]
+        # Set thrust to exceed drag, weight to equal lift for this scenario
+        p['thrust'][:, 0] = [500, 600, 700]
+        p['drag'][:, 0] = [400, 400, 400]
+        p['weight'][:, 1] = [1000, 1001, 1002]
+        p['lift'][:, 1] = [1000, 1000, 1000]
 
         p.run_model()
 
         # print(p.get_val('totalforcecomp.total_force', units='kN'))
 
         # Verify the results
-        expected_i = np.array([[100, 200, 300],[0, -1, -2]]).T
+        expected_i = np.array([[100, 200, 300], [0, -1, -2]]).T
         assert_rel_error(self, p.get_val('totalforcecomp.total_force', units='kN'), expected_i)
 
 

--- a/openmdao/components/tests/test_akima_comp.py
+++ b/openmdao/components/tests/test_akima_comp.py
@@ -6,8 +6,7 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from openmdao.api import Problem, IndepVarComp
-from openmdao.components.akima_spline_comp import AkimaSplineComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
 
 
@@ -20,10 +19,10 @@ class AkimaTestCase(unittest.TestCase):
         n = 50
         x = np.linspace(1.0, 12.0, n)
 
-        prob = Problem()
+        prob = om.Problem()
 
-        comp = AkimaSplineComp(num_control_points=ncp, num_points=n,
-                               name='chord', input_x=True, input_xcp=True)
+        comp = om.AkimaSplineComp(num_control_points=ncp, num_points=n,
+                                  name='chord', input_x=True, input_xcp=True)
 
         prob.model.add_subsystem('akima', comp)
 
@@ -58,10 +57,10 @@ class AkimaTestCase(unittest.TestCase):
         ncp = len(ycp)
         n = 11
 
-        prob = Problem()
+        prob = om.Problem()
 
-        comp = AkimaSplineComp(num_control_points=ncp, num_points=n,
-                               name='chord', eval_at='end')
+        comp = om.AkimaSplineComp(num_control_points=ncp, num_points=n,
+                                 name='chord', eval_at='end')
 
         prob.model.add_subsystem('akima', comp)
 
@@ -92,10 +91,10 @@ class AkimaTestCase(unittest.TestCase):
         n = 12
         x = np.linspace(1.0, 12.0, n)
 
-        prob = Problem()
+        prob = om.Problem()
 
-        comp = AkimaSplineComp(num_control_points=ncp, num_points=n, vec_size=2,
-                               name='chord', input_x=True, input_xcp=True)
+        comp = om.AkimaSplineComp(num_control_points=ncp, num_points=n, vec_size=2,
+                                 name='chord', input_x=True, input_xcp=True)
 
         prob.model.add_subsystem('akima', comp)
 
@@ -126,8 +125,7 @@ class TestAkimaFeature(unittest.TestCase):
     def test_input_grid(self):
         import numpy as np
 
-        from openmdao.api import Problem
-        from openmdao.components.akima_spline_comp import AkimaSplineComp
+        import openmdao.api as om
 
         xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])
         ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])
@@ -135,10 +133,10 @@ class TestAkimaFeature(unittest.TestCase):
         n = 50
         x = np.linspace(1.0, 12.0, n)
 
-        prob = Problem()
+        prob = om.Problem()
 
-        comp = AkimaSplineComp(num_control_points=ncp, num_points=n,
-                               name='chord', input_x=True, input_xcp=True)
+        comp = om.AkimaSplineComp(num_control_points=ncp, num_points=n,
+                                  name='chord', input_x=True, input_xcp=True)
 
         prob.model.add_subsystem('akima', comp)
 
@@ -167,18 +165,16 @@ class TestAkimaFeature(unittest.TestCase):
     def test_fixed_grid(self):
         import numpy as np
 
-        from openmdao.api import Problem
-        from openmdao.components.akima_spline_comp import AkimaSplineComp
-
+        import openmdao.api as om
 
         ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])
         ncp = len(ycp)
         n = 11
 
-        prob = Problem()
+        prob = om.Problem()
 
-        comp = AkimaSplineComp(num_control_points=ncp, num_points=n,
-                               name='chord', eval_at='end')
+        comp = om.AkimaSplineComp(num_control_points=ncp, num_points=n,
+                                  name='chord', eval_at='end')
 
         prob.model.add_subsystem('akima', comp)
 

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -732,7 +732,7 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.linear_solver = DirectSolver(assemble_jac=True)
         prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # A reasonable initial guess to find the positive root.
         prob['balance.x'] = 1.0
@@ -766,7 +766,7 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.linear_solver = DirectSolver(assemble_jac=True)
         prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # A reasonable initial guess to find the positive root.
         prob['balance.x'] = 1.0
@@ -800,7 +800,7 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.linear_solver = DirectSolver(assemble_jac=True)
         prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['balance.x'] = np.random.rand(n)
 

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -1,3 +1,6 @@
+"""
+Unit tests for the BalanceComp.
+"""
 from __future__ import print_function, division, absolute_import
 
 import os
@@ -7,28 +10,24 @@ import warnings
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, \
-    NewtonSolver, DirectSolver
-from openmdao.api import BalanceComp
+import openmdao.api as om
 
 
 class TestBalanceComp(unittest.TestCase):
 
     def test_scalar_example(self):
 
-        prob = Problem()
+        prob = om.Problem()
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
         bal.add_balance('x', val=1.0)
 
-        tgt = IndepVarComp(name='y_tgt', val=2)
+        tgt = om.IndepVarComp(name='y_tgt', val=2)
 
-        exec_comp = ExecComp('y=x**2')
+        exec_comp = om.ExecComp('y=x**2')
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
-
         prob.model.add_subsystem(name='exec', subsys=exec_comp)
-
         prob.model.add_subsystem(name='balance', subsys=bal)
 
         prob.model.connect('y_tgt', 'balance.rhs:x')
@@ -49,8 +48,8 @@ class TestBalanceComp(unittest.TestCase):
             assert_almost_equal(cpd['balance'][of, wrt]['abs error'], 0.0, decimal=5)
 
         # set an actual solver, and re-setup. Then check derivatives at a converged point
-        prob.model.linear_solver = DirectSolver()
-        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.linear_solver = om.DirectSolver()
+        prob.model.nonlinear_solver = om.NewtonSolver()
 
         prob.setup()
 
@@ -65,26 +64,24 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_create_on_init(self):
 
-        prob = Problem()
+        prob = om.Problem()
 
-        bal = BalanceComp('x', val=1.0)
+        bal = om.BalanceComp('x', val=1.0)
 
-        tgt = IndepVarComp(name='y_tgt', val=2)
+        tgt = om.IndepVarComp(name='y_tgt', val=2)
 
-        exec_comp = ExecComp('y=x**2')
+        exec_comp = om.ExecComp('y=x**2')
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
-
         prob.model.add_subsystem(name='exec', subsys=exec_comp)
-
         prob.model.add_subsystem(name='balance', subsys=bal)
 
         prob.model.connect('y_tgt', 'balance.rhs:x')
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver()
-        prob.model.nonlinear_solver = NewtonSolver()
+        prob.model.linear_solver = om.DirectSolver()
+        prob.model.nonlinear_solver = om.NewtonSolver()
 
         prob.setup()
 
@@ -102,13 +99,13 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_create_on_init_no_normalization(self):
 
-        prob = Problem()
+        prob = om.Problem()
 
-        bal = BalanceComp('x', val=1.0, normalize=False)
+        bal = om.BalanceComp('x', val=1.0, normalize=False)
 
-        tgt = IndepVarComp(name='y_tgt', val=1.5)
+        tgt = om.IndepVarComp(name='y_tgt', val=1.5)
 
-        exec_comp = ExecComp('y=x**2')
+        exec_comp = om.ExecComp('y=x**2')
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
 
@@ -120,8 +117,8 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver()
-        prob.model.nonlinear_solver = NewtonSolver(iprint=0)
+        prob.model.linear_solver = om.DirectSolver()
+        prob.model.nonlinear_solver = om.NewtonSolver(iprint=0)
 
         prob.setup()
 
@@ -140,15 +137,15 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 100
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x', val=np.ones(n))
 
-        tgt = IndepVarComp(name='y_tgt', val=4*np.ones(n))
+        tgt = om.IndepVarComp(name='y_tgt', val=4*np.ones(n))
 
-        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+        exec_comp = om.ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
 
@@ -160,9 +157,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -181,15 +178,15 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 100
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x', val=np.ones(n), normalize=False)
 
-        tgt = IndepVarComp(name='y_tgt', val=1.7*np.ones(n))
+        tgt = om.IndepVarComp(name='y_tgt', val=1.7*np.ones(n))
 
-        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+        exec_comp = om.ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
 
@@ -201,9 +198,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -222,17 +219,17 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 100
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x', val=np.ones(n), use_mult=True)
 
-        tgt = IndepVarComp(name='y_tgt', val=4*np.ones(n))
+        tgt = om.IndepVarComp(name='y_tgt', val=4*np.ones(n))
 
-        mult_ivc = IndepVarComp(name='mult', val=2.0*np.ones(n))
+        mult_ivc = om.IndepVarComp(name='mult', val=2.0*np.ones(n))
 
-        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+        exec_comp = om.ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
         prob.model.add_subsystem(name='mult_comp', subsys=mult_ivc, promotes_outputs=['mult'])
@@ -246,9 +243,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -271,13 +268,13 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 100
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp('x', val=np.ones(n), use_mult=True, mult_val=2.0)
+        bal = om.BalanceComp('x', val=np.ones(n), use_mult=True, mult_val=2.0)
 
-        tgt = IndepVarComp(name='y_tgt', val=4 * np.ones(n))
+        tgt = om.IndepVarComp(name='y_tgt', val=4 * np.ones(n))
 
-        exec_comp = ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
+        exec_comp = om.ExecComp('y=x**2', x={'value': np.ones(n)}, y={'value': np.ones(n)})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
 
@@ -289,9 +286,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -309,14 +306,14 @@ class TestBalanceComp(unittest.TestCase):
     def test_shape(self):
         n = 100
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
         bal.add_balance('x', shape=(n,))
 
-        tgt = IndepVarComp(name='y_tgt', val=4*np.ones(n))
+        tgt = om.IndepVarComp(name='y_tgt', val=4*np.ones(n))
 
-        exe = ExecComp('y=x**2', x=np.zeros(n), y=np.zeros(n))
+        exe = om.ExecComp('y=x**2', x=np.zeros(n), y=np.zeros(n))
 
-        model = Group()
+        model = om.Group()
 
         model.add_subsystem('tgt', tgt, promotes_outputs=['y_tgt'])
         model.add_subsystem('exe', exe)
@@ -326,10 +323,10 @@ class TestBalanceComp(unittest.TestCase):
         model.connect('bal.x', 'exe.x')
         model.connect('exe.y', 'bal.lhs:x')
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
-        model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
         prob['bal.x'] = np.random.rand(n)
@@ -342,15 +339,15 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 1
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x')
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
 
@@ -362,9 +359,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup(force_alloc_complex=True)
 
@@ -383,15 +380,15 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 1
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x')
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
 
@@ -403,9 +400,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -424,16 +421,16 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 1
 
-        model=Group(assembled_jac_type='dense')
+        model=om.Group(assembled_jac_type='dense')
 
         def guess_function(inputs, outputs, residuals):
             outputs['x'] = np.sqrt(inputs['rhs:x'])
 
-        bal = BalanceComp('x', guess_func=guess_function)  # test guess_func as kwarg
+        bal = om.BalanceComp('x', guess_func=guess_function)  # test guess_func as kwarg
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
         model.add_subsystem(name='exec', subsys=exec_comp)
@@ -443,10 +440,10 @@ class TestBalanceComp(unittest.TestCase):
         model.connect('balance.x', 'exec.x')
         model.connect('exec.y', 'balance.lhs:x')
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
-        model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
         prob['balance.x'] = np.random.rand(n)
@@ -463,17 +460,17 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_scalar_with_guess_func_additional_input(self):
 
-        model = Group(assembled_jac_type='dense')
+        model = om.Group(assembled_jac_type='dense')
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
         bal.add_balance('x')
         bal.add_input('guess_x', val=0.0)
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='y_tgt', val=4)
         ivc.add_output(name='guess_x', val=2.5)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         model.add_subsystem(name='ivc', subsys=ivc, promotes_outputs=['y_tgt', 'guess_x'])
         model.add_subsystem(name='exec', subsys=exec_comp)
@@ -484,10 +481,10 @@ class TestBalanceComp(unittest.TestCase):
         model.connect('balance.x', 'exec.x')
         model.connect('exec.y', 'balance.lhs:x')
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
-        model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
         # run problem without a guess function
@@ -516,15 +513,15 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_scalar_guess_func_using_outputs(self):
 
-        model = Group()
+        model = om.Group()
 
-        ind = IndepVarComp()
+        ind = om.IndepVarComp()
         ind.add_output('a', 1)
         ind.add_output('b', -4)
         ind.add_output('c', 3)
 
-        lhs = ExecComp('lhs=-(a*x**2+b*x)')
-        bal = BalanceComp(name='x', rhs_name='c')
+        lhs = om.ExecComp('lhs=-(a*x**2+b*x)')
+        bal = om.BalanceComp(name='x', rhs_name='c')
 
         model.add_subsystem('ind_comp', ind, promotes_outputs=['a', 'b', 'c'])
         model.add_subsystem('lhs_comp', lhs, promotes_inputs=['a', 'b', 'x'])
@@ -532,12 +529,12 @@ class TestBalanceComp(unittest.TestCase):
 
         model.connect('lhs_comp.lhs', 'bal_comp.lhs:x')
 
-        model.linear_solver = DirectSolver()
-        model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        model.linear_solver = om.DirectSolver()
+        model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         # first verify behavior of the balance comp without the guess function
         # at initial conditions x=5, x=0 and x=-1
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
         # default solution with initial value of 5 is x=3.
@@ -583,11 +580,11 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 1
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp('x', rhs_val=4.0)
+        bal = om.BalanceComp('x', rhs_val=4.0)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='exec', subsys=exec_comp)
 
@@ -596,9 +593,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -617,17 +614,17 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 1
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x', use_mult=True)
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        mult_ivc = IndepVarComp(name='mult', val=2.0)
+        mult_ivc = om.IndepVarComp(name='mult', val=2.0)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
         prob.model.add_subsystem(name='mult_comp', subsys=mult_ivc, promotes_outputs=['mult'])
@@ -641,9 +638,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -662,17 +659,17 @@ class TestBalanceComp(unittest.TestCase):
 
         n = 1
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance('x', use_mult=True, mult_name='MUL', lhs_name='XSQ', rhs_name='TARGETXSQ')
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        mult_ivc = IndepVarComp(name='mult', val=2.0)
+        mult_ivc = om.IndepVarComp(name='mult', val=2.0)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
         prob.model.add_subsystem(name='mult_comp', subsys=mult_ivc, promotes_outputs=['mult'])
@@ -686,9 +683,9 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.XSQ')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -705,19 +702,18 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_feature_scalar(self):
         from numpy.testing import assert_almost_equal
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NewtonSolver, \
-            DirectSolver, BalanceComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
         bal.add_balance('x', use_mult=True)
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        mult_ivc = IndepVarComp(name='mult', val=2.0)
+        mult_ivc = om.IndepVarComp(name='mult', val=2.0)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
         prob.model.add_subsystem(name='mult_comp', subsys=mult_ivc, promotes_outputs=['mult'])
@@ -729,8 +725,8 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -743,17 +739,16 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_feature_scalar_with_default_mult(self):
         from numpy.testing import assert_almost_equal
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NewtonSolver, \
-            DirectSolver, BalanceComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
         bal.add_balance('x', use_mult=True, mult_val=2.0)
 
-        tgt = IndepVarComp(name='y_tgt', val=4)
+        tgt = om.IndepVarComp(name='y_tgt', val=4)
 
-        exec_comp = ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
+        exec_comp = om.ExecComp('y=x**2', x={'value': 1}, y={'value': 1})
 
         prob.model.add_subsystem(name='target', subsys=tgt, promotes_outputs=['y_tgt'])
         prob.model.add_subsystem(name='exec', subsys=exec_comp)
@@ -763,8 +758,8 @@ class TestBalanceComp(unittest.TestCase):
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 
@@ -779,26 +774,26 @@ class TestBalanceComp(unittest.TestCase):
         import numpy as np
         from numpy.testing import assert_almost_equal
 
-        from openmdao.api import Problem, Group, ExecComp, NewtonSolver, DirectSolver, BalanceComp
+        import openmdao.api as om
 
         n = 100
 
-        prob = Problem()
+        prob = om.Problem()
 
-        exec_comp = ExecComp('y=b*x+c',
-                             b={'value': np.random.uniform(0.01,100, size=n)},
-                             c={'value': np.random.rand(n)},
-                             x={'value': np.zeros(n)},
-                             y={'value': np.ones(n)})
+        exec_comp = om.ExecComp('y=b*x+c',
+                                b={'value': np.random.uniform(0.01, 100, size=n)},
+                                c={'value': np.random.rand(n)},
+                                x={'value': np.zeros(n)},
+                                y={'value': np.ones(n)})
 
         prob.model.add_subsystem(name='exec', subsys=exec_comp)
-        prob.model.add_subsystem(name='balance', subsys=BalanceComp('x', val=np.ones(n)))
+        prob.model.add_subsystem(name='balance', subsys=om.BalanceComp('x', val=np.ones(n)))
 
         prob.model.connect('balance.x', 'exec.x')
         prob.model.connect('exec.y', 'balance.lhs:x')
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -16,10 +16,9 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_scalar_example(self):
 
-        prob = Problem(model=Group())
+        prob = Problem()
 
         bal = BalanceComp()
-
         bal.add_balance('x', val=1.0)
 
         tgt = IndepVarComp(name='y_tgt', val=2)
@@ -66,7 +65,7 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_create_on_init(self):
 
-        prob = Problem(model=Group())
+        prob = Problem()
 
         bal = BalanceComp('x', val=1.0)
 
@@ -103,7 +102,7 @@ class TestBalanceComp(unittest.TestCase):
 
     def test_create_on_init_no_normalization(self):
 
-        prob = Problem(model=Group())
+        prob = Problem()
 
         bal = BalanceComp('x', val=1.0, normalize=False)
 

--- a/openmdao/components/tests/test_bsplines_comp.py
+++ b/openmdao/components/tests/test_bsplines_comp.py
@@ -38,7 +38,7 @@ class TestBsplinesComp(unittest.TestCase):
 
         model.connect('px.x', 'interp.h_cp')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         xx = prob['interp.h'].flatten()
@@ -63,7 +63,7 @@ class TestBsplinesComp(unittest.TestCase):
                               units='inch')
 
         prob = Problem(model=interp)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         # verify that both input and output of the bsplines comp have proper units
@@ -103,7 +103,7 @@ class TestBsplinesCompFeature(unittest.TestCase):
                                                    out_name='h'))
         model.connect('px.x', 'interp.h_cp')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         xx = prob['interp.h'].flatten()
@@ -145,7 +145,7 @@ class TestBsplinesCompFeature(unittest.TestCase):
                                                    out_name='h'))
         model.connect('px.x', 'interp.h_cp')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         xx = prob['interp.h']
@@ -197,7 +197,7 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
                                                    distribution='uniform'))
         model.connect('px.x', 'interp.h_cp')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         xx = prob['interp.h'].flatten()
@@ -236,7 +236,7 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
                                                    distribution='sine'))
         model.connect('px.x', 'interp.h_cp')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         xx = prob['interp.h'].flatten()

--- a/openmdao/components/tests/test_bsplines_comp.py
+++ b/openmdao/components/tests/test_bsplines_comp.py
@@ -12,15 +12,14 @@ try:
 except ImportError:
     matplotlib = None
 
-from openmdao.api import Problem, IndepVarComp
-from openmdao.components.bsplines_comp import BsplinesComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
 class TestBsplinesComp(unittest.TestCase):
 
     def test_basic(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n_cp = 80
@@ -29,12 +28,12 @@ class TestBsplinesComp(unittest.TestCase):
         t = np.linspace(0, 3.0*np.pi, n_cp)
         x = np.sin(t)
 
-        model.add_subsystem('px', IndepVarComp('x', val=x))
-        model.add_subsystem('interp', BsplinesComp(num_control_points=n_cp,
-                                                   num_points=n_point,
-                                                   in_name='h_cp',
-                                                   out_name='h',
-                                                   distribution='uniform'))
+        model.add_subsystem('px', om.IndepVarComp('x', val=x))
+        model.add_subsystem('interp', om.BsplinesComp(num_control_points=n_cp,
+                                                      num_points=n_point,
+                                                      in_name='h_cp',
+                                                      out_name='h',
+                                                      distribution='uniform'))
 
         model.connect('px.x', 'interp.h_cp')
 
@@ -56,13 +55,13 @@ class TestBsplinesComp(unittest.TestCase):
         n_cp = 5
         n_point = 10
 
-        interp = BsplinesComp(num_control_points=n_cp,
-                              num_points=n_point,
-                              in_name='h_cp',
-                              out_name='h',
-                              units='inch')
+        interp = om.BsplinesComp(num_control_points=n_cp,
+                                 num_points=n_point,
+                                 in_name='h_cp',
+                                 out_name='h',
+                                 units='inch')
 
-        prob = Problem(model=interp)
+        prob = om.Problem(model=interp)
         prob.setup()
         prob.run_model()
 
@@ -83,11 +82,11 @@ class TestBsplinesCompFeature(unittest.TestCase):
 
     def test_basic(self):
         import numpy as np
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.components.bsplines_comp import BsplinesComp
+
+        import openmdao.api as om
         from openmdao.utils.general_utils import printoptions
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n_cp = 5
@@ -96,11 +95,11 @@ class TestBsplinesCompFeature(unittest.TestCase):
         t = np.linspace(0, 0.5*np.pi, n_cp)
         x = np.sin(t)
 
-        model.add_subsystem('px', IndepVarComp('x', val=x))
-        model.add_subsystem('interp', BsplinesComp(num_control_points=n_cp,
-                                                   num_points=n_point,
-                                                   in_name='h_cp',
-                                                   out_name='h'))
+        model.add_subsystem('px', om.IndepVarComp('x', val=x))
+        model.add_subsystem('interp', om.BsplinesComp(num_control_points=n_cp,
+                                                      num_points=n_point,
+                                                      in_name='h_cp',
+                                                      out_name='h'))
         model.connect('px.x', 'interp.h_cp')
 
         prob.setup()
@@ -122,11 +121,11 @@ class TestBsplinesCompFeature(unittest.TestCase):
 
     def test_vectorized(self):
         import numpy as np
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.components.bsplines_comp import BsplinesComp
+
+        import openmdao.api as om
         from openmdao.utils.general_utils import printoptions
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n_cp = 5
@@ -137,12 +136,12 @@ class TestBsplinesCompFeature(unittest.TestCase):
         x[0, :] = np.sin(t)
         x[1, :] = 2.0*np.sin(t)
 
-        model.add_subsystem('px', IndepVarComp('x', val=x))
-        model.add_subsystem('interp', BsplinesComp(num_control_points=n_cp,
-                                                   num_points=n_point,
-                                                   vec_size=2,
-                                                   in_name='h_cp',
-                                                   out_name='h'))
+        model.add_subsystem('px', om.IndepVarComp('x', val=x))
+        model.add_subsystem('interp', om.BsplinesComp(num_control_points=n_cp,
+                                                      num_points=n_point,
+                                                      vec_size=2,
+                                                      in_name='h_cp',
+                                                      out_name='h'))
         model.connect('px.x', 'interp.h_cp')
 
         prob.setup()
@@ -177,10 +176,9 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
         matplotlib.use('Agg')
 
     def test_distribution_uniform(self):
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.components.bsplines_comp import BsplinesComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n_cp = 20
@@ -189,12 +187,12 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
         t = np.linspace(0, 3.0*np.pi, n_cp)
         x = np.sin(t)
 
-        model.add_subsystem('px', IndepVarComp('x', val=x))
-        model.add_subsystem('interp', BsplinesComp(num_control_points=n_cp,
-                                                   num_points=n_point,
-                                                   in_name='h_cp',
-                                                   out_name='h',
-                                                   distribution='uniform'))
+        model.add_subsystem('px', om.IndepVarComp('x', val=x))
+        model.add_subsystem('interp', om.BsplinesComp(num_control_points=n_cp,
+                                                      num_points=n_point,
+                                                      in_name='h_cp',
+                                                      out_name='h',
+                                                      distribution='uniform'))
         model.connect('px.x', 'interp.h_cp')
 
         prob.setup()
@@ -215,10 +213,9 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
         plt.show()
 
     def test_distribution_sine(self):
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.components.bsplines_comp import BsplinesComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n_cp = 20
@@ -228,12 +225,12 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
         t = 3.0 * np.pi * 0.5 * (1.0 + np.sin(-0.5 * np.pi + tvec * np.pi))
         x = np.sin(t)
 
-        model.add_subsystem('px', IndepVarComp('x', val=x))
-        model.add_subsystem('interp', BsplinesComp(num_control_points=n_cp,
-                                                   num_points=n_point,
-                                                   in_name='h_cp',
-                                                   out_name='h',
-                                                   distribution='sine'))
+        model.add_subsystem('px', om.IndepVarComp('x', val=x))
+        model.add_subsystem('interp', om.BsplinesComp(num_control_points=n_cp,
+                                                      num_points=n_point,
+                                                      in_name='h_cp',
+                                                      out_name='h',
+                                                      distribution='sine'))
         model.connect('px.x', 'interp.h_cp')
 
         prob.setup()
@@ -254,6 +251,7 @@ class TestBsplinesCompFeatureWithPlotting(unittest.TestCase):
         plt.legend(['Variable', 'Control Points'], loc=4)
         plt.grid(True)
         plt.show()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -13,7 +13,7 @@ class TestCrossProductCompNx3(unittest.TestCase):
     def setUp(self):
         self.n = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.n, 3))
@@ -68,7 +68,7 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3, 1))
@@ -121,7 +121,7 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
 class TestCrossProductCompNonVectorized(unittest.TestCase):
 
     def setUp(self):
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(3, 1))
@@ -177,7 +177,7 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3), units='ft')
@@ -223,7 +223,7 @@ class TestUnits(unittest.TestCase):
                                                decimal=6)
 
 
-class TestForDocs(unittest.TestCase):
+class TestFeature(unittest.TestCase):
 
     def test(self):
         import numpy as np
@@ -232,7 +232,7 @@ class TestForDocs(unittest.TestCase):
 
         n = 100
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='r', shape=(n, 3))

--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, CrossProductComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
@@ -13,9 +13,9 @@ class TestCrossProductCompNx3(unittest.TestCase):
     def setUp(self):
         self.n = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.n, 3))
         ivc.add_output(name='b', shape=(self.n, 3))
 
@@ -24,7 +24,7 @@ class TestCrossProductCompNx3(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='cross_prod_comp',
-                                   subsys=CrossProductComp(vec_size=self.n))
+                                   subsys=om.CrossProductComp(vec_size=self.n))
 
         self.p.model.connect('a', 'cross_prod_comp.a')
         self.p.model.connect('b', 'cross_prod_comp.b')
@@ -68,9 +68,9 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3, 1))
         ivc.add_output(name='b', shape=(self.nn, 3, 1))
 
@@ -79,7 +79,7 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='cross_prod_comp',
-                                   subsys=CrossProductComp(vec_size=self.nn))
+                                   subsys=om.CrossProductComp(vec_size=self.nn))
 
         self.p.model.connect('a', 'cross_prod_comp.a')
         self.p.model.connect('b', 'cross_prod_comp.b')
@@ -121,9 +121,9 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
 class TestCrossProductCompNonVectorized(unittest.TestCase):
 
     def setUp(self):
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(3, 1))
         ivc.add_output(name='b', shape=(3, 1))
 
@@ -132,7 +132,7 @@ class TestCrossProductCompNonVectorized(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='cross_prod_comp',
-                                   subsys=CrossProductComp())
+                                   subsys=om.CrossProductComp())
 
         self.p.model.connect('a', 'cross_prod_comp.a')
         self.p.model.connect('b', 'cross_prod_comp.b')
@@ -177,9 +177,9 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3), units='ft')
         ivc.add_output(name='b', shape=(self.nn, 3), units='lbf')
 
@@ -188,9 +188,9 @@ class TestUnits(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='cross_prod_comp',
-                                   subsys=CrossProductComp(vec_size=self.nn,
-                                                           a_units='m', b_units='N',
-                                                           c_units='N*m'))
+                                   subsys=om.CrossProductComp(vec_size=self.nn,
+                                                              a_units='m', b_units='N',
+                                                              c_units='N*m'))
 
         self.p.model.connect('a', 'cross_prod_comp.a')
         self.p.model.connect('b', 'cross_prod_comp.b')
@@ -227,14 +227,15 @@ class TestFeature(unittest.TestCase):
 
     def test(self):
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, CrossProductComp
+
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         n = 100
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='r', shape=(n, 3))
         ivc.add_output(name='F', shape=(n, 3))
 
@@ -243,9 +244,9 @@ class TestFeature(unittest.TestCase):
                               promotes_outputs=['r', 'F'])
 
         p.model.add_subsystem(name='cross_prod_comp',
-                              subsys=CrossProductComp(vec_size=n,
-                                                      a_name='r', b_name='F', c_name='torque',
-                                                      a_units='m', b_units='N', c_units='N*m'))
+                              subsys=om.CrossProductComp(vec_size=n,
+                                                         a_name='r', b_name='F', c_name='torque',
+                                                         a_units='m', b_units='N', c_units='N*m'))
 
         p.model.connect('r', 'cross_prod_comp.r')
         p.model.connect('F', 'cross_prod_comp.F')

--- a/openmdao/components/tests/test_demux_comp.py
+++ b/openmdao/components/tests/test_demux_comp.py
@@ -4,10 +4,8 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
-
-from openmdao.api import DemuxComp
 
 
 class TestDemuxCompOptions(unittest.TestCase):
@@ -15,14 +13,14 @@ class TestDemuxCompOptions(unittest.TestCase):
     def test_invalid_axis(self):
         nn = 10
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(nn,))
 
         p.model.add_subsystem(name='ivc', subsys=ivc, promotes_outputs=['a'])
 
-        demux_comp = p.model.add_subsystem(name='demux_comp', subsys=DemuxComp(vec_size=nn))
+        demux_comp = p.model.add_subsystem(name='demux_comp', subsys=om.DemuxComp(vec_size=nn))
 
         demux_comp.add_var('a', shape=(nn,), axis=1)
 
@@ -36,15 +34,15 @@ class TestDemuxCompOptions(unittest.TestCase):
     def test_axis_with_wrong_size(self):
         nn = 10
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(nn, 7))
         ivc.add_output(name='b', shape=(3, nn))
 
         p.model.add_subsystem(name='ivc', subsys=ivc, promotes_outputs=['a', 'b'])
 
-        demux_comp = p.model.add_subsystem(name='demux_comp', subsys=DemuxComp(vec_size=nn))
+        demux_comp = p.model.add_subsystem(name='demux_comp', subsys=om.DemuxComp(vec_size=nn))
 
         demux_comp.add_var('a', shape=(nn, 7), axis=1)
         demux_comp.add_var('b', shape=(3, nn), axis=1)
@@ -64,9 +62,9 @@ class TestDemuxComp1D(unittest.TestCase):
     def setUp(self):
         self.nn = 10
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn,))
         ivc.add_output(name='b', shape=(self.nn,))
 
@@ -75,7 +73,7 @@ class TestDemuxComp1D(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         demux_comp = self.p.model.add_subsystem(name='demux_comp',
-                                                subsys=DemuxComp(vec_size=self.nn))
+                                                subsys=om.DemuxComp(vec_size=self.nn))
 
         demux_comp.add_var('a', shape=(self.nn,))
         demux_comp.add_var('b', shape=(self.nn,))
@@ -111,9 +109,9 @@ class TestDemuxComp2D(unittest.TestCase):
     def setUp(self):
         self.nn = 10
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 7))
         ivc.add_output(name='b', shape=(3, self.nn))
 
@@ -122,7 +120,7 @@ class TestDemuxComp2D(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         demux_comp = self.p.model.add_subsystem(name='demux_comp',
-                                                subsys=DemuxComp(vec_size=self.nn))
+                                                subsys=om.DemuxComp(vec_size=self.nn))
 
         demux_comp.add_var('a', shape=(self.nn, 7), axis=0)
         demux_comp.add_var('b', shape=(3, self.nn), axis=1)
@@ -161,7 +159,8 @@ class TestFeature(unittest.TestCase):
         An example demonstrating a trivial use case of DemuxComp
         """
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, DemuxComp, ExecComp
+
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         # The number of elements to be demuxed
@@ -170,9 +169,9 @@ class TestFeature(unittest.TestCase):
         # The size of each element to be demuxed
         m = 100
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='pos_ecef', shape=(m, 3), units='km')
 
         p.model.add_subsystem(name='ivc',
@@ -180,15 +179,15 @@ class TestFeature(unittest.TestCase):
                               promotes_outputs=['pos_ecef'])
 
         mux_comp = p.model.add_subsystem(name='demux',
-                                         subsys=DemuxComp(vec_size=n))
+                                         subsys=om.DemuxComp(vec_size=n))
 
         mux_comp.add_var('pos', shape=(m, n), axis=1, units='km')
 
         p.model.add_subsystem(name='longitude_comp',
-                              subsys=ExecComp('long = atan(y/x)',
-                                              x={'value': np.ones(m), 'units': 'km'},
-                                              y={'value': np.ones(m), 'units': 'km'},
-                                              long={'value': np.ones(m), 'units': 'rad'}))
+                              subsys=om.ExecComp('long = atan(y/x)',
+                                                 x={'value': np.ones(m), 'units': 'km'},
+                                                 y={'value': np.ones(m), 'units': 'km'},
+                                                 long={'value': np.ones(m), 'units': 'rad'}))
 
         p.model.connect('demux.pos_0', 'longitude_comp.x')
         p.model.connect('demux.pos_1', 'longitude_comp.y')

--- a/openmdao/components/tests/test_demux_comp.py
+++ b/openmdao/components/tests/test_demux_comp.py
@@ -15,7 +15,7 @@ class TestDemuxCompOptions(unittest.TestCase):
     def test_invalid_axis(self):
         nn = 10
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(nn,))
@@ -32,11 +32,11 @@ class TestDemuxCompOptions(unittest.TestCase):
             p.setup()
         self.assertEqual(str(ctx.exception),
                          "Invalid axis (1) for variable 'a' of shape (10,)")
-            
+
     def test_axis_with_wrong_size(self):
         nn = 10
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(nn, 7))
@@ -64,7 +64,7 @@ class TestDemuxComp1D(unittest.TestCase):
     def setUp(self):
         self.nn = 10
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn,))
@@ -111,7 +111,7 @@ class TestDemuxComp2D(unittest.TestCase):
     def setUp(self):
         self.nn = 10
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 7))
@@ -154,7 +154,7 @@ class TestDemuxComp2D(unittest.TestCase):
         assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
 
-class TestForDocs(unittest.TestCase):
+class TestFeature(unittest.TestCase):
 
     def test(self):
         """
@@ -170,7 +170,7 @@ class TestForDocs(unittest.TestCase):
         # The size of each element to be demuxed
         m = 100
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='pos_ecef', shape=(m, 3), units='km')

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -1,10 +1,13 @@
+"""
+Unit test for DotProductComp.
+"""
 from __future__ import print_function, division, absolute_import
 
 import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, DotProductComp
+import openmdao.api as om
 
 
 class TestDotProductCompNx3(unittest.TestCase):
@@ -12,9 +15,9 @@ class TestDotProductCompNx3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
         ivc.add_output(name='b', shape=(self.nn, 3))
 
@@ -23,7 +26,7 @@ class TestDotProductCompNx3(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='dot_prod_comp',
-                                   subsys=DotProductComp(vec_size=self.nn))
+                                   subsys=om.DotProductComp(vec_size=self.nn))
 
         self.p.model.connect('a', 'dot_prod_comp.a')
         self.p.model.connect('b', 'dot_prod_comp.b')
@@ -60,9 +63,9 @@ class TestDotProductCompNx4(unittest.TestCase):
     def setUp(self):
         self.nn = 100
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 4))
         ivc.add_output(name='b', shape=(self.nn, 4))
 
@@ -71,7 +74,7 @@ class TestDotProductCompNx4(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='dot_prod_comp',
-                                   subsys=DotProductComp(vec_size=self.nn, length=4))
+                                   subsys=om.DotProductComp(vec_size=self.nn, length=4))
 
         self.p.model.connect('a', 'dot_prod_comp.a')
         self.p.model.connect('b', 'dot_prod_comp.b')
@@ -108,9 +111,9 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3), units='lbf')
         ivc.add_output(name='b', shape=(self.nn, 3), units='ft/s')
 
@@ -119,9 +122,9 @@ class TestUnits(unittest.TestCase):
                                    promotes_outputs=['a', 'b'])
 
         self.p.model.add_subsystem(name='dot_prod_comp',
-                                   subsys=DotProductComp(vec_size=self.nn,
-                                                         a_units='N', b_units='m/s',
-                                                         c_units='W'))
+                                   subsys=om.DotProductComp(vec_size=self.nn,
+                                                            a_units='N', b_units='m/s',
+                                                            c_units='W'))
 
         self.p.model.connect('a', 'dot_prod_comp.a')
         self.p.model.connect('b', 'dot_prod_comp.b')
@@ -162,14 +165,15 @@ class TestFeature(unittest.TestCase):
         at 100 points simultaneously.
         """
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, DotProductComp
+
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         n = 100
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='force', shape=(n, 3))
         ivc.add_output(name='vel', shape=(n, 3))
 
@@ -177,8 +181,8 @@ class TestFeature(unittest.TestCase):
                               subsys=ivc,
                               promotes_outputs=['force', 'vel'])
 
-        dp_comp = DotProductComp(vec_size=n, length=3, a_name='F', b_name='v', c_name='P',
-                                 a_units='N', b_units='m/s', c_units='W')
+        dp_comp = om.DotProductComp(vec_size=n, length=3, a_name='F', b_name='v', c_name='P',
+                                    a_units='N', b_units='m/s', c_units='W')
 
         p.model.add_subsystem(name='dot_prod_comp', subsys=dp_comp)
 

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -12,7 +12,7 @@ class TestDotProductCompNx3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
@@ -60,7 +60,7 @@ class TestDotProductCompNx4(unittest.TestCase):
     def setUp(self):
         self.nn = 100
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 4))
@@ -108,7 +108,7 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3), units='lbf')
@@ -154,7 +154,7 @@ class TestUnits(unittest.TestCase):
                                                decimal=6)
 
 
-class TestForDocs(unittest.TestCase):
+class TestFeature(unittest.TestCase):
 
     def test(self):
         """
@@ -167,7 +167,7 @@ class TestForDocs(unittest.TestCase):
 
         n = 100
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='force', shape=(n, 3))

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -4,18 +4,16 @@ import warnings
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, \
-    EQConstraintComp, ScipyOptimizeDriver
-
+import openmdao.api as om
 from openmdao.test_suite.components.sellar_feature import SellarIDF
-
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+
 
 class TestEQConstraintComp(unittest.TestCase):
 
     def test_sellar_idf(self):
-        prob = Problem(SellarIDF())
-        prob.driver = ScipyOptimizeDriver(optimizer='SLSQP', disp=False)
+        prob = om.Problem(SellarIDF())
+        prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False)
         prob.setup()
 
         # check derivatives
@@ -49,14 +47,14 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['equal.y2'], 0.0)
 
     def test_create_on_init(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find intersection of two non-parallel lines
-        model.add_subsystem('indep', IndepVarComp('x', val=0.))
-        model.add_subsystem('f', ExecComp('y=3*x-3', x=0.))
-        model.add_subsystem('g', ExecComp('y=2.3*x+4', x=0.))
-        model.add_subsystem('equal', EQConstraintComp('y', val=11.))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=0.))
+        model.add_subsystem('f', om.ExecComp('y=3*x-3', x=0.))
+        model.add_subsystem('g', om.ExecComp('y=2.3*x+4', x=0.))
+        model.add_subsystem('equal', om.EQConstraintComp('y', val=11.))
 
         model.connect('indep.x', 'f.x')
         model.connect('indep.x', 'g.x')
@@ -79,7 +77,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_constraint('equal.y', equals=0.)
         prob.setup(mode='fwd')
 
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
 
         prob.run_driver()
 
@@ -96,14 +94,14 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_create_on_init_add_constraint(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find intersection of two non-parallel lines
-        model.add_subsystem('indep', IndepVarComp('x', val=0.))
-        model.add_subsystem('f', ExecComp('y=3*x-3', x=0.))
-        model.add_subsystem('g', ExecComp('y=2.3*x+4', x=0.))
-        model.add_subsystem('equal', EQConstraintComp('y', add_constraint=True))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=0.))
+        model.add_subsystem('f', om.ExecComp('y=3*x-3', x=0.))
+        model.add_subsystem('g', om.ExecComp('y=2.3*x+4', x=0.))
+        model.add_subsystem('equal', om.EQConstraintComp('y', add_constraint=True))
 
         model.connect('indep.x', 'f.x')
         model.connect('indep.x', 'g.x')
@@ -119,7 +117,7 @@ class TestEQConstraintComp(unittest.TestCase):
         # verify that the constraint has been added as requested
         self.assertTrue('equal.y' in model.get_constraints())
 
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
 
         prob.run_driver()
 
@@ -136,15 +134,15 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_create_on_init_add_constraint_no_normalization(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find intersection of two non-parallel lines
-        model.add_subsystem('indep', IndepVarComp('x', val=-2.0))
-        model.add_subsystem('f', ExecComp('y=3*x-3', x=0.))
-        model.add_subsystem('g', ExecComp('y=2.3*x+4', x=0.))
-        model.add_subsystem('equal', EQConstraintComp('y', add_constraint=True, normalize=False,
-                                                      ref0=0, ref=100.0))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=-2.0))
+        model.add_subsystem('f', om.ExecComp('y=3*x-3', x=0.))
+        model.add_subsystem('g', om.ExecComp('y=2.3*x+4', x=0.))
+        model.add_subsystem('equal', om.EQConstraintComp('y', add_constraint=True, normalize=False,
+                                                         ref0=0, ref=100.0))
 
         model.connect('indep.x', 'f.x')
         model.connect('indep.x', 'g.x')
@@ -167,7 +165,7 @@ class TestEQConstraintComp(unittest.TestCase):
         diff = lhs - rhs
         assert_rel_error(self, prob['equal.y'], diff)
 
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
 
         prob.run_driver()
 
@@ -184,17 +182,17 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_vectorized(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n = 100
 
         # find intersection of two non-parallel lines, vectorized
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(n)))
-        model.add_subsystem('f', ExecComp('y=3*x-3', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('g', ExecComp('y=2.3*x+4', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('equal', EQConstraintComp('y', val=np.ones(n), add_constraint=True))
-        model.add_subsystem('obj_cmp', ExecComp('obj=sum(y)', y=np.zeros(n)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(n)))
+        model.add_subsystem('f', om.ExecComp('y=3*x-3', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('g', om.ExecComp('y=2.3*x+4', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('equal', om.EQConstraintComp('y', val=np.ones(n), add_constraint=True))
+        model.add_subsystem('obj_cmp', om.ExecComp('obj=sum(y)', y=np.zeros(n)))
 
         model.connect('indep.x', 'f.x')
         model.connect('indep.x', 'g.x')
@@ -207,7 +205,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         prob.setup(mode='fwd')
 
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
 
         prob.run_driver()
 
@@ -224,18 +222,18 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_vectorized_no_normalization(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n = 100
 
         # find intersection of two non-parallel lines, vectorized
-        model.add_subsystem('indep', IndepVarComp('x', val=-2.0*np.ones(n)))
-        model.add_subsystem('f', ExecComp('y=3*x-3', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('g', ExecComp('y=2.3*x+4', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('equal', EQConstraintComp('y', val=np.ones(n), add_constraint=True,
-                                                      normalize=False))
-        model.add_subsystem('obj_cmp', ExecComp('obj=sum(y)', y=np.zeros(n)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=-2.0*np.ones(n)))
+        model.add_subsystem('f', om.ExecComp('y=3*x-3', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('g', om.ExecComp('y=2.3*x+4', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('equal', om.EQConstraintComp('y', val=np.ones(n), add_constraint=True,
+                                                         normalize=False))
+        model.add_subsystem('obj_cmp', om.ExecComp('obj=sum(y)', y=np.zeros(n)))
 
         model.connect('indep.x', 'f.x')
         model.connect('indep.x', 'g.x')
@@ -248,7 +246,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         prob.setup(mode='fwd')
 
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
 
         # verify that the output is not being normalized
         prob.run_model()
@@ -272,14 +270,14 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_scalar_with_mult(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find where 2*x == x^2
-        model.add_subsystem('indep', IndepVarComp('x', val=1.))
-        model.add_subsystem('multx', IndepVarComp('m', val=2.))
-        model.add_subsystem('f', ExecComp('y=x**2', x=1.))
-        model.add_subsystem('equal', EQConstraintComp('y', use_mult=True))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=1.))
+        model.add_subsystem('multx', om.IndepVarComp('m', val=2.))
+        model.add_subsystem('f', om.ExecComp('y=x**2', x=1.))
+        model.add_subsystem('equal', om.EQConstraintComp('y', use_mult=True))
 
         model.connect('indep.x', 'f.x')
 
@@ -292,7 +290,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('f.y')
 
         prob.setup(mode='fwd')
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         assert_rel_error(self, prob['equal.y'], 0., 1e-6)
@@ -306,14 +304,14 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_complex_step(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find where 2*x == x^2
-        model.add_subsystem('indep', IndepVarComp('x', val=1.))
-        model.add_subsystem('multx', IndepVarComp('m', val=2.))
-        model.add_subsystem('f', ExecComp('y=x**2', x=1.))
-        model.add_subsystem('equal', EQConstraintComp('y', use_mult=True))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=1.))
+        model.add_subsystem('multx', om.IndepVarComp('m', val=2.))
+        model.add_subsystem('f', om.ExecComp('y=x**2', x=1.))
+        model.add_subsystem('equal', om.EQConstraintComp('y', use_mult=True))
 
         model.connect('indep.x', 'f.x')
 
@@ -326,7 +324,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('f.y')
 
         prob.setup(mode='fwd', force_alloc_complex=True)
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         with warnings.catch_warnings():
@@ -336,18 +334,18 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)
 
     def test_vectorized_with_mult(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n = 100
 
         # find where 2*x == x^2, vectorized
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(n)))
-        model.add_subsystem('multx', IndepVarComp('m', val=np.ones(n)*2.))
-        model.add_subsystem('f', ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('equal', EQConstraintComp('y', val=np.ones(n),
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(n)))
+        model.add_subsystem('multx', om.IndepVarComp('m', val=np.ones(n)*2.))
+        model.add_subsystem('f', om.ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('equal', om.EQConstraintComp('y', val=np.ones(n),
                             use_mult=True, add_constraint=True))
-        model.add_subsystem('obj_cmp', ExecComp('obj=sum(y)', y=np.zeros(n)))
+        model.add_subsystem('obj_cmp', om.ExecComp('obj=sum(y)', y=np.zeros(n)))
 
         model.connect('indep.x', 'f.x')
 
@@ -360,7 +358,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('obj_cmp.obj')
 
         prob.setup(mode='fwd')
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         assert_rel_error(self, prob['equal.y'], np.zeros(n), 1e-6)
@@ -374,17 +372,17 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_vectorized_with_default_mult(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n = 100
 
         # find where 2*x == x^2, vectorized
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(n)))
-        model.add_subsystem('f', ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('equal', EQConstraintComp('y', val=np.ones(n),
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(n)))
+        model.add_subsystem('f', om.ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('equal', om.EQConstraintComp('y', val=np.ones(n),
                             use_mult=True, mult_val=2., add_constraint=True))
-        model.add_subsystem('obj_cmp', ExecComp('obj=sum(y)', y=np.zeros(n)))
+        model.add_subsystem('obj_cmp', om.ExecComp('obj=sum(y)', y=np.zeros(n)))
 
         model.connect('indep.x', 'f.x')
 
@@ -396,7 +394,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('obj_cmp.obj')
 
         prob.setup(mode='fwd')
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         assert_rel_error(self, prob['equal.y'], np.zeros(n), 1e-6)
@@ -410,13 +408,13 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_rhs_val(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find where x^2 == 4
-        model.add_subsystem('indep', IndepVarComp('x', val=1.))
-        model.add_subsystem('f', ExecComp('y=x**2', x=1.))
-        model.add_subsystem('equal', EQConstraintComp('y', rhs_val=4.))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=1.))
+        model.add_subsystem('f', om.ExecComp('y=x**2', x=1.))
+        model.add_subsystem('equal', om.EQConstraintComp('y', rhs_val=4.))
 
         model.connect('indep.x', 'f.x')
         model.connect('f.y', 'equal.lhs:y')
@@ -426,7 +424,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('f.y')
 
         prob.setup(mode='fwd')
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         assert_rel_error(self, prob['equal.y'], 0., 1e-6)
@@ -441,17 +439,17 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_vectorized_rhs_val(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         n = 100
 
         # find where x^2 == 4, vectorized
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(n)))
-        model.add_subsystem('f', ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('equal', EQConstraintComp('y', val=np.ones(n),
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(n)))
+        model.add_subsystem('f', om.ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
+        model.add_subsystem('equal', om.EQConstraintComp('y', val=np.ones(n),
                             rhs_val=np.ones(n)*4., use_mult=True, mult_val=2.))
-        model.add_subsystem('obj_cmp', ExecComp('obj=sum(y)', y=np.zeros(n)))
+        model.add_subsystem('obj_cmp', om.ExecComp('obj=sum(y)', y=np.zeros(n)))
 
         model.connect('indep.x', 'f.x')
 
@@ -463,7 +461,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('obj_cmp.obj')
 
         prob.setup(mode='fwd')
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         assert_rel_error(self, prob['equal.y'], np.zeros(n), 1e-6)
@@ -475,16 +473,16 @@ class TestEQConstraintComp(unittest.TestCase):
             assert_almost_equal(cpd['equal'][of, wrt]['abs error'], 0.0, decimal=5)
 
     def test_renamed_vars(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # find intersection of two non-parallel lines, fx_y and gx_y
-        equal = EQConstraintComp('y', lhs_name='fx_y', rhs_name='gx_y',
-                                        add_constraint=True)
+        equal = om.EQConstraintComp('y', lhs_name='fx_y', rhs_name='gx_y',
+                                    add_constraint=True)
 
-        model.add_subsystem('indep', IndepVarComp('x', val=0.))
-        model.add_subsystem('f', ExecComp('y=3*x-3', x=0.))
-        model.add_subsystem('g', ExecComp('y=2.3*x+4', x=0.))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=0.))
+        model.add_subsystem('f', om.ExecComp('y=3*x-3', x=0.))
+        model.add_subsystem('g', om.ExecComp('y=2.3*x+4', x=0.))
         model.add_subsystem('equal', equal)
 
         model.connect('indep.x', 'f.x')
@@ -497,7 +495,7 @@ class TestEQConstraintComp(unittest.TestCase):
         model.add_objective('f.y')
 
         prob.setup(mode='fwd')
-        prob.driver = ScipyOptimizeDriver(disp=False)
+        prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
         assert_almost_equal(prob['equal.y'], 0.)
@@ -516,11 +514,11 @@ class TestEQConstraintComp(unittest.TestCase):
 class TestFeatureEQConstraintComp(unittest.TestCase):
 
     def test_feature_sellar_idf(self):
-        from openmdao.api import Problem, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar_feature import SellarIDF
 
-        prob = Problem(model=SellarIDF())
-        prob.driver = ScipyOptimizeDriver(optimizer='SLSQP', disp=True)
+        prob = om.Problem(model=SellarIDF())
+        prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', disp=True)
         prob.setup()
         prob.run_driver()
 

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -263,7 +263,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('C1', ExecComp())
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: No valid expressions provided to ExecComp(): [].")
 
@@ -271,7 +271,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=foo:bar+1.'))
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: failed to compile expression 'y=foo:bar+1.'.")
 
@@ -279,7 +279,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=x+1.', xx=2.0))
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: arg 'xx' in call to ExecComp() does not refer to any variable "
                          "in the expressions ['y=x+1.']")
@@ -289,7 +289,7 @@ class TestExecComp(unittest.TestCase):
         prob.model.add_subsystem('C1', ExecComp('y=x+1.',
                                                 x={'val': 2, 'low': 0, 'high': 10, 'units': 'ft'}))
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: the following metadata names were not recognized for "
                          "variable 'x': ['high', 'low', 'val']")
@@ -298,7 +298,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('e=x+1.'))
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: cannot assign to variable 'e' because it's already defined "
                          "as an internal function or constant.")
@@ -307,7 +307,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('sin=x+1.'))
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: cannot assign to variable 'sin' because it's already defined "
                          "as an internal function or constant.")
@@ -316,7 +316,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=sin+1.'))
         with self.assertRaises(Exception) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: cannot use 'sin' as a variable because it's already defined "
                          "as an internal function.")
@@ -325,7 +325,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=sum(x)',
                                                      x=np.arange(10, dtype=float)))
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -342,7 +342,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x+1.', x=2.0))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -359,7 +359,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y = pi * x', x=2.0))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -382,7 +382,7 @@ class TestExecComp(unittest.TestCase):
                                                      z=2.0))
         prob.model.connect('indep.x', 'C1.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.set_solver_print(level=0)
         prob.run_model()
@@ -422,7 +422,7 @@ class TestExecComp(unittest.TestCase):
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(NameError) as cm:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(cm.exception),
                          "C1: cannot use variable name 'units' because it's a reserved keyword.")
@@ -465,7 +465,7 @@ class TestExecComp(unittest.TestCase):
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(RuntimeError) as cm:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(cm.exception),
                          "C1: units of 'km' have been specified for variable 'x', but "
@@ -579,7 +579,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=sin(x)', x=2.0))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -598,7 +598,7 @@ class TestExecComp(unittest.TestCase):
                                                      x=np.array([1., 2., 3.]),
                                                      y=0.0))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -617,7 +617,7 @@ class TestExecComp(unittest.TestCase):
                                                      x=np.array([1., 2., 3.]),
                                                      y=np.array([0., 0.])))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -632,7 +632,6 @@ class TestExecComp(unittest.TestCase):
 
     def test_simple_array_model(self):
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('x', np.ones([2])))
         prob.model.add_subsystem('comp', ExecComp(['y[0]=2.0*x[0]+7.0*x[1]',
                                                    'y[1]=5.0*x[0]-3.0*x[1]'],
@@ -640,7 +639,7 @@ class TestExecComp(unittest.TestCase):
 
         prob.model.connect('p1.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -655,7 +654,6 @@ class TestExecComp(unittest.TestCase):
 
     def test_simple_array_model2(self):
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('x', np.ones([2])))
         prob.model.add_subsystem('comp', ExecComp('y = mat.dot(x)',
                                                   x=np.zeros((2,)), y=np.zeros((2,)),
@@ -663,7 +661,7 @@ class TestExecComp(unittest.TestCase):
 
         prob.model.connect('p1.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -680,7 +678,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -720,7 +718,7 @@ class TestExecComp(unittest.TestCase):
         prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=2.0*abs(x)', x=-2.0))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -744,7 +742,7 @@ class TestExecComp(unittest.TestCase):
         C1 = prob.model.add_subsystem('C1', ExecComp('y=2.0*abs(x)',
                                                      x=np.ones(3)*-2.0, y=np.zeros(3)))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -823,7 +823,7 @@ class TestExecComp(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', 2.0))
         model.add_subsystem('comp', ExecComp('y=x+1.'))
@@ -841,7 +841,7 @@ class TestExecComp(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', 2.0))
         model.add_subsystem('comp', ExecComp(['y1=x+1.', 'y2=x-1.']))
@@ -862,7 +862,7 @@ class TestExecComp(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', np.array([1., 2., 3.])))
         model.add_subsystem('comp', ExecComp('y=x[1]',
@@ -883,7 +883,7 @@ class TestExecComp(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.pi/2.0))
         model.add_subsystem('p2', IndepVarComp('y', np.pi/2.0))
@@ -905,7 +905,7 @@ class TestExecComp(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', np.array([1., 2., 3.])))
         model.add_subsystem('comp', ExecComp('y=sum(x)', x=np.zeros((3, ))))
@@ -922,7 +922,7 @@ class TestExecComp(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 12.0, units='inch'))
         model.add_subsystem('p2', IndepVarComp('y', 1.0, units='ft'))
@@ -971,7 +971,7 @@ class TestExecCompParameterized(unittest.TestCase):
         test_data = _ufunc_test_data[f]
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         if len(test_data['args']) > 1:
             ivc = model.add_subsystem(name='ivc', subsys=IndepVarComp())
@@ -1016,7 +1016,7 @@ class TestExecCompParameterized(unittest.TestCase):
         test_data = _ufunc_test_data[f]
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         if len(test_data['args']) > 1:
             ivc = model.add_subsystem(name='ivc', subsys=IndepVarComp())

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -14,7 +14,7 @@ try:
 except ImportError:
     from openmdao.utils.assert_utils import SkipParameterized as parameterized
 
-from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+import openmdao.api as om
 from openmdao.components.exec_comp import _expr_dict
 from openmdao.utils.assert_utils import assert_rel_error
 
@@ -260,24 +260,24 @@ _ufunc_test_data = {
 class TestExecComp(unittest.TestCase):
 
     def test_no_expr(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp())
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp())
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: No valid expressions provided to ExecComp(): [].")
 
     def test_colon_vars(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('y=foo:bar+1.'))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('y=foo:bar+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
                          "C1: failed to compile expression 'y=foo:bar+1.'.")
 
     def test_bad_kwargs(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('y=x+1.', xx=2.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('y=x+1.', xx=2.0))
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
@@ -285,9 +285,9 @@ class TestExecComp(unittest.TestCase):
                          "in the expressions ['y=x+1.']")
 
     def test_bad_kwargs_meta(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('y=x+1.',
-                                                x={'val': 2, 'low': 0, 'high': 10, 'units': 'ft'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('y=x+1.',
+                                                   x={'val': 2, 'low': 0, 'high': 10, 'units': 'ft'}))
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
@@ -295,8 +295,8 @@ class TestExecComp(unittest.TestCase):
                          "variable 'x': ['high', 'low', 'val']")
 
     def test_name_collision_const(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('e=x+1.'))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('e=x+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
@@ -304,8 +304,8 @@ class TestExecComp(unittest.TestCase):
                          "as an internal function or constant.")
 
     def test_name_collision_func(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('sin=x+1.'))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('sin=x+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
@@ -313,8 +313,8 @@ class TestExecComp(unittest.TestCase):
                          "as an internal function or constant.")
 
     def test_func_as_rhs_var(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('y=sin+1.'))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('y=sin+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup()
         self.assertEqual(str(context.exception),
@@ -322,9 +322,9 @@ class TestExecComp(unittest.TestCase):
                          "as an internal function.")
 
     def test_mixed_type(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=sum(x)',
-                                                     x=np.arange(10, dtype=float)))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=sum(x)',
+                                                        x=np.arange(10, dtype=float)))
         prob.setup()
 
         # Conclude setup but don't run model.
@@ -339,8 +339,8 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 45.0, 0.00001)
 
     def test_simple(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=x+1.', x=2.0))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+1.', x=2.0))
 
         prob.setup()
 
@@ -356,8 +356,8 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 3.0, 0.00001)
 
     def test_for_spaces(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y = pi * x', x=2.0))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y = pi * x', x=2.0))
 
         prob.setup()
 
@@ -374,12 +374,12 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 2 * math.pi, 0.00001)
 
     def test_units(self):
-        prob = Problem()
-        prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=x+z+1.',
-                                                     x={'value': 2.0, 'units': 'm'},
-                                                     y={'units': 'm'},
-                                                     z=2.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+z+1.',
+                                                        x={'value': 2.0, 'units': 'm'},
+                                                        y={'units': 'm'},
+                                                        z=2.0))
         prob.model.connect('indep.x', 'C1.x')
 
         prob.setup()
@@ -390,35 +390,35 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 4.0, 0.00001)
 
     def test_units_varname(self):
-        prob = Problem()
+        prob = om.Problem()
 
         with self.assertRaises(TypeError) as cm:
-            prob.model.add_subsystem('C1', ExecComp('y=x+units+1.',
-                                                    x={'value': 2.0, 'units': 'm'},
-                                                    y={'units': 'm'},
-                                                    units=2.0))
+            prob.model.add_subsystem('C1', om.ExecComp('y=x+units+1.',
+                                                       x={'value': 2.0, 'units': 'm'},
+                                                       y={'units': 'm'},
+                                                       units=2.0))
 
         self.assertEqual(str(cm.exception),
                          "Value (2.0) of option 'units' has type 'float', "
                          "but type 'str' was expected.")
 
     def test_units_varname_str(self):
-        prob = Problem()
+        prob = om.Problem()
 
         with self.assertRaises(ValueError) as cm:
-            prob.model.add_subsystem('C1', ExecComp('y=x+units+1.',
-                                                    x={'value': 2.0, 'units': 'm'},
-                                                    y={'units': 'm'},
-                                                    units='two'))
+            prob.model.add_subsystem('C1', om.ExecComp('y=x+units+1.',
+                                                       x={'value': 2.0, 'units': 'm'},
+                                                       y={'units': 'm'},
+                                                       units='two'))
 
         self.assertEqual(str(cm.exception), "The units 'two' are invalid.")
 
     def test_units_varname_novalue(self):
-        prob = Problem()
-        prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=x+units+1.',
-                                                     x={'value': 2.0, 'units': 'm'},
-                                                     y={'units': 'm'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+units+1.',
+                                                        x={'value': 2.0, 'units': 'm'},
+                                                        y={'units': 'm'}))
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(NameError) as cm:
@@ -429,12 +429,12 @@ class TestExecComp(unittest.TestCase):
 
     def test_common_units(self):
         # all variables in the ExecComp have the same units
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
-        prob.model.add_subsystem('comp', ExecComp('y=x+z+1.', units='m',
-                                                  x={'value': 2.0},
-                                                  z=2.0))
+        prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
+        prob.model.add_subsystem('comp', om.ExecComp('y=x+z+1.', units='m',
+                                                     x={'value': 2.0},
+                                                     z=2.0))
         prob.model.connect('indep.x', 'comp.x')
 
         prob.setup()
@@ -444,10 +444,10 @@ class TestExecComp(unittest.TestCase):
 
     def test_common_units_no_meta(self):
         # make sure common units are assigned when no metadata is provided
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('indep', IndepVarComp('x', 2.0, units='km'))
-        prob.model.add_subsystem('comp', ExecComp('y = x+1', units='m'))
+        prob.model.add_subsystem('indep', om.IndepVarComp('x', 2.0, units='km'))
+        prob.model.add_subsystem('comp', om.ExecComp('y = x+1', units='m'))
 
         prob.model.connect('indep.x', 'comp.x')
 
@@ -457,11 +457,11 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], 2001., 0.00001)
 
     def test_conflicting_units(self):
-        prob = Problem()
-        prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=x+z+1.', units='m',
-                                                     x={'value': 2.0, 'units': 'km'},
-                                                     z=2.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+z+1.', units='m',
+                                                        x={'value': 2.0, 'units': 'km'},
+                                                        z=2.0))
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(RuntimeError) as cm:
@@ -472,13 +472,13 @@ class TestExecComp(unittest.TestCase):
                          "units of 'm' have been specified for the entire component.")
 
     def test_shape_and_value(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5',
-                                             x={'shape': (5,), 'value': np.zeros(5)},
-                                             y={'shape': (5,), 'value': np.zeros(5)}))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5',
+                                                x={'shape': (5,), 'value': np.zeros(5)},
+                                                y={'shape': (5,), 'value': np.zeros(5)}))
 
         model.connect('indep.x', 'comp.x')
 
@@ -490,13 +490,13 @@ class TestExecComp(unittest.TestCase):
         assert_almost_equal(J, np.eye(5)*3., decimal=6)
 
     def test_conflicting_shape(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5',
-                                             x={'shape': (5,), 'value': 5},
-                                             y={'shape': (5,)}))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5',
+                                                x={'shape': (5,), 'value': 5},
+                                                y={'shape': (5,)}))
 
         model.connect('indep.x', 'comp.x')
 
@@ -508,11 +508,11 @@ class TestExecComp(unittest.TestCase):
                          "but a value of shape (1,) has been provided.")
 
     def test_common_shape(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5', shape=(5,)))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5', shape=(5,)))
 
         model.connect('indep.x', 'comp.x')
 
@@ -524,13 +524,13 @@ class TestExecComp(unittest.TestCase):
         assert_almost_equal(J, np.eye(5)*3., decimal=6)
 
     def test_common_shape_with_values(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5', shape=(5,),
-                                             x={'value': np.zeros(5)},
-                                             y={'value': np.zeros(5)}))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5', shape=(5,),
+                                                x={'value': np.zeros(5)},
+                                                y={'value': np.zeros(5)}))
 
         model.connect('indep.x', 'comp.x')
 
@@ -542,12 +542,12 @@ class TestExecComp(unittest.TestCase):
         assert_almost_equal(J, np.eye(5)*3., decimal=6)
 
     def test_common_shape_conflicting_shape(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5', shape=(5,),
-                                             y={'shape': (10,)}))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5', shape=(5,),
+                                                y={'shape': (10,)}))
 
         model.connect('indep.x', 'comp.x')
 
@@ -559,12 +559,12 @@ class TestExecComp(unittest.TestCase):
                          "but shape of (5,) has been specified for the entire component.")
 
     def test_common_shape_conflicting_value(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5', shape=(5,),
-                                             x={'value': 5}))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5', shape=(5,),
+                                                x={'value': 5}))
 
         model.connect('indep.x', 'comp.x')
 
@@ -576,8 +576,8 @@ class TestExecComp(unittest.TestCase):
                          "but shape of (5,) has been specified for the entire component.")
 
     def test_math(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=sin(x)', x=2.0))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=sin(x)', x=2.0))
 
         prob.setup()
 
@@ -593,10 +593,10 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], math.sin(2.0), 0.00001)
 
     def test_array(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=x[1]',
-                                                     x=np.array([1., 2., 3.]),
-                                                     y=0.0))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x[1]',
+                                                        x=np.array([1., 2., 3.]),
+                                                        y=0.0))
 
         prob.setup()
 
@@ -612,10 +612,10 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 2.0, 0.00001)
 
     def test_array_lhs(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp(['y[0]=x[1]', 'y[1]=x[0]'],
-                                                     x=np.array([1., 2., 3.]),
-                                                     y=np.array([0., 0.])))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp(['y[0]=x[1]', 'y[1]=x[0]'],
+                                                        x=np.array([1., 2., 3.]),
+                                                        y=np.array([0., 0.])))
 
         prob.setup()
 
@@ -631,11 +631,11 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], np.array([2., 1.]), 0.00001)
 
     def test_simple_array_model(self):
-        prob = Problem()
-        prob.model.add_subsystem('p1', IndepVarComp('x', np.ones([2])))
-        prob.model.add_subsystem('comp', ExecComp(['y[0]=2.0*x[0]+7.0*x[1]',
-                                                   'y[1]=5.0*x[0]-3.0*x[1]'],
-                                                  x=np.zeros([2]), y=np.zeros([2])))
+        prob = om.Problem()
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', np.ones([2])))
+        prob.model.add_subsystem('comp', om.ExecComp(['y[0]=2.0*x[0]+7.0*x[1]',
+                                                      'y[1]=5.0*x[0]-3.0*x[1]'],
+                                                     x=np.zeros([2]), y=np.zeros([2])))
 
         prob.model.connect('p1.x', 'comp.x')
 
@@ -653,11 +653,11 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_simple_array_model2(self):
-        prob = Problem()
-        prob.model.add_subsystem('p1', IndepVarComp('x', np.ones([2])))
-        prob.model.add_subsystem('comp', ExecComp('y = mat.dot(x)',
-                                                  x=np.zeros((2,)), y=np.zeros((2,)),
-                                                  mat=np.array([[2., 7.], [5., -3.]])))
+        prob = om.Problem()
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', np.ones([2])))
+        prob.model.add_subsystem('comp', om.ExecComp('y = mat.dot(x)',
+                                                     x=np.zeros((2,)), y=np.zeros((2,)),
+                                                     mat=np.array([[2., 7.], [5., -3.]])))
 
         prob.model.connect('p1.x', 'comp.x')
 
@@ -675,8 +675,8 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_complex_step(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp(['y=2.0*x+1.'], x=2.0))
 
         prob.setup()
 
@@ -696,9 +696,9 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._jacobian[('y', 'x')], [[2.0]], 0.00001)
 
     def test_complex_step2(self):
-        prob = Problem(Group())
-        prob.model.add_subsystem('p1', IndepVarComp('x', 2.0))
-        prob.model.add_subsystem('comp', ExecComp('y=x*x + x*2.0'))
+        prob = om.Problem(om.Group())
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 2.0))
+        prob.model.add_subsystem('comp', om.ExecComp('y=x*x + x*2.0'))
         prob.model.connect('p1.x', 'comp.x')
         prob.set_solver_print(level=0)
 
@@ -715,8 +715,8 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, J['comp.y', 'p1.x'], np.array([[6.0]]), 0.00001)
 
     def test_abs_complex_step(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=2.0*abs(x)', x=-2.0))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=2.0*abs(x)', x=-2.0))
 
         prob.setup()
         prob.set_solver_print(level=0)
@@ -738,9 +738,9 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._jacobian['y', 'x'], [[2.0]], 0.00001)
 
     def test_abs_array_complex_step(self):
-        prob = Problem()
-        C1 = prob.model.add_subsystem('C1', ExecComp('y=2.0*abs(x)',
-                                                     x=np.ones(3)*-2.0, y=np.zeros(3)))
+        prob = om.Problem()
+        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=2.0*abs(x)',
+                                                        x=np.ones(3)*-2.0, y=np.zeros(3)))
 
         prob.setup()
         prob.set_solver_print(level=0)
@@ -771,13 +771,13 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._jacobian['y', 'x'], expect, 0.00001)
 
     def test_vectorize_error(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(3)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(3)))
         model.add_design_var('indep.x')
 
         mat = np.arange(15).reshape((3,5))
-        model.add_subsystem('comp', ExecComp('y=A.dot(x)', vectorize=True, A=mat, x=np.ones(5), y=np.ones(3)))
+        model.add_subsystem('comp', om.ExecComp('y=A.dot(x)', vectorize=True, A=mat, x=np.ones(5), y=np.ones(3)))
         model.connect('indep.x', 'comp.x')
 
         with self.assertRaises(Exception) as context:
@@ -786,12 +786,12 @@ class TestExecComp(unittest.TestCase):
                          "comp: vectorize is True but partial(y, A) is not square (shape=(3, 15)).")
 
     def test_vectorize_shape_only(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5', vectorize=True,
-                                             x={'shape': (5,)}, y={'shape': (5,)}))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5', vectorize=True,
+                                                x={'shape': (5,)}, y={'shape': (5,)}))
         model.connect('indep.x', 'comp.x')
 
         p.setup()
@@ -803,13 +803,13 @@ class TestExecComp(unittest.TestCase):
 
     def test_feature_vectorize(self):
         import numpy as np
-        from openmdao.api import IndepVarComp, Problem, ExecComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indep', IndepVarComp('x', val=np.ones(5)))
+        model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(5)))
 
-        model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5', vectorize=True, x=np.ones(5), y=np.ones(5)))
+        model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5', vectorize=True, x=np.ones(5), y=np.ones(5)))
         model.connect('indep.x', 'comp.x')
 
         p.setup()
@@ -820,13 +820,13 @@ class TestExecComp(unittest.TestCase):
         assert_almost_equal(J, np.eye(5)*3., decimal=6)
 
     def test_feature_simple(self):
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0))
-        model.add_subsystem('comp', ExecComp('y=x+1.'))
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('comp', om.ExecComp('y=x+1.'))
 
         model.connect('p.x', 'comp.x')
 
@@ -838,13 +838,13 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], 3.0, 0.00001)
 
     def test_feature_multi_output(self):
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0))
-        model.add_subsystem('comp', ExecComp(['y1=x+1.', 'y2=x-1.']))
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('comp', om.ExecComp(['y1=x+1.', 'y2=x-1.']))
 
         model.connect('p.x', 'comp.x')
 
@@ -859,15 +859,15 @@ class TestExecComp(unittest.TestCase):
     def test_feature_array(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', np.array([1., 2., 3.])))
-        model.add_subsystem('comp', ExecComp('y=x[1]',
-                                             x=np.array([1., 2., 3.]),
-                                             y=0.0))
+        model.add_subsystem('p', om.IndepVarComp('x', np.array([1., 2., 3.])))
+        model.add_subsystem('comp', om.ExecComp('y=x[1]',
+                                                x=np.array([1., 2., 3.]),
+                                                y=0.0))
         model.connect('p.x', 'comp.x')
 
         prob.setup()
@@ -880,14 +880,14 @@ class TestExecComp(unittest.TestCase):
     def test_feature_math(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', np.pi/2.0))
-        model.add_subsystem('p2', IndepVarComp('y', np.pi/2.0))
-        model.add_subsystem('comp', ExecComp('z = sin(x)**2 + cos(y)**2'))
+        model.add_subsystem('p1', om.IndepVarComp('x', np.pi/2.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', np.pi/2.0))
+        model.add_subsystem('comp', om.ExecComp('z = sin(x)**2 + cos(y)**2'))
 
         model.connect('p1.x', 'comp.x')
         model.connect('p2.y', 'comp.y')
@@ -902,13 +902,13 @@ class TestExecComp(unittest.TestCase):
     def test_feature_numpy(self):
         import numpy as np
 
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', np.array([1., 2., 3.])))
-        model.add_subsystem('comp', ExecComp('y=sum(x)', x=np.zeros((3, ))))
+        model.add_subsystem('p', om.IndepVarComp('x', np.array([1., 2., 3.])))
+        model.add_subsystem('comp', om.ExecComp('y=sum(x)', x=np.zeros((3, ))))
         model.connect('p.x', 'comp.x')
 
         prob.setup()
@@ -919,17 +919,17 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], 6.0, 0.00001)
 
     def test_feature_metadata(self):
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 12.0, units='inch'))
-        model.add_subsystem('p2', IndepVarComp('y', 1.0, units='ft'))
-        model.add_subsystem('comp', ExecComp('z=x+y',
-                                             x={'value': 0.0, 'units': 'inch'},
-                                             y={'value': 0.0, 'units': 'inch'},
-                                             z={'value': 0.0, 'units': 'inch'}))
+        model.add_subsystem('p1', om.IndepVarComp('x', 12.0, units='inch'))
+        model.add_subsystem('p2', om.IndepVarComp('y', 1.0, units='ft'))
+        model.add_subsystem('comp', om.ExecComp('z=x+y',
+                                                x={'value': 0.0, 'units': 'inch'},
+                                                y={'value': 0.0, 'units': 'inch'},
+                                                z={'value': 0.0, 'units': 'inch'}))
         model.connect('p1.x', 'comp.x')
         model.connect('p2.y', 'comp.y')
 
@@ -941,18 +941,18 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, prob['comp.z'], 24.0, 0.00001)
 
     def test_feature_options(self):
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        model = Group()
+        model = om.Group()
 
-        indep = model.add_subsystem('indep', IndepVarComp('x', shape=(2,), units='cm'))
-        xcomp = model.add_subsystem('comp', ExecComp('y=2*x', shape=(2,)))
+        indep = model.add_subsystem('indep', om.IndepVarComp('x', shape=(2,), units='cm'))
+        xcomp = model.add_subsystem('comp', om.ExecComp('y=2*x', shape=(2,)))
 
         xcomp.options['units'] = 'm'
 
         model.connect('indep.x', 'comp.x')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
         prob['indep.x'] = [100., 200.]
@@ -970,18 +970,18 @@ class TestExecCompParameterized(unittest.TestCase):
     def test_exec_comp_value(self, f):
         test_data = _ufunc_test_data[f]
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         if len(test_data['args']) > 1:
-            ivc = model.add_subsystem(name='ivc', subsys=IndepVarComp())
+            ivc = model.add_subsystem(name='ivc', subsys=om.IndepVarComp())
             for arg_name, arg_value in iteritems(test_data['args']):
                 if arg_name == 'f':
                     continue
                 ivc.add_output(name=arg_name, val=arg_value['value'])
                 model.connect('ivc.{0}'.format(arg_name), 'comp.{0}'.format(arg_name))
 
-        model.add_subsystem('comp', ExecComp(test_data['str'], **test_data['args']),
+        model.add_subsystem('comp', om.ExecComp(test_data['str'], **test_data['args']),
                             promotes_outputs=['f'])
         prob.setup()
         prob.run_model()
@@ -1015,11 +1015,11 @@ class TestExecCompParameterized(unittest.TestCase):
     def test_exec_comp_jac(self, f):
         test_data = _ufunc_test_data[f]
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         if len(test_data['args']) > 1:
-            ivc = model.add_subsystem(name='ivc', subsys=IndepVarComp())
+            ivc = model.add_subsystem(name='ivc', subsys=om.IndepVarComp())
             for arg_name, arg_value in iteritems(test_data['args']):
                 if arg_name == 'f':
                     continue
@@ -1028,7 +1028,7 @@ class TestExecCompParameterized(unittest.TestCase):
                               '{0}_comp.{1}'.format(f, arg_name))
 
         model.add_subsystem('{0}_comp'.format(f),
-                            ExecComp(test_data['str'], **test_data['args']),
+                            om.ExecComp(test_data['str'], **test_data['args']),
                             promotes_outputs=['f'])
         prob.setup()
         prob.run_model()

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -260,7 +260,7 @@ _ufunc_test_data = {
 class TestExecComp(unittest.TestCase):
 
     def test_no_expr(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp())
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
@@ -268,7 +268,7 @@ class TestExecComp(unittest.TestCase):
                          "C1: No valid expressions provided to ExecComp(): [].")
 
     def test_colon_vars(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=foo:bar+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
@@ -276,7 +276,7 @@ class TestExecComp(unittest.TestCase):
                          "C1: failed to compile expression 'y=foo:bar+1.'.")
 
     def test_bad_kwargs(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=x+1.', xx=2.0))
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
@@ -285,7 +285,7 @@ class TestExecComp(unittest.TestCase):
                          "in the expressions ['y=x+1.']")
 
     def test_bad_kwargs_meta(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=x+1.',
                                                 x={'val': 2, 'low': 0, 'high': 10, 'units': 'ft'}))
         with self.assertRaises(Exception) as context:
@@ -295,7 +295,7 @@ class TestExecComp(unittest.TestCase):
                          "variable 'x': ['high', 'low', 'val']")
 
     def test_name_collision_const(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('e=x+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
@@ -304,7 +304,7 @@ class TestExecComp(unittest.TestCase):
                          "as an internal function or constant.")
 
     def test_name_collision_func(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('sin=x+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
@@ -313,7 +313,7 @@ class TestExecComp(unittest.TestCase):
                          "as an internal function or constant.")
 
     def test_func_as_rhs_var(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=sin+1.'))
         with self.assertRaises(Exception) as context:
             prob.setup(check=False)
@@ -322,7 +322,7 @@ class TestExecComp(unittest.TestCase):
                          "as an internal function.")
 
     def test_mixed_type(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=sum(x)',
                                                      x=np.arange(10, dtype=float)))
         prob.setup(check=False)
@@ -339,7 +339,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 45.0, 0.00001)
 
     def test_simple(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x+1.', x=2.0))
 
         prob.setup(check=False)
@@ -356,7 +356,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 3.0, 0.00001)
 
     def test_for_spaces(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y = pi * x', x=2.0))
 
         prob.setup(check=False)
@@ -374,7 +374,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 2 * math.pi, 0.00001)
 
     def test_units(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x+z+1.',
                                                      x={'value': 2.0, 'units': 'm'},
@@ -390,7 +390,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 4.0, 0.00001)
 
     def test_units_varname(self):
-        prob = Problem(model=Group())
+        prob = Problem()
 
         with self.assertRaises(TypeError) as cm:
             prob.model.add_subsystem('C1', ExecComp('y=x+units+1.',
@@ -403,7 +403,7 @@ class TestExecComp(unittest.TestCase):
                          "but type 'str' was expected.")
 
     def test_units_varname_str(self):
-        prob = Problem(model=Group())
+        prob = Problem()
 
         with self.assertRaises(ValueError) as cm:
             prob.model.add_subsystem('C1', ExecComp('y=x+units+1.',
@@ -414,7 +414,7 @@ class TestExecComp(unittest.TestCase):
         self.assertEqual(str(cm.exception), "The units 'two' are invalid.")
 
     def test_units_varname_novalue(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x+units+1.',
                                                      x={'value': 2.0, 'units': 'm'},
@@ -429,7 +429,7 @@ class TestExecComp(unittest.TestCase):
 
     def test_common_units(self):
         # all variables in the ExecComp have the same units
-        prob = Problem(model=Group())
+        prob = Problem()
 
         prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
         prob.model.add_subsystem('comp', ExecComp('y=x+z+1.', units='m',
@@ -457,7 +457,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], 2001., 0.00001)
 
     def test_conflicting_units(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('indep', IndepVarComp('x', 100.0, units='cm'))
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x+z+1.', units='m',
                                                      x={'value': 2.0, 'units': 'km'},
@@ -576,7 +576,7 @@ class TestExecComp(unittest.TestCase):
                          "but shape of (5,) has been specified for the entire component.")
 
     def test_math(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=sin(x)', x=2.0))
 
         prob.setup(check=False)
@@ -593,7 +593,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], math.sin(2.0), 0.00001)
 
     def test_array(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=x[1]',
                                                      x=np.array([1., 2., 3.]),
                                                      y=0.0))
@@ -612,7 +612,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._outputs['y'], 2.0, 0.00001)
 
     def test_array_lhs(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp(['y[0]=x[1]', 'y[1]=x[0]'],
                                                      x=np.array([1., 2., 3.]),
                                                      y=np.array([0., 0.])))
@@ -677,7 +677,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_complex_step(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0))
 
         prob.setup(check=False)
@@ -717,7 +717,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, J['comp.y', 'p1.x'], np.array([[6.0]]), 0.00001)
 
     def test_abs_complex_step(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=2.0*abs(x)', x=-2.0))
 
         prob.setup(check=False)
@@ -740,7 +740,7 @@ class TestExecComp(unittest.TestCase):
         assert_rel_error(self, C1._jacobian['y', 'x'], [[2.0]], 0.00001)
 
     def test_abs_array_complex_step(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         C1 = prob.model.add_subsystem('C1', ExecComp('y=2.0*abs(x)',
                                                      x=np.ones(3)*-2.0, y=np.zeros(3)))
 

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -192,7 +192,7 @@ class TestExternalCodeComp(unittest.TestCase):
         # Set command to nonexistant path.
         self.extcode.options['command'] = ['no-such-command']
 
-        self.prob.setup(check=False)
+        self.prob.setup()
         try:
             self.prob.run_model()
         except ValueError as exc:
@@ -206,7 +206,7 @@ class TestExternalCodeComp(unittest.TestCase):
         self.extcode.stdout = 'nullcmd.out'
         self.extcode.stderr = STDOUT
 
-        self.prob.setup(check=False)
+        self.prob.setup()
         try:
             self.prob.run_model()
         except ValueError as exc:
@@ -656,7 +656,7 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
         group.nonlinear_solver.options['maxiter'] = 20
         group.linear_solver = DirectSolver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         area_ratio = 1.3
         super_sonic = False

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -9,7 +9,7 @@ import unittest
 
 from scipy.optimize import fsolve
 
-from openmdao.api import Problem, ExternalCodeComp, AnalysisError
+import openmdao.api as om
 from openmdao.components.external_code_comp import STDOUT
 
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
@@ -52,9 +52,9 @@ class TestExternalCodeComp(unittest.TestCase):
         shutil.copy(os.path.join(DIRECTORY, 'extcode_example.py'),
                     os.path.join(self.tempdir, 'extcode_example.py'))
 
-        self.prob = Problem()
+        self.prob = om.Problem()
 
-        self.extcode = self.prob.model.add_subsystem('extcode', ExternalCodeComp())
+        self.extcode = self.prob.model.add_subsystem('extcode', om.ExternalCodeComp())
 
     def tearDown(self):
         os.chdir(self.startdir)
@@ -117,7 +117,7 @@ class TestExternalCodeComp(unittest.TestCase):
         self.prob.setup(check=True)
         try:
             self.prob.run_model()
-        except AnalysisError as exc:
+        except om.AnalysisError as exc:
             self.assertEqual(str(exc), 'Timed out after 1.0 sec.')
         else:
             self.fail('Expected AnalysisError')
@@ -152,7 +152,7 @@ class TestExternalCodeComp(unittest.TestCase):
         self.prob.setup(check=True)
         try:
             self.prob.run_model()
-        except AnalysisError as err:
+        except om.AnalysisError as err:
             self.assertTrue("delay must be >= 0" in str(err),
                             "expected 'delay must be >= 0' to be in '%s'" % str(err))
             self.assertTrue('Traceback' in str(err),
@@ -237,12 +237,12 @@ class TestExternalCodeCompArgs(unittest.TestCase):
 
     def test_kwargs(self):
         # check kwargs are passed to options
-        extcode = ExternalCodeComp(poll_delay=999)
+        extcode = om.ExternalCodeComp(poll_delay=999)
 
         self.assertTrue(extcode.options['poll_delay'] == 999)
 
         # check subclass kwargs are also passed to options
-        class MyComp(ExternalCodeComp):
+        class MyComp(om.ExternalCodeComp):
             def initialize(self):
                 self.options.declare('my_arg', 'foo', desc='subclass option')
 
@@ -258,7 +258,7 @@ class TestExternalCodeCompArgs(unittest.TestCase):
         self.assertEqual(my_comp_opts.difference(extcode_opts), set(('my_arg',)))
 
 
-class ParaboloidExternalCodeComp(ExternalCodeComp):
+class ParaboloidExternalCodeComp(om.ExternalCodeComp):
     def setup(self):
         self.add_input('x', val=0.0)
         self.add_input('y', val=0.0)
@@ -295,7 +295,7 @@ class ParaboloidExternalCodeComp(ExternalCodeComp):
         outputs['f_xy'] = f_xy
 
 
-class ParaboloidExternalCodeCompFD(ExternalCodeComp):
+class ParaboloidExternalCodeCompFD(om.ExternalCodeComp):
     def setup(self):
         self.add_input('x', val=0.0)
         self.add_input('y', val=0.0)
@@ -335,7 +335,7 @@ class ParaboloidExternalCodeCompFD(ExternalCodeComp):
         outputs['f_xy'] = f_xy
 
 
-class ParaboloidExternalCodeCompDerivs(ExternalCodeComp):
+class ParaboloidExternalCodeCompDerivs(om.ExternalCodeComp):
     def setup(self):
         self.add_input('x', val=0.0)
         self.add_input('y', val=0.0)
@@ -419,15 +419,15 @@ class TestExternalCodeCompFeature(unittest.TestCase):
             pass
 
     def test_main(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
         from openmdao.components.tests.test_external_code_comp import ParaboloidExternalCodeComp
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # create and connect inputs
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('p', ParaboloidExternalCodeComp())
 
         model.connect('p1.x', 'p.x')
@@ -441,16 +441,15 @@ class TestExternalCodeCompFeature(unittest.TestCase):
         self.assertEqual(prob['p.f_xy'], -15.0)
 
     def test_optimize_fd(self):
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.api import ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.components.tests.test_external_code_comp import ParaboloidExternalCodeCompFD
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # create and connect inputs
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('p', ParaboloidExternalCodeCompFD())
 
         model.connect('p1.x', 'p.x')
@@ -458,7 +457,7 @@ class TestExternalCodeCompFeature(unittest.TestCase):
 
         # find optimal solution with SciPy optimize
         # solution (minimum): x = 6.6667; y = -7.3333
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('p1.x', lower=-50, upper=50)
@@ -476,16 +475,15 @@ class TestExternalCodeCompFeature(unittest.TestCase):
         assert_rel_error(self, prob['p2.y'], -7.3333333, 1e-6)
 
     def test_optimize_derivs(self):
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.api import ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.components.tests.test_external_code_comp import ParaboloidExternalCodeCompDerivs
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         # create and connect inputs
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('p', ParaboloidExternalCodeCompDerivs())
 
         model.connect('p1.x', 'p.x')
@@ -493,7 +491,7 @@ class TestExternalCodeCompFeature(unittest.TestCase):
 
         # find optimal solution with SciPy optimize
         # solution (minimum): x = 6.6667; y = -7.3333
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('p1.x', lower=-50, upper=50)
@@ -537,7 +535,7 @@ class TestDeprecatedExternalCode(unittest.TestCase):
         with assert_warning(DeprecationWarning, msg):
             self.extcode = DeprecatedExternalCodeForTesting()
 
-        self.prob = Problem()
+        self.prob = om.Problem()
 
         self.prob.model.add_subsystem('extcode', self.extcode)
 
@@ -591,10 +589,9 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
             pass
 
     def test_simple_external_code_implicit_comp(self):
-        from openmdao.api import Group, NewtonSolver, Problem, IndepVarComp, DirectSolver, \
-            ExternalCodeImplicitComp
+        import openmdao.api as om
 
-        class MachExternalCodeComp(ExternalCodeImplicitComp):
+        class MachExternalCodeComp(om.ExternalCodeImplicitComp):
 
             def initialize(self):
                 self.options.declare('super_sonic', types=bool)
@@ -646,15 +643,15 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
                     mach = float(output_file.read())
                 outputs['mach'] = mach
 
-        group = Group()
-        group.add_subsystem('ar', IndepVarComp('area_ratio', 0.5))
+        group = om.Group()
+        group.add_subsystem('ar', om.IndepVarComp('area_ratio', 0.5))
         mach_comp = group.add_subsystem('comp', MachExternalCodeComp(), promotes=['*'])
-        prob = Problem(model=group)
-        group.nonlinear_solver = NewtonSolver()
+        prob = om.Problem(model=group)
+        group.nonlinear_solver = om.NewtonSolver()
         group.nonlinear_solver.options['solve_subsystems'] = True
         group.nonlinear_solver.options['iprint'] = 0
         group.nonlinear_solver.options['maxiter'] = 20
-        group.linear_solver = DirectSolver()
+        group.linear_solver = om.DirectSolver()
 
         prob.setup()
 

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -5,9 +5,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, IndepVarComp, Group, ExecComp, ScipyOptimizeDriver, \
-     ExplicitComponent
-from openmdao.components.ks_comp import KSComp
+import openmdao.api as om
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_stress import MultipointBeamGroup
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
@@ -16,12 +14,12 @@ from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 class TestKSFunction(unittest.TestCase):
 
     def test_basic_ks(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
+        model.add_subsystem('px', om.IndepVarComp(name="x", val=np.ones((2, ))))
         model.add_subsystem('comp', DoubleArrayComp())
-        model.add_subsystem('ks', KSComp(width=2))
+        model.add_subsystem('ks', om.KSComp(width=2))
         model.connect('px.x', 'comp.x1')
         model.connect('comp.y2', 'ks.g')
 
@@ -35,7 +33,7 @@ class TestKSFunction(unittest.TestCase):
         assert_rel_error(self, max(prob['comp.y2']), prob['ks.KS'][0])
 
     def test_vectorized(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         x = np.zeros((3, 5))
@@ -43,8 +41,8 @@ class TestKSFunction(unittest.TestCase):
         x[1, :] = np.array([13.0, 11.0, 5.0, 17.0, 3.0])*2
         x[2, :] = np.array([11.0, 3.0, 17.0, 5.0, 13.0])*3
 
-        model.add_subsystem('px', IndepVarComp(name="x", val=x))
-        model.add_subsystem('ks', KSComp(width=5, vec_size=3))
+        model.add_subsystem('px', om.IndepVarComp(name="x", val=x))
+        model.add_subsystem('ks', om.KSComp(width=5, vec_size=3))
         model.connect('px.x', 'ks.g')
 
         model.add_design_var('px.x')
@@ -63,13 +61,13 @@ class TestKSFunction(unittest.TestCase):
             assert_rel_error(self, partials['ks'][of, wrt]['abs error'][0], 0.0, 1e-6)
 
     def test_partials_no_compute(self):
-        prob = Problem()
+        prob = om.Problem()
 
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([5.0, 4.0])))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([5.0, 4.0])))
 
-        ks_comp = model.add_subsystem('ks', KSComp(width=2))
+        ks_comp = model.add_subsystem('ks', om.KSComp(width=2))
 
         model.connect('px.x', 'ks.g')
 
@@ -101,11 +99,11 @@ class TestKSFunction(unittest.TestCase):
         num_elements = 25
         num_load_cases = 2
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume, max_bending = max_bending,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        prob = om.Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume, max_bending = max_bending,
+                                                    num_elements=num_elements, num_cp=num_cp,
+                                                    num_load_cases=num_load_cases))
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -127,12 +125,12 @@ class TestKSFunction(unittest.TestCase):
 
     def test_upper(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([5.0, 4.0])))
-        model.add_subsystem('comp', ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
-        model.add_subsystem('ks', KSComp(width=2))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([5.0, 4.0])))
+        model.add_subsystem('comp', om.ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
+        model.add_subsystem('ks', om.KSComp(width=2))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.y', 'ks.g')
@@ -145,12 +143,12 @@ class TestKSFunction(unittest.TestCase):
 
     def test_lower_flag(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([5.0, 4.0])))
-        model.add_subsystem('comp', ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
-        model.add_subsystem('ks', KSComp(width=2))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([5.0, 4.0])))
+        model.add_subsystem('comp', om.ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
+        model.add_subsystem('ks', om.KSComp(width=2))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.y', 'ks.g')
@@ -167,10 +165,10 @@ class TestKSFunction(unittest.TestCase):
         # self-contained, to be removed when class name goes away.
         from openmdao.components.ks_comp import KSComponent  # deprecated
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2,))))
+        model.add_subsystem('px', om.IndepVarComp(name="x", val=np.ones((2,))))
         model.add_subsystem('comp', DoubleArrayComp())
 
         msg = "'KSComponent' has been deprecated. Use 'KSComp' instead."
@@ -196,15 +194,15 @@ class TestKSFunctionFeatures(unittest.TestCase):
     def test_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
-        from openmdao.components.ks_comp import KSComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([5.0, 4.0])))
-        model.add_subsystem('comp', ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
-        model.add_subsystem('ks', KSComp(width=2))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([5.0, 4.0])))
+        model.add_subsystem('comp', om.ExecComp('y = 3.0*x', x=np.zeros((2, )),
+                                                y=np.zeros((2, ))))
+        model.add_subsystem('ks', om.KSComp(width=2))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.y', 'ks.g')
@@ -217,15 +215,15 @@ class TestKSFunctionFeatures(unittest.TestCase):
     def test_vectorized(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
-        from openmdao.components.ks_comp import KSComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([[5.0, 4.0], [10.0, 8.0]])))
-        model.add_subsystem('comp', ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('ks', KSComp(width=2, vec_size=2))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([[5.0, 4.0], [10.0, 8.0]])))
+        model.add_subsystem('comp', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)),
+                                                y=np.zeros((2, 2))))
+        model.add_subsystem('ks', om.KSComp(width=2, vec_size=2))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.y', 'ks.g')
@@ -239,15 +237,15 @@ class TestKSFunctionFeatures(unittest.TestCase):
     def test_upper(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
-        from openmdao.components.ks_comp import KSComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([5.0, 4.0])))
-        model.add_subsystem('comp', ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
-        model.add_subsystem('ks', KSComp(width=2))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([5.0, 4.0])))
+        model.add_subsystem('comp', om.ExecComp('y = 3.0*x', x=np.zeros((2, )),
+                                                y=np.zeros((2, ))))
+        model.add_subsystem('ks', om.KSComp(width=2))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.y', 'ks.g')
@@ -261,15 +259,15 @@ class TestKSFunctionFeatures(unittest.TestCase):
     def test_lower_flag(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
-        from openmdao.components.ks_comp import KSComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', val=np.array([5.0, 4.0])))
-        model.add_subsystem('comp', ExecComp('y = 3.0*x', x=np.zeros((2, )), y=np.zeros((2, ))))
-        model.add_subsystem('ks', KSComp(width=2))
+        model.add_subsystem('px', om.IndepVarComp('x', val=np.array([5.0, 4.0])))
+        model.add_subsystem('comp', om.ExecComp('y = 3.0*x', x=np.zeros((2, )),
+                                                y=np.zeros((2, ))))
+        model.add_subsystem('ks', om.KSComp(width=2))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.y', 'ks.g')

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -17,7 +17,7 @@ class TestKSFunction(unittest.TestCase):
 
     def test_basic_ks(self):
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
         model.add_subsystem('comp', DoubleArrayComp())
@@ -36,7 +36,7 @@ class TestKSFunction(unittest.TestCase):
 
     def test_vectorized(self):
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         x = np.zeros((3, 5))
         x[0, :] = np.array([3.0, 5.0, 11.0, 13.0, 17.0])
@@ -168,7 +168,7 @@ class TestKSFunction(unittest.TestCase):
         from openmdao.components.ks_comp import KSComponent  # deprecated
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2,))))
         model.add_subsystem('comp', DoubleArrayComp())

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -29,7 +29,7 @@ class TestKSFunction(unittest.TestCase):
         model.add_objective('comp.y1')
         model.add_constraint('ks.KS', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         assert_rel_error(self, max(prob['comp.y2']), prob['ks.KS'][0])
@@ -50,7 +50,7 @@ class TestKSFunction(unittest.TestCase):
         model.add_design_var('px.x')
         model.add_constraint('ks.KS', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         assert_rel_error(self, prob['ks.KS'][0], 17.0)
@@ -73,7 +73,7 @@ class TestKSFunction(unittest.TestCase):
 
         model.connect('px.x', 'ks.g')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # compute partials with the current model inputs
@@ -185,7 +185,7 @@ class TestKSFunction(unittest.TestCase):
         model.add_objective('comp.y1')
         model.add_constraint('ks.KS', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         assert_rel_error(self, max(prob['comp.y2']), prob['ks.KS'][0])

--- a/openmdao/components/tests/test_linear_system_comp.py
+++ b/openmdao/components/tests/test_linear_system_comp.py
@@ -4,8 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Group, Problem, IndepVarComp
-from openmdao.api import LinearSystemComp, ScipyKrylov, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
@@ -15,25 +14,25 @@ class TestLinearSystemComp(unittest.TestCase):
     def test_basic(self):
         """Check against the scipy solver."""
 
-        model = Group()
+        model = om.Group()
 
         x = np.array([1, 2, -3])
         A = np.array([[5.0, -3.0, 2.0], [1.0, 7.0, -4.0], [1.0, 0.0, 8.0]])
         b = A.dot(x)
 
-        model.add_subsystem('p1', IndepVarComp('A', A))
-        model.add_subsystem('p2', IndepVarComp('b', b))
+        model.add_subsystem('p1', om.IndepVarComp('A', A))
+        model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = model.add_subsystem('lingrp', Group(), promotes=['*'])
-        lingrp.add_subsystem('lin', LinearSystemComp(size=3))
+        lingrp = model.add_subsystem('lingrp', om.Group(), promotes=['*'])
+        lingrp.add_subsystem('lin', om.LinearSystemComp(size=3))
 
         model.connect('p1.A', 'lin.A')
         model.connect('p2.b', 'lin.b')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
-        lingrp.linear_solver = ScipyKrylov()
+        lingrp.linear_solver = om.ScipyKrylov()
 
         prob.set_solver_print(level=0)
         prob.run_model()
@@ -50,25 +49,25 @@ class TestLinearSystemComp(unittest.TestCase):
     def test_vectorized(self):
         """Check against the scipy solver."""
 
-        model = Group()
+        model = om.Group()
 
         x = np.array([[1, 2, -3], [2, -1, 4]])
         A = np.array([[5.0, -3.0, 2.0], [1.0, 7.0, -4.0], [1.0, 0.0, 8.0]])
         b = np.einsum('jk,ik->ij', A, x)
 
-        model.add_subsystem('p1', IndepVarComp('A', A))
-        model.add_subsystem('p2', IndepVarComp('b', b))
+        model.add_subsystem('p1', om.IndepVarComp('A', A))
+        model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = model.add_subsystem('lingrp', Group(), promotes=['*'])
-        lingrp.add_subsystem('lin', LinearSystemComp(size=3, vec_size=2))
+        lingrp = model.add_subsystem('lingrp', om.Group(), promotes=['*'])
+        lingrp.add_subsystem('lin', om.LinearSystemComp(size=3, vec_size=2))
 
         model.connect('p1.A', 'lin.A')
         model.connect('p2.b', 'lin.b')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
-        lingrp.linear_solver = ScipyKrylov()
+        lingrp.linear_solver = om.ScipyKrylov()
 
         prob.set_solver_print(level=0)
         prob.run_model()
@@ -85,26 +84,26 @@ class TestLinearSystemComp(unittest.TestCase):
     def test_vectorized_A(self):
         """Check against the scipy solver."""
 
-        model = Group()
+        model = om.Group()
 
         x = np.array([[1, 2, -3], [2, -1, 4]])
         A = np.array([[[5.0, -3.0, 2.0], [1.0, 7.0, -4.0], [1.0, 0.0, 8.0]],
                       [[2.0, 3.0, 4.0], [1.0, -1.0, -2.0], [3.0, 2.0, -2.0]]])
         b = np.einsum('ijk,ik->ij', A, x)
 
-        model.add_subsystem('p1', IndepVarComp('A', A))
-        model.add_subsystem('p2', IndepVarComp('b', b))
+        model.add_subsystem('p1', om.IndepVarComp('A', A))
+        model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = model.add_subsystem('lingrp', Group(), promotes=['*'])
-        lingrp.add_subsystem('lin', LinearSystemComp(size=3, vec_size=2, vectorize_A=True))
+        lingrp = model.add_subsystem('lingrp', om.Group(), promotes=['*'])
+        lingrp.add_subsystem('lin', om.LinearSystemComp(size=3, vec_size=2, vectorize_A=True))
 
         model.connect('p1.A', 'lin.A')
         model.connect('p2.b', 'lin.b')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
-        lingrp.linear_solver = ScipyKrylov()
+        lingrp.linear_solver = om.ScipyKrylov()
 
         prob.set_solver_print(level=0)
         prob.run_model()
@@ -126,14 +125,14 @@ class TestLinearSystemComp(unittest.TestCase):
         b = A.dot(x)
         b_T = A.T.dot(x)
 
-        lin_sys_comp = LinearSystemComp(size=3)
+        lin_sys_comp = om.LinearSystemComp(size=3)
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('A', A))
-        prob.model.add_subsystem('p2', IndepVarComp('b', b))
+        prob.model.add_subsystem('p1', om.IndepVarComp('A', A))
+        prob.model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = prob.model.add_subsystem('lingrp', Group(), promotes=['*'])
+        lingrp = prob.model.add_subsystem('lingrp', om.Group(), promotes=['*'])
         lingrp.add_subsystem('lin', lin_sys_comp)
 
         prob.model.connect('p1.A', 'lin.A')
@@ -187,14 +186,14 @@ class TestLinearSystemComp(unittest.TestCase):
         b = np.einsum('jk,ik->ij', A, x)
         b_T = np.einsum('jk,ik->ij', A.T, x)
 
-        lin_sys_comp = LinearSystemComp(size=3, vec_size=2)
+        lin_sys_comp = om.LinearSystemComp(size=3, vec_size=2)
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('A', A))
-        prob.model.add_subsystem('p2', IndepVarComp('b', b))
+        prob.model.add_subsystem('p1', om.IndepVarComp('A', A))
+        prob.model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = prob.model.add_subsystem('lingrp', Group(), promotes=['*'])
+        lingrp = prob.model.add_subsystem('lingrp', om.Group(), promotes=['*'])
         lingrp.add_subsystem('lin', lin_sys_comp)
 
         prob.model.connect('p1.A', 'lin.A')
@@ -249,14 +248,14 @@ class TestLinearSystemComp(unittest.TestCase):
         b = np.einsum('ijk,ik->ij', A, x)
         b_T = np.einsum('ijk,ik->ij', A.transpose(0, 2, 1), x)
 
-        lin_sys_comp = LinearSystemComp(size=3, vec_size=2, vectorize_A=True)
+        lin_sys_comp = om.LinearSystemComp(size=3, vec_size=2, vectorize_A=True)
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('A', A))
-        prob.model.add_subsystem('p2', IndepVarComp('b', b))
+        prob.model.add_subsystem('p1', om.IndepVarComp('A', A))
+        prob.model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = prob.model.add_subsystem('lingrp', Group(), promotes=['*'])
+        lingrp = prob.model.add_subsystem('lingrp', om.Group(), promotes=['*'])
         lingrp.add_subsystem('lin', lin_sys_comp)
 
         prob.model.connect('p1.A', 'lin.A')
@@ -315,27 +314,26 @@ class TestLinearSystemComp(unittest.TestCase):
     def test_feature_basic(self):
         import numpy as np
 
-        from openmdao.api import Group, Problem, IndepVarComp
-        from openmdao.api import LinearSystemComp, ScipyKrylov
+        import openmdao.api as om
 
-        model = Group()
+        model = om.Group()
 
         A = np.array([[5.0, -3.0, 2.0], [1.0, 7.0, -4.0], [1.0, 0.0, 8.0]])
         b = np.array([1.0, 2.0, -3.0])
 
-        model.add_subsystem('p1', IndepVarComp('A', A))
-        model.add_subsystem('p2', IndepVarComp('b', b))
+        model.add_subsystem('p1', om.IndepVarComp('A', A))
+        model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = model.add_subsystem('lingrp', Group(), promotes=['*'])
-        lingrp.add_subsystem('lin', LinearSystemComp(size=3))
+        lingrp = model.add_subsystem('lingrp', om.Group(), promotes=['*'])
+        lingrp.add_subsystem('lin', om.LinearSystemComp(size=3))
 
         model.connect('p1.A', 'lin.A')
         model.connect('p2.b', 'lin.b')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
-        lingrp.linear_solver = ScipyKrylov()
+        lingrp.linear_solver = om.ScipyKrylov()
 
         prob.run_model()
 
@@ -344,27 +342,26 @@ class TestLinearSystemComp(unittest.TestCase):
     def test_feature_vectorized(self):
         import numpy as np
 
-        from openmdao.api import Group, Problem, IndepVarComp
-        from openmdao.api import LinearSystemComp, ScipyKrylov
+        import openmdao.api as om
 
-        model = Group()
+        model = om.Group()
 
         A = np.array([[5.0, -3.0, 2.0], [1.0, 7.0, -4.0], [1.0, 0.0, 8.0]])
         b = np.array([[2.0, -3.0, 4.0], [1.0, 0.0, -1.0]])
 
-        model.add_subsystem('p1', IndepVarComp('A', A))
-        model.add_subsystem('p2', IndepVarComp('b', b))
+        model.add_subsystem('p1', om.IndepVarComp('A', A))
+        model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = model.add_subsystem('lingrp', Group(), promotes=['*'])
-        lingrp.add_subsystem('lin', LinearSystemComp(size=3, vec_size=2))
+        lingrp = model.add_subsystem('lingrp', om.Group(), promotes=['*'])
+        lingrp.add_subsystem('lin', om.LinearSystemComp(size=3, vec_size=2))
 
         model.connect('p1.A', 'lin.A')
         model.connect('p2.b', 'lin.b')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
-        lingrp.linear_solver = ScipyKrylov()
+        lingrp.linear_solver = om.ScipyKrylov()
 
         prob.run_model()
 
@@ -375,28 +372,27 @@ class TestLinearSystemComp(unittest.TestCase):
     def test_feature_vectorized_A(self):
         import numpy as np
 
-        from openmdao.api import Group, Problem, IndepVarComp
-        from openmdao.api import LinearSystemComp, ScipyKrylov
+        import openmdao.api as om
 
-        model = Group()
+        model = om.Group()
 
         A = np.array([[[5.0, -3.0, 2.0], [1.0, 7.0, -4.0], [1.0, 0.0, 8.0]],
                       [[2.0, 3.0, 4.0], [1.0, -1.0, -2.0], [3.0, 2.0, -2.0]]])
         b = np.array([[-5.0, 2.0, 3.0], [-1.0, 1.0, -3.0]])
 
-        model.add_subsystem('p1', IndepVarComp('A', A))
-        model.add_subsystem('p2', IndepVarComp('b', b))
+        model.add_subsystem('p1', om.IndepVarComp('A', A))
+        model.add_subsystem('p2', om.IndepVarComp('b', b))
 
-        lingrp = model.add_subsystem('lingrp', Group(), promotes=['*'])
-        lingrp.add_subsystem('lin', LinearSystemComp(size=3, vec_size=2, vectorize_A=True))
+        lingrp = model.add_subsystem('lingrp', om.Group(), promotes=['*'])
+        lingrp.add_subsystem('lin', om.LinearSystemComp(size=3, vec_size=2, vectorize_A=True))
 
         model.connect('p1.A', 'lin.A')
         model.connect('p2.b', 'lin.b')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
-        lingrp.linear_solver = ScipyKrylov()
+        lingrp.linear_solver = om.ScipyKrylov()
 
         prob.run_model()
 

--- a/openmdao/components/tests/test_linear_system_comp.py
+++ b/openmdao/components/tests/test_linear_system_comp.py
@@ -139,7 +139,7 @@ class TestLinearSystemComp(unittest.TestCase):
         prob.model.connect('p1.A', 'lin.A')
         prob.model.connect('p2.b', 'lin.b')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob.run_model()
@@ -200,7 +200,7 @@ class TestLinearSystemComp(unittest.TestCase):
         prob.model.connect('p1.A', 'lin.A')
         prob.model.connect('p2.b', 'lin.b')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob.run_model()
@@ -262,7 +262,7 @@ class TestLinearSystemComp(unittest.TestCase):
         prob.model.connect('p1.A', 'lin.A')
         prob.model.connect('p2.b', 'lin.b')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob.run_model()

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, MatrixVectorProductComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
@@ -13,9 +13,9 @@ class TestMatrixVectorProductComp3x3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='A', shape=(self.nn, 3, 3))
         ivc.add_output(name='x', shape=(self.nn, 3))
 
@@ -24,7 +24,7 @@ class TestMatrixVectorProductComp3x3(unittest.TestCase):
                                    promotes_outputs=['A', 'x'])
 
         self.p.model.add_subsystem(name='mat_vec_product_comp',
-                                   subsys=MatrixVectorProductComp(vec_size=self.nn))
+                                   subsys=om.MatrixVectorProductComp(vec_size=self.nn))
 
         self.p.model.connect('A', 'mat_vec_product_comp.A')
         self.p.model.connect('x', 'mat_vec_product_comp.x')
@@ -62,9 +62,9 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='A', shape=(self.nn, 6, 4))
         ivc.add_output(name='x', shape=(self.nn, 4))
 
@@ -73,8 +73,8 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
                                    promotes_outputs=['A', 'x'])
 
         self.p.model.add_subsystem(name='mat_vec_product_comp',
-                                   subsys=MatrixVectorProductComp(vec_size=self.nn,
-                                                                  A_shape=(6, 4)))
+                                   subsys=om.MatrixVectorProductComp(vec_size=self.nn,
+                                                                     A_shape=(6, 4)))
 
         self.p.model.connect('A', 'mat_vec_product_comp.A')
         self.p.model.connect('x', 'mat_vec_product_comp.x')
@@ -109,9 +109,9 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
 class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
 
     def setUp(self):
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='A', shape=(3, 3))
         ivc.add_output(name='x', shape=(3, 1))
 
@@ -120,7 +120,7 @@ class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
                                    promotes_outputs=['A', 'x'])
 
         self.p.model.add_subsystem(name='mat_vec_product_comp',
-                                   subsys=MatrixVectorProductComp())
+                                   subsys=om.MatrixVectorProductComp())
 
         self.p.model.connect('A', 'mat_vec_product_comp.A')
         self.p.model.connect('x', 'mat_vec_product_comp.x')
@@ -157,9 +157,9 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='A', shape=(self.nn, 3, 3), units='ft')
         ivc.add_output(name='x', shape=(self.nn, 3), units='lbf')
 
@@ -168,9 +168,9 @@ class TestUnits(unittest.TestCase):
                                    promotes_outputs=['A', 'x'])
 
         self.p.model.add_subsystem(name='mat_vec_product_comp',
-                                   subsys=MatrixVectorProductComp(vec_size=self.nn,
-                                                                  A_units='m', x_units='N',
-                                                                  b_units='N*m'))
+                                   subsys=om.MatrixVectorProductComp(vec_size=self.nn,
+                                                                     A_units='m', x_units='N',
+                                                                     b_units='N*m'))
 
         self.p.model.connect('A', 'mat_vec_product_comp.A')
         self.p.model.connect('x', 'mat_vec_product_comp.x')
@@ -207,14 +207,14 @@ class TestFeature(unittest.TestCase):
 
     def test(self):
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, MatrixVectorProductComp
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         nn = 100
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='A', shape=(nn, 3, 3))
         ivc.add_output(name='x', shape=(nn, 3))
 
@@ -223,8 +223,8 @@ class TestFeature(unittest.TestCase):
                               promotes_outputs=['A', 'x'])
 
         p.model.add_subsystem(name='mat_vec_product_comp',
-                              subsys=MatrixVectorProductComp(A_name='M', vec_size=nn,
-                                                             b_name='y', b_units='m'))
+                              subsys=om.MatrixVectorProductComp(A_name='M', vec_size=nn,
+                                                                b_name='y', b_units='m'))
 
         p.model.connect('A', 'mat_vec_product_comp.M')
         p.model.connect('x', 'mat_vec_product_comp.x')

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -13,7 +13,7 @@ class TestMatrixVectorProductComp3x3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='A', shape=(self.nn, 3, 3))
@@ -62,7 +62,7 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='A', shape=(self.nn, 6, 4))
@@ -109,7 +109,7 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
 class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
 
     def setUp(self):
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='A', shape=(3, 3))
@@ -157,7 +157,7 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='A', shape=(self.nn, 3, 3), units='ft')
@@ -203,7 +203,7 @@ class TestUnits(unittest.TestCase):
                                                decimal=6)
 
 
-class TestForDocs(unittest.TestCase):
+class TestFeature(unittest.TestCase):
 
     def test(self):
         import numpy as np
@@ -212,7 +212,7 @@ class TestForDocs(unittest.TestCase):
 
         nn = 100
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='A', shape=(nn, 3, 3))

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -43,7 +43,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         # check that output with no specified surrogate gets the default
         sin_mm.options['default_surrogate'] = KrigingSurrogate()
-        prob.setup(check=False)
+        prob.setup()
         surrogate = sin_mm._metadata('f_x').get('surrogate')
         self.assertTrue(isinstance(surrogate, KrigingSurrogate),
                         'sin_mm.f_x should get the default surrogate')
@@ -76,7 +76,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('sin_mm', sin_mm)
 
-        prob.setup(check=False)
+        prob.setup()
 
         sin_mm.options['train:x'] = np.linspace(0,10,20)
         sin_mm.options['train:f_x'] = .5*np.sin(sin_mm.options['train:x'])
@@ -117,7 +117,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         # check that output with no specified surrogate gets the default
         sin_mm.options['default_surrogate'] = KrigingSurrogate()
-        prob.setup(check=False)
+        prob.setup()
 
         surrogate = sin_mm._metadata('f_x').get('surrogate')
         self.assertTrue(isinstance(surrogate, KrigingSurrogate),
@@ -140,7 +140,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem
         prob = Problem()
         prob.model.add_subsystem('sin_mm', sin_mm)
-        prob.setup(check=False)
+        prob.setup()
 
         # train the surrogate and check predicted value
         sin_mm.options['train:x'] = np.linspace(0,10,20)
@@ -168,7 +168,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add metamodel to a problem
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         # check that surrogates were properly assigned
         surrogate = mm._metadata('y1').get('surrogate')
@@ -204,7 +204,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         # change default surrogate, re-setup and check that metamodel re-trains
         mm.options['default_surrogate'] = KrigingSurrogate()
-        prob.setup(check=False)
+        prob.setup()
 
         surrogate = mm._metadata('y1').get('surrogate')
         self.assertTrue(isinstance(surrogate, KrigingSurrogate))
@@ -221,7 +221,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [
             [1.0, 1.0, 1.0, 1.0],
@@ -249,7 +249,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [
             [[1.0, 1.0], [1.0, 1.0]],
@@ -276,7 +276,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [
             [[1.0, 1.0], [1.0, 1.0]],
@@ -308,7 +308,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [
             [[1.0, 1.0], [1.0, 1.0]],
@@ -341,7 +341,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [1.0, 1.0, 1.0, 1.0]
         mm.options['train:y'] = [1.0, 2.0]
@@ -369,7 +369,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [1.0, 1.0, 1.0, 1.0]
         mm.options['train:y'] = [1.0, 2.0, 3.0, 4.0]
@@ -454,7 +454,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem, run and check the predicted values
         prob = Problem()
         prob.model.add_subsystem('trig', trig)
-        prob.setup(check=False)
+        prob.setup()
 
         prob['trig.x'] = 2.1
         prob.run_model()
@@ -476,7 +476,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem
         prob = Problem()
         prob.model.add_subsystem('trig', trig)
-        prob.setup(check=False)
+        prob.setup()
 
         # provide training data
         trig.options['train:x'] = np.linspace(0, 10, 20)
@@ -506,7 +506,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem
         prob = Problem()
         prob.model.add_subsystem('trig', trig)
-        prob.setup(check=False)
+        prob.setup()
 
         # provide training data
         trig.options['train:x'] = np.linspace(0, 10, 20)
@@ -540,7 +540,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem
         prob = Problem()
         prob.model.add_subsystem('trig', trig)
-        prob.setup(check=False)
+        prob.setup()
 
         # provide training data
         trig.options['train:x'] = np.linspace(0, 10, 20)
@@ -566,7 +566,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [
             [[1.0, 2.0, 1.0], [1.0, 2.0, 1.0]],
@@ -649,7 +649,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem
         prob = Problem()
         prob.model.add_subsystem('trig', trig)
-        prob.setup(check=False)
+        prob.setup()
 
         # provide training data
         trig.options['train:x'] = np.linspace(0, 10, 20)
@@ -678,7 +678,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add it to a Problem
         prob = Problem()
         prob.model.add_subsystem('trig', trig)
-        prob.setup(check=False)
+        prob.setup()
 
         # provide training data
         trig.options['train:x'] = np.linspace(0, 10, 20)
@@ -770,7 +770,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add metamodel to a problem
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         # check that surrogates were properly assigned
         surrogate = mm._metadata('y1').get('surrogate')
@@ -815,7 +815,7 @@ class MetaModelTestCase(unittest.TestCase):
         with assert_warning(DeprecationWarning, msg):
             mm.default_surrogate = KrigingSurrogate()
 
-        prob.setup(check=False)
+        prob.setup()
 
         surrogate = mm._metadata('y1').get('surrogate')
         self.assertTrue(isinstance(surrogate, KrigingSurrogate))
@@ -854,7 +854,7 @@ class MetaModelTestCase(unittest.TestCase):
         # add metamodel to a problem
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         # check that surrogates were properly assigned
         surrogate = mm._metadata('y1').get('surrogate')
@@ -899,7 +899,7 @@ class MetaModelTestCase(unittest.TestCase):
         with assert_warning(DeprecationWarning, msg):
             mm.default_surrogate = KrigingSurrogate()
 
-        prob.setup(check=False)
+        prob.setup()
 
         surrogate = mm._metadata('y1').get('surrogate')
         self.assertTrue(isinstance(surrogate, KrigingSurrogate))
@@ -978,7 +978,7 @@ class MetaModelTestCase(unittest.TestCase):
             prob.model.add_subsystem('indep', indep)
             prob.model.add_subsystem('trig', trig)
             prob.model.connect('indep.x', 'trig.x')
-            prob.setup(check=False)
+            prob.setup()
             prob['indep.x'] = 5.0
             trig.train = False
             prob.run_model()
@@ -1039,7 +1039,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob.model.add_subsystem('trig', trig)
         prob.model.connect('indep.x', 'trig.x')
         with self.assertRaises(ValueError) as context:
-            prob.setup(check=False)
+            prob.setup()
         expected_msg = 'Complex step has not been tested for MetaModelUnStructuredComp'
         self.assertEqual(expected_msg, str(context.exception))
 
@@ -1055,7 +1055,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob.model.add_subsystem('trig', trig)
         prob.model.connect('indep.x1', 'trig.x1')
         prob.model.connect('indep.x2', 'trig.x2')
-        prob.setup(check=False)
+        prob.setup()
         prob['indep.x1'] = 5.0
         prob['indep.x2'] = 5.0
         trig.train = False
@@ -1137,7 +1137,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob.model.add_design_var('indep.x', lower=4, upper=7)
         prob.model.add_objective('trig.sin_x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob['indep.x'] = 5.0
         prob.run_model()
         J = prob.compute_totals()
@@ -1145,7 +1145,7 @@ class MetaModelTestCase(unittest.TestCase):
         deriv_first_time = J[('trig.sin_x', 'indep.x')]
 
         # Setup and run a second time
-        prob.setup(check=False)
+        prob.setup()
         prob['indep.x'] = 5.0
         prob.run_model()
         J = prob.compute_totals()
@@ -1182,7 +1182,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob.model.add_objective('trig.sin_x')
 
         # Check to make sure bug reported in story 160200719 is fixed
-        prob.setup(check=False)
+        prob.setup()
         prob['indep.x'] = 5.0
         prob.run_model()
         J = prob.compute_totals()
@@ -1190,7 +1190,7 @@ class MetaModelTestCase(unittest.TestCase):
         deriv_first_time = J[('trig.sin_x', 'indep.x')]
 
         # Setup and run a second time
-        prob.setup(check=False)
+        prob.setup()
         prob['indep.x'] = 5.0
         prob.run_model()
         J = prob.compute_totals()

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -166,7 +166,7 @@ class MetaModelTestCase(unittest.TestCase):
         mm.options['default_surrogate'] = ResponseSurface()
 
         # add metamodel to a problem
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('mm', mm)
         prob.setup(check=False)
 
@@ -768,7 +768,7 @@ class MetaModelTestCase(unittest.TestCase):
             mm.default_surrogate = ResponseSurface()
 
         # add metamodel to a problem
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('mm', mm)
         prob.setup(check=False)
 
@@ -852,7 +852,7 @@ class MetaModelTestCase(unittest.TestCase):
             mm.default_surrogate = ResponseSurface()
 
         # add metamodel to a problem
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('mm', mm)
         prob.setup(check=False)
 

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -32,7 +32,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [0.0, 0.4, 1.0]
         mm.options['train:y'] = [3.02720998, 0.11477697, 15.82973195]
@@ -57,7 +57,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [0.0, 0.4, 1.0]
         mm.options['train:x2'] = [0.0, 0.4, 1.0, 999.0]
@@ -85,7 +85,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [0.0, 0.4, 1.0]
         mm.options['train:y'] = [3.02720998, 0.11477697, 15.82973195]
@@ -111,7 +111,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         self.assertEqual(mm.options['train:x'], None)
         self.assertEqual(mm.options['train:x_fi2'], None)
@@ -129,7 +129,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [0.0, 0.4, 1.0]
         mm.options['train:y'] = [3.02720998, 0.11477697, 15.82973195]
@@ -156,7 +156,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = [0.0, 0.4, 1.0]
         mm.options['train:y'] = [3.02720998, 0.11477697, 15.82973195]
@@ -175,7 +175,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
         np.testing.assert_array_equal(surr.xpredict, expected_xpredict)
 
         # Setup and run second time
-        prob.setup(check=False)
+        prob.setup()
         expected_xpredict=0.5
         prob['mm.x'] = expected_xpredict
         prob.run_model()
@@ -191,7 +191,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x']= [0.0, 0.4, 1.0]
         mm.options['train:x_fi2'] = [0.1, 0.2, 0.3, 0.5, 0.6,
@@ -226,7 +226,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x1']     = [1.0, 2.0, 3.0]
         mm.options['train:x1_fi2'] = [1.1, 2.1, 3.1, 1.0, 2.0, 3.0]
@@ -273,7 +273,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         x = [[[ 0.13073587,  0.24909577],  # expensive (hifi) doe
               [ 0.91915571,  0.4735261 ],
@@ -334,7 +334,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem()
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         mm.options['train:x'] = x[0]
         mm.options['train:y'] = y[0]
@@ -362,7 +362,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         self.assertEqual(mm.options['train:x'], None)
         self.assertEqual(mm.options['train:x_fi2'], None)
@@ -387,7 +387,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
 
         prob = Problem(Group())
         prob.model.add_subsystem('mm', mm)
-        prob.setup(check=False)
+        prob.setup()
 
         self.assertEqual(mm.options['train:x'], None)
         self.assertEqual(mm.options['train:x_fi2'], None)

--- a/openmdao/components/tests/test_mux_comp.py
+++ b/openmdao/components/tests/test_mux_comp.py
@@ -15,7 +15,7 @@ class TestMuxCompOptions(unittest.TestCase):
     def test_invalid_axis_scalar(self):
         nn = 10
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         for i in range(nn):
@@ -41,7 +41,7 @@ class TestMuxCompOptions(unittest.TestCase):
         a_size = 7
         b_size = 3
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         for i in range(nn):
@@ -72,7 +72,7 @@ class TestMuxCompScalar(unittest.TestCase):
     def setUp(self):
         self.nn = 10
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         for i in range(self.nn):
@@ -125,7 +125,7 @@ class TestMuxComp1D(unittest.TestCase):
         a_size = 7
         b_size = 3
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         for i in range(self.nn):
@@ -178,7 +178,7 @@ class TestMuxComp2D(unittest.TestCase):
         a_shape = (3, 3)
         b_shape = (2, 4)
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         for i in range(self.nn):
@@ -230,7 +230,7 @@ class TestMuxComp2D(unittest.TestCase):
         assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
 
-class TestForDocs(unittest.TestCase):
+class TestFeature(unittest.TestCase):
 
     def test(self):
         """
@@ -246,7 +246,7 @@ class TestForDocs(unittest.TestCase):
         # The size of each element to be muxed
         m = 100
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='x', shape=(m,), units='m')

--- a/openmdao/components/tests/test_mux_comp.py
+++ b/openmdao/components/tests/test_mux_comp.py
@@ -4,10 +4,8 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
-
-from openmdao.api import MuxComp
 
 
 class TestMuxCompOptions(unittest.TestCase):
@@ -15,15 +13,15 @@ class TestMuxCompOptions(unittest.TestCase):
     def test_invalid_axis_scalar(self):
         nn = 10
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         for i in range(nn):
             ivc.add_output(name='a_{0}'.format(i), val=1.0)
 
         p.model.add_subsystem(name='ivc', subsys=ivc, promotes_outputs=['*'])
 
-        mux_comp = p.model.add_subsystem(name='mux_comp', subsys=MuxComp(vec_size=nn))
+        mux_comp = p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=nn))
 
         mux_comp.add_var('a', shape=(1,), axis=2)
 
@@ -41,9 +39,9 @@ class TestMuxCompOptions(unittest.TestCase):
         a_size = 7
         b_size = 3
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         for i in range(nn):
             ivc.add_output(name='a_{0}'.format(i), shape=(a_size,))
             ivc.add_output(name='b_{0}'.format(i), shape=(b_size,))
@@ -52,7 +50,7 @@ class TestMuxCompOptions(unittest.TestCase):
                                    subsys=ivc,
                                    promotes_outputs=['*'])
 
-        mux_comp = p.model.add_subsystem(name='mux_comp', subsys=MuxComp(vec_size=nn))
+        mux_comp = p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=nn))
 
         mux_comp.add_var('a', shape=(a_size,), axis=0)
         mux_comp.add_var('b', shape=(b_size,), axis=2)
@@ -72,9 +70,9 @@ class TestMuxCompScalar(unittest.TestCase):
     def setUp(self):
         self.nn = 10
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         for i in range(self.nn):
             ivc.add_output(name='a_{0}'.format(i), val=1.0)
             ivc.add_output(name='b_{0}'.format(i), val=1.0)
@@ -83,7 +81,7 @@ class TestMuxCompScalar(unittest.TestCase):
                                    subsys=ivc,
                                    promotes_outputs=['*'])
 
-        mux_comp = self.p.model.add_subsystem(name='mux_comp', subsys=MuxComp(vec_size=self.nn))
+        mux_comp = self.p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=self.nn))
 
         mux_comp.add_var('a', shape=(1,), axis=0)
         mux_comp.add_var('b', shape=(1,), axis=1)
@@ -125,9 +123,9 @@ class TestMuxComp1D(unittest.TestCase):
         a_size = 7
         b_size = 3
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         for i in range(self.nn):
             ivc.add_output(name='a_{0}'.format(i), shape=(a_size,))
             ivc.add_output(name='b_{0}'.format(i), shape=(b_size,))
@@ -136,7 +134,7 @@ class TestMuxComp1D(unittest.TestCase):
                                    subsys=ivc,
                                    promotes_outputs=['*'])
 
-        mux_comp = self.p.model.add_subsystem(name='mux_comp', subsys=MuxComp(vec_size=self.nn))
+        mux_comp = self.p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=self.nn))
 
         mux_comp.add_var('a', shape=(a_size,), axis=0)
         mux_comp.add_var('b', shape=(b_size,), axis=1)
@@ -178,9 +176,9 @@ class TestMuxComp2D(unittest.TestCase):
         a_shape = (3, 3)
         b_shape = (2, 4)
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         for i in range(self.nn):
             ivc.add_output(name='a_{0}'.format(i), shape=a_shape)
             ivc.add_output(name='b_{0}'.format(i), shape=b_shape)
@@ -190,7 +188,7 @@ class TestMuxComp2D(unittest.TestCase):
                                    subsys=ivc,
                                    promotes_outputs=['*'])
 
-        mux_comp = self.p.model.add_subsystem(name='mux_comp', subsys=MuxComp(vec_size=self.nn))
+        mux_comp = self.p.model.add_subsystem(name='mux_comp', subsys=om.MuxComp(vec_size=self.nn))
 
         mux_comp.add_var('a', shape=a_shape, axis=0)
         mux_comp.add_var('b', shape=b_shape, axis=1)
@@ -237,7 +235,8 @@ class TestFeature(unittest.TestCase):
         An example demonstrating a trivial use case of MuxComp
         """
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, MuxComp, VectorMagnitudeComp
+
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         # The number of elements to be muxed
@@ -246,9 +245,9 @@ class TestFeature(unittest.TestCase):
         # The size of each element to be muxed
         m = 100
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='x', shape=(m,), units='m')
         ivc.add_output(name='y', shape=(m,), units='m')
         ivc.add_output(name='z', shape=(m,), units='m')
@@ -257,13 +256,13 @@ class TestFeature(unittest.TestCase):
                               subsys=ivc,
                               promotes_outputs=['x', 'y', 'z'])
 
-        mux_comp = p.model.add_subsystem(name='mux', subsys=MuxComp(vec_size=n))
+        mux_comp = p.model.add_subsystem(name='mux', subsys=om.MuxComp(vec_size=n))
 
         mux_comp.add_var('r', shape=(m,), axis=1, units='m')
 
         p.model.add_subsystem(name='vec_mag_comp',
-                              subsys=VectorMagnitudeComp(vec_size=m, length=n, in_name='r',
-                                                         mag_name='r_mag', units='m'))
+                              subsys=om.VectorMagnitudeComp(vec_size=m, length=n, in_name='r',
+                                                            mag_name='r_mag', units='m'))
 
         p.model.connect('x', 'mux.r_0')
         p.model.connect('y', 'mux.r_1')

--- a/openmdao/components/tests/test_vector_magnitude_comp.py
+++ b/openmdao/components/tests/test_vector_magnitude_comp.py
@@ -4,7 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, VectorMagnitudeComp
+import openmdao.api as om
 
 
 class TestVectorMagnitudeCompNx3(unittest.TestCase):
@@ -12,9 +12,9 @@ class TestVectorMagnitudeCompNx3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
 
         self.p.model.add_subsystem(name='ivc',
@@ -22,7 +22,7 @@ class TestVectorMagnitudeCompNx3(unittest.TestCase):
                                    promotes_outputs=['a'])
 
         self.p.model.add_subsystem(name='vec_mag_comp',
-                                   subsys=VectorMagnitudeComp(vec_size=self.nn))
+                                   subsys=om.VectorMagnitudeComp(vec_size=self.nn))
 
         self.p.model.connect('a', 'vec_mag_comp.a')
 
@@ -56,9 +56,9 @@ class TestVectorMagnitudeCompNx4(unittest.TestCase):
     def setUp(self):
         self.nn = 100
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 4))
 
         self.p.model.add_subsystem(name='ivc',
@@ -66,7 +66,7 @@ class TestVectorMagnitudeCompNx4(unittest.TestCase):
                                    promotes_outputs=['a'])
 
         self.p.model.add_subsystem(name='vec_mag_comp',
-                                   subsys=VectorMagnitudeComp(vec_size=self.nn, length=4))
+                                   subsys=om.VectorMagnitudeComp(vec_size=self.nn, length=4))
 
         self.p.model.connect('a', 'vec_mag_comp.a')
 
@@ -101,9 +101,9 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem()
+        self.p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3), units='m')
 
         self.p.model.add_subsystem(name='ivc',
@@ -111,7 +111,7 @@ class TestUnits(unittest.TestCase):
                                    promotes_outputs=['a'])
 
         self.p.model.add_subsystem(name='vec_mag_comp',
-                                   subsys=VectorMagnitudeComp(vec_size=self.nn, units='m'))
+                                   subsys=om.VectorMagnitudeComp(vec_size=self.nn, units='m'))
 
         self.p.model.connect('a', 'vec_mag_comp.a')
 
@@ -148,22 +148,22 @@ class TestFeature(unittest.TestCase):
         A simple example to compute the magnitude of 3-vectors at at 100 points simultaneously.
         """
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, VectorMagnitudeComp
+        import openmdao.api as om
         from openmdao.utils.assert_utils import assert_rel_error
 
         n = 100
 
-        p = Problem()
+        p = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output(name='pos', shape=(n, 3), units='m')
 
         p.model.add_subsystem(name='ivc',
                               subsys=ivc,
                               promotes_outputs=['pos'])
 
-        dp_comp = VectorMagnitudeComp(vec_size=n, length=3, in_name='r', mag_name='r_mag',
-                                      units='km')
+        dp_comp = om.VectorMagnitudeComp(vec_size=n, length=3, in_name='r', mag_name='r_mag',
+                                         units='km')
 
         p.model.add_subsystem(name='vec_mag_comp', subsys=dp_comp)
 

--- a/openmdao/components/tests/test_vector_magnitude_comp.py
+++ b/openmdao/components/tests/test_vector_magnitude_comp.py
@@ -12,7 +12,7 @@ class TestVectorMagnitudeCompNx3(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3))
@@ -56,7 +56,7 @@ class TestVectorMagnitudeCompNx4(unittest.TestCase):
     def setUp(self):
         self.nn = 100
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 4))
@@ -101,7 +101,7 @@ class TestUnits(unittest.TestCase):
     def setUp(self):
         self.nn = 5
 
-        self.p = Problem(model=Group())
+        self.p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='a', shape=(self.nn, 3), units='m')
@@ -141,7 +141,7 @@ class TestUnits(unittest.TestCase):
                                                decimal=6)
 
 
-class TestForDocs(unittest.TestCase):
+class TestFeature(unittest.TestCase):
 
     def test(self):
         """
@@ -153,7 +153,7 @@ class TestForDocs(unittest.TestCase):
 
         n = 100
 
-        p = Problem(model=Group())
+        p = Problem()
 
         ivc = IndepVarComp()
         ivc.add_output(name='pos', shape=(n, 3), units='m')

--- a/openmdao/core/tests/test_add_var.py
+++ b/openmdao/core/tests/test_add_var.py
@@ -1,14 +1,14 @@
 """Acceptance and developer tests for add_input and add_output."""
 from __future__ import division
-
-import numpy as np
 import unittest
 
-from openmdao.api import Problem, ExplicitComponent
+import numpy as np
+
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-class CompAddWithDefault(ExplicitComponent):
+class CompAddWithDefault(om.ExplicitComponent):
     """Component for tests for declaring only default value."""
 
     def setup(self):
@@ -24,7 +24,7 @@ class CompAddWithDefault(ExplicitComponent):
         self.add_output('y_e', val=6. * np.ones((3, 2)))
 
 
-class CompAddWithShape(ExplicitComponent):
+class CompAddWithShape(om.ExplicitComponent):
     """Component for tests for declaring only shape."""
 
     def setup(self):
@@ -36,7 +36,7 @@ class CompAddWithShape(ExplicitComponent):
         self.add_output('y_c', shape=[3, 3])
 
 
-class CompAddWithIndices(ExplicitComponent):
+class CompAddWithIndices(om.ExplicitComponent):
     """Component for tests for declaring only indices."""
 
     def setup(self):
@@ -49,7 +49,7 @@ class CompAddWithIndices(ExplicitComponent):
 
 
 
-class CompAddWithShapeAndIndices(ExplicitComponent):
+class CompAddWithShapeAndIndices(om.ExplicitComponent):
     """Component for tests for declaring shape and array indices."""
 
     def setup(self):
@@ -59,7 +59,7 @@ class CompAddWithShapeAndIndices(ExplicitComponent):
         self.add_input('x_d', shape=[2, 2], src_indices=np.arange(4).reshape((2, 2)))
 
 
-class CompAddArrayWithScalar(ExplicitComponent):
+class CompAddArrayWithScalar(om.ExplicitComponent):
     """Component for tests for declaring a scalar val with an array variable."""
 
     def setup(self):
@@ -71,7 +71,7 @@ class CompAddArrayWithScalar(ExplicitComponent):
         self.add_output('y_b', val=3.0, shape=(3, 2))
 
 
-class CompAddWithArrayIndices(ExplicitComponent):
+class CompAddWithArrayIndices(om.ExplicitComponent):
     """Component for tests for declaring with array val and array indices."""
 
     def setup(self):
@@ -80,7 +80,7 @@ class CompAddWithArrayIndices(ExplicitComponent):
         self.add_output('y')
 
 
-class CompAddWithBounds(ExplicitComponent):
+class CompAddWithBounds(om.ExplicitComponent):
     """Component for tests for declaring bounds."""
 
     def setup(self):
@@ -96,10 +96,10 @@ class TestAddVar(unittest.TestCase):
 
     def test_val(self):
         """Test declaring only default value."""
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_add_var import CompAddWithDefault
 
-        p = Problem(model=CompAddWithDefault())
+        p = om.Problem(model=CompAddWithDefault())
         p.setup()
 
         assert_rel_error(self, p['x_a'], 1.)
@@ -115,10 +115,10 @@ class TestAddVar(unittest.TestCase):
 
     def test_shape(self):
         """Test declaring only shape."""
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_add_var import CompAddWithShape
 
-        p = Problem(model=CompAddWithShape())
+        p = om.Problem(model=CompAddWithShape())
         p.setup()
 
         assert_rel_error(self, p['x_a'], np.ones(2))
@@ -130,10 +130,10 @@ class TestAddVar(unittest.TestCase):
 
     def test_indices(self):
         """Test declaring only indices."""
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_add_var import CompAddWithIndices
 
-        p = Problem(model=CompAddWithIndices())
+        p = om.Problem(model=CompAddWithIndices())
         p.setup()
 
         assert_rel_error(self, p['x_a'], 1.)
@@ -144,7 +144,7 @@ class TestAddVar(unittest.TestCase):
 
     def test_shape_and_indices(self):
         """Test declaring shape and indices."""
-        p = Problem(model=CompAddWithShapeAndIndices())
+        p = om.Problem(model=CompAddWithShapeAndIndices())
         p.setup()
 
         assert_rel_error(self, p['x_a'], np.ones(2))
@@ -154,10 +154,10 @@ class TestAddVar(unittest.TestCase):
 
     def test_scalar_array(self):
         """Test declaring a scalar val with an array variable."""
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_add_var import CompAddArrayWithScalar
 
-        p = Problem(model=CompAddArrayWithScalar())
+        p = om.Problem(model=CompAddArrayWithScalar())
         p.setup()
 
         assert_rel_error(self, p['x_a'], 2. * np.ones(6))
@@ -169,10 +169,10 @@ class TestAddVar(unittest.TestCase):
 
     def test_array_indices(self):
         """Test declaring with array val and array indices."""
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_add_var import CompAddWithArrayIndices
 
-        p = Problem(model=CompAddWithArrayIndices())
+        p = om.Problem(model=CompAddWithArrayIndices())
         p.setup()
 
         assert_rel_error(self, p['x_a'], 2. * np.ones(6))
@@ -180,10 +180,10 @@ class TestAddVar(unittest.TestCase):
 
     def test_bounds(self):
         """Test declaring bounds."""
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_add_var import CompAddWithBounds
 
-        p = Problem(model=CompAddWithBounds())
+        p = om.Problem(model=CompAddWithBounds())
         p.setup()
 
         assert_rel_error(self, p['y_a'], 2.)

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -699,7 +699,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_approx_totals_multi_input_constrained_desvar(self):
-        p = Problem(model=Group())
+        p = Problem()
 
         indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
 

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2056,27 +2056,27 @@ class ApproxTotalsFeature(unittest.TestCase):
 
         class CompOne(om.ExplicitComponent):
 
-                def setup(self):
-                    self.add_input('x', val=0.0)
-                    self.add_output('y', val=np.zeros(25))
-                    self._exec_count = 0
+            def setup(self):
+                self.add_input('x', val=0.0)
+                self.add_output('y', val=np.zeros(25))
+                self._exec_count = 0
 
-                def compute(self, inputs, outputs):
-                    x = inputs['x']
-                    outputs['y'] = np.arange(25) * x
-                    self._exec_count += 1
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                outputs['y'] = np.arange(25) * x
+                self._exec_count += 1
 
         class CompTwo(om.ExplicitComponent):
 
-                def setup(self):
-                    self.add_input('y', val=np.zeros(25))
-                    self.add_output('z', val=0.0)
-                    self._exec_count = 0
+            def setup(self):
+                self.add_input('y', val=np.zeros(25))
+                self.add_output('z', val=0.0)
+                self._exec_count = 0
 
-                def compute(self, inputs, outputs):
-                    y = inputs['y']
-                    outputs['z'] = np.sum(y)
-                    self._exec_count += 1
+            def compute(self, inputs, outputs):
+                y = inputs['y']
+                outputs['z'] = np.sum(y)
+                self._exec_count += 1
 
         prob = om.Problem()
         model = prob.model
@@ -2104,27 +2104,27 @@ class ApproxTotalsFeature(unittest.TestCase):
 
         class CompOne(om.ExplicitComponent):
 
-                def setup(self):
-                    self.add_input('x', val=0.0)
-                    self.add_output('y', val=np.zeros(25))
-                    self._exec_count = 0
+            def setup(self):
+                self.add_input('x', val=0.0)
+                self.add_output('y', val=np.zeros(25))
+                self._exec_count = 0
 
-                def compute(self, inputs, outputs):
-                    x = inputs['x']
-                    outputs['y'] = np.arange(25) * x
-                    self._exec_count += 1
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                outputs['y'] = np.arange(25) * x
+                self._exec_count += 1
 
         class CompTwo(om.ExplicitComponent):
 
-                def setup(self):
-                    self.add_input('y', val=np.zeros(25))
-                    self.add_output('z', val=0.0)
-                    self._exec_count = 0
+            def setup(self):
+                self.add_input('y', val=np.zeros(25))
+                self.add_output('z', val=0.0)
+                self._exec_count = 0
 
-                def compute(self, inputs, outputs):
-                    y = inputs['y']
-                    outputs['z'] = np.sum(y)
-                    self._exec_count += 1
+            def compute(self, inputs, outputs):
+                y = inputs['y']
+                outputs['z'] = np.sum(y)
+                self._exec_count += 1
 
         prob = om.Problem()
         model = prob.model
@@ -2151,27 +2151,27 @@ class ApproxTotalsFeature(unittest.TestCase):
 
         class CompOne(om.ExplicitComponent):
 
-                def setup(self):
-                    self.add_input('x', val=0.0)
-                    self.add_output('y', val=np.zeros(25))
-                    self._exec_count = 0
+            def setup(self):
+                self.add_input('x', val=0.0)
+                self.add_output('y', val=np.zeros(25))
+                self._exec_count = 0
 
-                def compute(self, inputs, outputs):
-                    x = inputs['x']
-                    outputs['y'] = np.arange(25) * x
-                    self._exec_count += 1
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                outputs['y'] = np.arange(25) * x
+                self._exec_count += 1
 
         class CompTwo(om.ExplicitComponent):
 
-                def setup(self):
-                    self.add_input('y', val=np.zeros(25))
-                    self.add_output('z', val=0.0)
-                    self._exec_count = 0
+            def setup(self):
+                self.add_input('y', val=np.zeros(25))
+                self.add_output('z', val=0.0)
+                self._exec_count = 0
 
-                def compute(self, inputs, outputs):
-                    y = inputs['y']
-                    outputs['z'] = np.sum(y)
-                    self._exec_count += 1
+            def compute(self, inputs, outputs):
+                y = inputs['y']
+                outputs['z'] = np.sum(y)
+                self._exec_count += 1
 
         prob = om.Problem()
         model = prob.model

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -7,9 +7,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, ExplicitComponent, ImplicitComponent, \
-    IndepVarComp, ExecComp, NonlinearRunOnce, NonlinearBlockGS, ScipyKrylov, NewtonSolver, \
-    DirectSolver, LinearBlockGS, BroydenSolver
+import openmdao.api as om
 from openmdao.core.tests.test_impl_comp import QuadraticLinearize, QuadraticJacVec
 from openmdao.core.tests.test_matmat import MultiJacVec
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayMatVec
@@ -29,7 +27,7 @@ except ImportError:
     PETScVector = None
 
 
-class ParaboloidTricky(ExplicitComponent):
+class ParaboloidTricky(om.ExplicitComponent):
     """
     Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.
     """
@@ -68,7 +66,7 @@ class ParaboloidTricky(ExplicitComponent):
         partials['f_xy', 'y'] = 2.0*y*sc*sc + 8.0*sc + x*sc*sc
 
 
-class MyCompGoodPartials(ExplicitComponent):
+class MyCompGoodPartials(om.ExplicitComponent):
     def setup(self):
         self.add_input('x1', 3.0)
         self.add_input('x2', 5.0)
@@ -85,7 +83,7 @@ class MyCompGoodPartials(ExplicitComponent):
         J['y', 'x2'] = np.array([4.0])
 
 
-class MyCompBadPartials(ExplicitComponent):
+class MyCompBadPartials(om.ExplicitComponent):
     def setup(self):
         self.add_input('y1', 3.0)
         self.add_input('y2', 5.0)
@@ -102,7 +100,7 @@ class MyCompBadPartials(ExplicitComponent):
         J['z', 'y2'] = np.array([40.0])
 
 
-class MyComp(ExplicitComponent):
+class MyComp(om.ExplicitComponent):
     def setup(self):
         self.add_input('x1', 3.0)
         self.add_input('x2', 5.0)
@@ -125,10 +123,10 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_incorrect_jacobian(self):
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyComp())
 
         prob.model.connect('p1.x1', 'comp.x1')
@@ -157,7 +155,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_component_only(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = MyComp()
 
         prob.set_solver_print(level=0)
@@ -177,7 +175,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_component_only_suppress(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = MyComp()
 
         prob.set_solver_print(level=0)
@@ -198,13 +196,13 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(len(lines), 0)
 
     def test_component_has_no_outputs(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem("indep", IndepVarComp('x', 5.))
-        model.add_subsystem("comp1", ExecComp("y=2*x"))
+        model.add_subsystem("indep", om.IndepVarComp('x', 5.))
+        model.add_subsystem("comp1", om.ExecComp("y=2*x"))
 
-        comp2 = model.add_subsystem("comp2", ExplicitComponent())
+        comp2 = model.add_subsystem("comp2", om.ExplicitComponent())
         comp2.add_input('x', val=0.)
 
         model.connect('indep.x', ['comp1.x', 'comp2.x'])
@@ -229,7 +227,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         assert_rel_error(self, data['comp1'][('y', 'x')]['J_rev'][0][0], 2., 1e-15)
 
     def test_missing_entry(self):
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -249,9 +247,9 @@ class TestProblemCheckPartials(unittest.TestCase):
                 J['y', 'x1'] = np.array([3.0])
                 self.lin_count += 1
 
-        prob = Problem()
-        prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p1', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyComp())
 
         prob.model.connect('p1.x1', 'comp.x1')
@@ -285,7 +283,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                                delta=1e-6)
 
     def test_nested_fd_units(self):
-        class UnitCompBase(ExplicitComponent):
+        class UnitCompBase(om.ExplicitComponent):
             def setup(self):
                 self.add_input('T', val=284., units="degR", desc="Temperature")
                 self.add_input('P', val=1., units='lbf/inch**2', desc="Pressure")
@@ -300,9 +298,9 @@ class TestProblemCheckPartials(unittest.TestCase):
                 outputs['flow:T'] = inputs['T']
                 outputs['flow:P'] = inputs['P']
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        indep = model.add_subsystem('indep', IndepVarComp(), promotes=['*'])
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes=['*'])
 
         indep.add_output('T', val=100., units='degK')
         indep.add_output('P', val=1., units='bar')
@@ -321,7 +319,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.assertAlmostEqual(np.linalg.norm(forward - fd), 0., delta=1e-6)
 
     def test_units(self):
-        class UnitCompBase(ExplicitComponent):
+        class UnitCompBase(om.ExplicitComponent):
             def setup(self):
                 self.add_input('T', val=284., units="degR", desc="Temperature")
                 self.add_input('P', val=1., units='lbf/inch**2', desc="Pressure")
@@ -343,16 +341,16 @@ class TestProblemCheckPartials(unittest.TestCase):
 
                 self.run_count += 1
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        indep = model.add_subsystem('indep', IndepVarComp(), promotes=['*'])
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes=['*'])
 
         indep.add_output('T', val=100., units='degK')
         indep.add_output('P', val=1., units='bar')
 
         units = model.add_subsystem('units', UnitCompBase(), promotes=['*'])
 
-        model.nonlinear_solver = NonlinearRunOnce()
+        model.nonlinear_solver = om.NonlinearRunOnce()
 
         p.setup()
         data = p.check_partials(out_stream=None)
@@ -371,7 +369,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(units.run_count, 5)
 
     def test_scalar_val(self):
-        class PassThrough(ExplicitComponent):
+        class PassThrough(om.ExplicitComponent):
             """
             Helper component that is needed when variables must be passed
             directly from input to output
@@ -409,9 +407,9 @@ class TestProblemCheckPartials(unittest.TestCase):
             def linearize(self, inputs, outputs, J):
                 pass
 
-        p = Problem()
+        p = om.Problem()
 
-        indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('foo', val=np.ones(4))
         indeps.add_output('foo2', val=np.ones(4))
 
@@ -434,10 +432,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         assert_rel_error(self, data['pt2'][('bar2', 'foo2')]['J_fd'], identity, 1e-9)
 
     def test_matrix_free_explicit(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidMatVec())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -467,9 +465,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         assert_rel_error(self, data['comp'][('f_xy', 'y')]['J_rev'][0][0], 21.0, 1e-6)
 
     def test_matrix_free_implicit(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('rhs', np.ones((2, ))))
+        prob.model.add_subsystem('p1', om.IndepVarComp('rhs', np.ones((2, ))))
         prob.model.add_subsystem('comp', TestImplCompArrayMatVec())
 
         prob.model.connect('p1.rhs', 'comp.rhs')
@@ -496,7 +494,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         # Test to see that check_partials works when state_wrt_input and state_wrt_state
         # partials are missing.
 
-        class ImplComp4Test(ImplicitComponent):
+        class ImplComp4Test(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.ones(2))
@@ -517,10 +515,10 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['y', 'x'] = -np.eye(2)
                 partials['y', 'y'] = self.mtx
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', np.ones((2, ))))
-        prob.model.add_subsystem('p2', IndepVarComp('dummy', np.ones((2, ))))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', np.ones((2, ))))
+        prob.model.add_subsystem('p2', om.IndepVarComp('dummy', np.ones((2, ))))
         prob.model.add_subsystem('comp', ImplComp4Test())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -541,7 +539,7 @@ class TestProblemCheckPartials(unittest.TestCase):
     def test_dependent_false_hide(self):
         # Test that we omit derivs declared with dependent=False
 
-        class SimpleComp1(ExplicitComponent):
+        class SimpleComp1(om.ExplicitComponent):
             def setup(self):
                 self.add_input('z', shape=(2, 2))
                 self.add_input('x', shape=(2, 2))
@@ -556,10 +554,10 @@ class TestProblemCheckPartials(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['g', 'x'] = 3.
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('z', np.ones((2, 2))))
-        prob.model.add_subsystem('p2', IndepVarComp('x', np.ones((2, 2))))
+        prob.model.add_subsystem('p1', om.IndepVarComp('z', np.ones((2, 2))))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x', np.ones((2, 2))))
         prob.model.add_subsystem('comp', SimpleComp1())
         prob.model.connect('p1.z', 'comp.z')
         prob.model.connect('p2.x', 'comp.x')
@@ -579,7 +577,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         # API Change: we no longer omit derivatives for compact_print, even when declared as not
         # dependent.
 
-        class SimpleComp1(ExplicitComponent):
+        class SimpleComp1(om.ExplicitComponent):
             def setup(self):
                 self.add_input('z', shape=(2, 2))
                 self.add_input('x', shape=(2, 2))
@@ -594,10 +592,10 @@ class TestProblemCheckPartials(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['g', 'x'] = 3.
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('z', np.ones((2, 2))))
-        prob.model.add_subsystem('p2', IndepVarComp('x', np.ones((2, 2))))
+        prob.model.add_subsystem('p1', om.IndepVarComp('z', np.ones((2, 2))))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x', np.ones((2, 2))))
         prob.model.add_subsystem('comp', SimpleComp1())
         prob.model.connect('p1.z', 'comp.z')
         prob.model.connect('p2.x', 'comp.x')
@@ -617,7 +615,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         # Test that we show derivs declared with dependent=False if the fd is not
         # ~zero.
 
-        class SimpleComp2(ExplicitComponent):
+        class SimpleComp2(om.ExplicitComponent):
             def setup(self):
                 self.add_input('z', shape=(2, 2))
                 self.add_input('x', shape=(2, 2))
@@ -632,10 +630,10 @@ class TestProblemCheckPartials(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['g', 'x'] = 3.
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('z', np.ones((2, 2))))
-        prob.model.add_subsystem('p2', IndepVarComp('x', np.ones((2, 2))))
+        prob.model.add_subsystem('p1', om.IndepVarComp('z', np.ones((2, 2))))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x', np.ones((2, 2))))
         prob.model.add_subsystem('comp', SimpleComp2())
         prob.model.connect('p1.z', 'comp.z')
         prob.model.connect('p2.x', 'comp.x')
@@ -652,10 +650,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertTrue(('g', 'x') in data['comp'])
 
     def test_set_step_on_comp(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -676,10 +674,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-5)
 
     def test_set_step_global(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -698,10 +696,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-5)
 
     def test_complex_step_not_allocated(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidMatVec())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -728,10 +726,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-5)
 
     def test_set_method_on_comp(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -751,10 +749,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-5)
 
     def test_set_method_global(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -772,10 +770,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-5)
 
     def test_set_form_on_comp(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -796,10 +794,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-3)
 
     def test_set_form_global(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -818,10 +816,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 1e-3)
 
     def test_set_step_calc_on_comp(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -842,10 +840,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertLess(x_error.reverse, 3e-3)
 
     def test_set_step_calc_global(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -866,7 +864,7 @@ class TestProblemCheckPartials(unittest.TestCase):
     def test_set_check_option_precedence(self):
         # Test that we omit derivs declared with dependent=False
 
-        class SimpleComp1(ExplicitComponent):
+        class SimpleComp1(om.ExplicitComponent):
             def setup(self):
                 self.add_input('ab', 13.0)
                 self.add_input('aba', 13.0)
@@ -891,11 +889,11 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['y', 'aba'] = 3.0*aba**2
                 partials['y', 'ba'] = 3.0*ba**2
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('ab', 13.0))
-        prob.model.add_subsystem('p2', IndepVarComp('aba', 13.0))
-        prob.model.add_subsystem('p3', IndepVarComp('ba', 13.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('ab', 13.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('aba', 13.0))
+        prob.model.add_subsystem('p3', om.IndepVarComp('ba', 13.0))
         comp = prob.model.add_subsystem('comp', SimpleComp1())
 
         prob.model.connect('p1.ab', 'comp.ab')
@@ -918,10 +916,10 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_option_printing(self):
         # Make sure we print the approximation type for each variable.
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -945,14 +943,14 @@ class TestProblemCheckPartials(unittest.TestCase):
                         msg='Did you change the format for printing check derivs?')
 
     def test_set_check_partial_options_invalid(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
         prob.model.add_subsystem('comp2', ParaboloidMatVec())
 
@@ -1031,7 +1029,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                          "for check_partial options on Component 'comp': ['a', 'b', 'c'].")
 
     def test_compact_print_formatting(self):
-        class MyCompShortVarNames(ExplicitComponent):
+        class MyCompShortVarNames(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -1047,7 +1045,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                 J['y', 'x1'] = np.array([4.0])
                 J['y', 'x2'] = np.array([40])
 
-        class MyCompLongVarNames(ExplicitComponent):
+        class MyCompLongVarNames(om.ExplicitComponent):
             def setup(self):
                 self.add_input('really_long_variable_name_x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -1065,9 +1063,9 @@ class TestProblemCheckPartials(unittest.TestCase):
                 J['really_long_variable_name_y', 'x2'] = np.array([40])
 
         # First short var names
-        prob = Problem()
-        prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p1', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyCompShortVarNames())
         prob.model.connect('p1.x1', 'comp.x1')
         prob.model.connect('p2.x2', 'comp.x2')
@@ -1090,9 +1088,9 @@ class TestProblemCheckPartials(unittest.TestCase):
                     header_locations_of_bars = [i for i, ltr in enumerate(line) if ltr == sep]
 
         # Then long var names
-        prob = Problem()
-        prob.model.add_subsystem('p1', IndepVarComp('really_long_variable_name_x1', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p1', om.IndepVarComp('really_long_variable_name_x1', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyCompLongVarNames())
         prob.model.connect('p1.really_long_variable_name_x1', 'comp.really_long_variable_name_x1')
         prob.model.connect('p2.x2', 'comp.x2')
@@ -1116,7 +1114,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_compact_print_exceed_tol(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = MyCompGoodPartials()
         prob.set_solver_print(level=0)
         prob.setup()
@@ -1126,7 +1124,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(stream.getvalue().count('>ABS_TOL'), 0)
         self.assertEqual(stream.getvalue().count('>REL_TOL'), 0)
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = MyCompBadPartials()
         prob.set_solver_print(level=0)
         prob.setup()
@@ -1139,8 +1137,8 @@ class TestProblemCheckPartials(unittest.TestCase):
     def test_check_partials_display_rev(self):
 
         # 1: Check display of revs for implicit comp for compact and non-compact display
-        group = Group()
-        comp1 = group.add_subsystem('comp1', IndepVarComp())
+        group = om.Group()
+        comp1 = group.add_subsystem('comp1', om.IndepVarComp())
         comp1.add_output('a', 1.0)
         comp1.add_output('b', -4.0)
         comp1.add_output('c', 3.0)
@@ -1152,7 +1150,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         group.connect('comp1.a', 'comp3.a')
         group.connect('comp1.b', 'comp3.b')
         group.connect('comp1.c', 'comp3.c')
-        prob = Problem(model=group)
+        prob = om.Problem(model=group)
         prob.setup()
 
         stream = cStringIO()
@@ -1169,7 +1167,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(stream.getvalue().count('Jrev'), 20)
 
         # 2: Explicit comp, all comps define Jacobians for compact and non-compact display
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -1185,7 +1183,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                 J['z', 'x1'] = np.array([3.0])
                 J['z', 'x2'] = np.array([-4444.0])
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = MyComp()
         prob.set_solver_print(level=0)
         prob.setup()
@@ -1207,9 +1205,9 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # 3: Explicit comp that does not define Jacobian. It defines compute_jacvec_product
         #      For both compact and non-compact display
-        prob = Problem()
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidMatVec())
         prob.model.connect('p1.x', 'comp.x')
         prob.model.connect('p2.y', 'comp.y')
@@ -1226,11 +1224,11 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(stream.getvalue().count('Jrev'), 10)
 
         # 4: Mixed comps. Some with jacobians. Some not
-        prob = Problem()
-        prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p0', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('c0', MyComp())  # in x1,x2, out is z
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidMatVec())
         prob.model.connect('p0.x1', 'c0.x1')
         prob.model.connect('p1.x2', 'c0.x2')
@@ -1259,10 +1257,10 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # 5: One comp defines compute_multi_jacvec_product
         size = 6
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('px', IndepVarComp('x', val=(np.arange(size, dtype=float) + 1.) * 3.0))
-        model.add_subsystem('py', IndepVarComp('y', val=(np.arange(size, dtype=float) + 1.) * 2.0))
+        model.add_subsystem('px', om.IndepVarComp('x', val=(np.arange(size, dtype=float) + 1.) * 3.0))
+        model.add_subsystem('py', om.IndepVarComp('y', val=(np.arange(size, dtype=float) + 1.) * 2.0))
         model.add_subsystem('comp', MultiJacVec(size))
 
         model.connect('px.x', 'comp.x')
@@ -1285,10 +1283,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         # repeat the full row for the worst-case subjac (i.e., output-input pair).
         # This should only occur in the compact_print=True case.
 
-        prob = Problem()
-        prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y2', 6.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p0', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x2', 5.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y2', 6.0))
         prob.model.add_subsystem('good', MyCompGoodPartials())
         prob.model.add_subsystem('bad', MyCompBadPartials())
         prob.model.connect('p0.x1', 'good.x1')
@@ -1310,10 +1308,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         # it should print only the subjacs found to be incorrect. This applies
         # to both compact_print=True and False.
 
-        prob = Problem()
-        prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y2', 6.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p0', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x2', 5.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y2', 6.0))
         prob.model.add_subsystem('good', MyCompGoodPartials())
         prob.model.add_subsystem('bad', MyCompBadPartials())
         prob.model.connect('p0.x1', 'good.x1')
@@ -1339,19 +1337,19 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_includes_excludes(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        sub = model.add_subsystem('c1c', Group())
-        sub.add_subsystem('d1', ExecComp('y=2*x'))
-        sub.add_subsystem('e1', ExecComp('y=2*x'))
+        sub = model.add_subsystem('c1c', om.Group())
+        sub.add_subsystem('d1', om.ExecComp('y=2*x'))
+        sub.add_subsystem('e1', om.ExecComp('y=2*x'))
 
-        sub2 = model.add_subsystem('sss', Group())
-        sub3 = sub2.add_subsystem('sss2', Group())
-        sub2.add_subsystem('d1', ExecComp('y=2*x'))
-        sub3.add_subsystem('e1', ExecComp('y=2*x'))
+        sub2 = model.add_subsystem('sss', om.Group())
+        sub3 = sub2.add_subsystem('sss2', om.Group())
+        sub2.add_subsystem('d1', om.ExecComp('y=2*x'))
+        sub3.add_subsystem('e1', om.ExecComp('y=2*x'))
 
-        model.add_subsystem('abc1cab', ExecComp('y=2*x'))
+        model.add_subsystem('abc1cab', om.ExecComp('y=2*x'))
 
         prob.setup()
         prob.run_model()
@@ -1380,7 +1378,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_directional_derivative_option(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
         mycomp = model.add_subsystem('mycomp', ArrayComp(), promotes=['*'])
 
@@ -1413,7 +1411,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                 super(ArrayCompCS, self).setup()
                 self.set_check_partial_options('x*', directional=True, method='cs')
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
         mycomp = model.add_subsystem('mycomp', ArrayCompCS(), promotes=['*'])
 
@@ -1436,7 +1434,7 @@ class TestProblemCheckPartials(unittest.TestCase):
     def test_bug_local_method(self):
         # This fixes a bug setting the check method on a component overrode the requested method for
         # subsequent components.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         model.add_subsystem('comp1', Paraboloid())
@@ -1463,7 +1461,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         # When the fd turns out to be zero, test that we switch the definition of relative
         # to divide by the forward derivative instead of reporting NaN.
 
-        class SimpleComp2(ExplicitComponent):
+        class SimpleComp2(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x', val=3.0)
                 self.add_output('y', val=4.0)
@@ -1477,9 +1475,9 @@ class TestProblemCheckPartials(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['y', 'x'] = 3.0
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.5))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.5))
         prob.model.add_subsystem('comp', SimpleComp2())
         prob.model.connect('p1.x', 'comp.x')
 
@@ -1497,9 +1495,9 @@ class TestCheckPartialsFeature(unittest.TestCase):
     def test_feature_incorrect_jacobian(self):
         import numpy as np
 
-        from openmdao.api import Group, ExplicitComponent, IndepVarComp, Problem
+        import openmdao.api as om
 
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -1517,10 +1515,10 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['y', 'x1'] = np.array([4.0])
                 J['y', 'x2'] = np.array([40])
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyComp())
 
         prob.model.connect('p1.x1', 'comp.x1')
@@ -1546,9 +1544,9 @@ class TestCheckPartialsFeature(unittest.TestCase):
     def test_feature_check_partials_suppress(self):
         import numpy as np
 
-        from openmdao.api import Group, ExplicitComponent, IndepVarComp, Problem
+        import openmdao.api as om
 
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -1566,10 +1564,10 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['y', 'x1'] = np.array([4.0])
                 J['y', 'x2'] = np.array([40])
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyComp())
 
         prob.model.connect('p1.x1', 'comp.x1')
@@ -1584,14 +1582,14 @@ class TestCheckPartialsFeature(unittest.TestCase):
         print(data)
 
     def test_set_step_on_comp(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
         prob.model.add_subsystem('comp2', ParaboloidMatVec())
 
@@ -1609,14 +1607,14 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(compact_print=True)
 
     def test_set_step_global(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
         prob.model.add_subsystem('comp2', ParaboloidMatVec())
 
@@ -1632,14 +1630,14 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(step=1e-2, compact_print=True)
 
     def test_set_method_on_comp(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         comp = prob.model.add_subsystem('comp', ParaboloidTricky())
         prob.model.add_subsystem('comp2', ParaboloidMatVec())
 
@@ -1657,14 +1655,14 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(compact_print=True)
 
     def test_set_method_global(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
         prob.model.add_subsystem('comp2', ParaboloidMatVec())
 
@@ -1680,14 +1678,14 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(method='cs', compact_print=True)
 
     def test_set_form_global(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
         prob.model.add_subsystem('comp2', ParaboloidMatVec())
 
@@ -1703,13 +1701,13 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(form='central', compact_print=True)
 
     def test_set_step_calc_global(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidTricky())
 
         prob.model.connect('p1.x', 'comp.x')
@@ -1724,9 +1722,9 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
     def test_feature_check_partials_show_only_incorrect(self):
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent
+        import openmdao.api as om
 
-        class MyCompGoodPartials(ExplicitComponent):
+        class MyCompGoodPartials(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x1', 3.0)
                 self.add_input('x2', 5.0)
@@ -1742,7 +1740,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['y', 'x1'] = np.array([3.0])
                 J['y', 'x2'] = np.array([4.0])
 
-        class MyCompBadPartials(ExplicitComponent):
+        class MyCompBadPartials(om.ExplicitComponent):
             def setup(self):
                 self.add_input('y1', 3.0)
                 self.add_input('y2', 5.0)
@@ -1758,10 +1756,10 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['z', 'y1'] = np.array([33.0])
                 J['z', 'y2'] = np.array([40.0])
 
-        prob = Problem()
-        prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
-        prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
-        prob.model.add_subsystem('p2', IndepVarComp('y2', 6.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('p0', om.IndepVarComp('x1', 3.0))
+        prob.model.add_subsystem('p1', om.IndepVarComp('x2', 5.0))
+        prob.model.add_subsystem('p2', om.IndepVarComp('y2', 6.0))
         prob.model.add_subsystem('good', MyCompGoodPartials())
         prob.model.add_subsystem('bad', MyCompBadPartials())
         prob.model.connect('p0.x1', 'good.x1')
@@ -1776,21 +1774,21 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(compact_print=False, show_only_incorrect=True)
 
     def test_includes_excludes(self):
-        from openmdao.api import Problem, Group, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        sub = model.add_subsystem('c1c', Group())
-        sub.add_subsystem('d1', ExecComp('y=2*x'))
-        sub.add_subsystem('e1', ExecComp('y=2*x'))
+        sub = model.add_subsystem('c1c', om.Group())
+        sub.add_subsystem('d1', om.ExecComp('y=2*x'))
+        sub.add_subsystem('e1', om.ExecComp('y=2*x'))
 
-        sub2 = model.add_subsystem('sss', Group())
-        sub3 = sub2.add_subsystem('sss2', Group())
-        sub2.add_subsystem('d1', ExecComp('y=2*x'))
-        sub3.add_subsystem('e1', ExecComp('y=2*x'))
+        sub2 = model.add_subsystem('sss', om.Group())
+        sub3 = sub2.add_subsystem('sss2', om.Group())
+        sub2.add_subsystem('d1', om.ExecComp('y=2*x'))
+        sub3.add_subsystem('e1', om.ExecComp('y=2*x'))
 
-        model.add_subsystem('abc1cab', ExecComp('y=2*x'))
+        model.add_subsystem('abc1cab', om.ExecComp('y=2*x'))
 
         prob.setup()
         prob.run_model()
@@ -1804,10 +1802,10 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.check_partials(compact_print=True, includes='*c*c*', excludes=['*e*'])
 
     def test_directional(self):
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.test_suite.components.array_comp import ArrayComp
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
         mycomp = model.add_subsystem('mycomp', ArrayComp(), promotes=['*'])
 
@@ -1820,9 +1818,9 @@ class TestCheckPartialsFeature(unittest.TestCase):
 class TestProblemCheckTotals(unittest.TestCase):
 
     def test_cs(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -1854,9 +1852,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fd'], [[0.09692762]], 1e-5)
 
     def test_desvar_as_obj(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_objective('x')
@@ -1885,7 +1883,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
     def test_desvar_and_response_with_indices(self):
 
-        class ArrayComp2D(ExplicitComponent):
+        class ArrayComp2D(om.ExplicitComponent):
             """
             A fairly simple array component.
             """
@@ -1917,9 +1915,9 @@ class TestProblemCheckTotals(unittest.TestCase):
                 """
                 partials[('y1', 'x1')] = self.JJ
 
-        prob = Problem()
-        prob.model = model = Group()
-        model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))),
+        prob = om.Problem()
+        model = prob.model
+        model.add_subsystem('x_param1', om.IndepVarComp('x1', np.ones((4))),
                             promotes=['x1'])
         mycomp = model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
 
@@ -1950,9 +1948,9 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # Objective instead
 
-        prob = Problem()
-        prob.model = model = Group()
-        model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))),
+        prob = om.Problem()
+        model = prob.model
+        model.add_subsystem('x_param1', om.IndepVarComp('x1', np.ones((4))),
                             promotes=['x1'])
         mycomp = model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
 
@@ -1978,9 +1976,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_rel_error(self, jac[0][1], Jbase[1, 3], 1e-8)
 
     def test_cs_suppress(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -2006,9 +2004,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertTrue('magnitude' in data)
 
     def test_two_desvar_as_con(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('z', lower=-100, upper=100)
         prob.model.add_design_var('x', lower=-100, upper=100)
@@ -2035,9 +2033,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_rel_error(self, totals['pz.z', 'px.x']['J_fd'], [[0.0], [0.0]], 1e-5)
 
     def test_full_con_with_index_desvar(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('z', lower=-100, upper=100, indices=[1])
         prob.model.add_constraint('z', upper=0.0)
@@ -2056,9 +2054,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], [[0.0], [1.0]], 1e-5)
 
     def test_full_desvar_with_index_con(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('z', lower=-100, upper=100)
         prob.model.add_constraint('z', upper=0.0, indices=[1])
@@ -2077,9 +2075,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], [[0.0, 1.0]], 1e-5)
 
     def test_full_desvar_with_index_obj(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('z', lower=-100, upper=100)
         prob.model.add_objective('z', index=1)
@@ -2100,7 +2098,7 @@ class TestProblemCheckTotals(unittest.TestCase):
     def test_bug_fd_with_sparse(self):
         # This bug was found via the x57 model in pointer.
 
-        class TimeComp(ExplicitComponent):
+        class TimeComp(om.ExplicitComponent):
 
             def setup(self):
                 self.node_ptau = node_ptau = np.array([-1., 0., 1.])
@@ -2126,7 +2124,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
                 jacobian['time', 't_duration'] = 0.5 * (node_ptau + 33)
 
-        class CellComp(ExplicitComponent):
+        class CellComp(om.ExplicitComponent):
 
             def initialize(self):
                 self.options.declare('num_nodes', types=int)
@@ -2148,12 +2146,12 @@ class TestProblemCheckTotals(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['zSOC', 'I_Li'] = -1./(3600.0)
 
-        class GaussLobattoPhase(Group):
+        class GaussLobattoPhase(om.Group):
 
             def setup(self):
                 self.connect('t_duration', 'time.t_duration')
 
-                indep = IndepVarComp()
+                indep = om.IndepVarComp()
                 indep.add_output('t_duration', val=1.0)
                 self.add_subsystem('time_extents', indep, promotes_outputs=['*'])
                 self.add_design_var('t_duration', 5.0, 25.0)
@@ -2163,18 +2161,18 @@ class TestProblemCheckTotals(unittest.TestCase):
 
                 self.add_subsystem(name='cell', subsys=CellComp(num_nodes=3))
 
-                self.linear_solver = ScipyKrylov()
-                self.nonlinear_solver = NewtonSolver()
+                self.linear_solver = om.ScipyKrylov()
+                self.nonlinear_solver = om.NewtonSolver()
                 self.nonlinear_solver.options['maxiter'] = 1
 
             def initialize(self):
                 self.options.declare('ode_class', desc='System defining the ODE.')
 
-        p = Problem(model=GaussLobattoPhase())
+        p = om.Problem(model=GaussLobattoPhase())
 
         p.model.add_objective('time', index=-1)
 
-        p.model.linear_solver = ScipyKrylov(assemble_jac=True)
+        p.model.linear_solver = om.ScipyKrylov(assemble_jac=True)
 
         p.setup(mode='fwd')
         p.set_solver_print(level=0)
@@ -2188,12 +2186,12 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # Try again with a direct solver and sparse assembled hierarchy.
 
-        p = Problem()
+        p = om.Problem()
         p.model.add_subsystem('sub', GaussLobattoPhase())
 
         p.model.sub.add_objective('time', index=-1)
 
-        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         p.setup(mode='fwd')
         p.set_solver_print(level=0)
@@ -2207,10 +2205,10 @@ class TestProblemCheckTotals(unittest.TestCase):
 
     def test_vector_scaled_derivs(self):
 
-        prob = Problem()
-        prob.model = model = Group()
+        prob = om.Problem()
+        model = prob.model
 
-        model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
+        model.add_subsystem('px', om.IndepVarComp(name="x", val=np.ones((2, ))))
         comp = model.add_subsystem('comp', DoubleArrayComp())
         model.connect('px.x', 'comp.x1')
 
@@ -2259,28 +2257,28 @@ class TestProblemCheckTotals(unittest.TestCase):
     def test_cs_around_newton(self):
         # Basic sellar test.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        sub = model.add_subsystem('sub', Group(), promotes=['*'])
+        sub = model.add_subsystem('sub', om.Group(), promotes=['*'])
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        sub.nonlinear_solver = NewtonSolver()
-        sub.linear_solver = DirectSolver(assemble_jac=False)
+        sub.nonlinear_solver = om.NewtonSolver()
+        sub.linear_solver = om.DirectSolver(assemble_jac=False)
 
         # Need this.
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -2301,28 +2299,28 @@ class TestProblemCheckTotals(unittest.TestCase):
     def test_cs_around_broyden(self):
         # Basic sellar test.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        sub = model.add_subsystem('sub', Group(), promotes=['*'])
+        sub = model.add_subsystem('sub', om.Group(), promotes=['*'])
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        sub.nonlinear_solver = BroydenSolver()
-        sub.linear_solver = DirectSolver()
+        sub.nonlinear_solver = om.BroydenSolver()
+        sub.linear_solver = om.DirectSolver()
 
         # Need this.
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -2341,9 +2339,9 @@ class TestProblemCheckTotals(unittest.TestCase):
             assert_rel_error(self, val['rel error'][0], 0.0, 1e-6)
 
     def test_cs_error_allocate(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p', IndepVarComp('x', 3.0), promotes=['*'])
+        model.add_subsystem('p', om.IndepVarComp('x', 3.0), promotes=['*'])
         model.add_subsystem('comp', ParaboloidTricky(), promotes=['*'])
         prob.setup()
         prob.run_model()
@@ -2363,7 +2361,7 @@ class TestProblemCheckTotalsMPI(unittest.TestCase):
 
     def test_indepvarcomp_under_par_sys(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanInSubbedIDVC()
 
         prob.setup(check=False, mode='rev')

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -126,7 +126,6 @@ class TestProblemCheckPartials(unittest.TestCase):
     def test_incorrect_jacobian(self):
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
@@ -137,7 +136,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         stream = cStringIO()
@@ -163,7 +162,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         stream = cStringIO()
@@ -183,7 +182,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         stream = cStringIO()
@@ -251,7 +250,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.lin_count += 1
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyComp())
@@ -261,7 +259,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -303,7 +301,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                 outputs['flow:P'] = inputs['P']
 
         p = Problem()
-        model = p.model = Group()
+        model = p.model
         indep = model.add_subsystem('indep', IndepVarComp(), promotes=['*'])
 
         indep.add_output('T', val=100., units='degK')
@@ -346,7 +344,7 @@ class TestProblemCheckPartials(unittest.TestCase):
                 self.run_count += 1
 
         p = Problem()
-        model = p.model = Group()
+        model = p.model
         indep = model.add_subsystem('indep', IndepVarComp(), promotes=['*'])
 
         indep.add_output('T', val=100., units='degK')
@@ -437,7 +435,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_matrix_free_explicit(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -448,7 +445,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -471,7 +468,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_matrix_free_implicit(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('rhs', np.ones((2, ))))
         prob.model.add_subsystem('comp', TestImplCompArrayMatVec())
@@ -480,7 +476,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -522,7 +518,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['y', 'y'] = self.mtx
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', np.ones((2, ))))
         prob.model.add_subsystem('p2', IndepVarComp('dummy', np.ones((2, ))))
@@ -533,7 +528,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -562,7 +557,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['g', 'x'] = 3.
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('z', np.ones((2, 2))))
         prob.model.add_subsystem('p2', IndepVarComp('x', np.ones((2, 2))))
@@ -570,7 +564,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('p1.z', 'comp.z')
         prob.model.connect('p2.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         stream = cStringIO()
         data = prob.check_partials(out_stream=stream)
@@ -601,7 +595,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['g', 'x'] = 3.
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('z', np.ones((2, 2))))
         prob.model.add_subsystem('p2', IndepVarComp('x', np.ones((2, 2))))
@@ -609,7 +602,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('p1.z', 'comp.z')
         prob.model.connect('p2.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         stream = cStringIO()
         data = prob.check_partials(out_stream=stream, compact_print=True)
@@ -640,7 +633,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['g', 'x'] = 3.
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('z', np.ones((2, 2))))
         prob.model.add_subsystem('p2', IndepVarComp('x', np.ones((2, 2))))
@@ -648,7 +640,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('p1.z', 'comp.z')
         prob.model.connect('p2.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         stream = cStringIO()
         data = prob.check_partials(out_stream=stream)
@@ -661,7 +653,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_step_on_comp(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -674,7 +665,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         comp.set_check_partial_options(wrt='*', step=1e-2)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, compact_print=True)
@@ -686,7 +677,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_step_global(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -697,7 +687,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, step=1e-2)
@@ -709,7 +699,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_complex_step_not_allocated(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -722,7 +711,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         comp.set_check_partial_options(wrt='*', method='cs')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         msg = "The following components requested complex step, but force_alloc_complex " + \
@@ -740,7 +729,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_method_on_comp(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -764,7 +752,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_method_global(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -786,7 +773,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_form_on_comp(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -799,7 +785,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         comp.set_check_partial_options(wrt='*', form='central')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, compact_print=True)
@@ -811,7 +797,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_form_global(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -822,7 +807,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, form='central')
@@ -834,7 +819,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_step_calc_on_comp(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -847,7 +831,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         comp.set_check_partial_options(wrt='*', step_calc='rel')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, compact_print=True)
@@ -859,7 +843,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
     def test_set_step_calc_global(self):
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -870,7 +853,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, step_calc='rel')
@@ -909,7 +892,6 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['y', 'ba'] = 3.0*ba**2
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('ab', 13.0))
         prob.model.add_subsystem('p2', IndepVarComp('aba', 13.0))
@@ -920,7 +902,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('p2.aba', 'comp.aba')
         prob.model.connect('p3.ba', 'comp.ba')
 
-        prob.setup(check=False)
+        prob.setup()
 
         comp.set_check_partial_options(wrt='a*', step=1e-2)
         comp.set_check_partial_options(wrt='*a', step=1e-4)
@@ -937,7 +919,6 @@ class TestProblemCheckPartials(unittest.TestCase):
     def test_option_printing(self):
         # Make sure we print the approximation type for each variable.
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -969,7 +950,6 @@ class TestProblemCheckPartials(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1086,14 +1066,13 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # First short var names
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyCompShortVarNames())
         prob.model.connect('p1.x1', 'comp.x1')
         prob.model.connect('p2.x2', 'comp.x2')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1112,14 +1091,13 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # Then long var names
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('really_long_variable_name_x1', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('comp', MyCompLongVarNames())
         prob.model.connect('p1.really_long_variable_name_x1', 'comp.really_long_variable_name_x1')
         prob.model.connect('p2.x2', 'comp.x2')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1141,7 +1119,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob = Problem()
         prob.model = MyCompGoodPartials()
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1151,7 +1129,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob = Problem()
         prob.model = MyCompBadPartials()
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1175,7 +1153,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         group.connect('comp1.b', 'comp3.b')
         group.connect('comp1.c', 'comp3.c')
         prob = Problem(model=group)
-        prob.setup(check=False)
+        prob.setup()
 
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1210,7 +1188,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob = Problem()
         prob.model = MyComp()
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1230,14 +1208,13 @@ class TestProblemCheckPartials(unittest.TestCase):
         # 3: Explicit comp that does not define Jacobian. It defines compute_jacvec_product
         #      For both compact and non-compact display
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
         prob.model.add_subsystem('comp', ParaboloidMatVec())
         prob.model.connect('p1.x', 'comp.x')
         prob.model.connect('p2.y', 'comp.y')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1250,7 +1227,6 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # 4: Mixed comps. Some with jacobians. Some not
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('c0', MyComp())  # in x1,x2, out is z
@@ -1261,7 +1237,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('c0.z', 'comp.x')
         prob.model.connect('p2.y', 'comp.y')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         stream = cStringIO()
@@ -1296,7 +1272,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         model.add_design_var('py.y', vectorize_derivs=False)
         model.add_constraint('comp.f_xy', vectorize_derivs=False)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         stream = cStringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
@@ -1310,7 +1286,6 @@ class TestProblemCheckPartials(unittest.TestCase):
         # This should only occur in the compact_print=True case.
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('p2', IndepVarComp('y2', 6.0))
@@ -1321,7 +1296,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('good.y', 'bad.y1')
         prob.model.connect('p2.y2', 'bad.y2')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         stream = cStringIO()
@@ -1336,7 +1311,6 @@ class TestProblemCheckPartials(unittest.TestCase):
         # to both compact_print=True and False.
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('p2', IndepVarComp('y2', 6.0))
@@ -1347,7 +1321,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.model.connect('good.y', 'bad.y1')
         prob.model.connect('p2.y2', 'bad.y2')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         stream = cStringIO()
@@ -1410,7 +1384,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         model = prob.model
         mycomp = model.add_subsystem('mycomp', ArrayComp(), promotes=['*'])
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -1504,13 +1478,12 @@ class TestProblemCheckPartials(unittest.TestCase):
                 partials['y', 'x'] = 3.0
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.5))
         prob.model.add_subsystem('comp', SimpleComp2())
         prob.model.connect('p1.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         stream = cStringIO()
         data = prob.check_partials(out_stream=stream)
@@ -1545,7 +1518,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['y', 'x2'] = np.array([40])
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
@@ -1556,7 +1528,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials()
@@ -1595,7 +1567,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['y', 'x2'] = np.array([40])
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('x2', 5.0))
@@ -1606,7 +1577,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None, compact_print=True)
@@ -1618,7 +1589,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1644,7 +1614,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1668,7 +1637,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1694,7 +1662,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1718,7 +1685,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1741,7 +1707,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
         from openmdao.core.tests.test_check_derivs import ParaboloidTricky
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('p1', IndepVarComp('x', 3.0))
         prob.model.add_subsystem('p2', IndepVarComp('y', 5.0))
@@ -1794,7 +1759,6 @@ class TestCheckPartialsFeature(unittest.TestCase):
                 J['z', 'y2'] = np.array([40.0])
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('p0', IndepVarComp('x1', 3.0))
         prob.model.add_subsystem('p1', IndepVarComp('x2', 5.0))
         prob.model.add_subsystem('p2', IndepVarComp('y2', 6.0))
@@ -1805,7 +1769,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.model.connect('good.y', 'bad.y1')
         prob.model.connect('p2.y2', 'bad.y2')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         prob.check_partials(compact_print=True, show_only_incorrect=True)
@@ -1847,7 +1811,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
         model = prob.model
         mycomp = model.add_subsystem('mycomp', ArrayComp(), promotes=['*'])
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials()
@@ -2053,7 +2017,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # We don't call run_driver() here because we don't
         # actually want the optimizer to run
@@ -2080,7 +2044,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # We don't call run_driver() here because we don't
         # actually want the optimizer to run
@@ -2101,7 +2065,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # We don't call run_driver() here because we don't
         # actually want the optimizer to run
@@ -2122,7 +2086,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # We don't call run_driver() here because we don't
         # actually want the optimizer to run
@@ -2255,7 +2219,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         model.add_constraint('comp.y2', lower=0.0, upper=1.0,
                              ref=np.array([[2.0, 4.0]]), ref0=np.array([1.2, 2.3]))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # First, test that we get scaled results in compute and check totals.
@@ -2381,7 +2345,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         model = prob.model
         model.add_subsystem('p', IndepVarComp('x', 3.0), promotes=['*'])
         model.add_subsystem('comp', ParaboloidTricky(), promotes=['*'])
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         with self.assertRaises(RuntimeError) as cm:

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -939,91 +939,91 @@ def _get_mat(rows, cols):
         return np.random.random(rows * cols).reshape((rows, cols)) - 0.5
 
 
-@unittest.skipUnless(MPI is not None and PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
-class MatMultMultipointTestCase(unittest.TestCase):
-    N_PROCS = 4
+#@unittest.skipUnless(MPI is not None and PETScVector is not None and OPTIMIZER is not None, "PETSc and pyOptSparse required.")
+#class MatMultMultipointTestCase(unittest.TestCase):
+    #N_PROCS = 4
 
-    def setUp(self):
-        self.startdir = os.getcwd()
-        if MPI.COMM_WORLD.rank == 0:
-            self.tempdir = tempfile.mkdtemp(prefix=self.__class__.__name__ + '_')
-            MPI.COMM_WORLD.bcast(self.tempdir, root=0)
-        else:
-            self.tempdir = MPI.COMM_WORLD.bcast(None, root=0)
-        os.chdir(self.tempdir)
+    #def setUp(self):
+        #self.startdir = os.getcwd()
+        #if MPI.COMM_WORLD.rank == 0:
+            #self.tempdir = tempfile.mkdtemp(prefix=self.__class__.__name__ + '_')
+            #MPI.COMM_WORLD.bcast(self.tempdir, root=0)
+        #else:
+            #self.tempdir = MPI.COMM_WORLD.bcast(None, root=0)
+        #os.chdir(self.tempdir)
 
-    def tearDown(self):
-        os.chdir(self.startdir)
-        MPI.COMM_WORLD.bcast(None, root=0)
-        if MPI.COMM_WORLD.rank == 0:
-            try:
-                shutil.rmtree(self.tempdir)
-            except OSError:
-                pass
+    #def tearDown(self):
+        #os.chdir(self.startdir)
+        #MPI.COMM_WORLD.bcast(None, root=0)
+        #if MPI.COMM_WORLD.rank == 0:
+            #try:
+                #shutil.rmtree(self.tempdir)
+            #except OSError:
+                #pass
 
-    def test_multipoint_with_coloring(self):
-        size = 10
-        num_pts = self.N_PROCS
+    #def test_multipoint_with_coloring(self):
+        #size = 10
+        #num_pts = self.N_PROCS
 
-        np.random.seed(11)
+        #np.random.seed(11)
 
-        p = om.Problem()
-        p.driver = pyOptSparseDriver()
-        p.driver.options['optimizer'] = OPTIMIZER
-        p.driver.declare_coloring()
-        if OPTIMIZER == 'SNOPT':
-            p.driver.opt_settings['Major iterations limit'] = 100
-            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-            p.driver.opt_settings['iSumm'] = 6
+        #p = om.Problem()
+        #p.driver = pyOptSparseDriver()
+        #p.driver.options['optimizer'] = OPTIMIZER
+        #p.driver.declare_coloring()
+        #if OPTIMIZER == 'SNOPT':
+            #p.driver.opt_settings['Major iterations limit'] = 100
+            #p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            #p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+            #p.driver.opt_settings['iSumm'] = 6
 
-        model = p.model
-        for i in range(num_pts):
-            model.add_subsystem('indep%d' % i, om.IndepVarComp('x', val=np.ones(size)))
-            model.add_design_var('indep%d.x' % i)
+        #model = p.model
+        #for i in range(num_pts):
+            #model.add_subsystem('indep%d' % i, om.IndepVarComp('x', val=np.ones(size)))
+            #model.add_design_var('indep%d.x' % i)
 
-        par1 = model.add_subsystem('par1', om.ParallelGroup())
-        for i in range(num_pts):
-            mat = _get_mat(5, size)
-            par1.add_subsystem('comp%d' % i, om.ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
-            model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
+        #par1 = model.add_subsystem('par1', om.ParallelGroup())
+        #for i in range(num_pts):
+            #mat = _get_mat(5, size)
+            #par1.add_subsystem('comp%d' % i, om.ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
+            #model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
 
-        par2 = model.add_subsystem('par2', om.ParallelGroup())
-        for i in range(num_pts):
-            mat = _get_mat(size, 5)
-            par2.add_subsystem('comp%d' % i, om.ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
-            model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
-            par2.add_constraint('comp%d.y' % i, lower=-1.)
+        #par2 = model.add_subsystem('par2', om.ParallelGroup())
+        #for i in range(num_pts):
+            #mat = _get_mat(size, 5)
+            #par2.add_subsystem('comp%d' % i, om.ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
+            #model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
+            #par2.add_constraint('comp%d.y' % i, lower=-1.)
 
-            model.add_subsystem('normcomp%d' % i, om.ExecComp("y=sum(x*x)", x=np.ones(size)))
-            model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
+            #model.add_subsystem('normcomp%d' % i, om.ExecComp("y=sum(x*x)", x=np.ones(size)))
+            #model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
 
-        model.add_subsystem('obj', om.ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
+        #model.add_subsystem('obj', om.ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
 
-        for i in range(num_pts):
-            model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
+        #for i in range(num_pts):
+            #model.connect('normcomp%d.y' % i, 'obj.x%d' % i)
 
-        model.add_objective('obj.y')
+        #model.add_objective('obj.y')
 
-        try:
-            p.setup()
+        #try:
+            #p.setup()
 
-            p.run_driver()
+            #p.run_driver()
 
-            J = p.compute_totals()
+            #J = p.compute_totals()
 
-            for i in range(num_pts):
-                vname = 'par2.comp%d.A' % i
-                if vname in model._var_abs_names['input']:
-                    norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
-                                          getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
-                    self.assertLess(norm, 1.e-7)
-                elif vname not in model._var_allprocs_abs_names['input']:
-                    self.fail("Can't find variable par2.comp%d.A" % i)
+            #for i in range(num_pts):
+                #vname = 'par2.comp%d.A' % i
+                #if vname in model._var_abs_names['input']:
+                    #norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
+                                          #getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
+                    #self.assertLess(norm, 1.e-7)
+                #elif vname not in model._var_allprocs_abs_names['input']:
+                    #self.fail("Can't find variable par2.comp%d.A" % i)
 
-            print("final obj:", p['obj.y'])
-        except Exception as err:
-            print(str(err))
+            #print("final obj:", p['obj.y'])
+        #except Exception as err:
+            #print(str(err))
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -19,9 +19,7 @@ try:
 except ImportError:
     load_npz = None
 
-from openmdao.api import Problem, IndepVarComp, ExecComp, DirectSolver,\
-    ExplicitComponent, LinearRunOnce, ScipyOptimizeDriver, ParallelGroup, Group, \
-    SqliteRecorder, CaseReader
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.coloring import Coloring, _compute_coloring, array_viz
@@ -42,7 +40,7 @@ if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 
-class CounterGroup(Group):
+class CounterGroup(om.Group):
     def __init__(self, *args, **kwargs):
         self._solve_count = 0
         self._solve_nl_count = 0
@@ -66,7 +64,7 @@ class CounterGroup(Group):
 SIZE = 10
 
 
-class DynPartialsComp(ExplicitComponent):
+class DynPartialsComp(om.ExplicitComponent):
     def __init__(self, size):
         super(DynPartialsComp, self).__init__()
         self.size = size
@@ -91,13 +89,13 @@ def run_opt(driver_class, mode, assemble_type=None, color_info=None, sparsity=No
             recorder=None, has_lin_constraint=True, vectorize=True, partial_coloring=False,
             **options):
 
-    p = Problem(model=CounterGroup())
+    p = om.Problem(model=CounterGroup())
 
     if assemble_type is not None:
-        p.model.linear_solver = DirectSolver(assemble_jac=True)
+        p.model.linear_solver = om.DirectSolver(assemble_jac=True)
         p.model.options['assembled_jac_type'] = assemble_type
 
-    indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
+    indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes_outputs=['*'])
 
     # the following were randomly generated using np.random.random(10)*2-1 to randomly
     # disperse them within a unit circle centered at the origin.
@@ -110,25 +108,25 @@ def run_opt(driver_class, mode, assemble_type=None, color_info=None, sparsity=No
     if partial_coloring:
         arctan_yox = DynPartialsComp(SIZE)
     else:
-        arctan_yox = ExecComp('g=arctan(y/x)', vectorize=vectorize,
-                              g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE))
+        arctan_yox = om.ExecComp('g=arctan(y/x)', vectorize=vectorize,
+                                 g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE))
 
     p.model.add_subsystem('arctan_yox', arctan_yox)
 
-    p.model.add_subsystem('circle', ExecComp('area=pi*r**2'))
+    p.model.add_subsystem('circle', om.ExecComp('area=pi*r**2'))
 
-    p.model.add_subsystem('r_con', ExecComp('g=x**2 + y**2 - r', vectorize=vectorize,
-                                            g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
+    p.model.add_subsystem('r_con', om.ExecComp('g=x**2 + y**2 - r', vectorize=vectorize,
+                                               g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
     thetas = np.linspace(0, np.pi/4, SIZE)
-    p.model.add_subsystem('theta_con', ExecComp('g = x - theta', vectorize=vectorize,
-                                                g=np.ones(SIZE), x=np.ones(SIZE),
-                                                theta=thetas))
-    p.model.add_subsystem('delta_theta_con', ExecComp('g = even - odd', vectorize=vectorize,
-                                                      g=np.ones(SIZE//2), even=np.ones(SIZE//2),
-                                                      odd=np.ones(SIZE//2)))
+    p.model.add_subsystem('theta_con', om.ExecComp('g = x - theta', vectorize=vectorize,
+                                                   g=np.ones(SIZE), x=np.ones(SIZE),
+                                                   theta=thetas))
+    p.model.add_subsystem('delta_theta_con', om.ExecComp('g = even - odd', vectorize=vectorize,
+                                                         g=np.ones(SIZE//2), even=np.ones(SIZE//2),
+                                                         odd=np.ones(SIZE//2)))
 
-    p.model.add_subsystem('l_conx', ExecComp('g=x-1', vectorize=vectorize, g=np.ones(SIZE), x=np.ones(SIZE)))
+    p.model.add_subsystem('l_conx', om.ExecComp('g=x-1', vectorize=vectorize, g=np.ones(SIZE), x=np.ones(SIZE)))
 
     IND = np.arange(SIZE, dtype=int)
     ODD_IND = IND[1::2]  # all odd indices
@@ -375,12 +373,12 @@ class SimulColoringRecordingTestCase(unittest.TestCase):
     def test_recording(self):
         # coloring involves an underlying call to run_model (and final_setup),
         # this verifies that it is handled properly by the recording setup logic
-        recorder = SqliteRecorder('cases.sql')
+        recorder = om.SqliteRecorder('cases.sql')
 
         p = run_opt(pyOptSparseDriver, 'auto', assemble_type='csc', optimizer='SNOPT',
                     dynamic_total_coloring=True, print_results=False, recorder=recorder)
 
-        cr = CaseReader('cases.sql')
+        cr = om.CaseReader('cases.sql')
 
         self.assertEqual(cr.list_cases(), ['rank0:pyOptSparse_SNOPT|%d' % i for i in range(p.driver.iter_count)])
 
@@ -471,19 +469,19 @@ class SimulColoringScipyTestCase(unittest.TestCase):
             pass
 
     def test_bad_mode(self):
-        p_color_fwd = run_opt(ScipyOptimizeDriver, 'fwd', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
+        p_color_fwd = run_opt(om.ScipyOptimizeDriver, 'fwd', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
         coloring = p_color_fwd.driver._coloring_info['coloring']
 
         with self.assertRaises(Exception) as context:
-            p_color = run_opt(ScipyOptimizeDriver, 'rev', color_info=coloring, optimizer='SLSQP', disp=False)
+            p_color = run_opt(om.ScipyOptimizeDriver, 'rev', color_info=coloring, optimizer='SLSQP', disp=False)
         self.assertEqual(str(context.exception),
                          "Simultaneous coloring does forward solves but mode has been set to 'rev'")
 
     def test_dynamic_total_coloring_auto(self):
 
         # first, run w/o coloring
-        p = run_opt(ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False)
-        p_color = run_opt(ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
+        p = run_opt(om.ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False)
+        p_color = run_opt(om.ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
 
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
@@ -498,14 +496,14 @@ class SimulColoringScipyTestCase(unittest.TestCase):
 
     def test_simul_coloring_example(self):
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, ScipyOptimizeDriver
         import numpy as np
+        import openmdao.api as om
 
         SIZE = 10
 
-        p = Problem()
+        p = om.Problem()
 
-        indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
+        indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes_outputs=['*'])
 
         # the following were randomly generated using np.random.random(10)*2-1 to randomly
         # disperse them within a unit circle centered at the origin.
@@ -515,23 +513,23 @@ class SimulColoringScipyTestCase(unittest.TestCase):
                                           -0.86236787, -0.97500023,  0.47739414,  0.51174103,  0.10052582]))
         indeps.add_output('r', .7)
 
-        p.model.add_subsystem('arctan_yox', ExecComp('g=arctan(y/x)', vectorize=True,
-                                                    g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
+        p.model.add_subsystem('arctan_yox', om.ExecComp('g=arctan(y/x)', vectorize=True,
+                                                        g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
-        p.model.add_subsystem('circle', ExecComp('area=pi*r**2'))
+        p.model.add_subsystem('circle', om.ExecComp('area=pi*r**2'))
 
-        p.model.add_subsystem('r_con', ExecComp('g=x**2 + y**2 - r', vectorize=True,
-                                                g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
+        p.model.add_subsystem('r_con', om.ExecComp('g=x**2 + y**2 - r', vectorize=True,
+                                                   g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
         thetas = np.linspace(0, np.pi/4, SIZE)
-        p.model.add_subsystem('theta_con', ExecComp('g = x - theta', vectorize=True,
-                                                    g=np.ones(SIZE), x=np.ones(SIZE),
-                                                    theta=thetas))
-        p.model.add_subsystem('delta_theta_con', ExecComp('g = even - odd', vectorize=True,
-                                                        g=np.ones(SIZE//2), even=np.ones(SIZE//2),
-                                                        odd=np.ones(SIZE//2)))
+        p.model.add_subsystem('theta_con', om.ExecComp('g = x - theta', vectorize=True,
+                                                       g=np.ones(SIZE), x=np.ones(SIZE),
+                                                       theta=thetas))
+        p.model.add_subsystem('delta_theta_con', om.ExecComp('g = even - odd', vectorize=True,
+                                                             g=np.ones(SIZE//2), even=np.ones(SIZE//2),
+                                                             odd=np.ones(SIZE//2)))
 
-        p.model.add_subsystem('l_conx', ExecComp('g=x-1', vectorize=True, g=np.ones(SIZE), x=np.ones(SIZE)))
+        p.model.add_subsystem('l_conx', om.ExecComp('g=x-1', vectorize=True, g=np.ones(SIZE), x=np.ones(SIZE)))
 
         IND = np.arange(SIZE, dtype=int)
         ODD_IND = IND[1::2]  # all odd indices
@@ -544,7 +542,7 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         p.model.connect('arctan_yox.g', 'delta_theta_con.even', src_indices=EVEN_IND)
         p.model.connect('arctan_yox.g', 'delta_theta_con.odd', src_indices=ODD_IND)
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['disp'] = False
 
@@ -577,10 +575,9 @@ class SimulColoringScipyTestCase(unittest.TestCase):
     def test_total_and_partial_coloring_example(self):
 
         import numpy as np
-        from openmdao.api import Problem, IndepVarComp, ExecComp, ExplicitComponent, ScipyOptimizeDriver
+        import openmdao.api as om
 
-
-        class DynamicPartialsComp(ExplicitComponent):
+        class DynamicPartialsComp(om.ExplicitComponent):
             def __init__(self, size):
                 super(DynamicPartialsComp, self).__init__()
                 self.size = size
@@ -604,9 +601,9 @@ class SimulColoringScipyTestCase(unittest.TestCase):
 
         SIZE = 10
 
-        p = Problem()
+        p = om.Problem()
 
-        indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
+        indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes_outputs=['*'])
 
         # the following were randomly generated using np.random.random(10)*2-1 to randomly
         # disperse them within a unit circle centered at the origin.
@@ -621,20 +618,20 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         arctan_yox = p.model.add_subsystem('arctan_yox', DynamicPartialsComp(SIZE))
         ########################################################################
 
-        p.model.add_subsystem('circle', ExecComp('area=pi*r**2'))
+        p.model.add_subsystem('circle', om.ExecComp('area=pi*r**2'))
 
-        p.model.add_subsystem('r_con', ExecComp('g=x**2 + y**2 - r', vectorize=True,
-                                                g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
+        p.model.add_subsystem('r_con', om.ExecComp('g=x**2 + y**2 - r', vectorize=True,
+                                                   g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
         thetas = np.linspace(0, np.pi/4, SIZE)
-        p.model.add_subsystem('theta_con', ExecComp('g = x - theta', vectorize=True,
-                                                    g=np.ones(SIZE), x=np.ones(SIZE),
-                                                    theta=thetas))
-        p.model.add_subsystem('delta_theta_con', ExecComp('g = even - odd', vectorize=True,
-                                                        g=np.ones(SIZE//2), even=np.ones(SIZE//2),
-                                                        odd=np.ones(SIZE//2)))
+        p.model.add_subsystem('theta_con', om.ExecComp('g = x - theta', vectorize=True,
+                                                       g=np.ones(SIZE), x=np.ones(SIZE),
+                                                       theta=thetas))
+        p.model.add_subsystem('delta_theta_con', om.ExecComp('g = even - odd', vectorize=True,
+                                                             g=np.ones(SIZE//2), even=np.ones(SIZE//2),
+                                                             odd=np.ones(SIZE//2)))
 
-        p.model.add_subsystem('l_conx', ExecComp('g=x-1', vectorize=True, g=np.ones(SIZE), x=np.ones(SIZE)))
+        p.model.add_subsystem('l_conx', om.ExecComp('g=x-1', vectorize=True, g=np.ones(SIZE), x=np.ones(SIZE)))
 
         IND = np.arange(SIZE, dtype=int)
         ODD_IND = IND[1::2]  # all odd indices
@@ -647,7 +644,7 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         p.model.connect('arctan_yox.g', 'delta_theta_con.even', src_indices=EVEN_IND)
         p.model.connect('arctan_yox.g', 'delta_theta_con.odd', src_indices=ODD_IND)
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.options['disp'] = False
 
@@ -707,7 +704,7 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
             pass
 
     def test_summary(self):
-        p_color = run_opt(ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
+        p_color = run_opt(om.ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
         coloring = p_color.driver._coloring_info['coloring']
         save_out = sys.stdout
         sys.stdout = StringIO()
@@ -739,7 +736,7 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
         self.assertTrue('Time to compute coloring:' in summary)
 
     def test_repr(self):
-        p_color = run_opt(ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
+        p_color = run_opt(om.ScipyOptimizeDriver, 'auto', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
         coloring = p_color.driver._coloring_info['coloring']
         rep = repr(coloring)
         self.assertEqual(rep.replace('L', ''), 'Coloring (direction: fwd, ncolors: 5, shape: (22, 21)')
@@ -750,18 +747,18 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
         self.assertEqual(rep.replace('L', ''), 'Coloring (direction: rev, ncolors: 50, shape: (50, 50)')
 
     def test_bad_mode(self):
-        p_color_rev = run_opt(ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
+        p_color_rev = run_opt(om.ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
         coloring = p_color_rev.driver._coloring_info['coloring']
 
         with self.assertRaises(Exception) as context:
-            p_color = run_opt(ScipyOptimizeDriver, 'fwd', color_info=coloring, optimizer='SLSQP', disp=False)
+            p_color = run_opt(om.ScipyOptimizeDriver, 'fwd', color_info=coloring, optimizer='SLSQP', disp=False)
         self.assertEqual(str(context.exception),
                          "Simultaneous coloring does reverse solves but mode has been set to 'fwd'")
 
     def test_dynamic_total_coloring(self):
 
-        p_color = run_opt(ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
-        p = run_opt(ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False)
+        p_color = run_opt(om.ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False, dynamic_total_coloring=True)
+        p = run_opt(om.ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False)
 
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
@@ -776,7 +773,7 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
 
     def test_dynamic_total_coloring_no_derivs(self):
         with self.assertRaises(Exception) as context:
-            p_color = run_opt(ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False,
+            p_color = run_opt(om.ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False,
                               dynamic_total_coloring=True, derivs=False)
         self.assertEqual(str(context.exception),
                          "Derivative support has been turned off but compute_totals was called.")
@@ -970,7 +967,7 @@ class MatMultMultipointTestCase(unittest.TestCase):
 
         np.random.seed(11)
 
-        p = Problem()
+        p = om.Problem()
         p.driver = pyOptSparseDriver()
         p.driver.options['optimizer'] = OPTIMIZER
         p.driver.declare_coloring()
@@ -982,26 +979,26 @@ class MatMultMultipointTestCase(unittest.TestCase):
 
         model = p.model
         for i in range(num_pts):
-            model.add_subsystem('indep%d' % i, IndepVarComp('x', val=np.ones(size)))
+            model.add_subsystem('indep%d' % i, om.IndepVarComp('x', val=np.ones(size)))
             model.add_design_var('indep%d.x' % i)
 
-        par1 = model.add_subsystem('par1', ParallelGroup())
+        par1 = model.add_subsystem('par1', om.ParallelGroup())
         for i in range(num_pts):
             mat = _get_mat(5, size)
-            par1.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
+            par1.add_subsystem('comp%d' % i, om.ExecComp('y=A.dot(x)', A=mat, x=np.ones(size), y=np.ones(5)))
             model.connect('indep%d.x' % i, 'par1.comp%d.x' % i)
 
-        par2 = model.add_subsystem('par2', ParallelGroup())
+        par2 = model.add_subsystem('par2', om.ParallelGroup())
         for i in range(num_pts):
             mat = _get_mat(size, 5)
-            par2.add_subsystem('comp%d' % i, ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
+            par2.add_subsystem('comp%d' % i, om.ExecComp('y=A.dot(x)', A=mat, x=np.ones(5), y=np.ones(size)))
             model.connect('par1.comp%d.y' % i, 'par2.comp%d.x' % i)
             par2.add_constraint('comp%d.y' % i, lower=-1.)
 
-            model.add_subsystem('normcomp%d' % i, ExecComp("y=sum(x*x)", x=np.ones(size)))
+            model.add_subsystem('normcomp%d' % i, om.ExecComp("y=sum(x*x)", x=np.ones(size)))
             model.connect('par2.comp%d.y' % i, 'normcomp%d.x' % i)
 
-        model.add_subsystem('obj', ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
+        model.add_subsystem('obj', om.ExecComp("y=" + '+'.join(['x%d' % i for i in range(num_pts)])))
 
         for i in range(num_pts):
             model.connect('normcomp%d.y' % i, 'obj.x%d' % i)

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -21,7 +21,7 @@ class TestExplicitComponent(unittest.TestCase):
     def test___init___simple(self):
         """Test a simple explicit component."""
         comp = TestExplCompSimple()
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         # check optional metadata (desc)
         self.assertEqual(
@@ -42,7 +42,7 @@ class TestExplicitComponent(unittest.TestCase):
     def test___init___array(self):
         """Test an explicit component with array inputs/outputs."""
         comp = TestExplCompArray(thickness=1.)
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         prob['lengths'] = 3.
         prob['widths'] = 2.
@@ -210,15 +210,15 @@ class TestExplicitComponent(unittest.TestCase):
                 self.add_output('y', val=0.0)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         comp = model.add_subsystem('comp', MyComp())
 
-        prob.setup(check=False)
+        prob.setup()
         self.assertEqual(comp._var_abs_names['input'], ['comp.x'])
         self.assertEqual(comp._var_abs_names['output'], ['comp.y'])
 
         prob.run_model()
-        prob.setup(check=False)
+        prob.setup()
         self.assertEqual(comp._var_abs_names['input'], ['comp.x'])
         self.assertEqual(comp._var_abs_names['output'], ['comp.y'])
 
@@ -231,7 +231,7 @@ class TestExplicitComponent(unittest.TestCase):
                 self.add_output('y', val=3.0)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('px', IndepVarComp('x', val=3.0))
         model.add_subsystem('comp', Comp())
 
@@ -239,7 +239,7 @@ class TestExplicitComponent(unittest.TestCase):
 
         msg = "Variable name 'x' already exists."
         with assertRaisesRegex(self, ValueError, msg):
-            prob.setup(check=False)
+            prob.setup()
 
         class Comp(ExplicitComponent):
             def setup(self):
@@ -248,7 +248,7 @@ class TestExplicitComponent(unittest.TestCase):
                 self.add_output('y', val=3.0)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('px', IndepVarComp('x', val=3.0))
         model.add_subsystem('comp', Comp())
 
@@ -256,7 +256,7 @@ class TestExplicitComponent(unittest.TestCase):
 
         msg = "Variable name 'y' already exists."
         with assertRaisesRegex(self, ValueError, msg):
-            prob.setup(check=False)
+            prob.setup()
 
         class Comp(ExplicitComponent):
             def setup(self):
@@ -265,7 +265,7 @@ class TestExplicitComponent(unittest.TestCase):
                 self.add_output('y', val=3.0)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('px', IndepVarComp('x', val=3.0))
         model.add_subsystem('comp', Comp())
 
@@ -273,7 +273,7 @@ class TestExplicitComponent(unittest.TestCase):
 
         msg = "Variable name 'x' already exists."
         with assertRaisesRegex(self, ValueError, msg):
-            prob.setup(check=False)
+            prob.setup()
 
         # Make sure we can reconfigure.
 
@@ -283,16 +283,16 @@ class TestExplicitComponent(unittest.TestCase):
                 self.add_output('y', val=3.0)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('px', IndepVarComp('x', val=3.0))
         model.add_subsystem('comp', Comp())
 
         model.connect('px.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         # pretend we reconfigured
-        prob.setup(check=False)
+        prob.setup()
 
 
 class TestImplicitComponent(unittest.TestCase):
@@ -303,7 +303,7 @@ class TestImplicitComponent(unittest.TestCase):
         a = np.abs(np.exp(0.5 * x) / x)
 
         comp = TestImplCompSimple()
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         prob['a'] = a
         prob.run_model()
@@ -312,7 +312,7 @@ class TestImplicitComponent(unittest.TestCase):
     def test___init___array(self):
         """Test an implicit component with array inputs/outputs."""
         comp = TestImplCompArray()
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         prob['rhs'] = np.ones(2)
         prob.run_model()
@@ -361,7 +361,7 @@ class TestRangePartials(unittest.TestCase):
         comp = RangePartialsComp()
 
         prob = Problem(model=comp)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['vSum'], np.array([2., 3., 4., 5.]), 0.00001)

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -16,7 +16,7 @@ class TestConnections(unittest.TestCase):
         self.setup_model(None, None)
 
     def setup_model(self, c1meta=None, c3meta=None):
-        self.p = Problem(model=Group())
+        self.p = Problem()
         root = self.p.model
 
         if c1meta is None:
@@ -247,7 +247,7 @@ class TestConnections(unittest.TestCase):
     def test_diff_conn_input_units_w_src(self):
         raise unittest.SkipTest("no compatability checking of connected inputs yet")
 
-        p = Problem(model=Group())
+        p = Problem()
         root = p.model
 
         num_comps = 50
@@ -288,7 +288,7 @@ class TestConnectionsPromoted(unittest.TestCase):
 
     def test_inp_inp_promoted_no_src(self):
 
-        p = Problem(model=Group())
+        p = Problem()
         root = p.model
 
         G1 = root.add_subsystem("G1", Group())
@@ -312,7 +312,7 @@ class TestConnectionsPromoted(unittest.TestCase):
                          "[G3.G4.C3.x, G3.G4.C4.x] that are not connected to an output variable.")
 
     def test_inp_inp_promoted_w_prom_src(self):
-        p = Problem(model=Group())
+        p = Problem()
         root = p.model
 
         G1 = root.add_subsystem("G1", Group(), promotes=['x'])
@@ -337,7 +337,7 @@ class TestConnectionsPromoted(unittest.TestCase):
         self.assertEqual(C4._inputs['x'], 999.)
 
     def test_inp_inp_promoted_w_explicit_src(self):
-        p = Problem(model=Group())
+        p = Problem()
         root = p.model
 
         G1 = root.add_subsystem("G1", Group())
@@ -364,7 +364,7 @@ class TestConnectionsPromoted(unittest.TestCase):
 
     def test_unit_conv_message(self):
         raise unittest.SkipTest("no units yet")
-        prob = Problem(model=Group())
+        prob = Problem()
         root = prob.model
 
         root.add_subsystem("C1", ExecComp('y=x*2.0', units={'x': 'ft'}), promotes=['x'])
@@ -383,7 +383,7 @@ class TestConnectionsPromoted(unittest.TestCase):
 
         # Remedy the problem with an Indepvarcomp
 
-        prob = Problem(model=Group())
+        prob = Problem()
         root = prob.model
 
         root.add_subsystem("C1", ExecComp('y=x*2.0', units={'x': 'ft'}), promotes=['x'])

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -36,7 +36,7 @@ class TestConnections(unittest.TestCase):
         self.C4 = self.G4.add_subsystem("C4", ExecComp('y=x*2.0'))
 
     def test_no_conns(self):
-        self.p.setup(check=False)
+        self.p.setup()
 
         self.p['G1.G2.C1.x'] = 111.
         self.p['G3.G4.C3.x'] = 222.
@@ -52,7 +52,7 @@ class TestConnections(unittest.TestCase):
         raise unittest.SkipTest("explicit input-input connections not supported yet")
         self.p.model.connect('G3.G4.C3.x', 'G3.G4.C4.x')  # connect inputs
         self.p.model.connect('G1.G2.C2.x', 'G3.G4.C3.x')  # connect src to one of connected inputs
-        self.p.setup(check=False)
+        self.p.setup()
 
         self.p['G1.G2.C2.x'] = 999.
         self.assertEqual(self.C3._inputs['x'], 0.)
@@ -103,7 +103,7 @@ class TestConnections(unittest.TestCase):
         p.model.connect('src.y1', 'tgt.x1')
         p.model.connect('src.y2', 'tgt.x2')
 
-        p.setup(check=False)
+        p.setup()
         p.run_model()
 
         self.assertEqual(p['tgt.y1'], 12.0)
@@ -161,7 +161,7 @@ class TestConnections(unittest.TestCase):
         top.model.connect('src.y2', 'tgt.x2', src_indices=(0, 1))
         top.model.connect('src.y3', 'tgt.x3')
 
-        top.setup(check=False)
+        top.setup()
         top.run_model()
 
         self.assertEqual(top['tgt.y1'], 6.0)
@@ -197,7 +197,7 @@ class TestConnections(unittest.TestCase):
         self.p.model.connect('G1.G2.C1.x', 'G3.G4.C3.x')
 
         try:
-            self.p.setup(check=False)
+            self.p.setup()
         except Exception as err:
             self.assertTrue(
                 "The following sourceless connected inputs have different initial values: "
@@ -216,7 +216,7 @@ class TestConnections(unittest.TestCase):
         self.p.model.connect('G1.G2.C1.x', 'G3.G4.C3.x')
 
         try:
-            self.p.setup(check=False)
+            self.p.setup()
         except Exception as err:
             msg = "The following connected inputs have no source and different units: " \
                   "[('G1.G2.C1.x', 'ft'), ('G3.G4.C3.x', 'inch')]. " \
@@ -235,7 +235,7 @@ class TestConnections(unittest.TestCase):
         self.p.model.connect('G3.G4.C3.x', 'G1.G2.C1.x')
 
         try:
-            self.p.setup(check=False)
+            self.p.setup()
         except Exception as err:
             msg = "The following connected inputs have no source and different units: " \
                   "[('G1.G2.C1.x', 'ft'), ('G3.G4.C3.x', 'inch')]. " \
@@ -268,7 +268,7 @@ class TestConnections(unittest.TestCase):
             root.connect("C%d.x" % (i-1), "C%d.x" % i)
 
         try:
-            p.setup(check=False)
+            p.setup()
         except Exception as err:
             self.assertTrue("The following connected inputs have no source and different units" in
                             str(err))
@@ -281,7 +281,7 @@ class TestConnections(unittest.TestCase):
 
         root.connect('desvars.dvar1', 'C10.x')
 
-        p.setup(check=False)
+        p.setup()
 
 
 class TestConnectionsPromoted(unittest.TestCase):
@@ -325,7 +325,7 @@ class TestConnectionsPromoted(unittest.TestCase):
         C3 = G4.add_subsystem("C3", ExecComp('y=x*2.0'), promotes=['x'])
         C4 = G4.add_subsystem("C4", ExecComp('y=x*2.0'), promotes=['x'])
 
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # setting promoted name will set the value into the outputs, but will
@@ -351,7 +351,7 @@ class TestConnectionsPromoted(unittest.TestCase):
         C4 = G4.add_subsystem("C4", ExecComp('y=x*2.0'), promotes=['x'])
 
         p.model.connect('G1.x', 'G3.x')
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # setting promoted name will set the value into the outputs, but will
@@ -372,7 +372,7 @@ class TestConnectionsPromoted(unittest.TestCase):
         root.add_subsystem("C3", ExecComp('y=x*2.0', units={'x': 'm'}), promotes=['x'])
 
         try:
-            prob.setup(check=False)
+            prob.setup()
         except Exception as err:
             msg = "The following connected inputs are promoted to 'x', but have different units: " \
                   "[('C1.x', 'ft'), ('C2.x', 'inch'), ('C3.x', 'm')]. " \
@@ -391,12 +391,12 @@ class TestConnectionsPromoted(unittest.TestCase):
         root.add_subsystem("C3", ExecComp('y=x*2.0', units={'x': 'm'}), promotes=['x'])
         root.add_subsystem('p', IndepVarComp('x', 1.0, units='cm'), promotes=['x'])
 
-        prob.setup(check=False)
+        prob.setup()
 
     def test_overlapping_system_names(self):
         # This ensures that _setup_connections does not think g1 and g1a are the same system
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         g1 = model.add_subsystem('g1', Group())
         g1a = model.add_subsystem('g1a', Group())
@@ -441,7 +441,7 @@ class TestConnectionsIndices(unittest.TestCase):
                     r" Expected \(2.*,\) but got \(1.*,\).")
 
         with assertRaisesRegex(self, ValueError, expected):
-            self.prob.setup(check=False)
+            self.prob.setup()
 
     def test_bad_length(self):
         # Should not be allowed because the length of src_indices is greater than
@@ -453,7 +453,7 @@ class TestConnectionsIndices(unittest.TestCase):
                     r"The target shape is \(2.*,\) but indices are \(3.*,\).")
 
         with assertRaisesRegex(self, ValueError, expected):
-            self.prob.setup(check=False)
+            self.prob.setup()
 
     def test_bad_value(self):
         # Should not be allowed because the index value within src_indices is outside
@@ -466,7 +466,7 @@ class TestConnectionsIndices(unittest.TestCase):
                     "size 5.")
 
         try:
-            self.prob.setup(check=False)
+            self.prob.setup()
         except ValueError as err:
             self.assertEqual(str(err), expected)
         else:

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -153,7 +153,6 @@ class TestConnections(unittest.TestCase):
                 outputs['y3'] = np.sum(x3)
 
         top = Problem()
-        top.model = Group()
         top.model.add_subsystem('src', Src())
         top.model.add_subsystem('tgt', Tgt())
 

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -96,7 +96,6 @@ class TestConnections(unittest.TestCase):
                 outputs['y2'] = np.sum(x2)
 
         p = Problem()
-        p.model = Group()
         p.model.add_subsystem('src', Src())
         p.model.add_subsystem('tgt', Tgt())
 

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -7,13 +7,12 @@ import unittest
 
 import numpy as np
 
-import openmdao
-from openmdao.api import Problem, NonlinearBlockGS, Group, IndepVarComp
+from openmdao.api import Problem, NonlinearBlockGS, Group, IndepVarComp, ExecComp, ScipyKrylov
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.mpi import MPI
 
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1withDerivatives, \
-     SellarDis2withDerivatives, ExecComp, ScipyKrylov
+     SellarDis2withDerivatives
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -38,7 +38,7 @@ class TestDesVarsResponses(unittest.TestCase):
         prob.driver.add_constraint('con1')
         prob.driver.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_des_vars()
         obj = prob.model.get_objectives()
@@ -61,7 +61,7 @@ class TestDesVarsResponses(unittest.TestCase):
         prob.model.add_constraint('con1')
         prob.model.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
         obj = prob.model.get_objectives()
@@ -84,7 +84,7 @@ class TestDesVarsResponses(unittest.TestCase):
         prob.model.add_response('con1', type_="con")
         prob.model.add_response('con2', type_="con")
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
         responses = prob.model.get_responses()
@@ -109,7 +109,7 @@ class TestDesVarsResponses(unittest.TestCase):
         prob.model.add_constraint('con1')
         prob.model.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
         obj = prob.model.get_objectives()
@@ -134,7 +134,7 @@ class TestDesVarsResponses(unittest.TestCase):
         prob.model.add_constraint('con1')
         prob.model.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
         obj = prob.model.get_objectives()
@@ -160,7 +160,7 @@ class TestDesVarsResponses(unittest.TestCase):
         prob.model.add_constraint('con1')
         prob.model.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
         obj = prob.model.get_objectives()
@@ -173,7 +173,7 @@ class TestDesVarsResponses(unittest.TestCase):
     def test_api_on_subsystems(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0))
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
@@ -210,7 +210,7 @@ class TestDesVarsResponses(unittest.TestCase):
         con_comp2 = prob.model.con_cmp2
         con_comp2.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
         obj = prob.model.get_objectives()
@@ -233,7 +233,7 @@ class TestDesvarOnModel(unittest.TestCase):
         prob.model.add_design_var('junk')
 
         with self.assertRaises(RuntimeError) as context:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(context.exception), "Output not found for design variable 'junk' in system ''.")
 
@@ -290,7 +290,7 @@ class TestDesvarOnModel(unittest.TestCase):
         prob.model.add_constraint('con1')
         prob.model.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
 
@@ -316,7 +316,7 @@ class TestDesvarOnModel(unittest.TestCase):
         prob.model.add_constraint('con1', scaler=1e6)
         prob.model.add_constraint('con2', scaler=1e6)
 
-        prob.setup(check=False)
+        prob.setup()
 
         des_vars = prob.model.get_design_vars()
 
@@ -376,7 +376,7 @@ class TestConstraintOnModel(unittest.TestCase):
         prob.model.add_constraint('junk')
 
         with self.assertRaises(RuntimeError) as context:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(context.exception), "Output not found for response 'junk' in system ''.")
 
@@ -433,7 +433,7 @@ class TestConstraintOnModel(unittest.TestCase):
                                   ref=100)
         prob.model.add_constraint('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         constraints = prob.model.get_constraints()
 
@@ -595,7 +595,7 @@ class TestObjectiveOnModel(unittest.TestCase):
         prob.model.add_objective('junk')
 
         with self.assertRaises(RuntimeError) as context:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(context.exception),
                          "Output not found for response 'junk' in system ''.")
@@ -654,7 +654,7 @@ class TestObjectiveOnModel(unittest.TestCase):
         prob.model.add_objective('obj', ref0=1000, ref=1010)
         prob.model.add_objective('con2')
 
-        prob.setup(check=False)
+        prob.setup()
 
         objectives = prob.model.get_objectives()
 

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -507,7 +507,7 @@ class SolverDiscreteTestCase(unittest.TestCase):
         model.nonlinear_solver = solver_class()
 
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         return prob
 

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -8,19 +8,17 @@ from six import assertRaisesRegex, StringIO, assertRegex
 
 import numpy as np
 
+import openmdao.api as om
 from openmdao.core.group import get_relevant_vars
 from openmdao.core.driver import Driver
-from openmdao.api import Problem, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, \
-    ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent, \
-    ImplicitComponent, ParallelGroup, BroydenSolver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.devtools.problem_viewer.problem_viewer import _get_viewer_data
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import StateConnection, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.devtools.problem_viewer.problem_viewer import _get_viewer_data
+from openmdao.utils.assert_utils import assert_rel_error
 
 
-class ModCompEx(ExplicitComponent):
+class ModCompEx(om.ExplicitComponent):
     def __init__(self, modval, **kwargs):
         super(ModCompEx, self).__init__(**kwargs)
         self.modval = modval
@@ -36,7 +34,7 @@ class ModCompEx(ExplicitComponent):
         discrete_outputs['y'] = discrete_inputs['x'] % self.modval
 
 
-class ModCompIm(ImplicitComponent):
+class ModCompIm(om.ImplicitComponent):
     def __init__(self, modval, **kwargs):
         super(ModCompIm, self).__init__(**kwargs)
         self.modval = modval
@@ -52,7 +50,7 @@ class ModCompIm(ImplicitComponent):
         discrete_outputs['y'] = discrete_inputs['x'] % self.modval
 
 
-class CompDiscWDerivs(ExplicitComponent):
+class CompDiscWDerivs(om.ExplicitComponent):
     def setup(self):
         self.add_discrete_input('N', 2)
         self.add_discrete_output('Nout', 2)
@@ -86,7 +84,7 @@ class CompDiscWDerivsImplicit(StateConnection):
         super(CompDiscWDerivsImplicit, self).linearize(inputs, outputs, J)
 
 
-class MixedCompDiscIn(ExplicitComponent):
+class MixedCompDiscIn(om.ExplicitComponent):
     def __init__(self, mult, **kwargs):
         super(MixedCompDiscIn, self).__init__(**kwargs)
         self.mult = mult
@@ -99,7 +97,7 @@ class MixedCompDiscIn(ExplicitComponent):
         outputs['y'] = discrete_inputs['x'] * self.mult
 
 
-class MixedCompDiscOut(ExplicitComponent):
+class MixedCompDiscOut(om.ExplicitComponent):
     def __init__(self, mult, **kwargs):
         super(MixedCompDiscOut, self).__init__(**kwargs)
         self.mult = mult
@@ -112,7 +110,7 @@ class MixedCompDiscOut(ExplicitComponent):
         discrete_outputs['y'] = inputs['x'] * self.mult
 
 
-class InternalDiscreteGroup(Group):
+class InternalDiscreteGroup(om.Group):
     # this group has an internal discrete connection with continuous external vars,
     # so it can be spliced into an existing continuous model to test for discrete
     # var error checking.
@@ -158,7 +156,7 @@ class _DiscreteVal(object):
         return self
 
 
-class PathCompEx(ExplicitComponent):
+class PathCompEx(om.ExplicitComponent):
 
     def setup(self):
         self.add_discrete_input('x', val=self.pathname)
@@ -168,7 +166,7 @@ class PathCompEx(ExplicitComponent):
         discrete_outputs['y'] = discrete_inputs['x'] + self.pathname + '/'
 
 
-class ObjAdderCompEx(ExplicitComponent):
+class ObjAdderCompEx(om.ExplicitComponent):
     def __init__(self, val, **kwargs):
         super(ObjAdderCompEx, self).__init__(**kwargs)
         self.val = val
@@ -184,10 +182,10 @@ class ObjAdderCompEx(ExplicitComponent):
 class DiscreteTestCase(unittest.TestCase):
 
     def test_simple_run_once(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_discrete_output('x', 11)
         model.add_subsystem('comp', ModCompEx(3))
 
@@ -199,10 +197,10 @@ class DiscreteTestCase(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], 2)
 
     def test_simple_run_once_promoted(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp(), promotes=['*'])
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes=['*'])
         indep.add_discrete_output('x', 11)
         model.add_subsystem('comp', ModCompEx(3), promotes=['*'])
 
@@ -212,10 +210,10 @@ class DiscreteTestCase(unittest.TestCase):
         assert_rel_error(self, prob['y'], 2)
 
     def test_simple_run_once_implicit(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_discrete_output('x', 11)
         model.add_subsystem('comp', ModCompIm(3))
 
@@ -227,10 +225,10 @@ class DiscreteTestCase(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], 2)
 
     def test_list_inputs_outputs(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_discrete_output('x', 11)
 
         model.add_subsystem('expl', ModCompEx(3))
@@ -297,10 +295,10 @@ class DiscreteTestCase(unittest.TestCase):
         self.assertEqual(text.count('    y'), 2)      # both implicit & explicit
 
     def test_float_to_discrete_error(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_output('x', 1.0)
         model.add_subsystem('comp', ModCompEx(3))
 
@@ -312,12 +310,12 @@ class DiscreteTestCase(unittest.TestCase):
                          "Can't connect discrete output 'indep.x' to continuous input 'comp.x'.")
 
     def test_discrete_to_float_error(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_discrete_output('x', 1)
-        model.add_subsystem('comp', ExecComp("y=2.0*x"))
+        model.add_subsystem('comp', om.ExecComp("y=2.0*x"))
 
         model.connect('indep.x', 'comp.x')
 
@@ -327,10 +325,10 @@ class DiscreteTestCase(unittest.TestCase):
                          "Can't connect discrete output 'indep.x' to continuous input 'comp.x'.")
 
     def test_discrete_mismatch_error(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_discrete_output('x', val='foo')
         model.add_subsystem('comp', ModCompEx(3))
 
@@ -343,10 +341,10 @@ class DiscreteTestCase(unittest.TestCase):
 
     def test_driver_discrete_enforce_int(self):
         # Drivers require discrete vars to be int or ndarrays of int.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_discrete_output('x', 11)
         model.add_subsystem('comp', ModCompIm(3))
 
@@ -389,10 +387,10 @@ class DiscreteTestCase(unittest.TestCase):
         prob.run_driver()
 
     def test_discrete_deriv_explicit(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_output('x', 1.0)
 
         comp = model.add_subsystem('comp', CompDiscWDerivs())
@@ -409,10 +407,10 @@ class DiscreteTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(J, np.array([[3.]]))
 
     def test_discrete_deriv_implicit(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_output('x', 1.0, ref=10.)
         indep.add_discrete_output('N', 1)
 
@@ -433,23 +431,23 @@ class DiscreteTestCase(unittest.TestCase):
         np.testing.assert_almost_equal(J, np.array([[-1]]))
 
     def test_deriv_err(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp(), promotes_outputs=['x'])
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes_outputs=['x'])
         indep.add_output('x', 1.0)
 
-        G = model.add_subsystem('G', Group(), promotes_inputs=['x'])
+        G = model.add_subsystem('G', om.Group(), promotes_inputs=['x'])
 
         G1 = G.add_subsystem('G1', InternalDiscreteGroup(), promotes_inputs=['x'], promotes_outputs=['y'])
 
-        G2 = G.add_subsystem('G2', Group(), promotes_inputs=['x'])
-        G2.add_subsystem('C2_1', ExecComp('y=3*x'), promotes_inputs=['x'])
-        G2.add_subsystem('C2_2', ExecComp('y=4*x'), promotes_outputs=['y'])
+        G2 = G.add_subsystem('G2', om.Group(), promotes_inputs=['x'])
+        G2.add_subsystem('C2_1', om.ExecComp('y=3*x'), promotes_inputs=['x'])
+        G2.add_subsystem('C2_2', om.ExecComp('y=4*x'), promotes_outputs=['y'])
         G2.connect('C2_1.y', 'C2_2.x')
 
-        model.add_subsystem('C3', ExecComp('y=3+x'))
-        model.add_subsystem('C4', ExecComp('y=4+x'))
+        model.add_subsystem('C3', om.ExecComp('y=3+x'))
+        model.add_subsystem('C4', om.ExecComp('y=4+x'))
 
         model.connect('G.y', 'C3.x')
         model.connect('G.G2.y', 'C4.x')
@@ -472,16 +470,16 @@ class DiscreteTestCase(unittest.TestCase):
 
 class SolverDiscreteTestCase(unittest.TestCase):
     def _setup_model(self, solver_class):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         proms = ['x', 'z', 'y1', 'state_eq.y2_actual', 'state_eq.y2_command', 'd1.y2', 'd2.y2']
-        sub = model.add_subsystem('sub', Group(), promotes=proms)
+        sub = model.add_subsystem('sub', om.Group(), promotes=proms)
 
-        subgrp = sub.add_subsystem('state_eq_group', Group(),
+        subgrp = sub.add_subsystem('state_eq_group', om.Group(),
                                    promotes=['state_eq.y2_actual', 'state_eq.y2_command'])
         subgrp.add_subsystem('state_eq', StateConnection())
 
@@ -491,13 +489,13 @@ class SolverDiscreteTestCase(unittest.TestCase):
         model.connect('state_eq.y2_command', 'd1.y2')
         model.connect('d2.y2', 'state_eq.y2_actual')
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0, y1=0.0, y2=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0, y1=0.0, y2=0.0),
                             promotes=['x', 'z', 'y1', 'obj'])
         model.connect('d2.y2', 'obj_cmp.y2')
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
 
         # splice a group containing discrete vars into the model
         model.add_subsystem('discrete_g', InternalDiscreteGroup())
@@ -512,7 +510,7 @@ class SolverDiscreteTestCase(unittest.TestCase):
         return prob
 
     def test_discrete_err_newton(self):
-        prob = self._setup_model(NewtonSolver)
+        prob = self._setup_model(om.NewtonSolver)
 
         with self.assertRaises(Exception) as ctx:
             prob.run_model()
@@ -521,7 +519,7 @@ class SolverDiscreteTestCase(unittest.TestCase):
                          "System '' has a NewtonSolver solver and contains discrete outputs ['discrete_g.C1.y'].")
 
     def test_discrete_err_broyden(self):
-        prob = self._setup_model(BroydenSolver)
+        prob = self._setup_model(om.BroydenSolver)
 
         with self.assertRaises(Exception) as ctx:
             prob.run_model()
@@ -532,20 +530,20 @@ class SolverDiscreteTestCase(unittest.TestCase):
 
 class DiscretePromTestCase(unittest.TestCase):
     def test_str_pass(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp(), promotes_outputs=['x'])
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes_outputs=['x'])
         indep.add_discrete_output('x', 'indep/')
 
-        G = model.add_subsystem('G', ParallelGroup(), promotes_inputs=['x'])
+        G = model.add_subsystem('G', om.ParallelGroup(), promotes_inputs=['x'])
 
-        G1 = G.add_subsystem('G1', Group(), promotes_inputs=['x'], promotes_outputs=['y'])
+        G1 = G.add_subsystem('G1', om.Group(), promotes_inputs=['x'], promotes_outputs=['y'])
         G1.add_subsystem('C1_1', PathCompEx(), promotes_inputs=['x'])
         G1.add_subsystem('C1_2', PathCompEx(), promotes_outputs=['y'])
         G1.connect('C1_1.y', 'C1_2.x')
 
-        G2 = G.add_subsystem('G2', Group(), promotes_inputs=['x'])
+        G2 = G.add_subsystem('G2', om.Group(), promotes_inputs=['x'])
         G2.add_subsystem('C2_1', PathCompEx(), promotes_inputs=['x'])
         G2.add_subsystem('C2_2', PathCompEx(), promotes_outputs=['y'])
         G2.connect('C2_1.y', 'C2_2.x')
@@ -569,20 +567,20 @@ class DiscretePromTestCase(unittest.TestCase):
         self.assertEqual(prob['C4.y'], 'foobar/G.G2.C2_1/G.G2.C2_2/C4/')
 
     def test_obj_pass(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = model.add_subsystem('indep', IndepVarComp(), promotes_outputs=['x'])
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes_outputs=['x'])
         indep.add_discrete_output('x', _DiscreteVal(19))
 
-        G = model.add_subsystem('G', ParallelGroup(), promotes_inputs=['x'])
+        G = model.add_subsystem('G', om.ParallelGroup(), promotes_inputs=['x'])
 
-        G1 = G.add_subsystem('G1', Group(), promotes_inputs=['x'], promotes_outputs=['y'])
+        G1 = G.add_subsystem('G1', om.Group(), promotes_inputs=['x'], promotes_outputs=['y'])
         G1.add_subsystem('C1_1', ObjAdderCompEx(_DiscreteVal(5)), promotes_inputs=['x'])
         G1.add_subsystem('C1_2', ObjAdderCompEx(_DiscreteVal(7)), promotes_outputs=['y'])
         G1.connect('C1_1.y', 'C1_2.x')
 
-        G2 = G.add_subsystem('G2', Group(), promotes_inputs=['x'])
+        G2 = G.add_subsystem('G2', om.Group(), promotes_inputs=['x'])
         G2.add_subsystem('C2_1', ObjAdderCompEx(_DiscreteVal(1)), promotes_inputs=['x'])
         G2.add_subsystem('C2_2', ObjAdderCompEx(_DiscreteVal(11)), promotes_outputs=['y'])
         G2.connect('C2_1.y', 'C2_2.x')
@@ -635,9 +633,9 @@ class DiscretePromTestCase(unittest.TestCase):
 class DiscreteFeatureTestCase(unittest.TestCase):
     def test_feature_discrete(self):
         import numpy as np
-        from openmdao.api import Problem, IndepVarComp, ExplicitComponent
+        import openmdao.api as om
 
-        class BladeSolidity(ExplicitComponent):
+        class BladeSolidity(om.ExplicitComponent):
             def setup(self):
 
                 # Continuous Inputs
@@ -659,8 +657,8 @@ class DiscreteFeatureTestCase(unittest.TestCase):
                 outputs['blade_solidity'] = chord / (2.0 * np.pi * r_m / num_blades)
 
         # build the model
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('r_m', 3.2, units="ft")
         indeps.add_output('chord', .3, units='ft')
         indeps.add_discrete_output('num_blades', 2)

--- a/openmdao/core/tests/test_distrib_adder.py
+++ b/openmdao/core/tests/test_distrib_adder.py
@@ -85,13 +85,12 @@ class DistributedAdderTest(unittest.TestCase):
         size = 100  # how many items in the array
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size)), promotes=['x'])
         prob.model.add_subsystem('plus', DistributedAdder(size=size), promotes=['x', 'y'])
         summer = prob.model.add_subsystem('summer', Summer(size=size), promotes=['y', 'sum'])
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['x'] = np.ones(size)
 

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -87,13 +87,12 @@ class DistributedListVarsTest(unittest.TestCase):
         size = 100  # how many items in the array
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size)), promotes=['x'])
         prob.model.add_subsystem('plus', DistributedAdder(size=size), promotes=['x', 'y'])
         prob.model.add_subsystem('summer', Summer(size=size), promotes=['y', 'sum'])
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['x'] = np.arange(size)
 

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -276,7 +276,7 @@ class NOMPITests(unittest.TestCase):
               "available. The default non-distributed vectors will be used."
 
         with assert_warning(UserWarning, msg):
-            p.setup(check=False)
+            p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -302,7 +302,7 @@ class MPITests(unittest.TestCase):
         C2 = top.add_subsystem("C2", DistribCompSimple(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
 
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -322,7 +322,7 @@ class MPITests(unittest.TestCase):
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
 
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -344,7 +344,7 @@ class MPITests(unittest.TestCase):
                                               y=np.zeros(size*commsize)))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.x')
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -366,7 +366,7 @@ class MPITests(unittest.TestCase):
         C3 = top.add_subsystem("C3", DistribGatherComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.invec')
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -388,7 +388,7 @@ class MPITests(unittest.TestCase):
         C3 = top.add_subsystem("C3", DistribGatherComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.invec')
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -422,7 +422,7 @@ class MPITests(unittest.TestCase):
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribOverlappingInputComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -450,7 +450,7 @@ class MPITests(unittest.TestCase):
         C3 = top.add_subsystem("C3", NonDistribGatherComp(size=size))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.invec')
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -525,9 +525,9 @@ class DeprecatedMPITests(unittest.TestCase):
 
         if PETScVector is None:
             with assert_warning(UserWarning, msg):
-                p.setup(check=False)
+                p.setup()
         else:
-            p.setup(check=False)
+            p.setup()
 
         p.final_setup()
 
@@ -552,7 +552,7 @@ class ProbRemoteTests(unittest.TestCase):
         par = top.add_subsystem('par', ParallelGroup())
         C1 = par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
         C2 = par.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -265,7 +265,7 @@ class NOMPITests(unittest.TestCase):
     def test_distrib_idx_in_full_out(self):
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
@@ -296,7 +296,7 @@ class MPITests(unittest.TestCase):
     def test_distrib_full_in_out(self):
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribCompSimple(arr_size=size))
@@ -316,7 +316,7 @@ class MPITests(unittest.TestCase):
     def test_distrib_idx_in_full_out(self):
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
@@ -336,7 +336,7 @@ class MPITests(unittest.TestCase):
     def test_distrib_1D_dist_output(self):
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
@@ -359,7 +359,7 @@ class MPITests(unittest.TestCase):
         # normal comp to distrib comp to distrb gather comp
         size = 3
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
@@ -381,7 +381,7 @@ class MPITests(unittest.TestCase):
         # take even input indices in 0 rank and odd ones in 1 rank
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribNoncontiguousComp(arr_size=size))
@@ -417,7 +417,7 @@ class MPITests(unittest.TestCase):
         # entries are distributed to multiple processes
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribOverlappingInputComp(arr_size=size))
@@ -443,7 +443,7 @@ class MPITests(unittest.TestCase):
         # automagically gather the full vector without declaring src_indices
         size = 11
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
@@ -547,7 +547,7 @@ class ProbRemoteTests(unittest.TestCase):
     def test_prob_getitem_err(self):
         size = 3
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         par = top.add_subsystem('par', ParallelGroup())
         C1 = par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
@@ -668,7 +668,7 @@ class MPIFeatureTests(unittest.TestCase):
 
                 outputs['out'] = total[0]
 
-        p = Problem(model=Group())
+        p = Problem()
         top = p.model
         top.add_subsystem("indep", IndepVarComp('x', np.zeros(size)))
         top.add_subsystem("C2", DistribComp(size=size))

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -549,7 +549,7 @@ class ProbRemoteTests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        par = top.add_subsystem('par', ParallelGroup())
+        par = top.add_subsystem('par', om.ParallelGroup())
         C1 = par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
         C2 = par.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
         p.setup()

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -5,7 +5,7 @@ import time
 
 import numpy as np
 
-from openmdao.api import Problem, ExplicitComponent, Group, ExecComp, ParallelGroup
+import openmdao.api as om
 from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import evenly_distrib_idxs, take_nth
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
@@ -23,7 +23,7 @@ else:
     commsize = 1
 
 
-class InOutArrayComp(ExplicitComponent):
+class InOutArrayComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('arr_size', types=int, default=10,
@@ -43,7 +43,7 @@ class InOutArrayComp(ExplicitComponent):
         outputs['outvec'] = inputs['invec'] * 2.
 
 
-class DistribCompSimple(ExplicitComponent):
+class DistribCompSimple(om.ExplicitComponent):
     """Uses 2 procs but takes full input vars"""
 
     def initialize(self):
@@ -75,7 +75,7 @@ class DistribCompSimple(ExplicitComponent):
             outputs['outvec'] = inputs['invec'] * 0.75
 
 
-class DistribInputComp(ExplicitComponent):
+class DistribInputComp(om.ExplicitComponent):
     """Uses 2 procs and takes input var slices"""
 
     def initialize(self):
@@ -107,7 +107,7 @@ class DistribInputComp(ExplicitComponent):
         self.add_output('outvec', np.ones(arr_size, float), shape=np.int32(arr_size))
 
 
-class DistribOverlappingInputComp(ExplicitComponent):
+class DistribOverlappingInputComp(om.ExplicitComponent):
     """Uses 2 procs and takes input var slices"""
 
     def initialize(self):
@@ -151,7 +151,7 @@ class DistribOverlappingInputComp(ExplicitComponent):
                        src_indices=np.arange(start, end, dtype=int))
 
 
-class DistribInputDistribOutputComp(ExplicitComponent):
+class DistribInputDistribOutputComp(om.ExplicitComponent):
     """Uses 2 procs and takes input var slices."""
 
     def initialize(self):
@@ -179,7 +179,7 @@ class DistribInputDistribOutputComp(ExplicitComponent):
         self.add_output('outvec', np.ones(sizes[rank], float))
 
 
-class DistribNoncontiguousComp(ExplicitComponent):
+class DistribNoncontiguousComp(om.ExplicitComponent):
     """Uses 2 procs and takes non-contiguous input var slices and has output
     var slices as well
     """
@@ -207,7 +207,7 @@ class DistribNoncontiguousComp(ExplicitComponent):
         self.add_output('outvec', np.ones(len(idxs), float))
 
 
-class DistribGatherComp(ExplicitComponent):
+class DistribGatherComp(om.ExplicitComponent):
     """Uses 2 procs gathers a distrib input into a full output"""
 
     def initialize(self):
@@ -242,7 +242,7 @@ class DistribGatherComp(ExplicitComponent):
         self.add_output('outvec', np.ones(arr_size, float))
 
 
-class NonDistribGatherComp(ExplicitComponent):
+class NonDistribGatherComp(om.ExplicitComponent):
     """Uses 2 procs gathers a distrib output into a full input"""
 
     def initialize(self):
@@ -265,7 +265,7 @@ class NOMPITests(unittest.TestCase):
     def test_distrib_idx_in_full_out(self):
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
@@ -296,7 +296,7 @@ class MPITests(unittest.TestCase):
     def test_distrib_full_in_out(self):
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribCompSimple(arr_size=size))
@@ -316,7 +316,7 @@ class MPITests(unittest.TestCase):
     def test_distrib_idx_in_full_out(self):
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
@@ -336,12 +336,12 @@ class MPITests(unittest.TestCase):
     def test_distrib_1D_dist_output(self):
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
-        C3 = top.add_subsystem("C3", ExecComp("y=x", x=np.zeros(size*commsize),
-                                              y=np.zeros(size*commsize)))
+        C3 = top.add_subsystem("C3", om.ExecComp("y=x", x=np.zeros(size*commsize),
+                                                 y=np.zeros(size*commsize)))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.x')
         p.setup()
@@ -359,7 +359,7 @@ class MPITests(unittest.TestCase):
         # normal comp to distrib comp to distrb gather comp
         size = 3
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
@@ -381,7 +381,7 @@ class MPITests(unittest.TestCase):
         # take even input indices in 0 rank and odd ones in 1 rank
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribNoncontiguousComp(arr_size=size))
@@ -417,7 +417,7 @@ class MPITests(unittest.TestCase):
         # entries are distributed to multiple processes
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribOverlappingInputComp(arr_size=size))
@@ -443,7 +443,7 @@ class MPITests(unittest.TestCase):
         # automagically gather the full vector without declaring src_indices
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
@@ -469,7 +469,7 @@ class DeprecatedMPITests(unittest.TestCase):
 
     def test_distrib_idx_in_full_out_deprecated(self):
 
-        class DeprecatedDistribInputComp(ExplicitComponent):
+        class DeprecatedDistribInputComp(om.ExplicitComponent):
             """Deprecated version of DistribInputComp, uses attribute instead of option."""
 
             def __init__(self, arr_size=11):
@@ -500,7 +500,7 @@ class DeprecatedMPITests(unittest.TestCase):
 
         size = 11
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
 
         C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
@@ -547,7 +547,7 @@ class ProbRemoteTests(unittest.TestCase):
     def test_prob_getitem_err(self):
         size = 3
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
         par = top.add_subsystem('par', ParallelGroup())
         C1 = par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
@@ -593,7 +593,7 @@ class MPIFeatureTests(unittest.TestCase):
     def test_distribcomp_feature(self):
         import numpy as np
 
-        from openmdao.api import Problem, ExplicitComponent, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.utils.mpi import MPI
         from openmdao.utils.array_utils import evenly_distrib_idxs
 
@@ -603,7 +603,7 @@ class MPIFeatureTests(unittest.TestCase):
         rank = MPI.COMM_WORLD.rank
         size = 15
 
-        class DistribComp(ExplicitComponent):
+        class DistribComp(om.ExplicitComponent):
             def initialize(self):
                 self.options['distributed'] = True
 
@@ -632,7 +632,7 @@ class MPIFeatureTests(unittest.TestCase):
                 else:
                     outputs['outvec'] = inputs['invec'] * -3.0
 
-        class Summer(ExplicitComponent):
+        class Summer(om.ExplicitComponent):
             """Sums a distributed input."""
 
             def initialize(self):
@@ -668,9 +668,9 @@ class MPIFeatureTests(unittest.TestCase):
 
                 outputs['out'] = total[0]
 
-        p = Problem()
+        p = om.Problem()
         top = p.model
-        top.add_subsystem("indep", IndepVarComp('x', np.zeros(size)))
+        top.add_subsystem("indep", om.IndepVarComp('x', np.zeros(size)))
         top.add_subsystem("C2", DistribComp(size=size))
         top.add_subsystem("C3", Summer(size=size))
 
@@ -693,9 +693,9 @@ class TestGroupMPI(unittest.TestCase):
     def test_promote_distrib(self):
         import numpy as np
 
-        from openmdao.api import Problem, ExplicitComponent, IndepVarComp
+        import openmdao.api as om
 
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 # decide what parts of the array we want based on our rank
                 if self.comm.rank == 0:
@@ -711,9 +711,9 @@ class TestGroupMPI(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])*2.0
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('indep', IndepVarComp('x', np.arange(5, dtype=float)),
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.arange(5, dtype=float)),
                               promotes_outputs=['x'])
 
         p.model.add_subsystem('C1', MyComp(),

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -29,7 +29,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con1', lower=0)
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         designvars = prob.driver.get_design_var_values()
@@ -51,7 +51,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con1', lower=0)
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -74,7 +74,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con1', lower=0, ref=2.0, ref0=3.0)
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         cv = prob.driver.get_constraint_values()['con_cmp1.con1'][0]
@@ -91,7 +91,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con1', lower=0)
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         cv = prob.driver.get_objective_values()['obj_cmp.obj'][0]
@@ -108,7 +108,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con1')
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         base = prob.compute_totals(of=['obj', 'con1'], wrt=['z'])
@@ -121,7 +121,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con1', lower=0, ref=2.0, ref0=0.0)
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         derivs = prob.driver._compute_totals(of=['obj_cmp.obj', 'con_cmp1.con1'], wrt=['pz.z'],
@@ -142,7 +142,7 @@ class TestDriver(unittest.TestCase):
         model.add_objective('comp.y1', ref=np.array([[7.0, 11.0]]), ref0=np.array([5.2, 6.3]))
         model.add_constraint('comp.y2', lower=0.0, upper=1.0, ref=np.array([[2.0, 4.0]]), ref0=np.array([1.2, 2.3]))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         derivs = prob.driver._compute_totals(of=['comp.y1'], wrt=['px.x'],
@@ -205,7 +205,7 @@ class TestDriver(unittest.TestCase):
         model.add_objective('comp.y1', ref=np.array([[7.0, 11.0, 2.0]]), ref0=np.array([5.2, 6.3, 1.2]))
         model.add_constraint('comp.y2', lower=0.0, upper=1.0, ref=np.array([[2.0]]), ref0=np.array([1.2]))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         derivs = prob.driver._compute_totals(of=['comp.y1'], wrt=['px.x'],
@@ -243,7 +243,7 @@ class TestDriver(unittest.TestCase):
         model.add_constraint('con2', lower=0, linear=True)
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Make sure nothing prints if debug_print is the default of empty list
         stdout = sys.stdout
@@ -280,7 +280,7 @@ class TestDriver(unittest.TestCase):
 
     def test_debug_print_desvar_physical_with_indices(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         size = 3
         model.add_subsystem('p1', IndepVarComp('x', np.array([50.0] * size)))
@@ -309,7 +309,7 @@ class TestDriver(unittest.TestCase):
         model.add_objective('comp.f_xy', index=1)
         model.add_constraint('con.c', indices=[1], upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.driver.options['debug_print'] = ['desvars',]
         stdout = sys.stdout
@@ -332,7 +332,7 @@ class TestDriver(unittest.TestCase):
 
     def test_debug_print_response_physical(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         size = 3
         model.add_subsystem('p1', IndepVarComp('x', np.array([50.0] * size)))
@@ -361,7 +361,7 @@ class TestDriver(unittest.TestCase):
         model.add_objective('comp.f_xy', index=1, ref=1.5)
         model.add_constraint('con.c', indices=[1], upper=-15.0, ref=1.02)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.driver.options['debug_print'] = ['objs', 'nl_cons']
         stdout = sys.stdout
@@ -427,7 +427,7 @@ class TestDriver(unittest.TestCase):
 
         prob.driver = ScipyOptimizeDriver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(RuntimeError) as context:
             prob.final_setup()

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -132,7 +132,7 @@ class TestDriver(unittest.TestCase):
     def test_vector_scaled_derivs(self):
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
         comp = model.add_subsystem('comp', DoubleArrayComp())
@@ -171,7 +171,7 @@ class TestDriver(unittest.TestCase):
 
         # make sure no overflow when there is no specified upper/lower bound and significatn scaling
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
         comp = model.add_subsystem('comp', DoubleArrayComp())
@@ -195,7 +195,7 @@ class TestDriver(unittest.TestCase):
     def test_vector_scaled_derivs_diff_sizes(self):
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
         comp = model.add_subsystem('comp', NonSquareArrayComp())

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -8,18 +8,17 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, ExplicitComponent, NewtonSolver, ScipyKrylov, Group, \
-    IndepVarComp, LinearBlockGS, AnalysisError
-from openmdao.utils.assert_utils import assert_rel_error
+import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import SubSellar
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimple, \
     TestExplCompSimpleDense
+from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.general_utils import printoptions
 
 
 # Note: The following class definitions are used in feature docs
 
-class RectangleComp(ExplicitComponent):
+class RectangleComp(om.ExplicitComponent):
     """
     A simple Explicit Component that computes the area of a rectangle.
     """
@@ -59,10 +58,10 @@ class RectangleJacVec(RectangleComp):
                     d_inputs['width'] += inputs['length'] * d_outputs['area']
 
 
-class RectangleGroup(Group):
+class RectangleGroup(om.Group):
 
     def setup(self):
-        comp1 = self.add_subsystem('comp1', IndepVarComp())
+        comp1 = self.add_subsystem('comp1', om.IndepVarComp())
         comp1.add_output('length', 1.0)
         comp1.add_output('width', 1.0)
 
@@ -78,20 +77,20 @@ class RectangleGroup(Group):
 class ExplCompTestCase(unittest.TestCase):
 
     def test_simple(self):
-        prob = Problem(RectangleComp())
+        prob = om.Problem(RectangleComp())
         prob.setup()
         prob.run_model()
 
     def test_feature_simple(self):
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_expl_comp import RectangleComp
 
-        prob = Problem(RectangleComp())
+        prob = om.Problem(RectangleComp())
         prob.setup()
         prob.run_model()
 
     def test_compute_and_list(self):
-        prob = Problem(RectangleGroup())
+        prob = om.Problem(RectangleGroup())
         prob.setup()
 
         msg = "Unable to list inputs until model has been run."
@@ -156,23 +155,23 @@ class ExplCompTestCase(unittest.TestCase):
 
     def test_simple_list_vars_options(self):
 
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 12.0,
-                                               lower=1.0, upper=100.0,
-                                               ref=1.1, ref0=2.1,
-                                               units='inch'))
-        model.add_subsystem('p2', IndepVarComp('y', 1.0,
-                                               lower=2.0, upper=200.0,
-                                               ref=1.2, res_ref=2.2,
-                                               units='ft'))
-        model.add_subsystem('comp', ExecComp('z=x+y',
-                                             x={'value': 0.0, 'units': 'inch'},
-                                             y={'value': 0.0, 'units': 'inch'},
-                                             z={'value': 0.0, 'units': 'inch'}))
+        model.add_subsystem('p1', om.IndepVarComp('x', 12.0,
+                                                  lower=1.0, upper=100.0,
+                                                  ref=1.1, ref0=2.1,
+                                                  units='inch'))
+        model.add_subsystem('p2', om.IndepVarComp('y', 1.0,
+                                                  lower=2.0, upper=200.0,
+                                                  ref=1.2, res_ref=2.2,
+                                                  units='ft'))
+        model.add_subsystem('comp', om.ExecComp('z=x+y',
+                                                x={'value': 0.0, 'units': 'inch'},
+                                                y={'value': 0.0, 'units': 'inch'},
+                                                z={'value': 0.0, 'units': 'inch'}))
         model.connect('p1.x', 'comp.x')
         model.connect('p2.y', 'comp.y')
 
@@ -261,25 +260,25 @@ class ExplCompTestCase(unittest.TestCase):
 
     def test_for_feature_docs_list_vars_options(self):
 
-        from openmdao.api import IndepVarComp, Group, Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 12.0,
-                                               lower=1.0, upper=100.0,
-                                               ref=1.1, ref0=2.1,
-                                               units='inch',
-                                               ))
-        model.add_subsystem('p2', IndepVarComp('y', 1.0,
-                                               lower=2.0, upper=200.0,
-                                               ref=1.2, res_ref=2.2,
-                                               units='ft',
-                                               ))
-        model.add_subsystem('comp', ExecComp('z=x+y',
-                                             x={'value': 0.0, 'units': 'inch'},
-                                             y={'value': 0.0, 'units': 'inch'},
-                                             z={'value': 0.0, 'units': 'inch'}))
+        model.add_subsystem('p1', om.IndepVarComp('x', 12.0,
+                                                  lower=1.0, upper=100.0,
+                                                  ref=1.1, ref0=2.1,
+                                                  units='inch',
+                                                  ))
+        model.add_subsystem('p2', om.IndepVarComp('y', 1.0,
+                                                  lower=2.0, upper=200.0,
+                                                  ref=1.2, res_ref=2.2,
+                                                  units='ft',
+                                                  ))
+        model.add_subsystem('comp', om.ExecComp('z=x+y',
+                                                x={'value': 0.0, 'units': 'inch'},
+                                                y={'value': 0.0, 'units': 'inch'},
+                                                z={'value': 0.0, 'units': 'inch'}))
         model.connect('p1.x', 'comp.x')
         model.connect('p2.y', 'comp.y')
 
@@ -321,13 +320,13 @@ class ExplCompTestCase(unittest.TestCase):
 
     def test_hierarchy_list_vars_options(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -335,17 +334,17 @@ class ExplCompTestCase(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
 
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = LinearBlockGS()
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.LinearBlockGS()
 
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = ScipyKrylov()
-        g2.linear_solver.precon = LinearBlockGS()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.ScipyKrylov()
+        g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
         prob.setup()
@@ -434,7 +433,7 @@ class ExplCompTestCase(unittest.TestCase):
 
     def test_array_list_vars_options(self):
 
-        class ArrayAdder(ExplicitComponent):
+        class ArrayAdder(om.ExplicitComponent):
             """
             Just a simple component that has array inputs and outputs
             """
@@ -452,9 +451,9 @@ class ExplCompTestCase(unittest.TestCase):
 
         size = 100  # how many items in the array
 
-        prob = Problem()
+        prob = om.Problem()
 
-        prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size), units='inch'),
+        prob.model.add_subsystem('des_vars', om.IndepVarComp('x', np.ones(size), units='inch'),
                                  promotes=['x'])
         prob.model.add_subsystem('mult', ArrayAdder(size), promotes=['x', 'y'])
 
@@ -612,10 +611,11 @@ class ExplCompTestCase(unittest.TestCase):
     def test_for_docs_array_list_vars_options(self):
 
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent
+
+        import openmdao.api as om
         from openmdao.utils.general_utils import printoptions
 
-        class ArrayAdder(ExplicitComponent):
+        class ArrayAdder(om.ExplicitComponent):
             """
             Just a simple component that has array inputs and outputs
             """
@@ -633,8 +633,8 @@ class ExplCompTestCase(unittest.TestCase):
 
         size = 30
 
-        prob = Problem()
-        prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size), units='inch'),
+        prob = om.Problem()
+        prob.model.add_subsystem('des_vars', om.IndepVarComp('x', np.ones(size), units='inch'),
                                  promotes=['x'])
         prob.model.add_subsystem('mult', ArrayAdder(size), promotes=['x', 'y'])
 
@@ -677,7 +677,7 @@ class ExplCompTestCase(unittest.TestCase):
                 super(BadComp, self).compute(inputs, outputs)
                 inputs['length'] = 0.  # should not be allowed
 
-        prob = Problem(BadComp())
+        prob = om.Problem(BadComp())
         prob.setup()
 
         with self.assertRaises(ValueError) as cm:
@@ -691,11 +691,11 @@ class ExplCompTestCase(unittest.TestCase):
         class BadComp(TestExplCompSimple):
             def compute(self, inputs, outputs):
                 super(BadComp, self).compute(inputs, outputs)
-                raise AnalysisError("It's just a scratch.")
+                raise om.AnalysisError("It's just a scratch.")
 
-        prob = Problem(BadComp())
+        prob = om.Problem(BadComp())
         prob.setup()
-        with self.assertRaises(AnalysisError):
+        with self.assertRaises(om.AnalysisError):
             prob.run_model()
 
         # verify read_only status is reset after AnalysisError
@@ -707,7 +707,7 @@ class ExplCompTestCase(unittest.TestCase):
                 super(BadComp, self).compute_partials(inputs, partials)
                 inputs['length'] = 0.  # should not be allowed
 
-        prob = Problem(BadComp())
+        prob = om.Problem(BadComp())
         prob.setup()
         prob.run_model()
 
@@ -722,13 +722,13 @@ class ExplCompTestCase(unittest.TestCase):
         class BadComp(TestExplCompSimpleDense):
             def compute_partials(self, inputs, partials):
                 super(BadComp, self).compute_partials(inputs, partials)
-                raise AnalysisError("It's just a scratch.")
+                raise om.AnalysisError("It's just a scratch.")
 
-        prob = Problem(BadComp())
+        prob = om.Problem(BadComp())
         prob.setup()
         prob.run_model()
 
-        with self.assertRaises(AnalysisError):
+        with self.assertRaises(om.AnalysisError):
             prob.check_partials()
 
         # verify read_only status is reset after AnalysisError
@@ -740,7 +740,7 @@ class ExplCompTestCase(unittest.TestCase):
                 super(BadComp, self).compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
                 inputs['length'] = 0.  # should not be allowed
 
-        prob = Problem(BadComp())
+        prob = om.Problem(BadComp())
         prob.setup()
         prob.run_model()
 
@@ -755,13 +755,13 @@ class ExplCompTestCase(unittest.TestCase):
         class BadComp(RectangleJacVec):
             def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
                 super(BadComp, self).compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
-                raise AnalysisError("It's just a scratch.")
+                raise om.AnalysisError("It's just a scratch.")
 
-        prob = Problem(BadComp())
+        prob = om.Problem(BadComp())
         prob.setup()
         prob.run_model()
 
-        with self.assertRaises(AnalysisError):
+        with self.assertRaises(om.AnalysisError):
             prob.check_partials()
 
         # verify read_only status is reset after AnalysisError

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -79,7 +79,7 @@ class ExplCompTestCase(unittest.TestCase):
 
     def test_simple(self):
         prob = Problem(RectangleComp())
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
     def test_feature_simple(self):
@@ -87,12 +87,12 @@ class ExplCompTestCase(unittest.TestCase):
         from openmdao.core.tests.test_expl_comp import RectangleComp
 
         prob = Problem(RectangleComp())
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
     def test_compute_and_list(self):
         prob = Problem(RectangleGroup())
-        prob.setup(check=False)
+        prob.setup()
 
         msg = "Unable to list inputs until model has been run."
         try:
@@ -348,7 +348,7 @@ class ExplCompTestCase(unittest.TestCase):
         g2.linear_solver.precon = LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # logging inputs
@@ -453,13 +453,12 @@ class ExplCompTestCase(unittest.TestCase):
         size = 100  # how many items in the array
 
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size), units='inch'),
                                  promotes=['x'])
         prob.model.add_subsystem('mult', ArrayAdder(size), promotes=['x', 'y'])
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['x'] = np.ones(size)
 
@@ -635,12 +634,11 @@ class ExplCompTestCase(unittest.TestCase):
         size = 30
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size), units='inch'),
                                  promotes=['x'])
         prob.model.add_subsystem('mult', ArrayAdder(size), promotes=['x', 'y'])
 
-        prob.setup(check=False)
+        prob.setup()
         prob['x'] = np.arange(size)
         prob.run_driver()
 

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -159,7 +159,7 @@ class ExplCompTestCase(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 12.0,
                                                lower=1.0, upper=100.0,
@@ -264,7 +264,7 @@ class ExplCompTestCase(unittest.TestCase):
         from openmdao.api import IndepVarComp, Group, Problem, ExecComp
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 12.0,
                                                lower=1.0, upper=100.0,

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -443,7 +443,7 @@ class TestColoringSemitotals(unittest.TestCase):
     )
     def test_simple_semitotals(self, method, isplit, osplit):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         sparsity = setup_sparsity(_BIGMASK)
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'sub.comp')
@@ -481,7 +481,7 @@ class TestColoringSemitotals(unittest.TestCase):
     )
     def test_simple_semitotals_static(self, method, isplit, osplit):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         sparsity = setup_sparsity(_BIGMASK)
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'sub.comp')
@@ -507,7 +507,7 @@ class TestColoringSemitotals(unittest.TestCase):
 
         # now create a second problem and use the static coloring
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'sub.comp')
 
@@ -818,7 +818,7 @@ class TestStaticColoring(unittest.TestCase):
     )
     def test_simple_totals_static(self, method, isplit, osplit):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         sparsity = setup_sparsity(_BIGMASK)
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'comp')
@@ -845,7 +845,7 @@ class TestStaticColoring(unittest.TestCase):
 
         # new Problem, loading the coloring we just computed
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'comp')
 
@@ -885,7 +885,7 @@ class TestStaticColoring(unittest.TestCase):
     )
     def test_totals_over_implicit_comp(self, method, isplit, osplit):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         sparsity = setup_sparsity(_BIGMASK)
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'comp')
@@ -911,7 +911,7 @@ class TestStaticColoring(unittest.TestCase):
         model._save_coloring(compute_total_coloring(prob))
 
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, _BIGMASK.shape[1], 'indeps', 'comp')
 
@@ -951,7 +951,7 @@ class TestStaticColoring(unittest.TestCase):
     )
     def test_totals_of_indices(self, method):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         mask = np.array(
             [[1, 0, 0, 1, 1],
@@ -983,7 +983,7 @@ class TestStaticColoring(unittest.TestCase):
 
 
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 
@@ -1019,7 +1019,7 @@ class TestStaticColoring(unittest.TestCase):
     )
     def test_totals_wrt_indices(self, method):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         mask = np.array(
             [[1, 0, 0, 1, 1],
@@ -1052,7 +1052,7 @@ class TestStaticColoring(unittest.TestCase):
 
 
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 
@@ -1090,7 +1090,7 @@ class TestStaticColoring(unittest.TestCase):
     )
     def test_totals_of_wrt_indices(self, method):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         mask = np.array(
             [[1, 0, 0, 1, 1],
@@ -1125,7 +1125,7 @@ class TestStaticColoring(unittest.TestCase):
 
 
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 
@@ -1186,7 +1186,7 @@ class TestStaticColoringParallelCS(unittest.TestCase):
     )
     def test_simple_semitotals_all_local_vars(self, method):
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         mask = np.array(
             [[1, 0, 0, 1, 1],
@@ -1227,7 +1227,7 @@ class TestStaticColoringParallelCS(unittest.TestCase):
 
         # now create a second problem and use the static coloring
         prob = Problem(coloring_dir=self.tempdir)
-        model = prob.model = Group()
+        model = prob.model
 
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -5,15 +5,16 @@ from distutils.version import LooseVersion
 import unittest
 from copy import deepcopy
 from six.moves import cStringIO
+
 import numpy as np
 import scipy
 from scipy.sparse.linalg import gmres
 
-from openmdao.api import Problem, Group, ImplicitComponent, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-class CacheLinearTestCase(unittest.TestCase): 
+class CacheLinearTestCase(unittest.TestCase):
 
     def test_feature_cache_linear(self):
 
@@ -22,10 +23,10 @@ class CacheLinearTestCase(unittest.TestCase):
         import scipy
         from scipy.sparse.linalg import gmres
 
-        from openmdao.api import ImplicitComponent, Group, IndepVarComp, Problem
+        import openmdao.api as om
 
 
-        class QuadraticComp(ImplicitComponent):
+        class QuadraticComp(om.ImplicitComponent):
             """
             A Simple Implicit Component representing a Quadratic Equation.
 
@@ -88,9 +89,8 @@ class CacheLinearTestCase(unittest.TestCase):
                     else:
                         d_residuals['states'] = gmres(self.state_jac, d_outputs['states'], x0=d_residuals['states'], atol='legacy')[0]
 
-        p = Problem()
-        p.model = Group()
-        indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['a', 'b', 'c'])
+        p = om.Problem()
+        indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes_outputs=['a', 'b', 'c'])
         indeps.add_output('a', 1.)
         indeps.add_output('b', 4.)
         indeps.add_output('c', 1.)
@@ -113,6 +113,6 @@ class CacheLinearTestCase(unittest.TestCase):
         assert_rel_error(self, derivs['states', 'a'], [[-0.02072594],[4.]], 1e-6)
 
 
-if __name__ == "__main__": 
+if __name__ == "__main__":
     unittest.main()
 

--- a/openmdao/core/tests/test_getset_vars.py
+++ b/openmdao/core/tests/test_getset_vars.py
@@ -21,7 +21,7 @@ class TestGetSetVariables(unittest.TestCase):
         model.add_subsystem('g', g)
 
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         # -------------------------------------------------------------------
 
@@ -66,7 +66,7 @@ class TestGetSetVariables(unittest.TestCase):
         model.add_subsystem('g', g, promotes=['*'])
 
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         # -------------------------------------------------------------------
 
@@ -109,7 +109,7 @@ class TestGetSetVariables(unittest.TestCase):
         p = Problem()
         model = p.model
         model.add_subsystem('g', g)
-        p.setup(check=False)
+        p.setup()
 
         # -------------------------------------------------------------------
 
@@ -199,7 +199,7 @@ class TestGetSetVariables(unittest.TestCase):
         model.add_subsystem('g', g, promotes=['*'])
 
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -274,7 +274,7 @@ class TestGetSetVariables(unittest.TestCase):
         model.add_subsystem('g', g)
 
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         # -------------------------------------------------------------------
 
@@ -291,7 +291,7 @@ class TestGetSetVariables(unittest.TestCase):
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
         # -------------------------------------------------------------------
@@ -304,7 +304,7 @@ class TestGetSetVariables(unittest.TestCase):
 
         # Start from a clean state again
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         with self.assertRaises(Exception) as context:
             self.assertEqual(p['g.x'], 5.0)
@@ -327,7 +327,7 @@ class TestGetSetVariables(unittest.TestCase):
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
         with self.assertRaises(Exception) as context:
@@ -352,7 +352,7 @@ class TestGetSetVariables(unittest.TestCase):
         model.connect('x', 'g.x')
 
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         # inputs (g.x is connected to x)
         p['g.x'] = 5.0
@@ -362,7 +362,7 @@ class TestGetSetVariables(unittest.TestCase):
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
         # inputs (g.x is connected to x)
@@ -372,7 +372,7 @@ class TestGetSetVariables(unittest.TestCase):
 
         # Final test, the getitem
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
 
         with self.assertRaises(Exception) as context:
             self.assertEqual(p['g.x'], 5.0)
@@ -389,7 +389,7 @@ class TestGetSetVariables(unittest.TestCase):
 
         # Repeat test for post final_setup when vectors are allocated.
         p = Problem(model)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
         with self.assertRaises(Exception) as context:

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -358,7 +358,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('comp2', om.ExecComp('y=2*foo'), promotes_inputs=['foo'])
 
         with self.assertRaises(Exception) as err:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(err.exception),
                          "comp1: 'promotes_outputs' failed to find any matches for "
                          "the following names or patterns: ['xx'].")
@@ -370,7 +370,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('comp2', om.ExecComp('y=2*foo'), promotes_inputs=['foo'])
 
         with self.assertRaises(Exception) as err:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(err.exception),
                          "when adding subsystem 'comp1', entry '('x', 'foo', 'bar')' "
                          "is not a string or tuple of size 2")
@@ -423,7 +423,7 @@ class TestGroup(unittest.TestCase):
         p.model = Sellar()
 
         with self.assertRaises(Exception) as err:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(err.exception),
                          "d1: 'promotes_outputs' failed to find any matches for "
                          "the following names or patterns: ['foo'].")
@@ -484,7 +484,7 @@ class TestGroup(unittest.TestCase):
         G1.add_subsystem("C2", om.ExecComp("y=2.0*x"), promotes=['y'])
         msg = r"Output name 'y' refers to multiple outputs: \['G1.C1.y', 'G1.C2.y'\]."
         with assertRaisesRegex(self, Exception, msg):
-            prob.setup(check=False)
+            prob.setup()
 
     def test_basic_connect_units(self):
         import numpy as np
@@ -548,7 +548,7 @@ class TestGroup(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x', src_indices=[1, 0, 2])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          ": src_indices has been defined in both "
                          "connect('indep.x', 'C1.x') and add_input('C1.x', ...).")
@@ -609,7 +609,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('C2', om.ExecComp('y=x'), promotes_outputs=['x*'])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          "C2: 'promotes_outputs' failed to find any matches for "
                          "the following names or patterns: ['x*'].")
@@ -622,7 +622,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('C2', om.ExecComp('y=x'), promotes_inputs=['xx'])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          "C2: 'promotes_inputs' failed to find any matches for "
                          "the following names or patterns: ['xx'].")
@@ -635,7 +635,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('C2', om.ExecComp('y=x'), promotes=['xx'])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          "C2: 'promotes' failed to find any matches for "
                          "the following names or patterns: ['xx'].")
@@ -650,7 +650,7 @@ class TestGroup(unittest.TestCase):
                               promotes_inputs=['z', 'foo'])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          "d1: 'promotes_inputs' failed to find any matches for "
                          "the following names or patterns: ['foo'].")
@@ -665,7 +665,7 @@ class TestGroup(unittest.TestCase):
                               promotes_outputs=['y1', 'blammo', ('bar', 'blah')])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          "d1: 'promotes_outputs' failed to find any matches for "
                          "the following names or patterns: ['bar', 'blammo'].")
@@ -790,7 +790,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
         with self.assertRaises(Exception) as context:
-            p.setup(check=False)
+            p.setup()
         self.assertEqual(str(context.exception),
                          "src_indices for 'x' is not flat, so its input shape "
                          "must be provided. src_indices may contain an extra "
@@ -837,7 +837,7 @@ class TestGroup(unittest.TestCase):
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
         p.set_solver_print(level=0)
-        p.setup(check=False)
+        p.setup()
         p.run_model()
         assert_rel_error(self, p['C1.x'],
                          np.array([0., 10., 7., 4.]).reshape(tgt_shape))
@@ -902,7 +902,7 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(['indeps', 'C1', 'C2', 'C3'],
                          [s.name for s in model._static_subsystems_allprocs])
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         self.assertEqual(['C1', 'C2', 'C3'], order_list)
@@ -912,7 +912,7 @@ class TestGroup(unittest.TestCase):
         # Big boy rules
         model.set_order(['indeps', 'C2', 'C1', 'C3'])
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         self.assertEqual(['C2', 'C1', 'C3'], order_list)
 
@@ -951,7 +951,7 @@ class TestGroup(unittest.TestCase):
         model = prob.model
         model.add_subsystem('indeps', om.IndepVarComp('x', 1.))
         model.add_subsystem('G1', SetOrderGroup())
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         # this test passes if it doesn't raise an exception
@@ -1083,7 +1083,7 @@ def src_indices_model(src_shape, tgt_shape, src_indices=None, flat_src_indices=F
     if promotes is None:
         prob.model.connect('indeps.x', 'C1.x', src_indices=src_indices,
                            flat_src_indices=flat_src_indices)
-    prob.setup(check=False)
+    prob.setup()
     return prob
 
 
@@ -1147,7 +1147,7 @@ class TestConnect(unittest.TestCase):
         # because setup is not called until then
         self.sub.connect('src.z', 'tgt.x', src_indices=[1])
         with assertRaisesRegex(self, NameError, msg):
-            self.prob.setup(check=False)
+            self.prob.setup()
 
     def test_invalid_target(self):
         msg = "Input 'tgt.z' does not exist for connection " + \
@@ -1157,7 +1157,7 @@ class TestConnect(unittest.TestCase):
         # because setup is not called until then
         self.sub.connect('src.x', 'tgt.z', src_indices=[1])
         with assertRaisesRegex(self, NameError, msg):
-            self.prob.setup(check=False)
+            self.prob.setup()
 
     def test_connect_within_system(self):
         msg = "Output and input are in the same System for connection " + \
@@ -1177,7 +1177,7 @@ class TestConnect(unittest.TestCase):
               "in 'sub' from 'y' to 'tgt.x'."
 
         with assertRaisesRegex(self, RuntimeError, msg):
-            prob.setup(check=False)
+            prob.setup()
 
     def test_connect_units_with_unitless(self):
         prob = om.Problem()
@@ -1192,7 +1192,7 @@ class TestConnect(unittest.TestCase):
               "to input 'tgt.x' which has no units."
 
         with assert_warning(UserWarning, msg):
-            prob.setup(check=False)
+            prob.setup()
 
     def test_connect_incompatible_units(self):
         msg = "Output units of 'degC' for 'src.x2' are incompatible " \
@@ -1207,7 +1207,7 @@ class TestConnect(unittest.TestCase):
         prob.model.connect('src.x2', 'tgt.x')
 
         with assertRaisesRegex(self, RuntimeError, msg):
-            prob.setup(check=False)
+            prob.setup()
 
     def test_connect_units_with_nounits(self):
         prob = om.Problem()
@@ -1224,7 +1224,7 @@ class TestConnect(unittest.TestCase):
               "connected to output 'src.x2' which has no units."
 
         with assert_warning(UserWarning, msg):
-            prob.setup(check=False)
+            prob.setup()
 
         prob.run_model()
 
@@ -1242,7 +1242,7 @@ class TestConnect(unittest.TestCase):
               "connected to output 'src.y' which has no units."
 
         with assert_warning(UserWarning, msg):
-            prob.setup(check=False)
+            prob.setup()
 
         prob.run_model()
 
@@ -1254,7 +1254,7 @@ class TestConnect(unittest.TestCase):
                                  promotes=['x', 'y'], promotes_outputs=['y2'])
 
         with self.assertRaises(RuntimeError) as context:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(context.exception),
                          "src: 'promotes' cannot be used at the same time as "
@@ -1265,7 +1265,7 @@ class TestConnect(unittest.TestCase):
         prob.model.add_subsystem('src', om.ExecComp(['y = 2 * x', 'y2 = 3 * x2']),
                                  promotes=['x', 'y'], promotes_inputs=['x2'])
         with self.assertRaises(RuntimeError) as context:
-            prob.setup(check=False)
+            prob.setup()
 
         self.assertEqual(str(context.exception),
                          "src: 'promotes' cannot be used at the same time as "
@@ -1289,7 +1289,7 @@ class TestConnect(unittest.TestCase):
         root.connect('p.x', 'G1.par1.c2.x')
         root.connect('G1.par1.c2.y', 'G1.par1.c4.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         assert_rel_error(self, prob['G1.par1.c4.y'], 8.0)
@@ -1301,7 +1301,7 @@ class TestConnect(unittest.TestCase):
                "'sub.src.s' to 'sub.arr.x'.")
 
         with assertRaisesRegex(self, ValueError, msg):
-            self.prob.setup(check=False)
+            self.prob.setup()
 
     def test_bad_indices_shape(self):
         p = om.Problem()
@@ -1315,7 +1315,7 @@ class TestConnect(unittest.TestCase):
                r"shape is \(2.*, 2.*\) but indices are \(1.*, 2.*\).")
 
         with assertRaisesRegex(self, ValueError, msg):
-            p.setup(check=False)
+            p.setup()
 
     def test_bad_indices_dimensions(self):
         self.sub.connect('src.x', 'arr.x', src_indices=[(2, -1, 2), (2, 2, 2)],
@@ -1326,7 +1326,7 @@ class TestConnect(unittest.TestCase):
                "The source has 2 dimensions but the indices expect 3.")
 
         try:
-            self.prob.setup(check=False)
+            self.prob.setup()
         except ValueError as err:
             self.assertEqual(str(err), msg)
         else:
@@ -1342,7 +1342,7 @@ class TestConnect(unittest.TestCase):
                "is out of range for source dimension of size 3.")
 
         try:
-            self.prob.setup(check=False)
+            self.prob.setup()
         except ValueError as err:
             self.assertEqual(str(err), msg)
         else:

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1,11 +1,13 @@
+"""
+Unit tests for Group.
+"""
 from __future__ import print_function
 
+import itertools
 import unittest
 
 from six import assertRaisesRegex, iteritems
 from six.moves import range
-
-import itertools
 
 import numpy as np
 
@@ -14,42 +16,41 @@ try:
 except ImportError:
     from openmdao.utils.assert_utils import SkipParameterized as parameterized
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent, \
-    NonlinearRunOnce, NonLinearRunOnce, BalanceComp, NewtonSolver, DirectSolver
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis2
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
-class SimpleGroup(Group):
+class SimpleGroup(om.Group):
 
     def __init__(self):
         super(SimpleGroup, self).__init__()
 
-        self.add_subsystem('comp1', IndepVarComp('x', 5.0))
-        self.add_subsystem('comp2', ExecComp('b=2*a'))
+        self.add_subsystem('comp1', om.IndepVarComp('x', 5.0))
+        self.add_subsystem('comp2', om.ExecComp('b=2*a'))
         self.connect('comp1.x', 'comp2.a')
 
 
-class BranchGroup(Group):
+class BranchGroup(om.Group):
 
     def __init__(self):
         super(BranchGroup, self).__init__()
 
-        b1 = self.add_subsystem('Branch1', Group())
-        g1 = b1.add_subsystem('G1', Group())
-        g2 = g1.add_subsystem('G2', Group())
-        g2.add_subsystem('comp1', ExecComp('b=2.0*a', a=3.0, b=6.0))
+        b1 = self.add_subsystem('Branch1', om.Group())
+        g1 = b1.add_subsystem('G1', om.Group())
+        g2 = g1.add_subsystem('G2', om.Group())
+        g2.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))
 
-        b2 = self.add_subsystem('Branch2', Group())
-        g3 = b2.add_subsystem('G3', Group())
-        g3.add_subsystem('comp2', ExecComp('b=3.0*a', a=4.0, b=12.0))
+        b2 = self.add_subsystem('Branch2', om.Group())
+        g3 = b2.add_subsystem('G3', om.Group())
+        g3.add_subsystem('comp2', om.ExecComp('b=3.0*a', a=4.0, b=12.0))
 
 
-class SetOrderGroup(Group):
+class SetOrderGroup(om.Group):
     def setup(self):
-        self.add_subsystem('C1', ExecComp('y=2.0*x'))
-        self.add_subsystem('C2', ExecComp('y=2.0*x'))
-        self.add_subsystem('C3', ExecComp('y=2.0*x'))
+        self.add_subsystem('C1', om.ExecComp('y=2.0*x'))
+        self.add_subsystem('C2', om.ExecComp('y=2.0*x'))
+        self.add_subsystem('C3', om.ExecComp('y=2.0*x'))
 
         self.set_order(['C1', 'C3', 'C2'])
 
@@ -57,7 +58,7 @@ class SetOrderGroup(Group):
         self.connect('C3.y', 'C2.x')
 
 
-class ReportOrderComp(ExplicitComponent):
+class ReportOrderComp(om.ExplicitComponent):
     def __init__(self, order_list):
         super(ReportOrderComp, self).__init__()
         self._order_list = order_list
@@ -73,9 +74,9 @@ class ReportOrderComp(ExplicitComponent):
 class TestGroup(unittest.TestCase):
 
     def test_add_subsystem_class(self):
-        p = Problem()
+        p = om.Problem()
         try:
-            p.model.add_subsystem('comp', IndepVarComp)
+            p.model.add_subsystem('comp', om.IndepVarComp)
         except TypeError as err:
             self.assertEqual(str(err), "Subsystem 'comp' should be an instance, "
                                        "but a class object was found.")
@@ -84,32 +85,32 @@ class TestGroup(unittest.TestCase):
 
     def test_same_sys_name(self):
         """Test error checking for the case where we add two subsystems with the same name."""
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp('x', 5.0))
-        p.model.add_subsystem('comp2', ExecComp('b=2*a'))
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp('x', 5.0))
+        p.model.add_subsystem('comp2', om.ExecComp('b=2*a'))
 
         try:
-            p.model.add_subsystem('comp2', ExecComp('b=2*a'))
+            p.model.add_subsystem('comp2', om.ExecComp('b=2*a'))
         except Exception as err:
             self.assertEqual(str(err), "Subsystem name 'comp2' is already used.")
         else:
             self.fail('Exception expected.')
 
     def test_deprecated_runonce(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', 5.0))
-        p.model.add_subsystem('comp', ExecComp('b=2*a'))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', 5.0))
+        p.model.add_subsystem('comp', om.ExecComp('b=2*a'))
 
         msg = "NonLinearRunOnce is deprecated.  Use NonlinearRunOnce instead."
 
         with assert_warning(DeprecationWarning, msg):
-            p.model.nonlinear_solver = NonLinearRunOnce()
+            p.model.nonlinear_solver = om.NonLinearRunOnce()
 
     def test_group_simple(self):
-        from openmdao.api import ExecComp, Problem
+        import openmdao.api as om
 
-        p = Problem()
-        p.model.add_subsystem('comp1', ExecComp('b=2.0*a', a=3.0, b=6.0))
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))
 
         p.setup()
 
@@ -117,8 +118,8 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['comp1.b'], 6.0)
 
     def test_group_add(self):
-        model = Group()
-        ecomp = ExecComp('b=2.0*a', a=3.0, b=6.0)
+        model = om.Group()
+        ecomp = om.ExecComp('b=2.0*a', a=3.0, b=6.0)
 
         msg = "The 'add' method provides backwards compatibility with OpenMDAO <= 1.x ; " \
               "use 'add_subsystem' instead."
@@ -129,12 +130,12 @@ class TestGroup(unittest.TestCase):
         self.assertTrue(ecomp is comp1)
 
     def test_group_simple_promoted(self):
-        from openmdao.api import ExecComp, Problem, IndepVarComp
+        import openmdao.api as om
 
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('a', 3.0),
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('a', 3.0),
                               promotes_outputs=['a'])
-        p.model.add_subsystem('comp1', ExecComp('b=2.0*a'),
+        p.model.add_subsystem('comp1', om.ExecComp('b=2.0*a'),
                               promotes_inputs=['a'])
 
         p.setup()
@@ -144,10 +145,10 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['comp1.b'], 6.0)
 
     def test_inner_connect_w_extern_promote(self):
-        p = Problem()
-        g = p.model.add_subsystem('g', Group(), promotes_inputs=['c0.x'])
-        g.add_subsystem('ivc', IndepVarComp('x', 2.))
-        g.add_subsystem('c0', ExecComp('y = 2*x'))
+        p = om.Problem()
+        g = p.model.add_subsystem('g', om.Group(), promotes_inputs=['c0.x'])
+        g.add_subsystem('ivc', om.IndepVarComp('x', 2.))
+        g.add_subsystem('c0', om.ExecComp('y = 2*x'))
         g.connect('ivc.x', 'c0.x')
 
         p.setup()
@@ -163,11 +164,11 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(mans, [('c0.x', 'g')])
 
     def test_inner_connect_w_2extern_promotes(self):
-        p = Problem()
-        g0 = p.model.add_subsystem('g0', Group(), promotes_inputs=['c0.x'])
-        g = g0.add_subsystem('g', Group(), promotes_inputs=['c0.x'])
-        g.add_subsystem('ivc', IndepVarComp('x', 2.))
-        g.add_subsystem('c0', ExecComp('y = 2*x'))
+        p = om.Problem()
+        g0 = p.model.add_subsystem('g0', om.Group(), promotes_inputs=['c0.x'])
+        g = g0.add_subsystem('g', om.Group(), promotes_inputs=['c0.x'])
+        g.add_subsystem('ivc', om.IndepVarComp('x', 2.))
+        g.add_subsystem('c0', om.ExecComp('y = 2*x'))
         g.connect('ivc.x', 'c0.x')
 
         p.setup()
@@ -183,17 +184,17 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(mans, [('c0.x', 'g0.g')])
 
     def test_group_rename_connect(self):
-        from openmdao.api import Problem, IndepVarComp, ExecComp
+        import openmdao.api as om
 
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('aa', 3.0),
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('aa', 3.0),
                               promotes=['aa'])
-        p.model.add_subsystem('comp1', ExecComp('b=2.0*aa'),
+        p.model.add_subsystem('comp1', om.ExecComp('b=2.0*aa'),
                               promotes_inputs=['aa'])
 
         # here we alias 'a' to 'aa' so that it will be automatically
         # connected to the independent variable 'aa'.
-        p.model.add_subsystem('comp2', ExecComp('b=3.0*a'),
+        p.model.add_subsystem('comp2', om.ExecComp('b=3.0*a'),
                               promotes_inputs=[('a', 'aa')])
 
         p.setup()
@@ -203,13 +204,13 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['comp2.b'], 9.0)
 
     def test_subsys_attributes(self):
-        p = Problem()
+        p = om.Problem()
 
-        class MyGroup(Group):
+        class MyGroup(om.Group):
             def setup(self):
                 # two subsystems added during setup
-                self.add_subsystem('comp1', ExecComp('b=2.0*a', a=3.0, b=6.0))
-                self.add_subsystem('comp2', ExecComp('b=3.0*a', a=4.0, b=12.0))
+                self.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))
+                self.add_subsystem('comp2', om.ExecComp('b=3.0*a', a=4.0, b=12.0))
 
         # subsystems become attributes
         my_group = p.model.add_subsystem('gg', MyGroup())
@@ -228,25 +229,25 @@ class TestGroup(unittest.TestCase):
 
         # name cannot start with an underscore
         with self.assertRaises(Exception) as err:
-            p.model.add_subsystem('_bad_name', Group())
+            p.model.add_subsystem('_bad_name', om.Group())
         self.assertEqual(str(err.exception),
                          "'_bad_name' is not a valid system name.")
 
         # 'name', 'pathname', 'comm' and 'options' are reserved names
         for reserved in ['name', 'pathname', 'comm', 'options']:
             with self.assertRaises(Exception) as err:
-                p.model.add_subsystem(reserved, Group())
+                p.model.add_subsystem(reserved, om.Group())
             self.assertEqual(str(err.exception),
                              "Group '' already has an attribute '%s'." %
                              reserved)
 
     def test_group_nested(self):
-        from openmdao.api import ExecComp, Problem, Group
+        import openmdao.api as om
 
-        p = Problem()
-        p.model.add_subsystem('G1', Group())
-        p.model.G1.add_subsystem('comp1', ExecComp('b=2.0*a', a=3.0, b=6.0))
-        p.model.G1.add_subsystem('comp2', ExecComp('b=3.0*a', a=4.0, b=12.0))
+        p = om.Problem()
+        p.model.add_subsystem('G1', om.Group())
+        p.model.G1.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))
+        p.model.G1.add_subsystem('comp2', om.ExecComp('b=3.0*a', a=4.0, b=12.0))
 
         p.setup()
 
@@ -256,10 +257,10 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['G1.comp2.b'], 12.0)
 
     def test_group_getsystem_top(self):
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_group import BranchGroup
 
-        p = Problem(model=BranchGroup())
+        p = om.Problem(model=BranchGroup())
         p.setup()
 
         c1 = p.model.Branch1.G1.G2.comp1
@@ -269,14 +270,14 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(c2.pathname, 'Branch2.G3.comp2')
 
     def test_group_nested_promoted1(self):
-        from openmdao.api import Problem, Group, ExecComp
+        import openmdao.api as om
 
         # promotes from bottom level up 1
-        p = Problem()
-        g1 = p.model.add_subsystem('G1', Group())
-        g1.add_subsystem('comp1', ExecComp('b=2.0*a', a=3.0, b=6.0),
+        p = om.Problem()
+        g1 = p.model.add_subsystem('G1', om.Group())
+        g1.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0),
                          promotes_inputs=['a'], promotes_outputs=['b'])
-        g1.add_subsystem('comp2', ExecComp('b=3.0*a', a=4.0, b=12.0),
+        g1.add_subsystem('comp2', om.ExecComp('b=3.0*a', a=4.0, b=12.0),
                          promotes_inputs=['a'])
         p.setup()
 
@@ -290,13 +291,13 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['G1.comp2.a'], 4.0)
 
     def test_group_nested_promoted2(self):
-        from openmdao.api import Problem, Group, ExecComp
+        import openmdao.api as om
 
         # promotes up from G1 level
-        p = Problem()
-        g1 = Group()
-        g1.add_subsystem('comp1', ExecComp('b=2.0*a', a=3.0, b=6.0))
-        g1.add_subsystem('comp2', ExecComp('b=3.0*a', a=4.0, b=12.0))
+        p = om.Problem()
+        g1 = om.Group()
+        g1.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))
+        g1.add_subsystem('comp2', om.ExecComp('b=3.0*a', a=4.0, b=12.0))
 
         # use glob pattern 'comp?.a' to promote both comp1.a and comp2.a
         # use glob pattern 'comp?.b' to promote both comp1.b and comp2.b
@@ -316,10 +317,10 @@ class TestGroup(unittest.TestCase):
 
     def test_group_promotes(self):
         """Promoting a single variable."""
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp([('a', 2.0), ('x', 5.0)]),
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp([('a', 2.0), ('x', 5.0)]),
                               promotes_outputs=['x'])
-        p.model.add_subsystem('comp2', ExecComp('y=2*x'), promotes_inputs=['x'])
+        p.model.add_subsystem('comp2', om.ExecComp('y=2*x'), promotes_inputs=['x'])
         p.setup()
 
         p.set_solver_print(level=0)
@@ -330,10 +331,10 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['comp2.y'], 10)
 
     def test_group_renames(self):
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp('x', 5.0),
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp('x', 5.0),
                               promotes_outputs=[('x', 'foo')])
-        p.model.add_subsystem('comp2', ExecComp('y=2*foo'), promotes_inputs=['foo'])
+        p.model.add_subsystem('comp2', om.ExecComp('y=2*foo'), promotes_inputs=['foo'])
         p.setup()
 
         p.set_solver_print(level=0)
@@ -343,18 +344,18 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['comp2.y'], 10)
 
     def test_group_renames_errors_single_string(self):
-        p = Problem()
+        p = om.Problem()
         with self.assertRaises(Exception) as err:
-            p.model.add_subsystem('comp1', IndepVarComp('x', 5.0),
+            p.model.add_subsystem('comp1', om.IndepVarComp('x', 5.0),
                                   promotes_outputs='x')
         self.assertEqual(str(err.exception),
                          ": promotes must be an iterator of strings and/or tuples.")
 
     def test_group_renames_errors_not_found(self):
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp('x', 5.0),
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp('x', 5.0),
                               promotes_outputs=[('xx', 'foo')])
-        p.model.add_subsystem('comp2', ExecComp('y=2*foo'), promotes_inputs=['foo'])
+        p.model.add_subsystem('comp2', om.ExecComp('y=2*foo'), promotes_inputs=['foo'])
 
         with self.assertRaises(Exception) as err:
             p.setup(check=False)
@@ -363,10 +364,10 @@ class TestGroup(unittest.TestCase):
                          "the following names or patterns: ['xx'].")
 
     def test_group_renames_errors_bad_tuple(self):
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp('x', 5.0),
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp('x', 5.0),
                               promotes_outputs=[('x', 'foo', 'bar')])
-        p.model.add_subsystem('comp2', ExecComp('y=2*foo'), promotes_inputs=['foo'])
+        p.model.add_subsystem('comp2', om.ExecComp('y=2*foo'), promotes_inputs=['foo'])
 
         with self.assertRaises(Exception) as err:
             p.setup(check=False)
@@ -376,10 +377,10 @@ class TestGroup(unittest.TestCase):
 
     def test_group_promotes_multiple(self):
         """Promoting multiple variables."""
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp([('a', 2.0), ('x', 5.0)]),
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp([('a', 2.0), ('x', 5.0)]),
                               promotes_outputs=['a', 'x'])
-        p.model.add_subsystem('comp2', ExecComp('y=2*x'),
+        p.model.add_subsystem('comp2', om.ExecComp('y=2*x'),
                               promotes_inputs=['x'])
         p.setup()
 
@@ -392,10 +393,10 @@ class TestGroup(unittest.TestCase):
 
     def test_group_promotes_all(self):
         """Promoting all variables with asterisk."""
-        p = Problem()
-        p.model.add_subsystem('comp1', IndepVarComp([('a', 2.0), ('x', 5.0)]),
+        p = om.Problem()
+        p.model.add_subsystem('comp1', om.IndepVarComp([('a', 2.0), ('x', 5.0)]),
                               promotes_outputs=['*'])
-        p.model.add_subsystem('comp2', ExecComp('y=2*x'),
+        p.model.add_subsystem('comp2', om.ExecComp('y=2*x'),
                               promotes_inputs=['x'])
         p.setup()
 
@@ -408,9 +409,9 @@ class TestGroup(unittest.TestCase):
 
     def test_group_promotes2(self):
 
-        class Sellar(Group):
+        class Sellar(om.Group):
             def setup(self):
-                dv = self.add_subsystem('des_vars', IndepVarComp(), promotes=['*'])
+                dv = self.add_subsystem('des_vars', om.IndepVarComp(), promotes=['*'])
                 dv.add_output('x', 1.0)
                 dv.add_output('z', np.array([5.0, 2.0]))
 
@@ -418,7 +419,7 @@ class TestGroup(unittest.TestCase):
                                    promotes_inputs=['y1'], promotes_outputs=['foo'])
                 self.add_subsystem('d2', SellarDis2())
 
-        p = Problem()
+        p = om.Problem()
         p.model = Sellar()
 
         with self.assertRaises(Exception) as err:
@@ -429,21 +430,21 @@ class TestGroup(unittest.TestCase):
 
     def test_group_nested_conn(self):
         """Example of adding subsystems and issuing connections with nested groups."""
-        g1 = Group()
-        c1_1 = g1.add_subsystem('comp1', IndepVarComp('x', 5.0))
-        c1_2 = g1.add_subsystem('comp2', ExecComp('b=2*a'))
+        g1 = om.Group()
+        c1_1 = g1.add_subsystem('comp1', om.IndepVarComp('x', 5.0))
+        c1_2 = g1.add_subsystem('comp2', om.ExecComp('b=2*a'))
         g1.connect('comp1.x', 'comp2.a')
-        g2 = Group()
-        c2_1 = g2.add_subsystem('comp1', ExecComp('b=2*a'))
-        c2_2 = g2.add_subsystem('comp2', ExecComp('b=2*a'))
+        g2 = om.Group()
+        c2_1 = g2.add_subsystem('comp1', om.ExecComp('b=2*a'))
+        c2_2 = g2.add_subsystem('comp2', om.ExecComp('b=2*a'))
         g2.connect('comp1.b', 'comp2.a')
 
-        model = Group()
+        model = om.Group()
         model.add_subsystem('group1', g1)
         model.add_subsystem('group2', g2)
         model.connect('group1.comp2.b', 'group2.comp1.a')
 
-        p = Problem(model=model)
+        p = om.Problem(model=model)
         p.setup()
 
         c1_1 = p.model.group1.comp1
@@ -476,11 +477,11 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['group2.comp2.b'], 40.0)
 
     def test_reused_output_promoted_names(self):
-        prob = Problem()
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0))
-        G1 = prob.model.add_subsystem('G1', Group())
-        G1.add_subsystem("C1", ExecComp("y=2.0*x"), promotes=['y'])
-        G1.add_subsystem("C2", ExecComp("y=2.0*x"), promotes=['y'])
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
+        G1 = prob.model.add_subsystem('G1', om.Group())
+        G1.add_subsystem("C1", om.ExecComp("y=2.0*x"), promotes=['y'])
+        G1.add_subsystem("C2", om.ExecComp("y=2.0*x"), promotes=['y'])
         msg = r"Output name 'y' refers to multiple outputs: \['G1.C1.y', 'G1.C2.y'\]."
         with assertRaisesRegex(self, Exception, msg):
             prob.setup(check=False)
@@ -488,16 +489,16 @@ class TestGroup(unittest.TestCase):
     def test_basic_connect_units(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
 
-        indep_comp = IndepVarComp()
+        indep_comp = om.IndepVarComp()
         indep_comp.add_output('x', np.ones(5), units='ft')
 
-        exec_comp = ExecComp('y=sum(x)',
-                             x={'value': np.zeros(5), 'units': 'inch'},
-                             y={'units': 'inch'})
+        exec_comp = om.ExecComp('y=sum(x)',
+                                x={'value': np.zeros(5), 'units': 'inch'},
+                                y={'units': 'inch'})
 
         p.model.add_subsystem('indep', indep_comp)
         p.model.add_subsystem('comp1', exec_comp)
@@ -513,14 +514,14 @@ class TestGroup(unittest.TestCase):
     def test_connect_1_to_many(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)))
-        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros(5)))
-        p.model.add_subsystem('C2', ExecComp('y=sum(x)*4.0', x=np.zeros(5)))
-        p.model.add_subsystem('C3', ExecComp('y=sum(x)*6.0', x=np.zeros(5)))
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)))
+        p.model.add_subsystem('C1', om.ExecComp('y=sum(x)*2.0', x=np.zeros(5)))
+        p.model.add_subsystem('C2', om.ExecComp('y=sum(x)*4.0', x=np.zeros(5)))
+        p.model.add_subsystem('C3', om.ExecComp('y=sum(x)*6.0', x=np.zeros(5)))
 
         p.model.connect('indep.x', ['C1.x', 'C2.x', 'C3.x'])
 
@@ -532,7 +533,7 @@ class TestGroup(unittest.TestCase):
         assert_rel_error(self, p['C3.y'], 30.)
 
     def test_double_src_indices(self):
-        class MyComp1(ExplicitComponent):
+        class MyComp1(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x', np.ones(3), src_indices=[0, 1, 2])
                 self.add_output('y', 1.0)
@@ -540,9 +541,9 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])*2.0
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)))
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)))
         p.model.add_subsystem('C1', MyComp1())
         p.model.connect('indep.x', 'C1.x', src_indices=[1, 0, 2])
 
@@ -555,13 +556,13 @@ class TestGroup(unittest.TestCase):
     def test_connect_src_indices(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)))
-        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros(3)))
-        p.model.add_subsystem('C2', ExecComp('y=sum(x)*4.0', x=np.zeros(2)))
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)))
+        p.model.add_subsystem('C1', om.ExecComp('y=sum(x)*2.0', x=np.zeros(3)))
+        p.model.add_subsystem('C2', om.ExecComp('y=sum(x)*4.0', x=np.zeros(2)))
 
         # connect C1.x to the first 3 entries of indep.x
         p.model.connect('indep.x', 'C1.x', src_indices=[0, 1, 2])
@@ -581,12 +582,12 @@ class TestGroup(unittest.TestCase):
     def test_connect_src_indices_noflat(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('indep', IndepVarComp('x', np.arange(12).reshape((4, 3))))
-        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros((2, 2))))
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.arange(12).reshape((4, 3))))
+        p.model.add_subsystem('C1', om.ExecComp('y=sum(x)*2.0', x=np.zeros((2, 2))))
 
         # connect C1.x to entries (0,0), (-1,1), (2,1), (1,1) of indep.x
         p.model.connect('indep.x', 'C1.x',
@@ -601,11 +602,11 @@ class TestGroup(unittest.TestCase):
         assert_rel_error(self, p['C1.y'], 42.)
 
     def test_promote_not_found1(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)),
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)),
                               promotes_outputs=['x'])
-        p.model.add_subsystem('C1', ExecComp('y=x'), promotes_inputs=['x'])
-        p.model.add_subsystem('C2', ExecComp('y=x'), promotes_outputs=['x*'])
+        p.model.add_subsystem('C1', om.ExecComp('y=x'), promotes_inputs=['x'])
+        p.model.add_subsystem('C2', om.ExecComp('y=x'), promotes_outputs=['x*'])
 
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
@@ -614,11 +615,11 @@ class TestGroup(unittest.TestCase):
                          "the following names or patterns: ['x*'].")
 
     def test_promote_not_found2(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)),
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)),
                               promotes_outputs=['x'])
-        p.model.add_subsystem('C1', ExecComp('y=x'), promotes_inputs=['x'])
-        p.model.add_subsystem('C2', ExecComp('y=x'), promotes_inputs=['xx'])
+        p.model.add_subsystem('C1', om.ExecComp('y=x'), promotes_inputs=['x'])
+        p.model.add_subsystem('C2', om.ExecComp('y=x'), promotes_inputs=['xx'])
 
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
@@ -627,11 +628,11 @@ class TestGroup(unittest.TestCase):
                          "the following names or patterns: ['xx'].")
 
     def test_promote_not_found3(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)),
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)),
                               promotes_outputs=['x'])
-        p.model.add_subsystem('C1', ExecComp('y=x'), promotes=['x'])
-        p.model.add_subsystem('C2', ExecComp('y=x'), promotes=['xx'])
+        p.model.add_subsystem('C1', om.ExecComp('y=x'), promotes=['x'])
+        p.model.add_subsystem('C2', om.ExecComp('y=x'), promotes=['xx'])
 
         with self.assertRaises(Exception) as context:
             p.setup(check=False)
@@ -640,12 +641,12 @@ class TestGroup(unittest.TestCase):
                          "the following names or patterns: ['xx'].")
 
     def test_missing_promote_var(self):
-        p = Problem()
+        p = om.Problem()
 
-        indep_var_comp = IndepVarComp('z', val=2.)
+        indep_var_comp = om.IndepVarComp('z', val=2.)
         p.model.add_subsystem('indep_vars', indep_var_comp, promotes=['*'])
 
-        p.model.add_subsystem('d1', ExecComp("y1=z+bar"),
+        p.model.add_subsystem('d1', om.ExecComp("y1=z+bar"),
                               promotes_inputs=['z', 'foo'])
 
         with self.assertRaises(Exception) as context:
@@ -655,12 +656,12 @@ class TestGroup(unittest.TestCase):
                          "the following names or patterns: ['foo'].")
 
     def test_missing_promote_var2(self):
-        p = Problem()
+        p = om.Problem()
 
-        indep_var_comp = IndepVarComp('z', val=2.)
+        indep_var_comp = om.IndepVarComp('z', val=2.)
         p.model.add_subsystem('indep_vars', indep_var_comp, promotes=['*'])
 
-        p.model.add_subsystem('d1', ExecComp("y1=z+bar"),
+        p.model.add_subsystem('d1', om.ExecComp("y1=z+bar"),
                               promotes_outputs=['y1', 'blammo', ('bar', 'blah')])
 
         with self.assertRaises(Exception) as context:
@@ -672,9 +673,9 @@ class TestGroup(unittest.TestCase):
     def test_promote_src_indices(self):
         import numpy as np
 
-        from openmdao.api import ExplicitComponent, Problem, IndepVarComp
+        import openmdao.api as om
 
-        class MyComp1(ExplicitComponent):
+        class MyComp1(om.ExplicitComponent):
             def setup(self):
                 # this input will connect to entries 0, 1, and 2 of its source
                 self.add_input('x', np.ones(3), src_indices=[0, 1, 2])
@@ -683,7 +684,7 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])*2.0
 
-        class MyComp2(ExplicitComponent):
+        class MyComp2(om.ExplicitComponent):
             def setup(self):
                 # this input will connect to entries 3 and 4 of its source
                 self.add_input('x', np.ones(2), src_indices=[3, 4])
@@ -692,11 +693,11 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])*4.0
 
-        p = Problem()
+        p = om.Problem()
 
         # by promoting the following output and inputs to 'x', they will
         # be automatically connected
-        p.model.add_subsystem('indep', IndepVarComp('x', np.ones(5)),
+        p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp1(), promotes_inputs=['x'])
         p.model.add_subsystem('C2', MyComp2(), promotes_inputs=['x'])
@@ -712,9 +713,9 @@ class TestGroup(unittest.TestCase):
     def test_promote_src_indices_nonflat(self):
         import numpy as np
 
-        from openmdao.api import ExplicitComponent, Problem, IndepVarComp
+        import openmdao.api as om
 
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 # We want to pull the following 4 values out of the source:
                 # [(0,0), (3,1), (2,1), (1,1)].
@@ -732,12 +733,12 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])
 
-        p = Problem()
+        p = om.Problem()
 
         # by promoting the following output and inputs to 'x', they will
         # be automatically connected
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape((4, 3))),
+                              om.IndepVarComp('x', np.arange(12).reshape((4, 3))),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(),
                               promotes_inputs=['x'])
@@ -751,7 +752,7 @@ class TestGroup(unittest.TestCase):
         assert_rel_error(self, p['C1.y'], 21.)
 
     def test_promote_src_indices_nonflat_to_scalars(self):
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x', 1.0, src_indices=[(3, 1)], shape=(1,))
                 self.add_output('y', 1.0)
@@ -759,10 +760,10 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = inputs['x']*2.0
 
-        p = Problem()
+        p = om.Problem()
 
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape((4, 3))),
+                              om.IndepVarComp('x', np.arange(12).reshape((4, 3))),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
@@ -773,7 +774,7 @@ class TestGroup(unittest.TestCase):
         assert_rel_error(self, p['C1.y'], 20.)
 
     def test_promote_src_indices_nonflat_error(self):
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x', 1.0, src_indices=[(3, 1)])
                 self.add_output('y', 1.0)
@@ -781,10 +782,10 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])
 
-        p = Problem()
+        p = om.Problem()
 
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape((4, 3))),
+                              om.IndepVarComp('x', np.arange(12).reshape((4, 3))),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
@@ -806,7 +807,7 @@ class TestGroup(unittest.TestCase):
     def test_promote_src_indices_param(self, src_info, tgt_shape):
         src_shape, idxvals = src_info
 
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
             def setup(self):
                 if len(tgt_shape) == 1:
                     tshape = None  # don't need to set shape if input is flat
@@ -828,10 +829,10 @@ class TestGroup(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['y'] = np.sum(inputs['x'])
 
-        p = Problem()
+        p = om.Problem()
 
         p.model.add_subsystem('indep',
-                              IndepVarComp('x', np.arange(12).reshape(src_shape)),
+                              om.IndepVarComp('x', np.arange(12).reshape(src_shape)),
                               promotes_outputs=['x'])
         p.model.add_subsystem('C1', MyComp(), promotes_inputs=['x'])
 
@@ -843,9 +844,9 @@ class TestGroup(unittest.TestCase):
         assert_rel_error(self, p['C1.y'], 21.)
 
     def test_set_order_feature(self):
-        from openmdao.api import Problem, IndepVarComp, ExplicitComponent
+        import openmdao.api as om
 
-        class ReportOrderComp(ExplicitComponent):
+        class ReportOrderComp(om.ExplicitComponent):
             """Adds name to list."""
 
             def __init__(self, order_list):
@@ -858,10 +859,10 @@ class TestGroup(unittest.TestCase):
         # this list will record the execution order of our C1, C2, and C3 components
         order_list = []
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', 1.))
+        model.add_subsystem('indeps', om.IndepVarComp('x', 1.))
         model.add_subsystem('C1', ReportOrderComp(order_list))
         model.add_subsystem('C2', ReportOrderComp(order_list))
         model.add_subsystem('C3', ReportOrderComp(order_list))
@@ -886,10 +887,10 @@ class TestGroup(unittest.TestCase):
     def test_set_order(self):
 
         order_list = []
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.nonlinear_solver = NonlinearRunOnce()
-        model.add_subsystem('indeps', IndepVarComp('x', 1.))
+        model.nonlinear_solver = om.NonlinearRunOnce()
+        model.add_subsystem('indeps', om.IndepVarComp('x', 1.))
         model.add_subsystem('C1', ReportOrderComp(order_list))
         model.add_subsystem('C2', ReportOrderComp(order_list))
         model.add_subsystem('C3', ReportOrderComp(order_list))
@@ -946,9 +947,9 @@ class TestGroup(unittest.TestCase):
                          ": Duplicate name(s) found in subsystem order list: ['C1']")
 
     def test_set_order_init_subsystems(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('indeps', IndepVarComp('x', 1.))
+        model.add_subsystem('indeps', om.IndepVarComp('x', 1.))
         model.add_subsystem('G1', SetOrderGroup())
         prob.setup(check=False)
         prob.run_model()
@@ -956,16 +957,16 @@ class TestGroup(unittest.TestCase):
         # this test passes if it doesn't raise an exception
 
     def test_guess_nonlinear_feature(self):
-        from openmdao.api import Problem, Group, ExecComp, IndepVarComp, BalanceComp, NewtonSolver, DirectSolver
+        import openmdao.api as om
 
-        class Discipline(Group):
+        class Discipline(om.Group):
 
             def setup(self):
-                self.add_subsystem('comp0', ExecComp('y=x**2'))
-                self.add_subsystem('comp1', ExecComp('z=2*external_input'),
+                self.add_subsystem('comp0', om.ExecComp('y=x**2'))
+                self.add_subsystem('comp1', om.ExecComp('z=2*external_input'),
                                    promotes_inputs=['external_input'])
 
-                self.add_subsystem('balance', BalanceComp('x', lhs_name='y', rhs_name='z'),
+                self.add_subsystem('balance', om.BalanceComp('x', lhs_name='y', rhs_name='z'),
                                    promotes_outputs=['x'])
 
                 self.connect('comp0.y', 'balance.y')
@@ -973,8 +974,8 @@ class TestGroup(unittest.TestCase):
 
                 self.connect('x', 'comp0.x')
 
-                self.nonlinear_solver = NewtonSolver(iprint=2, solve_subsystems=True)
-                self.linear_solver = DirectSolver()
+                self.nonlinear_solver = om.NewtonSolver(iprint=2, solve_subsystems=True)
+                self.linear_solver = om.DirectSolver()
 
             def guess_nonlinear(self, inputs, outputs, residuals):
                 # inputs are addressed using full path name, regardless of promotion
@@ -986,9 +987,9 @@ class TestGroup(unittest.TestCase):
                 # outputs are addressed by the their promoted names
                 outputs['x'] = x_guess # perfect guess should converge in 0 iterations
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('parameters', IndepVarComp('input_value', 1.))
+        p.model.add_subsystem('parameters', om.IndepVarComp('input_value', 1.))
         p.model.add_subsystem('discipline', Discipline())
 
         p.model.connect('parameters.input_value', 'discipline.external_input')
@@ -1002,14 +1003,14 @@ class TestGroup(unittest.TestCase):
 
     def test_guess_nonlinear_complex_step(self):
 
-        class Discipline(Group):
+        class Discipline(om.Group):
 
             def setup(self):
-                self.add_subsystem('comp0', ExecComp('y=x**2'))
-                self.add_subsystem('comp1', ExecComp('z=2*external_input'),
+                self.add_subsystem('comp0', om.ExecComp('y=x**2'))
+                self.add_subsystem('comp1', om.ExecComp('z=2*external_input'),
                                    promotes_inputs=['external_input'])
 
-                self.add_subsystem('balance', BalanceComp('x', lhs_name='y', rhs_name='z'),
+                self.add_subsystem('balance', om.BalanceComp('x', lhs_name='y', rhs_name='z'),
                                    promotes_outputs=['x'])
 
                 self.connect('comp0.y', 'balance.y')
@@ -1017,8 +1018,8 @@ class TestGroup(unittest.TestCase):
 
                 self.connect('x', 'comp0.x')
 
-                self.nonlinear_solver = NewtonSolver(iprint=2, solve_subsystems=True)
-                self.linear_solver = DirectSolver()
+                self.nonlinear_solver = om.NewtonSolver(iprint=2, solve_subsystems=True)
+                self.linear_solver = om.DirectSolver()
 
             def guess_nonlinear(self, inputs, outputs, residuals):
 
@@ -1034,9 +1035,9 @@ class TestGroup(unittest.TestCase):
                 # outputs are addressed by the their promoted names
                 outputs['x'] = x_guess # perfect guess should converge in 0 iterations
 
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('parameters', IndepVarComp('input_value', 1.))
+        p.model.add_subsystem('parameters', om.IndepVarComp('input_value', 1.))
         p.model.add_subsystem('discipline', Discipline())
 
         p.model.connect('parameters.input_value', 'discipline.external_input')
@@ -1054,7 +1055,7 @@ class TestGroup(unittest.TestCase):
             assert_rel_error(self, val['rel error'][0], 0.0, 1e-15)
 
 
-class MyComp(ExplicitComponent):
+class MyComp(om.ExplicitComponent):
     def __init__(self, input_shape, src_indices=None, flat_src_indices=False):
         super(MyComp, self).__init__()
         self._input_shape = input_shape
@@ -1072,8 +1073,8 @@ class MyComp(ExplicitComponent):
 
 def src_indices_model(src_shape, tgt_shape, src_indices=None, flat_src_indices=False,
                       promotes=None):
-    prob = Problem()
-    prob.model.add_subsystem('indeps', IndepVarComp('x', shape=src_shape),
+    prob = om.Problem()
+    prob.model.add_subsystem('indeps', om.IndepVarComp('x', shape=src_shape),
                              promotes=promotes)
     prob.model.add_subsystem('C1', MyComp(tgt_shape,
                                           src_indices=src_indices if promotes else None,
@@ -1089,17 +1090,17 @@ def src_indices_model(src_shape, tgt_shape, src_indices=None, flat_src_indices=F
 class TestConnect(unittest.TestCase):
 
     def setUp(self):
-        prob = Problem(Group())
+        prob = om.Problem(om.Group())
 
-        sub = prob.model.add_subsystem('sub', Group())
+        sub = prob.model.add_subsystem('sub', om.Group())
 
-        idv = sub.add_subsystem('src', IndepVarComp())
+        idv = sub.add_subsystem('src', om.IndepVarComp())
         idv.add_output('x', np.arange(15).reshape((5, 3)))  # array
         idv.add_output('s', 3.)                             # scalar
 
-        sub.add_subsystem('tgt', ExecComp('y = x'))
-        sub.add_subsystem('cmp', ExecComp('z = x'))
-        sub.add_subsystem('arr', ExecComp('a = x', x=np.zeros(2)))
+        sub.add_subsystem('tgt', om.ExecComp('y = x'))
+        sub.add_subsystem('cmp', om.ExecComp('z = x'))
+        sub.add_subsystem('arr', om.ExecComp('a = x', x=np.zeros(2)))
 
         self.sub = sub
         self.prob = prob
@@ -1166,10 +1167,10 @@ class TestConnect(unittest.TestCase):
             self.sub.connect('tgt.y', 'tgt.x', src_indices=[1])
 
     def test_connect_within_system_with_promotes(self):
-        prob = Problem(Group())
+        prob = om.Problem()
 
-        sub = prob.model.add_subsystem('sub', Group())
-        sub.add_subsystem('tgt', ExecComp('y = x'), promotes_outputs=['y'])
+        sub = prob.model.add_subsystem('sub', om.Group())
+        sub.add_subsystem('tgt', om.ExecComp('y = x'), promotes_outputs=['y'])
         sub.connect('y', 'tgt.x', src_indices=[1])
 
         msg = "Output and input are in the same System for connection " + \
@@ -1179,10 +1180,10 @@ class TestConnect(unittest.TestCase):
             prob.setup(check=False)
 
     def test_connect_units_with_unitless(self):
-        prob = Problem(Group())
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0))
-        prob.model.add_subsystem('src', ExecComp('x2 = 2 * x1', x2={'units': 'degC'}))
-        prob.model.add_subsystem('tgt', ExecComp('y = 3 * x', x={'units': 'unitless'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
+        prob.model.add_subsystem('src', om.ExecComp('x2 = 2 * x1', x2={'units': 'degC'}))
+        prob.model.add_subsystem('tgt', om.ExecComp('y = 3 * x', x={'units': 'unitless'}))
 
         prob.model.connect('px1.x1', 'src.x1')
         prob.model.connect('src.x2', 'tgt.x')
@@ -1197,10 +1198,10 @@ class TestConnect(unittest.TestCase):
         msg = "Output units of 'degC' for 'src.x2' are incompatible " \
               "with input units of 'm' for 'tgt.x'."
 
-        prob = Problem(Group())
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0))
-        prob.model.add_subsystem('src', ExecComp('x2 = 2 * x1', x2={'units': 'degC'}))
-        prob.model.add_subsystem('tgt', ExecComp('y = 3 * x', x={'units': 'm'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
+        prob.model.add_subsystem('src', om.ExecComp('x2 = 2 * x1', x2={'units': 'degC'}))
+        prob.model.add_subsystem('tgt', om.ExecComp('y = 3 * x', x={'units': 'm'}))
 
         prob.model.connect('px1.x1', 'src.x1')
         prob.model.connect('src.x2', 'tgt.x')
@@ -1209,10 +1210,10 @@ class TestConnect(unittest.TestCase):
             prob.setup(check=False)
 
     def test_connect_units_with_nounits(self):
-        prob = Problem(Group())
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0))
-        prob.model.add_subsystem('src', ExecComp('x2 = 2 * x1'))
-        prob.model.add_subsystem('tgt', ExecComp('y = 3 * x', x={'units': 'degC'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
+        prob.model.add_subsystem('src', om.ExecComp('x2 = 2 * x1'))
+        prob.model.add_subsystem('tgt', om.ExecComp('y = 3 * x', x={'units': 'degC'}))
 
         prob.model.connect('px1.x1', 'src.x1')
         prob.model.connect('src.x2', 'tgt.x')
@@ -1230,10 +1231,10 @@ class TestConnect(unittest.TestCase):
         assert_rel_error(self, prob['tgt.y'], 600.)
 
     def test_connect_units_with_nounits_prom(self):
-        prob = Problem(Group())
-        prob.model.add_subsystem('px1', IndepVarComp('x', 100.0), promotes_outputs=['x'])
-        prob.model.add_subsystem('src', ExecComp('y = 2 * x'), promotes=['x', 'y'])
-        prob.model.add_subsystem('tgt', ExecComp('z = 3 * y', y={'units': 'degC'}), promotes=['y'])
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x', 100.0), promotes_outputs=['x'])
+        prob.model.add_subsystem('src', om.ExecComp('y = 2 * x'), promotes=['x', 'y'])
+        prob.model.add_subsystem('tgt', om.ExecComp('z = 3 * y', y={'units': 'degC'}), promotes=['y'])
 
         prob.set_solver_print(level=0)
 
@@ -1248,8 +1249,8 @@ class TestConnect(unittest.TestCase):
         assert_rel_error(self, prob['tgt.z'], 600.)
 
     def test_mix_promotes_types(self):
-        prob = Problem()
-        prob.model.add_subsystem('src', ExecComp(['y = 2 * x', 'y2 = 3 * x']),
+        prob = om.Problem()
+        prob.model.add_subsystem('src', om.ExecComp(['y = 2 * x', 'y2 = 3 * x']),
                                  promotes=['x', 'y'], promotes_outputs=['y2'])
 
         with self.assertRaises(RuntimeError) as context:
@@ -1260,8 +1261,8 @@ class TestConnect(unittest.TestCase):
                          "'promotes_inputs' or 'promotes_outputs'.")
 
     def test_mix_promotes_types2(self):
-        prob = Problem()
-        prob.model.add_subsystem('src', ExecComp(['y = 2 * x', 'y2 = 3 * x2']),
+        prob = om.Problem()
+        prob.model.add_subsystem('src', om.ExecComp(['y = 2 * x', 'y2 = 3 * x2']),
                                  promotes=['x', 'y'], promotes_inputs=['x2'])
         with self.assertRaises(RuntimeError) as context:
             prob.setup(check=False)
@@ -1271,16 +1272,16 @@ class TestConnect(unittest.TestCase):
                          "'promotes_inputs' or 'promotes_outputs'.")
 
     def test_nested_nested_conn(self):
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
 
-        root.add_subsystem('p', IndepVarComp('x', 1.0))
+        root.add_subsystem('p', om.IndepVarComp('x', 1.0))
 
-        G1 = root.add_subsystem('G1', Group())
-        par1 = G1.add_subsystem('par1', Group())
+        G1 = root.add_subsystem('G1', om.Group())
+        par1 = G1.add_subsystem('par1', om.Group())
 
-        par1.add_subsystem('c2', ExecComp('y = x * 2.0'))
-        par1.add_subsystem('c4', ExecComp('y = x * 4.0'))
+        par1.add_subsystem('c2', om.ExecComp('y = x * 2.0'))
+        par1.add_subsystem('c4', om.ExecComp('y = x * 4.0'))
 
         prob.model.add_design_var('p.x')
         prob.model.add_constraint('G1.par1.c4.y', upper=0.0)
@@ -1303,9 +1304,9 @@ class TestConnect(unittest.TestCase):
             self.prob.setup(check=False)
 
     def test_bad_indices_shape(self):
-        p = Problem()
-        p.model.add_subsystem('IV', IndepVarComp('x', np.arange(12).reshape((4, 3))))
-        p.model.add_subsystem('C1', ExecComp('y=sum(x)*2.0', x=np.zeros((2, 2))))
+        p = om.Problem()
+        p.model.add_subsystem('IV', om.IndepVarComp('x', np.arange(12).reshape((4, 3))))
+        p.model.add_subsystem('C1', om.ExecComp('y=sum(x)*2.0', x=np.zeros((2, 2))))
 
         p.model.connect('IV.x', 'C1.x', src_indices=[(1, 1)])
 

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -133,7 +133,7 @@ class ImplicitCompTestCase(unittest.TestCase):
         group.connect('comp1.c', 'comp3.c')
 
         prob = Problem(model=group)
-        prob.setup(check=False)
+        prob.setup()
 
         self.prob = prob
 
@@ -306,7 +306,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         group.nonlinear_solver.options['max_sub_solves'] = 1
         group.linear_solver = ScipyKrylov()
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['pa.a'] = 1.
         prob['pb.b'] = -4.
@@ -362,7 +362,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
                 outputs['x'] = 5.0
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         indep = IndepVarComp()
         indep.add_output('a', 1.0)
@@ -428,7 +428,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         prob = Problem(model=group)
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
         assert_rel_error(self, prob['comp2.y'], 77., 1e-5)
@@ -471,7 +471,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         prob = Problem(model=group)
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
         assert_rel_error(self, prob['sub.comp2.y'], 77., 1e-5)
@@ -514,7 +514,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         prob = Problem(model=group)
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
         assert_rel_error(self, prob['sub.comp2.y'], 77., 1e-5)
@@ -560,7 +560,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
                 outputs['x'] = 5.0
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('comp', ImpWithInitial())
 
@@ -596,7 +596,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         prob = Problem(model=group)
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(ValueError) as cm:
             prob.run_model()
@@ -628,7 +628,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         prob = Problem(model=group)
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(AnalysisError):
             prob.run_model()
@@ -660,7 +660,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
         prob = Problem(model=group)
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(ValueError) as cm:
             prob.run_model()
@@ -1201,7 +1201,7 @@ class ListFeatureTestCase(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarImplicitDis1, SellarImplicitDis2
         from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, LinearBlockGS
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 1.0))
         model.add_subsystem('d1', SellarImplicitDis1())
@@ -1214,7 +1214,7 @@ class ListFeatureTestCase(unittest.TestCase):
         model.linear_solver = ScipyKrylov()
         model.linear_solver.precon = LinearBlockGS()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=-1)
 
         prob.run_model()

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -3,7 +3,7 @@ from __future__ import division
 
 import unittest
 
-from openmdao.api import Problem, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
@@ -11,10 +11,10 @@ class TestIndepVarComp(unittest.TestCase):
 
     def test_simple(self):
         """Define one independent variable and set its value."""
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        comp = IndepVarComp('indep_var')
-        prob = Problem(comp).setup()
+        comp = om.IndepVarComp('indep_var')
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], 1.0)
 
@@ -23,19 +23,19 @@ class TestIndepVarComp(unittest.TestCase):
 
     def test_simple_default(self):
         """Define one independent variable with a default value."""
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        comp = IndepVarComp('indep_var', val=2.0)
-        prob = Problem(comp).setup()
+        comp = om.IndepVarComp('indep_var', val=2.0)
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], 2.0)
 
     def test_simple_kwargs(self):
         """Define one independent variable with a default value and additional options."""
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        comp = IndepVarComp('indep_var', val=2.0, units='m', lower=0, upper=10)
-        prob = Problem(comp).setup()
+        comp = om.IndepVarComp('indep_var', val=2.0, units='m', lower=0, upper=10)
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], 2.0)
 
@@ -43,62 +43,62 @@ class TestIndepVarComp(unittest.TestCase):
         """Define one independent array variable."""
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
         array = np.array([
             [1., 2.],
             [3., 4.],
         ])
 
-        comp = IndepVarComp('indep_var', val=array)
-        prob = Problem(comp).setup()
+        comp = om.IndepVarComp('indep_var', val=array)
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], array)
 
     def test_multiple_default(self):
         """Define two independent variables at once."""
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        comp = IndepVarComp((
+        comp = om.IndepVarComp((
             ('indep_var_1', 1.0),
             ('indep_var_2', 2.0),
         ))
 
-        prob = Problem(comp).setup()
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var_1'], 1.0)
         assert_rel_error(self, prob['indep_var_2'], 2.0)
 
     def test_multiple_kwargs(self):
         """Define two independent variables at once and additional options."""
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        comp = IndepVarComp((
+        comp = om.IndepVarComp((
             ('indep_var_1', 1.0, {'lower': 0, 'upper': 10}),
             ('indep_var_2', 2.0, {'lower': 1., 'upper': 20}),
         ))
 
-        prob = Problem(comp).setup()
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var_1'], 1.0)
         assert_rel_error(self, prob['indep_var_2'], 2.0)
 
     def test_add_output(self):
         """Define two independent variables using the add_output method."""
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        comp = IndepVarComp()
+        comp = om.IndepVarComp()
         comp.add_output('indep_var_1', val=1.0, lower=0, upper=10)
         comp.add_output('indep_var_2', val=2.0, lower=1, upper=20)
 
-        prob = Problem(comp).setup()
+        prob = om.Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var_1'], 1.0)
         assert_rel_error(self, prob['indep_var_2'], 2.0)
 
     def test_error_novars(self):
         try:
-            prob = Problem(IndepVarComp()).setup()
+            prob = om.Problem(om.IndepVarComp()).setup()
         except Exception as err:
             self.assertEqual(str(err),
                 "No outputs (independent variables) have been declared for "
@@ -109,11 +109,11 @@ class TestIndepVarComp(unittest.TestCase):
 
     def test_error_badtup(self):
         try:
-            comp = IndepVarComp((
+            comp = om.IndepVarComp((
                 ('indep_var_1', 1.0, {'lower': 0, 'upper': 10}),
                 'indep_var_2',
             ))
-            prob = Problem(comp).setup()
+            prob = om.Problem(comp).setup()
         except Exception as err:
             self.assertEqual(str(err),
                 "IndepVarComp init: arg indep_var_2 must be a tuple of the "
@@ -123,8 +123,8 @@ class TestIndepVarComp(unittest.TestCase):
 
     def test_error_bad_arg(self):
         try:
-            comp = IndepVarComp(1.0)
-            prob = Problem(comp).setup()
+            comp = om.IndepVarComp(1.0)
+            prob = om.Problem(comp).setup()
         except Exception as err:
             self.assertEqual(str(err),
                 "first argument to IndepVarComp init must be either of type "
@@ -134,10 +134,10 @@ class TestIndepVarComp(unittest.TestCase):
             self.fail('Exception expected.')
 
     def test_add_output_type_bug(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
         ivc.add_output('x1', val=[1, 2, 3], lower=0, upper=10)
 
         model.add_subsystem('p', ivc)

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -14,7 +14,7 @@ class TestIndepVarComp(unittest.TestCase):
         from openmdao.api import Problem, IndepVarComp
 
         comp = IndepVarComp('indep_var')
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], 1.0)
 
@@ -26,7 +26,7 @@ class TestIndepVarComp(unittest.TestCase):
         from openmdao.api import Problem, IndepVarComp
 
         comp = IndepVarComp('indep_var', val=2.0)
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], 2.0)
 
@@ -35,7 +35,7 @@ class TestIndepVarComp(unittest.TestCase):
         from openmdao.api import Problem, IndepVarComp
 
         comp = IndepVarComp('indep_var', val=2.0, units='m', lower=0, upper=10)
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], 2.0)
 
@@ -51,7 +51,7 @@ class TestIndepVarComp(unittest.TestCase):
         ])
 
         comp = IndepVarComp('indep_var', val=array)
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var'], array)
 
@@ -64,7 +64,7 @@ class TestIndepVarComp(unittest.TestCase):
             ('indep_var_2', 2.0),
         ))
 
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var_1'], 1.0)
         assert_rel_error(self, prob['indep_var_2'], 2.0)
@@ -78,7 +78,7 @@ class TestIndepVarComp(unittest.TestCase):
             ('indep_var_2', 2.0, {'lower': 1., 'upper': 20}),
         ))
 
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var_1'], 1.0)
         assert_rel_error(self, prob['indep_var_2'], 2.0)
@@ -91,14 +91,14 @@ class TestIndepVarComp(unittest.TestCase):
         comp.add_output('indep_var_1', val=1.0, lower=0, upper=10)
         comp.add_output('indep_var_2', val=2.0, lower=1, upper=20)
 
-        prob = Problem(comp).setup(check=False)
+        prob = Problem(comp).setup()
 
         assert_rel_error(self, prob['indep_var_1'], 1.0)
         assert_rel_error(self, prob['indep_var_2'], 2.0)
 
     def test_error_novars(self):
         try:
-            prob = Problem(IndepVarComp()).setup(check=False)
+            prob = Problem(IndepVarComp()).setup()
         except Exception as err:
             self.assertEqual(str(err),
                 "No outputs (independent variables) have been declared for "
@@ -113,7 +113,7 @@ class TestIndepVarComp(unittest.TestCase):
                 ('indep_var_1', 1.0, {'lower': 0, 'upper': 10}),
                 'indep_var_2',
             ))
-            prob = Problem(comp).setup(check=False)
+            prob = Problem(comp).setup()
         except Exception as err:
             self.assertEqual(str(err),
                 "IndepVarComp init: arg indep_var_2 must be a tuple of the "
@@ -124,7 +124,7 @@ class TestIndepVarComp(unittest.TestCase):
     def test_error_bad_arg(self):
         try:
             comp = IndepVarComp(1.0)
-            prob = Problem(comp).setup(check=False)
+            prob = Problem(comp).setup()
         except Exception as err:
             self.assertEqual(str(err),
                 "first argument to IndepVarComp init must be either of type "

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -4,12 +4,11 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, \
-    ScipyOptimizeDriver, ImplicitComponent, LinearBlockGS
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-class QuadraticCompVectorized(ImplicitComponent):
+class QuadraticCompVectorized(om.ImplicitComponent):
     """
     A Simple Implicit Component representing a Quadratic Equation.
 
@@ -79,7 +78,7 @@ class QuadraticCompVectorized(ImplicitComponent):
             d_residuals['x'] = self.inv_jac * d_outputs['x']
 
 
-class QCVProblem(Problem):
+class QCVProblem(om.Problem):
     """
     A QuadraticCompVectorized problem with configurable component class.
     """
@@ -89,7 +88,7 @@ class QCVProblem(Problem):
 
         model = self.model
 
-        comp1 = model.add_subsystem('p', IndepVarComp())
+        comp1 = model.add_subsystem('p', om.IndepVarComp())
         comp1.add_output('a', np.array([1.0, 2.0, 3.0]))
         comp1.add_output('b', np.array([2.0, 3.0, 4.0]))
         comp1.add_output('c', np.array([-1.0, -2.0, -3.0]))
@@ -104,10 +103,10 @@ class QCVProblem(Problem):
         model.add_design_var('p.c', vectorize_derivs=True)
         model.add_constraint('comp.x', vectorize_derivs=True)
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
 
-class RectangleCompVectorized(ExplicitComponent):
+class RectangleCompVectorized(om.ExplicitComponent):
     """
     A simple Explicit Component that computes the area of a rectangle.
     """
@@ -283,7 +282,7 @@ def lagrange_matrices(x_disc, x_interp):
     return Li, Di
 
 
-class LGLFit(ExplicitComponent):
+class LGLFit(om.ExplicitComponent):
     """
     Given values at discretization nodes, provide interpolated values at midpoint nodes and
     an approximation of arclength.
@@ -316,7 +315,7 @@ class LGLFit(ExplicitComponent):
         outputs['yp_lgl'] = np.dot(self.D_lgl, inputs['y_lgl'])/np.pi
 
 
-class DefectComp(ExplicitComponent):
+class DefectComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare(name='num_nodes', types=int)
@@ -336,7 +335,7 @@ class DefectComp(ExplicitComponent):
         outputs['defect'] = inputs['y_truth'] - inputs['y_approx']
 
 
-class ArcLengthFunction(ExplicitComponent):
+class ArcLengthFunction(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare(name='num_nodes', types=int)
@@ -357,7 +356,7 @@ class ArcLengthFunction(ExplicitComponent):
         partials['f_arclength', 'yp_lgl'] = inputs['yp_lgl'] / np.sqrt(1 + inputs['yp_lgl']**2)
 
 
-class ArcLengthQuadrature(ExplicitComponent):
+class ArcLengthQuadrature(om.ExplicitComponent):
     """
     Computes the arclength of a polynomial segment whose values are given at the LGL nodes.
     """
@@ -391,7 +390,7 @@ class ArcLengthQuadrature(ExplicitComponent):
         outputs['arclength'] = outputs['arclength']*np.pi
 
 
-class Phase(Group):
+class Phase(om.Group):
 
     def initialize(self):
         self.options.declare('order', types=int, default=10)
@@ -401,16 +400,16 @@ class Phase(Group):
         n = order + 1
 
         # Step 1:  Make an indep var comp that provides the approximated values at the LGL nodes.
-        self.add_subsystem('y_lgl_ivc', IndepVarComp('y_lgl', val=np.zeros(n), desc='values at LGL nodes'),
+        self.add_subsystem('y_lgl_ivc', om.IndepVarComp('y_lgl', val=np.zeros(n), desc='values at LGL nodes'),
                            promotes_outputs=['y_lgl'])
 
         # Step 2:  Make an indep var comp that provides the 'truth' values at the midpoint nodes.
         x_lgl, _ = lgl(n)
         x_lgl = x_lgl * np.pi  # put x_lgl on [-pi, pi]
         x_mid = (x_lgl[1:] + x_lgl[:-1]) * 0.5  # midpoints on [-pi, pi]
-        self.add_subsystem('truth', IndepVarComp('y_mid',
-                                                 val=np.sin(x_mid),
-                                                 desc='truth values at midpoint nodes'))
+        self.add_subsystem('truth', om.IndepVarComp('y_mid',
+                                                    val=np.sin(x_mid),
+                                                    desc='truth values at midpoint nodes'))
 
         # Step 3: Make a polynomial fitting component
         self.add_subsystem('lgl_fit', LGLFit(num_nodes=n))
@@ -429,7 +428,7 @@ class Phase(Group):
         self.connect('arclength_func.f_arclength', 'arclength_quad.f_arclength')
 
 
-class Summer(ExplicitComponent):
+class Summer(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('n_phases', types=int)
@@ -451,20 +450,20 @@ class Summer(ExplicitComponent):
 def simple_model(order, dvgroup='pardv', congroup='parc', vectorize=False):
     n = order + 1
 
-    p = Problem()
+    p = om.Problem()
 
     # Step 1:  Make an indep var comp that provides the approximated values at the LGL nodes.
-    p.model.add_subsystem('y_lgl_ivc', IndepVarComp('y_lgl', val=np.zeros(n),
-                                                    desc='values at LGL nodes'),
+    p.model.add_subsystem('y_lgl_ivc', om.IndepVarComp('y_lgl', val=np.zeros(n),
+                                                       desc='values at LGL nodes'),
                           promotes_outputs=['y_lgl'])
 
     # Step 2:  Make an indep var comp that provides the 'truth' values at the midpoint nodes.
     x_lgl, _ = lgl(n)
     x_lgl = x_lgl * np.pi  # put x_lgl on [-pi, pi]
     x_mid = (x_lgl[1:] + x_lgl[:-1])/2.0  # midpoints on [-pi, pi]
-    p.model.add_subsystem('truth', IndepVarComp('y_mid',
-                                                val=np.sin(x_mid),
-                                                desc='truth values at midpoint nodes'))
+    p.model.add_subsystem('truth', om.IndepVarComp('y_mid',
+                                                   val=np.sin(x_mid),
+                                                   desc='truth values at midpoint nodes'))
 
     # Step 3: Make a polynomial fitting component
     p.model.add_subsystem('lgl_fit', LGLFit(num_nodes=n))
@@ -487,7 +486,7 @@ def simple_model(order, dvgroup='pardv', congroup='parc', vectorize=False):
     p.model.add_constraint('defect.defect', lower=-1e-6, upper=1e-6,
                            parallel_deriv_color=congroup, vectorize_derivs=vectorize)
     p.model.add_objective('arclength_quad.arclength')
-    p.driver = ScipyOptimizeDriver()
+    p.driver = om.ScipyOptimizeDriver()
     return p, np.sin(x_lgl)
 
 
@@ -497,7 +496,7 @@ def phase_model(order, nphases, dvgroup='pardv', congroup='parc', vectorize=Fals
 
     n = PHASE_ORDER + 1
 
-    p = Problem()
+    p = om.Problem()
 
     # Step 1:  Make an indep var comp that provides the approximated values at the LGL nodes.
     for i in range(N_PHASES):
@@ -513,7 +512,7 @@ def phase_model(order, nphases, dvgroup='pardv', congroup='parc', vectorize=Fals
     p.model.add_subsystem('sum', Summer(n_phases=N_PHASES))
 
     p.model.add_objective('sum.total_arc_length')
-    p.driver = ScipyOptimizeDriver()
+    p.driver = om.ScipyOptimizeDriver()
 
     x_lgl, _ = lgl(n)
     x_lgl = x_lgl * np.pi  # put x_lgl on [-pi, pi]
@@ -526,11 +525,11 @@ class MatMatTestCase(unittest.TestCase):
 
     def test_feature_vectorized_derivs(self):
         import numpy as np
-        from openmdao.api import ExplicitComponent, IndepVarComp, Problem, ScipyOptimizeDriver
+        import openmdao.api as om
 
         SIZE = 5
 
-        class ExpensiveAnalysis(ExplicitComponent):
+        class ExpensiveAnalysis(om.ExplicitComponent):
 
             def setup(self):
 
@@ -551,7 +550,7 @@ class MatMatTestCase(unittest.TestCase):
                 J['f', 'x'] = inputs['y']*inputs['x']**(inputs['y']-1)
                 J['f', 'y'] = (inputs['x']**inputs['y'])*np.log(inputs['x'])
 
-        class CheapConstraint(ExplicitComponent):
+        class CheapConstraint(om.ExplicitComponent):
 
             def setup(self):
 
@@ -571,9 +570,9 @@ class MatMatTestCase(unittest.TestCase):
 
                 J['g', 'y'] = 2*inputs['y']
 
-        p = Problem()
+        p = om.Problem()
 
-        dvs = p.model.add_subsystem('des_vars', IndepVarComp(), promotes=['*'])
+        dvs = p.model.add_subsystem('des_vars', om.IndepVarComp(), promotes=['*'])
         dvs.add_output('x', 2*np.ones(SIZE))
         dvs.add_output('y', 2*np.ones(SIZE))
 
@@ -589,7 +588,7 @@ class MatMatTestCase(unittest.TestCase):
 
         p.run_model()
 
-        p.driver = ScipyOptimizeDriver()
+        p.driver = om.ScipyOptimizeDriver()
         p.run_driver()
 
         assert_rel_error(self, p['x'], [0.10000691, 0.1, 0.1, 0.1, 0.1], 1e-5)
@@ -654,10 +653,10 @@ class MatMatTestCase(unittest.TestCase):
 
     def test_feature_declaration(self):
         # Tests the code that shows the signature for compute_multi_jacvec
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        comp1 = model.add_subsystem('p', IndepVarComp())
+        comp1 = model.add_subsystem('p', om.IndepVarComp())
         comp1.add_output('length', np.array([3.0, 4.0, 5.0]))
         comp1.add_output('width', np.array([1.0, 2.0, 3.0]))
 
@@ -785,7 +784,7 @@ class MatMatTestCase(unittest.TestCase):
                          "when it is read only.")
 
 
-class JacVec(ExplicitComponent):
+class JacVec(om.ExplicitComponent):
 
     def __init__(self, size):
         super(JacVec, self).__init__()
@@ -822,10 +821,10 @@ class MultiJacVec(JacVec):
 
 class ComputeMultiJacVecTestCase(unittest.TestCase):
     def setup_model(self, size, comp_class, vectorize, mode):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('px', IndepVarComp('x', val=(np.arange(5, dtype=float) + 1.) * 3.0))
-        model.add_subsystem('py', IndepVarComp('y', val=(np.arange(5, dtype=float) + 1.) * 2.0))
+        model.add_subsystem('px', om.IndepVarComp('x', val=(np.arange(5, dtype=float) + 1.) * 3.0))
+        model.add_subsystem('py', om.IndepVarComp('y', val=(np.arange(5, dtype=float) + 1.) * 2.0))
         model.add_subsystem('comp', comp_class(size))
 
         model.connect('px.x', 'comp.x')

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -451,7 +451,7 @@ class Summer(ExplicitComponent):
 def simple_model(order, dvgroup='pardv', congroup='parc', vectorize=False):
     n = order + 1
 
-    p = Problem(model=Group())
+    p = Problem()
 
     # Step 1:  Make an indep var comp that provides the approximated values at the LGL nodes.
     p.model.add_subsystem('y_lgl_ivc', IndepVarComp('y_lgl', val=np.zeros(n),

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -11,13 +11,12 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, LinearBlockGS, \
-    ExecComp, ExplicitComponent, PETScVector, ScipyKrylov, NonlinearBlockGS
-from openmdao.utils.mpi import MPI
+import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDerivatives, \
     SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.groups.parallel_groups import FanOutGrouped, FanInGrouped
 from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.mpi import MPI
 
 
 if MPI:
@@ -34,10 +33,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_fan_in_serial_sets_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanInGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x1')
         prob.model.add_design_var('iv.x2')
@@ -55,10 +54,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_fan_in_serial_sets_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanInGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x1')
         prob.model.add_design_var('iv.x2')
@@ -76,10 +75,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_fan_out_serial_sets_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanOutGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x')
         prob.model.add_constraint('c2.y', upper=0.0)
@@ -97,10 +96,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_fan_out_serial_sets_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanOutGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x')
         prob.model.add_constraint('c2.y', upper=0.0)
@@ -118,10 +117,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_fan_in_parallel_sets_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanInGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x1', parallel_deriv_color='par_dv')
         prob.model.add_design_var('iv.x2', parallel_deriv_color='par_dv')
@@ -140,10 +139,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_debug_print_option_totals_color(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanInGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x1', parallel_deriv_color='par_dv')
         prob.model.add_design_var('iv.x2', parallel_deriv_color='par_dv')
@@ -176,10 +175,10 @@ class ParDerivTestCase(unittest.TestCase):
 
     def test_fan_out_parallel_sets_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = FanOutGrouped()
-        prob.model.linear_solver = LinearBlockGS()
-        prob.model.sub.linear_solver = LinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        prob.model.sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('iv.x')
         prob.model.add_constraint('c2.y', upper=0.0, parallel_deriv_color='par_resp')
@@ -203,24 +202,24 @@ class DecoupledTestCase(unittest.TestCase):
 
     def setup_model(self):
         asize = self.asize
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
-        root.linear_solver = LinearBlockGS()
+        root.linear_solver = om.LinearBlockGS()
 
-        Indep1 = root.add_subsystem('Indep1', IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        Indep2 = root.add_subsystem('Indep2', IndepVarComp('x', np.arange(asize+2, dtype=float)+1.0))
-        G1 = root.add_subsystem('G1', ParallelGroup())
-        G1.linear_solver = LinearBlockGS()
+        Indep1 = root.add_subsystem('Indep1', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        Indep2 = root.add_subsystem('Indep2', om.IndepVarComp('x', np.arange(asize+2, dtype=float)+1.0))
+        G1 = root.add_subsystem('G1', om.ParallelGroup())
+        G1.linear_solver = om.LinearBlockGS()
 
-        c1 = G1.add_subsystem('c1', ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
-        c2 = G1.add_subsystem('c2', ExecComp('y = x[:%d] * 2.0' % asize,
-                                        x=np.zeros(asize+2), y=np.zeros(asize)))
+        c1 = G1.add_subsystem('c1', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                                x=np.zeros(asize), y=np.zeros(asize)))
+        c2 = G1.add_subsystem('c2', om.ExecComp('y = x[:%d] * 2.0' % asize,
+                                                x=np.zeros(asize+2), y=np.zeros(asize)))
 
-        Con1 = root.add_subsystem('Con1', ExecComp('y = x * 5.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
-        Con2 = root.add_subsystem('Con2', ExecComp('y = x * 4.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
+        Con1 = root.add_subsystem('Con1', om.ExecComp('y = x * 5.0',
+                                                      x=np.zeros(asize), y=np.zeros(asize)))
+        Con2 = root.add_subsystem('Con2', om.ExecComp('y = x * 4.0',
+                                                      x=np.zeros(asize), y=np.zeros(asize)))
         root.connect('Indep1.x', 'G1.c1.x')
         root.connect('Indep2.x', 'G1.c2.x')
         root.connect('G1.c1.y', 'Con1.x')
@@ -337,22 +336,22 @@ class IndicesTestCase(unittest.TestCase):
 
     def setup_model(self, mode):
         asize = 3
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
-        root.linear_solver = LinearBlockGS()
+        root.linear_solver = om.LinearBlockGS()
 
-        p = root.add_subsystem('p', IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        G1 = root.add_subsystem('G1', ParallelGroup())
-        G1.linear_solver = LinearBlockGS()
+        p = root.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        G1 = root.add_subsystem('G1', om.ParallelGroup())
+        G1.linear_solver = om.LinearBlockGS()
 
-        c2 = G1.add_subsystem('c2', ExecComp('y = x * 2.0',
-                                        x=np.zeros(asize), y=np.zeros(asize)))
-        c3 = G1.add_subsystem('c3', ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
-                                        x=np.zeros(asize), y=np.zeros(asize)))
-        c4 = root.add_subsystem('c4', ExecComp('y = x * 4.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
-        c5 = root.add_subsystem('c5', ExecComp('y = x * 5.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
+        c2 = G1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
+                                                x=np.zeros(asize), y=np.zeros(asize)))
+        c3 = G1.add_subsystem('c3', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                                x=np.zeros(asize), y=np.zeros(asize)))
+        c4 = root.add_subsystem('c4', om.ExecComp('y = x * 4.0',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
+        c5 = root.add_subsystem('c5', om.ExecComp('y = x * 5.0',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
 
         prob.model.add_design_var('p.x', indices=[1, 2])
         prob.model.add_constraint('c4.y', upper=0.0, indices=[1], parallel_deriv_color='par_resp')
@@ -393,30 +392,30 @@ class IndicesTestCase2(unittest.TestCase):
 
     def setup_model(self, mode):
         asize = 3
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
 
-        root.linear_solver = LinearBlockGS()
+        root.linear_solver = om.LinearBlockGS()
 
-        G1 = root.add_subsystem('G1', ParallelGroup())
-        G1.linear_solver = LinearBlockGS()
+        G1 = root.add_subsystem('G1', om.ParallelGroup())
+        G1.linear_solver = om.LinearBlockGS()
 
-        par1 = G1.add_subsystem('par1', Group())
-        par1.linear_solver = LinearBlockGS()
-        par2 = G1.add_subsystem('par2', Group())
-        par2.linear_solver = LinearBlockGS()
+        par1 = G1.add_subsystem('par1', om.Group())
+        par1.linear_solver = om.LinearBlockGS()
+        par2 = G1.add_subsystem('par2', om.Group())
+        par2.linear_solver = om.LinearBlockGS()
 
-        p1 = par1.add_subsystem('p', IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        p2 = par2.add_subsystem('p', IndepVarComp('x', np.arange(asize, dtype=float)+10.0))
+        p1 = par1.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        p2 = par2.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+10.0))
 
-        c2 = par1.add_subsystem('c2', ExecComp('y = x * 2.0',
-                                        x=np.zeros(asize), y=np.zeros(asize)))
-        c3 = par2.add_subsystem('c3', ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
-                                        x=np.zeros(asize), y=np.zeros(asize)))
-        c4 = par1.add_subsystem('c4', ExecComp('y = x * 4.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
-        c5 = par2.add_subsystem('c5', ExecComp('y = x * 5.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
+        c2 = par1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
+        c3 = par2.add_subsystem('c3', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
+        c4 = par1.add_subsystem('c4', om.ExecComp('y = x * 4.0',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
+        c5 = par2.add_subsystem('c5', om.ExecComp('y = x * 5.0',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
 
         prob.model.add_design_var('G1.par1.p.x', indices=[1, 2])
         prob.model.add_design_var('G1.par2.p.x', indices=[1, 2])
@@ -466,24 +465,24 @@ class MatMatTestCase(unittest.TestCase):
 
     def setup_model(self):
         asize = self.asize
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
-        root.linear_solver = LinearBlockGS()
+        root.linear_solver = om.LinearBlockGS()
 
-        p1 = root.add_subsystem('p1', IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        p2 = root.add_subsystem('p2', IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        G1 = root.add_subsystem('G1', ParallelGroup())
-        G1.linear_solver = LinearBlockGS()
+        p1 = root.add_subsystem('p1', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        p2 = root.add_subsystem('p2', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        G1 = root.add_subsystem('G1', om.ParallelGroup())
+        G1.linear_solver = om.LinearBlockGS()
 
-        c1 = G1.add_subsystem('c1', ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+        c1 = G1.add_subsystem('c1', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                                x=np.zeros(asize), y=np.zeros(asize)))
+        c2 = G1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
+                                                x=np.zeros(asize), y=np.zeros(asize)))
+
+        c3 = root.add_subsystem('c3', om.ExecComp('y = x * 5.0',
                                                   x=np.zeros(asize), y=np.zeros(asize)))
-        c2 = G1.add_subsystem('c2', ExecComp('y = x * 2.0',
-                                        x=np.zeros(asize), y=np.zeros(asize)))
-
-        c3 = root.add_subsystem('c3', ExecComp('y = x * 5.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
-        c4 = root.add_subsystem('c4', ExecComp('y = x * 4.0',
-                                          x=np.zeros(asize), y=np.zeros(asize)))
+        c4 = root.add_subsystem('c4', om.ExecComp('y = x * 4.0',
+                                                  x=np.zeros(asize), y=np.zeros(asize)))
         root.connect('p1.x', 'G1.c1.x')
         root.connect('p2.x', 'G1.c2.x')
         root.connect('G1.c1.y', 'c3.x')
@@ -568,7 +567,7 @@ class MatMatTestCase(unittest.TestCase):
         assert_rel_error(self, J['c4.y', 'p2.x'], expected, 1e-6)
 
 
-class SumComp(ExplicitComponent):
+class SumComp(om.ExplicitComponent):
     def __init__(self, size):
         super(SumComp, self).__init__()
         self.size = size
@@ -586,7 +585,7 @@ class SumComp(ExplicitComponent):
         partials['y', 'x'] = np.ones(inputs['x'].size)
 
 
-class SlowComp(ExplicitComponent):
+class SlowComp(om.ExplicitComponent):
     """
     Component with a delay that multiplies the input by a multiplier.
     """
@@ -614,17 +613,17 @@ class SlowComp(ExplicitComponent):
         super(SlowComp, self)._apply_linear(jac, vec_names, rel_systems, mode, scope_out, scope_in)
 
 
-class PartialDependGroup(Group):
+class PartialDependGroup(om.Group):
     def setup(self):
         size = 4
 
-        Indep1 = self.add_subsystem('Indep1', IndepVarComp('x', np.arange(size, dtype=float)+1.0))
+        Indep1 = self.add_subsystem('Indep1', om.IndepVarComp('x', np.arange(size, dtype=float)+1.0))
         Comp1 = self.add_subsystem('Comp1', SumComp(size))
-        pargroup = self.add_subsystem('ParallelGroup1', ParallelGroup())
+        pargroup = self.add_subsystem('ParallelGroup1', om.ParallelGroup())
 
-        self.linear_solver = LinearBlockGS()
+        self.linear_solver = om.LinearBlockGS()
         self.linear_solver.options['iprint'] = -1
-        pargroup.linear_solver = LinearBlockGS()
+        pargroup.linear_solver = om.LinearBlockGS()
         pargroup.linear_solver.options['iprint'] = -1
 
         delay = .1
@@ -653,7 +652,7 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
 
         import numpy as np
 
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_parallel_derivatives import PartialDependGroup
 
         size = 4
@@ -662,7 +661,7 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         wrt = ['Indep1.x']
 
         # run first in fwd mode
-        p = Problem(model=PartialDependGroup())
+        p = om.Problem(model=PartialDependGroup())
         p.setup(mode='rev')
         p.run_model()
 
@@ -676,7 +675,7 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
 
         import numpy as np
 
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.core.tests.test_parallel_derivatives import PartialDependGroup
 
         size = 4
@@ -685,7 +684,7 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         wrt = ['Indep1.x']
 
         # run first in fwd mode
-        p = Problem(model=PartialDependGroup())
+        p = om.Problem(model=PartialDependGroup())
         p.setup(mode='fwd')
         p.run_model()
 
@@ -697,7 +696,7 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         assert_rel_error(self, J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
 
         # now run in rev mode and compare times for deriv calculation
-        p = Problem(model=PartialDependGroup())
+        p = om.Problem(model=PartialDependGroup())
         p.setup(check=False, mode='rev')
 
         p.run_model()
@@ -718,29 +717,29 @@ class CleanupTestCase(unittest.TestCase):
     # to converge.  The problem was due to garbage in the doutputs vector that
     # was coming from transfers to irrelevant variables during Group._apply_linear.
     def setUp(self):
-        p = self.p = Problem()
+        p = self.p = om.Problem()
         root = p.model
-        root.linear_solver = LinearBlockGS()
+        root.linear_solver = om.LinearBlockGS()
         root.linear_solver.options['err_on_maxiter'] = True
 
-        inputs = root.add_subsystem("inputs", IndepVarComp("x", 1.0))
-        G1 = root.add_subsystem("G1", Group())
-        dparam = G1.add_subsystem("dparam", ExecComp("y = .5*x"))
-        G1_inputs = G1.add_subsystem("inputs", IndepVarComp("x", 1.5))
-        start = G1.add_subsystem("start", ExecComp("y = .7*x"))
-        timecomp = G1.add_subsystem("time", ExecComp("y = -.2*x"))
+        inputs = root.add_subsystem("inputs", om.IndepVarComp("x", 1.0))
+        G1 = root.add_subsystem("G1", om.Group())
+        dparam = G1.add_subsystem("dparam", om.ExecComp("y = .5*x"))
+        G1_inputs = G1.add_subsystem("inputs", om.IndepVarComp("x", 1.5))
+        start = G1.add_subsystem("start", om.ExecComp("y = .7*x"))
+        timecomp = G1.add_subsystem("time", om.ExecComp("y = -.2*x"))
 
-        G2 = G1.add_subsystem("G2", Group())
+        G2 = G1.add_subsystem("G2", om.Group())
         stage_step = G2.add_subsystem("stage_step",
-                                      ExecComp("y = -0.1*x + .5*x2 - .4*x3 + .9*x4"))
-        ode = G2.add_subsystem("ode", ExecComp("y = .8*x - .6*x2"))
-        dummy = G2.add_subsystem("dummy", IndepVarComp("x", 1.3))
+                                      om.ExecComp("y = -0.1*x + .5*x2 - .4*x3 + .9*x4"))
+        ode = G2.add_subsystem("ode", om.ExecComp("y = .8*x - .6*x2"))
+        dummy = G2.add_subsystem("dummy", om.IndepVarComp("x", 1.3))
 
-        step = G1.add_subsystem("step", ExecComp("y = -.2*x + .4*x2 - .4*x3"))
-        output = G1.add_subsystem("output", ExecComp("y = .6*x"))
+        step = G1.add_subsystem("step", om.ExecComp("y = -.2*x + .4*x2 - .4*x3"))
+        output = G1.add_subsystem("output", om.ExecComp("y = .6*x"))
 
-        con = root.add_subsystem("con", ExecComp("y = .2 * x"))
-        obj = root.add_subsystem("obj", ExecComp("y = .3 * x"))
+        con = root.add_subsystem("con", om.ExecComp("y = .2 * x"))
+        obj = root.add_subsystem("obj", om.ExecComp("y = .3 * x"))
 
         root.connect("inputs.x", "G1.dparam.x")
 

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -133,7 +133,7 @@ class ProbRemote4TestCase(unittest.TestCase):
         self.assertEqual(comm.size, 2)
 
         prob = Problem(comm=comm)
-        model = prob.model = Group()
+        model = prob.model
 
         p1 = model.add_subsystem('p1', IndepVarComp('x', 99.0))
         p1.add_design_var('x', lower=-50.0, upper=50.0)
@@ -156,7 +156,7 @@ class ProbRemote4TestCase(unittest.TestCase):
         prob.driver.options['optimizer'] = OPTIMIZER
         prob.driver.options['print_results'] = False
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         failed = prob.run_driver()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -512,7 +512,7 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['f_xy'], 22.0, 1e-6)
 
         # skip the setup error checking
-        prob.setup(check=False)
+        prob.setup()
         prob['x'] = 4
         prob['y'] = 8.
 
@@ -845,7 +845,7 @@ class TestProblem(unittest.TestCase):
                                                    ayy={'value': 0.0, 'units': 'degC'}),
                                  promotes=['axx', 'ayy'])
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Make sure everything works before final setup with caching system.
 
@@ -1392,7 +1392,7 @@ class TestProblem(unittest.TestCase):
 
         top = Problem(model=Super())
 
-        top.setup(check=False)
+        top.setup()
 
         self.assertTrue(isinstance(top.model.sub.nonlinear_solver, NewtonSolver))
         self.assertTrue(isinstance(top.model.sub.linear_solver, ScipyKrylov))
@@ -1434,7 +1434,7 @@ class TestProblem(unittest.TestCase):
 
         top = Problem(model=Super())
 
-        top.setup(check=False)
+        top.setup()
 
         # These solvers override the ones set in the setup method of the 'sub' groups
         top.model.sub.nonlinear_solver = NewtonSolver()
@@ -1481,7 +1481,7 @@ class TestProblem(unittest.TestCase):
 
         top = Problem(model=Super())
 
-        top.setup(check=False)
+        top.setup()
 
         print(isinstance(top.model.sub.nonlinear_solver, NewtonSolver))
         print(isinstance(top.model.sub.linear_solver, ScipyKrylov))
@@ -1523,7 +1523,7 @@ class TestProblem(unittest.TestCase):
 
         top = Problem(model=Super())
 
-        top.setup(check=False)
+        top.setup()
 
         # This will solve it.
         top.model.sub.nonlinear_solver = NewtonSolver()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -7,16 +7,15 @@ from six import assertRaisesRegex, StringIO, assertRegex, iteritems
 
 import numpy as np
 
+import openmdao.api as om
 from openmdao.core.group import get_relevant_vars
 from openmdao.core.driver import Driver
-from openmdao.api import Problem, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, DirectSolver, \
-    ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent, NonlinearRunOnce
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
 
 
-class SellarOneComp(ImplicitComponent):
+class SellarOneComp(om.ImplicitComponent):
 
     def initialize(self):
         self.options.declare('solve_y1', types=bool, default=True)
@@ -115,14 +114,14 @@ class SellarOneComp(ImplicitComponent):
 class TestProblem(unittest.TestCase):
 
     def test_feature_simple_run_once_no_promote(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('comp', Paraboloid())
 
         model.connect('p1.x', 'comp.x')
@@ -134,13 +133,13 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['comp.f_xy'], -15.0)
 
     def test_feature_simple_run_once_input_input(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
 
         # promote the two inputs to the same name
         model.add_subsystem('comp1', Paraboloid(), promotes_inputs=['x'])
@@ -156,14 +155,14 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['comp2.f_xy'], 13.0)
 
     def test_feature_simple_run_once_compute_totals(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('comp', Paraboloid())
 
         model.connect('p1.x', 'comp.x')
@@ -181,14 +180,14 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, totals['comp.f_xy']['p2.y'][0][0], 3.0)
 
     def test_feature_simple_run_once_compute_totals_scaled(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('comp', Paraboloid())
 
         model.connect('p1.x', 'comp.x')
@@ -206,14 +205,14 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, totals[('comp.f_xy', 'p2.y')][0][0], 3.0)
 
     def test_feature_simple_run_once_set_deriv_mode(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('comp', Paraboloid())
 
         model.connect('p1.x', 'comp.x')
@@ -228,13 +227,13 @@ class TestProblem(unittest.TestCase):
         prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'])
 
     def test_compute_totals_cleanup(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        model.add_subsystem('indeps1', IndepVarComp('x', np.ones(5)))
-        model.add_subsystem('indeps2', IndepVarComp('x', np.ones(3)))
+        model.add_subsystem('indeps1', om.IndepVarComp('x', np.ones(5)))
+        model.add_subsystem('indeps2', om.IndepVarComp('x', np.ones(3)))
 
-        model.add_subsystem('MP1', ExecComp('y=7*x', x=np.zeros(5), y=np.zeros(5)))
-        model.add_subsystem('MP2', ExecComp('y=-3*x', x=np.zeros(3), y=np.zeros(3)))
+        model.add_subsystem('MP1', om.ExecComp('y=7*x', x=np.zeros(5), y=np.zeros(5)))
+        model.add_subsystem('MP2', om.ExecComp('y=-3*x', x=np.zeros(3), y=np.zeros(3)))
 
         model.add_design_var('indeps1.x')
         model.add_design_var('indeps2.x')
@@ -259,12 +258,12 @@ class TestProblem(unittest.TestCase):
     def test_set_2d_array(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, Group
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
         model.add_subsystem(name='indeps',
-                            subsys=IndepVarComp(name='X_c', shape=(3, 1)))
+                            subsys=om.IndepVarComp(name='X_c', shape=(3, 1)))
         prob.setup()
 
         new_val = -5*np.ones((3, 1))
@@ -282,13 +281,13 @@ class TestProblem(unittest.TestCase):
 
     def test_set_checks_shape(self):
 
-        model = Group()
+        model = om.Group()
 
-        indep = model.add_subsystem('indep', IndepVarComp())
+        indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_output('num')
         indep.add_output('arr', shape=(10, 1))
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
 
         msg = "Incompatible shape for '.*': Expected (.*) but got (.*)"
@@ -334,10 +333,10 @@ class TestProblem(unittest.TestCase):
     def test_compute_totals_basic(self):
         # Basic test for the method using default solvers on simple model.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         prob.setup(check=False, mode='fwd')
@@ -364,10 +363,10 @@ class TestProblem(unittest.TestCase):
     def test_compute_totals_basic_return_dict(self):
         # Make sure 'dict' return_format works.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         prob.setup(check=False, mode='fwd')
@@ -392,12 +391,12 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, derivs['f_xy']['y'], [[8.0]], 1e-6)
 
     def test_compute_totals_no_args_no_desvar(self):
-        p = Problem()
+        p = om.Problem()
 
-        dv = p.model.add_subsystem('des_vars', IndepVarComp())
+        dv = p.model.add_subsystem('des_vars', om.IndepVarComp())
         dv.add_output('x', val=2.)
 
-        p.model.add_subsystem('calc', ExecComp('y=2*x'))
+        p.model.add_subsystem('calc', om.ExecComp('y=2*x'))
 
         p.model.connect('des_vars.x', 'calc.x')
 
@@ -413,12 +412,12 @@ class TestProblem(unittest.TestCase):
                          "Driver is not providing any design variables for compute_totals.")
 
     def test_compute_totals_no_args_no_response(self):
-        p = Problem()
+        p = om.Problem()
 
-        dv = p.model.add_subsystem('des_vars', IndepVarComp())
+        dv = p.model.add_subsystem('des_vars', om.IndepVarComp())
         dv.add_output('x', val=2.)
 
-        p.model.add_subsystem('calc', ExecComp('y=2*x'))
+        p.model.add_subsystem('calc', om.ExecComp('y=2*x'))
 
         p.model.connect('des_vars.x', 'calc.x')
 
@@ -434,12 +433,12 @@ class TestProblem(unittest.TestCase):
                          "Driver is not providing any response variables for compute_totals.")
 
     def test_compute_totals_no_args(self):
-        p = Problem()
+        p = om.Problem()
 
-        dv = p.model.add_subsystem('des_vars', IndepVarComp())
+        dv = p.model.add_subsystem('des_vars', om.IndepVarComp())
         dv.add_output('x', val=2.)
 
-        p.model.add_subsystem('calc', ExecComp('y=2*x'))
+        p.model.add_subsystem('calc', om.ExecComp('y=2*x'))
 
         p.model.connect('des_vars.x', 'calc.x')
 
@@ -454,12 +453,12 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, derivs['calc.y', 'des_vars.x'], [[2.0]], 1e-6)
 
     def test_compute_totals_no_args_promoted(self):
-        p = Problem()
+        p = om.Problem()
 
-        dv = p.model.add_subsystem('des_vars', IndepVarComp(), promotes=['*'])
+        dv = p.model.add_subsystem('des_vars', om.IndepVarComp(), promotes=['*'])
         dv.add_output('x', val=2.)
 
-        p.model.add_subsystem('calc', ExecComp('y=2*x'), promotes=['*'])
+        p.model.add_subsystem('calc', om.ExecComp('y=2*x'), promotes=['*'])
 
         p.model.add_design_var('x')
         p.model.add_objective('y')
@@ -472,14 +471,14 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, derivs['calc.y', 'des_vars.x'], [[2.0]], 1e-6)
 
     def test_feature_set_indeps(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
 
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         prob.setup()
@@ -490,13 +489,13 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['f_xy'], 214.0, 1e-6)
 
     def test_feature_basic_setup(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         prob.setup()
@@ -520,13 +519,13 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['f_xy'], 174.0, 1e-6)
 
     def test_feature_petsc_setup(self):
-        from openmdao.api import Problem, Group, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         # PETScVectors will be used automatically where needed. No need to set manually.
@@ -538,12 +537,12 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['f_xy'], 214.0, 1e-6)
 
     def test_feature_check_totals_manual(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
         prob.run_model()
@@ -552,12 +551,12 @@ class TestProblem(unittest.TestCase):
         prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'])
 
     def test_feature_check_totals_from_driver_compact(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -575,12 +574,12 @@ class TestProblem(unittest.TestCase):
         prob.check_totals(compact_print=True)
 
     def test_feature_check_totals_from_driver(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -598,12 +597,12 @@ class TestProblem(unittest.TestCase):
         prob.check_totals()
 
     def test_feature_check_totals_from_driver_scaled(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100, ref=100.0, ref0=-100.0)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -621,12 +620,12 @@ class TestProblem(unittest.TestCase):
         prob.check_totals(driver_scaling=True)
 
     def test_feature_check_totals_suppress(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -645,12 +644,12 @@ class TestProblem(unittest.TestCase):
         print(totals)
 
     def test_feature_check_totals_cs(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -672,7 +671,7 @@ class TestProblem(unittest.TestCase):
 
     def test_check_totals_user_detect(self):
 
-        class SimpleComp(ExplicitComponent):
+        class SimpleComp(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', val=1.0)
@@ -692,8 +691,8 @@ class TestProblem(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['y', 'x'] = 3.
 
-        prob = Problem()
-        prob.model.add_subsystem('px', IndepVarComp('x', 2.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('px', om.IndepVarComp('x', 2.0))
         prob.model.add_subsystem('comp', SimpleComp())
         prob.model.connect('px.x', 'comp.x')
 
@@ -710,9 +709,9 @@ class TestProblem(unittest.TestCase):
                          msg="The under_complex_step flag should be reset.")
 
     def test_feature_check_totals_user_detect_forced(self):
-        from openmdao.api import Problem, ExplicitComponent, IndepVarComp
+        import openmdao.api as om
 
-        class SimpleComp(ExplicitComponent):
+        class SimpleComp(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', val=1.0)
@@ -729,8 +728,8 @@ class TestProblem(unittest.TestCase):
             def compute_partials(self, inputs, partials):
                 partials['y', 'x'] = 3.
 
-        prob = Problem()
-        prob.model.add_subsystem('px', IndepVarComp('x', val=1.0))
+        prob = om.Problem()
+        prob.model.add_subsystem('px', om.IndepVarComp('x', val=1.0))
         prob.model.add_subsystem('comp', SimpleComp())
         prob.model.connect('px.x', 'comp.x')
 
@@ -746,14 +745,14 @@ class TestProblem(unittest.TestCase):
     def test_feature_run_driver(self):
         import numpy as np
 
-        from openmdao.api import Problem, NonlinearBlockGS, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives())
+        prob = om.Problem(model=SellarDerivatives())
         model = prob.model
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
 
@@ -773,11 +772,11 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['obj'], 3.18339395, 1e-2)
 
     def test_feature_promoted_sellar_set_get_outputs(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob = om.Problem(model=SellarDerivatives())
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
 
@@ -790,11 +789,11 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['y1'], 27.3049178437, 1e-6)
 
     def test_feature_not_promoted_sellar_set_get_outputs(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesConnected
 
-        prob = Problem(model= SellarDerivativesConnected())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob = om.Problem(model= SellarDerivativesConnected())
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
 
@@ -807,11 +806,11 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['d1.y1'], 27.3049178437, 1e-6)
 
     def test_feature_promoted_sellar_set_get_inputs(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob = om.Problem(model=SellarDerivatives())
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
 
@@ -827,22 +826,22 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['d2.y1'], 27.3049178437, 1e-6)
 
     def test_get_set_with_units_exhaustive(self):
-        from openmdao.api import Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
-        prob.model.add_subsystem('comp', ExecComp('y=x-25.',
-                                                  x={'value': 77.0, 'units': 'degF'},
-                                                  y={'value': 0.0, 'units': 'degC'}))
-        prob.model.add_subsystem('prom', ExecComp('yy=xx-25.',
-                                                  xx={'value': 77.0, 'units': 'degF'},
-                                                  yy={'value': 0.0, 'units': 'degC'}),
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x-25.',
+                                                     x={'value': 77.0, 'units': 'degF'},
+                                                     y={'value': 0.0, 'units': 'degC'}))
+        prob.model.add_subsystem('prom', om.ExecComp('yy=xx-25.',
+                                                     xx={'value': 77.0, 'units': 'degF'},
+                                                     yy={'value': 0.0, 'units': 'degC'}),
                                  promotes=['xx', 'yy'])
-        prob.model.add_subsystem('acomp', ExecComp('y=x-25.',
-                                                   x={'value': np.array([77.0, 95.0]), 'units': 'degF'},
-                                                   y={'value': 0.0, 'units': 'degC'}))
-        prob.model.add_subsystem('aprom', ExecComp('ayy=axx-25.',
-                                                   axx={'value': np.array([77.0, 95.0]), 'units': 'degF'},
-                                                   ayy={'value': 0.0, 'units': 'degC'}),
+        prob.model.add_subsystem('acomp', om.ExecComp('y=x-25.',
+                                                      x={'value': np.array([77.0, 95.0]), 'units': 'degF'},
+                                                      y={'value': 0.0, 'units': 'degC'}))
+        prob.model.add_subsystem('aprom', om.ExecComp('ayy=axx-25.',
+                                                      axx={'value': np.array([77.0, 95.0]), 'units': 'degF'},
+                                                      ayy={'value': 0.0, 'units': 'degC'}),
                                  promotes=['axx', 'ayy'])
 
         prob.setup()
@@ -942,13 +941,13 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob.get_val('axx', 'degC', indices=np.array([0])), 35.0, 1e-6)
 
     def test_get_set_with_units_error_messages(self):
-        from openmdao.api import Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
-        prob.model.add_subsystem('comp', ExecComp('y=x+1.',
-                                                  x={'value': 100.0, 'units': 'cm'},
-                                                  y={'units': 'm'}))
-        prob.model.add_subsystem('no_unit', ExecComp('y=x+1.', x={'value': 100.0}))
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
+                                                     x={'value': 100.0, 'units': 'cm'},
+                                                     y={'units': 'm'}))
+        prob.model.add_subsystem('no_unit', om.ExecComp('y=x+1.', x={'value': 100.0}))
 
         prob.setup()
         prob.run_model()
@@ -970,12 +969,12 @@ class TestProblem(unittest.TestCase):
             prob.set_val('no_unit.x', 55.0, 'degK')
 
     def test_feature_get_set_with_units(self):
-        from openmdao.api import Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
-        prob.model.add_subsystem('comp', ExecComp('y=x+1.',
-                                                  x={'value': 100.0, 'units': 'cm'},
-                                                  y={'units': 'm'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
+                                                     x={'value': 100.0, 'units': 'cm'},
+                                                     y={'units': 'm'}))
 
         prob.setup()
         prob.run_model()
@@ -988,12 +987,12 @@ class TestProblem(unittest.TestCase):
 
     def test_feature_get_set_array_with_units(self):
         import numpy as np
-        from openmdao.api import Problem, ExecComp
+        import openmdao.api as om
 
-        prob = Problem()
-        prob.model.add_subsystem('comp', ExecComp('y=x+1.',
-                                                  x={'value': np.array([100.0, 33.3]), 'units': 'cm'},
-                                                  y={'shape': (2, ), 'units': 'm'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
+                                                     x={'value': np.array([100.0, 33.3]), 'units': 'cm'},
+                                                     y={'shape': (2, ), 'units': 'm'}))
 
         prob.setup()
         prob.run_model()
@@ -1013,11 +1012,11 @@ class TestProblem(unittest.TestCase):
     def test_feature_set_get_array(self):
         import numpy as np
 
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob = om.Problem(model=SellarDerivatives())
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
 
@@ -1045,11 +1044,11 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob['y2'], 8.14191301549, 1e-6)
 
     def test_feature_residuals(self):
-        from openmdao.api import Problem, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
+        prob = om.Problem(model=SellarDerivatives())
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
 
@@ -1064,7 +1063,7 @@ class TestProblem(unittest.TestCase):
     def test_setup_bad_mode(self):
         # Test error message when passing bad mode to setup.
 
-        prob = Problem()
+        prob = om.Problem()
 
         try:
             prob.setup(mode='junk')
@@ -1076,9 +1075,9 @@ class TestProblem(unittest.TestCase):
 
     def test_setup_bad_mode_direction_fwd(self):
 
-        prob = Problem()
-        prob.model.add_subsystem("indep", IndepVarComp("x", np.ones(99)))
-        prob.model.add_subsystem("C1", ExecComp("y=2.0*x", x=np.zeros(10), y=np.zeros(10)))
+        prob = om.Problem()
+        prob.model.add_subsystem("indep", om.IndepVarComp("x", np.ones(99)))
+        prob.model.add_subsystem("C1", om.ExecComp("y=2.0*x", x=np.zeros(10), y=np.zeros(10)))
 
         prob.model.connect("indep.x", "C1.x", src_indices=list(range(10)))
 
@@ -1096,10 +1095,10 @@ class TestProblem(unittest.TestCase):
 
     def test_setup_bad_mode_direction_rev(self):
 
-        prob = Problem()
-        prob.model.add_subsystem("indep", IndepVarComp("x", np.ones(10)))
-        prob.model.add_subsystem("C1", ExecComp("y=2.0*x", x=np.zeros(10), y=np.zeros(10)))
-        prob.model.add_subsystem("C2", ExecComp("y=2.0*x", x=np.zeros(10), y=np.zeros(10)))
+        prob = om.Problem()
+        prob.model.add_subsystem("indep", om.IndepVarComp("x", np.ones(10)))
+        prob.model.add_subsystem("C1", om.ExecComp("y=2.0*x", x=np.zeros(10), y=np.zeros(10)))
+        prob.model.add_subsystem("C2", om.ExecComp("y=2.0*x", x=np.zeros(10), y=np.zeros(10)))
 
         prob.model.connect("indep.x", ["C1.x", "C2.x"])
 
@@ -1119,7 +1118,7 @@ class TestProblem(unittest.TestCase):
     def test_run_before_setup(self):
         # Test error message when running before setup.
 
-        prob = Problem()
+        prob = om.Problem()
 
         try:
             prob.run_model()
@@ -1142,7 +1141,7 @@ class TestProblem(unittest.TestCase):
 
         msg = "The 'case_prefix' argument should be a string."
 
-        prob = Problem()
+        prob = om.Problem()
 
         try:
             prob.setup()
@@ -1165,18 +1164,18 @@ class TestProblem(unittest.TestCase):
         msg = "The 'root' property provides backwards compatibility " \
               "with OpenMDAO <= 1.x ; use 'model' instead."
 
-        prob = Problem()
+        prob = om.Problem()
 
         # check deprecation on setter & getter
         with assert_warning(DeprecationWarning, msg):
-            prob.root = Group()
+            prob.root = om.Group()
 
         with assert_warning(DeprecationWarning, msg):
             prob.root
 
         # testing the root kwarg
         with self.assertRaises(ValueError) as cm:
-            prob = Problem(root=Group(), model=Group())
+            prob = om.Problem(root=om.Group(), model=om.Group())
 
         self.assertEqual(str(cm.exception),
                          "Cannot specify both 'root' and 'model'. "
@@ -1186,60 +1185,60 @@ class TestProblem(unittest.TestCase):
               "compatibility with OpenMDAO <= 1.x ; use 'model' instead."
 
         with assert_warning(DeprecationWarning, msg):
-            prob = Problem(root=Group())
+            prob = om.Problem(root=om.Group())
 
     def test_args(self):
         # defaults
-        prob = Problem()
-        self.assertTrue(isinstance(prob.model, Group))
+        prob = om.Problem()
+        self.assertTrue(isinstance(prob.model, om.Group))
         self.assertTrue(isinstance(prob.driver, Driver))
 
         # model
-        prob = Problem(SellarDerivatives())
+        prob = om.Problem(SellarDerivatives())
         self.assertTrue(isinstance(prob.model, SellarDerivatives))
         self.assertTrue(isinstance(prob.driver, Driver))
 
         # driver
-        prob = Problem(driver=ScipyOptimizeDriver())
-        self.assertTrue(isinstance(prob.model, Group))
-        self.assertTrue(isinstance(prob.driver, ScipyOptimizeDriver))
+        prob = om.Problem(driver=om.ScipyOptimizeDriver())
+        self.assertTrue(isinstance(prob.model, om.Group))
+        self.assertTrue(isinstance(prob.driver, om.ScipyOptimizeDriver))
 
         # model and driver
-        prob = Problem(model=SellarDerivatives(), driver=ScipyOptimizeDriver())
+        prob = om.Problem(model=SellarDerivatives(), driver=om.ScipyOptimizeDriver())
         self.assertTrue(isinstance(prob.model, SellarDerivatives))
-        self.assertTrue(isinstance(prob.driver, ScipyOptimizeDriver))
+        self.assertTrue(isinstance(prob.driver, om.ScipyOptimizeDriver))
 
         # invalid model
         with self.assertRaises(TypeError) as cm:
-            prob = Problem(ScipyOptimizeDriver())
+            prob = om.Problem(om.ScipyOptimizeDriver())
 
         self.assertEqual(str(cm.exception),
                          "The value provided for 'model' is not a valid System.")
 
         # invalid driver
         with self.assertRaises(TypeError) as cm:
-            prob = Problem(driver=SellarDerivatives())
+            prob = om.Problem(driver=SellarDerivatives())
 
         self.assertEqual(str(cm.exception),
                          "The value provided for 'driver' is not a valid Driver.")
 
     def test_relevance(self):
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem("indep1", IndepVarComp('x', 1.0))
-        G1 = model.add_subsystem('G1', Group())
-        G1.add_subsystem('C1', ExecComp(['x=2.0*a', 'y=2.0*b', 'z=2.0*a']))
-        G1.add_subsystem('C2', ExecComp(['x=2.0*a', 'y=2.0*b', 'z=2.0*b']))
-        model.add_subsystem("C3", ExecComp(['x=2.0*a', 'y=2.0*b+3.0*c']))
-        model.add_subsystem("C4", ExecComp(['x=2.0*a', 'y=2.0*b']))
-        model.add_subsystem("indep2", IndepVarComp('x', 1.0))
-        G2 = model.add_subsystem('G2', Group())
-        G2.add_subsystem('C5', ExecComp(['x=2.0*a', 'y=2.0*b+3.0*c']))
-        G2.add_subsystem('C6', ExecComp(['x=2.0*a', 'y=2.0*b+3.0*c']))
-        G2.add_subsystem('C7', ExecComp(['x=2.0*a', 'y=2.0*b']))
-        model.add_subsystem("C8", ExecComp(['y=1.5*a+2.0*b']))
-        model.add_subsystem("Unconnected", ExecComp('y=99.*x'))
+        model.add_subsystem("indep1", om.IndepVarComp('x', 1.0))
+        G1 = model.add_subsystem('G1', om.Group())
+        G1.add_subsystem('C1', om.ExecComp(['x=2.0*a', 'y=2.0*b', 'z=2.0*a']))
+        G1.add_subsystem('C2', om.ExecComp(['x=2.0*a', 'y=2.0*b', 'z=2.0*b']))
+        model.add_subsystem("C3", om.ExecComp(['x=2.0*a', 'y=2.0*b+3.0*c']))
+        model.add_subsystem("C4", om.ExecComp(['x=2.0*a', 'y=2.0*b']))
+        model.add_subsystem("indep2", om.IndepVarComp('x', 1.0))
+        G2 = model.add_subsystem('G2', om.Group())
+        G2.add_subsystem('C5', om.ExecComp(['x=2.0*a', 'y=2.0*b+3.0*c']))
+        G2.add_subsystem('C6', om.ExecComp(['x=2.0*a', 'y=2.0*b+3.0*c']))
+        G2.add_subsystem('C7', om.ExecComp(['x=2.0*a', 'y=2.0*b']))
+        model.add_subsystem("C8", om.ExecComp(['y=1.5*a+2.0*b']))
+        model.add_subsystem("Unconnected", om.ExecComp('y=99.*x'))
 
         model.connect('indep1.x', 'G1.C1.a')
         model.connect('indep2.x', 'G2.C6.a')
@@ -1311,18 +1310,18 @@ class TestProblem(unittest.TestCase):
         SOLVE_Y1 = False
         SOLVE_Y2 = True
 
-        p_opt = Problem()
+        p_opt = om.Problem()
 
         p_opt.model = SellarOneComp(solve_y1=SOLVE_Y1, solve_y2=SOLVE_Y2)
 
         if SOLVE_Y1 or SOLVE_Y2:
-            newton = p_opt.model.nonlinear_solver = NewtonSolver()
+            newton = p_opt.model.nonlinear_solver = om.NewtonSolver()
             newton.options['iprint'] = 0
 
         # NOTE: need to have this direct solver attached to the sellar comp until I define a solve_linear for it
-        p_opt.model.linear_solver = DirectSolver(assemble_jac=True)
+        p_opt.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        p_opt.driver = ScipyOptimizeDriver()
+        p_opt.driver = om.ScipyOptimizeDriver()
         p_opt.driver.options['disp'] = False
 
         if not SOLVE_Y1:
@@ -1353,7 +1352,7 @@ class TestProblem(unittest.TestCase):
         # Test that we can change solver settings on a subsystem in a system's setup method.
         # Also assures that highest system's settings take precedence.
 
-        class ImplSimple(ImplicitComponent):
+        class ImplSimple(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('a', val=1.)
@@ -1368,39 +1367,39 @@ class TestProblem(unittest.TestCase):
                     2 * inputs['a']**2 * outputs['x']
                 jacobian['x', 'a'] = -2 * inputs['a'] * outputs['x']**2
 
-        class Sub(Group):
+        class Sub(om.Group):
 
             def setup(self):
                 self.add_subsystem('comp', ImplSimple())
 
                 # This will not solve it
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
             def configure(self):
                 # This will not solve it either.
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
-        class Super(Group):
+        class Super(om.Group):
 
             def setup(self):
                 self.add_subsystem('sub', Sub())
 
             def configure(self):
                 # This will solve it.
-                self.sub.nonlinear_solver = NewtonSolver()
-                self.sub.linear_solver = ScipyKrylov()
+                self.sub.nonlinear_solver = om.NewtonSolver()
+                self.sub.linear_solver = om.ScipyKrylov()
 
-        top = Problem(model=Super())
+        top = om.Problem(model=Super())
 
         top.setup()
 
-        self.assertTrue(isinstance(top.model.sub.nonlinear_solver, NewtonSolver))
-        self.assertTrue(isinstance(top.model.sub.linear_solver, ScipyKrylov))
+        self.assertTrue(isinstance(top.model.sub.nonlinear_solver, om.NewtonSolver))
+        self.assertTrue(isinstance(top.model.sub.linear_solver, om.ScipyKrylov))
 
     def test_post_setup_solver_configure(self):
         # Test that we can change solver settings after we have instantiated our model.
 
-        class ImplSimple(ImplicitComponent):
+        class ImplSimple(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('a', val=1.)
@@ -1415,38 +1414,38 @@ class TestProblem(unittest.TestCase):
                     2 * inputs['a']**2 * outputs['x']
                 jacobian['x', 'a'] = -2 * inputs['a'] * outputs['x']**2
 
-        class Sub(Group):
+        class Sub(om.Group):
 
             def setup(self):
                 self.add_subsystem('comp', ImplSimple())
 
                 # This solver will get over-ridden below
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
             def configure(self):
                 # This solver will get over-ridden below
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
-        class Super(Group):
+        class Super(om.Group):
 
             def setup(self):
                 self.add_subsystem('sub', Sub())
 
-        top = Problem(model=Super())
+        top = om.Problem(model=Super())
 
         top.setup()
 
         # These solvers override the ones set in the setup method of the 'sub' groups
-        top.model.sub.nonlinear_solver = NewtonSolver()
-        top.model.sub.linear_solver = ScipyKrylov()
+        top.model.sub.nonlinear_solver = om.NewtonSolver()
+        top.model.sub.linear_solver = om.ScipyKrylov()
 
-        self.assertTrue(isinstance(top.model.sub.nonlinear_solver, NewtonSolver))
-        self.assertTrue(isinstance(top.model.sub.linear_solver, ScipyKrylov))
+        self.assertTrue(isinstance(top.model.sub.nonlinear_solver, om.NewtonSolver))
+        self.assertTrue(isinstance(top.model.sub.linear_solver, om.ScipyKrylov))
 
     def test_feature_system_configure(self):
-        from openmdao.api import Problem, Group, ImplicitComponent, NewtonSolver, ScipyKrylov, NonlinearBlockGS
+        import openmdao.api as om
 
-        class ImplSimple(ImplicitComponent):
+        class ImplSimple(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('a', val=1.)
@@ -1461,35 +1460,35 @@ class TestProblem(unittest.TestCase):
                     2 * inputs['a']**2 * outputs['x']
                 jacobian['x', 'a'] = -2 * inputs['a'] * outputs['x']**2
 
-        class Sub(Group):
+        class Sub(om.Group):
             def setup(self):
                 self.add_subsystem('comp', ImplSimple())
 
             def configure(self):
                 # This solver won't solve the system. We want
                 # to override it in the parent.
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
-        class Super(Group):
+        class Super(om.Group):
             def setup(self):
                 self.add_subsystem('sub', Sub())
 
             def configure(self):
                 # This will solve it.
-                self.sub.nonlinear_solver = NewtonSolver()
-                self.sub.linear_solver = ScipyKrylov()
+                self.sub.nonlinear_solver = om.NewtonSolver()
+                self.sub.linear_solver = om.ScipyKrylov()
 
-        top = Problem(model=Super())
+        top = om.Problem(model=Super())
 
         top.setup()
 
-        print(isinstance(top.model.sub.nonlinear_solver, NewtonSolver))
-        print(isinstance(top.model.sub.linear_solver, ScipyKrylov))
+        print(isinstance(top.model.sub.nonlinear_solver, om.NewtonSolver))
+        print(isinstance(top.model.sub.linear_solver, om.ScipyKrylov))
 
     def test_feature_post_setup_solver_configure(self):
-        from openmdao.api import Problem, Group, ImplicitComponent, NewtonSolver, ScipyKrylov, NonlinearBlockGS
+        import openmdao.api as om
 
-        class ImplSimple(ImplicitComponent):
+        class ImplSimple(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('a', val=1.)
@@ -1504,46 +1503,46 @@ class TestProblem(unittest.TestCase):
                     2 * inputs['a']**2 * outputs['x']
                 jacobian['x', 'a'] = -2 * inputs['a'] * outputs['x']**2
 
-        class Sub(Group):
+        class Sub(om.Group):
 
             def setup(self):
                 self.add_subsystem('comp', ImplSimple())
 
                 # This will not solve it
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
             def configure(self):
                 # This will not solve it either.
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
-        class Super(Group):
+        class Super(om.Group):
 
             def setup(self):
                 self.add_subsystem('sub', Sub())
 
-        top = Problem(model=Super())
+        top = om.Problem(model=Super())
 
         top.setup()
 
         # This will solve it.
-        top.model.sub.nonlinear_solver = NewtonSolver()
-        top.model.sub.linear_solver = ScipyKrylov()
+        top.model.sub.nonlinear_solver = om.NewtonSolver()
+        top.model.sub.linear_solver = om.ScipyKrylov()
 
-        self.assertTrue(isinstance(top.model.sub.nonlinear_solver, NewtonSolver))
-        self.assertTrue(isinstance(top.model.sub.linear_solver, ScipyKrylov))
+        self.assertTrue(isinstance(top.model.sub.nonlinear_solver, om.NewtonSolver))
+        self.assertTrue(isinstance(top.model.sub.linear_solver, om.ScipyKrylov))
 
     def test_post_setup_hook(self):
         def hook_func(prob):
             prob['p2.y'] = 5.0
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        Problem._post_setup_func = hook_func
+        om.Problem._post_setup_func = hook_func
 
         try:
-            model.add_subsystem('p1', IndepVarComp('x', 3.0))
-            model.add_subsystem('p2', IndepVarComp('y', -4.0))
-            model.add_subsystem('comp', ExecComp("f_xy=2.0*x+3.0*y"))
+            model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+            model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
+            model.add_subsystem('comp', om.ExecComp("f_xy=2.0*x+3.0*y"))
 
             model.connect('p1.x', 'comp.x')
             model.connect('p2.y', 'comp.y')
@@ -1554,14 +1553,14 @@ class TestProblem(unittest.TestCase):
             assert_rel_error(self, prob['p2.y'], 5.0)
             assert_rel_error(self, prob['comp.f_xy'], 21.0)
         finally:
-            Problem._post_setup_func = None
+            om.Problem._post_setup_func = None
 
     def test_list_problem_vars(self):
         model = SellarDerivatives()
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        prob = Problem(model)
-        prob.driver = ScipyOptimizeDriver()
+        prob = om.Problem(model)
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
 
@@ -1670,14 +1669,14 @@ class TestProblem(unittest.TestCase):
 
     def test_feature_list_problem_vars(self):
         import numpy as np
-        from openmdao.api import Problem, ScipyOptimizeDriver, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives())
+        prob = om.Problem(model=SellarDerivatives())
         model = prob.model
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
 
@@ -1708,22 +1707,22 @@ class NestedProblemTestCase(unittest.TestCase):
 
     def test_nested_prob(self):
 
-        class _ProblemSolver(NonlinearRunOnce):
+        class _ProblemSolver(om.NonlinearRunOnce):
             def solve(self):
                 # create a simple subproblem and run it to test for global solver_info bug
-                p = Problem()
-                p.model.add_subsystem('indep', IndepVarComp('x', 1.0))
-                p.model.add_subsystem('comp', ExecComp('y=2*x'))
+                p = om.Problem()
+                p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
+                p.model.add_subsystem('comp', om.ExecComp('y=2*x'))
                 p.model.connect('indep.x', 'comp.x')
                 p.setup()
                 p.run_model()
 
                 return super(_ProblemSolver, self).solve()
 
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', 1.0))
-        G = p.model.add_subsystem('G', Group())
-        G.add_subsystem('comp', ExecComp('y=2*x'))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
+        G = p.model.add_subsystem('G', om.Group())
+        G.add_subsystem('comp', om.ExecComp('y=2*x'))
         G.nonlinear_solver = _ProblemSolver()
         p.model.connect('indep.x', 'G.comp.x')
         p.setup()

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -158,7 +158,7 @@ class ProcTestCase3(unittest.TestCase):
         model.add_design_var('indep.x')
         model.add_objective('objective.y')
 
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
 
         all_inds = _get_which_procs(p.model)

--- a/openmdao/core/tests/test_reconf.py
+++ b/openmdao/core/tests/test_reconf.py
@@ -52,7 +52,6 @@ class Test(unittest.TestCase):
     def test(self):
         p = Problem()
 
-        p.model = Group()
         p.model.add_subsystem('c1', IndepVarComp('x', 1.0), promotes_outputs=['x'])
         p.model.add_subsystem('c2', ReconfComp(), promotes_inputs=['x'], promotes_outputs=['y'])
         p.model.add_subsystem('c3', Comp(), promotes_inputs=['x'], promotes_outputs=['z'])

--- a/openmdao/core/tests/test_reconf_dynamic.py
+++ b/openmdao/core/tests/test_reconf_dynamic.py
@@ -58,7 +58,6 @@ class Test(unittest.TestCase):
     def ttest_reconf_comp(self):
         p = Problem()
 
-        p.model = Group()
         p.model.add_subsystem('c1', IndepVarComp('x', 1.0), promotes_outputs=['x'])
         p.model.add_subsystem('c2', ReconfComp(), promotes_inputs=['x'], promotes_outputs=['y'])
         p.model.add_subsystem('c3', Comp(), promotes_inputs=['x'], promotes_outputs=['z'])
@@ -86,7 +85,6 @@ class Test(unittest.TestCase):
     def test_reconf_group(self):
         p = Problem()
 
-        p.model = Group()
         p.model.add_subsystem('s1', IndepVarComp('x', 1.0), promotes_outputs=['x'])
         s2 = p.model.add_subsystem('s2', ReconfGroup(), promotes=['*'])
         p.model.add_subsystem('s3', ExecComp('z=3*x'), promotes=['*'])

--- a/openmdao/core/tests/test_reconf_group.py
+++ b/openmdao/core/tests/test_reconf_group.py
@@ -31,7 +31,7 @@ class Test(unittest.TestCase):
         prob = Problem()
         prob.model.add_subsystem('Cx', IndepVarComp('x', 1.0), promotes=['x'])
         prob.model.add_subsystem('g', ReconfGroup(), promotes=['*'])
-        prob.setup(check=False)
+        prob.setup()
 
         # First run with the initial setup.
         prob['x'] = 2.0

--- a/openmdao/core/tests/test_reconf_group.py
+++ b/openmdao/core/tests/test_reconf_group.py
@@ -28,7 +28,7 @@ class ReconfGroup(Group):
 class Test(unittest.TestCase):
 
     def test(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('Cx', IndepVarComp('x', 1.0), promotes=['x'])
         prob.model.add_subsystem('g', ReconfGroup(), promotes=['*'])
         prob.setup(check=False)

--- a/openmdao/core/tests/test_reconf_parallel_group.py
+++ b/openmdao/core/tests/test_reconf_parallel_group.py
@@ -47,7 +47,7 @@ class Test(unittest.TestCase):
         prob.model.add_subsystem('Cx0', IndepVarComp('x0'), promotes=['x0'])
         prob.model.add_subsystem('Cx1', IndepVarComp('x1'), promotes=['x1'])
         prob.model.add_subsystem('g', ReconfGroup(), promotes=['*'])
-        prob.setup(check=False)
+        prob.setup()
 
         # First, run with full setup, so ReconfGroup should be a parallel group
         prob['x0'] = 6.

--- a/openmdao/core/tests/test_reconf_parallel_group.py
+++ b/openmdao/core/tests/test_reconf_parallel_group.py
@@ -43,7 +43,7 @@ class Test(unittest.TestCase):
     N_PROCS = 2
 
     def test(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('Cx0', IndepVarComp('x0'), promotes=['x0'])
         prob.model.add_subsystem('Cx1', IndepVarComp('x1'), promotes=['x1'])
         prob.model.add_subsystem('g', ReconfGroup(), promotes=['*'])

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -199,12 +199,12 @@ class TestScaling(unittest.TestCase):
                 self.add_output('zz', val=np.ones((4, 2)), ref=np.ones((3, 5)))
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('comp', EComp())
 
         msg = "'comp': When adding output 'zz', expected shape (4, 2) but got shape (3, 5) for argument 'ref'."
         with self.assertRaises(ValueError) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(_winfix(str(context.exception)), msg)
 
         class EComp(ImplicitComponent):
@@ -212,12 +212,12 @@ class TestScaling(unittest.TestCase):
                 self.add_output('zz', val=np.ones((4, 2)), ref0=np.ones((3, 5)))
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('comp', EComp())
 
         msg = "'comp': When adding output 'zz', expected shape (4, 2) but got shape (3, 5) for argument 'ref0'."
         with self.assertRaises(ValueError) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(_winfix(str(context.exception)), msg)
 
         class EComp(ImplicitComponent):
@@ -225,12 +225,12 @@ class TestScaling(unittest.TestCase):
                 self.add_output('zz', val=np.ones((4, 2)), res_ref=np.ones((3, 5)))
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('comp', EComp())
 
         msg = "'comp': When adding output 'zz', expected shape (4, 2) but got shape (3, 5) for argument 'res_ref'."
         with self.assertRaises(ValueError) as context:
-            prob.setup(check=False)
+            prob.setup()
         self.assertEqual(_winfix(str(context.exception)), msg)
 
     def test_pass_through(self):
@@ -242,7 +242,7 @@ class TestScaling(unittest.TestCase):
 
         prob = Problem(group)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob['sys1.old_length'] = 3.e5
@@ -266,7 +266,7 @@ class TestScaling(unittest.TestCase):
         group.connect('c1.time', 'c2.time')
 
         prob = Problem(model=group)
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob.run_model()
@@ -291,7 +291,7 @@ class TestScaling(unittest.TestCase):
 
             prob.set_solver_print(level=0)
 
-            prob.setup(check=False)
+            prob.setup()
             prob.run_model()
 
             return np.linalg.norm(prob.model._residuals._data) < 1e-5
@@ -366,7 +366,7 @@ class TestScaling(unittest.TestCase):
         # Baseline - all should be equal.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('p1', Simple())
         model.add_subsystem('p2', Simple())
         model.connect('p1.y', 'p2.x')
@@ -378,7 +378,7 @@ class TestScaling(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         res1 = -model.p1._residuals._data[0]
@@ -405,7 +405,7 @@ class TestScaling(unittest.TestCase):
         ref0 = 1.5
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('p1', Simple(ref=ref, ref0=ref0))
         model.add_subsystem('p2', Simple(ref=ref, ref0=ref0))
         model.connect('p1.y', 'p2.x')
@@ -417,7 +417,7 @@ class TestScaling(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         res1 = -model.p1._residuals._data[0]
@@ -440,7 +440,7 @@ class TestScaling(unittest.TestCase):
         res_ref = 4.0
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('p1', Simple(res_ref=res_ref))
         model.add_subsystem('p2', Simple(res_ref=res_ref))
         model.connect('p1.y', 'p2.x')
@@ -452,7 +452,7 @@ class TestScaling(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         res1 = -model.p1._residuals._data[0]
@@ -477,7 +477,7 @@ class TestScaling(unittest.TestCase):
         res_ref = 4.0
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('p1', Simple(ref=ref, ref0=ref0, res_ref=res_ref))
         model.add_subsystem('p2', Simple(ref=ref, ref0=ref0, res_ref=res_ref))
         model.connect('p1.y', 'p2.x')
@@ -489,7 +489,7 @@ class TestScaling(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         res1 = -model.p1._residuals._data[0]
@@ -523,13 +523,13 @@ class TestScaling(unittest.TestCase):
                 outputs['stuff'] = inputs['widths'] + inputs['lengths']
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.ones((2, 2))))
         model.add_subsystem('comp', ExpCompArrayScale())
         model.connect('p1.x', 'comp.lengths')
 
-        prob.setup(check=False)
+        prob.setup()
         prob['comp.widths'] = np.ones((2, 2))
 
         prob.run_model()
@@ -565,13 +565,13 @@ class TestScaling(unittest.TestCase):
                 outputs['stuff'] = inputs['widths'] + inputs['lengths']
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.ones((2, 2))))
         model.add_subsystem('comp', ExpCompArrayScale())
         model.connect('p1.x', 'comp.lengths')
 
-        prob.setup(check=False)
+        prob.setup()
         prob['comp.widths'] = np.ones((2, 2))
         prob.run_model()
 
@@ -610,13 +610,13 @@ class TestScaling(unittest.TestCase):
                 outputs['stuff'] = inputs['widths'] + inputs['lengths']
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.ones((2, 2))))
         model.add_subsystem('comp', ExpCompArrayScale())
         model.connect('p1.x', 'comp.lengths')
 
-        prob.setup(check=False)
+        prob.setup()
         prob['comp.widths'] = np.ones((2, 2))
         prob.run_model()
 
@@ -686,13 +686,13 @@ class TestScaling(unittest.TestCase):
 
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.ones(2)))
         comp = model.add_subsystem('comp', ImpCompArrayScale())
         model.connect('p1.x', 'comp.rhs')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         base_x = model.comp._outputs['x'].copy()
@@ -745,13 +745,13 @@ class TestScaling(unittest.TestCase):
 
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.ones(2)))
         comp = model.add_subsystem('comp', ImpCompArrayScale())
         model.connect('p1.x', 'comp.rhs')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         base_x = model.comp._outputs['x'].copy()
@@ -812,7 +812,7 @@ class TestScaling(unittest.TestCase):
                 outputs['total_volume'] = np.sum(outputs['areas']) + np.sum(outputs['stuff'])
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', np.ones((2, 2))))
         model.add_subsystem('p2', IndepVarComp('x', np.ones((1, 3))))
@@ -823,7 +823,7 @@ class TestScaling(unittest.TestCase):
         model.connect('comp1.areas', 'comp2.lengths')
         model.connect('comp1.stuff', 'comp2.widths')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['comp1.total_volume'], 14.)
@@ -858,7 +858,7 @@ class TestScaling(unittest.TestCase):
         model.nonlinear_solver = NewtonSolver()
         model.linear_solver = DirectSolver()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['comp.y'], 2.0)
@@ -866,7 +866,7 @@ class TestScaling(unittest.TestCase):
         # Now, let's try with an AssembledJacobian.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 6.0))
         model.add_subsystem('comp', SimpleComp())
@@ -876,7 +876,7 @@ class TestScaling(unittest.TestCase):
         model.nonlinear_solver = NewtonSolver()
         model.linear_solver = DirectSolver(assemble_jac=True)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['comp.y'], 2.0)
@@ -886,7 +886,7 @@ class TestScaling(unittest.TestCase):
         from openmdao.core.tests.test_scaling import ScalingExample1
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x1', 1.0))
         model.add_subsystem('p2', IndepVarComp('x2', 1.0))
@@ -894,7 +894,7 @@ class TestScaling(unittest.TestCase):
         model.connect('p1.x1', 'comp.x1')
         model.connect('p2.x2', 'comp.x2')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         model.run_apply_nonlinear()
@@ -910,7 +910,7 @@ class TestScaling(unittest.TestCase):
         from openmdao.core.tests.test_scaling import ScalingExample2
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x1', 1.0))
         model.add_subsystem('p2', IndepVarComp('x2', 1.0))
@@ -918,7 +918,7 @@ class TestScaling(unittest.TestCase):
         model.connect('p1.x1', 'comp.x1')
         model.connect('p2.x2', 'comp.x2')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         model.run_apply_nonlinear()
@@ -934,7 +934,7 @@ class TestScaling(unittest.TestCase):
         from openmdao.core.tests.test_scaling import ScalingExample3
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x1', 1.0))
         model.add_subsystem('p2', IndepVarComp('x2', 1.0))
@@ -942,7 +942,7 @@ class TestScaling(unittest.TestCase):
         model.connect('p1.x1', 'comp.x1')
         model.connect('p2.x2', 'comp.x2')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         model.run_apply_nonlinear()
@@ -958,13 +958,13 @@ class TestScaling(unittest.TestCase):
         from openmdao.core.tests.test_scaling import ScalingExampleVector
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', np.ones((2))))
         comp = model.add_subsystem('comp', ScalingExampleVector())
         model.connect('p.x', 'comp.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         model.run_apply_nonlinear()

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -279,7 +279,7 @@ class TestScaling(unittest.TestCase):
     def test_scaling(self):
         """Test convergence in essentially one Newton iteration to atol=1e-5."""
         def runs_successfully(use_scal, coeffs):
-            prob = Problem(model=Group())
+            prob = Problem()
             prob.model.add_subsystem('row1', ScalingTestComp(row=1, coeffs=coeffs,
                                                              use_scal=use_scal))
             prob.model.add_subsystem('row2', ScalingTestComp(row=2, coeffs=coeffs,

--- a/openmdao/core/tests/test_simple_impl_comp.py
+++ b/openmdao/core/tests/test_simple_impl_comp.py
@@ -85,7 +85,7 @@ class Test(unittest.TestCase):
         self.p = Problem(group)
 
         self.p.model.linear_solver = LinearBlockGS()
-        self.p.setup(check=False)
+        self.p.setup()
 
         # Conclude setup but don't run model.
         self.p.final_setup()

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -236,9 +236,6 @@ class TestSystem(unittest.TestCase):
         self.assertTrue(isinstance(solver, DummySolver))
 
     def test_deprecated_metadata(self):
-        from openmdao.api import Problem, IndepVarComp
-        from openmdao.test_suite.components.options_feature_vector import VectorDoublingComp
-
         prob = Problem()
         prob.model.add_subsystem('inputs', IndepVarComp('x', shape=3))
         prob.model.add_subsystem('double', VectorDoublingComp())

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -6,6 +6,7 @@ from six import assertRaisesRegex
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp
+from openmdao.test_suite.components.options_feature_vector import VectorDoublingComp
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -60,7 +60,7 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
 
     def test_dangling_input_w_units(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=x', x={'units': 'ft'}, y={'units': 'm'}))
         prob.setup()
         prob.run_model()
@@ -74,7 +74,7 @@ class TestUnitConversion(unittest.TestCase):
         comp.add_output('distance', val=1., units='m')
         comp.add_output('time', val=1., units='s')
 
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('c1', comp)
         prob.model.add_subsystem('c2', SpeedComp())
         prob.model.add_subsystem('c3', ExecComp('f=speed',speed={'units': 'm/s'}))
@@ -291,7 +291,7 @@ class TestUnitConversion(unittest.TestCase):
         self.assertTrue(expected_msg in str(cm.exception))
 
     def test_add_unitless_output(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('indep', IndepVarComp('x', 0.0, units='unitless'))
 
         msg = "Output 'x' has units='unitless' but 'unitless' has been deprecated. " \
@@ -302,7 +302,7 @@ class TestUnitConversion(unittest.TestCase):
             prob.setup(check=False)
 
     def test_add_unitless_input(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('C1', ExecComp('y=x', x={'units': 'unitless'}))
 
         msg = "Input 'x' has units='unitless' but 'unitless' has been deprecated. " \
@@ -314,7 +314,7 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_incompatible_units(self):
         """Test error handling when only one of src and tgt have units."""
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
         prob.model.add_subsystem('src', SrcComp(), promotes_inputs=['x1'])
         prob.model.add_subsystem('tgt', ExecComp('yy=xx', xx={'value': 0.0, 'units': 'unitless'}))
@@ -327,7 +327,7 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic_implicit_conn(self):
         """Test units with all implicit connections."""
-        prob = Problem(model=Group())
+        prob = Problem()
         prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
         prob.model.add_subsystem('src', SrcComp(), promotes_inputs=['x1'], promotes_outputs=['x2'])
         prob.model.add_subsystem('tgtF', TgtCompF(), promotes_inputs=['x2'])

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -4,14 +4,13 @@ import unittest
 
 from six import iteritems
 
-from openmdao.api import Problem, Group, ExplicitComponent, IndepVarComp, DirectSolver
-from openmdao.api import ExecComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.test_suite.components.unit_conv import UnitConvGroup, SrcComp, TgtCompC, TgtCompF, \
     TgtCompK, SrcCompFD, TgtCompCFD, TgtCompFFD, TgtCompKFD, TgtCompFMulti
 
 
-class SpeedComp(ExplicitComponent):
+class SpeedComp(om.ExplicitComponent):
     """Simple speed computation from distance and time with unit conversations."""
 
     def setup(self):
@@ -28,9 +27,9 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic_dense_jac(self):
         """Test that output values and total derivatives are correct."""
-        prob = Problem(model=UnitConvGroup(assembled_jac_type='dense'))
+        prob = om.Problem(model=UnitConvGroup(assembled_jac_type='dense'))
 
-        prob.model.linear_solver = DirectSolver(assemble_jac=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         # Check the outputs after running to test the unit conversions
         prob.setup(check=False, mode='fwd')
@@ -60,24 +59,24 @@ class TestUnitConversion(unittest.TestCase):
         assert_rel_error(self, J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
 
     def test_dangling_input_w_units(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('y=x', x={'units': 'ft'}, y={'units': 'm'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('y=x', x={'units': 'ft'}, y={'units': 'm'}))
         prob.setup()
         prob.run_model()
         # this test passes as long as it doesn't raise an exception
 
     def test_speed(self):
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp
+        import openmdao.api as om
         from openmdao.core.tests.test_units import SpeedComp
 
-        comp = IndepVarComp()
+        comp = om.IndepVarComp()
         comp.add_output('distance', val=1., units='m')
         comp.add_output('time', val=1., units='s')
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('c1', comp)
         prob.model.add_subsystem('c2', SpeedComp())
-        prob.model.add_subsystem('c3', ExecComp('f=speed',speed={'units': 'm/s'}))
+        prob.model.add_subsystem('c3', om.ExecComp('f=speed',speed={'units': 'm/s'}))
         prob.model.connect('c1.distance', 'c2.distance')
         prob.model.connect('c1.time', 'c2.time')
         prob.model.connect('c2.speed', 'c3.speed')
@@ -96,7 +95,7 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic(self):
         """Test that output values and total derivatives are correct."""
-        prob = Problem(model=UnitConvGroup())
+        prob = om.Problem(model=UnitConvGroup())
 
         # Check the outputs after running to test the unit conversions
         prob.setup(check=False, mode='fwd')
@@ -140,7 +139,7 @@ class TestUnitConversion(unittest.TestCase):
     def test_basic_apply(self):
         """Test that output values and total derivatives are correct."""
 
-        class SrcCompa(ExplicitComponent):
+        class SrcCompa(om.ExplicitComponent):
             """Source provides degrees Celsius."""
 
             def setup(self):
@@ -159,7 +158,7 @@ class TestUnitConversion(unittest.TestCase):
                 else:
                     d_inputs['x1'] += d_outputs['x2']
 
-        class TgtCompFa(ExplicitComponent):
+        class TgtCompFa(om.ExplicitComponent):
             """Target expressed in degrees F."""
 
             def setup(self):
@@ -178,10 +177,10 @@ class TestUnitConversion(unittest.TestCase):
                 else:
                     d_inputs['x2'] += d_outputs['x3']
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px1', IndepVarComp('x1', 100.0))
+        model.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
         model.add_subsystem('src', SrcCompa())
         model.add_subsystem('tgtF', TgtCompFa())
 
@@ -211,8 +210,8 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic_fd_comps(self):
 
-        prob = Problem()
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes=['x1'])
         prob.model.add_subsystem('src', SrcCompFD())
         prob.model.add_subsystem('tgtF', TgtCompFFD())
         prob.model.add_subsystem('tgtC', TgtCompCFD())
@@ -269,29 +268,29 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_bad_units(self):
         """Test error handling when invalid units are declared."""
-        class Comp1(ExplicitComponent):
+        class Comp1(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x', 0.0, units='junk')
 
-        class Comp2(ExplicitComponent):
+        class Comp2(om.ExplicitComponent):
             def setup(self):
                 self.add_output('x', 0.0, units='junk')
 
         with self.assertRaises(Exception) as cm:
-            prob = Problem(model=Comp1())
+            prob = om.Problem(model=Comp1())
             prob.setup()
         expected_msg = "The units 'junk' are invalid"
         self.assertTrue(expected_msg in str(cm.exception))
 
         with self.assertRaises(Exception) as cm:
-            prob = Problem(model=Comp2())
+            prob = om.Problem(model=Comp2())
             prob.setup()
         expected_msg = "The units 'junk' are invalid"
         self.assertTrue(expected_msg in str(cm.exception))
 
     def test_add_unitless_output(self):
-        prob = Problem()
-        prob.model.add_subsystem('indep', IndepVarComp('x', 0.0, units='unitless'))
+        prob = om.Problem()
+        prob.model.add_subsystem('indep', om.IndepVarComp('x', 0.0, units='unitless'))
 
         msg = "Output 'x' has units='unitless' but 'unitless' has been deprecated. " \
               "Use units=None instead.  Note that connecting a unitless variable to " \
@@ -301,8 +300,8 @@ class TestUnitConversion(unittest.TestCase):
             prob.setup()
 
     def test_add_unitless_input(self):
-        prob = Problem()
-        prob.model.add_subsystem('C1', ExecComp('y=x', x={'units': 'unitless'}))
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('y=x', x={'units': 'unitless'}))
 
         msg = "Input 'x' has units='unitless' but 'unitless' has been deprecated. " \
               "Use units=None instead.  Note that connecting a unitless variable to " \
@@ -313,10 +312,10 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_incompatible_units(self):
         """Test error handling when only one of src and tgt have units."""
-        prob = Problem()
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
         prob.model.add_subsystem('src', SrcComp(), promotes_inputs=['x1'])
-        prob.model.add_subsystem('tgt', ExecComp('yy=xx', xx={'value': 0.0, 'units': 'unitless'}))
+        prob.model.add_subsystem('tgt', om.ExecComp('yy=xx', xx={'value': 0.0, 'units': 'unitless'}))
         prob.model.connect('src.x2', 'tgt.xx')
 
         msg = "Output 'src.x2' with units of 'degC' is connected to input 'tgt.xx' which has no units."
@@ -326,8 +325,8 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic_implicit_conn(self):
         """Test units with all implicit connections."""
-        prob = Problem()
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
         prob.model.add_subsystem('src', SrcComp(), promotes_inputs=['x1'], promotes_outputs=['x2'])
         prob.model.add_subsystem('tgtF', TgtCompF(), promotes_inputs=['x2'])
         prob.model.add_subsystem('tgtC', TgtCompC(), promotes_inputs=['x2'])
@@ -362,10 +361,10 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic_grouped(self):
 
-        prob = Problem()
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
-        sub1 = prob.model.add_subsystem('sub1', Group())
-        sub2 = prob.model.add_subsystem('sub2', Group())
+        prob = om.Problem()
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes=['x1'])
+        sub1 = prob.model.add_subsystem('sub1', om.Group())
+        sub2 = prob.model.add_subsystem('sub2', om.Group())
 
         sub1.add_subsystem('src', SrcComp())
         sub2.add_subsystem('tgtF', TgtCompF())
@@ -404,11 +403,11 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_basic_grouped_bug_from_pycycle(self):
 
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
 
-        prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
-        sub1 = prob.model.add_subsystem('sub1', Group(), promotes=['x2'])
+        prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes=['x1'])
+        sub1 = prob.model.add_subsystem('sub1', om.Group(), promotes=['x2'])
         sub1.add_subsystem('src', SrcComp(), promotes=['x2'])
         root.add_subsystem('tgtF', TgtCompFMulti())
         root.add_subsystem('tgtC', TgtCompC())
@@ -446,15 +445,15 @@ class TestUnitConversion(unittest.TestCase):
 
     #def test_basic_grouped_grouped_implicit(self):
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #sub1 = prob.model.add('sub1', Group(), promotes=['x2'])
-        #sub2 = prob.model.add('sub2', Group(), promotes=['x2'])
+        #sub1 = prob.model.add('sub1', om.Group(), promotes=['x2'])
+        #sub2 = prob.model.add('sub2', om.Group(), promotes=['x2'])
         #sub1.add('src', SrcComp(), promotes = ['x2'])
         #sub2.add('tgtF', TgtCompFMulti(), promotes=['x2'])
         #sub2.add('tgtC', TgtCompC(), promotes=['x2'])
         #sub2.add('tgtK', TgtCompK(), promotes=['x2'])
-        #prob.model.add('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
+        #prob.model.add('px1', om.IndepVarComp('x1', 100.0), promotes=['x1'])
         #prob.model.connect('x1', 'sub1.src.x1')
 
         #prob.setup()
@@ -574,11 +573,11 @@ class TestUnitConversion(unittest.TestCase):
                                     #dinputs['Odot_BI'][i, j, :] -= -self.dw_dOdot[:, k, i, j] * \
                                         #dw_B[k, :]
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
         #prob.model.add('comp', Attitude_Angular(n=5), promotes=['*'])
-        #prob.model.add('p1', IndepVarComp('O_BI', np.ones((3, 3, 5))), promotes=['*'])
-        #prob.model.add('p2', IndepVarComp('Odot_BI', np.ones((3, 3, 5))), promotes=['*'])
+        #prob.model.add('p1', om.IndepVarComp('O_BI', np.ones((3, 3, 5))), promotes=['*'])
+        #prob.model.add('p2', om.IndepVarComp('Odot_BI', np.ones((3, 3, 5))), promotes=['*'])
 
         #prob.setup()
         #prob.run()
@@ -600,13 +599,13 @@ class TestUnitConversion(unittest.TestCase):
 
     def test_incompatible_connections(self):
 
-        class BadComp(ExplicitComponent):
+        class BadComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x2', 100.0, units='m')
                 self.add_output('x3', 100.0)
 
         # Explicit Connection
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('src', SrcComp())
         prob.model.add_subsystem('dest', BadComp())
         prob.model.connect('src.x2', 'dest.x2')
@@ -618,7 +617,7 @@ class TestUnitConversion(unittest.TestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
         # Implicit Connection
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('src', SrcComp(), promotes=['x2'])
         prob.model.add_subsystem('dest', BadComp(),promotes=['x2'])
         with self.assertRaises(Exception) as cm:
@@ -634,14 +633,14 @@ class TestUnitConversion(unittest.TestCase):
         ## "rest" of the problem that the others are testing, namely that
         ## outscope vars could sometimes cause a problem even absent any units.
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #root.add('p1', IndepVarComp('xx', 3.0))
-        #root.add('c1', ExecComp(['y1=0.5*x + 0.1*xx', 'y2=0.3*x - 1.0*xx']))
-        #root.add('c2', ExecComp(['y=0.5*x']))
-        #sub = root.add('sub', Group())
-        #sub.add('cc1', ExecComp(['y=0.1*x1 + 0.01*x2']))
-        #sub.add('cc2', ExecComp(['y=0.1*x']))
+        #root.add('p1', om.IndepVarComp('xx', 3.0))
+        #root.add('c1', om.ExecComp(['y1=0.5*x + 0.1*xx', 'y2=0.3*x - 1.0*xx']))
+        #root.add('c2', om.ExecComp(['y=0.5*x']))
+        #sub = root.add('sub', om.Group())
+        #sub.add('cc1', om.ExecComp(['y=0.1*x1 + 0.01*x2']))
+        #sub.add('cc2', om.ExecComp(['y=0.1*x']))
 
         #root.connect('p1.xx', 'c1.xx')
         #root.connect('c1.y1', 'c2.x')
@@ -654,7 +653,7 @@ class TestUnitConversion(unittest.TestCase):
         #root.linear_solver = ScipyKrylov()
 
         #sub.nonlinear_solver = Newton()
-        #sub.linear_solver = DirectSolver()
+        #sub.linear_solver = om.DirectSolver()
 
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('c1.y2')
@@ -680,14 +679,14 @@ class TestUnitConversion(unittest.TestCase):
         ## higher scopes aren't sitting there converting themselves during sub
         ## iterations.
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #root.add('p1', IndepVarComp('xx', 3.0))
-        #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
-        #root.add('c2', ExecComp(['y=0.5*x']))
-        #sub = root.add('sub', Group())
-        #sub.add('cc1', ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'nm'}))
-        #sub.add('cc2', ExecComp(['y=1.01*x']))
+        #root.add('p1', om.IndepVarComp('xx', 3.0))
+        #root.add('c1', om.ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
+        #root.add('c2', om.ExecComp(['y=0.5*x']))
+        #sub = root.add('sub', om.Group())
+        #sub.add('cc1', om.ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'nm'}))
+        #sub.add('cc2', om.ExecComp(['y=1.01*x']))
 
         #root.connect('p1.xx', 'c1.xx')
         #root.connect('c1.y1', 'c2.x')
@@ -702,7 +701,7 @@ class TestUnitConversion(unittest.TestCase):
         #root.linear_solver.options['maxiter'] = 1
 
         #sub.nonlinear_solver = Newton()
-        #sub.linear_solver = DirectSolver()
+        #sub.linear_solver = om.DirectSolver()
 
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
@@ -718,14 +717,14 @@ class TestUnitConversion(unittest.TestCase):
         ## higher scopes aren't sitting there converting themselves during sub
         ## iterations.
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #root.add('p1', IndepVarComp('xx', 3.0))
-        #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
-        #root.add('c2', ExecComp(['y=0.5*x']))
-        #sub = root.add('sub', Group())
-        #sub.add('cc1', ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'nm'}))
-        #sub.add('cc2', ExecComp(['y=1.01*x']))
+        #root.add('p1', om.IndepVarComp('xx', 3.0))
+        #root.add('c1', om.ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
+        #root.add('c2', om.ExecComp(['y=0.5*x']))
+        #sub = root.add('sub', om.Group())
+        #sub.add('cc1', om.ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'nm'}))
+        #sub.add('cc2', om.ExecComp(['y=1.01*x']))
 
         #root.connect('p1.xx', 'c1.xx')
         #root.connect('c1.y1', 'c2.x')
@@ -741,7 +740,7 @@ class TestUnitConversion(unittest.TestCase):
         #root.linear_solver.options['mode'] = 'rev'
 
         #sub.nonlinear_solver = Newton()
-        #sub.linear_solver = DirectSolver()
+        #sub.linear_solver = om.DirectSolver()
 
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
@@ -797,14 +796,14 @@ class TestUnitConversion(unittest.TestCase):
                         #dinputs['x2'] = 1.01*dresids['y']
                         #self.dx2count += 1
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #root.add('p1', IndepVarComp('xx', 3.0))
-        #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
-        #root.add('c2', ExecComp(['y=0.5*x']))
-        #sub = root.add('sub', Group())
+        #root.add('p1', om.IndepVarComp('xx', 3.0))
+        #root.add('c1', om.ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
+        #root.add('c2', om.ExecComp(['y=0.5*x']))
+        #sub = root.add('sub', om.Group())
         #sub.add('cc1', TestComp())
-        #sub.add('cc2', ExecComp(['y=1.01*x']))
+        #sub.add('cc2', om.ExecComp(['y=1.01*x']))
 
         #root.connect('p1.xx', 'c1.xx')
         #root.connect('c1.y1', 'c2.x')
@@ -820,7 +819,7 @@ class TestUnitConversion(unittest.TestCase):
         #root.linear_solver.options['mode'] = 'rev'
 
         #sub.nonlinear_solver = Newton()
-        #sub.linear_solver = DirectSolver()
+        #sub.linear_solver = om.DirectSolver()
 
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
@@ -838,14 +837,14 @@ class TestUnitConversion(unittest.TestCase):
         ## higher scopes aren't sitting there converting themselves during sub
         ## iterations.
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #root.add('p1', IndepVarComp('xx', 3.0))
-        #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
-        #root.add('c2', ExecComp(['y=0.5*x']))
-        #sub = root.add('sub', Group())
-        #sub.add('cc1', ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'fm'}))
-        #sub.add('cc2', ExecComp(['y=1.01*x']))
+        #root.add('p1', om.IndepVarComp('xx', 3.0))
+        #root.add('c1', om.ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
+        #root.add('c2', om.ExecComp(['y=0.5*x']))
+        #sub = root.add('sub', om.Group())
+        #sub.add('cc1', om.ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'fm'}))
+        #sub.add('cc2', om.ExecComp(['y=1.01*x']))
 
         #root.connect('p1.xx', 'c1.xx')
         #root.connect('c1.y1', 'c2.x')
@@ -880,14 +879,14 @@ class TestUnitConversion(unittest.TestCase):
 
         ## Make sure preconditioners also work
 
-        #prob = Problem()
+        #prob = om.Problem()
         #root = prob.model
-        #root.add('p1', IndepVarComp('xx', 3.0))
-        #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
-        #root.add('c2', ExecComp(['y=0.5*x']))
-        #sub = root.add('sub', Group())
-        #sub.add('cc1', ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'fm'}))
-        #sub.add('cc2', ExecComp(['y=1.01*x']))
+        #root.add('p1', om.IndepVarComp('xx', 3.0))
+        #root.add('c1', om.ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
+        #root.add('c2', om.ExecComp(['y=0.5*x']))
+        #sub = root.add('sub', om.Group())
+        #sub.add('cc1', om.ExecComp(['y=1.01*x1 + 1.01*x2'], units={'x1' : 'fm'}))
+        #sub.add('cc2', om.ExecComp(['y=1.01*x']))
 
         #root.connect('p1.xx', 'c1.xx')
         #root.connect('c1.y1', 'c2.x')
@@ -903,7 +902,7 @@ class TestUnitConversion(unittest.TestCase):
 
         #sub.nonlinear_solver = Newton()
         #sub.linear_solver = ScipyKrylov()
-        #sub.linear_solver.precon = DirectSolver()
+        #sub.linear_solver.precon = om.DirectSolver()
 
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
@@ -952,10 +951,10 @@ class TestUnitConversion(unittest.TestCase):
 
     #def test_basic(self):
 
-        #prob = Problem()
+        #prob = om.Problem()
         #prob.model.add('src', PBOSrcComp())
         #prob.model.add('tgtF', PBOTgtCompF())
-        #prob.model.add('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
+        #prob.model.add('px1', om.IndepVarComp('x1', 100.0), promotes=['x1'])
         #prob.model.connect('x1', 'src.x1')
         #prob.model.connect('src.x2', 'tgtF.x2')
 
@@ -1010,8 +1009,8 @@ class TestUnitConversion(unittest.TestCase):
                 #""" No action."""
                 #pass
 
-        #top = Problem()
-        #root = top.root = Group()
+        #top = om.Problem()
+        #root = top.root = om.Group()
         #root.add('src', Src())
         #root.add('tgt', Tgt())
 

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -179,7 +179,7 @@ class TestUnitConversion(unittest.TestCase):
                     d_inputs['x2'] += d_outputs['x3']
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px1', IndepVarComp('x1', 100.0))
         model.add_subsystem('src', SrcCompa())
@@ -212,7 +212,6 @@ class TestUnitConversion(unittest.TestCase):
     def test_basic_fd_comps(self):
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
         prob.model.add_subsystem('src', SrcCompFD())
         prob.model.add_subsystem('tgtF', TgtCompFFD())
@@ -223,7 +222,7 @@ class TestUnitConversion(unittest.TestCase):
         prob.model.connect('src.x2', 'tgtC.x2')
         prob.model.connect('src.x2', 'tgtK.x2')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
@@ -299,7 +298,7 @@ class TestUnitConversion(unittest.TestCase):
               "one with units is no longer an error, but will issue a warning instead."
 
         with assert_warning(DeprecationWarning, msg):
-            prob.setup(check=False)
+            prob.setup()
 
     def test_add_unitless_input(self):
         prob = Problem()
@@ -310,7 +309,7 @@ class TestUnitConversion(unittest.TestCase):
               "one with units is no longer an error, but will issue a warning instead."
 
         with assert_warning(DeprecationWarning, msg):
-            prob.setup(check=False)
+            prob.setup()
 
     def test_incompatible_units(self):
         """Test error handling when only one of src and tgt have units."""
@@ -335,7 +334,7 @@ class TestUnitConversion(unittest.TestCase):
         prob.model.add_subsystem('tgtK', TgtCompK(), promotes_inputs=['x2'])
 
         # Check the outputs after running to test the unit conversions
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['x2'], 100.0, 1e-6)
@@ -364,7 +363,6 @@ class TestUnitConversion(unittest.TestCase):
     def test_basic_grouped(self):
 
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
         sub1 = prob.model.add_subsystem('sub1', Group())
         sub2 = prob.model.add_subsystem('sub2', Group())
@@ -379,7 +377,7 @@ class TestUnitConversion(unittest.TestCase):
         prob.model.connect('sub1.src.x2', 'sub2.tgtC.x2')
         prob.model.connect('sub1.src.x2', 'sub2.tgtK.x2')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['sub1.src.x2'], 100.0, 1e-6)
@@ -407,7 +405,7 @@ class TestUnitConversion(unittest.TestCase):
     def test_basic_grouped_bug_from_pycycle(self):
 
         prob = Problem()
-        root = prob.model = Group()
+        root = prob.model
 
         prob.model.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
         sub1 = prob.model.add_subsystem('sub1', Group(), promotes=['x2'])
@@ -421,7 +419,7 @@ class TestUnitConversion(unittest.TestCase):
         prob.model.connect('x2', 'tgtC.x2')
         prob.model.connect('x2', 'tgtK.x2')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['x2'], 100.0, 1e-6)
@@ -449,7 +447,7 @@ class TestUnitConversion(unittest.TestCase):
     #def test_basic_grouped_grouped_implicit(self):
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #sub1 = prob.model.add('sub1', Group(), promotes=['x2'])
         #sub2 = prob.model.add('sub2', Group(), promotes=['x2'])
         #sub1.add('src', SrcComp(), promotes = ['x2'])
@@ -459,7 +457,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.model.add('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
         #prob.model.connect('x1', 'sub1.src.x1')
 
-        #prob.setup(check=False)
+        #prob.setup()
         #prob.run()
 
         #assert_rel_error(self, prob['x2'], 100.0, 1e-6)
@@ -577,12 +575,12 @@ class TestUnitConversion(unittest.TestCase):
                                         #dw_B[k, :]
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #prob.model.add('comp', Attitude_Angular(n=5), promotes=['*'])
         #prob.model.add('p1', IndepVarComp('O_BI', np.ones((3, 3, 5))), promotes=['*'])
         #prob.model.add('p2', IndepVarComp('Odot_BI', np.ones((3, 3, 5))), promotes=['*'])
 
-        #prob.setup(check=False)
+        #prob.setup()
         #prob.run()
 
         #indep_list = ['O_BI', 'Odot_BI']
@@ -609,12 +607,11 @@ class TestUnitConversion(unittest.TestCase):
 
         # Explicit Connection
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('src', SrcComp())
         prob.model.add_subsystem('dest', BadComp())
         prob.model.connect('src.x2', 'dest.x2')
         with self.assertRaises(Exception) as cm:
-            prob.setup(check=False)
+            prob.setup()
 
         expected_msg = "Output units of 'degC' for 'src.x2' are incompatible with input units of 'm' for 'dest.x2'."
 
@@ -622,11 +619,10 @@ class TestUnitConversion(unittest.TestCase):
 
         # Implicit Connection
         prob = Problem()
-        prob.model = Group()
         prob.model.add_subsystem('src', SrcComp(), promotes=['x2'])
         prob.model.add_subsystem('dest', BadComp(),promotes=['x2'])
         with self.assertRaises(Exception) as cm:
-            prob.setup(check=False)
+            prob.setup()
 
         expected_msg = "Output units of 'degC' for 'src.x2' are incompatible with input units of 'm' for 'dest.x2'."
 
@@ -639,7 +635,7 @@ class TestUnitConversion(unittest.TestCase):
         ## outscope vars could sometimes cause a problem even absent any units.
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #root.add('p1', IndepVarComp('xx', 3.0))
         #root.add('c1', ExecComp(['y1=0.5*x + 0.1*xx', 'y2=0.3*x - 1.0*xx']))
         #root.add('c2', ExecComp(['y=0.5*x']))
@@ -663,7 +659,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('c1.y2')
 
-        #prob.setup(check=False)
+        #prob.setup()
 
         #prob.run()
 
@@ -685,7 +681,7 @@ class TestUnitConversion(unittest.TestCase):
         ## iterations.
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #root.add('p1', IndepVarComp('xx', 3.0))
         #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
         #root.add('c2', ExecComp(['y=0.5*x']))
@@ -711,7 +707,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
 
-        #prob.setup(check=False)
+        #prob.setup()
 
         #prob.run()
         #self.assertTrue(not np.isnan(prob['sub.cc2.y']))
@@ -723,7 +719,7 @@ class TestUnitConversion(unittest.TestCase):
         ## iterations.
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #root.add('p1', IndepVarComp('xx', 3.0))
         #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
         #root.add('c2', ExecComp(['y=0.5*x']))
@@ -750,7 +746,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
 
-        #prob.setup(check=False)
+        #prob.setup()
 
         #prob.run()
         #self.assertTrue(not np.isnan(prob['sub.cc2.y']))
@@ -802,7 +798,7 @@ class TestUnitConversion(unittest.TestCase):
                         #self.dx2count += 1
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #root.add('p1', IndepVarComp('xx', 3.0))
         #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
         #root.add('c2', ExecComp(['y=0.5*x']))
@@ -829,7 +825,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
 
-        #prob.setup(check=False)
+        #prob.setup()
         #prob.run()
 
         ## x1 deriv code should be called less if the dinputs vec only
@@ -843,7 +839,7 @@ class TestUnitConversion(unittest.TestCase):
         ## iterations.
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #root.add('p1', IndepVarComp('xx', 3.0))
         #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
         #root.add('c2', ExecComp(['y=0.5*x']))
@@ -869,7 +865,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
 
-        #prob.setup(check=False)
+        #prob.setup()
 
         #prob.run()
 
@@ -885,7 +881,7 @@ class TestUnitConversion(unittest.TestCase):
         ## Make sure preconditioners also work
 
         #prob = Problem()
-        #root = prob.model = Group()
+        #root = prob.model
         #root.add('p1', IndepVarComp('xx', 3.0))
         #root.add('c1', ExecComp(['y1=0.5*x + 1.0*xx', 'y2=0.3*x - 1.0*xx'], units={'y2' : 'km'}))
         #root.add('c2', ExecComp(['y=0.5*x']))
@@ -912,7 +908,7 @@ class TestUnitConversion(unittest.TestCase):
         #prob.driver.add_desvar('p1.xx')
         #prob.driver.add_objective('sub.cc2.y')
 
-        #prob.setup(check=False)
+        #prob.setup()
 
         #prob.run()
 
@@ -957,7 +953,6 @@ class TestUnitConversion(unittest.TestCase):
     #def test_basic(self):
 
         #prob = Problem()
-        #prob.model = Group()
         #prob.model.add('src', PBOSrcComp())
         #prob.model.add('tgtF', PBOTgtCompF())
         #prob.model.add('px1', IndepVarComp('x1', 100.0), promotes=['x1'])
@@ -966,7 +961,7 @@ class TestUnitConversion(unittest.TestCase):
 
         #prob.model.deriv_options['type'] = 'fd'
 
-        #prob.setup(check=False)
+        #prob.setup()
         #prob.run()
 
         #assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
@@ -1024,7 +1019,7 @@ class TestUnitConversion(unittest.TestCase):
         #root.connect('src.x2', 'tgt.x2')
         #root.connect('src.x3', 'tgt.x3')
 
-        #top.setup(check=False)
+        #top.setup()
         #top.run()
 
         #assert_rel_error(self, top['tgt.x1'], np.pi, 1e-6)

--- a/openmdao/devtools/problem_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/devtools/problem_viewer/tests/test_viewmodeldata.py
@@ -94,7 +94,7 @@ class TestViewModelData(unittest.TestCase):
         to the expected structure, using the SellarStateConnection model.
         """
         p = Problem(model=SellarStateConnection())
-        p.setup(check=False)
+        p.setup()
 
         model_viewer_data = _get_viewer_data(p)
 
@@ -129,7 +129,7 @@ class TestViewModelData(unittest.TestCase):
         r = SqliteRecorder(self.sqlite_db_filename)
         p.driver.add_recorder(r)
 
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
         r.shutdown()
 
@@ -161,7 +161,7 @@ class TestViewModelData(unittest.TestCase):
         """
         p = Problem()
         p.model = SellarStateConnection()
-        p.setup(check=False)
+        p.setup()
         view_model(p, outfile=self.problem_html_filename, show_browser=DEBUG)
 
         # Check that the html file has been created and has something in it.
@@ -177,7 +177,7 @@ class TestViewModelData(unittest.TestCase):
         p.model = SellarStateConnection()
         r = SqliteRecorder(self.sqlite_db_filename2)
         p.driver.add_recorder(r)
-        p.setup(check=False)
+        p.setup()
         p.final_setup()
         r.shutdown()
         view_model(self.sqlite_db_filename2, outfile=self.sqlite_html_filename, show_browser=DEBUG)
@@ -204,7 +204,7 @@ class TestViewModelData(unittest.TestCase):
         """
         p = Problem()
         p.model = SellarStateConnection()
-        p.setup(check=False)
+        p.setup()
         view_model(p, outfile=self.problem_html_filename, show_browser=DEBUG,
                    title="Sellar State Connection")
 

--- a/openmdao/devtools/tests/test_viewconns.py
+++ b/openmdao/devtools/tests/test_viewconns.py
@@ -12,7 +12,7 @@ class TestSellarFeature(unittest.TestCase):
         prob = Problem()
         prob.model = SellarNoDerivatives()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # no output checking, just make sure no exceptions raised

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -60,7 +60,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output (outputs on the left)
@@ -109,7 +109,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         recorder = SqliteRecorder(case_recording_filename)
         prob.driver.add_recorder(recorder)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -136,7 +136,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -181,7 +181,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.model.add_objective('f')
         prob.model.add_constraint('c', lower=1.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # requesting 'pdf', but if 'pdflatex' is not found we will only get 'tex'
@@ -242,7 +242,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         p.model.add_design_var('orbit_phase.t_initial')
         p.model.add_design_var('orbit_phase.t_duration')
         p.model.add_objective('systems_phase.time.time')
-        p.setup(check=False)
+        p.setup()
 
         p.run_model()
 
@@ -286,7 +286,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         model.add_design_var('source.I')
         model.add_objective('circuit.D1.I')
 
-        p.setup(check=False)
+        p.setup()
 
         # set some initial guesses
         p['circuit.n1.V'] = 10.
@@ -324,7 +324,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.driver = ScipyOptimizeDriver()
         prob.model.add_objective('obj')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         filename = 'pyxdsm_solver'
@@ -345,7 +345,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         filename = 'pyxdsm_mda'
         out_format = PYXDSM_OUT
         prob = Problem(model=SellarMDA())
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -368,7 +368,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -420,7 +420,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -439,7 +439,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.driver = ScipyOptimizeDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -459,7 +459,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.driver = DOEDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -500,7 +500,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         model.add_subsystem('comp', comp, promotes=["*"])
         prob = Problem(model)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
@@ -542,7 +542,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -570,7 +570,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -597,7 +597,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -714,7 +714,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         p.model.add_design_var('orbit_phase.t_initial')
         p.model.add_design_var('orbit_phase.t_duration')
         p.model.add_objective('systems_phase.time.time')
-        p.setup(check=False)
+        p.setup()
 
         p.run_model()
 
@@ -725,7 +725,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         filename = 'xdsmjs_mda'
         out_format = 'html'
         prob = Problem(model=SellarMDA())
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -748,7 +748,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -767,7 +767,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.driver = ScipyOptimizeDriver()
         prob.model.add_objective('obj')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         # Write output
@@ -819,7 +819,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # Write output
@@ -838,7 +838,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.driver = ScipyOptimizeDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -858,7 +858,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.driver = DOEDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()
@@ -899,7 +899,7 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         model.add_subsystem('comp', comp, promotes=["*"])
         prob = Problem(model)
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
@@ -926,7 +926,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_design_var('source.I')
         model.add_objective('circuit.D1.I')
 
-        p.setup(check=False)
+        p.setup()
 
         # set some initial guesses
         p['circuit.n1.V'] = 10.
@@ -955,7 +955,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_design_var('source.I')
         model.add_objective('circuit.D1.I')
 
-        p.setup(check=False)
+        p.setup()
 
         # set some initial guesses
         p['circuit.n1.V'] = 10.
@@ -979,7 +979,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         msg = 'Right side outputs not implemented for XDSMjs.'
@@ -999,7 +999,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob = Problem()
         prob.model = SellarNoDerivatives()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         # no output checking, just make sure no exceptions raised
@@ -1031,7 +1031,7 @@ class TestCustomXDSMViewer(unittest.TestCase):
         prob = Problem()
         prob.model = SellarNoDerivatives()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.final_setup()
 
         my_writer = CustomWriter()

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -6,10 +6,8 @@ import unittest
 import numpy as np
 from numpy.distutils.exec_command import find_executable
 
-from openmdao.api import Problem, ExplicitComponent, IndepVarComp, ExecComp, ScipyOptimizeDriver, \
-    Group, write_xdsm
+import openmdao.api as om
 from openmdao.devtools.xdsm_viewer.html_writer import write_html
-from openmdao.drivers.doe_driver import DOEDriver
 from openmdao.test_suite.components.sellar import SellarNoDerivatives, SellarDis1, SellarDis2
 from openmdao.test_suite.components.sellar_feature import SellarMDA
 from openmdao.test_suite.scripts.circuit import Circuit
@@ -51,7 +49,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
     def test_pyxdsm_output_sides(self):
         """Makes XDSM for the Sellar problem"""
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -65,24 +63,24 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         # Write output (outputs on the left)
         filename = 'xdsm_outputs_on_the_left'
-        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, quiet=QUIET,
-                   output_side='left')
+        om.write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, quiet=QUIET,
+                      output_side='left')
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
         filename = 'xdsm_outputs_on_the_right'
         # Write output (all outputs on the right)
-        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, quiet=QUIET,
-                   output_side='right')
+        om.write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, quiet=QUIET,
+                      output_side='right')
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
         filename = 'xdsm_outputs_side_mixed'
         # Write output (outputs mixed)
-        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, quiet=QUIET,
-                   output_side={'optimization': 'left', 'default': 'right'})
+        om.write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, quiet=QUIET,
+                      output_side={'optimization': 'left', 'default': 'right'})
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
@@ -97,7 +95,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         filename = 'xdsm_from_sql'
         case_recording_filename = filename + '.sql'
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -113,8 +111,8 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(case_recording_filename, filename=filename, out_format='tex',
-                   show_browser=False, quiet=QUIET)
+        om.write_xdsm(case_recording_filename, filename=filename, out_format='tex',
+                      show_browser=False, quiet=QUIET)
 
         # Check if file was created
         self.assertTrue(os.path.isfile(case_recording_filename))
@@ -127,7 +125,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         """Makes XDSM for the Sellar problem, with no recursion."""
 
         filename = 'xdsm1'
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -140,8 +138,8 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, recurse=False,
-                   quiet=QUIET)
+        om.write_xdsm(prob, filename=filename, out_format=PYXDSM_OUT, show_browser=SHOW, recurse=False,
+                      quiet=QUIET)
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
@@ -151,7 +149,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         Makes an XDSM of the Sphere test case. It also adds a design variable, constraint and
         objective.
         """
-        class Rosenbrock(ExplicitComponent):
+        class Rosenbrock(om.ExplicitComponent):
 
             def __init__(self, problem):
                 super(Rosenbrock, self).__init__()
@@ -170,13 +168,13 @@ class TestPyXDSMViewer(unittest.TestCase):
         x0 = np.array([1.2, 1.5])
         filename = 'xdsm2'
 
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(problem=prob), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(problem=prob), promotes=['*'])
         indeps.add_output('x', list(x0))
 
         prob.model.add_subsystem('sphere', Rosenbrock(problem=prob), promotes=['*'])
-        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
+        prob.model.add_subsystem('con', om.ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
+        prob.driver = om.ScipyOptimizeDriver()
         prob.model.add_design_var('x')
         prob.model.add_objective('f')
         prob.model.add_constraint('c', lower=1.0)
@@ -188,7 +186,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         pdflatex = find_executable('pdflatex')
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='pdf', show_browser=SHOW, quiet=QUIET)
+        om.write_xdsm(prob, filename=filename, out_format='pdf', show_browser=SHOW, quiet=QUIET)
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'tex'])))
@@ -196,7 +194,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         self.assertTrue(not pdflatex or os.path.isfile('.'.join([filename, 'pdf'])))
 
     def test_pyxdsm_identical_relative_names(self):
-        class TimeComp(ExplicitComponent):
+        class TimeComp(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('t_initial', val=0.)
@@ -210,12 +208,12 @@ class TestPyXDSMViewer(unittest.TestCase):
                 outputs['time'][0] = t_initial
                 outputs['time'][1] = t_initial + t_duration
 
-        class Phase(Group):
+        class Phase(om.Group):
 
             def setup(self):
                 super(Phase, self).setup()
 
-                indep = IndepVarComp()
+                indep = om.IndepVarComp()
                 for var in ['t_initial', 't_duration']:
                     indep.add_output(var, val=1.0)
 
@@ -229,8 +227,8 @@ class TestPyXDSMViewer(unittest.TestCase):
 
                 self.set_order(['time_extents', 'time'])
 
-        p = Problem()
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem()
+        p.driver = om.ScipyOptimizeDriver()
         orbit_phase = Phase()
         p.model.add_subsystem('orbit_phase', orbit_phase)
 
@@ -248,35 +246,35 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         # Test non unique local names
         filename = 'pyxdsm_identical_rel_names'
-        write_xdsm(p, filename, out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW)
+        om.write_xdsm(p, filename, out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW)
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
         # Check formatting
 
         # Max character box formatting
         filename = 'pyxdsm_cut_char'
-        write_xdsm(p, filename, out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
-                   box_stacking='cut_chars', box_width=15)
+        om.write_xdsm(p, filename, out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
+                      box_stacking='cut_chars', box_width=15)
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
         # Cut characters box formatting
         filename = 'pyxdsm_max_chars'
-        write_xdsm(p, filename, out_format=PYXDSM_OUT, quiet=True, show_browser=SHOW,
-                   box_stacking='max_chars', box_width=15)
+        om.write_xdsm(p, filename, out_format=PYXDSM_OUT, quiet=True, show_browser=SHOW,
+                      box_stacking='max_chars', box_width=15)
         self.assertTrue(os.path.isfile('.'.join([filename, PYXDSM_OUT])))
 
     def test_model_path_and_recursion(self):
 
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        group = model.add_subsystem('G1', Group(), promotes=['*'])
-        group2 = model.add_subsystem('G2', Group())
-        group.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        group.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
-        group2.add_subsystem('source2', IndepVarComp('I', 0.1, units='A'))
+        group = model.add_subsystem('G1', om.Group(), promotes=['*'])
+        group2 = model.add_subsystem('G2', om.Group())
+        group.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        group.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
+        group2.add_subsystem('source2', om.IndepVarComp('I', 0.1, units='A'))
         group.add_subsystem('circuit', Circuit())
 
         group.connect('source.I', 'circuit.I_in')
@@ -295,33 +293,33 @@ class TestPyXDSMViewer(unittest.TestCase):
         p.run_model()
 
         # No model path, no recursion
-        write_xdsm(p, 'xdsm_circuit', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
-                   recurse=False)
+        om.write_xdsm(p, 'xdsm_circuit', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
+                      recurse=False)
         self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit', PYXDSM_OUT])))
 
         # Model path given + recursion
-        write_xdsm(p, 'xdsm_circuit2', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
-                   recurse=True, model_path='G2', include_external_outputs=False)
+        om.write_xdsm(p, 'xdsm_circuit2', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
+                      recurse=True, model_path='G2', include_external_outputs=False)
         self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit2', PYXDSM_OUT])))
 
         # Model path given + no recursion
-        write_xdsm(p, 'xdsm_circuit3', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
-                   recurse=False, model_path='G1')
+        om.write_xdsm(p, 'xdsm_circuit3', out_format=PYXDSM_OUT, quiet=QUIET, show_browser=SHOW,
+                      recurse=False, model_path='G1')
         self.assertTrue(os.path.isfile('.'.join(['xdsm_circuit3', PYXDSM_OUT])))
 
         # Invalid model path, should raise error
         with self.assertRaises(ValueError):
-            write_xdsm(p, 'xdsm_circuit4', out_format='tex', quiet=QUIET, show_browser=SHOW,
-                       recurse=False, model_path='G3')
+            om.write_xdsm(p, 'xdsm_circuit4', out_format='tex', quiet=QUIET, show_browser=SHOW,
+                          recurse=False, model_path='G3')
 
     def test_pyxdsm_solver(self):
-        from openmdao.api import NonlinearBlockGS
+        import openmdao.api as om
 
         out_format = PYXDSM_OUT
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
-        model.nonlinear_solver = NonlinearBlockGS()
-        prob.driver = ScipyOptimizeDriver()
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.model.add_objective('obj')
 
         prob.setup()
@@ -329,37 +327,37 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         filename = 'pyxdsm_solver'
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
-                   show_browser=SHOW, include_solver=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
+                      show_browser=SHOW, include_solver=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
         filename = 'pyxdsm_solver2'
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
-                   show_browser=SHOW, include_solver=True, recurse=False)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
+                      show_browser=SHOW, include_solver=True, recurse=False)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_pyxdsm_mda(self):
         filename = 'pyxdsm_mda'
         out_format = PYXDSM_OUT
-        prob = Problem(model=SellarMDA())
+        prob = om.Problem(model=SellarMDA())
         prob.setup()
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
-                   show_browser=SHOW, include_solver=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
+                      show_browser=SHOW, include_solver=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_pyxdsm_mdf(self):
         filename = 'pyxdsm_mdf'
         out_format = PYXDSM_OUT
-        prob = Problem(model=SellarMDA())
+        prob = om.Problem(model=SellarMDA())
         model = prob.model
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -372,46 +370,46 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
-                   show_browser=SHOW, include_solver=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
+                      show_browser=SHOW, include_solver=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_parallel(self):
-        from openmdao.api import ParallelGroup, NonlinearBlockGS
+        import openmdao.api as om
 
-        class SellarMDA(Group):
+        class SellarMDA(om.Group):
             """
             Group containing the Sellar MDA.
             """
 
             def setup(self):
-                indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+                indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
                 indeps.add_output('x', 1.0)
                 indeps.add_output('z', np.array([5.0, 2.0]))
-                cycle = self.add_subsystem('cycle', ParallelGroup(), promotes=['*'])
+                cycle = self.add_subsystem('cycle', om.ParallelGroup(), promotes=['*'])
                 cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'],
                                     promotes_outputs=['y1'])
                 cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'],
                                     promotes_outputs=['y2'])
 
                 # Nonlinear Block Gauss Seidel is a gradient free solver
-                cycle.nonlinear_solver = NonlinearBlockGS()
+                cycle.nonlinear_solver = om.NonlinearBlockGS()
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                       z=np.array([0.0, 0.0]), x=0.0),
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0),
                                    promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'),
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'),
                                    promotes=['con1', 'y1'])
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'),
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'),
                                    promotes=['con2', 'y2'])
 
         filename = 'pyxdsm_parallel'
         out_format = PYXDSM_OUT
-        prob = Problem(model=SellarMDA())
+        prob = om.Problem(model=SellarMDA())
         model = prob.model
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -424,19 +422,19 @@ class TestPyXDSMViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_execcomp(self):
         filename = 'pyxdsm_execcomp'
         out_format = PYXDSM_OUT
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
-        prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
+        prob.model.add_subsystem('C1', om.ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
+        prob.driver = om.ScipyOptimizeDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
         prob.setup()
@@ -444,19 +442,19 @@ class TestPyXDSMViewer(unittest.TestCase):
         # Conclude setup but don't run model.
         prob.final_setup()
 
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_doe(self):
         filename = 'pyxdsm_doe'
         out_format = PYXDSM_OUT
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
-        prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
-        prob.driver = DOEDriver()
+        prob.model.add_subsystem('C1', om.ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
+        prob.driver = om.DOEDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
         prob.setup()
@@ -464,19 +462,19 @@ class TestPyXDSMViewer(unittest.TestCase):
         # Conclude setup but don't run model.
         prob.final_setup()
 
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_meta_model(self):
+        import openmdao.api as om
         from openmdao.components.tests.test_meta_model_structured_comp import SampleMap
-        from openmdao.components.meta_model_structured_comp import MetaModelStructuredComp
 
         filename = 'pyxdsm_meta_model'
         out_format = PYXDSM_OUT
-        model = Group()
-        ivc = IndepVarComp()
+        model = om.Group()
+        ivc = om.IndepVarComp()
 
         mapdata = SampleMap()
 
@@ -490,7 +488,7 @@ class TestPyXDSMViewer(unittest.TestCase):
 
         model.add_subsystem('des_vars', ivc, promotes=["*"])
 
-        comp = MetaModelStructuredComp(method='slinear', extrapolate=True)
+        comp = om.MetaModelStructuredComp(method='slinear', extrapolate=True)
 
         for param in params:
             comp.add_input(param['name'], param['default'], param['values'])
@@ -499,12 +497,12 @@ class TestPyXDSMViewer(unittest.TestCase):
             comp.add_output(out['name'], out['default'], out['values'])
 
         model.add_subsystem('comp', comp, promotes=["*"])
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
         prob.final_setup()
 
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
@@ -533,7 +531,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         """
 
         filename = 'xdsmjs'  # this name is needed for XDSMjs
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -546,8 +544,8 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=SHOW,
-                   embed_data=False)
+        om.write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=SHOW,
+                      embed_data=False)
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'json'])))
@@ -561,7 +559,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         """
 
         filename = 'xdsmjs_embedded'  # this name is needed for XDSMjs
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -574,8 +572,8 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=SHOW,
-                   embed_data=True)
+        om.write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=SHOW,
+                      embed_data=True)
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'html'])))
@@ -588,7 +586,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         """
 
         filename = 'xdsmjs_embeddable'  # this name is needed for XDSMjs
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -601,8 +599,8 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=SHOW,
-                   embed_data=True, embeddable=True)
+        om.write_xdsm(prob, filename=filename, out_format='html', subs=(), show_browser=SHOW,
+                      embed_data=True, embeddable=True)
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'html'])))
@@ -668,7 +666,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         self.assertTrue(os.path.isfile(outfile))
 
     def test_pyxdsm_identical_relative_names(self):
-        class TimeComp(ExplicitComponent):
+        class TimeComp(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('t_initial', val=0.)
@@ -682,12 +680,12 @@ class TestXDSMjsViewer(unittest.TestCase):
                 outputs['time'][0] = t_initial
                 outputs['time'][1] = t_initial + t_duration
 
-        class Phase(Group):
+        class Phase(om.Group):
 
             def setup(self):
                 super(Phase, self).setup()
 
-                indep = IndepVarComp()
+                indep = om.IndepVarComp()
                 for var in ['t_initial', 't_duration']:
                     indep.add_output(var, val=1.0)
 
@@ -701,8 +699,8 @@ class TestXDSMjsViewer(unittest.TestCase):
 
                 self.set_order(['time_extents', 'time'])
 
-        p = Problem()
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem()
+        p.driver = om.ScipyOptimizeDriver()
         orbit_phase = Phase()
         p.model.add_subsystem('orbit_phase', orbit_phase)
 
@@ -718,28 +716,28 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         p.run_model()
 
-        write_xdsm(p, 'xdsmjs_orbit', out_format='html', show_browser=SHOW)
+        om.write_xdsm(p, 'xdsmjs_orbit', out_format='html', show_browser=SHOW)
         self.assertTrue(os.path.isfile('.'.join(['xdsmjs_orbit', 'html'])))
 
     def test_xdsmjs_mda(self):
         filename = 'xdsmjs_mda'
         out_format = 'html'
-        prob = Problem(model=SellarMDA())
+        prob = om.Problem(model=SellarMDA())
         prob.setup()
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
-                   show_browser=SHOW, embed_data=True, embeddable=True, include_solver=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET,
+                      show_browser=SHOW, embed_data=True, embeddable=True, include_solver=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_xdsmjs_mdf(self):
         filename = 'xdsmjs_mdf'
         out_format = 'html'
-        prob = Problem(model=SellarMDA())
+        prob = om.Problem(model=SellarMDA())
         model = prob.model
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -752,65 +750,65 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format,
-                   show_browser=SHOW, include_solver=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format,
+                      show_browser=SHOW, include_solver=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_xdsm_solver(self):
-        from openmdao.api import NonlinearBlockGS
+        import openmdao.api as om
 
         filename = 'xdsmjs_solver'
         out_format = 'html'
-        prob = Problem(model=SellarNoDerivatives())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
-        prob.driver = ScipyOptimizeDriver()
+        prob = om.Problem(model=SellarNoDerivatives())
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.model.add_objective('obj')
 
         prob.setup()
         prob.run_model()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format,
-                   show_browser=SHOW, include_solver=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format,
+                      show_browser=SHOW, include_solver=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_parallel(self):
-        from openmdao.api import ParallelGroup, NonlinearBlockGS
+        import openmdao.api as om
 
-        class SellarMDA(Group):
+        class SellarMDA(om.Group):
             """
             Group containing the Sellar MDA.
             """
 
             def setup(self):
-                indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+                indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
                 indeps.add_output('x', 1.0)
                 indeps.add_output('z', np.array([5.0, 2.0]))
-                cycle = self.add_subsystem('cycle', ParallelGroup(), promotes=['*'])
+                cycle = self.add_subsystem('cycle', om.ParallelGroup(), promotes=['*'])
                 cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'],
                                     promotes_outputs=['y1'])
                 cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'],
                                     promotes_outputs=['y2'])
 
                 # Nonlinear Block Gauss Seidel is a gradient free solver
-                cycle.nonlinear_solver = NonlinearBlockGS()
+                cycle.nonlinear_solver = om.NonlinearBlockGS()
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                       z=np.array([0.0, 0.0]), x=0.0),
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0),
                                    promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'),
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'),
                                    promotes=['con1', 'y1'])
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'),
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'),
                                    promotes=['con2', 'y2'])
 
         filename = 'xdsmjs_parallel'
         out_format = 'html'
-        prob = Problem(model=SellarMDA())
+        prob = om.Problem(model=SellarMDA())
         model = prob.model
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -823,19 +821,19 @@ class TestXDSMjsViewer(unittest.TestCase):
         prob.final_setup()
 
         # Write output
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_execcomp(self):
         filename = 'xdsmjs_execcomp'
         out_format = 'html'
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
-        prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
+        prob.model.add_subsystem('C1', om.ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
+        prob.driver = om.ScipyOptimizeDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
         prob.setup()
@@ -843,19 +841,19 @@ class TestXDSMjsViewer(unittest.TestCase):
         # Conclude setup but don't run model.
         prob.final_setup()
 
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_doe(self):
         filename = 'xdsmjs_doe'
         out_format = 'html'
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
-        prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
-        prob.driver = DOEDriver()
+        prob.model.add_subsystem('C1', om.ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
+        prob.driver = om.DOEDriver()
         prob.model.add_design_var('x', lower=0.0, upper=10.0)
         prob.model.add_objective('y')
         prob.setup()
@@ -863,19 +861,19 @@ class TestXDSMjsViewer(unittest.TestCase):
         # Conclude setup but don't run model.
         prob.final_setup()
 
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_meta_model(self):
+        import openmdao.api as om
         from openmdao.components.tests.test_meta_model_structured_comp import SampleMap
-        from openmdao.components.meta_model_structured_comp import MetaModelStructuredComp
 
         filename = 'xdsmjs_meta_model'
         out_format = 'html'
-        model = Group()
-        ivc = IndepVarComp()
+        model = om.Group()
+        ivc = om.IndepVarComp()
 
         mapdata = SampleMap()
 
@@ -889,7 +887,7 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         model.add_subsystem('des_vars', ivc, promotes=["*"])
 
-        comp = MetaModelStructuredComp(method='slinear', extrapolate=True)
+        comp = om.MetaModelStructuredComp(method='slinear', extrapolate=True)
 
         for param in params:
             comp.add_input(param['name'], param['default'], param['values'])
@@ -898,25 +896,25 @@ class TestXDSMjsViewer(unittest.TestCase):
             comp.add_output(out['name'], out['default'], out['values'])
 
         model.add_subsystem('comp', comp, promotes=["*"])
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
         prob.final_setup()
 
-        write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
-                   show_parallel=True)
+        om.write_xdsm(prob, filename=filename, out_format=out_format, quiet=QUIET, show_browser=SHOW,
+                      show_parallel=True)
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, out_format])))
 
     def test_circuit_recurse(self):
         # Implicit component is also tested here
 
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -934,18 +932,18 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         p.run_model()
 
-        write_xdsm(p, 'xdsmjs_circuit', out_format='html', quiet=QUIET, show_browser=SHOW,
-                   recurse=True)
+        om.write_xdsm(p, 'xdsmjs_circuit', out_format='html', quiet=QUIET, show_browser=SHOW,
+                      recurse=True)
         self.assertTrue(os.path.isfile('.'.join(['xdsmjs_circuit', 'html'])))
 
     def test_legend(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -963,14 +961,14 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         p.run_model()
 
-        write_xdsm(p, 'xdsmjs_circuit_legend', out_format='html', quiet=QUIET, show_browser=SHOW,
-                   recurse=True, legend=True)
+        om.write_xdsm(p, 'xdsmjs_circuit_legend', out_format='html', quiet=QUIET, show_browser=SHOW,
+                      recurse=True, legend=True)
         self.assertTrue(os.path.isfile('.'.join(['xdsmjs_circuit_legend', 'html'])))
 
     def test_xdsmjs_right_outputs(self):
         """Makes XDSM for the Sellar problem"""
         filename = 'xdsmjs_outputs_on_the_right'
-        prob = Problem()
+        prob = om.Problem()
         prob.model = model = SellarNoDerivatives()
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                              upper=np.array([10.0, 10.0]), indices=np.arange(2, dtype=int))
@@ -986,8 +984,8 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         # Write output
         with assert_warning(Warning, msg):
-            write_xdsm(prob, filename=filename, out_format='html', show_browser=SHOW, quiet=QUIET,
-                       output_side='right')
+            om.write_xdsm(prob, filename=filename, out_format='html', show_browser=SHOW, quiet=QUIET,
+                          output_side='right')
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, 'html'])))
@@ -996,7 +994,7 @@ class TestXDSMjsViewer(unittest.TestCase):
         """Incorrect output format error."""
 
         filename = 'xdsm_wrong_format'  # this name is needed for XDSMjs
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarNoDerivatives()
 
         prob.setup()
@@ -1004,7 +1002,7 @@ class TestXDSMjsViewer(unittest.TestCase):
 
         # no output checking, just make sure no exceptions raised
         with self.assertRaises(ValueError):
-            write_xdsm(prob, filename=filename, out_format='jpg', subs=(), show_browser=SHOW)
+            om.write_xdsm(prob, filename=filename, out_format='jpg', subs=(), show_browser=SHOW)
 
     def test_command(self):
         """
@@ -1028,7 +1026,7 @@ class TestCustomXDSMViewer(unittest.TestCase):
                 """This method is overwritten, to implement some different formatting."""
                 return [name.upper() for name in names]
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarNoDerivatives()
 
         prob.setup()
@@ -1037,7 +1035,7 @@ class TestCustomXDSMViewer(unittest.TestCase):
         my_writer = CustomWriter()
         filename = 'xdsm_custom_writer'  # this name is needed for XDSMjs
         # Write output
-        write_xdsm(prob, filename=filename, writer=my_writer, show_browser=SHOW)
+        om.write_xdsm(prob, filename=filename, writer=my_writer, show_browser=SHOW)
 
         # Check if file was created
         self.assertTrue(os.path.isfile('.'.join([filename, my_writer.extension])))
@@ -1045,7 +1043,7 @@ class TestCustomXDSMViewer(unittest.TestCase):
         # Check that error is raised in case of wrong writer type
         filename = 'xdsm_custom_writer2'  # this name is needed for XDSMjs
         with self.assertRaises(TypeError):  # Wrong type passed for writer
-            write_xdsm(prob, filename=filename, writer=1, subs=(), show_browser=SHOW)
+            om.write_xdsm(prob, filename=filename, writer=1, subs=(), show_browser=SHOW)
 
         # Check warning, if settings for custom writer are not found
         my_writer2 = CustomWriter(name='my_writer')
@@ -1057,7 +1055,7 @@ class TestCustomXDSMViewer(unittest.TestCase):
 
         # Write output
         with assert_warning(Warning, msg):
-            write_xdsm(prob, filename=filename, writer=my_writer2, show_browser=SHOW)
+            om.write_xdsm(prob, filename=filename, writer=my_writer2, show_browser=SHOW)
 
 
 if __name__ == "__main__":

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -90,7 +90,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         Writes a recorder file, and the XDSM writer makes the diagram based on the SQL file
         and not the Problem instance.
         """
-        from openmdao.recorders.sqlite_recorder import SqliteRecorder
+        import openmdao.api as om
 
         filename = 'xdsm_from_sql'
         case_recording_filename = filename + '.sql'
@@ -104,7 +104,7 @@ class TestPyXDSMViewer(unittest.TestCase):
         model.add_constraint('con1', equals=np.zeros(1))
         model.add_constraint('con2', upper=0.0)
 
-        recorder = SqliteRecorder(case_recording_filename)
+        recorder = om.SqliteRecorder(case_recording_filename)
         prob.driver.add_recorder(recorder)
 
         prob.setup()

--- a/openmdao/devtools/tests/test_xdsm_viewer.py
+++ b/openmdao/devtools/tests/test_xdsm_viewer.py
@@ -432,7 +432,7 @@ class TestPyXDSMViewer(unittest.TestCase):
     def test_execcomp(self):
         filename = 'pyxdsm_execcomp'
         out_format = PYXDSM_OUT
-        prob = Problem(model=Group())
+        prob = Problem()
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
         prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
@@ -452,7 +452,7 @@ class TestPyXDSMViewer(unittest.TestCase):
     def test_doe(self):
         filename = 'pyxdsm_doe'
         out_format = PYXDSM_OUT
-        prob = Problem(model=Group())
+        prob = Problem()
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
         prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
@@ -831,7 +831,7 @@ class TestXDSMjsViewer(unittest.TestCase):
     def test_execcomp(self):
         filename = 'xdsmjs_execcomp'
         out_format = 'html'
-        prob = Problem(model=Group())
+        prob = Problem()
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
         prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])
@@ -851,7 +851,7 @@ class TestXDSMjsViewer(unittest.TestCase):
     def test_doe(self):
         filename = 'xdsmjs_doe'
         out_format = 'html'
-        prob = Problem(model=Group())
+        prob = Problem()
         indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
         indeps.add_output('x')
         prob.model.add_subsystem('C1', ExecComp(['y=2.0*x+1.'], x=2.0), promotes=['*'])

--- a/openmdao/docs/advanced_guide/implicit_comps/implicit_with_balancecomp.rst
+++ b/openmdao/docs/advanced_guide/implicit_comps/implicit_with_balancecomp.rst
@@ -76,8 +76,8 @@ You can do the same thing programmatically by adding the following to your pytho
 
     p.setup()
 
-    from openmdao.api import view_model
-    view_model(p)
+    import openmdao.api as om
+    om.view_model(p)
 
 Here is what the resulting visualization would look like for the above model:
 

--- a/openmdao/docs/basic_guide/first_analysis.rst
+++ b/openmdao/docs/basic_guide/first_analysis.rst
@@ -38,15 +38,16 @@ Preamble
 ::
 
     from __future__ import division, print_function
-    from openmdao.api import ExplicitComponent
+    import openmdao.api as om
 
 At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions.
 On the first import line, the `print_function` is used so that the code in the script will work in either Python 2 or 3.
 If you want to know whats going on with the division operator, check out this `detailed explanation <https://www.python.org/dev/peps/pep-0238/>`_.
 
-The second import line brings in OpenMDAO classes that are needed to build and run a model.
-As you progress to more complex models, you can expect to import more classes from `openmdao.api`,
-but for now we only need this one to define our paraboloid component.
+The second import line make availabe the most common OpenMDAO classes that are needed to build and run a model.
+The `openmdao.api` module contains the class `ExplicitComponent` that we need to define the Paraboloid model. This
+can be accessed via "om.ExplicitComponent" when we need it. As you progress to more complex models, you will learn about
+more classes available in `openmdao.api`,but for now we only need this one to define our paraboloid component.
 
 Defining a Component
 ---------------------
@@ -111,12 +112,10 @@ In this case, there are no units on the source (i.e. `des_vars.x`).
 .. code::
 
     if __name__ == "__main__":
-        from openmdao.api import Problem
-        from openmdao.api import Group
-        from openmdao.api import IndepVarComp
+        import openmdao.api as om
 
-        model = Group()
-        ivc = IndepVarComp()
+        model = om.Group()
+        ivc = om.IndepVarComp()
         ivc.add_output('x', 3.0)
         ivc.add_output('y', -4.0)
         model.add_subsystem('des_vars', ivc)
@@ -125,7 +124,7 @@ In this case, there are no units on the source (i.e. `des_vars.x`).
         model.connect('des_vars.x', 'parab_comp.x')
         model.connect('des_vars.y', 'parab_comp.y')
 
-        prob = Problem(model)
+        prob = om.Problem(model)
         prob.setup()
         prob.run_model()
         print(prob['parab_comp.f_xy'])

--- a/openmdao/docs/basic_guide/first_optimization.rst
+++ b/openmdao/docs/basic_guide/first_optimization.rst
@@ -55,7 +55,7 @@ Here we'll use the :ref:`ScipyOptimizeDriver <scipy_optimize_driver>`, and tell 
 
 .. code::
 
-    prob.driver = ScipyOptimizeDriver()
+    prob.driver = om.ScipyOptimizeDriver()
     prob.driver.options['optimizer'] = 'COBYLA'
 
 Defining the Design Variables and Objective

--- a/openmdao/docs/basic_guide/sellar.rst
+++ b/openmdao/docs/basic_guide/sellar.rst
@@ -68,7 +68,7 @@ Then, inside the :code:`setup` method of :code:`SellarMDA` we're also working di
 
 .. code::
 
-    cycle = self.add_subsystem('cycle', Group(), promotes=['*'])
+    cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
     cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'], promotes_outputs=['y1'])
     cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'], promotes_outputs=['y2'])
 

--- a/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
@@ -24,7 +24,7 @@ AddSubtractComp Example
 In the following example AddSubtractComp is used to add thrust, drag, lift, and weight forces. Note the scaling factor of -1 for the drag force and weight force.
 
 .. embed-code::
-    openmdao.components.tests.test_add_subtract_comp.TestForDocs.test
+    openmdao.components.tests.test_add_subtract_comp.TestFeature.test
     :layout: code, output
 
 .. tags:: AddSubtractComp, Component

--- a/openmdao/docs/features/building_blocks/components/cross_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/cross_product_comp.rst
@@ -46,6 +46,6 @@ Note that no internal checks are performed to ensure that `c_units` are consiste
 with `a_units` and `b_units`.
 
 .. embed-code::
-    openmdao.components.tests.test_cross_product_comp.TestForDocs.test
+    openmdao.components.tests.test_cross_product_comp.TestFeature.test
 
 .. tags:: CrossProductComp, Component

--- a/openmdao/docs/features/building_blocks/components/dot_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/dot_product_comp.rst
@@ -41,6 +41,6 @@ Note that no internal checks are performed to ensure that `c_units` are consiste
 with `a_units` and `b_units`.
 
 .. embed-code::
-    openmdao.components.tests.test_dot_product_comp.TestForDocs.test
+    openmdao.components.tests.test_dot_product_comp.TestFeature.test
 
 .. tags:: DotProductComp, Component

--- a/openmdao/docs/features/building_blocks/components/matrix_vector_product_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/matrix_vector_product_comp.rst
@@ -34,7 +34,7 @@ The following code demonstrates the use of the MatrixVectorProductComp, finding 
 of a random 3x3 matrix `M` and a 3-vector `x` at 100 points simultaneously.
 
 .. embed-code::
-    openmdao.components.tests.test_matrix_vector_product_comp.TestForDocs.test
+    openmdao.components.tests.test_matrix_vector_product_comp.TestFeature.test
 
 
 .. tags:: MatrixVectorProductComp, Component

--- a/openmdao/docs/features/building_blocks/components/mux_demux_comps.rst
+++ b/openmdao/docs/features/building_blocks/components/mux_demux_comps.rst
@@ -60,7 +60,7 @@ Earth-centered, Earth-fixed (ECEF) frame (n x 3), extract the three (n x 1) colu
 and use the first two to compute the longitude at the given position vector.
 
 .. embed-code::
-    openmdao.components.tests.test_demux_comp.TestForDocs.test
+    openmdao.components.tests.test_demux_comp.TestFeature.test
     :layout: interleave
 
 Example: Muxing 3 (n x 1) columns into a single (n x 3) matrix
@@ -72,7 +72,7 @@ along `axis = 1`.  Like the previous example, this is somewhat contrived but is 
 the capabilities of the MuxComp.
 
 .. embed-code::
-    openmdao.components.tests.test_mux_comp.TestForDocs.test
+    openmdao.components.tests.test_mux_comp.TestFeature.test
     :layout: interleave
 
 .. tags:: DemuxComp, MuxComp, Component

--- a/openmdao/docs/features/building_blocks/components/vector_magnitude_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/vector_magnitude_comp.rst
@@ -37,6 +37,6 @@ Units are assigned using `units`.  The units of the output magnitude are the sam
 the input.
 
 .. embed-code::
-    openmdao.components.tests.test_vector_magnitude_comp.TestForDocs.test
+    openmdao.components.tests.test_vector_magnitude_comp.TestFeature.test
 
 .. tags:: VectorMagnitudeComp, Component

--- a/openmdao/docs/features/experimental/xdsm_visualization.rst
+++ b/openmdao/docs/features/experimental/xdsm_visualization.rst
@@ -74,8 +74,8 @@ You can do the same thing programmatically by calling the `write_xdsm` function.
 .. autofunction:: openmdao.devtools.xdsm_viewer.xdsm_writer.write_xdsm
    :noindex:
 
-Notice that the data source can be either a :code:`Problem` containing the model or 
-or a case recorder database containing the model data. The latter is indicated by a string 
+Notice that the data source can be either a :code:`Problem` containing the model or
+or a case recorder database containing the model data. The latter is indicated by a string
 giving the file path to the case recorder file.
 
 Here are some code snippets showing the two cases.
@@ -88,8 +88,8 @@ Problem as Data Source
     p.setup()
     p.run_model()
 
-    from openmdao.api import write_xdsm
-    write_xdsm(p, 'xdsmjs_circuit', out_format='html', show_browser=False)
+    import openmdao.api as om
+    om.write_xdsm(p, 'xdsmjs_circuit', out_format='html', show_browser=False)
 
 
 Case Recorder as Data Source
@@ -104,8 +104,8 @@ Case Recorder as Data Source
     p.final_setup()
     r.shutdown()
 
-    from openmdao.devtools.xdsm_viewer.xdsm_writer import write_xdsm
-    write_xdsm('circuit.sqlite', 'xdsmjs_circuit', out_format='html', show_browser=False)
+    import openmdao.api as om
+    om.write_xdsm('circuit.sqlite', 'xdsmjs_circuit', out_format='html', show_browser=False)
 
 
 In the latter case, you could view the XDSM diagram at a later time using the command:

--- a/openmdao/docs/features/model_visualization/n2_basics.rst
+++ b/openmdao/docs/features/model_visualization/n2_basics.rst
@@ -69,7 +69,7 @@ You can do the same thing programmatically by calling the :code:`view_model` fun
    :noindex:
 
 Notice that the data source can be either a :code:`Problem` or case recorder database containing
-the model or model data. The latter is indicated by a string giving the file path to the case 
+the model or model data. The latter is indicated by a string giving the file path to the case
 recorder file.
 
 Here are some code snippets showing the two cases.
@@ -81,8 +81,8 @@ Problem as Data Source
 
     p.setup()
 
-    from openmdao.api import view_model
-    view_model(p)
+    import openmdao.api as om
+    om.view_model(p)
 
 Case Recorder as Data Source
 ****************************
@@ -96,9 +96,9 @@ Case Recorder as Data Source
     p.final_setup()
     r.shutdown()
 
-    from openmdao.api import view_model
+    import openmdao.api as om
 
-    view_model('circuit.sqlite', outfile='circuit.html')
+    om.view_model('circuit.sqlite', outfile='circuit.html')
 
 
 In the latter case, you could view the N2 diagram at a later time using the command:

--- a/openmdao/docs/theory_manual/total_derivs/aerostruct_n2.html
+++ b/openmdao/docs/theory_manual/total_derivs/aerostruct_n2.html
@@ -1,4 +1,5 @@
-    <style type="text/css">[hidden] { display: none; }
+<style type="text/css">
+[hidden] { display: none; }
 
 .visually-hidden {
 	position: absolute;
@@ -95,8 +96,12 @@ div.awesomplete > ul:empty {
 			background: hsl(86, 100%, 21%);
 			color: inherit;
 		}
+
 </style>
-    <style type="text/css">.myButton {
+
+
+<style type="text/css">
+.myButton {
     background-color:#f9f9f9;
     -moz-border-radius:4px;
     -webkit-border-radius:4px;
@@ -191,6 +196,12 @@ body {
     margin-left: 10px;
     margin-top: 20px;
 }
+.component_connectivity {
+    font-family: helvetica, Courier;
+    font-size: 18px;
+    margin-left: 10px;
+    margin-top: 20px;
+}
 .ptN2ChartClass {
     margin-left: 10px;
     margin-top: 20px;
@@ -277,7 +288,7 @@ body {
 @font-face {
     /* Subset of fonts from Font Awesome v4.6.3 created using http://fontello.com/ */
     font-family: 'fontello';
-    src: url('data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAABXsAA8AAAAAI4gAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABHU1VCAAABWAAAADsAAABUIIwleU9TLzIAAAGUAAAAQwAAAFY+IFN7Y21hcAAAAdgAAADAAAACiI4T0pdjdnQgAAACmAAAABMAAAAgBtX/BGZwZ20AAAKsAAAFkAAAC3CKkZBZZ2FzcAAACDwAAAAIAAAACAAAABBnbHlmAAAIRAAACj0AAA6ScgMJamhlYWQAABKEAAAAMgAAADYLmegtaGhlYQAAErgAAAAgAAAAJAeFA6lobXR4AAAS2AAAAC0AAABIPjb//GxvY2EAABMIAAAAJgAAACYjaR+ibWF4cAAAEzAAAAAgAAAAIAE4DBhuYW1lAAATUAAAAXcAAALNzJ0cHnBvc3QAABTIAAAApQAAAOhel6ZjcHJlcAAAFXAAAAB6AAAAhuVBK7x4nGNgZGBg4GIwYLBjYMpJLMlj4HNx8wlhkGJgYYAAkDwymzEnMz2RgQPGA8qxgGkOIGaDiAIAKVkFSAB4nGNgZC5lnMDAysDAVMW0h4GBoQdCMz5gMGRkAooysDIzYAUBaa4pDA4vGD6VMwf9z2KIYg5imAYUZgTJAQDusgwjAHic5ZK5EcJADEWfwdynqYCAgACaogkYCiKiJApQQIBoAL68SoASkOd5Zv/sNXoL9ICu2IkaqisVURelVZt3Gbd5zVnjFUslHRs97r72re/94Kfn8fUC4zf7qkrrNx9fZB3tWOsmfQYMGem8CVNmzFnotEZT+j87/V9N2/8tR030uxCeLFEvsSS8WhJuLQnnlqjnWKLuY4k8YImMYEm8hce9IEv4uhC3821B5vB9QQ7xQ0E28VNBXnkeCzRv+9VD0HicY2BAAxIQyBz0PwuEARJsA90AeJytVml300YUHXlJnIQsJQstamHExGmwRiZswYAJQbJjIF2crZWgixQ76b7xid/gX/Nk2nPoN35a7xsvJJC053Cak6N3583VzNtlElqS2AvrkZSbL8XU1iaN7DwJ6YZNy1F8KDt7IWWKyd8FURCtltq3HYdERCJQta6wRBD7HlmaZHzoUUbLtqRXTcotPekuW+NBvVXffho6yrE7oaRmM3RoPbIlVRhVokimPVLSpmWo+itJK7y/wsxXzVDCiE4iabwZxtBI3htntMpoNbbjKIpsstwoUiSa4UEUeZTVEufkigkMygfNkPLKpxHlw/yIrNijnFawS7bT/L4vead3OT+xX29RtuRAH8iO7ODsdCVfhFtbYdy0k+0oVBF213dCbNnsVP9mj/KaRgO3KzK90IxgqXyFECs/ocz+IVktnE/5kkejWrKRE0HrZU7sSz6B1uOIKXHNGFnQ3dEJEdT9kjMM9pg+Hvzx3imWCxMCeBzLekclnAgTKWFzNEnaMHJgJWWLKqn1rpg45XVaxFvCfu3a0ZfOaONQd2I8Ww8dWzlRyfFoUqeZTJ3aSc2jKQ2ilHQmeMyvAyg/oklebWM1iZVH0zhmxoREIgIt3EtTQSw7saQpBM2jGb25G6a5di1apMkD9dyj9/TmVri501PaDvSzRn9Wp2I62AvT6WnkL/Fp2uUiRen66Rl+TOJB1gIykS02w5SDB2/9DtLL15YchdcG2O7t8yuofdZE8KQB+xvQHk/VKQlMhZhViFZAYq1rWZbJ1awWqcjUd0OaVr6s0wSKchwXx76Mcf1fMzOWmBK+34nTsyMuPXPtSwjTHHybdT2a16nFcgFxZnlOp1mW7+s0x/IDneZZntfpCEtbp6MsP9RpgeVHOh1jeUELmnTfwZCLMOQCDpAwhKUDQ1hegiEsFQxhuQhDWBZhCMslGMLyYxjCchmGsLysZdXUU0nj2plYBmxCYGKOHrnMReVqKrlUQrtoVGpDnhJulVQUz6p/ZaBePPKGObAWSJfIml8xzpWPRuX41hUtbxo7V8Cx6m8fjvY58VLWi4U/Bf/V1lQlvWLNw5Or8BuGnmwnqjapeHRNl89VPbr+X1RUWAv0G0iFWCjKsmxwZyKEjzqdhmqglUPMbMw8tOt1y5qfw/03MUIWUP34NxQaC9yDTllJWe3grNXX27LcO4NyOBMsSTE38/pW+CIjs9J+kVnKno98HnAFjEpl2GoDrRW82ScxD5neJM8EcVtRNkja2M4EiQ0c84B5850EJmHqqg3kTuGGDfgFYW7BeSdconqjLIfuRezzKKT8W6fiRPaoaIzAs9kbYa/vQspvcQwkNPmlfgxUFaGpGDUV0DRSbqgGX8bZum1Cxg70Iyp2w7Ks4sPHFveVkm0ZhHykiNWjo5/WXqJOqtx+ZhSX752+BcEgNTF/e990cZDKu1rJMkdtA1O3GpVT15pD41WH6uZR9b3j7BM5a5puuiceel/TqtvBxVwssPZtDtJSJhfU9WGFDaLLxaVQ6mU0Se+4BxgWGNDvUIqN/6v62HyeK1WF0XEk307Ut9HnYAz8D9h/R/UD0Pdj6HINLs/3mhOfbvThbJmuohfrp+g3MGutuVm6BtzQdAPiIUetjrjKDXynBnF6pLkc6SHgY90V4gHAJoDF4BPdtYzmUwCj+Yw5PsDnzGHQZA6DLeYw2GbOGsAOcxjsMofBHnMYfMGcdYAvmcMgZA6DiDkMnjAnAHjKHAZfMYfB18xh8A1z7gN8yxwGMXMYJMxhsK/p1jDMLV7QXaC2QVWgA1NPWNzD4lBTZcj+jheG/b1BzP7BIKb+qOn2kPoTLwz1Z4OY+otBTP1V050h9TdeGOrvBjH1D4OY+ky/GMtlBr+MfJcKB5RdbD7n74n3D9vFQLkAAQAB//8AD3icpVdfbFtXGT/fOfec+8fOvXZ877GbOI7/xXbjxk3j2G6TNLkN7ZJ12ZqkZSQFSjRGx5p0GavQJMb2wKRpnaYGyjYhtIG2dS/ApDYDiVRjfVj3Mgk0hJQKlaftgYIEvBSJjcbhO9fuViEEDyTX1+fc+/n6+875/flMKCHbl9hxFiIJMkj2+JVS7w5Gtc4wYwToFNGotkooo6uEAVslQGCVEHJyxI13NTjfUQbXgbh0hZ7LFoq14XHohUZ9qBckeK4Nu0EX2d1QGJ6AYmG43qgOSXiDb8xarvOJ44JMhmYvc1v4HH7ups3ZDaHG/PJccF8C18XGnJXCQBvDaRgDxISA659OfPxwOwKzUrVssHnMPI61DPoD/fluRpkjaKsUhqXgHOsB+lkprrdvJBGU4rmi8G8ZjwJm3C6xDNlCozZcl5+W+CYWMLfBI5ovxMZsCLO0sb7Phm7KmlM1Yc4jOKfm3GXOfbyAEUkp4WGdXw5GdnB3dgPvcoKZke1n2SL9C+kheT/TWn5M91HCCGHHCBa4gAMyU4jLnMYTQea5DObogMgWMfkGBAniPDMk2WK+p/n4Bc/r90a95guuCyveiOz3vAtwticPJ6ZS/RfcMbfcvgHLnrdTjsgLJdJe04vsz4iPbnIGmB/5KjDjsUf3MMIWIUTY1D0XzdkFf1/E1pkmtFWOt4nByGnqUBIySGiZhMAIwXLYogCPEGEY4hgRwljoMKkhjJnuey5a+ICJ//kAApYB1nIYLOs/Peb/SGFx0d+ZTAJJnkmeWX544Qv3Hzs6d8CfGC0Vc6muhBtzOsKW4KQbuqPcLfcNSbXMiBFERxRhP9FabMRHFHFSHapXM436BI3LhvRcXeiIqQoUK4ierF4siKwuMNrThYynoLVnBT0rcsVx2qjXhhWL6oXhYiGXtZmOM/brmBWaCqXxZcV27bpzcuv5lL6644EEVE2dGQmdM6AyYkcFF7gGhhFmfcmuSpSD+qNCnnApxMo/yicf66bm0JiN60E1qh/rPOhFXDtu+K5z3MHDpWO3R1tX6fsOw3XTLPWQ8ScHIgZN7O6WBdAEVY9lldTvLxwv9ZY6wwlT2gYAblHW6Yzo8Xf2fbj3sBGOWEy3nckRcKxNhakWvmuI71SA74CTePVRJCbQY4RSWEDGwozsK7gBvl0dbrMyky3sh+F6PFNUs/pQHCSruc0X5YjXL+Xrzcd78vkeOPu6RIQrMLswknIV6vu9Me/1/hSiHd5AuCP+my+6QS6X2NP0j5hL2u+J6BSFbgrJxVYpUo4g8eBk3Ku182jtfLSld7VoWysa7TyeRuKMum+UetuUwu/ABMbw5MFwMqCcyg8KSTjb5qNiGyYf8Oxjdp6+RyJkD6n45UqhL+E5docBLAxKvzT4VIExM3Kyv5TLZqIu5/FyK6FazlMiHDVBNnSVYNEEJWiFeksOai0561GgY53S3lzbRA2GA/j/7SzXqc6bTzWf0jt4TqMcvtc5GHvWMpYN61sCSs2/Y+jmprTBAaP5D8jvRJbBZPMdDN0pbA73Oc43VgzLMj46qUVwj7VgXRdRNxjJYEWHyJx/X7k/l9UMDaY6EDxg0LuIpYNmWNoSMQgTBlsiAgsUcIJTSkyTzKt3Yi4Qk5gz/v69tXihGo2NRqOREO8pxzO1DK9GhwOC6YEGKhPKRatYahWVT2fIJ5RtEfdcieZT59F2ULQV0Asp2IQ3m0fh5nSYv8KTRirefEemYHo67cFvZRo2cQl0BHRwfjAV3+pE1qYl5fG683JE6pubcNPo0l8WYbgh02l5Y6sevENqXa3GuvqstfWJukT/KtMJ+xWnfpsDp+A5Nk/SpOT3aUA4cAKnGTKAA10mnIenkQkd9G4v0+dlYoJ3If5EEasbSkFbgYbbElRvaxCclfbUlHLHNStlraGNTk8rZ1kLJUNrIfpj9KStq+hKa6EQBiiap0LnQngQur29fYq9yjpwJzKk7Jd6AYiNe6yME9PVyBLmjEKAexRkFc+5sc7ANocrIFw5Dpgd5iRy2Qod11I07upxSZ8+/8F5PCC1a8S98uATs+e/7tOxlXMXzq2MwaErHnznofP0pfd/IJ5v/rCn37tyaPzUd18798iINnnypXufePCKF3gQ5vYu+xO9hD3KHnKvf7gMXKD+cEDaUDZlosEfJCh6yA40eWCnMVGNqUUkGnDthGIXnce8yf3K0Q7HCrF4LOnqvLvch7DRM+rU1pe6YohyzYDrqDWZlutXM3hSa8xuWMYWsQyhr3P+FncsRnCTg9EWCaDCiGXjzV8t6xaol1gXDl/niCELSgZfF2GxjIdh4YHX29x/lc4Rl+RJzR8ycd1TuNoSUI2mCM5QH1ElCcXKsGLVAtAF1RfMFErJTiVNJtzRtrR10YU2J5RgKrjDVPOf2DElhbh+XYgkNi7AOf081nNDgZUmDAsqGMKT2KNc/0MrtHmLR5q3cipAndo9wcd0H32XOGSULP9CaRJgI+CgjxewzaJM+xpKOYJF7QDTOFPYIXAMw1TnAgTtutgKxIr+e+SibxbdcqqQVwQIdivXdgBsJmMueqQNd1xtjANaKHqsjkBUutCoI18onLWNZ0zbNp8xw5ciiUKXF0/hxAgf7s8kh7P5hFvSLV3/okG1xZ8MHJ+uvIiBEHwG7exQajib7rQ6BjusCEizqzIfi6SHshCxh0ztLhExXsiOKGRtN7c/1oZwXVQHOuD3BzaiqljVkNYU5jVlmAuq/5whRMbCpoqIcu6V+xoZHXsI9LlAnwLNDrbs5tvNo2+zD01hN8My3TzqZRF6Ntz00vCml/evXaOLsX5n62pCuvhOxxIy0N5TbBy1xSJZ4pN58oD/lSP33T19V1yEtBoYSi6NAaC6NmV30BCxzJB1AjWWgEmWOO4GMXQwlsKgaShCuk4XBASkP3DgwPyB+bnZQwc/Nzmxv69YcnN5mcs6KMZ9atlRB5TKunc0SC3T8VC1ZB/uFrpSodiQQZ/UyNmA2zYOeI95mRrKdqOW04UDxUY1Sv82mO3JlgrJUvOnYh2x+JZhdCwHjoQHvGand00WcjtsS5qG5+3ea0Kokhidgdn9h74UbX7yZexMuJUbWD74zfwI9I/vSg22GGt6jCgwI4d7c5Pju5Kmpk1gFzQ52BGZPTN/Cvb6/i2dmrpupQcfan4/0Gqk31W6l0iS8rvDAdw/w+n9KuJwIU65bHUILdFokQ5FQ2nGVX7NkFvTAct+KY1rHJYM8Z5hhp+09BXdejJsGe+K4GuCvfsd7l036UN2zfr3xhEzfShjqMQm+qMpThNN57rGlVmgOwJZMiwqiK4JXYkzbhnnHfzuYmFk39767oHCaHG02pmr9tVCykOCjjN3Z4LqZ5nuZVAyqu3OphH0CUoZb6siBlY99hvOjzjogTb+ZIFJdBc0FEjFnWblXHvygbq11SkjRzA0gjZ4jv4MdQaH9potc+pHn52LbF1sfhQM0SWcNRxhuC2OOCsr5F8lsjBmAAAAeJxjYGRgYADi8yFN2vH8Nl8ZuJlfAEUYrqgGucHo///+Z7EYMQcBuRwMTCBRAEJ7C4UAAHicY2BkYGAO+p/FwMCi///f/78sRgxAERQgBACXBgY1eJxjfsHAwByJhGH8BVAMZDOuAbH//2d+AcRAMSZrBgYW/f//4OqBGAABuBBiAAAAAAAAAABmAMoBEAI6AoACxAMsA7wEBARSBMIFGgWmBeoGkgbIB0kAAAABAAAAEgB0AAQAAAAAAAIAIgAyAHMAAACMC3AAAAAAeJx1kMtOwkAUhv+RiwqJGk3cOisDMZZLIgsSEhIMbHRDDFtTSmlLSodMBxJew3fwYXwJn8WfdjAGYpvpfOebM2dOB8A1viGQP08cOQucMcr5BKfoWS7QP1sukl8sl1DFm+Uy/bvlCh4QWK7iBh+sIIrnjBb4tCxwJS4tn+BC3Fku0D9aLpJ7lku4Fa+Wy/Se5QomIrVcxb34GqjVVkdBaGRtUJftZqsjp1upqKLEjaW7NqHSqezLuUqMH8fK8dRyz2M/WMeu3of7eeLrNFKJbDnNvRr5ia9d48921dNN0DZmLudaLeXQZsiVVgvfM05ozKrbaPw9DwMorLCFRsSrCmEgUaOtc26jiRY6pCkzJDPzrAgJXMQ0LtbcEWYrKeM+x5xRQuszIyY78PhdHvkxKeD+mFX00ephPCHtzogyL9mXw+4Os0akJMt0Mzv77T3Fhqe1aQ137brUWVcSw4MakvexW1vQePROdiuGtosG33/+7wfjaYRPAHicbY1ZDsIwEENjaEMXoCznyKFCNW0iTdpokiLg9KjAJ+/DtixZVhv1pVH/uWCDLQqU0NihQo0GLfY44IgOJ5xxwVW1Qsm/yAwL8/6XU7DMFdOQzc2PbaZHNo786HItq66tXuJqhZsD6YHnGJ/db34nyb63rBNZ6V1Fj97ZaaQqkwQ/WS4ccdQkNpEc0yzZTEu4kZgllp+DOthokh+npNQbHk461QAAAHicY/DewXAiKGIjI2Nf5AbGnRwMHAzJBRsZWJ02MTAyaIEYm7mYGDkgLD4GMIvNaRfTAaA0J5DN7rSLwQHCZmZw2ajC2BEYscGhI2Ijc4rLRjUQbxdHAwMji0NHckgESEkkEGzmYWLk0drB+L91A0vvRiYGFwAMdiP0AAA=') format('woff');
+    src: url('data:application/font-woff;charset=utf-8;base64,d09GRgABAAAAABYcAA8AAAAAI/gAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABHU1VCAAABWAAAADsAAABUIIslek9TLzIAAAGUAAAAQwAAAFY+IFN1Y21hcAAAAdgAAADCAAAClrJhfoZjdnQgAAACnAAAABMAAAAgBtX/BGZwZ20AAAKwAAAFkAAAC3CKkZBZZ2FzcAAACEAAAAAIAAAACAAAABBnbHlmAAAISAAACmcAAA7m+BqkyGhlYWQAABKwAAAAMgAAADYTxVd1aGhlYQAAEuQAAAAgAAAAJAeFA6pobXR4AAATBAAAAC8AAABMQUf//GxvY2EAABM0AAAAKAAAACgg8CSZbWF4cAAAE1wAAAAgAAAAIAE5DBhuYW1lAAATfAAAAXcAAALNzJ0eIHBvc3QAABT0AAAAqwAAAPCOuMBCcHJlcAAAFaAAAAB6AAAAhuVBK7x4nGNgZGBg4GIwYLBjYHJx8wlh4MtJLMljkGJgYYAAkDwymzEnMz2RgQPGA8qxgGkOIGaDiAIAJjsFSAB4nGNgZM5nnMDAysDAVMW0h4GBoQdCMz5gMGRkAooysDIzYAUBaa4pDA4vGD6VMwf9z2KIYg5imAYUZgTJAQDswAwdAHic5ZK5EcJADEXfgrlvV+CIIYCmaAICCiKiLgUEyA3AX68ScAnI8zzWn9lj9AyMgKE4igrSg0Suu9LU5UPmXV5xU1+zVTKw+evpjR/85Ge/tpf3G4x+9lNJ6/dfT84G2rHSTcZMmDLTeQuWrFiz0Wk7rSGNe3v9Xy27t0VXl8+ulSkLNE0syGYtyHYtyNYt0NSxQPPHApnAAjnBgvw3WCBPcl7It/OmIHf4oSCL+Kkgn/i5ILP4tSDHtJcC9QeU5UX8AAB4nGNgQAMSEMgc9D8LhAESbAPdAHicrVZpd9NGFB15SZyELCULLWphxMRpsEYmbMGACUGyYyBdnK2VoIsUO+m+8Ynf4F/zZNpz6Dd+Wu8bLySQtOdwmpOjd+fN1czbZRJaktgL65GUmy/F1NYmjew8CemGTctRfCg7eyFlisnfBVEQrZbatx2HREQiULWusEQQ+x5ZmmR86FFGy7akV03KLT3pLlvjQb1V334aOsqxO6GkZjN0aD2yJVUYVaJIpj1S0qZlqPorSSu8v8LMV81QwohOImm8GcbQSN4bZ7TKaDW24yiKbLLcKFIkmuFBFHmU1RLn5IoJDMoHzZDyyqcR5cP8iKzYo5xWsEu20/y+L3mndzk/sV9vUbbkQB/Ijuzg7HQlX4RbW2HctJPtKFQRdtd3QmzZ7FT/Zo/ymkYDtysyvdCMYKl8hRArP6HM/iFZLZxP+ZJHo1qykRNB62VO7Es+gdbjiClxzRhZ0N3RCRHU/ZIzDPaYPh788d4plgsTAngcy3pHJZwIEylhczRJ2jByYCVliyqp9a6YOOV1WsRbwn7t2tGXzmjjUHdiPFsPHVs5UcnxaFKnmUyd2knNoykNopR0JnjMrwMoP6JJXm1jNYmVR9M4ZsaERCICLdxLU0EsO7GkKQTNoxm9uRumuXYtWqTJA/Xco/f05la4udNT2g70s0Z/VqdiOtgL0+lp5C/xadrlIkXp+ukZfkziQdYCMpEtNsOUgwdv/Q7Sy9eWHIXXBtju7fMrqH3WRPCkAfsb0B5P1SkJTIWYVYhWQGKta1mWydWsFqnI1HdDmla+rNMEinIcF8e+jHH9XzMzlpgSvt+J07MjLj1z7UsI0xx8m3U9mtepxXIBcWZ5TqdZlu/rNMfyA53mWZ7X6QhLW6ejLD/UaYHlRzodY3lBC5p038GQizDkAg6QMISlA0NYXoIhLBUMYbkIQ1gWYQjLJRjC8mMYwnIZhrC8rGXV1FNJ49qZWAZsQmBijh65zEXlaiq5VEK7aFRqQ54SbpVUFM+qf2WgXjzyhjmwFkiXyJpfMc6Vj0bl+NYVLW8aO1fAsepvH472OfFS1ouFPwX/1dZUJb1izcOTq/Abhp5sJ6o2qXh0TZfPVT26/l9UVFgL9BtIhVgoyrJscGcihI86nYZqoJVDzGzMPLTrdcuan8P9NzFCFlD9+DcUGgvcg05ZSVnt4KzV19uy3DuDcjgTLEkxN/P6VvgiI7PSfpFZyp6PfB5wBYxKZdhqA60VvNknMQ+Z3iTPBHFbUTZI2tjOBIkNHPOAefOdBCZh6qoN5E7hhg34BWFuwXknXKJ6oyyH7kXs8yik/Fun4kT2qGiMwLPZG2Gv70LKb3EMJDT5pX4MVBWhqRg1FdA0Um6oBl/G2bptQsYO9CMqdsOyrOLDxxb3lZJtGYR8pIjVo6Of1l6iTqrcfmYUl++dvgXBIDUxf3vfdHGQyrtayTJHbQNTtxqVU9eaQ+NVh+rmUfW94+wTOWuabronHnpf06rbwcVcLLD2bQ7SUiYX1PVhhQ2iy8WlUOplNEnvuAcYFhjQ71CKjf+r+th8nitVhdFxJN9O1LfR52AM/A/Yf0f1A9D3Y+hyDS7P95oTn2704WyZrqIX66foNzBrrblZugbc0HQD4iFHrY64yg18pwZxeqS5HOkh4GPdFeIBwCaAxeAT3bWM5lMAo/mMOT7A58xh0GQOgy3mMNhmzhrADnMY7DKHwR5zGHzBnHWAL5nDIGQOg4g5DJ4wJwB4yhwGXzGHwdfMYfANc+4DfMscBjFzGCTMYbCv6dYwzC1e0F2gtkFVoANTT1jcw+JQU2XI/o4Xhv29Qcz+wSCm/qjp9pD6Ey8M9WeDmPqLQUz9VdOdIfU3Xhjq7wYx9Q+DmPpMvxjLZQa/jHyXCgeUXWw+5++J9w/bxUC5AAEAAf//AA94nKVXXWwcVxW+5965d352PbPrnbm7sdfr/fHObuzYcbze3cR27IlJajd1G9sJxQ4QrFJSGjtNaYQqUdoHKlVNVcUQ2gqhFtQ25QGolLogcFSah6YvlUBFSI5QeGofCEiFlyDREq85d3aTRhWCB+zZ2Xtnzs6ec75zvu8soYRsfczO0XdJjOwiA0HfgF9MeY7dZgCLAgE6pQEDdorg+hQFQo73lgv5XNzlPNkHcVfohWrBK+T9UtwEWddxny+ZIPyd4NfqUBvqhupwbRSGZBckpcvapb2xuuG4APvw/9t5rlOdN55oPKG38YJGOXyvfTDxtGUsG9a3BJQb/0DTjQ1pgwNG45/Qs52jO5ONt9F0u7A53OM431gxLMv48LgWIwTdJFtPs0X6EekiPUGOUEZD3x8mjBB2hDBGFnBBZvykLGg81QeeKwo5dM0BkS+BP9x0Wu1zQ5It9nQ1Hj3veb3eqNd4znVhxRuRvZ53Hs509cCxqUzveXfM7WvdgGXP2y5H5PkyueVLFX3JhL4winnEqw8TCkCPEEphATMMM7Lou6Evro5OYOaGJyCX9/fCcC2ZK6ldbSgJklXdxvNyxOuV8tXGo109PV1w5lWJ3qgvdmEk4yoPe70x79XeDHoGr6Fr6GvjeTf05Q32JP0z+pINumI6JQymMBFMoQoEkwTHk1615YcT+hHCm/ercb3pVb3lx5MY5Kj7Wrm7FT5+BzowhicPhtNhepR/4KfhTCt3KjPoPKGhH0dZhKTIINkVDJS7tzGqtUcRGCw2olHtVBO0W1WHmTw+4iY76pxvC11DsEK/StXhceiGeogX4mjDTtBv5g/TVqtXhiS8xtdnLdf5BAtJpiOzF7ktAg6/cLPm7LpQa35xLrwvgetifc7KoKGN5jSKBmJCwNVbmwA/3LJAr1Qs62wePU9iLINBf29PJ2LsCNoMhWEoIeYU6KehuN6ekVQYClae/xmPVaPcDLEP8n4dm0feCvF1DGBunce0QIj12Qh6aWN8ny7djDWnYkKfR3BPzbmLnAd4AS3SUsKDOr8Yruzw7uw63uXNOC6wvyImneQ0sCD2VWDGIw/vwuJYhAhhU3ddMGcXgj0xW2ea0E5hCxrEYOQkdSiJGCSyTCJgRGA5amFhP0SEYYgjRAhjoc2khjBmOu+6YOEDJv7nAwhYBljLUbCs//SY/8OFxcVgezoNJH06fXr5wYUv3Hvk8Ny+YGK0XCpkOlJuwmmLWoKTTuiMc7evOCSbHeAjInEstYkmKSAmccSmMlSr5Oq1CZqUdem5SHqI4wCUBhCxvF7yRV4XaO3pQiYz0OQWX8+LQmmc1mvVYVW5NX+45BfyNtNxx36bsCJTkSy+rMSOHbdvbjyb0U9tuy8FFVNnRkrnDKiM2XHBBebAMKKsmO4YiHNQf1TIYy6FRN+PetKPdFJzaMzGfFCN6kfa93sx104agescdfBw6djN1eZl+p7DMG+apR4y/nh/zKCpnZ3SB01Q9Vg2kPnj+aPl7nJ7NGVK2wBAiPJOe0xPvr3ng90HjWjMYrrtTI6AY23c5L4T8AybJ1lSDooaEA6cwEmGT+NAlwnn0WlkwDZ6p5crermE4B3Y3KJUiFeGMtDK/nAr/bVW/uGMtKemVDeuWhlrFdt2elpV8mokHVmN0B9jD2xexi5YjUTQQIWYiZyN4EG0kHcWscYZyaHSHSBzwT19vYW8Zmgw1YaBgkHvIJYOmmFpS8QgTBhsiQiMRMAxTikxTTKv3om5QExizgR7d1eTfiWeGI3HYxHe1ZfMVXO8Eh8Oi0EPdUWRFEaEcFdQTXSG2GNbi6TnSiSnGo+3jOJNg27IwAa83jgM16ej/CWeNjLJxtsyA9PTWQ9+L7OwgdKoY/LD8/2Z5GY7VlhWUp6sOS/GpL6xAdeNDv1FEYVrMpuV1zZr4Ttk1pRKrqnPWpufqEv0bzKbsl9yagovurW1dYK9zNow8hzpC8rdAMRGrVVEhnBqZAkzgUWCOQlRSxbcRHtIY8MDIFw5DogeYiYK+QE6rmVo0tWTkj557v1zeEBmx4h76f7HZs99PaBjK2fPn10ZgwOXPPjOA+foC+/9QDzb+GFXr3fpwPiJ775y9qERbfL4C3c/dv8lr1VLKNnt8BFxSCrw1B6OoF4pJQcyU61QLkM2LYX5Rt5Xyt2elZtHm8n5Cb79ahmzl0kuqyuteN9hf6FvoA7tIncHB/uAC6x3DkiHlE2ZSOL7CTYZEjcSObCTGLzGVOESDbh2TLEmncdckHsVgx5M+IlkIu3qvLOviK7oOXVqMXtNTT/Kp1BXUddzTWav5PCk6ppds4xNYhlCX+P8Te5YjCBQ4WqThHAzYtl48zfLugXqJdaEw9c41oEFZYOviahYxsOw8MDrpDnXvUzniEt6SDUYMhHLDCIoAZV/iuAO1QjViVCMDCNWoxFdUNI745fT7WoMMOE2aWrNIC606loNJ6pkYarxL1TFtBBXrwqRRnECzunnMZ5rquBoyrBgAE14GnXo6p+apo0bPNa4UVAG6tTS0o/pHvoOYjxKln+p5BJQeBzUDR+llDLta6ijWIAKAaZxtvTZOugMSk1DjOi/Wy4GZsnty/g9inRCtAqtaQsHhoSLnGzDbVfr44CUjZyuY3Gr3q7XkKMonLGNp0zbNp8yo2/EUn6Hl8zgxoge7M2lh/M9KbesW7r+RYNqiz/tPzo98DwaQvgZpM8DmeF8tt1qG2yzYiDNjoH5RCw7lIeYPWRqd4iY8Vx+RFXWVmPrY20I86KmjP6gNxzZVBSnNKRSCvOaIugFNWPMECITUVNZxDn3+or1nI6ahTNlyDHhPB5Cdv2txuG32AemsBtRmW0c9vJYejZc97LwutcTXLlCFxO9zubllHTxnY6lZMifJ9g48rlF8iQg8+S+4CuH7rlz+o6kiGhVMBTlGf1AdW3KbqMRYpkR6xjyJAGTLHFEgxg6GEtR0DQkfl2nCwJCItm3b9/8vvm52QP7Pzc5sbdYKruFHlnIO0ioRZV25BbFlO5tgtyckzxUCllEtPAXh1+qy1CX6wUbELZxwHvMy1WReuvVgi4cKNUrcfr3wXxXvuyny42fiTWsxTcNo205/LWBB7xiZ3dM+oVttiVNw/N27jYhMpAanYHZvQe+FG988mVUQm4V+pf3f7NnBHrHd2QGmx1reoyoYsYe7i5Mju9Im5o2gao7OdgWmz09fwJ2B8ENnZq6bmUHH2h8/yanXaa7iSSZoDMalvundXqvsjjoJ0NmC8eHvXCr6ZA0FGdc5lcMuTkddtmvpXGFw5Ih3jXM6OOWvqJbj0ct4x0Rfk2I3R8Qu05SxO6aDe5OYs0UkcaQ3U3UOFOcJJrOdY0rgUaFA7JkWFQQXRO6InyEjPM2fmfJH9mzu7az3x8tjVbaC5ViNaJ0O5xwCrc7qEZv3cshZVRavyLq4W9AxYw3WRENKx77HeeHHNQxG8dSmERFRxFHonYaA2dbm/fVrc12GTuEpjGUsrP058gzuLRXbVlQg71diG1eaHwYLlF5nFVcobktDjkrK+TfB/g69AB4nGNgZGBgAGKOA+dz4/ltvjJwM78AijDcsOZ8BaP///ufxWLEHATkcjAwgUQBXusMowAAeJxjYGRgYA76n8XAwKL//9//vyxGDEARFCAMAJcHBjZ4nGN+wcDAvACII6EYmQ2UY1wDE///n1kQJAakgWqYrBkYWPT//4OpA2EAKHMQdgAAAAAAAGgArgD0ATgBngICAywDdAQEBFIEfATsBUQF0AYUBrwG8gdzAAEAAAATAHQABAAAAAAAAgAiADIAcwAAAIwLcAAAAAB4nHWQ3WrCMBiG38yfbQrb2GCny9FQxuoPDEQQBIeebCcyPB211rZSG0mj4G3sHnYxu4ldy17bOIayljTP9+TLl68BcI1vCOTPE0fOAmeMcj7BKXqWC/TPlovkF8slVPFmuUz/brmCBwSWq7jBByuI4jmjBT4tC1yJS8snuBB3lgv0j5aL5J7lEm7Fq+UyvWe5golILVdxL74GarXVURAaWRvUZbvZ6sjpViqqKHFj6a5NqHQq+3KuEuPHsXI8tdzz2A/Wsav34X6e+DqNVCJbTnOvRn7ia9f4s131dBO0jZnLuVZLObQZcqXVwveMExqz6jYaf8/DAAorbKER8apCGEjUaOuc22iihQ5pygzJzDwrQgIXMY2LNXeE2UrKuM8xZ5TQ+syIyQ48fpdHfkwKuD9mFX20ehhPSLszosxL9uWwu8OsESnJMt3Mzn57T7HhaW1aw127LnXWlcTwoIbkfezWFjQevZPdiqHtosH3n//7AelzhFMAeJxtjs2OwjAQg2O2DS0Fyi68Rh4qVNMm0qSNJskKeHp+j3wXW7YPViv1ZqO+c8QKP6hQQ2ONBi026LDFDnv0OOAXfzjipCq3BGqYxmzOfmrFT+7ldIlP6YSSv5EZC/P241OwzF2mSzaOnvv+U/yTZD9Y1iMvMV51IiuDq4OfS2roMjg7T9RkkkdiuXLEUZPYRLJPi2Qzl3AmMSXWrxttsNEkP81JqTt4Pz0cAHicY/DewXAiKGIjI2Nf5AbGnRwMHAzJBRsZWJ02MTAyaIEYm7mYGDkgLD4GMIvNaRfTAaA0J5DN7rSLwQHCZmZw2ajC2BEYscGhI2Ijc4rLRjUQbxdHAwMji0NHckgESEkkEGzmYWLk0drB+L91A0vvRiYGFwAMdiP0AAA=') format('woff');
 }            
 
 [class^="icon-"]:before, [class*=" icon-"]:before {
@@ -294,16 +305,19 @@ body {
     line-height: 0.75em;
     vertical-align: -15%;
 }
-.icon-resize-full:before { content: '\e800'; }
-.icon-resize-small:before { content: '\e801'; }
-.icon-left-big:before { content: '\e802'; }
-.icon-text-height:before { content: '\e803'; }
-.icon-right-big:before { content: '\e804'; }
-.icon-up-big:before { content: '\e805'; }
-.icon-home:before { content: '\e806'; }
-.icon-floppy:before { content: '\e807'; }
-.icon-resize-vertical:before { content: '\e808'; }
+
+/* To get SVG and PNG images of these icon fonts, use https://icomoon.io/app/#/select */
+.icon-home:before { content: '\e800'; }
+.icon-left-big:before { content: '\e801'; }
+.icon-right-big:before { content: '\e802'; }
+.icon-up-big:before { content: '\e803'; }
+.icon-resize-full:before { content: '\e804'; }
+.icon-resize-small:before { content: '\e805'; }
+.icon-text-height:before { content: '\e806'; }
+.icon-resize-vertical:before { content: '\e807'; }
+.icon-floppy:before { content: '\e808'; }
 .icon-search:before { content: '\e809'; }
+.icon-minus:before { content: '\e80a'; }
 .icon-exchange:before { content: '\f0ec'; }
 .icon-terminal:before { content: '\f120'; }
 .icon-help:before { content: '\f128'; }
@@ -352,125 +366,174 @@ body {
 .context-menu__link:hover {
   color: #fff;
   background-color: #0066aa;
-}</style>
+}
 
-    <div id="all_pt_n2_content_div">
-        <div id="maintitle" style="text-align: center">
-            <h1>OpenMDAO Partition Tree and N<sup>2</sup> diagram.</h1>
-        </div>
+.tool-tip {
+  z-index: 10;
+  font-size: 11px;
+  padding: 5;
+  background-color: #fff;
+  border: solid 1px #dfdfdf;   
+}
+
+</style>
+
+
+ <div id="all_pt_n2_content_div">
+        <div style="text-align: center" id="maintitle"><h1 >OpenMDAO Model Hierarchy and N2 diagram</h1>
+</div>
+
         <div id="ptN2ContentDivId">
             <!-- The Modal -->
-            <div id="myModal" class="modal">
-                <!-- Modal content -->
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <span id="idSpanModalClose" class="close">×</span> Instructions
-                    </div>
-                    <div class="modal-body">
-                        <p>Left clicking on a node in the partition tree will navigate to that node. Right clicking on a node
-                            in the partition tree will collapse/uncollapse it. A click on any element in the N^2 diagram
-                            will allow those arrows to persist.</p>
-                    </div>
-                    <div class="modal-footer">
-                        OpenMDAO Partition Tree and N^2 diagram.
-                    </div>
-                </div>
-            </div>
+            <div class="modal" id="myModal"><div class="modal-content"><div class="modal-header"><span class="close" id="idSpanModalClose">&times;</span>
+Instructions</div>
+
+<div class="modal-body"><p >Left clicking on a node in the partition tree will navigate to that node. Right clicking on a node in the model hierarchy will collapse/uncollapse it. A click on any element in the N^2 diagram will allow those arrows to persist.</p>
+</div>
+
+<div class="modal-footer">OpenMDAO Model Hierarchy and N^2 diagram</div>
+</div>
+</div>
+
             <div id="toolbarLoc">
-                <div class="toolbar" id="toolbarDiv">
-                    <div class="button-group">
-                        <button class="myButton" id="returnToRootButtonId" disabled="disabled" title="Return To Root">
-                            <i class="icon-home"></i>
-                        </button>
-                        <button class="myButton" id="backButtonId" disabled="disabled" title="Back">
-                            <i class="icon-left-big"></i>
-                        </button>
-                        <button class="myButton" id="forwardButtonId" disabled="disabled" title="Forward">
-                            <i class="icon-right-big"></i>
-                        </button>
-                        <button class="myButton" id="upOneLevelButtonId" disabled="disabled" title="Up One Level">
-                            <i class="icon-up-big"></i>
-                        </button>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="uncollapseInViewButtonId" title="Uncollapse In View Only">
-                            <i class="icon-resize-full"></i>
-                        </button>
-                        <button class="myButton" id="uncollapseAllButtonId" title="Uncollapse All">
-                            <i class="icon-resize-full bigger-font"></i>
-                        </button>
-                        <button class="myButton" id="collapseInViewButtonId" title="Collapse Outputs In View Only">
-                            <i class="icon-resize-small"></i>
-                        </button>
-                        <button class="myButton" id="collapseAllButtonId" title="Collapse All Outputs">
-                            <i class="icon-resize-small bigger-font"></i>
-                        </button>
-                        <div class="dropdown">
-                            <button class="myButton" title="Collapse Depth">
-                                <i class="icon-sort-number-up"></i>
-                            </button>
-                            <div id="idCollapseDepthDiv" class="dropdown-content">
-                                <span class="fakeLink">Collapse Depth</span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="clearArrowsAndConnectsButtonId" title="Clear Arrows and Connections">
-                            <i class="icon-eraser"></i>
-                        </button>
-                        <button class="myButton" id="showCurrentPathButtonId" title="Show Path">
-                            <i class="icon-terminal"></i>
-                        </button>
-                        <button class="myButton" id="showLegendButtonId" title="Show Legend">
-                            <i class="icon-map-signs"></i>
-                        </button>
-                        <button class="myButton" id="showParamsButtonId" type="checkbox" title="Show Params">
-                            <i class="icon-exchange"></i>
-                        </button>
-                        <div class="dropdown">
-                            <button class="myButton" title="Font Size">
-                                <i class="icon-text-height"></i>
-                            </button>
-                            <div class="dropdown-content">
-                                <span class="fakeLink">Font Size</span>
-                                <span class="fakeLink" id="idFontSize8px">8px</span>
-                                <span class="fakeLink" id="idFontSize9px">9px</span>
-                                <span class="fakeLink" id="idFontSize10px">10px</span>
-                                <span class="fakeLink" id="idFontSize11px"><b>11px</b></span>
-                                <span class="fakeLink" id="idFontSize12px">12px</span>
-                                <span class="fakeLink" id="idFontSize13px">13px</span>
-                                <span class="fakeLink" id="idFontSize14px">14px</span>
-                            </div>
-                        </div>
-                        <div class="dropdown">
-                            <button class="myButton" title="Vertically Resize">
-                                <i class="icon-resize-vertical"></i>
-                            </button>
-                            <div class="dropdown-content">
-                                <span class="fakeLink">Model Height</span>
-                                <span class="fakeLink" id="idVerticalResize600px"><b>600px</b></span>
-                                <span class="fakeLink" id="idVerticalResize650px">650px</span>
-                                <span class="fakeLink" id="idVerticalResize700px">700px</span>
-                                <span class="fakeLink" id="idVerticalResize750px">750px</span>
-                                <span class="fakeLink" id="idVerticalResize800px">800px</span>
-                                <span class="fakeLink" id="idVerticalResize850px">850px</span>
-                                <span class="fakeLink" id="idVerticalResize900px">900px</span>
-                                <span class="fakeLink" id="idVerticalResize950px">950px</span>
-                                <span class="fakeLink" id="idVerticalResize1000px">1000px</span>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="saveSvgButtonId" title="Save SVG">
-                            <i class="icon-floppy"></i>
-                        </button>
-                    </div>
-                    <div class="button-group">
-                        <button class="myButton" id="helpButtonId" title="Help">
-                            <i class="icon-help"></i>
-                        </button>
-                    </div>
-                </div>
+                <div class="toolbar" id="toolbarDiv"><div class="button-group">        <button title="Return To Root" disabled="disabled" class="myButton" id="returnToRootButtonId">
+<i class="icon-home"></i>
+
+</button>
+
+
+        <button title="Back" disabled="disabled" class="myButton" id="backButtonId">
+<i class="icon-left-big"></i>
+
+</button>
+
+
+        <button title="Forward" disabled="disabled" class="myButton" id="forwardButtonId">
+<i class="icon-right-big"></i>
+
+</button>
+
+
+        <button title="Up One Level" disabled="disabled" class="myButton" id="upOneLevelButtonId">
+<i class="icon-up-big"></i>
+
+</button>
+</div>
+
+
+<div class="button-group">        <button title="Uncollapse In View Only" class="myButton" id="uncollapseInViewButtonId">
+<i class="icon-resize-full"></i>
+
+</button>
+
+
+        <button title="Uncollapse All" class="myButton" id="uncollapseAllButtonId">
+<i class="icon-resize-full bigger-font"></i>
+
+</button>
+
+
+        <button title="Collapse Outputs In View Only" class="myButton" id="collapseInViewButtonId">
+<i class="icon-resize-small"></i>
+
+</button>
+
+
+        <button title="Collapse All Outputs" class="myButton" id="collapseAllButtonId">
+<i class="icon-resize-small bigger-font"></i>
+
+</button>
+
+
+        <div class="dropdown"><button title="Collapse Depth" class="myButton">
+<i class="icon-sort-number-up"></i>
+
+</button>
+
+<div class="dropdown-content" id="idCollapseDepthDiv"><span class="fakeLink">Collapse Depth</span>
+</div>
+</div>
+</div>
+
+
+<div class="button-group">        <button title="Clear Arrows and Connections" class="myButton" id="clearArrowsAndConnectsButtonId">
+<i class="icon-eraser"></i>
+
+</button>
+
+
+        <button title="Show Path" class="myButton" id="showCurrentPathButtonId">
+<i class="icon-terminal"></i>
+
+</button>
+
+
+        <button title="Show Legend" class="myButton" id="showLegendButtonId">
+<i class="icon-map-signs"></i>
+
+</button>
+
+
+        <button title="Toggle Solver Names" class="myButton" id="toggleSolverNamesButtonId">
+<i class="icon-minus"></i>
+
+</button>
+
+
+        <div class="dropdown"><button title="Font Size" class="myButton">
+<i class="icon-text-height"></i>
+
+</button>
+
+<div class="dropdown-content"><span class="fakeLink">Font Size</span>
+<span class="fakeLink" id="idFontSize8px">8px</span>
+<span class="fakeLink" id="idFontSize9px">9px</span>
+<span class="fakeLink" id="idFontSize10px">10px</span>
+<span class="fakeLink" id="idFontSize11px">11px</span>
+<span class="fakeLink" id="idFontSize12px">12px</span>
+<span class="fakeLink" id="idFontSize13px">13px</span>
+<span class="fakeLink" id="idFontSize14px">14px</span>
+</div>
+</div>
+
+
+        <div class="dropdown"><button title="Vertically Resize" class="myButton">
+<i class="icon-resize-vertical"></i>
+
+</button>
+
+<div class="dropdown-content"><span class="fakeLink">Model Height</span>
+<span class="fakeLink" id="idVerticalResize600px">600px</span>
+<span class="fakeLink" id="idVerticalResize650px">650px</span>
+<span class="fakeLink" id="idVerticalResize700px">700px</span>
+<span class="fakeLink" id="idVerticalResize750px">750px</span>
+<span class="fakeLink" id="idVerticalResize800px">800px</span>
+<span class="fakeLink" id="idVerticalResize850px">850px</span>
+<span class="fakeLink" id="idVerticalResize900px">900px</span>
+<span class="fakeLink" id="idVerticalResize950px">950px</span>
+<span class="fakeLink" id="idVerticalResize1000px">1000px</span>
+<span class="fakeLink" id="idVerticalResize2000px">2000px</span>
+<span class="fakeLink" id="idVerticalResize3000px">3000px</span>
+<span class="fakeLink" id="idVerticalResize4000px">4000px</span>
+</div>
+</div>
+</div>
+
+
+<div class="button-group">        <button title="Save SVG" class="myButton" id="saveSvgButtonId">
+<i class="icon-floppy"></i>
+
+</button>
+</div>
+
+
+<div class="button-group">        <button title="Help" class="myButton" id="helpButtonId">
+<i class="icon-help"></i>
+
+</button>
+</div>
+</div>
+
             </div>
             <div style="margin-top:5px;">
                 <input type="text" id="awesompleteId" size="80" />
@@ -478,6 +541,9 @@ body {
                 <label id="searchCountId" style="display:inline-block;width:120px"></label>
             </div>
             <!--<select id="outputNamingSelect" onchange="OutputNameSelectChange()" style="display:none">-->
+            <div class="component_connectivity">
+                Note: Derivative declarations ignored, so dense component connectivity is assumed
+            </div>
             <div id="currentPathId" class="path_string" style="display:none"></div>
             <div id="d3_content_div"></div>
             <div id="connectionId">
@@ -500,7 +566,8 @@ body {
         <input id="katexInput"></input>
     </div>
 
-    <script type="text/javascript">// https://d3js.org Version 4.1.1. Copyright 2016 Mike Bostock.
+    <script type="text/javascript">
+// https://d3js.org Version 4.1.1. Copyright 2016 Mike Bostock.
 !function(t,n){"object"==typeof exports&&"undefined"!=typeof module?n(exports):"function"==typeof define&&define.amd?define(["exports"],n):n(t.d3=t.d3||{})}(this,function(t){"use strict";function n(t,n){return t<n?-1:t>n?1:t>=n?0:NaN}function e(t){return 1===t.length&&(t=r(t)),{left:function(n,e,r,i){for(null==r&&(r=0),null==i&&(i=n.length);r<i;){var o=r+i>>>1;t(n[o],e)<0?r=o+1:i=o}return r},right:function(n,e,r,i){for(null==r&&(r=0),null==i&&(i=n.length);r<i;){var o=r+i>>>1;t(n[o],e)>0?i=o:r=o+1}return r}}}function r(t){return function(e,r){return n(t(e),r)}}function i(t,n){return n<t?-1:n>t?1:n>=t?0:NaN}function o(t){return null===t?NaN:+t}function u(t,n){var e,r,i=t.length,u=0,a=0,c=-1,s=0;if(null==n)for(;++c<i;)isNaN(e=o(t[c]))||(r=e-u,u+=r/++s,a+=r*(e-u));else for(;++c<i;)isNaN(e=o(n(t[c],c,t)))||(r=e-u,u+=r/++s,a+=r*(e-u));if(s>1)return a/(s-1)}function a(t,n){var e=u(t,n);return e?Math.sqrt(e):e}function c(t,n){var e,r,i,o=-1,u=t.length;if(null==n){for(;++o<u;)if(null!=(r=t[o])&&r>=r){e=i=r;break}for(;++o<u;)null!=(r=t[o])&&(e>r&&(e=r),i<r&&(i=r))}else{for(;++o<u;)if(null!=(r=n(t[o],o,t))&&r>=r){e=i=r;break}for(;++o<u;)null!=(r=n(t[o],o,t))&&(e>r&&(e=r),i<r&&(i=r))}return[e,i]}function s(t){return function(){return t}}function f(t){return t}function l(t,n,e){t=+t,n=+n,e=(i=arguments.length)<2?(n=t,t=0,1):i<3?1:+e;for(var r=-1,i=0|Math.max(0,Math.ceil((n-t)/e)),o=new Array(i);++r<i;)o[r]=t+r*e;return o}function h(t,n,e){var r=p(t,n,e);return l(Math.ceil(t/r)*r,Math.floor(n/r)*r+r/2,r)}function p(t,n,e){var r=Math.abs(n-t)/Math.max(0,e),i=Math.pow(10,Math.floor(Math.log(r)/Math.LN10)),o=r/i;return o>=Pd?i*=10:o>=qd?i*=5:o>=Ld&&(i*=2),n<t?-i:i}function d(t){return Math.ceil(Math.log(t.length)/Math.LN2)+1}function v(){function t(t){var i,o,u=t.length,a=new Array(u);for(i=0;i<u;++i)a[i]=n(t[i],i,t);var c=e(a),s=c[0],f=c[1],l=r(a,s,f);Array.isArray(l)||(l=h(s,f,l));for(var p=l.length;l[0]<=s;)l.shift(),--p;for(;l[p-1]>=f;)l.pop(),--p;var d,v=new Array(p+1);for(i=0;i<=p;++i)d=v[i]=[],d.x0=i>0?l[i-1]:s,d.x1=i<p?l[i]:f;for(i=0;i<u;++i)o=a[i],s<=o&&o<=f&&v[Sd(l,o,0,p)].push(t[i]);return v}var n=f,e=c,r=d;return t.value=function(e){return arguments.length?(n="function"==typeof e?e:s(e),t):n},t.domain=function(n){return arguments.length?(e="function"==typeof n?n:s([n[0],n[1]]),t):e},t.thresholds=function(n){return arguments.length?(r="function"==typeof n?n:s(Array.isArray(n)?Cd.call(n):n),t):r},t}function _(t,n,e){if(null==e&&(e=o),r=t.length){if((n=+n)<=0||r<2)return+e(t[0],0,t);if(n>=1)return+e(t[r-1],r-1,t);var r,i=(r-1)*n,u=Math.floor(i),a=+e(t[u],u,t),c=+e(t[u+1],u+1,t);return a+(c-a)*(i-u)}}function y(t,e,r){return t=zd.call(t,o).sort(n),Math.ceil((r-e)/(2*(_(t,.75)-_(t,.25))*Math.pow(t.length,-1/3)))}function g(t,n,e){return Math.ceil((e-n)/(3.5*a(t)*Math.pow(t.length,-1/3)))}function m(t,n){var e,r,i=-1,o=t.length;if(null==n){for(;++i<o;)if(null!=(r=t[i])&&r>=r){e=r;break}for(;++i<o;)null!=(r=t[i])&&r>e&&(e=r)}else{for(;++i<o;)if(null!=(r=n(t[i],i,t))&&r>=r){e=r;break}for(;++i<o;)null!=(r=n(t[i],i,t))&&r>e&&(e=r)}return e}function x(t,n){var e,r=0,i=t.length,u=-1,a=i;if(null==n)for(;++u<i;)isNaN(e=o(t[u]))?--a:r+=e;else for(;++u<i;)isNaN(e=o(n(t[u],u,t)))?--a:r+=e;if(a)return r/a}function b(t,e){var r,i=[],u=t.length,a=-1;if(null==e)for(;++a<u;)isNaN(r=o(t[a]))||i.push(r);else for(;++a<u;)isNaN(r=o(e(t[a],a,t)))||i.push(r);return _(i.sort(n),.5)}function w(t){for(var n,e,r,i=t.length,o=-1,u=0;++o<i;)u+=t[o].length;for(e=new Array(u);--i>=0;)for(r=t[i],n=r.length;--n>=0;)e[--u]=r[n];return e}function M(t,n){var e,r,i=-1,o=t.length;if(null==n){for(;++i<o;)if(null!=(r=t[i])&&r>=r){e=r;break}for(;++i<o;)null!=(r=t[i])&&e>r&&(e=r)}else{for(;++i<o;)if(null!=(r=n(t[i],i,t))&&r>=r){e=r;break}for(;++i<o;)null!=(r=n(t[i],i,t))&&e>r&&(e=r)}return e}function T(t){for(var n=0,e=t.length-1,r=t[0],i=new Array(e<0?0:e);n<e;)i[n]=[r,r=t[++n]];return i}function k(t,n){for(var e=n.length,r=new Array(e);e--;)r[e]=t[n[e]];return r}function N(t,e){if(r=t.length){var r,i,o=0,u=0,a=t[u];for(e||(e=n);++o<r;)(e(i=t[o],a)<0||0!==e(a,a))&&(a=i,u=o);return 0===e(a,a)?u:void 0}}function S(t,n,e){for(var r,i,o=(null==e?t.length:e)-(n=null==n?0:+n);o;)i=Math.random()*o--|0,r=t[o+n],t[o+n]=t[i+n],t[i+n]=r;return t}function A(t,n){var e,r=0,i=t.length,o=-1;if(null==n)for(;++o<i;)(e=+t[o])&&(r+=e);else for(;++o<i;)(e=+n(t[o],o,t))&&(r+=e);return r}function E(t){if(!(i=t.length))return[];for(var n=-1,e=M(t,C),r=new Array(e);++n<e;)for(var i,o=-1,u=r[n]=new Array(i);++o<i;)u[o]=t[o][n];return r}function C(t){return t.length}function z(){return E(arguments)}function P(){}function q(t,n){var e=new P;if(t instanceof P)t.each(function(t,n){e.set(n,t)});else if(Array.isArray(t)){var r,i=-1,o=t.length;if(null==n)for(;++i<o;)e.set(i,t[i]);else for(;++i<o;)e.set(n(r=t[i],i,t),r)}else if(t)for(var u in t)e.set(u,t[u]);return e}function L(){function t(n,i,u,a){if(i>=o.length)return null!=r?r(n):null!=e?n.sort(e):n;for(var c,s,f,l=-1,h=n.length,p=o[i++],d=q(),v=u();++l<h;)(f=d.get(c=p(s=n[l])+""))?f.push(s):d.set(c,[s]);return d.each(function(n,e){a(v,e,t(n,i,u,a))}),v}function n(t,e){if(++e>o.length)return t;var i,a=u[e-1];return null!=r&&e>=o.length?i=t.entries():(i=[],t.each(function(t,r){i.push({key:r,values:n(t,e)})})),null!=a?i.sort(function(t,n){return a(t.key,n.key)}):i}var e,r,i,o=[],u=[];return i={object:function(n){return t(n,0,R,U)},map:function(n){return t(n,0,D,O)},entries:function(e){return n(t(e,0,D,O),0)},key:function(t){return o.push(t),i},sortKeys:function(t){return u[o.length-1]=t,i},sortValues:function(t){return e=t,i},rollup:function(t){return r=t,i}}}function R(){return{}}function U(t,n,e){t[n]=e}function D(){return q()}function O(t,n,e){t.set(n,e)}function F(){}function I(t,n){var e=new F;if(t instanceof F)t.each(function(t){e.add(t)});else if(t){var r=-1,i=t.length;if(null==n)for(;++r<i;)e.add(t[r]);else for(;++r<i;)e.add(n(t[r],r,t))}return e}function Y(t){var n=[];for(var e in t)n.push(e);return n}function B(t){var n=[];for(var e in t)n.push(t[e]);return n}function j(t){var n=[];for(var e in t)n.push({key:e,value:t[e]});return n}function H(t,n){return t=null==t?0:+t,n=null==n?1:+n,1===arguments.length?(n=t,t=0):n-=t,function(){return Math.random()*n+t}}function X(t,n){var e,r;return t=null==t?0:+t,n=null==n?1:+n,function(){var i;if(null!=e)i=e,e=null;else do e=2*Math.random()-1,i=2*Math.random()-1,r=e*e+i*i;while(!r||r>1);return t+n*i*Math.sqrt(-2*Math.log(r)/r)}}function V(){var t=X.apply(this,arguments);return function(){return Math.exp(t())}}function W(t){return function(){for(var n=0,e=0;e<t;++e)n+=Math.random();return n}}function $(t){var n=W(t);return function(){return n()/t}}function Z(t){return function(){return-Math.log(1-Math.random())/t}}function G(t){return+t}function J(t){return t*t}function Q(t){return t*(2-t)}function K(t){return((t*=2)<=1?t*t:--t*(2-t)+1)/2}function tt(t){return t*t*t}function nt(t){return--t*t*t+1}function et(t){return((t*=2)<=1?t*t*t:(t-=2)*t*t+2)/2}function rt(t){return 1-Math.cos(t*Bd)}function it(t){return Math.sin(t*Bd)}function ot(t){return(1-Math.cos(Yd*t))/2}function ut(t){return Math.pow(2,10*t-10)}function at(t){return 1-Math.pow(2,-10*t)}function ct(t){return((t*=2)<=1?Math.pow(2,10*t-10):2-Math.pow(2,10-10*t))/2}function st(t){return 1-Math.sqrt(1-t*t)}function ft(t){return Math.sqrt(1- --t*t)}function lt(t){return((t*=2)<=1?1-Math.sqrt(1-t*t):Math.sqrt(1-(t-=2)*t)+1)/2}function ht(t){return 1-pt(1-t)}function pt(t){return(t=+t)<jd?Qd*t*t:t<Xd?Qd*(t-=Hd)*t+Vd:t<$d?Qd*(t-=Wd)*t+Zd:Qd*(t-=Gd)*t+Jd}function dt(t){return((t*=2)<=1?1-pt(1-t):pt(t-1)+1)/2}function vt(t){for(var n,e=-1,r=t.length,i=t[r-1],o=0;++e<r;)n=i,i=t[e],o+=n[1]*i[0]-n[0]*i[1];return o/2}function _t(t){for(var n,e,r=-1,i=t.length,o=0,u=0,a=t[i-1],c=0;++r<i;)n=a,a=t[r],c+=e=n[0]*a[1]-a[0]*n[1],o+=(n[0]+a[0])*e,u+=(n[1]+a[1])*e;return c*=3,[o/c,u/c]}function yt(t,n,e){return(n[0]-t[0])*(e[1]-t[1])-(n[1]-t[1])*(e[0]-t[0])}function gt(t,n){return t[0]-n[0]||t[1]-n[1]}function mt(t){for(var n=t.length,e=[0,1],r=2,i=2;i<n;++i){for(;r>1&&yt(t[e[r-2]],t[e[r-1]],t[i])<=0;)--r;e[r++]=i}return e.slice(0,r)}function xt(t){if((e=t.length)<3)return null;var n,e,r=new Array(e),i=new Array(e);for(n=0;n<e;++n)r[n]=[+t[n][0],+t[n][1],n];for(r.sort(gt),n=0;n<e;++n)i[n]=[r[n][0],-r[n][1]];var o=mt(r),u=mt(i),a=u[0]===o[0],c=u[u.length-1]===o[o.length-1],s=[];for(n=o.length-1;n>=0;--n)s.push(t[r[o[n]][2]]);for(n=+a;n<u.length-c;++n)s.push(t[r[u[n]][2]]);return s}function bt(t,n){for(var e,r,i=t.length,o=t[i-1],u=n[0],a=n[1],c=o[0],s=o[1],f=!1,l=0;l<i;++l)o=t[l],e=o[0],r=o[1],r>a!=s>a&&u<(c-e)*(a-r)/(s-r)+e&&(f=!f),c=e,s=r;return f}function wt(t){for(var n,e,r=-1,i=t.length,o=t[i-1],u=o[0],a=o[1],c=0;++r<i;)n=u,e=a,o=t[r],u=o[0],a=o[1],n-=u,e-=a,c+=Math.sqrt(n*n+e*e);return c}function Mt(){this._x0=this._y0=this._x1=this._y1=null,this._=[]}function Tt(){return new Mt}function kt(t){var n=+this._x.call(null,t),e=+this._y.call(null,t);return Nt(this.cover(n,e),n,e,t)}function Nt(t,n,e,r){if(isNaN(n)||isNaN(e))return t;var i,o,u,a,c,s,f,l,h,p=t._root,d={data:r},v=t._x0,_=t._y0,y=t._x1,g=t._y1;if(!p)return t._root=d,t;for(;p.length;)if((s=n>=(o=(v+y)/2))?v=o:y=o,(f=e>=(u=(_+g)/2))?_=u:g=u,i=p,!(p=p[l=f<<1|s]))return i[l]=d,t;if(a=+t._x.call(null,p.data),c=+t._y.call(null,p.data),n===a&&e===c)return d.next=p,i?i[l]=d:t._root=d,t;do i=i?i[l]=new Array(4):t._root=new Array(4),(s=n>=(o=(v+y)/2))?v=o:y=o,(f=e>=(u=(_+g)/2))?_=u:g=u;while((l=f<<1|s)===(h=(c>=u)<<1|a>=o));return i[h]=p,i[l]=d,t}function St(t){var n,e,r,i,o=t.length,u=new Array(o),a=new Array(o),c=1/0,s=1/0,f=-(1/0),l=-(1/0);for(e=0;e<o;++e)isNaN(r=+this._x.call(null,n=t[e]))||isNaN(i=+this._y.call(null,n))||(u[e]=r,a[e]=i,r<c&&(c=r),r>f&&(f=r),i<s&&(s=i),i>l&&(l=i));for(f<c&&(c=this._x0,f=this._x1),l<s&&(s=this._y0,l=this._y1),this.cover(c,s).cover(f,l),e=0;e<o;++e)Nt(this,u[e],a[e],t[e]);return this}function At(t,n){if(isNaN(t=+t)||isNaN(n=+n))return this;var e=this._x0,r=this._y0,i=this._x1,o=this._y1;if(isNaN(e))i=(e=Math.floor(t))+1,o=(r=Math.floor(n))+1;else{if(!(e>t||t>i||r>n||n>o))return this;var u,a,c=i-e,s=this._root;switch(a=(n<(r+o)/2)<<1|t<(e+i)/2){case 0:do u=new Array(4),u[a]=s,s=u;while(c*=2,i=e+c,o=r+c,t>i||n>o);break;case 1:do u=new Array(4),u[a]=s,s=u;while(c*=2,e=i-c,o=r+c,e>t||n>o);break;case 2:do u=new Array(4),u[a]=s,s=u;while(c*=2,i=e+c,r=o-c,t>i||r>n);break;case 3:do u=new Array(4),u[a]=s,s=u;while(c*=2,e=i-c,r=o-c,e>t||r>n)}this._root&&this._root.length&&(this._root=s)}return this._x0=e,this._y0=r,this._x1=i,this._y1=o,this}function Et(){var t=[];return this.visit(function(n){if(!n.length)do t.push(n.data);while(n=n.next)}),t}function Ct(t){return arguments.length?this.cover(+t[0][0],+t[0][1]).cover(+t[1][0],+t[1][1]):isNaN(this._x0)?void 0:[[this._x0,this._y0],[this._x1,this._y1]]}function zt(t,n,e,r,i){this.node=t,this.x0=n,this.y0=e,this.x1=r,this.y1=i}function Pt(t,n,e){var r,i,o,u,a,c,s,f=this._x0,l=this._y0,h=this._x1,p=this._y1,d=[],v=this._root;for(v&&d.push(new zt(v,f,l,h,p)),null==e?e=1/0:(f=t-e,l=n-e,h=t+e,p=n+e,e*=e);c=d.pop();)if(!(!(v=c.node)||(i=c.x0)>h||(o=c.y0)>p||(u=c.x1)<f||(a=c.y1)<l))if(v.length){var _=(i+u)/2,y=(o+a)/2;d.push(new zt(v[3],_,y,u,a),new zt(v[2],i,y,_,a),new zt(v[1],_,o,u,y),new zt(v[0],i,o,_,y)),(s=(n>=y)<<1|t>=_)&&(c=d[d.length-1],d[d.length-1]=d[d.length-1-s],d[d.length-1-s]=c)}else{var g=t-+this._x.call(null,v.data),m=n-+this._y.call(null,v.data),x=g*g+m*m;if(x<e){var b=Math.sqrt(e=x);f=t-b,l=n-b,h=t+b,p=n+b,r=v.data}}return r}function qt(t){if(isNaN(o=+this._x.call(null,t))||isNaN(u=+this._y.call(null,t)))return this;var n,e,r,i,o,u,a,c,s,f,l,h,p=this._root,d=this._x0,v=this._y0,_=this._x1,y=this._y1;if(!p)return this;if(p.length)for(;;){if((s=o>=(a=(d+_)/2))?d=a:_=a,(f=u>=(c=(v+y)/2))?v=c:y=c,n=p,!(p=p[l=f<<1|s]))return this;if(!p.length)break;(n[l+1&3]||n[l+2&3]||n[l+3&3])&&(e=n,h=l)}for(;p.data!==t;)if(r=p,!(p=p.next))return this;return(i=p.next)&&delete p.next,r?(i?r.next=i:delete r.next,this):n?(i?n[l]=i:delete n[l],(p=n[0]||n[1]||n[2]||n[3])&&p===(n[3]||n[2]||n[1]||n[0])&&!p.length&&(e?e[h]=p:this._root=p),this):(this._root=i,this)}function Lt(t){for(var n=0,e=t.length;n<e;++n)this.remove(t[n]);return this}function Rt(){return this._root}function Ut(){var t=0;return this.visit(function(n){if(!n.length)do++t;while(n=n.next)}),t}function Dt(t){var n,e,r,i,o,u,a=[],c=this._root;for(c&&a.push(new zt(c,this._x0,this._y0,this._x1,this._y1));n=a.pop();)if(!t(c=n.node,r=n.x0,i=n.y0,o=n.x1,u=n.y1)&&c.length){var s=(r+o)/2,f=(i+u)/2;(e=c[3])&&a.push(new zt(e,s,f,o,u)),(e=c[2])&&a.push(new zt(e,r,f,s,u)),(e=c[1])&&a.push(new zt(e,s,i,o,f)),(e=c[0])&&a.push(new zt(e,r,i,s,f))}return this}function Ot(t){var n,e=[],r=[];for(this._root&&e.push(new zt(this._root,this._x0,this._y0,this._x1,this._y1));n=e.pop();){var i=n.node;if(i.length){var o,u=n.x0,a=n.y0,c=n.x1,s=n.y1,f=(u+c)/2,l=(a+s)/2;(o=i[0])&&e.push(new zt(o,u,a,f,l)),(o=i[1])&&e.push(new zt(o,f,a,c,l)),(o=i[2])&&e.push(new zt(o,u,l,f,s)),(o=i[3])&&e.push(new zt(o,f,l,c,s))}r.push(n)}for(;n=r.pop();)t(n.node,n.x0,n.y0,n.x1,n.y1);return this}function Ft(t){return t[0]}function It(t){return arguments.length?(this._x=t,this):this._x}function Yt(t){return t[1]}function Bt(t){return arguments.length?(this._y=t,this):this._y}function jt(t,n,e){var r=new Ht(null==n?Ft:n,null==e?Yt:e,NaN,NaN,NaN,NaN);return null==t?r:r.addAll(t)}function Ht(t,n,e,r,i,o){this._x=t,this._y=n,this._x0=e,this._y0=r,this._x1=i,this._y1=o,this._root=void 0}function Xt(t){for(var n={data:t.data},e=n;t=t.next;)e=e.next={data:t.data};return n}function Vt(t){if(!(t>=1))throw new Error;this._size=t,this._call=this._error=null,this._tasks=[],this._data=[],this._waiting=this._active=this._ended=this._start=0}function Wt(t){if(!t._start)try{$t(t)}catch(n){t._tasks[t._ended+t._active-1]&&Gt(t,n)}}function $t(t){for(;t._start=t._waiting&&t._active<t._size;){var n=t._ended+t._active,e=t._tasks[n],r=e.length-1,i=e[r];e[r]=Zt(t,n),--t._waiting,++t._active,e=i.apply(null,e),t._tasks[n]&&(t._tasks[n]=e||vv)}}function Zt(t,n){return function(e,r){t._tasks[n]&&(--t._active,++t._ended,t._tasks[n]=null,null==t._error&&(null!=e?Gt(t,e):(t._data[n]=r,t._waiting?Wt(t):Jt(t))))}}function Gt(t,n){var e,r=t._tasks.length;for(t._error=n,t._data=void 0,t._waiting=NaN;--r>=0;)if((e=t._tasks[r])&&(t._tasks[r]=null,e.abort))try{e.abort()}catch(t){}t._active=NaN,Jt(t)}function Jt(t){!t._active&&t._call&&t._call(t._error,t._data)}function Qt(t){return new Vt(arguments.length?+t:1/0)}function Kt(t){return function(){return t}}function tn(t){return t.innerRadius}function nn(t){return t.outerRadius}function en(t){return t.startAngle}function rn(t){return t.endAngle}function on(t){return t&&t.padAngle}function un(t){return t>=1?gv:t<=-1?-gv:Math.asin(t)}function an(t,n,e,r,i,o,u,a){var c=e-t,s=r-n,f=u-i,l=a-o,h=(f*(n-o)-l*(t-i))/(l*c-f*s);return[t+h*c,n+h*s]}function cn(t,n,e,r,i,o,u){var a=t-e,c=n-r,s=(u?o:-o)/Math.sqrt(a*a+c*c),f=s*c,l=-s*a,h=t+f,p=n+l,d=e+f,v=r+l,_=(h+d)/2,y=(p+v)/2,g=d-h,m=v-p,x=g*g+m*m,b=i-o,w=h*v-d*p,M=(m<0?-1:1)*Math.sqrt(Math.max(0,b*b*x-w*w)),T=(w*m-g*M)/x,k=(-w*g-m*M)/x,N=(w*m+g*M)/x,S=(-w*g+m*M)/x,A=T-_,E=k-y,C=N-_,z=S-y;return A*A+E*E>C*C+z*z&&(T=N,k=S),{cx:T,cy:k,x01:-f,y01:-l,x11:T*(i/b-1),y11:k*(i/b-1)}}function sn(){function t(){var t,s,f=+n.apply(this,arguments),l=+e.apply(this,arguments),h=o.apply(this,arguments)-gv,p=u.apply(this,arguments)-gv,d=Math.abs(p-h),v=p>h;if(c||(c=t=Tt()),l<f&&(s=l,l=f,f=s),l>_v)if(d>mv-_v)c.moveTo(l*Math.cos(h),l*Math.sin(h)),c.arc(0,0,l,h,p,!v),f>_v&&(c.moveTo(f*Math.cos(p),f*Math.sin(p)),c.arc(0,0,f,p,h,v));else{var _,y,g=h,m=p,x=h,b=p,w=d,M=d,T=a.apply(this,arguments)/2,k=T>_v&&(i?+i.apply(this,arguments):Math.sqrt(f*f+l*l)),N=Math.min(Math.abs(l-f)/2,+r.apply(this,arguments)),S=N,A=N;if(k>_v){var E=un(k/f*Math.sin(T)),C=un(k/l*Math.sin(T));(w-=2*E)>_v?(E*=v?1:-1,x+=E,b-=E):(w=0,x=b=(h+p)/2),(M-=2*C)>_v?(C*=v?1:-1,g+=C,m-=C):(M=0,g=m=(h+p)/2)}var z=l*Math.cos(g),P=l*Math.sin(g),q=f*Math.cos(b),L=f*Math.sin(b);if(N>_v){var R=l*Math.cos(m),U=l*Math.sin(m),D=f*Math.cos(x),O=f*Math.sin(x);if(d<yv){var F=w>_v?an(z,P,D,O,R,U,q,L):[q,L],I=z-F[0],Y=P-F[1],B=R-F[0],j=U-F[1],H=1/Math.sin(Math.acos((I*B+Y*j)/(Math.sqrt(I*I+Y*Y)*Math.sqrt(B*B+j*j)))/2),X=Math.sqrt(F[0]*F[0]+F[1]*F[1]);S=Math.min(N,(f-X)/(H-1)),A=Math.min(N,(l-X)/(H+1))}}M>_v?A>_v?(_=cn(D,O,z,P,l,A,v),y=cn(R,U,q,L,l,A,v),c.moveTo(_.cx+_.x01,_.cy+_.y01),A<N?c.arc(_.cx,_.cy,A,Math.atan2(_.y01,_.x01),Math.atan2(y.y01,y.x01),!v):(c.arc(_.cx,_.cy,A,Math.atan2(_.y01,_.x01),Math.atan2(_.y11,_.x11),!v),c.arc(0,0,l,Math.atan2(_.cy+_.y11,_.cx+_.x11),Math.atan2(y.cy+y.y11,y.cx+y.x11),!v),c.arc(y.cx,y.cy,A,Math.atan2(y.y11,y.x11),Math.atan2(y.y01,y.x01),!v))):(c.moveTo(z,P),c.arc(0,0,l,g,m,!v)):c.moveTo(z,P),f>_v&&w>_v?S>_v?(_=cn(q,L,R,U,f,-S,v),y=cn(z,P,D,O,f,-S,v),c.lineTo(_.cx+_.x01,_.cy+_.y01),S<N?c.arc(_.cx,_.cy,S,Math.atan2(_.y01,_.x01),Math.atan2(y.y01,y.x01),!v):(c.arc(_.cx,_.cy,S,Math.atan2(_.y01,_.x01),Math.atan2(_.y11,_.x11),!v),c.arc(0,0,f,Math.atan2(_.cy+_.y11,_.cx+_.x11),Math.atan2(y.cy+y.y11,y.cx+y.x11),v),c.arc(y.cx,y.cy,S,Math.atan2(y.y11,y.x11),Math.atan2(y.y01,y.x01),!v))):c.arc(0,0,f,b,x,v):c.lineTo(q,L)}else c.moveTo(0,0);if(c.closePath(),t)return c=null,t+""||null}var n=tn,e=nn,r=Kt(0),i=null,o=en,u=rn,a=on,c=null;return t.centroid=function(){var t=(+n.apply(this,arguments)+ +e.apply(this,arguments))/2,r=(+o.apply(this,arguments)+ +u.apply(this,arguments))/2-yv/2;return[Math.cos(r)*t,Math.sin(r)*t]},t.innerRadius=function(e){return arguments.length?(n="function"==typeof e?e:Kt(+e),t):n},t.outerRadius=function(n){return arguments.length?(e="function"==typeof n?n:Kt(+n),t):e},t.cornerRadius=function(n){return arguments.length?(r="function"==typeof n?n:Kt(+n),t):r},t.padRadius=function(n){return arguments.length?(i=null==n?null:"function"==typeof n?n:Kt(+n),t):i},t.startAngle=function(n){return arguments.length?(o="function"==typeof n?n:Kt(+n),t):o},t.endAngle=function(n){return arguments.length?(u="function"==typeof n?n:Kt(+n),t):u},t.padAngle=function(n){return arguments.length?(a="function"==typeof n?n:Kt(+n),t):a},t.context=function(n){return arguments.length?(c=null==n?null:n,t):c},t}function fn(t){this._context=t}function ln(t){return new fn(t)}function hn(t){return t[0]}function pn(t){return t[1]}function dn(){function t(t){var a,c,s,f=t.length,l=!1;for(null==i&&(u=o(s=Tt())),a=0;a<=f;++a)!(a<f&&r(c=t[a],a,t))===l&&((l=!l)?u.lineStart():u.lineEnd()),l&&u.point(+n(c,a,t),+e(c,a,t));if(s)return u=null,s+""||null}var n=hn,e=pn,r=Kt(!0),i=null,o=ln,u=null;return t.x=function(e){return arguments.length?(n="function"==typeof e?e:Kt(+e),t):n},t.y=function(n){return arguments.length?(e="function"==typeof n?n:Kt(+n),t):e},t.defined=function(n){return arguments.length?(r="function"==typeof n?n:Kt(!!n),t):r},t.curve=function(n){return arguments.length?(o=n,null!=i&&(u=o(i)),t):o},t.context=function(n){return arguments.length?(null==n?i=u=null:u=o(i=n),t):i},t}function vn(){function t(t){var n,f,l,h,p,d=t.length,v=!1,_=new Array(d),y=new Array(d);for(null==a&&(s=c(p=Tt())),n=0;n<=d;++n){if(!(n<d&&u(h=t[n],n,t))===v)if(v=!v)f=n,s.areaStart(),s.lineStart();else{for(s.lineEnd(),s.lineStart(),l=n-1;l>=f;--l)s.point(_[l],y[l]);s.lineEnd(),s.areaEnd()}v&&(_[n]=+e(h,n,t),y[n]=+i(h,n,t),s.point(r?+r(h,n,t):_[n],o?+o(h,n,t):y[n]))}if(p)return s=null,p+""||null}function n(){return dn().defined(u).curve(c).context(a)}var e=hn,r=null,i=Kt(0),o=pn,u=Kt(!0),a=null,c=ln,s=null;return t.x=function(n){return arguments.length?(e="function"==typeof n?n:Kt(+n),r=null,t):e},t.x0=function(n){return arguments.length?(e="function"==typeof n?n:Kt(+n),t):e},t.x1=function(n){return arguments.length?(r=null==n?null:"function"==typeof n?n:Kt(+n),t):r},t.y=function(n){return arguments.length?(i="function"==typeof n?n:Kt(+n),o=null,t):i},t.y0=function(n){return arguments.length?(i="function"==typeof n?n:Kt(+n),t):i},t.y1=function(n){return arguments.length?(o=null==n?null:"function"==typeof n?n:Kt(+n),t):o},t.lineX0=t.lineY0=function(){return n().x(e).y(i)},t.lineY1=function(){return n().x(e).y(o)},t.lineX1=function(){return n().x(r).y(i)},t.defined=function(n){return arguments.length?(u="function"==typeof n?n:Kt(!!n),t):u},t.curve=function(n){return arguments.length?(c=n,null!=a&&(s=c(a)),t):c},t.context=function(n){return arguments.length?(null==n?a=s=null:s=c(a=n),t):a},t}function _n(t,n){return n<t?-1:n>t?1:n>=t?0:NaN}function yn(t){return t}function gn(){function t(t){var a,c,s,f,l,h=t.length,p=0,d=new Array(h),v=new Array(h),_=+i.apply(this,arguments),y=Math.min(mv,Math.max(-mv,o.apply(this,arguments)-_)),g=Math.min(Math.abs(y)/h,u.apply(this,arguments)),m=g*(y<0?-1:1);for(a=0;a<h;++a)(l=v[d[a]=a]=+n(t[a],a,t))>0&&(p+=l);for(null!=e?d.sort(function(t,n){return e(v[t],v[n])}):null!=r&&d.sort(function(n,e){return r(t[n],t[e])}),a=0,s=p?(y-h*m)/p:0;a<h;++a,_=f)c=d[a],l=v[c],f=_+(l>0?l*s:0)+m,v[c]={data:t[c],index:a,value:l,startAngle:_,endAngle:f,padAngle:g};return v}var n=yn,e=_n,r=null,i=Kt(0),o=Kt(mv),u=Kt(0);return t.value=function(e){return arguments.length?(n="function"==typeof e?e:Kt(+e),t):n},t.sortValues=function(n){return arguments.length?(e=n,r=null,t):e},t.sort=function(n){return arguments.length?(r=n,e=null,t):r},t.startAngle=function(n){return arguments.length?(i="function"==typeof n?n:Kt(+n),t):i},t.endAngle=function(n){return arguments.length?(o="function"==typeof n?n:Kt(+n),t):o},t.padAngle=function(n){return arguments.length?(u="function"==typeof n?n:Kt(+n),t):u},t}function mn(t){this._curve=t}function xn(t){function n(n){return new mn(t(n))}return n._curve=t,n}function bn(t){var n=t.curve;return t.angle=t.x,delete t.x,t.radius=t.y,delete t.y,t.curve=function(t){return arguments.length?n(xn(t)):n()._curve},t}function wn(){return bn(dn().curve(xv))}function Mn(){var t=vn().curve(xv),n=t.curve,e=t.lineX0,r=t.lineX1,i=t.lineY0,o=t.lineY1;return t.angle=t.x,delete t.x,t.startAngle=t.x0,delete t.x0,t.endAngle=t.x1,delete t.x1,t.radius=t.y,delete t.y,t.innerRadius=t.y0,delete t.y0,t.outerRadius=t.y1,delete t.y1,t.lineStartAngle=function(){return bn(e())},delete t.lineX0,t.lineEndAngle=function(){return bn(r())},delete t.lineX1,t.lineInnerRadius=function(){return bn(i())},delete t.lineY0,t.lineOuterRadius=function(){return bn(o())},delete t.lineY1,t.curve=function(t){return arguments.length?n(xn(t)):n()._curve},t}function Tn(){function t(){var t;if(r||(r=t=Tt()),n.apply(this,arguments).draw(r,+e.apply(this,arguments)),t)return r=null,t+""||null}var n=Kt(bv),e=Kt(64),r=null;return t.type=function(e){return arguments.length?(n="function"==typeof e?e:Kt(e),t):n},t.size=function(n){return arguments.length?(e="function"==typeof n?n:Kt(+n),t):e},t.context=function(n){return arguments.length?(r=null==n?null:n,t):r},t}function kn(){}function Nn(t,n,e){t._context.bezierCurveTo((2*t._x0+t._x1)/3,(2*t._y0+t._y1)/3,(t._x0+2*t._x1)/3,(t._y0+2*t._y1)/3,(t._x0+4*t._x1+n)/6,(t._y0+4*t._y1+e)/6)}function Sn(t){this._context=t}function An(t){return new Sn(t)}function En(t){this._context=t}function Cn(t){return new En(t)}function zn(t){this._context=t}function Pn(t){return new zn(t)}function qn(t,n){this._basis=new Sn(t),this._beta=n}function Ln(t,n,e){t._context.bezierCurveTo(t._x1+t._k*(t._x2-t._x0),t._y1+t._k*(t._y2-t._y0),t._x2+t._k*(t._x1-n),t._y2+t._k*(t._y1-e),t._x2,t._y2)}function Rn(t,n){this._context=t,this._k=(1-n)/6}function Un(t,n){this._context=t,this._k=(1-n)/6}function Dn(t,n){this._context=t,this._k=(1-n)/6}function On(t,n,e){var r=t._x1,i=t._y1,o=t._x2,u=t._y2;if(t._l01_a>_v){var a=2*t._l01_2a+3*t._l01_a*t._l12_a+t._l12_2a,c=3*t._l01_a*(t._l01_a+t._l12_a);r=(r*a-t._x0*t._l12_2a+t._x2*t._l01_2a)/c,i=(i*a-t._y0*t._l12_2a+t._y2*t._l01_2a)/c}if(t._l23_a>_v){var s=2*t._l23_2a+3*t._l23_a*t._l12_a+t._l12_2a,f=3*t._l23_a*(t._l23_a+t._l12_a);o=(o*s+t._x1*t._l23_2a-n*t._l12_2a)/f,u=(u*s+t._y1*t._l23_2a-e*t._l12_2a)/f}t._context.bezierCurveTo(r,i,o,u,t._x2,t._y2)}function Fn(t,n){this._context=t,this._alpha=n}function In(t,n){this._context=t,this._alpha=n}function Yn(t,n){this._context=t,this._alpha=n}function Bn(t){this._context=t}function jn(t){return new Bn(t)}function Hn(t){return t<0?-1:1}function Xn(t,n,e){var r=t._x1-t._x0,i=n-t._x1,o=(t._y1-t._y0)/(r||i<0&&-0),u=(e-t._y1)/(i||r<0&&-0),a=(o*i+u*r)/(r+i);return(Hn(o)+Hn(u))*Math.min(Math.abs(o),Math.abs(u),.5*Math.abs(a))||0}function Vn(t,n){var e=t._x1-t._x0;return e?(3*(t._y1-t._y0)/e-n)/2:n}function Wn(t,n,e){var r=t._x0,i=t._y0,o=t._x1,u=t._y1,a=(o-r)/3;t._context.bezierCurveTo(r+a,i+a*n,o-a,u-a*e,o,u)}function $n(t){this._context=t}function Zn(t){this._context=new Gn(t)}function Gn(t){this._context=t}function Jn(t){return new $n(t)}function Qn(t){return new Zn(t)}function Kn(t){this._context=t}function te(t){var n,e,r=t.length-1,i=new Array(r),o=new Array(r),u=new Array(r);for(i[0]=0,o[0]=2,u[0]=t[0]+2*t[1],n=1;n<r-1;++n)i[n]=1,o[n]=4,u[n]=4*t[n]+2*t[n+1];for(i[r-1]=2,o[r-1]=7,u[r-1]=8*t[r-1]+t[r],n=1;n<r;++n)e=i[n]/o[n-1],o[n]-=e,u[n]-=e*u[n-1];for(i[r-1]=u[r-1]/o[r-1],n=r-2;n>=0;--n)i[n]=(u[n]-i[n+1])/o[n];for(o[r-1]=(t[r]+i[r-1])/2,n=0;n<r-1;++n)o[n]=2*t[n+1]-i[n+1];return[i,o]}function ne(t){return new Kn(t)}function ee(t,n){this._context=t,this._t=n}function re(t){return new ee(t,.5)}function ie(t){return new ee(t,0)}function oe(t){return new ee(t,1)}function ue(t,n){if((r=t.length)>1)for(var e,r,i=1,o=t[n[0]],u=o.length;i<r;++i){e=o,o=t[n[i]];for(var a=0;a<u;++a)o[a][1]+=o[a][0]=isNaN(e[a][1])?e[a][0]:e[a][1]}}function ae(t){for(var n=t.length,e=new Array(n);--n>=0;)e[n]=n;return e}function ce(t,n){return t[n]}function se(){function t(t){var o,u,a=n.apply(this,arguments),c=t.length,s=a.length,f=new Array(s);for(o=0;o<s;++o){for(var l,h=a[o],p=f[o]=new Array(c),d=0;d<c;++d)p[d]=l=[0,+i(t[d],h,d,t)],l.data=t[d];p.key=h}for(o=0,u=e(f);o<s;++o)f[u[o]].index=o;return r(f,u),f}var n=Kt([]),e=ae,r=ue,i=ce;return t.keys=function(e){return arguments.length?(n="function"==typeof e?e:Kt(Wv.call(e)),t):n},t.value=function(n){return arguments.length?(i="function"==typeof n?n:Kt(+n),t):i},t.order=function(n){return arguments.length?(e=null==n?ae:"function"==typeof n?n:Kt(Wv.call(n)),t):e},t.offset=function(n){return arguments.length?(r=null==n?ue:n,t):r},t}function fe(t,n){if((r=t.length)>0){for(var e,r,i,o=0,u=t[0].length;o<u;++o){for(i=e=0;e<r;++e)i+=t[e][o][1]||0;if(i)for(e=0;e<r;++e)t[e][o][1]/=i}ue(t,n)}}function le(t,n){if((e=t.length)>0){for(var e,r=0,i=t[n[0]],o=i.length;r<o;++r){for(var u=0,a=0;u<e;++u)a+=t[u][r][1]||0;i[r][1]+=i[r][0]=-a/2}ue(t,n)}}function he(t,n){if((i=t.length)>0&&(r=(e=t[n[0]]).length)>0){for(var e,r,i,o=0,u=1;u<r;++u){for(var a=0,c=0,s=0;a<i;++a){for(var f=t[n[a]],l=f[u][1]||0,h=f[u-1][1]||0,p=(l-h)/2,d=0;d<a;++d){var v=t[n[d]],_=v[u][1]||0,y=v[u-1][1]||0;p+=_-y}c+=l,s+=p*l}e[u-1][1]+=e[u-1][0]=o,c&&(o-=s/c)}e[u-1][1]+=e[u-1][0]=o,ue(t,n)}}function pe(t){var n=t.map(de);return ae(t).sort(function(t,e){return n[t]-n[e]})}function de(t){for(var n,e=0,r=-1,i=t.length;++r<i;)(n=+t[r][1])&&(e+=n);return e}function ve(t){return pe(t).reverse()}function _e(t){var n,e,r=t.length,i=t.map(de),o=ae(t).sort(function(t,n){return i[n]-i[t]}),u=0,a=0,c=[],s=[];for(n=0;n<r;++n)e=o[n],u<a?(u+=i[e],c.push(e)):(a+=i[e],s.push(e));return s.reverse().concat(c)}function ye(t){return ae(t).reverse()}function ge(t,n,e){t.prototype=n.prototype=e,e.constructor=t}function me(t,n){var e=Object.create(t.prototype);for(var r in n)e[r]=n[r];return e}function xe(){}function be(t){var n;return t=(t+"").trim().toLowerCase(),(n=Gv.exec(t))?(n=parseInt(n[1],16),new Ne(n>>8&15|n>>4&240,n>>4&15|240&n,(15&n)<<4|15&n,1)):(n=Jv.exec(t))?we(parseInt(n[1],16)):(n=Qv.exec(t))?new Ne(n[1],n[2],n[3],1):(n=Kv.exec(t))?new Ne(255*n[1]/100,255*n[2]/100,255*n[3]/100,1):(n=t_.exec(t))?Me(n[1],n[2],n[3],n[4]):(n=n_.exec(t))?Me(255*n[1]/100,255*n[2]/100,255*n[3]/100,n[4]):(n=e_.exec(t))?Se(n[1],n[2]/100,n[3]/100,1):(n=r_.exec(t))?Se(n[1],n[2]/100,n[3]/100,n[4]):i_.hasOwnProperty(t)?we(i_[t]):"transparent"===t?new Ne(NaN,NaN,NaN,0):null}function we(t){return new Ne(t>>16&255,t>>8&255,255&t,1)}function Me(t,n,e,r){return r<=0&&(t=n=e=NaN),new Ne(t,n,e,r)}function Te(t){return t instanceof xe||(t=be(t)),t?(t=t.rgb(),new Ne(t.r,t.g,t.b,t.opacity)):new Ne}function ke(t,n,e,r){return 1===arguments.length?Te(t):new Ne(t,n,e,null==r?1:r)}function Ne(t,n,e,r){this.r=+t,this.g=+n,this.b=+e,this.opacity=+r}function Se(t,n,e,r){return r<=0?t=n=e=NaN:e<=0||e>=1?t=n=NaN:n<=0&&(t=NaN),new Ce(t,n,e,r)}function Ae(t){if(t instanceof Ce)return new Ce(t.h,t.s,t.l,t.opacity);if(t instanceof xe||(t=be(t)),!t)return new Ce;if(t instanceof Ce)return t;t=t.rgb();var n=t.r/255,e=t.g/255,r=t.b/255,i=Math.min(n,e,r),o=Math.max(n,e,r),u=NaN,a=o-i,c=(o+i)/2;return a?(u=n===o?(e-r)/a+6*(e<r):e===o?(r-n)/a+2:(n-e)/a+4,a/=c<.5?o+i:2-o-i,u*=60):a=c>0&&c<1?0:u,new Ce(u,a,c,t.opacity)}function Ee(t,n,e,r){return 1===arguments.length?Ae(t):new Ce(t,n,e,null==r?1:r)}function Ce(t,n,e,r){this.h=+t,this.s=+n,this.l=+e,this.opacity=+r}function ze(t,n,e){return 255*(t<60?n+(e-n)*t/60:t<180?e:t<240?n+(e-n)*(240-t)/60:n)}function Pe(t){if(t instanceof Le)return new Le(t.l,t.a,t.b,t.opacity);if(t instanceof Ye){var n=t.h*o_;return new Le(t.l,Math.cos(n)*t.c,Math.sin(n)*t.c,t.opacity)}t instanceof Ne||(t=Te(t));var e=Oe(t.r),r=Oe(t.g),i=Oe(t.b),o=Re((.4124564*e+.3575761*r+.1804375*i)/c_),u=Re((.2126729*e+.7151522*r+.072175*i)/s_),a=Re((.0193339*e+.119192*r+.9503041*i)/f_);return new Le(116*u-16,500*(o-u),200*(u-a),t.opacity)}function qe(t,n,e,r){return 1===arguments.length?Pe(t):new Le(t,n,e,null==r?1:r)}function Le(t,n,e,r){this.l=+t,this.a=+n,this.b=+e,this.opacity=+r}function Re(t){return t>d_?Math.pow(t,1/3):t/p_+l_}function Ue(t){return t>h_?t*t*t:p_*(t-l_)}function De(t){return 255*(t<=.0031308?12.92*t:1.055*Math.pow(t,1/2.4)-.055)}function Oe(t){return(t/=255)<=.04045?t/12.92:Math.pow((t+.055)/1.055,2.4)}function Fe(t){if(t instanceof Ye)return new Ye(t.h,t.c,t.l,t.opacity);t instanceof Le||(t=Pe(t));var n=Math.atan2(t.b,t.a)*u_;return new Ye(n<0?n+360:n,Math.sqrt(t.a*t.a+t.b*t.b),t.l,t.opacity)}function Ie(t,n,e,r){return 1===arguments.length?Fe(t):new Ye(t,n,e,null==r?1:r)}function Ye(t,n,e,r){this.h=+t,this.c=+n,this.l=+e,this.opacity=+r}function Be(t){if(t instanceof He)return new He(t.h,t.s,t.l,t.opacity);t instanceof Ne||(t=Te(t));var n=t.r/255,e=t.g/255,r=t.b/255,i=(w_*r+x_*n-b_*e)/(w_+x_-b_),o=r-i,u=(m_*(e-i)-y_*o)/g_,a=Math.sqrt(u*u+o*o)/(m_*i*(1-i)),c=a?Math.atan2(u,o)*u_-120:NaN;return new He(c<0?c+360:c,a,i,t.opacity)}function je(t,n,e,r){return 1===arguments.length?Be(t):new He(t,n,e,null==r?1:r)}function He(t,n,e,r){this.h=+t,this.s=+n,this.l=+e,this.opacity=+r}function Xe(t,n,e,r,i){var o=t*t,u=o*t;return((1-3*t+3*o-u)*n+(4-6*o+3*u)*e+(1+3*t+3*o-3*u)*r+u*i)/6}function Ve(t){var n=t.length-1;return function(e){var r=e<=0?e=0:e>=1?(e=1,n-1):Math.floor(e*n),i=t[r],o=t[r+1],u=r>0?t[r-1]:2*i-o,a=r<n-1?t[r+2]:2*o-i;return Xe((e-r/n)*n,u,i,o,a)}}function We(t){var n=t.length;return function(e){var r=Math.floor(((e%=1)<0?++e:e)*n),i=t[(r+n-1)%n],o=t[r%n],u=t[(r+1)%n],a=t[(r+2)%n];return Xe((e-r/n)*n,i,o,u,a)}}function $e(t){return function(){return t}}function Ze(t,n){return function(e){return t+e*n}}function Ge(t,n,e){return t=Math.pow(t,e),n=Math.pow(n,e)-t,e=1/e,function(r){return Math.pow(t+r*n,e)}}function Je(t,n){var e=n-t;return e?Ze(t,e>180||e<-180?e-360*Math.round(e/360):e):$e(isNaN(t)?n:t)}function Qe(t){return 1===(t=+t)?Ke:function(n,e){return e-n?Ge(n,e,t):$e(isNaN(n)?e:n)}}function Ke(t,n){var e=n-t;return e?Ze(t,e):$e(isNaN(t)?n:t)}function tr(t){return function(n){var e,r,i=n.length,o=new Array(i),u=new Array(i),a=new Array(i);for(e=0;e<i;++e)r=ke(n[e]),o[e]=r.r||0,u[e]=r.g||0,a[e]=r.b||0;return o=t(o),u=t(u),a=t(a),r.opacity=1,function(t){return r.r=o(t),r.g=u(t),r.b=a(t),r+""}}}function nr(t,n){var e,r=n?n.length:0,i=t?Math.min(r,t.length):0,o=new Array(r),u=new Array(r);for(e=0;e<i;++e)o[e]=cr(t[e],n[e]);
 for(;e<r;++e)u[e]=n[e];return function(t){for(e=0;e<i;++e)u[e]=o[e](t);return u}}function er(t,n){var e=new Date;return t=+t,n-=t,function(r){return e.setTime(t+n*r),e}}function rr(t,n){return t=+t,n-=t,function(e){return t+n*e}}function ir(t,n){var e,r={},i={};null!==t&&"object"==typeof t||(t={}),null!==n&&"object"==typeof n||(n={});for(e in n)e in t?r[e]=cr(t[e],n[e]):i[e]=n[e];return function(t){for(e in r)i[e]=r[e](t);return i}}function or(t){return function(){return t}}function ur(t){return function(n){return t(n)+""}}function ar(t,n){var e,r,i,o=C_.lastIndex=z_.lastIndex=0,u=-1,a=[],c=[];for(t+="",n+="";(e=C_.exec(t))&&(r=z_.exec(n));)(i=r.index)>o&&(i=n.slice(o,i),a[u]?a[u]+=i:a[++u]=i),(e=e[0])===(r=r[0])?a[u]?a[u]+=r:a[++u]=r:(a[++u]=null,c.push({i:u,x:rr(e,r)})),o=z_.lastIndex;return o<n.length&&(i=n.slice(o),a[u]?a[u]+=i:a[++u]=i),a.length<2?c[0]?ur(c[0].x):or(n):(n=c.length,function(t){for(var e,r=0;r<n;++r)a[(e=c[r]).i]=e.x(t);return a.join("")})}function cr(t,n){var e,r=typeof n;return null==n||"boolean"===r?$e(n):("number"===r?rr:"string"===r?(e=be(n))?(n=e,S_):ar:n instanceof be?S_:n instanceof Date?er:Array.isArray(n)?nr:isNaN(n)?ir:rr)(t,n)}function sr(t,n){return t=+t,n-=t,function(e){return Math.round(t+n*e)}}function fr(t,n,e,r,i,o){var u,a,c;return(u=Math.sqrt(t*t+n*n))&&(t/=u,n/=u),(c=t*e+n*r)&&(e-=t*c,r-=n*c),(a=Math.sqrt(e*e+r*r))&&(e/=a,r/=a,c/=a),t*r<n*e&&(t=-t,n=-n,c=-c,u=-u),{translateX:i,translateY:o,rotate:Math.atan2(n,t)*P_,skewX:Math.atan(c)*P_,scaleX:u,scaleY:a}}function lr(t){return"none"===t?q_:(M_||(M_=document.createElement("DIV"),T_=document.documentElement,k_=document.defaultView),M_.style.transform=t,t=k_.getComputedStyle(T_.appendChild(M_),null).getPropertyValue("transform"),T_.removeChild(M_),t=t.slice(7,-1).split(","),fr(+t[0],+t[1],+t[2],+t[3],+t[4],+t[5]))}function hr(t){return null==t?q_:(N_||(N_=document.createElementNS("http://www.w3.org/2000/svg","g")),N_.setAttribute("transform",t),(t=N_.transform.baseVal.consolidate())?(t=t.matrix,fr(t.a,t.b,t.c,t.d,t.e,t.f)):q_)}function pr(t,n,e,r){function i(t){return t.length?t.pop()+" ":""}function o(t,r,i,o,u,a){if(t!==i||r!==o){var c=u.push("translate(",null,n,null,e);a.push({i:c-4,x:rr(t,i)},{i:c-2,x:rr(r,o)})}else(i||o)&&u.push("translate("+i+n+o+e)}function u(t,n,e,o){t!==n?(t-n>180?n+=360:n-t>180&&(t+=360),o.push({i:e.push(i(e)+"rotate(",null,r)-2,x:rr(t,n)})):n&&e.push(i(e)+"rotate("+n+r)}function a(t,n,e,o){t!==n?o.push({i:e.push(i(e)+"skewX(",null,r)-2,x:rr(t,n)}):n&&e.push(i(e)+"skewX("+n+r)}function c(t,n,e,r,o,u){if(t!==e||n!==r){var a=o.push(i(o)+"scale(",null,",",null,")");u.push({i:a-4,x:rr(t,e)},{i:a-2,x:rr(n,r)})}else 1===e&&1===r||o.push(i(o)+"scale("+e+","+r+")")}return function(n,e){var r=[],i=[];return n=t(n),e=t(e),o(n.translateX,n.translateY,e.translateX,e.translateY,r,i),u(n.rotate,e.rotate,r,i),a(n.skewX,e.skewX,r,i),c(n.scaleX,n.scaleY,e.scaleX,e.scaleY,r,i),n=e=null,function(t){for(var n,e=-1,o=i.length;++e<o;)r[(n=i[e]).i]=n.x(t);return r.join("")}}}function dr(t){return((t=Math.exp(t))+1/t)/2}function vr(t){return((t=Math.exp(t))-1/t)/2}function _r(t){return((t=Math.exp(2*t))-1)/(t+1)}function yr(t,n){var e,r,i=t[0],o=t[1],u=t[2],a=n[0],c=n[1],s=n[2],f=a-i,l=c-o,h=f*f+l*l;if(h<F_)r=Math.log(s/u)/U_,e=function(t){return[i+t*f,o+t*l,u*Math.exp(U_*t*r)]};else{var p=Math.sqrt(h),d=(s*s-u*u+O_*h)/(2*u*D_*p),v=(s*s-u*u-O_*h)/(2*s*D_*p),_=Math.log(Math.sqrt(d*d+1)-d),y=Math.log(Math.sqrt(v*v+1)-v);r=(y-_)/U_,e=function(t){var n=t*r,e=dr(_),a=u/(D_*p)*(e*_r(U_*n+_)-vr(_));return[i+a*f,o+a*l,u*e/dr(U_*n+_)]}}return e.duration=1e3*r,e}function gr(t){return function(n,e){var r=t((n=Ee(n)).h,(e=Ee(e)).h),i=Ke(n.s,e.s),o=Ke(n.l,e.l),u=Ke(n.opacity,e.opacity);return function(t){return n.h=r(t),n.s=i(t),n.l=o(t),n.opacity=u(t),n+""}}}function mr(t,n){var e=Ke((t=qe(t)).l,(n=qe(n)).l),r=Ke(t.a,n.a),i=Ke(t.b,n.b),o=Ke(t.opacity,n.opacity);return function(n){return t.l=e(n),t.a=r(n),t.b=i(n),t.opacity=o(n),t+""}}function xr(t){return function(n,e){var r=t((n=Ie(n)).h,(e=Ie(e)).h),i=Ke(n.c,e.c),o=Ke(n.l,e.l),u=Ke(n.opacity,e.opacity);return function(t){return n.h=r(t),n.c=i(t),n.l=o(t),n.opacity=u(t),n+""}}}function br(t){return function n(e){function r(n,r){var i=t((n=je(n)).h,(r=je(r)).h),o=Ke(n.s,r.s),u=Ke(n.l,r.l),a=Ke(n.opacity,r.opacity);return function(t){return n.h=i(t),n.s=o(t),n.l=u(Math.pow(t,e)),n.opacity=a(t),n+""}}return e=+e,r.gamma=n,r}(1)}function wr(t,n){for(var e=new Array(n),r=0;r<n;++r)e[r]=t(r/(n-1));return e}function Mr(){for(var t,n=0,e=arguments.length,r={};n<e;++n){if(!(t=arguments[n]+"")||t in r)throw new Error("illegal type: "+t);r[t]=[]}return new Tr(r)}function Tr(t){this._=t}function kr(t,n){return t.trim().split(/^|\s+/).map(function(t){var e="",r=t.indexOf(".");if(r>=0&&(e=t.slice(r+1),t=t.slice(0,r)),t&&!n.hasOwnProperty(t))throw new Error("unknown type: "+t);return{type:t,name:e}})}function Nr(t,n){for(var e,r=0,i=t.length;r<i;++r)if((e=t[r]).name===n)return e.value}function Sr(t,n,e){for(var r=0,i=t.length;r<i;++r)if(t[r].name===n){t[r]=V_,t=t.slice(0,r).concat(t.slice(r+1));break}return null!=e&&t.push({name:n,value:e}),t}function Ar(t){return new Function("d","return {"+t.map(function(t,n){return JSON.stringify(t)+": d["+n+"]"}).join(",")+"}")}function Er(t,n){var e=Ar(t);return function(r,i){return n(e(r),i,t)}}function Cr(t){var n=Object.create(null),e=[];return t.forEach(function(t){for(var r in t)r in n||e.push(n[r]=r)}),e}function zr(t){function n(t,n){var r,i,o=e(t,function(t,e){return r?r(t,e-1):(i=t,void(r=n?Er(t,n):Ar(t)))});return o.columns=i,o}function e(t,n){function e(){if(f>=s)return u;if(i)return i=!1,o;var n,e=f;if(34===t.charCodeAt(e)){for(var r=e;r++<s;)if(34===t.charCodeAt(r)){if(34!==t.charCodeAt(r+1))break;++r}return f=r+2,n=t.charCodeAt(r+1),13===n?(i=!0,10===t.charCodeAt(r+2)&&++f):10===n&&(i=!0),t.slice(e+1,r).replace(/""/g,'"')}for(;f<s;){var a=1;if(n=t.charCodeAt(f++),10===n)i=!0;else if(13===n)i=!0,10===t.charCodeAt(f)&&(++f,++a);else if(n!==c)continue;return t.slice(e,f-a)}return t.slice(e)}for(var r,i,o={},u={},a=[],s=t.length,f=0,l=0;(r=e())!==u;){for(var h=[];r!==o&&r!==u;)h.push(r),r=e();n&&null==(h=n(h,l++))||a.push(h)}return a}function r(n,e){return null==e&&(e=Cr(n)),[e.map(u).join(t)].concat(n.map(function(n){return e.map(function(t){return u(n[t])}).join(t)})).join("\n")}function i(t){return t.map(o).join("\n")}function o(n){return n.map(u).join(t)}function u(t){return null==t?"":a.test(t+="")?'"'+t.replace(/\"/g,'""')+'"':t}var a=new RegExp('["'+t+"\n]"),c=t.charCodeAt(0);return{parse:n,parseRows:e,format:r,formatRows:i}}function Pr(t,n){function e(t){var n,e=s.status;if(!e&&Lr(s)||e>=200&&e<300||304===e){if(o)try{n=o.call(r,s)}catch(t){return void a.call("error",r,t)}else n=s;a.call("load",r,n)}else a.call("error",r,t)}var r,i,o,u,a=Mr("beforesend","progress","load","error"),c=q(),s=new XMLHttpRequest,f=null,l=null,h=0;if("undefined"==typeof XDomainRequest||"withCredentials"in s||!/^(http(s)?:)?\/\//.test(t)||(s=new XDomainRequest),"onload"in s?s.onload=s.onerror=s.ontimeout=e:s.onreadystatechange=function(t){s.readyState>3&&e(t)},s.onprogress=function(t){a.call("progress",r,t)},r={header:function(t,n){return t=(t+"").toLowerCase(),arguments.length<2?c.get(t):(null==n?c.remove(t):c.set(t,n+""),r)},mimeType:function(t){return arguments.length?(i=null==t?null:t+"",r):i},responseType:function(t){return arguments.length?(u=t,r):u},timeout:function(t){return arguments.length?(h=+t,r):h},user:function(t){return arguments.length<1?f:(f=null==t?null:t+"",r)},password:function(t){return arguments.length<1?l:(l=null==t?null:t+"",r)},response:function(t){return o=t,r},get:function(t,n){return r.send("GET",t,n)},post:function(t,n){return r.send("POST",t,n)},send:function(n,e,o){return s.open(n,t,!0,f,l),null==i||c.has("accept")||c.set("accept",i+",*/*"),s.setRequestHeader&&c.each(function(t,n){s.setRequestHeader(n,t)}),null!=i&&s.overrideMimeType&&s.overrideMimeType(i),null!=u&&(s.responseType=u),h>0&&(s.timeout=h),null==o&&"function"==typeof e&&(o=e,e=null),null!=o&&1===o.length&&(o=qr(o)),null!=o&&r.on("error",o).on("load",function(t){o(null,t)}),a.call("beforesend",r,s),s.send(null==e?null:e),r},abort:function(){return s.abort(),r},on:function(){var t=a.on.apply(a,arguments);return t===a?r:t}},null!=n){if("function"!=typeof n)throw new Error("invalid callback: "+n);return r.get(n)}return r}function qr(t){return function(n,e){t(null==n?e:null)}}function Lr(t){var n=t.responseType;return n&&"text"!==n?t.response:t.responseText}function Rr(t,n){return function(e,r){var i=Pr(e).mimeType(t).response(n);if(null!=r){if("function"!=typeof r)throw new Error("invalid callback: "+r);return i.get(r)}return i}}function Ur(t,n){return function(e,r,i){arguments.length<3&&(i=r,r=null);var o=Pr(e).mimeType(t);return o.row=function(t){return arguments.length?o.response(Dr(n,r=t)):r},o.row(r),i?o.get(i):o}}function Dr(t,n){return function(e){return t(e.responseText,n)}}function Or(){return _y||(my(Fr),_y=gy.now()+yy)}function Fr(){_y=0}function Ir(){this._call=this._time=this._next=null}function Yr(t,n,e){var r=new Ir;return r.restart(t,n,e),r}function Br(){Or(),++ly;for(var t,n=W_;n;)(t=_y-n._time)>=0&&n._call.call(null,t),n=n._next;--ly}function jr(t){_y=(vy=t||gy.now())+yy,ly=hy=0;try{Br()}finally{ly=0,Xr(),_y=0}}function Hr(){var t=gy.now(),n=t-vy;n>dy&&(yy-=n,vy=t)}function Xr(){for(var t,n,e=W_,r=1/0;e;)e._call?(r>e._time&&(r=e._time),t=e,e=e._next):(n=e._next,e._next=null,e=t?t._next=n:W_=n);$_=t,Vr(r)}function Vr(t){if(!ly){hy&&(hy=clearTimeout(hy));var n=t-_y;n>24?(t<1/0&&(hy=setTimeout(jr,n)),py&&(py=clearInterval(py))):(py||(py=setInterval(Hr,dy)),ly=1,my(jr))}}function Wr(t,n,e){var r=new Ir;return n=null==n?0:+n,r.restart(function(e){r.stop(),t(e+n)},n,e),r}function $r(t,n,e){var r=new Ir,i=n;return null==n?(r.restart(t,n,e),r):(n=+n,e=null==e?Or():+e,r.restart(function o(u){u+=i,r.restart(o,i+=n,e),t(u)},n,e),r)}function Zr(t,n,e,r){function i(n){return t(n=new Date((+n))),n}return i.floor=i,i.ceil=function(e){return t(e=new Date(e-1)),n(e,1),t(e),e},i.round=function(t){var n=i(t),e=i.ceil(t);return t-n<e-t?n:e},i.offset=function(t,e){return n(t=new Date((+t)),null==e?1:Math.floor(e)),t},i.range=function(e,r,o){var u=[];if(e=i.ceil(e),o=null==o?1:Math.floor(o),!(e<r&&o>0))return u;do u.push(new Date((+e)));while(n(e,o),t(e),e<r);return u},i.filter=function(e){return Zr(function(n){for(;t(n),!e(n);)n.setTime(n-1)},function(t,r){for(;--r>=0;)for(;n(t,1),!e(t););})},e&&(i.count=function(n,r){return xy.setTime(+n),by.setTime(+r),t(xy),t(by),Math.floor(e(xy,by))},i.every=function(t){return t=Math.floor(t),isFinite(t)&&t>0?t>1?i.filter(r?function(n){return r(n)%t===0}:function(n){return i.count(0,n)%t===0}):i:null}),i}function Gr(t){return Zr(function(n){n.setDate(n.getDate()-(n.getDay()+7-t)%7),n.setHours(0,0,0,0)},function(t,n){t.setDate(t.getDate()+7*n)},function(t,n){return(n-t-(n.getTimezoneOffset()-t.getTimezoneOffset())*ky)/Ay})}function Jr(t){return Zr(function(n){n.setUTCDate(n.getUTCDate()-(n.getUTCDay()+7-t)%7),n.setUTCHours(0,0,0,0)},function(t,n){t.setUTCDate(t.getUTCDate()+7*n)},function(t,n){return(n-t)/Ay})}function Qr(t,n){if((e=(t=n?t.toExponential(n-1):t.toExponential()).indexOf("e"))<0)return null;var e,r=t.slice(0,e);return[r.length>1?r[0]+r.slice(2):r,+t.slice(e+1)]}function Kr(t){return t=Qr(Math.abs(t)),t?t[1]:NaN}function ti(t,n){return function(e,r){for(var i=e.length,o=[],u=0,a=t[0],c=0;i>0&&a>0&&(c+a+1>r&&(a=Math.max(1,r-c)),o.push(e.substring(i-=a,i+a)),!((c+=a+1)>r));)a=t[u=(u+1)%t.length];return o.reverse().join(n)}}function ni(t,n){t=t.toPrecision(n);t:for(var e,r=t.length,i=1,o=-1;i<r;++i)switch(t[i]){case".":o=e=i;break;case"0":0===o&&(o=i),e=i;break;case"e":break t;default:o>0&&(o=0)}return o>0?t.slice(0,o)+t.slice(e+1):t}function ei(t,n){var e=Qr(t,n);if(!e)return t+"";var r=e[0],i=e[1],o=i-(Tg=3*Math.max(-8,Math.min(8,Math.floor(i/3))))+1,u=r.length;return o===u?r:o>u?r+new Array(o-u+1).join("0"):o>0?r.slice(0,o)+"."+r.slice(o):"0."+new Array(1-o).join("0")+Qr(t,Math.max(0,n+o-1))[0]}function ri(t,n){var e=Qr(t,n);if(!e)return t+"";var r=e[0],i=e[1];return i<0?"0."+new Array((-i)).join("0")+r:r.length>i+1?r.slice(0,i+1)+"."+r.slice(i+1):r+new Array(i-r.length+2).join("0")}function ii(t){return new oi(t)}function oi(t){if(!(n=Sg.exec(t)))throw new Error("invalid format: "+t);var n,e=n[1]||" ",r=n[2]||">",i=n[3]||"-",o=n[4]||"",u=!!n[5],a=n[6]&&+n[6],c=!!n[7],s=n[8]&&+n[8].slice(1),f=n[9]||"";"n"===f?(c=!0,f="g"):Ng[f]||(f=""),(u||"0"===e&&"="===r)&&(u=!0,e="0",r="="),this.fill=e,this.align=r,this.sign=i,this.symbol=o,this.zero=u,this.width=a,this.comma=c,this.precision=s,this.type=f}function ui(t){return t}function ai(t){function n(t){function n(t){var n,i,c,g=d,m=v;if("c"===p)m=_(t)+m,t="";else{t=+t;var x=(t<0||1/t<0)&&(t*=-1,!0);if(t=_(t,h),x)for(n=-1,i=t.length,x=!1;++n<i;)if(c=t.charCodeAt(n),48<c&&c<58||"x"===p&&96<c&&c<103||"X"===p&&64<c&&c<71){x=!0;break}if(g=(x?"("===a?a:"-":"-"===a||"("===a?"":a)+g,m=m+("s"===p?Eg[8+Tg/3]:"")+(x&&"("===a?")":""),y)for(n=-1,i=t.length;++n<i;)if(c=t.charCodeAt(n),48>c||c>57){m=(46===c?o+t.slice(n+1):t.slice(n))+m,t=t.slice(0,n);break}}l&&!s&&(t=r(t,1/0));var b=g.length+t.length+m.length,w=b<f?new Array(f-b+1).join(e):"";switch(l&&s&&(t=r(w+t,w.length?f-m.length:1/0),w=""),u){case"<":return g+t+m+w;case"=":return g+w+t+m;case"^":return w.slice(0,b=w.length>>1)+g+t+m+w.slice(b)}return w+g+t+m}t=ii(t);var e=t.fill,u=t.align,a=t.sign,c=t.symbol,s=t.zero,f=t.width,l=t.comma,h=t.precision,p=t.type,d="$"===c?i[0]:"#"===c&&/[boxX]/.test(p)?"0"+p.toLowerCase():"",v="$"===c?i[1]:/[%p]/.test(p)?"%":"",_=Ng[p],y=!p||/[defgprs%]/.test(p);return h=null==h?p?6:12:/[gprs]/.test(p)?Math.max(1,Math.min(21,h)):Math.max(0,Math.min(20,h)),n.toString=function(){return t+""},n}function e(t,e){var r=n((t=ii(t),t.type="f",t)),i=3*Math.max(-8,Math.min(8,Math.floor(Kr(e)/3))),o=Math.pow(10,-i),u=Eg[8+i/3];return function(t){return r(o*t)+u}}var r=t.grouping&&t.thousands?ti(t.grouping,t.thousands):ui,i=t.currency,o=t.decimal;return{format:n,formatPrefix:e}}function ci(n){return Ag=ai(n),t.format=Ag.format,t.formatPrefix=Ag.formatPrefix,Ag}function si(t){return Math.max(0,-Kr(Math.abs(t)))}function fi(t,n){return Math.max(0,3*Math.max(-8,Math.min(8,Math.floor(Kr(n)/3)))-Kr(Math.abs(t)))}function li(t,n){return t=Math.abs(t),n=Math.abs(n)-t,Math.max(0,Kr(n)-Kr(t))+1}function hi(t){if(0<=t.y&&t.y<100){var n=new Date((-1),t.m,t.d,t.H,t.M,t.S,t.L);return n.setFullYear(t.y),n}return new Date(t.y,t.m,t.d,t.H,t.M,t.S,t.L)}function pi(t){if(0<=t.y&&t.y<100){var n=new Date(Date.UTC(-1,t.m,t.d,t.H,t.M,t.S,t.L));return n.setUTCFullYear(t.y),n}return new Date(Date.UTC(t.y,t.m,t.d,t.H,t.M,t.S,t.L))}function di(t){return{y:t,m:0,d:1,H:0,M:0,S:0,L:0}}function vi(t){function n(t,n){return function(e){var r,i,o,u=[],a=-1,c=0,s=t.length;for(e instanceof Date||(e=new Date((+e)));++a<s;)37===t.charCodeAt(a)&&(u.push(t.slice(c,a)),null!=(i=zg[r=t.charAt(++a)])?r=t.charAt(++a):i="e"===r?" ":"0",(o=n[r])&&(r=o(e,i)),u.push(r),c=a+1);return u.push(t.slice(c,a)),u.join("")}}function e(t,n){return function(e){var i=di(1900),o=r(i,t,e+="",0);if(o!=e.length)return null;if("p"in i&&(i.H=i.H%12+12*i.p),"W"in i||"U"in i){"w"in i||(i.w="W"in i?1:0);var u="Z"in i?pi(di(i.y)).getUTCDay():n(di(i.y)).getDay();i.m=0,i.d="W"in i?(i.w+6)%7+7*i.W-(u+5)%7:i.w+7*i.U-(u+6)%7}return"Z"in i?(i.H+=i.Z/100|0,i.M+=i.Z%100,pi(i)):n(i)}}function r(t,n,e,r){for(var i,o,u=0,a=n.length,c=e.length;u<a;){if(r>=c)return-1;if(i=n.charCodeAt(u++),37===i){if(i=n.charAt(u++),o=B[i in zg?n.charAt(u++):i],!o||(r=o(t,e,r))<0)return-1}else if(i!=e.charCodeAt(r++))return-1}return r}function i(t,n,e){var r=C.exec(n.slice(e));return r?(t.p=z[r[0].toLowerCase()],e+r[0].length):-1}function o(t,n,e){var r=L.exec(n.slice(e));return r?(t.w=R[r[0].toLowerCase()],e+r[0].length):-1}function u(t,n,e){var r=P.exec(n.slice(e));return r?(t.w=q[r[0].toLowerCase()],e+r[0].length):-1}function a(t,n,e){var r=O.exec(n.slice(e));return r?(t.m=F[r[0].toLowerCase()],e+r[0].length):-1}function c(t,n,e){var r=U.exec(n.slice(e));return r?(t.m=D[r[0].toLowerCase()],e+r[0].length):-1}function s(t,n,e){return r(t,w,n,e)}function f(t,n,e){return r(t,M,n,e)}function l(t,n,e){return r(t,T,n,e)}function h(t){return S[t.getDay()]}function p(t){return N[t.getDay()]}function d(t){return E[t.getMonth()]}function v(t){return A[t.getMonth()]}function _(t){return k[+(t.getHours()>=12)]}function y(t){return S[t.getUTCDay()]}function g(t){return N[t.getUTCDay()]}function m(t){return E[t.getUTCMonth()]}function x(t){return A[t.getUTCMonth()]}function b(t){return k[+(t.getUTCHours()>=12)]}var w=t.dateTime,M=t.date,T=t.time,k=t.periods,N=t.days,S=t.shortDays,A=t.months,E=t.shortMonths,C=gi(k),z=mi(k),P=gi(N),q=mi(N),L=gi(S),R=mi(S),U=gi(A),D=mi(A),O=gi(E),F=mi(E),I={a:h,A:p,b:d,B:v,c:null,d:Li,e:Li,H:Ri,I:Ui,j:Di,L:Oi,m:Fi,M:Ii,p:_,S:Yi,U:Bi,w:ji,W:Hi,x:null,X:null,y:Xi,Y:Vi,Z:Wi,"%":co},Y={a:y,A:g,b:m,B:x,c:null,d:$i,e:$i,H:Zi,I:Gi,j:Ji,L:Qi,m:Ki,M:to,p:b,S:no,U:eo,w:ro,W:io,x:null,X:null,y:oo,Y:uo,Z:ao,"%":co},B={a:o,A:u,b:a,B:c,c:s,d:Si,e:Si,H:Ei,I:Ei,j:Ai,L:Pi,m:Ni,M:Ci,p:i,S:zi,U:bi,w:xi,W:wi,x:f,X:l,y:Ti,Y:Mi,Z:ki,"%":qi};return I.x=n(M,I),I.X=n(T,I),I.c=n(w,I),Y.x=n(M,Y),Y.X=n(T,Y),Y.c=n(w,Y),{format:function(t){var e=n(t+="",I);return e.toString=function(){return t},e},parse:function(t){var n=e(t+="",hi);return n.toString=function(){return t},n},utcFormat:function(t){var e=n(t+="",Y);return e.toString=function(){return t},e},utcParse:function(t){var n=e(t,pi);return n.toString=function(){return t},n}}}function _i(t,n,e){var r=t<0?"-":"",i=(r?-t:t)+"",o=i.length;return r+(o<e?new Array(e-o+1).join(n)+i:i)}function yi(t){return t.replace(Lg,"\\$&")}function gi(t){return new RegExp("^(?:"+t.map(yi).join("|")+")","i")}function mi(t){for(var n={},e=-1,r=t.length;++e<r;)n[t[e].toLowerCase()]=e;return n}function xi(t,n,e){var r=Pg.exec(n.slice(e,e+1));return r?(t.w=+r[0],e+r[0].length):-1}function bi(t,n,e){var r=Pg.exec(n.slice(e));return r?(t.U=+r[0],e+r[0].length):-1}function wi(t,n,e){var r=Pg.exec(n.slice(e));return r?(t.W=+r[0],e+r[0].length):-1}function Mi(t,n,e){var r=Pg.exec(n.slice(e,e+4));return r?(t.y=+r[0],e+r[0].length):-1}function Ti(t,n,e){var r=Pg.exec(n.slice(e,e+2));return r?(t.y=+r[0]+(+r[0]>68?1900:2e3),e+r[0].length):-1}function ki(t,n,e){var r=/^(Z)|([+-]\d\d)(?:\:?(\d\d))?/.exec(n.slice(e,e+6));return r?(t.Z=r[1]?0:-(r[2]+(r[3]||"00")),e+r[0].length):-1}function Ni(t,n,e){var r=Pg.exec(n.slice(e,e+2));return r?(t.m=r[0]-1,e+r[0].length):-1}function Si(t,n,e){var r=Pg.exec(n.slice(e,e+2));return r?(t.d=+r[0],e+r[0].length):-1}function Ai(t,n,e){var r=Pg.exec(n.slice(e,e+3));return r?(t.m=0,t.d=+r[0],e+r[0].length):-1}function Ei(t,n,e){var r=Pg.exec(n.slice(e,e+2));return r?(t.H=+r[0],e+r[0].length):-1}function Ci(t,n,e){var r=Pg.exec(n.slice(e,e+2));return r?(t.M=+r[0],e+r[0].length):-1}function zi(t,n,e){var r=Pg.exec(n.slice(e,e+2));return r?(t.S=+r[0],e+r[0].length):-1}function Pi(t,n,e){var r=Pg.exec(n.slice(e,e+3));return r?(t.L=+r[0],e+r[0].length):-1}function qi(t,n,e){var r=qg.exec(n.slice(e,e+1));return r?e+r[0].length:-1}function Li(t,n){return _i(t.getDate(),n,2)}function Ri(t,n){return _i(t.getHours(),n,2)}function Ui(t,n){return _i(t.getHours()%12||12,n,2)}function Di(t,n){return _i(1+Ry.count(Ky(t),t),n,3)}function Oi(t,n){return _i(t.getMilliseconds(),n,3)}function Fi(t,n){return _i(t.getMonth()+1,n,2)}function Ii(t,n){return _i(t.getMinutes(),n,2)}function Yi(t,n){return _i(t.getSeconds(),n,2)}function Bi(t,n){return _i(Dy.count(Ky(t),t),n,2)}function ji(t){return t.getDay()}function Hi(t,n){return _i(Oy.count(Ky(t),t),n,2)}function Xi(t,n){return _i(t.getFullYear()%100,n,2)}function Vi(t,n){return _i(t.getFullYear()%1e4,n,4)}function Wi(t){var n=t.getTimezoneOffset();return(n>0?"-":(n*=-1,"+"))+_i(n/60|0,"0",2)+_i(n%60,"0",2)}function $i(t,n){return _i(t.getUTCDate(),n,2)}function Zi(t,n){return _i(t.getUTCHours(),n,2)}function Gi(t,n){return _i(t.getUTCHours()%12||12,n,2)}function Ji(t,n){return _i(1+og.count(Mg(t),t),n,3)}function Qi(t,n){return _i(t.getUTCMilliseconds(),n,3)}function Ki(t,n){return _i(t.getUTCMonth()+1,n,2)}function to(t,n){return _i(t.getUTCMinutes(),n,2)}function no(t,n){return _i(t.getUTCSeconds(),n,2)}function eo(t,n){return _i(ag.count(Mg(t),t),n,2)}function ro(t){return t.getUTCDay()}function io(t,n){return _i(cg.count(Mg(t),t),n,2)}function oo(t,n){return _i(t.getUTCFullYear()%100,n,2)}function uo(t,n){return _i(t.getUTCFullYear()%1e4,n,4)}function ao(){return"+0000"}function co(){return"%"}function so(n){return Cg=vi(n),t.timeFormat=Cg.format,t.timeParse=Cg.parse,t.utcFormat=Cg.utcFormat,t.utcParse=Cg.utcParse,Cg}function fo(t){return t.toISOString()}function lo(t){var n=new Date(t);return isNaN(n)?null:n}function ho(t){function n(n){var o=n+"",u=e.get(o);if(!u){if(i!==Yg)return i;e.set(o,u=r.push(n))}return t[(u-1)%t.length]}var e=q(),r=[],i=Yg;return t=null==t?[]:Ig.call(t),n.domain=function(t){if(!arguments.length)return r.slice();r=[],e=q();for(var i,o,u=-1,a=t.length;++u<a;)e.has(o=(i=t[u])+"")||e.set(o,r.push(i));return n},n.range=function(e){return arguments.length?(t=Ig.call(e),n):t.slice()},n.unknown=function(t){return arguments.length?(i=t,n):i},n.copy=function(){return ho().domain(r).range(t).unknown(i)},n}function po(){function t(){var t=i().length,r=u[1]<u[0],h=u[r-0],p=u[1-r];n=(p-h)/Math.max(1,t-c+2*s),a&&(n=Math.floor(n)),h+=(p-h-n*(t-c))*f,e=n*(1-c),a&&(h=Math.round(h),e=Math.round(e));var d=l(t).map(function(t){return h+n*t});return o(r?d.reverse():d)}var n,e,r=ho().unknown(void 0),i=r.domain,o=r.range,u=[0,1],a=!1,c=0,s=0,f=.5;return delete r.unknown,r.domain=function(n){return arguments.length?(i(n),t()):i()},r.range=function(n){return arguments.length?(u=[+n[0],+n[1]],t()):u.slice()},r.rangeRound=function(n){return u=[+n[0],+n[1]],a=!0,t()},r.bandwidth=function(){return e},r.step=function(){return n},r.round=function(n){return arguments.length?(a=!!n,t()):a},r.padding=function(n){return arguments.length?(c=s=Math.max(0,Math.min(1,n)),t()):c},r.paddingInner=function(n){return arguments.length?(c=Math.max(0,Math.min(1,n)),t()):c},r.paddingOuter=function(n){return arguments.length?(s=Math.max(0,Math.min(1,n)),t()):s},r.align=function(n){return arguments.length?(f=Math.max(0,Math.min(1,n)),t()):f},r.copy=function(){return po().domain(i()).range(u).round(a).paddingInner(c).paddingOuter(s).align(f)},t()}function vo(t){var n=t.copy;return t.padding=t.paddingOuter,delete t.paddingInner,delete t.paddingOuter,t.copy=function(){return vo(n())},t}function _o(){return vo(po().paddingInner(1))}function yo(t){return function(){return t}}function go(t){return+t}function mo(t,n){return(n-=t=+t)?function(e){return(e-t)/n}:yo(n)}function xo(t){return function(n,e){var r=t(n=+n,e=+e);return function(t){return t<=n?0:t>=e?1:r(t)}}}function bo(t){return function(n,e){var r=t(n=+n,e=+e);return function(t){return t<=0?n:t>=1?e:r(t)}}}function wo(t,n,e,r){var i=t[0],o=t[1],u=n[0],a=n[1];return o<i?(i=e(o,i),u=r(a,u)):(i=e(i,o),u=r(u,a)),function(t){return u(i(t))}}function Mo(t,n,e,r){var i=Math.min(t.length,n.length)-1,o=new Array(i),u=new Array(i),a=-1;for(t[i]<t[0]&&(t=t.slice().reverse(),n=n.slice().reverse());++a<i;)o[a]=e(t[a],t[a+1]),u[a]=r(n[a],n[a+1]);return function(n){var e=Sd(t,n,1,i)-1;return u[e](o[e](n))}}function To(t,n){return n.domain(t.domain()).range(t.range()).interpolate(t.interpolate()).clamp(t.clamp())}function ko(t,n){function e(){return i=Math.min(a.length,c.length)>2?Mo:wo,o=u=null,r}function r(n){return(o||(o=i(a,c,f?xo(t):t,s)))(+n)}var i,o,u,a=Bg,c=Bg,s=cr,f=!1;return r.invert=function(t){return(u||(u=i(c,a,mo,f?bo(n):n)))(+t)},r.domain=function(t){return arguments.length?(a=Fg.call(t,go),e()):a.slice()},r.range=function(t){return arguments.length?(c=Ig.call(t),e()):c.slice()},r.rangeRound=function(t){return c=Ig.call(t),s=sr,e()},r.clamp=function(t){return arguments.length?(f=!!t,e()):f},r.interpolate=function(t){return arguments.length?(s=t,e()):s},e()}function No(n,e,r){var i,o=n[0],u=n[n.length-1],a=p(o,u,null==e?10:e);switch(r=ii(null==r?",f":r),r.type){case"s":var c=Math.max(Math.abs(o),Math.abs(u));return null!=r.precision||isNaN(i=fi(a,c))||(r.precision=i),t.formatPrefix(r,c);case"":case"e":case"g":case"p":case"r":null!=r.precision||isNaN(i=li(a,Math.max(Math.abs(o),Math.abs(u))))||(r.precision=i-("e"===r.type));break;case"f":case"%":null!=r.precision||isNaN(i=si(a))||(r.precision=i-2*("%"===r.type))}return t.format(r)}function So(t){var n=t.domain;return t.ticks=function(t){var e=n();return h(e[0],e[e.length-1],null==t?10:t)},t.tickFormat=function(t,e){return No(n(),t,e)},t.nice=function(e){var r=n(),i=r.length-1,o=null==e?10:e,u=r[0],a=r[i],c=p(u,a,o);return c&&(c=p(Math.floor(u/c)*c,Math.ceil(a/c)*c,o),r[0]=Math.floor(u/c)*c,r[i]=Math.ceil(a/c)*c,n(r)),t},t}function Ao(){var t=ko(mo,rr);return t.copy=function(){return To(t,Ao())},So(t)}function Eo(){function t(t){return+t}var n=[0,1];return t.invert=t,t.domain=t.range=function(e){return arguments.length?(n=Fg.call(e,go),t):n.slice()},t.copy=function(){return Eo().domain(n)},So(t)}function Co(t,n){t=t.slice();var e,r=0,i=t.length-1,o=t[r],u=t[i];return u<o&&(e=r,r=i,i=e,e=o,o=u,u=e),t[r]=n.floor(o),t[i]=n.ceil(u),t}function zo(t,n){return(n=Math.log(n/t))?function(e){return Math.log(e/t)/n}:yo(n)}function Po(t,n){return t<0?function(e){return-Math.pow(-n,e)*Math.pow(-t,1-e)}:function(e){return Math.pow(n,e)*Math.pow(t,1-e)}}function qo(t){return isFinite(t)?+("1e"+t):t<0?0:t}function Lo(t){return 10===t?qo:t===Math.E?Math.exp:function(n){return Math.pow(t,n)}}function Ro(t){return t===Math.E?Math.log:10===t&&Math.log10||2===t&&Math.log2||(t=Math.log(t),function(n){return Math.log(n)/t})}function Uo(t){return function(n){return-t(-n)}}function Do(){function n(){return o=Ro(i),u=Lo(i),r()[0]<0&&(o=Uo(o),u=Uo(u)),e}var e=ko(zo,Po).domain([1,10]),r=e.domain,i=10,o=Ro(10),u=Lo(10);return e.base=function(t){return arguments.length?(i=+t,n()):i},e.domain=function(t){return arguments.length?(r(t),n()):r()},e.ticks=function(t){var n,e=r(),a=e[0],c=e[e.length-1];(n=c<a)&&(p=a,a=c,c=p);var s,f,l,p=o(a),d=o(c),v=null==t?10:+t,_=[];if(!(i%1)&&d-p<v){if(p=Math.round(p)-1,d=Math.round(d)+1,a>0){for(;p<d;++p)for(f=1,s=u(p);f<i;++f)if(l=s*f,!(l<a)){if(l>c)break;_.push(l)}}else for(;p<d;++p)for(f=i-1,s=u(p);f>=1;--f)if(l=s*f,!(l<a)){if(l>c)break;_.push(l)}}else _=h(p,d,Math.min(d-p,v)).map(u);return n?_.reverse():_},e.tickFormat=function(n,r){if(null==r&&(r=10===i?".0e":","),"function"!=typeof r&&(r=t.format(r)),n===1/0)return r;null==n&&(n=10);var a=Math.max(1,i*n/e.ticks().length);return function(t){var n=t/u(Math.round(o(t)));return n*i<i-.5&&(n*=i),n<=a?r(t):""}},e.nice=function(){return r(Co(r(),{floor:function(t){return u(Math.floor(o(t)))},ceil:function(t){return u(Math.ceil(o(t)))}}))},e.copy=function(){return To(e,Do().base(i))},e}function Oo(t,n){return t<0?-Math.pow(-t,n):Math.pow(t,n)}function Fo(){function t(t,n){return(n=Oo(n,e)-(t=Oo(t,e)))?function(r){return(Oo(r,e)-t)/n}:yo(n)}function n(t,n){return n=Oo(n,e)-(t=Oo(t,e)),function(r){return Oo(t+n*r,1/e)}}var e=1,r=ko(t,n),i=r.domain;return r.exponent=function(t){return arguments.length?(e=+t,i(i())):e},r.copy=function(){return To(r,Fo().exponent(e))},So(r)}function Io(){return Fo().exponent(.5)}function Yo(){function t(){var t=0,n=Math.max(1,i.length);for(o=new Array(n-1);++t<n;)o[t-1]=_(r,t/n);return e}function e(t){if(!isNaN(t=+t))return i[Sd(o,t)]}var r=[],i=[],o=[];return e.invertExtent=function(t){var n=i.indexOf(t);return n<0?[NaN,NaN]:[n>0?o[n-1]:r[0],n<o.length?o[n]:r[r.length-1]]},e.domain=function(e){if(!arguments.length)return r.slice();r=[];for(var i,o=0,u=e.length;o<u;++o)i=e[o],null==i||isNaN(i=+i)||r.push(i);return r.sort(n),t()},e.range=function(n){return arguments.length?(i=Ig.call(n),t()):i.slice()},e.quantiles=function(){return o.slice()},e.copy=function(){return Yo().domain(r).range(i)},e}function Bo(){function t(t){if(t<=t)return u[Sd(o,t,0,i)]}function n(){var n=-1;for(o=new Array(i);++n<i;)o[n]=((n+1)*r-(n-i)*e)/(i+1);return t}var e=0,r=1,i=1,o=[.5],u=[0,1];return t.domain=function(t){return arguments.length?(e=+t[0],r=+t[1],n()):[e,r]},t.range=function(t){return arguments.length?(i=(u=Ig.call(t)).length-1,n()):u.slice()},t.invertExtent=function(t){var n=u.indexOf(t);return n<0?[NaN,NaN]:n<1?[e,o[0]]:n>=i?[o[i-1],r]:[o[n-1],o[n]]},t.copy=function(){return Bo().domain([e,r]).range(u)},So(t)}function jo(){function t(t){if(t<=t)return e[Sd(n,t,0,r)]}var n=[.5],e=[0,1],r=1;return t.domain=function(i){return arguments.length?(n=Ig.call(i),r=Math.min(n.length,e.length-1),t):n.slice()},t.range=function(i){return arguments.length?(e=Ig.call(i),r=Math.min(n.length,e.length-1),t):e.slice()},t.invertExtent=function(t){var r=e.indexOf(t);return[n[r-1],n[r]]},t.copy=function(){return jo().domain(n).range(e)},t}function Ho(t){return new Date(t)}function Xo(t){return t instanceof Date?+t:+new Date((+t))}function Vo(t,n,r,i,o,u,a,c,s){function f(e){return(a(e)<e?_:u(e)<e?y:o(e)<e?g:i(e)<e?m:n(e)<e?r(e)<e?x:b:t(e)<e?w:M)(e)}function l(n,r,i,o){if(null==n&&(n=10),"number"==typeof n){var u=Math.abs(i-r)/n,a=e(function(t){return t[2]}).right(T,u);a===T.length?(o=p(r/Zg,i/Zg,n),n=t):a?(a=T[u/T[a-1][2]<T[a][2]/u?a-1:a],o=a[1],n=a[0]):(o=p(r,i,n),n=c)}return null==o?n:n.every(o)}var h=ko(mo,rr),d=h.invert,v=h.domain,_=s(".%L"),y=s(":%S"),g=s("%I:%M"),m=s("%I %p"),x=s("%a %d"),b=s("%b %d"),w=s("%B"),M=s("%Y"),T=[[a,1,jg],[a,5,5*jg],[a,15,15*jg],[a,30,30*jg],[u,1,Hg],[u,5,5*Hg],[u,15,15*Hg],[u,30,30*Hg],[o,1,Xg],[o,3,3*Xg],[o,6,6*Xg],[o,12,12*Xg],[i,1,Vg],[i,2,2*Vg],[r,1,Wg],[n,1,$g],[n,3,3*$g],[t,1,Zg]];return h.invert=function(t){return new Date(d(t))},h.domain=function(t){return arguments.length?v(Fg.call(t,Xo)):v().map(Ho)},h.ticks=function(t,n){var e,r=v(),i=r[0],o=r[r.length-1],u=o<i;return u&&(e=i,i=o,o=e),e=l(t,i,o,n),e=e?e.range(i,o+1):[],u?e.reverse():e},h.tickFormat=function(t,n){return null==n?f:s(n)},h.nice=function(t,n){var e=v();return(t=l(t,e[0],e[e.length-1],n))?v(Co(e,t)):h},h.copy=function(){return To(h,Vo(t,n,r,i,o,u,a,c,s))},h}function Wo(){return Vo(Ky,Jy,Dy,Ry,qy,zy,Ey,wy,t.timeFormat).domain([new Date(2e3,0,1),new Date(2e3,0,2)])}function $o(){return Vo(Mg,bg,ag,og,rg,ng,Ey,wy,t.utcFormat).domain([Date.UTC(2e3,0,1),Date.UTC(2e3,0,2)])}function Zo(t){return t.match(/.{6}/g).map(function(t){return"#"+t})}function Go(t){(t<0||t>1)&&(t-=Math.floor(t));var n=Math.abs(t-.5);return rm.h=360*t-100,rm.s=1.5-1.5*n,rm.l=.8-.9*n,rm+""}function Jo(t){var n=t.length;return function(e){return t[Math.max(0,Math.min(n-1,Math.floor(e*n)))]}}function Qo(t){function n(n){var o=(n-e)/(r-e);return t(i?Math.max(0,Math.min(1,o)):o)}var e=0,r=1,i=!1;return n.domain=function(t){return arguments.length?(e=+t[0],r=+t[1],n):[e,r]},n.clamp=function(t){return arguments.length?(i=!!t,n):i},n.interpolator=function(e){return arguments.length?(t=e,n):t},n.copy=function(){return Qo(t).domain([e,r]).clamp(i)},So(n)}function Ko(t){var n=t+="",e=n.indexOf(":");return e>=0&&"xmlns"!==(n=t.slice(0,e))&&(t=t.slice(e+1)),sm.hasOwnProperty(n)?{space:sm[n],local:t}:t}function tu(t){return function(){var n=this.ownerDocument,e=this.namespaceURI;return e===cm&&n.documentElement.namespaceURI===cm?n.createElement(t):n.createElementNS(e,t)}}function nu(t){return function(){return this.ownerDocument.createElementNS(t.space,t.local)}}function eu(t){var n=Ko(t);return(n.local?nu:tu)(n)}function ru(){return new iu}function iu(){this._="@"+(++fm).toString(36)}function ou(t,n,e){return t=uu(t,n,e),function(n){var e=n.relatedTarget;e&&(e===this||8&e.compareDocumentPosition(this))||t.call(this,n)}}function uu(n,e,r){return function(i){var o=t.event;t.event=i;try{n.call(this,this.__data__,e,r)}finally{t.event=o}}}function au(t){return t.trim().split(/^|\s+/).map(function(t){var n="",e=t.indexOf(".");return e>=0&&(n=t.slice(e+1),
 t=t.slice(0,e)),{type:t,name:n}})}function cu(t){return function(){var n=this.__on;if(n){for(var e,r=0,i=-1,o=n.length;r<o;++r)e=n[r],t.type&&e.type!==t.type||e.name!==t.name?n[++i]=e:this.removeEventListener(e.type,e.listener,e.capture);++i?n.length=i:delete this.__on}}}function su(t,n,e){var r=vm.hasOwnProperty(t.type)?ou:uu;return function(i,o,u){var a,c=this.__on,s=r(n,o,u);if(c)for(var f=0,l=c.length;f<l;++f)if((a=c[f]).type===t.type&&a.name===t.name)return this.removeEventListener(a.type,a.listener,a.capture),this.addEventListener(a.type,a.listener=s,a.capture=e),void(a.value=n);this.addEventListener(t.type,s,e),a={type:t.type,name:t.name,value:n,listener:s,capture:e},c?c.push(a):this.__on=[a]}}function fu(t,n,e){var r,i,o=au(t+""),u=o.length;{if(!(arguments.length<2)){for(a=n?su:cu,null==e&&(e=!1),r=0;r<u;++r)this.each(a(o[r],n,e));return this}var a=this.node().__on;if(a)for(var c,s=0,f=a.length;s<f;++s)for(r=0,c=a[s];r<u;++r)if((i=o[r]).type===c.type&&i.name===c.name)return c.value}}function lu(n,e,r,i){var o=t.event;n.sourceEvent=t.event,t.event=n;try{return e.apply(r,i)}finally{t.event=o}}function hu(){for(var n,e=t.event;n=e.sourceEvent;)e=n;return e}function pu(t,n){var e=t.ownerSVGElement||t;if(e.createSVGPoint){var r=e.createSVGPoint();return r.x=n.clientX,r.y=n.clientY,r=r.matrixTransform(t.getScreenCTM().inverse()),[r.x,r.y]}var i=t.getBoundingClientRect();return[n.clientX-i.left-t.clientLeft,n.clientY-i.top-t.clientTop]}function du(t){var n=hu();return n.changedTouches&&(n=n.changedTouches[0]),pu(t,n)}function vu(){}function _u(t){return null==t?vu:function(){return this.querySelector(t)}}function yu(t){"function"!=typeof t&&(t=_u(t));for(var n=this._groups,e=n.length,r=new Array(e),i=0;i<e;++i)for(var o,u,a=n[i],c=a.length,s=r[i]=new Array(c),f=0;f<c;++f)(o=a[f])&&(u=t.call(o,o.__data__,f,a))&&("__data__"in o&&(u.__data__=o.__data__),s[f]=u);return new qa(r,this._parents)}function gu(){return[]}function mu(t){return null==t?gu:function(){return this.querySelectorAll(t)}}function xu(t){"function"!=typeof t&&(t=mu(t));for(var n=this._groups,e=n.length,r=[],i=[],o=0;o<e;++o)for(var u,a=n[o],c=a.length,s=0;s<c;++s)(u=a[s])&&(r.push(t.call(u,u.__data__,s,a)),i.push(u));return new qa(r,i)}function bu(t){"function"!=typeof t&&(t=dm(t));for(var n=this._groups,e=n.length,r=new Array(e),i=0;i<e;++i)for(var o,u=n[i],a=u.length,c=r[i]=[],s=0;s<a;++s)(o=u[s])&&t.call(o,o.__data__,s,u)&&c.push(o);return new qa(r,this._parents)}function wu(t){return new Array(t.length)}function Mu(){return new qa(this._enter||this._groups.map(wu),this._parents)}function Tu(t,n){this.ownerDocument=t.ownerDocument,this.namespaceURI=t.namespaceURI,this._next=null,this._parent=t,this.__data__=n}function ku(t){return function(){return t}}function Nu(t,n,e,r,i,o){for(var u,a=0,c=n.length,s=o.length;a<s;++a)(u=n[a])?(u.__data__=o[a],r[a]=u):e[a]=new Tu(t,o[a]);for(;a<c;++a)(u=n[a])&&(i[a]=u)}function Su(t,n,e,r,i,o,u){var a,c,s,f={},l=n.length,h=o.length,p=new Array(l);for(a=0;a<l;++a)(c=n[a])&&(p[a]=s=ym+u.call(c,c.__data__,a,n),s in f?i[a]=c:f[s]=c);for(a=0;a<h;++a)s=ym+u.call(t,o[a],a,o),(c=f[s])?(r[a]=c,c.__data__=o[a],f[s]=null):e[a]=new Tu(t,o[a]);for(a=0;a<l;++a)(c=n[a])&&f[p[a]]===c&&(i[a]=c)}function Au(t,n){if(!t)return p=new Array(this.size()),s=-1,this.each(function(t){p[++s]=t}),p;var e=n?Su:Nu,r=this._parents,i=this._groups;"function"!=typeof t&&(t=ku(t));for(var o=i.length,u=new Array(o),a=new Array(o),c=new Array(o),s=0;s<o;++s){var f=r[s],l=i[s],h=l.length,p=t.call(f,f&&f.__data__,s,r),d=p.length,v=a[s]=new Array(d),_=u[s]=new Array(d),y=c[s]=new Array(h);e(f,l,v,_,y,p,n);for(var g,m,x=0,b=0;x<d;++x)if(g=v[x]){for(x>=b&&(b=x+1);!(m=_[b])&&++b<d;);g._next=m||null}}return u=new qa(u,r),u._enter=a,u._exit=c,u}function Eu(){return new qa(this._exit||this._groups.map(wu),this._parents)}function Cu(t){for(var n=this._groups,e=t._groups,r=n.length,i=e.length,o=Math.min(r,i),u=new Array(r),a=0;a<o;++a)for(var c,s=n[a],f=e[a],l=s.length,h=u[a]=new Array(l),p=0;p<l;++p)(c=s[p]||f[p])&&(h[p]=c);for(;a<r;++a)u[a]=n[a];return new qa(u,this._parents)}function zu(){for(var t=this._groups,n=-1,e=t.length;++n<e;)for(var r,i=t[n],o=i.length-1,u=i[o];--o>=0;)(r=i[o])&&(u&&u!==r.nextSibling&&u.parentNode.insertBefore(r,u),u=r);return this}function Pu(t){function n(n,e){return n&&e?t(n.__data__,e.__data__):!n-!e}t||(t=qu);for(var e=this._groups,r=e.length,i=new Array(r),o=0;o<r;++o){for(var u,a=e[o],c=a.length,s=i[o]=new Array(c),f=0;f<c;++f)(u=a[f])&&(s[f]=u);s.sort(n)}return new qa(i,this._parents).order()}function qu(t,n){return t<n?-1:t>n?1:t>=n?0:NaN}function Lu(){var t=arguments[0];return arguments[0]=this,t.apply(null,arguments),this}function Ru(){var t=new Array(this.size()),n=-1;return this.each(function(){t[++n]=this}),t}function Uu(){for(var t=this._groups,n=0,e=t.length;n<e;++n)for(var r=t[n],i=0,o=r.length;i<o;++i){var u=r[i];if(u)return u}return null}function Du(){var t=0;return this.each(function(){++t}),t}function Ou(){return!this.node()}function Fu(t){for(var n=this._groups,e=0,r=n.length;e<r;++e)for(var i,o=n[e],u=0,a=o.length;u<a;++u)(i=o[u])&&t.call(i,i.__data__,u,o);return this}function Iu(t){return function(){this.removeAttribute(t)}}function Yu(t){return function(){this.removeAttributeNS(t.space,t.local)}}function Bu(t,n){return function(){this.setAttribute(t,n)}}function ju(t,n){return function(){this.setAttributeNS(t.space,t.local,n)}}function Hu(t,n){return function(){var e=n.apply(this,arguments);null==e?this.removeAttribute(t):this.setAttribute(t,e)}}function Xu(t,n){return function(){var e=n.apply(this,arguments);null==e?this.removeAttributeNS(t.space,t.local):this.setAttributeNS(t.space,t.local,e)}}function Vu(t,n){var e=Ko(t);if(arguments.length<2){var r=this.node();return e.local?r.getAttributeNS(e.space,e.local):r.getAttribute(e)}return this.each((null==n?e.local?Yu:Iu:"function"==typeof n?e.local?Xu:Hu:e.local?ju:Bu)(e,n))}function Wu(t){return t.ownerDocument&&t.ownerDocument.defaultView||t.document&&t||t.defaultView}function $u(t){return function(){this.style.removeProperty(t)}}function Zu(t,n,e){return function(){this.style.setProperty(t,n,e)}}function Gu(t,n,e){return function(){var r=n.apply(this,arguments);null==r?this.style.removeProperty(t):this.style.setProperty(t,r,e)}}function Ju(t,n,e){var r;return arguments.length>1?this.each((null==n?$u:"function"==typeof n?Gu:Zu)(t,n,null==e?"":e)):Wu(r=this.node()).getComputedStyle(r,null).getPropertyValue(t)}function Qu(t){return function(){delete this[t]}}function Ku(t,n){return function(){this[t]=n}}function ta(t,n){return function(){var e=n.apply(this,arguments);null==e?delete this[t]:this[t]=e}}function na(t,n){return arguments.length>1?this.each((null==n?Qu:"function"==typeof n?ta:Ku)(t,n)):this.node()[t]}function ea(t){return t.trim().split(/^|\s+/)}function ra(t){return t.classList||new ia(t)}function ia(t){this._node=t,this._names=ea(t.getAttribute("class")||"")}function oa(t,n){for(var e=ra(t),r=-1,i=n.length;++r<i;)e.add(n[r])}function ua(t,n){for(var e=ra(t),r=-1,i=n.length;++r<i;)e.remove(n[r])}function aa(t){return function(){oa(this,t)}}function ca(t){return function(){ua(this,t)}}function sa(t,n){return function(){(n.apply(this,arguments)?oa:ua)(this,t)}}function fa(t,n){var e=ea(t+"");if(arguments.length<2){for(var r=ra(this.node()),i=-1,o=e.length;++i<o;)if(!r.contains(e[i]))return!1;return!0}return this.each(("function"==typeof n?sa:n?aa:ca)(e,n))}function la(){this.textContent=""}function ha(t){return function(){this.textContent=t}}function pa(t){return function(){var n=t.apply(this,arguments);this.textContent=null==n?"":n}}function da(t){return arguments.length?this.each(null==t?la:("function"==typeof t?pa:ha)(t)):this.node().textContent}function va(){this.innerHTML=""}function _a(t){return function(){this.innerHTML=t}}function ya(t){return function(){var n=t.apply(this,arguments);this.innerHTML=null==n?"":n}}function ga(t){return arguments.length?this.each(null==t?va:("function"==typeof t?ya:_a)(t)):this.node().innerHTML}function ma(){this.nextSibling&&this.parentNode.appendChild(this)}function xa(){return this.each(ma)}function ba(){this.previousSibling&&this.parentNode.insertBefore(this,this.parentNode.firstChild)}function wa(){return this.each(ba)}function Ma(t){var n="function"==typeof t?t:eu(t);return this.select(function(){return this.appendChild(n.apply(this,arguments))})}function Ta(){return null}function ka(t,n){var e="function"==typeof t?t:eu(t),r=null==n?Ta:"function"==typeof n?n:_u(n);return this.select(function(){return this.insertBefore(e.apply(this,arguments),r.apply(this,arguments)||null)})}function Na(){var t=this.parentNode;t&&t.removeChild(this)}function Sa(){return this.each(Na)}function Aa(t){return arguments.length?this.property("__data__",t):this.node().__data__}function Ea(t,n,e){var r=Wu(t),i=r.CustomEvent;i?i=new i(n,e):(i=r.document.createEvent("Event"),e?(i.initEvent(n,e.bubbles,e.cancelable),i.detail=e.detail):i.initEvent(n,!1,!1)),t.dispatchEvent(i)}function Ca(t,n){return function(){return Ea(this,t,n)}}function za(t,n){return function(){return Ea(this,t,n.apply(this,arguments))}}function Pa(t,n){return this.each(("function"==typeof n?za:Ca)(t,n))}function qa(t,n){this._groups=t,this._parents=n}function La(){return new qa([[document.documentElement]],gm)}function Ra(t){return"string"==typeof t?new qa([[document.querySelector(t)]],[document.documentElement]):new qa([[t]],gm)}function Ua(t){return"string"==typeof t?new qa([document.querySelectorAll(t)],[document.documentElement]):new qa([null==t?[]:t],gm)}function Da(t,n,e){arguments.length<3&&(e=n,n=hu().changedTouches);for(var r,i=0,o=n?n.length:0;i<o;++i)if((r=n[i]).identifier===e)return pu(t,r);return null}function Oa(t,n){null==n&&(n=hu().touches);for(var e=0,r=n?n.length:0,i=new Array(r);e<r;++e)i[e]=pu(t,n[e]);return i}function Fa(t,n,e,r,i,o){var u=t.__transition;if(u){if(e in u)return}else t.__transition={};ja(t,e,{name:n,index:r,group:i,on:mm,tween:xm,time:o.time,delay:o.delay,duration:o.duration,ease:o.ease,timer:null,state:bm})}function Ia(t,n){var e=t.__transition;if(!e||!(e=e[n])||e.state>bm)throw new Error("too late");return e}function Ya(t,n){var e=t.__transition;if(!e||!(e=e[n])||e.state>Mm)throw new Error("too late");return e}function Ba(t,n){var e=t.__transition;if(!e||!(e=e[n]))throw new Error("too late");return e}function ja(t,n,e){function r(t){e.state=wm,e.delay<=t?i(t-e.delay):e.timer.restart(i,e.delay,e.time)}function i(r){var i,c,s,f;for(i in a)f=a[i],f.name===e.name&&(f.state===Tm?(f.state=Nm,f.timer.stop(),f.on.call("interrupt",t,t.__data__,f.index,f.group),delete a[i]):+i<n&&(f.state=Nm,f.timer.stop(),delete a[i]));if(Wr(function(){e.state===Tm&&(e.timer.restart(o,e.delay,e.time),o(r))}),e.state=Mm,e.on.call("start",t,t.__data__,e.index,e.group),e.state===Mm){for(e.state=Tm,u=new Array(s=e.tween.length),i=0,c=-1;i<s;++i)(f=e.tween[i].value.call(t,t.__data__,e.index,e.group))&&(u[++c]=f);u.length=c+1}}function o(r){for(var i=r<e.duration?e.ease.call(null,r/e.duration):(e.state=km,1),o=-1,c=u.length;++o<c;)u[o].call(null,i);if(e.state===km){e.state=Nm,e.timer.stop(),e.on.call("end",t,t.__data__,e.index,e.group);for(o in a)if(+o!==n)return void delete a[n];delete t.__transition}}var u,a=t.__transition;a[n]=e,e.timer=Yr(r,0,e.time)}function Ha(t,n){var e,r,i,o=t.__transition,u=!0;if(o){n=null==n?null:n+"";for(i in o)(e=o[i]).name===n?(r=e.state===Tm,e.state=Nm,e.timer.stop(),r&&e.on.call("interrupt",t,t.__data__,e.index,e.group),delete o[i]):u=!1;u&&delete t.__transition}}function Xa(t){return this.each(function(){Ha(this,t)})}function Va(t,n){var e,r;return function(){var i=Ya(this,t),o=i.tween;if(o!==e){r=e=o;for(var u=0,a=r.length;u<a;++u)if(r[u].name===n){r=r.slice(),r.splice(u,1);break}}i.tween=r}}function Wa(t,n,e){var r,i;if("function"!=typeof e)throw new Error;return function(){var o=Ya(this,t),u=o.tween;if(u!==r){i=(r=u).slice();for(var a={name:n,value:e},c=0,s=i.length;c<s;++c)if(i[c].name===n){i[c]=a;break}c===s&&i.push(a)}o.tween=i}}function $a(t,n){var e=this._id;if(t+="",arguments.length<2){for(var r,i=Ba(this.node(),e).tween,o=0,u=i.length;o<u;++o)if((r=i[o]).name===t)return r.value;return null}return this.each((null==n?Va:Wa)(e,t,n))}function Za(t,n,e){var r=t._id;return t.each(function(){var t=Ya(this,r);(t.value||(t.value={}))[n]=e.apply(this,arguments)}),function(t){return Ba(t,r).value[n]}}function Ga(t,n){var e;return("number"==typeof n?rr:n instanceof be?S_:(e=be(n))?(n=e,S_):ar)(t,n)}function Ja(t){return function(){this.removeAttribute(t)}}function Qa(t){return function(){this.removeAttributeNS(t.space,t.local)}}function Ka(t,n,e){var r,i;return function(){var o=this.getAttribute(t);return o===e?null:o===r?i:i=n(r=o,e)}}function tc(t,n,e){var r,i;return function(){var o=this.getAttributeNS(t.space,t.local);return o===e?null:o===r?i:i=n(r=o,e)}}function nc(t,n,e){var r,i,o;return function(){var u,a=e(this);return null==a?void this.removeAttribute(t):(u=this.getAttribute(t),u===a?null:u===r&&a===i?o:o=n(r=u,i=a))}}function ec(t,n,e){var r,i,o;return function(){var u,a=e(this);return null==a?void this.removeAttributeNS(t.space,t.local):(u=this.getAttributeNS(t.space,t.local),u===a?null:u===r&&a===i?o:o=n(r=u,i=a))}}function rc(t,n){var e=Ko(t),r="transform"===e?R_:Ga;return this.attrTween(t,"function"==typeof n?(e.local?ec:nc)(e,r,Za(this,"attr."+t,n)):null==n?(e.local?Qa:Ja)(e):(e.local?tc:Ka)(e,r,n))}function ic(t,n){function e(){var e=this,r=n.apply(e,arguments);return r&&function(n){e.setAttributeNS(t.space,t.local,r(n))}}return e._value=n,e}function oc(t,n){function e(){var e=this,r=n.apply(e,arguments);return r&&function(n){e.setAttribute(t,r(n))}}return e._value=n,e}function uc(t,n){var e="attr."+t;if(arguments.length<2)return(e=this.tween(e))&&e._value;if(null==n)return this.tween(e,null);if("function"!=typeof n)throw new Error;var r=Ko(t);return this.tween(e,(r.local?ic:oc)(r,n))}function ac(t,n){return function(){Ia(this,t).delay=+n.apply(this,arguments)}}function cc(t,n){return n=+n,function(){Ia(this,t).delay=n}}function sc(t){var n=this._id;return arguments.length?this.each(("function"==typeof t?ac:cc)(n,t)):Ba(this.node(),n).delay}function fc(t,n){return function(){Ya(this,t).duration=+n.apply(this,arguments)}}function lc(t,n){return n=+n,function(){Ya(this,t).duration=n}}function hc(t){var n=this._id;return arguments.length?this.each(("function"==typeof t?fc:lc)(n,t)):Ba(this.node(),n).duration}function pc(t,n){if("function"!=typeof n)throw new Error;return function(){Ya(this,t).ease=n}}function dc(t){var n=this._id;return arguments.length?this.each(pc(n,t)):Ba(this.node(),n).ease}function vc(t){"function"!=typeof t&&(t=dm(t));for(var n=this._groups,e=n.length,r=new Array(e),i=0;i<e;++i)for(var o,u=n[i],a=u.length,c=r[i]=[],s=0;s<a;++s)(o=u[s])&&t.call(o,o.__data__,s,u)&&c.push(o);return new Uc(r,this._parents,this._name,this._id)}function _c(t){if(t._id!==this._id)throw new Error;for(var n=this._groups,e=t._groups,r=n.length,i=e.length,o=Math.min(r,i),u=new Array(r),a=0;a<o;++a)for(var c,s=n[a],f=e[a],l=s.length,h=u[a]=new Array(l),p=0;p<l;++p)(c=s[p]||f[p])&&(h[p]=c);for(;a<r;++a)u[a]=n[a];return new Uc(u,this._parents,this._name,this._id)}function yc(t){return(t+"").trim().split(/^|\s+/).every(function(t){var n=t.indexOf(".");return n>=0&&(t=t.slice(0,n)),!t||"start"===t})}function gc(t,n,e){var r,i,o=yc(n)?Ia:Ya;return function(){var u=o(this,t),a=u.on;a!==r&&(i=(r=a).copy()).on(n,e),u.on=i}}function mc(t,n){var e=this._id;return arguments.length<2?Ba(this.node(),e).on.on(t):this.each(gc(e,t,n))}function xc(t){return function(){var n=this.parentNode;for(var e in this.__transition)if(+e!==t)return;n&&n.removeChild(this)}}function bc(){return this.on("end.remove",xc(this._id))}function wc(t){var n=this._name,e=this._id;"function"!=typeof t&&(t=_u(t));for(var r=this._groups,i=r.length,o=new Array(i),u=0;u<i;++u)for(var a,c,s=r[u],f=s.length,l=o[u]=new Array(f),h=0;h<f;++h)(a=s[h])&&(c=t.call(a,a.__data__,h,s))&&("__data__"in a&&(c.__data__=a.__data__),l[h]=c,Fa(l[h],n,e,h,l,Ba(a,e)));return new Uc(o,this._parents,n,e)}function Mc(t){var n=this._name,e=this._id;"function"!=typeof t&&(t=mu(t));for(var r=this._groups,i=r.length,o=[],u=[],a=0;a<i;++a)for(var c,s=r[a],f=s.length,l=0;l<f;++l)if(c=s[l]){for(var h,p=t.call(c,c.__data__,l,s),d=Ba(c,e),v=0,_=p.length;v<_;++v)(h=p[v])&&Fa(h,n,e,v,p,d);o.push(p),u.push(c)}return new Uc(o,u,n,e)}function Tc(){return new Sm(this._groups,this._parents)}function kc(t,n){var e,r,i;return function(){var o=Wu(this).getComputedStyle(this,null),u=o.getPropertyValue(t),a=(this.style.removeProperty(t),o.getPropertyValue(t));return u===a?null:u===e&&a===r?i:i=n(e=u,r=a)}}function Nc(t){return function(){this.style.removeProperty(t)}}function Sc(t,n,e){var r,i;return function(){var o=Wu(this).getComputedStyle(this,null).getPropertyValue(t);return o===e?null:o===r?i:i=n(r=o,e)}}function Ac(t,n,e){var r,i,o;return function(){var u=Wu(this).getComputedStyle(this,null),a=u.getPropertyValue(t),c=e(this);return null==c&&(this.style.removeProperty(t),c=u.getPropertyValue(t)),a===c?null:a===r&&c===i?o:o=n(r=a,i=c)}}function Ec(t,n,e){var r="transform"==(t+="")?L_:Ga;return null==n?this.styleTween(t,kc(t,r)).on("end.style."+t,Nc(t)):this.styleTween(t,"function"==typeof n?Ac(t,r,Za(this,"style."+t,n)):Sc(t,r,n),e)}function Cc(t,n,e){function r(){var r=this,i=n.apply(r,arguments);return i&&function(n){r.style.setProperty(t,i(n),e)}}return r._value=n,r}function zc(t,n,e){var r="style."+(t+="");if(arguments.length<2)return(r=this.tween(r))&&r._value;if(null==n)return this.tween(r,null);if("function"!=typeof n)throw new Error;return this.tween(r,Cc(t,n,null==e?"":e))}function Pc(t){return function(){this.textContent=t}}function qc(t){return function(){var n=t(this);this.textContent=null==n?"":n}}function Lc(t){return this.tween("text","function"==typeof t?qc(Za(this,"text",t)):Pc(null==t?"":t+""))}function Rc(){for(var t=this._name,n=this._id,e=Oc(),r=this._groups,i=r.length,o=0;o<i;++o)for(var u,a=r[o],c=a.length,s=0;s<c;++s)if(u=a[s]){var f=Ba(u,n);Fa(u,t,e,s,a,{time:f.time+f.delay+f.duration,delay:0,duration:f.duration,ease:f.ease})}return new Uc(r,this._parents,t,e)}function Uc(t,n,e,r){this._groups=t,this._parents=n,this._name=e,this._id=r}function Dc(t){return La().transition(t)}function Oc(){return++Am}function Fc(t,n){for(var e;!(e=t.__transition)||!(e=e[n]);)if(!(t=t.parentNode))return Cm.time=Or(),Cm;return e}function Ic(t){var n,e;t instanceof Uc?(n=t._id,t=t._name):(n=Oc(),(e=Cm).time=Or(),t=null==t?null:t+"");for(var r=this._groups,i=r.length,o=0;o<i;++o)for(var u,a=r[o],c=a.length,s=0;s<c;++s)(u=a[s])&&Fa(u,t,n,s,a,e||Fc(u,n));return new Uc(r,this._parents,t,n)}function Yc(t,n){var e,r,i=t.__transition;if(i){n=null==n?null:n+"";for(r in i)if((e=i[r]).state>wm&&e.name===n)return new Uc([[t]],zm,n,(+r))}return null}function Bc(t){return t}function jc(t,n,e){var r=t(e);return"translate("+(isFinite(r)?r:n(e))+",0)"}function Hc(t,n,e){var r=t(e);return"translate(0,"+(isFinite(r)?r:n(e))+")"}function Xc(t){var n=t.bandwidth()/2;return function(e){return t(e)+n}}function Vc(){return!this.__axis}function Wc(t,n){function e(e){var s,f=null==i?n.ticks?n.ticks.apply(n,r):n.domain():i,l=null==o?n.tickFormat?n.tickFormat.apply(n,r):Bc:o,h=Math.max(u,0)+c,p=t===qm||t===Rm?jc:Hc,d=n.range(),v=d[0]+.5,_=d[d.length-1]+.5,y=(n.bandwidth?Xc:Bc)(n.copy()),g=e.selection?e.selection():e,m=g.selectAll(".domain").data([null]),x=g.selectAll(".tick").data(f,n).order(),b=x.exit(),w=x.enter().append("g").attr("class","tick"),M=x.select("line"),T=x.select("text"),k=t===qm||t===Um?-1:1,N=t===Um||t===Lm?(s="x","y"):(s="y","x");m=m.merge(m.enter().insert("path",".tick").attr("class","domain").attr("stroke","#000")),x=x.merge(w),M=M.merge(w.append("line").attr("stroke","#000").attr(s+"2",k*u).attr(N+"1",.5).attr(N+"2",.5)),T=T.merge(w.append("text").attr("fill","#000").attr(s,k*h).attr(N,.5).attr("dy",t===qm?"0em":t===Rm?".71em":".32em")),e!==g&&(m=m.transition(e),x=x.transition(e),M=M.transition(e),T=T.transition(e),b=b.transition(e).attr("opacity",Dm).attr("transform",function(t){return p(y,this.parentNode.__axis||y,t)}),w.attr("opacity",Dm).attr("transform",function(t){return p(this.parentNode.__axis||y,y,t)})),b.remove(),m.attr("d",t===Um||t==Lm?"M"+k*a+","+v+"H0.5V"+_+"H"+k*a:"M"+v+","+k*a+"V0.5H"+_+"V"+k*a),x.attr("opacity",1).attr("transform",function(t){return p(y,y,t)}),M.attr(s+"2",k*u),T.attr(s,k*h).text(l),g.filter(Vc).attr("fill","none").attr("font-size",10).attr("font-family","sans-serif").attr("text-anchor",t===Lm?"start":t===Um?"end":"middle"),g.each(function(){this.__axis=y})}var r=[],i=null,o=null,u=6,a=6,c=3;return e.scale=function(t){return arguments.length?(n=t,e):n},e.ticks=function(){return r=Pm.call(arguments),e},e.tickArguments=function(t){return arguments.length?(r=null==t?[]:Pm.call(t),e):r.slice()},e.tickValues=function(t){return arguments.length?(i=null==t?null:Pm.call(t),e):i&&i.slice()},e.tickFormat=function(t){return arguments.length?(o=t,e):o},e.tickSize=function(t){return arguments.length?(u=a=+t,e):u},e.tickSizeInner=function(t){return arguments.length?(u=+t,e):u},e.tickSizeOuter=function(t){return arguments.length?(a=+t,e):a},e.tickPadding=function(t){return arguments.length?(c=+t,e):c},e}function $c(t){return Wc(qm,t)}function Zc(t){return Wc(Lm,t)}function Gc(t){return Wc(Rm,t)}function Jc(t){return Wc(Um,t)}function Qc(t,n){return t.parent===n.parent?1:2}function Kc(t){return t.reduce(ts,0)/t.length}function ts(t,n){return t+n.x}function ns(t){return 1+t.reduce(es,0)}function es(t,n){return Math.max(t,n.y)}function rs(t){for(var n;n=t.children;)t=n[0];return t}function is(t){for(var n;n=t.children;)t=n[n.length-1];return t}function os(){function t(t){var o,u=0;t.eachAfter(function(t){var e=t.children;e?(t.x=Kc(e),t.y=ns(e)):(t.x=o?u+=n(t,o):0,t.y=0,o=t)});var a=rs(t),c=is(t),s=a.x-n(a,c)/2,f=c.x+n(c,a)/2;return t.eachAfter(i?function(n){n.x=(n.x-t.x)*e,n.y=(t.y-n.y)*r}:function(n){n.x=(n.x-s)/(f-s)*e,n.y=(1-(t.y?n.y/t.y:1))*r})}var n=Qc,e=1,r=1,i=!1;return t.separation=function(e){return arguments.length?(n=e,t):n},t.size=function(n){return arguments.length?(i=!1,e=+n[0],r=+n[1],t):i?null:[e,r]},t.nodeSize=function(n){return arguments.length?(i=!0,e=+n[0],r=+n[1],t):i?[e,r]:null},t}function us(t){var n,e,r,i,o=this,u=[o];do for(n=u.reverse(),u=[];o=n.pop();)if(t(o),e=o.children)for(r=0,i=e.length;r<i;++r)u.push(e[r]);while(u.length);return this}function as(t){for(var n,e,r=this,i=[r];r=i.pop();)if(t(r),n=r.children)for(e=n.length-1;e>=0;--e)i.push(n[e]);return this}function cs(t){for(var n,e,r,i=this,o=[i],u=[];i=o.pop();)if(u.push(i),n=i.children)for(e=0,r=n.length;e<r;++e)o.push(n[e]);for(;i=u.pop();)t(i);return this}function ss(t){return this.eachAfter(function(n){for(var e=+t(n.data)||0,r=n.children,i=r&&r.length;--i>=0;)e+=r[i].value;n.value=e})}function fs(t){return this.eachBefore(function(n){n.children&&n.children.sort(t)})}function ls(t){for(var n=this,e=hs(n,t),r=[n];n!==e;)n=n.parent,r.push(n);for(var i=r.length;t!==e;)r.splice(i,0,t),t=t.parent;return r}function hs(t,n){if(t===n)return t;var e=t.ancestors(),r=n.ancestors(),i=null;for(t=e.pop(),n=r.pop();t===n;)i=t,t=e.pop(),n=r.pop();return i}function ps(){for(var t=this,n=[t];t=t.parent;)n.push(t);return n}function ds(){var t=[];return this.each(function(n){t.push(n)}),t}function vs(){var t=[];return this.eachBefore(function(n){n.children||t.push(n)}),t}function _s(){var t=this,n=[];return t.each(function(e){e!==t&&n.push({source:e.parent,target:e})}),n}function ys(t,n){var e,r,i,o,u,a=new ws(t),c=+t.value&&(a.value=t.value),s=[a];for(null==n&&(n=ms);e=s.pop();)if(c&&(e.value=+e.data.value),(i=n(e.data))&&(u=i.length))for(e.children=new Array(u),o=u-1;o>=0;--o)s.push(r=e.children[o]=new ws(i[o])),r.parent=e,r.depth=e.depth+1;return a.eachBefore(bs)}function gs(){return ys(this).eachBefore(xs)}function ms(t){return t.children}function xs(t){t.data=t.data.data}function bs(t){var n=0;do t.height=n;while((t=t.parent)&&t.height<++n)}function ws(t){this.data=t,this.depth=this.height=0,this.parent=null}function Ms(t){this._=t,this.next=null}function Ts(t){for(var n,e=(t=t.slice()).length,r=null,i=r;e;){var o=new Ms(t[e-1]);i=i?i.next=o:r=o,t[n]=t[--e]}return{head:r,tail:i}}function ks(t){return Ss(Ts(t),[])}function Ns(t,n){var e=n.x-t.x,r=n.y-t.y,i=t.r-n.r;return i*i+1e-6>e*e+r*r}function Ss(t,n){var e,r,i,o=null,u=t.head;switch(n.length){case 1:e=As(n[0]);break;case 2:e=Es(n[0],n[1]);break;case 3:e=Cs(n[0],n[1],n[2])}for(;u;)i=u._,r=u.next,e&&Ns(e,i)?o=u:(o?(t.tail=o,o.next=null):t.head=t.tail=null,n.push(i),e=Ss(t,n),n.pop(),t.head?(u.next=t.head,t.head=u):(u.next=null,t.head=t.tail=u),o=t.tail,o.next=r),u=r;return t.tail=o,e}function As(t){return{x:t.x,y:t.y,r:t.r}}function Es(t,n){var e=t.x,r=t.y,i=t.r,o=n.x,u=n.y,a=n.r,c=o-e,s=u-r,f=a-i,l=Math.sqrt(c*c+s*s);return{x:(e+o+c/l*f)/2,y:(r+u+s/l*f)/2,r:(l+i+a)/2}}function Cs(t,n,e){var r=t.x,i=t.y,o=t.r,u=n.x,a=n.y,c=n.r,s=e.x,f=e.y,l=e.r,h=2*(r-u),p=2*(i-a),d=2*(c-o),v=r*r+i*i-o*o-u*u-a*a+c*c,_=2*(r-s),y=2*(i-f),g=2*(l-o),m=r*r+i*i-o*o-s*s-f*f+l*l,x=_*p-h*y,b=(p*m-y*v)/x-r,w=(y*d-p*g)/x,M=(_*v-h*m)/x-i,T=(h*g-_*d)/x,k=w*w+T*T-1,N=2*(b*w+M*T+o),S=b*b+M*M-o*o,A=(-N-Math.sqrt(N*N-4*k*S))/(2*k);return{x:b+w*A+r,y:M+T*A+i,r:A}}function zs(t,n,e){var r=t.x,i=t.y,o=n.r+e.r,u=t.r+e.r,a=n.x-r,c=n.y-i,s=a*a+c*c;if(s){var f=.5+((u*=u)-(o*=o))/(2*s),l=Math.sqrt(Math.max(0,2*o*(u+s)-(u-=s)*u-o*o))/(2*s);e.x=r+f*a+l*c,e.y=i+f*c-l*a}else e.x=r+u,e.y=i}function Ps(t,n){var e=n.x-t.x,r=n.y-t.y,i=t.r+n.r;return i*i>e*e+r*r}function qs(t,n,e){var r=t.x-n,i=t.y-e;return r*r+i*i}function Ls(t){this._=t,this.next=null,this.previous=null}function Rs(t){if(!(i=t.length))return 0;var n,e,r,i;if(n=t[0],n.x=0,n.y=0,!(i>1))return n.r;if(e=t[1],n.x=-e.r,e.x=n.r,e.y=0,!(i>2))return n.r+e.r;zs(e,n,r=t[2]);var o,u,a,c,s,f,l,h=n.r*n.r,p=e.r*e.r,d=r.r*r.r,v=h+p+d,_=h*n.x+p*e.x+d*r.x,y=h*n.y+p*e.y+d*r.y;n=new Ls(n),e=new Ls(e),r=new Ls(r),n.next=r.previous=e,e.next=n.previous=r,r.next=e.previous=n;t:for(a=3;a<i;++a){if(zs(n._,e._,r=t[a]),r=new Ls(r),(s=n.previous)===(c=e.next)){if(Ps(c._,r._)){n=e,e=c,--a;continue t}}else{f=c._.r,l=s._.r;do if(f<=l){if(Ps(c._,r._)){e=c,n.next=e,e.previous=n,--a;continue t}c=c.next,f+=c._.r}else{if(Ps(s._,r._)){n=s,n.next=e,e.previous=n,--a;continue t}s=s.previous,l+=s._.r}while(c!==s.next)}for(r.previous=n,r.next=e,n.next=e.previous=e=r,v+=d=r._.r*r._.r,_+=d*r._.x,y+=d*r._.y,h=qs(n._,o=_/v,u=y/v);(r=r.next)!==e;)(d=qs(r._,o,u))<h&&(n=r,h=d);e=n.next}for(n=[e._],r=e;(r=r.next)!==e;)n.push(r._);for(r=ks(n),a=0;a<i;++a)n=t[a],n.x-=r.x,n.y-=r.y;return r.r}function Us(t){return Rs(t),t}function Ds(t){return null==t?null:Os(t)}function Os(t){if("function"!=typeof t)throw new Error;return t}function Fs(){return 0}function Is(t){return function(){return t}}function Ys(t){return Math.sqrt(t.value)}function Bs(){function t(t){return t.x=e/2,t.y=r/2,n?t.eachBefore(js(n)).eachAfter(Hs(i,.5)).eachBefore(Xs(1)):t.eachBefore(js(Ys)).eachAfter(Hs(Fs,1)).eachAfter(Hs(i,t.r/Math.min(e,r))).eachBefore(Xs(Math.min(e,r)/(2*t.r))),t}var n=null,e=1,r=1,i=Fs;return t.radius=function(e){return arguments.length?(n=Ds(e),t):n},t.size=function(n){return arguments.length?(e=+n[0],r=+n[1],t):[e,r]},t.padding=function(n){return arguments.length?(i="function"==typeof n?n:Is(+n),t):i},t}function js(t){return function(n){n.children||(n.r=Math.max(0,+t(n)||0))}}function Hs(t,n){return function(e){if(r=e.children){var r,i,o,u=r.length,a=t(e)*n||0;if(a)for(i=0;i<u;++i)r[i].r+=a;if(o=Rs(r),a)for(i=0;i<u;++i)r[i].r-=a;e.r=o+a}}}function Xs(t){return function(n){var e=n.parent;n.r*=t,e&&(n.x=e.x+t*n.x,n.y=e.y+t*n.y)}}function Vs(t){t.x0=Math.round(t.x0),t.y0=Math.round(t.y0),t.x1=Math.round(t.x1),t.y1=Math.round(t.y1)}function Ws(t,n,e,r,i){for(var o,u=t.children,a=-1,c=u.length,s=t.value&&(r-n)/t.value;++a<c;)o=u[a],o.y0=e,o.y1=i,o.x0=n,o.x1=n+=o.value*s}function $s(){function t(t){var u=t.height+1;return t.x0=t.y0=i,t.x1=e,t.y1=r/u,t.eachBefore(n(r,u)),o&&t.eachBefore(Vs),t}function n(t,n){return function(e){e.children&&Ws(e,e.x0,t*(e.depth+1)/n,e.x1,t*(e.depth+2)/n);var r=e.x0,o=e.y0,u=e.x1-i,a=e.y1-i;u<r&&(r=u=(r+u)/2),a<o&&(o=a=(o+a)/2),e.x0=r,e.y0=o,e.x1=u,e.y1=a}}var e=1,r=1,i=0,o=!1;return t.round=function(n){return arguments.length?(o=!!n,t):o},t.size=function(n){return arguments.length?(e=+n[0],r=+n[1],t):[e,r]},t.padding=function(n){return arguments.length?(i=+n,t):i},t}function Zs(t){return t.id}function Gs(t){return t.parentId}function Js(){function t(t){var r,i,o,u,a,c,s,f=t.length,l=new Array(f),h={};for(i=0;i<f;++i)r=t[i],a=l[i]=new ws(r),null!=(c=n(r,i,t))&&(c+="")&&(s=Om+(a.id=c),h[s]=s in h?Im:a);for(i=0;i<f;++i)if(a=l[i],c=e(t[i],i,t),null!=c&&(c+="")){if(u=h[Om+c],!u)throw new Error("missing: "+c);if(u===Im)throw new Error("ambiguous: "+c);u.children?u.children.push(a):u.children=[a],a.parent=u}else{if(o)throw new Error("multiple roots");o=a}if(!o)throw new Error("no root");if(o.parent=Fm,o.eachBefore(function(t){t.depth=t.parent.depth+1,--f}).eachBefore(bs),o.parent=null,f>0)throw new Error("cycle");return o}var n=Zs,e=Gs;return t.id=function(e){return arguments.length?(n=Os(e),t):n},t.parentId=function(n){return arguments.length?(e=Os(n),t):e},t}function Qs(t,n){return t.parent===n.parent?1:2}function Ks(t){var n=t.children;return n?n[0]:t.t}function tf(t){var n=t.children;return n?n[n.length-1]:t.t}function nf(t,n,e){var r=e/(n.i-t.i);n.c-=r,n.s+=e,t.c+=r,n.z+=e,n.m+=e}function ef(t){for(var n,e=0,r=0,i=t.children,o=i.length;--o>=0;)n=i[o],n.z+=e,n.m+=e,e+=n.s+(r+=n.c)}function rf(t,n,e){return t.a.parent===n.parent?t.a:e}function of(t,n){this._=t,this.parent=null,this.children=null,this.A=null,this.a=this,this.z=0,this.m=0,this.c=0,this.s=0,this.t=null,this.i=n}function uf(t){for(var n,e,r,i,o,u=new of(t,0),a=[u];n=a.pop();)if(r=n._.children)for(n.children=new Array(o=r.length),i=o-1;i>=0;--i)a.push(e=n.children[i]=new of(r[i],i)),e.parent=n;return(u.parent=new of(null,0)).children=[u],u}function af(){function t(t){var r=uf(t);if(r.eachAfter(n),r.parent.m=-r.z,r.eachBefore(e),c)t.eachBefore(i);else{var s=t,f=t,l=t;t.eachBefore(function(t){t.x<s.x&&(s=t),t.x>f.x&&(f=t),t.depth>l.depth&&(l=t)});var h=s===f?1:o(s,f)/2,p=h-s.x,d=u/(f.x+h+p),v=a/(l.depth||1);t.eachBefore(function(t){t.x=(t.x+p)*d,t.y=t.depth*v})}return t}function n(t){var n=t.children,e=t.parent.children,i=t.i?e[t.i-1]:null;if(n){ef(t);var u=(n[0].z+n[n.length-1].z)/2;i?(t.z=i.z+o(t._,i._),t.m=t.z-u):t.z=u}else i&&(t.z=i.z+o(t._,i._));t.parent.A=r(t,i,t.parent.A||e[0])}function e(t){t._.x=t.z+t.parent.m,t.m+=t.parent.m}function r(t,n,e){if(n){for(var r,i=t,u=t,a=n,c=i.parent.children[0],s=i.m,f=u.m,l=a.m,h=c.m;a=tf(a),i=Ks(i),a&&i;)c=Ks(c),u=tf(u),u.a=t,r=a.z+l-i.z-s+o(a._,i._),r>0&&(nf(rf(a,t,e),t,r),s+=r,f+=r),l+=a.m,s+=i.m,h+=c.m,f+=u.m;a&&!tf(u)&&(u.t=a,u.m+=l-f),i&&!Ks(c)&&(c.t=i,c.m+=s-h,e=t)}return e}function i(t){t.x*=u,t.y=t.depth*a}var o=Qs,u=1,a=1,c=null;return t.separation=function(n){return arguments.length?(o=n,t):o},t.size=function(n){return arguments.length?(c=!1,u=+n[0],a=+n[1],t):c?null:[u,a]},t.nodeSize=function(n){return arguments.length?(c=!0,u=+n[0],a=+n[1],t):c?[u,a]:null},t}function cf(t,n,e,r,i){for(var o,u=t.children,a=-1,c=u.length,s=t.value&&(i-e)/t.value;++a<c;)o=u[a],o.x0=n,o.x1=r,o.y0=e,o.y1=e+=o.value*s}function sf(t,n,e,r,i,o){for(var u,a,c,s,f,l,h,p,d,v,_,y,g=[],m=n.children,x=0,b=m.length,w=n.value;x<b;){for(s=i-e,f=o-r,h=p=l=m[x].value,_=Math.max(f/s,s/f)/(w*t),y=l*l*_,v=Math.max(p/y,y/h),c=x+1;c<b;++c){if(l+=a=m[c].value,a<h&&(h=a),a>p&&(p=a),y=l*l*_,d=Math.max(p/y,y/h),d>v){l-=a;break}v=d}g.push(u={value:l,dice:s<f,children:m.slice(x,c)}),u.dice?Ws(u,e,r,i,w?r+=f*l/w:o):cf(u,e,r,w?e+=s*l/w:i,o),w-=l,x=c}return g}function ff(){function t(t){return t.x0=t.y0=0,t.x1=i,t.y1=o,t.eachBefore(n),u=[0],r&&t.eachBefore(Vs),t}function n(t){var n=u[t.depth],r=t.x0+n,i=t.y0+n,o=t.x1-n,h=t.y1-n;
@@ -508,8 +575,11 @@ o<r&&(r=o=(r+o)/2),h<i&&(i=h=(i+h)/2),t.x0=r,t.y0=i,t.x1=o,t.y1=h,t.children&&(n
 t):i&&i._},t}function jl(t){return function(){return t}}function Hl(t){return t.source}function Xl(t){return t.target}function Vl(t){return t.radius}function Wl(t){return t.startAngle}function $l(t){return t.endAngle}function Zl(){function t(){var t,a=xx.call(arguments),c=n.apply(this,a),s=e.apply(this,a),f=+r.apply(this,(a[0]=c,a)),l=i.apply(this,a)-yx,h=o.apply(this,a)-yx,p=f*dx(l),d=f*vx(l),v=+r.apply(this,(a[0]=s,a)),_=i.apply(this,a)-yx,y=o.apply(this,a)-yx;if(u||(u=t=Tt()),u.moveTo(p,d),u.arc(0,0,f,l,h),l===_&&h===y||(u.quadraticCurveTo(0,0,v*dx(_),v*vx(_)),u.arc(0,0,v,_,y)),u.quadraticCurveTo(0,0,p,d),u.closePath(),t)return u=null,t+""||null}var n=Hl,e=Xl,r=Vl,i=Wl,o=$l,u=null;return t.radius=function(n){return arguments.length?(r="function"==typeof n?n:jl(+n),t):r},t.startAngle=function(n){return arguments.length?(i="function"==typeof n?n:jl(+n),t):i},t.endAngle=function(n){return arguments.length?(o="function"==typeof n?n:jl(+n),t):o},t.source=function(e){return arguments.length?(n=e,t):n},t.target=function(n){return arguments.length?(e=n,t):e},t.context=function(n){return arguments.length?(u=null==n?null:n,t):u},t}function Gl(){return new Jl}function Jl(){this.reset()}function Ql(t,n,e){var r=t.s=n+e,i=r-n,o=r-i;t.t=n-o+(e-i)}function Kl(t){return t>1?0:t<-1?ib:Math.acos(t)}function th(t){return t>1?ob:t<-1?-ob:Math.asin(t)}function nh(t){return(t=gb(t/2))*t}function eh(){}function rh(t,n){t&&Mb.hasOwnProperty(t.type)&&Mb[t.type](t,n)}function ih(t,n,e){var r,i=-1,o=t.length-e;for(n.lineStart();++i<o;)r=t[i],n.point(r[0],r[1],r[2]);n.lineEnd()}function oh(t,n){var e=-1,r=t.length;for(n.polygonStart();++e<r;)ih(t[e],n,1);n.polygonEnd()}function uh(t,n){t&&wb.hasOwnProperty(t.type)?wb[t.type](t,n):rh(t,n)}function ah(){Tb.point=sh}function ch(){fh(Mx,Tx)}function sh(t,n){Tb.point=fh,Mx=t,Tx=n,t*=sb,n*=sb,kx=t,Nx=pb(n=n/2+ub),Sx=gb(n)}function fh(t,n){t*=sb,n*=sb,n=n/2+ub;var e=t-kx,r=e>=0?1:-1,i=r*e,o=pb(n),u=gb(n),a=Sx*u,c=Nx*o+a*pb(i),s=a*r*gb(i);bx.add(hb(s,c)),kx=t,Nx=o,Sx=u}function lh(t){return wx?wx.reset():(wx=Gl(),bx=Gl()),uh(t,Tb),2*wx}function hh(t){return[hb(t[1],t[0]),th(t[2])]}function ph(t){var n=t[0],e=t[1],r=pb(e);return[r*pb(n),r*gb(n),gb(e)]}function dh(t,n){return t[0]*n[0]+t[1]*n[1]+t[2]*n[2]}function vh(t,n){return[t[1]*n[2]-t[2]*n[1],t[2]*n[0]-t[0]*n[2],t[0]*n[1]-t[1]*n[0]]}function _h(t,n){t[0]+=n[0],t[1]+=n[1],t[2]+=n[2]}function yh(t,n){return[t[0]*n,t[1]*n,t[2]*n]}function gh(t){var n=xb(t[0]*t[0]+t[1]*t[1]+t[2]*t[2]);t[0]/=n,t[1]/=n,t[2]/=n}function mh(t,n){Dx.push(Ox=[Ax=t,Cx=t]),n<Ex&&(Ex=n),n>zx&&(zx=n)}function xh(t,n){var e=ph([t*sb,n*sb]);if(Rx){var r=vh(Rx,e),i=[r[1],-r[0],0],o=vh(i,r);gh(o),o=hh(o);var u,a=t-Px,c=a>0?1:-1,s=o[0]*cb*c,f=fb(a)>180;f^(c*Px<s&&s<c*t)?(u=o[1]*cb,u>zx&&(zx=u)):(s=(s+360)%360-180,f^(c*Px<s&&s<c*t)?(u=-o[1]*cb,u<Ex&&(Ex=u)):(n<Ex&&(Ex=n),n>zx&&(zx=n))),f?t<Px?Nh(Ax,t)>Nh(Ax,Cx)&&(Cx=t):Nh(t,Cx)>Nh(Ax,Cx)&&(Ax=t):Cx>=Ax?(t<Ax&&(Ax=t),t>Cx&&(Cx=t)):t>Px?Nh(Ax,t)>Nh(Ax,Cx)&&(Cx=t):Nh(t,Cx)>Nh(Ax,Cx)&&(Ax=t)}else mh(t,n);Rx=e,Px=t}function bh(){kb.point=xh}function wh(){Ox[0]=Ax,Ox[1]=Cx,kb.point=mh,Rx=null}function Mh(t,n){if(Rx){var e=t-Px;Ux.add(fb(e)>180?e+(e>0?360:-360):e)}else qx=t,Lx=n;Tb.point(t,n),xh(t,n)}function Th(){Tb.lineStart()}function kh(){Mh(qx,Lx),Tb.lineEnd(),fb(Ux)>eb&&(Ax=-(Cx=180)),Ox[0]=Ax,Ox[1]=Cx,Rx=null}function Nh(t,n){return(n-=t)<0?n+360:n}function Sh(t,n){return t[0]-n[0]}function Ah(t,n){return t[0]<=t[1]?t[0]<=n&&n<=t[1]:n<t[0]||t[1]<n}function Eh(t){var n,e,r,i,o,u,a;if(Ux?Ux.reset():Ux=Gl(),zx=Cx=-(Ax=Ex=1/0),Dx=[],uh(t,kb),e=Dx.length){for(Dx.sort(Sh),n=1,r=Dx[0],o=[r];n<e;++n)i=Dx[n],Ah(r,i[0])||Ah(r,i[1])?(Nh(r[0],i[1])>Nh(r[0],r[1])&&(r[1]=i[1]),Nh(i[0],r[1])>Nh(r[0],r[1])&&(r[0]=i[0])):o.push(r=i);for(u=-(1/0),e=o.length-1,n=0,r=o[e];n<=e;r=i,++n)i=o[n],(a=Nh(r[1],i[0]))>u&&(u=a,Ax=i[0],Cx=r[1])}return Dx=Ox=null,Ax===1/0||Ex===1/0?[[NaN,NaN],[NaN,NaN]]:[[Ax,Ex],[Cx,zx]]}function Ch(t,n){t*=sb,n*=sb;var e=pb(n);zh(e*pb(t),e*gb(t),gb(n))}function zh(t,n,e){++Fx,Yx+=(t-Yx)/Fx,Bx+=(n-Bx)/Fx,jx+=(e-jx)/Fx}function Ph(){Nb.point=qh}function qh(t,n){t*=sb,n*=sb;var e=pb(n);Qx=e*pb(t),Kx=e*gb(t),tb=gb(n),Nb.point=Lh,zh(Qx,Kx,tb)}function Lh(t,n){t*=sb,n*=sb;var e=pb(n),r=e*pb(t),i=e*gb(t),o=gb(n),u=hb(xb((u=Kx*o-tb*i)*u+(u=tb*r-Qx*o)*u+(u=Qx*i-Kx*r)*u),Qx*r+Kx*i+tb*o);Ix+=u,Hx+=u*(Qx+(Qx=r)),Xx+=u*(Kx+(Kx=i)),Vx+=u*(tb+(tb=o)),zh(Qx,Kx,tb)}function Rh(){Nb.point=Ch}function Uh(){Nb.point=Oh}function Dh(){Fh(Gx,Jx),Nb.point=Ch}function Oh(t,n){Gx=t,Jx=n,t*=sb,n*=sb,Nb.point=Fh;var e=pb(n);Qx=e*pb(t),Kx=e*gb(t),tb=gb(n),zh(Qx,Kx,tb)}function Fh(t,n){t*=sb,n*=sb;var e=pb(n),r=e*pb(t),i=e*gb(t),o=gb(n),u=Kx*o-tb*i,a=tb*r-Qx*o,c=Qx*i-Kx*r,s=xb(u*u+a*a+c*c),f=Qx*r+Kx*i+tb*o,l=s&&-Kl(f)/s,h=hb(s,f);Wx+=l*u,$x+=l*a,Zx+=l*c,Ix+=h,Hx+=h*(Qx+(Qx=r)),Xx+=h*(Kx+(Kx=i)),Vx+=h*(tb+(tb=o)),zh(Qx,Kx,tb)}function Ih(t){Fx=Ix=Yx=Bx=jx=Hx=Xx=Vx=Wx=$x=Zx=0,uh(t,Nb);var n=Wx,e=$x,r=Zx,i=n*n+e*e+r*r;return i<rb&&(n=Hx,e=Xx,r=Vx,Ix<eb&&(n=Yx,e=Bx,r=jx),i=n*n+e*e+r*r,i<rb)?[NaN,NaN]:[hb(e,n)*cb,th(r/xb(i))*cb]}function Yh(t){return function(){return t}}function Bh(t,n){function e(e,r){return e=t(e,r),n(e[0],e[1])}return t.invert&&n.invert&&(e.invert=function(e,r){return e=n.invert(e,r),e&&t.invert(e[0],e[1])}),e}function jh(t,n){return[t>ib?t-ab:t<-ib?t+ab:t,n]}function Hh(t,n,e){return(t%=ab)?n||e?Bh(Vh(t),Wh(n,e)):Vh(t):n||e?Wh(n,e):jh}function Xh(t){return function(n,e){return n+=t,[n>ib?n-ab:n<-ib?n+ab:n,e]}}function Vh(t){var n=Xh(t);return n.invert=Xh(-t),n}function Wh(t,n){function e(t,n){var e=pb(n),a=pb(t)*e,c=gb(t)*e,s=gb(n),f=s*r+a*i;return[hb(c*o-f*u,a*r-s*i),th(f*o+c*u)]}var r=pb(t),i=gb(t),o=pb(n),u=gb(n);return e.invert=function(t,n){var e=pb(n),a=pb(t)*e,c=gb(t)*e,s=gb(n),f=s*o-c*u;return[hb(c*o+s*u,a*r+f*i),th(f*r-a*i)]},e}function $h(t){function n(n){return n=t(n[0]*sb,n[1]*sb),n[0]*=cb,n[1]*=cb,n}return t=Hh(t[0]*sb,t[1]*sb,t.length>2?t[2]*sb:0),n.invert=function(n){return n=t.invert(n[0]*sb,n[1]*sb),n[0]*=cb,n[1]*=cb,n},n}function Zh(t,n,e,r,i,o){if(e){var u=pb(n),a=gb(n),c=r*e;null==i?(i=n+r*ab,o=n-c/2):(i=Gh(u,i),o=Gh(u,o),(r>0?i<o:i>o)&&(i+=r*ab));for(var s,f=i;r>0?f>o:f<o;f-=c)s=hh([u,-a*pb(f),-a*gb(f)]),t.point(s[0],s[1])}}function Gh(t,n){n=ph(n),n[0]-=t,gh(n);var e=Kl(-n[1]);return((-n[2]<0?-e:e)+ab-eb)%ab}function Jh(){function t(t,n){e.push(t=r(t,n)),t[0]*=cb,t[1]*=cb}function n(){var t=i.apply(this,arguments),n=o.apply(this,arguments)*sb,c=u.apply(this,arguments)*sb;return e=[],r=Hh(-t[0]*sb,-t[1]*sb,0).invert,Zh(a,n,c,1),t={type:"Polygon",coordinates:[e]},e=r=null,t}var e,r,i=Yh([0,0]),o=Yh(90),u=Yh(6),a={point:t};return n.center=function(t){return arguments.length?(i="function"==typeof t?t:Yh([+t[0],+t[1]]),n):i},n.radius=function(t){return arguments.length?(o="function"==typeof t?t:Yh(+t),n):o},n.precision=function(t){return arguments.length?(u="function"==typeof t?t:Yh(+t),n):u},n}function Qh(){var t,n=[];return{point:function(n,e){t.push([n,e])},lineStart:function(){n.push(t=[])},lineEnd:eh,rejoin:function(){n.length>1&&n.push(n.pop().concat(n.shift()))},result:function(){var e=n;return n=[],t=null,e}}}function Kh(t,n,e,r,i,o){var u,a=t[0],c=t[1],s=n[0],f=n[1],l=0,h=1,p=s-a,d=f-c;if(u=e-a,p||!(u>0)){if(u/=p,p<0){if(u<l)return;u<h&&(h=u)}else if(p>0){if(u>h)return;u>l&&(l=u)}if(u=i-a,p||!(u<0)){if(u/=p,p<0){if(u>h)return;u>l&&(l=u)}else if(p>0){if(u<l)return;u<h&&(h=u)}if(u=r-c,d||!(u>0)){if(u/=d,d<0){if(u<l)return;u<h&&(h=u)}else if(d>0){if(u>h)return;u>l&&(l=u)}if(u=o-c,d||!(u<0)){if(u/=d,d<0){if(u>h)return;u>l&&(l=u)}else if(d>0){if(u<l)return;u<h&&(h=u)}return l>0&&(t[0]=a+l*p,t[1]=c+l*d),h<1&&(n[0]=a+h*p,n[1]=c+h*d),!0}}}}}function tp(t,n){return fb(t[0]-n[0])<eb&&fb(t[1]-n[1])<eb}function np(t,n,e,r){this.x=t,this.z=n,this.o=e,this.e=r,this.v=!1,this.n=this.p=null}function ep(t,n,e,r,i){var o,u,a=[],c=[];if(t.forEach(function(t){if(!((n=t.length-1)<=0)){var n,e,r=t[0],u=t[n];if(tp(r,u)){for(i.lineStart(),o=0;o<n;++o)i.point((r=t[o])[0],r[1]);return void i.lineEnd()}a.push(e=new np(r,t,null,(!0))),c.push(e.o=new np(r,null,e,(!1))),a.push(e=new np(u,t,null,(!1))),c.push(e.o=new np(u,null,e,(!0)))}}),a.length){for(c.sort(n),rp(a),rp(c),o=0,u=c.length;o<u;++o)c[o].e=e=!e;for(var s,f,l=a[0];;){for(var h=l,p=!0;h.v;)if((h=h.n)===l)return;s=h.z,i.lineStart();do{if(h.v=h.o.v=!0,h.e){if(p)for(o=0,u=s.length;o<u;++o)i.point((f=s[o])[0],f[1]);else r(h.x,h.n.x,1,i);h=h.n}else{if(p)for(s=h.p.z,o=s.length-1;o>=0;--o)i.point((f=s[o])[0],f[1]);else r(h.x,h.p.x,-1,i);h=h.p}h=h.o,s=h.z,p=!p}while(!h.v);i.lineEnd()}}}function rp(t){if(n=t.length){for(var n,e,r=0,i=t[0];++r<n;)i.n=e=t[r],e.p=i,i=e;i.n=e=t[0],e.p=i}}function ip(t,n,e,r){function i(i,o){return t<=i&&i<=e&&n<=o&&o<=r}function o(i,o,a,s){var f=0,l=0;if(null==i||(f=u(i,a))!==(l=u(o,a))||c(i,o)<0^a>0){do s.point(0===f||3===f?t:e,f>1?r:n);while((f=(f+a+4)%4)!==l)}else s.point(o[0],o[1])}function u(r,i){return fb(r[0]-t)<eb?i>0?0:3:fb(r[0]-e)<eb?i>0?2:1:fb(r[1]-n)<eb?i>0?1:0:i>0?3:2}function a(t,n){return c(t.x,n.x)}function c(t,n){var e=u(t,1),r=u(n,1);return e!==r?e-r:0===e?n[1]-t[1]:1===e?t[0]-n[0]:2===e?t[1]-n[1]:n[0]-t[0]}return function(u){function c(t,n){i(t,n)&&S.point(t,n)}function s(){for(var n=0,e=0,i=_.length;e<i;++e)for(var o,u,a=_[e],c=1,s=a.length,f=a[0],l=f[0],h=f[1];c<s;++c)o=l,u=h,f=a[c],l=f[0],h=f[1],u<=r?h>r&&(l-o)*(r-u)>(h-u)*(t-o)&&++n:h<=r&&(l-o)*(r-u)<(h-u)*(t-o)&&--n;return n}function f(){S=A,v=[],_=[],N=!0}function l(){var t=s(),n=N&&t,e=(v=w(v)).length;(n||e)&&(u.polygonStart(),n&&(u.lineStart(),o(null,null,1,u),u.lineEnd()),e&&ep(v,a,t,o,u),u.polygonEnd()),S=u,v=_=y=null}function h(){E.point=d,_&&_.push(y=[]),k=!0,T=!1,b=M=NaN}function p(){v&&(d(g,m),x&&T&&A.rejoin(),v.push(A.result())),E.point=c,T&&S.lineEnd()}function d(o,u){var a=i(o,u);if(_&&y.push([o,u]),k)g=o,m=u,x=a,k=!1,a&&(S.lineStart(),S.point(o,u));else if(a&&T)S.point(o,u);else{var c=[b=Math.max(Ib,Math.min(Fb,b)),M=Math.max(Ib,Math.min(Fb,M))],s=[o=Math.max(Ib,Math.min(Fb,o)),u=Math.max(Ib,Math.min(Fb,u))];Kh(c,s,t,n,e,r)?(T||(S.lineStart(),S.point(c[0],c[1])),S.point(s[0],s[1]),a||S.lineEnd(),N=!1):a&&(S.lineStart(),S.point(o,u),N=!1)}b=o,M=u,T=a}var v,_,y,g,m,x,b,M,T,k,N,S=u,A=Qh(),E={point:c,lineStart:h,lineEnd:p,polygonStart:f,polygonEnd:l};return E}}function op(){var t,n,e,r=0,i=0,o=960,u=500;return e={stream:function(e){return t&&n===e?t:t=ip(r,i,o,u)(n=e)},extent:function(a){return arguments.length?(r=+a[0][0],i=+a[0][1],o=+a[1][0],u=+a[1][1],t=n=null,e):[[r,i],[o,u]]}}}function up(){Yb.point=cp,Yb.lineEnd=ap}function ap(){Yb.point=Yb.lineEnd=eh}function cp(t,n){t*=sb,n*=sb,Ab=t,Eb=gb(n),Cb=pb(n),Yb.point=sp}function sp(t,n){t*=sb,n*=sb;var e=gb(n),r=pb(n),i=fb(t-Ab),o=pb(i),u=gb(i),a=r*u,c=Cb*e-Eb*r*o,s=Eb*e+Cb*r*o;Sb.add(hb(xb(a*a+c*c),s)),Ab=t,Eb=e,Cb=r}function fp(t){return Sb?Sb.reset():Sb=Gl(),uh(t,Yb),+Sb}function lp(t,n){return Bb[0]=t,Bb[1]=n,fp(jb)}function hp(t,n,e){var r=l(t,n-eb,e).concat(n);return function(t){return r.map(function(n){return[t,n]})}}function pp(t,n,e){var r=l(t,n-eb,e).concat(n);return function(t){return r.map(function(n){return[n,t]})}}function dp(){function t(){return{type:"MultiLineString",coordinates:n()}}function n(){return l(db(o/y)*y,i,y).map(p).concat(l(db(s/g)*g,c,g).map(d)).concat(l(db(r/v)*v,e,v).filter(function(t){return fb(t%y)>eb}).map(f)).concat(l(db(a/_)*_,u,_).filter(function(t){return fb(t%g)>eb}).map(h))}var e,r,i,o,u,a,c,s,f,h,p,d,v=10,_=v,y=90,g=360,m=2.5;return t.lines=function(){return n().map(function(t){return{type:"LineString",coordinates:t}})},t.outline=function(){return{type:"Polygon",coordinates:[p(o).concat(d(c).slice(1),p(i).reverse().slice(1),d(s).reverse().slice(1))]}},t.extent=function(n){return arguments.length?t.extentMajor(n).extentMinor(n):t.extentMinor()},t.extentMajor=function(n){return arguments.length?(o=+n[0][0],i=+n[1][0],s=+n[0][1],c=+n[1][1],o>i&&(n=o,o=i,i=n),s>c&&(n=s,s=c,c=n),t.precision(m)):[[o,s],[i,c]]},t.extentMinor=function(n){return arguments.length?(r=+n[0][0],e=+n[1][0],a=+n[0][1],u=+n[1][1],r>e&&(n=r,r=e,e=n),a>u&&(n=a,a=u,u=n),t.precision(m)):[[r,a],[e,u]]},t.step=function(n){return arguments.length?t.stepMajor(n).stepMinor(n):t.stepMinor()},t.stepMajor=function(n){return arguments.length?(y=+n[0],g=+n[1],t):[y,g]},t.stepMinor=function(n){return arguments.length?(v=+n[0],_=+n[1],t):[v,_]},t.precision=function(n){return arguments.length?(m=+n,f=hp(a,u,90),h=pp(r,e,m),p=hp(s,c,90),d=pp(o,i,m),t):m},t.extentMajor([[-180,-90+eb],[180,90-eb]]).extentMinor([[-180,-80-eb],[180,80+eb]])}function vp(t,n){var e=t[0]*sb,r=t[1]*sb,i=n[0]*sb,o=n[1]*sb,u=pb(r),a=gb(r),c=pb(o),s=gb(o),f=u*pb(e),l=u*gb(e),h=c*pb(i),p=c*gb(i),d=2*th(xb(nh(o-r)+u*c*nh(i-e))),v=gb(d),_=d?function(t){var n=gb(t*=d)/v,e=gb(d-t)/v,r=e*f+n*h,i=e*l+n*p,o=e*a+n*s;return[hb(i,r)*cb,hb(o,xb(r*r+i*i))*cb]}:function(){return[e*cb,r*cb]};return _.distance=d,_}function _p(t){return t}function yp(){Vb.point=gp}function gp(t,n){Vb.point=mp,zb=qb=t,Pb=Lb=n}function mp(t,n){Xb.add(Lb*t-qb*n),qb=t,Lb=n}function xp(){mp(zb,Pb)}function bp(t,n){t<Wb&&(Wb=t),t>Zb&&(Zb=t),n<$b&&($b=n),n>Gb&&(Gb=n)}function wp(t,n){Qb+=t,Kb+=n,++tw}function Mp(){aw.point=Tp}function Tp(t,n){aw.point=kp,wp(Db=t,Ob=n)}function kp(t,n){var e=t-Db,r=n-Ob,i=xb(e*e+r*r);nw+=i*(Db+t)/2,ew+=i*(Ob+n)/2,rw+=i,wp(Db=t,Ob=n)}function Np(){aw.point=wp}function Sp(){aw.point=Ep}function Ap(){Cp(Rb,Ub)}function Ep(t,n){aw.point=Cp,wp(Rb=Db=t,Ub=Ob=n)}function Cp(t,n){var e=t-Db,r=n-Ob,i=xb(e*e+r*r);nw+=i*(Db+t)/2,ew+=i*(Ob+n)/2,rw+=i,i=Ob*t-Db*n,iw+=i*(Db+t),ow+=i*(Ob+n),uw+=3*i,wp(Db=t,Ob=n)}function zp(t){function n(n,e){t.moveTo(n+u,e),t.arc(n,e,u,0,ab)}function e(n,e){t.moveTo(n,e),a.point=r}function r(n,e){t.lineTo(n,e)}function i(){a.point=n}function o(){t.closePath()}var u=4.5,a={point:n,lineStart:function(){a.point=e},lineEnd:i,polygonStart:function(){a.lineEnd=o},polygonEnd:function(){a.lineEnd=i,a.point=n},pointRadius:function(t){return u=t,a},result:eh};return a}function Pp(){function t(t,n){a.push("M",t,",",n,u)}function n(t,n){a.push("M",t,",",n),c.point=e}function e(t,n){a.push("L",t,",",n)}function r(){c.point=n}function i(){c.point=t}function o(){a.push("Z")}var u=qp(4.5),a=[],c={point:t,lineStart:r,lineEnd:i,polygonStart:function(){c.lineEnd=o},polygonEnd:function(){c.lineEnd=i,c.point=t},pointRadius:function(t){return u=qp(t),c},result:function(){if(a.length){var t=a.join("");return a=[],t}}};return c}function qp(t){return"m0,"+t+"a"+t+","+t+" 0 1,1 0,"+-2*t+"a"+t+","+t+" 0 1,1 0,"+2*t+"z"}function Lp(){function t(t){return t&&("function"==typeof o&&i.pointRadius(+o.apply(this,arguments)),uh(t,e(i))),i.result()}var n,e,r,i,o=4.5;return t.area=function(t){return uh(t,e(Vb)),Vb.result()},t.bounds=function(t){return uh(t,e(Jb)),Jb.result()},t.centroid=function(t){return uh(t,e(aw)),aw.result()},t.projection=function(r){return arguments.length?(e=null==(n=r)?_p:r.stream,t):n},t.context=function(n){return arguments.length?(i=null==(r=n)?new Pp:new zp(n),"function"!=typeof o&&i.pointRadius(o),t):r},t.pointRadius=function(n){return arguments.length?(o="function"==typeof n?n:(i.pointRadius(+n),+n),t):o},t.projection(null).context(null)}function Rp(t,n){for(var e=n[0],r=n[1],i=[gb(e),-pb(e),0],o=0,u=0,a=0,c=t.length;a<c;++a)if(f=(s=t[a]).length)for(var s,f,l=s[f-1],h=l[0],p=l[1]/2+ub,d=gb(p),v=pb(p),_=0;_<f;++_,h=g,d=x,v=b,l=y){var y=s[_],g=y[0],m=y[1]/2+ub,x=gb(m),b=pb(m),w=g-h,M=w>=0?1:-1,T=M*w,k=T>ib,N=d*x;if(cw.add(hb(N*M*gb(T),v*b+N*pb(T))),o+=k?w+M*ab:w,k^h>=e^g>=e){var S=vh(ph(l),ph(y));gh(S);var A=vh(i,S);gh(A);var E=(k^w>=0?-1:1)*th(A[2]);(r>E||r===E&&(S[0]||S[1]))&&(u+=k^w>=0?1:-1)}}var C=(o<-eb||o<eb&&cw<-eb)^1&u;return cw.reset(),C}function Up(t,n,e,r){return function(i,o){function u(n,e){var r=i(n,e);t(n=r[0],e=r[1])&&o.point(n,e)}function a(t,n){var e=i(t,n);_.point(e[0],e[1])}function c(){b.point=a,_.lineStart()}function s(){b.point=u,_.lineEnd()}function f(t,n){v.push([t,n]);var e=i(t,n);m.point(e[0],e[1])}function l(){m.lineStart(),v=[]}function h(){f(v[0][0],v[0][1]),m.lineEnd();var t,n,e,r,i=m.clean(),u=g.result(),a=u.length;if(v.pop(),p.push(v),v=null,a)if(1&i){if(e=u[0],(n=e.length-1)>0){for(x||(o.polygonStart(),x=!0),o.lineStart(),t=0;t<n;++t)o.point((r=e[t])[0],r[1]);o.lineEnd()}}else a>1&&2&i&&u.push(u.pop().concat(u.shift())),d.push(u.filter(Dp))}var p,d,v,_=n(o),y=i.invert(r[0],r[1]),g=Qh(),m=n(g),x=!1,b={point:u,lineStart:c,lineEnd:s,polygonStart:function(){b.point=f,b.lineStart=l,b.lineEnd=h,d=[],p=[]},polygonEnd:function(){b.point=u,b.lineStart=c,b.lineEnd=s,d=w(d);var t=Rp(p,y);d.length?(x||(o.polygonStart(),x=!0),ep(d,Op,t,e,o)):t&&(x||(o.polygonStart(),x=!0),o.lineStart(),e(null,null,1,o),o.lineEnd()),x&&(o.polygonEnd(),x=!1),d=p=null},sphere:function(){o.polygonStart(),o.lineStart(),e(null,null,1,o),o.lineEnd(),o.polygonEnd()}};return b}}function Dp(t){return t.length>1}function Op(t,n){return((t=t.x)[0]<0?t[1]-ob-eb:ob-t[1])-((n=n.x)[0]<0?n[1]-ob-eb:ob-n[1])}function Fp(t){var n,e=NaN,r=NaN,i=NaN;return{lineStart:function(){t.lineStart(),n=1},point:function(o,u){var a=o>0?ib:-ib,c=fb(o-e);fb(c-ib)<eb?(t.point(e,r=(r+u)/2>0?ob:-ob),t.point(i,r),t.lineEnd(),t.lineStart(),t.point(a,r),t.point(o,r),n=0):i!==a&&c>=ib&&(fb(e-i)<eb&&(e-=i*eb),fb(o-a)<eb&&(o-=a*eb),r=Ip(e,r,o,u),t.point(i,r),t.lineEnd(),t.lineStart(),t.point(a,r),n=0),t.point(e=o,r=u),i=a},lineEnd:function(){t.lineEnd(),e=r=NaN},clean:function(){return 2-n}}}function Ip(t,n,e,r){var i,o,u=gb(t-e);return fb(u)>eb?lb((gb(n)*(o=pb(r))*gb(e)-gb(r)*(i=pb(n))*gb(t))/(i*o*u)):(n+r)/2}function Yp(t,n,e,r){var i;if(null==t)i=e*ob,r.point(-ib,i),r.point(0,i),r.point(ib,i),r.point(ib,0),r.point(ib,-i),r.point(0,-i),r.point(-ib,-i),r.point(-ib,0),r.point(-ib,i);else if(fb(t[0]-n[0])>eb){var o=t[0]<n[0]?ib:-ib;i=e*o/2,r.point(-o,i),r.point(0,i),r.point(o,i)}else r.point(n[0],n[1])}function Bp(t,n){function e(e,r,i,o){Zh(o,t,n,i,e,r)}function r(t,n){return pb(t)*pb(n)>a}function i(t){var n,e,i,a,f;return{lineStart:function(){a=i=!1,f=1},point:function(l,h){var p,d=[l,h],v=r(l,h),_=c?v?0:u(l,h):v?u(l+(l<0?ib:-ib),h):0;if(!n&&(a=i=v)&&t.lineStart(),v!==i&&(p=o(n,d),(tp(n,p)||tp(d,p))&&(d[0]+=eb,d[1]+=eb,v=r(d[0],d[1]))),v!==i)f=0,v?(t.lineStart(),p=o(d,n),t.point(p[0],p[1])):(p=o(n,d),t.point(p[0],p[1]),t.lineEnd()),n=p;else if(s&&n&&c^v){var y;_&e||!(y=o(d,n,!0))||(f=0,c?(t.lineStart(),t.point(y[0][0],y[0][1]),t.point(y[1][0],y[1][1]),t.lineEnd()):(t.point(y[1][0],y[1][1]),t.lineEnd(),t.lineStart(),t.point(y[0][0],y[0][1])))}!v||n&&tp(n,d)||t.point(d[0],d[1]),n=d,i=v,e=_},lineEnd:function(){i&&t.lineEnd(),n=null},clean:function(){return f|(a&&i)<<1}}}function o(t,n,e){var r=ph(t),i=ph(n),o=[1,0,0],u=vh(r,i),c=dh(u,u),s=u[0],f=c-s*s;if(!f)return!e&&t;var l=a*c/f,h=-a*s/f,p=vh(o,u),d=yh(o,l),v=yh(u,h);_h(d,v);var _=p,y=dh(d,_),g=dh(_,_),m=y*y-g*(dh(d,d)-1);if(!(m<0)){var x=xb(m),b=yh(_,(-y-x)/g);if(_h(b,d),b=hh(b),!e)return b;var w,M=t[0],T=n[0],k=t[1],N=n[1];T<M&&(w=M,M=T,T=w);var S=T-M,A=fb(S-ib)<eb,E=A||S<eb;if(!A&&N<k&&(w=k,k=N,N=w),E?A?k+N>0^b[1]<(fb(b[0]-M)<eb?k:N):k<=b[1]&&b[1]<=N:S>ib^(M<=b[0]&&b[0]<=T)){var C=yh(_,(-y+x)/g);return _h(C,d),[b,hh(C)]}}}function u(n,e){var r=c?t:ib-t,i=0;return n<-r?i|=1:n>r&&(i|=2),e<-r?i|=4:e>r&&(i|=8),i}var a=pb(t),c=a>0,s=fb(a)>eb;return Up(r,i,e,c?[0,-t]:[-ib,t-ib])}function jp(t){return{stream:Hp(t)}}function Hp(t){function n(){}var e=n.prototype=Object.create(Xp.prototype);for(var r in t)e[r]=t[r];return function(t){var e=new n;return e.stream=t,e}}function Xp(){}function Vp(t,n){return+n?$p(t,n):Wp(t)}function Wp(t){return Hp({point:function(n,e){n=t(n,e),this.stream.point(n[0],n[1])}})}function $p(t,n){function e(r,i,o,u,a,c,s,f,l,h,p,d,v,_){var y=s-r,g=f-i,m=y*y+g*g;if(m>4*n&&v--){var x=u+h,b=a+p,w=c+d,M=xb(x*x+b*b+w*w),T=th(w/=M),k=fb(fb(w)-1)<eb||fb(o-l)<eb?(o+l)/2:hb(b,x),N=t(k,T),S=N[0],A=N[1],E=S-r,C=A-i,z=g*E-y*C;(z*z/m>n||fb((y*E+g*C)/m-.5)>.3||u*h+a*p+c*d<lw)&&(e(r,i,o,u,a,c,S,A,k,x/=M,b/=M,w,v,_),_.point(S,A),e(S,A,k,x,b,w,s,f,l,h,p,d,v,_))}}return function(n){function r(e,r){e=t(e,r),n.point(e[0],e[1])}function i(){y=NaN,w.point=o,n.lineStart()}function o(r,i){var o=ph([r,i]),u=t(r,i);e(y,g,_,m,x,b,y=u[0],g=u[1],_=r,m=o[0],x=o[1],b=o[2],fw,n),n.point(y,g)}function u(){w.point=r,n.lineEnd()}function a(){i(),w.point=c,w.lineEnd=s}function c(t,n){o(f=t,n),l=y,h=g,p=m,d=x,v=b,w.point=o}function s(){e(y,g,_,m,x,b,l,h,f,p,d,v,fw,n),w.lineEnd=u,u()}var f,l,h,p,d,v,_,y,g,m,x,b,w={point:r,lineStart:i,lineEnd:u,polygonStart:function(){n.polygonStart(),w.lineStart=a},polygonEnd:function(){n.polygonEnd(),w.lineStart=i}};return w}}function Zp(t){return Gp(function(){return t})()}function Gp(t){function n(t){return t=f(t[0]*sb,t[1]*sb),[t[0]*_+a,c-t[1]*_]}function e(t){return t=f.invert((t[0]-a)/_,(c-t[1])/_),t&&[t[0]*cb,t[1]*cb]}function r(t,n){return t=u(t,n),[t[0]*_+a,c-t[1]*_]}function i(){f=Bh(s=Hh(b,w,M),u);var t=u(m,x);return a=y-t[0]*_,c=g+t[1]*_,o()}function o(){return d=v=null,n}var u,a,c,s,f,l,h,p,d,v,_=150,y=480,g=250,m=0,x=0,b=0,w=0,M=0,T=null,k=sw,N=null,S=_p,A=.5,E=Vp(r,A);return n.stream=function(t){return d&&v===t?d:d=hw(k(s,E(S(v=t))))},n.clipAngle=function(t){return arguments.length?(k=+t?Bp(T=t*sb,6*sb):(T=null,sw),o()):T*cb},n.clipExtent=function(t){return arguments.length?(S=null==t?(N=l=h=p=null,_p):ip(N=+t[0][0],l=+t[0][1],h=+t[1][0],p=+t[1][1]),o()):null==N?null:[[N,l],[h,p]]},n.scale=function(t){return arguments.length?(_=+t,i()):_},n.translate=function(t){return arguments.length?(y=+t[0],g=+t[1],i()):[y,g]},n.center=function(t){return arguments.length?(m=t[0]%360*sb,x=t[1]%360*sb,i()):[m*cb,x*cb]},n.rotate=function(t){return arguments.length?(b=t[0]%360*sb,w=t[1]%360*sb,M=t.length>2?t[2]%360*sb:0,i()):[b*cb,w*cb,M*cb]},n.precision=function(t){return arguments.length?(E=Vp(r,A=t*t),o()):xb(A)},function(){return u=t.apply(this,arguments),n.invert=u.invert&&e,i()}}function Jp(t){var n=0,e=ib/3,r=Gp(t),i=r(n,e);return i.parallels=function(t){return arguments.length?r(n=t[0]*sb,e=t[1]*sb):[n*cb,e*cb]},i}function Qp(t,n){function e(t,n){var e=xb(o-2*i*gb(n))/i;return[e*gb(t*=i),u-e*pb(t)]}var r=gb(t),i=(r+gb(n))/2,o=1+r*(2*i-r),u=xb(o)/i;return e.invert=function(t,n){var e=u-n;return[hb(t,e)/i,th((o-(t*t+e*e)*i*i)/(2*i))]},e}function Kp(){return Jp(Qp).scale(155.424).center([0,33.6442])}function td(){return Kp().parallels([29.5,45.5]).scale(1070).translate([480,250]).rotate([96,0]).center([-.6,38.7])}function nd(t){var n=t.length;return{point:function(e,r){for(var i=-1;++i<n;)t[i].point(e,r)},sphere:function(){for(var e=-1;++e<n;)t[e].sphere()},lineStart:function(){for(var e=-1;++e<n;)t[e].lineStart()},lineEnd:function(){for(var e=-1;++e<n;)t[e].lineEnd()},polygonStart:function(){for(var e=-1;++e<n;)t[e].polygonStart()},polygonEnd:function(){for(var e=-1;++e<n;)t[e].polygonEnd()}}}function ed(){function t(t){var n=t[0],e=t[1];return u=null,r.point(n,e),u||(i.point(n,e),u)||(o.point(n,e),u)}var n,e,r,i,o,u,a=td(),c=Kp().rotate([154,0]).center([-2,58.5]).parallels([55,65]),s=Kp().rotate([157,0]).center([-3,19.9]).parallels([8,18]),f={point:function(t,n){u=[t,n]}};return t.invert=function(t){var n=a.scale(),e=a.translate(),r=(t[0]-e[0])/n,i=(t[1]-e[1])/n;return(i>=.12&&i<.234&&r>=-.425&&r<-.214?c:i>=.166&&i<.234&&r>=-.214&&r<-.115?s:a).invert(t)},t.stream=function(t){return n&&e===t?n:n=nd([a.stream(e=t),c.stream(t),s.stream(t)])},t.precision=function(n){return arguments.length?(a.precision(n),c.precision(n),s.precision(n),t):a.precision()},t.scale=function(n){return arguments.length?(a.scale(n),c.scale(.35*n),s.scale(n),t.translate(a.translate())):a.scale()},t.translate=function(n){if(!arguments.length)return a.translate();var e=a.scale(),u=+n[0],l=+n[1];return r=a.translate(n).clipExtent([[u-.455*e,l-.238*e],[u+.455*e,l+.238*e]]).stream(f),i=c.translate([u-.307*e,l+.201*e]).clipExtent([[u-.425*e+eb,l+.12*e+eb],[u-.214*e-eb,l+.234*e-eb]]).stream(f),o=s.translate([u-.205*e,l+.212*e]).clipExtent([[u-.214*e+eb,l+.166*e+eb],[u-.115*e-eb,l+.234*e-eb]]).stream(f),t},t.scale(1070)}function rd(t){return function(n,e){var r=pb(n),i=pb(e),o=t(r*i);return[o*i*gb(n),o*gb(e)]}}function id(t){return function(n,e){var r=xb(n*n+e*e),i=t(r),o=gb(i),u=pb(i);return[hb(n*o,r*u),th(r&&e*o/r)]}}function od(){return Zp(pw).scale(124.75).clipAngle(179.999)}function ud(){return Zp(dw).scale(79.4188).clipAngle(179.999)}function ad(t,n){return[t,_b(bb((ob+n)/2))]}function cd(){return sd(ad).scale(961/ab)}function sd(t){var n,e=Zp(t),r=e.scale,i=e.translate,o=e.clipExtent;return e.scale=function(t){return arguments.length?(r(t),n&&e.clipExtent(null),e):r()},e.translate=function(t){return arguments.length?(i(t),n&&e.clipExtent(null),e):i()},e.clipExtent=function(t){if(!arguments.length)return n?null:o();if(n=null==t){var u=ib*r(),a=i();t=[[a[0]-u,a[1]-u],[a[0]+u,a[1]+u]]}return o(t),e},e.clipExtent(null)}function fd(t){return bb((ob+t)/2)}function ld(t,n){function e(t,n){o>0?n<-ob+eb&&(n=-ob+eb):n>ob-eb&&(n=ob-eb);var e=o/yb(fd(n),i);return[e*gb(i*t),o-e*pb(i*t)]}var r=pb(t),i=t===n?gb(t):_b(r/pb(n))/_b(fd(n)/fd(t)),o=r*yb(fd(t),i)/i;return i?(e.invert=function(t,n){var e=o-n,r=mb(i)*xb(t*t+e*e);return[hb(t,e)/i,2*lb(yb(o/r,1/i))-ob]},e):ad}function hd(){return Jp(ld).scale(109.5).parallels([30,30])}function pd(t,n){return[t,n]}function dd(){return Zp(pd).scale(152.63)}function vd(t,n){function e(t,n){var e=o-n,r=i*t;return[e*gb(r),o-e*pb(r)]}var r=pb(t),i=t===n?gb(t):(r-pb(n))/(n-t),o=r/i+t;return fb(i)<eb?pd:(e.invert=function(t,n){var e=o-n;return[hb(t,e)/i,o-mb(i)*xb(t*t+e*e)]},e)}function _d(){return Jp(vd).scale(131.154).center([0,13.9389])}function yd(t,n){var e=pb(n),r=pb(t)*e;return[e*gb(t)/r,gb(n)/r]}function gd(){return Zp(yd).scale(144.049).clipAngle(60)}function md(t,n){return[pb(n)*gb(t),gb(n)]}function xd(){return Zp(md).scale(249.5).clipAngle(90+eb)}function bd(t,n){var e=pb(n),r=1+pb(t)*e;return[e*gb(t)/r,gb(n)/r]}function wd(){return Zp(bd).scale(250).clipAngle(142)}function Md(t,n){return[_b(bb((ob+n)/2)),-t]}function Td(){var t=sd(Md),n=t.center,e=t.rotate;return t.center=function(t){return arguments.length?n([-t[1],t[0]]):(t=n(),[t[1],-t[0]])},t.rotate=function(t){return arguments.length?e([t[0],t[1],t.length>2?t[2]+90:90]):(t=e(),[t[0],t[1],t[2]-90])},e([0,0,90]).scale(159.155)}var kd="4.1.1",Nd=e(n),Sd=Nd.right,Ad=Nd.left,Ed=Array.prototype,Cd=Ed.slice,zd=Ed.map,Pd=Math.sqrt(50),qd=Math.sqrt(10),Ld=Math.sqrt(2),Rd="$";P.prototype=q.prototype={constructor:P,has:function(t){return Rd+t in this},get:function(t){return this[Rd+t]},set:function(t,n){return this[Rd+t]=n,this},remove:function(t){var n=Rd+t;return n in this&&delete this[n]},clear:function(){for(var t in this)t[0]===Rd&&delete this[t]},keys:function(){var t=[];for(var n in this)n[0]===Rd&&t.push(n.slice(1));return t},values:function(){var t=[];for(var n in this)n[0]===Rd&&t.push(this[n]);return t},entries:function(){var t=[];for(var n in this)n[0]===Rd&&t.push({key:n.slice(1),value:this[n]});return t},size:function(){var t=0;for(var n in this)n[0]===Rd&&++t;return t},empty:function(){for(var t in this)if(t[0]===Rd)return!1;return!0},each:function(t){for(var n in this)n[0]===Rd&&t(this[n],n.slice(1),this)}};var Ud=q.prototype;F.prototype=I.prototype={constructor:F,has:Ud.has,add:function(t){return t+="",this[Rd+t]=t,this},remove:Ud.remove,clear:Ud.clear,values:Ud.keys,size:Ud.size,empty:Ud.empty,each:Ud.each};var Dd=3,Od=function t(n){function e(t){return Math.pow(t,n)}return n=+n,e.exponent=t,e}(Dd),Fd=function t(n){function e(t){return 1-Math.pow(1-t,n)}return n=+n,e.exponent=t,e}(Dd),Id=function t(n){function e(t){return((t*=2)<=1?Math.pow(t,n):2-Math.pow(2-t,n))/2}return n=+n,e.exponent=t,e}(Dd),Yd=Math.PI,Bd=Yd/2,jd=4/11,Hd=6/11,Xd=8/11,Vd=.75,Wd=9/11,$d=10/11,Zd=.9375,Gd=21/22,Jd=63/64,Qd=1/jd/jd,Kd=1.70158,tv=function t(n){function e(t){return t*t*((n+1)*t-n)}return n=+n,e.overshoot=t,e}(Kd),nv=function t(n){function e(t){return--t*t*((n+1)*t+n)+1}return n=+n,e.overshoot=t,e}(Kd),ev=function t(n){function e(t){return((t*=2)<1?t*t*((n+1)*t-n):(t-=2)*t*((n+1)*t+n)+2)/2}return n=+n,e.overshoot=t,e}(Kd),rv=2*Math.PI,iv=1,ov=.3,uv=function t(n,e){function r(t){return n*Math.pow(2,10*--t)*Math.sin((i-t)/e)}var i=Math.asin(1/(n=Math.max(1,n)))*(e/=rv);return r.amplitude=function(n){return t(n,e*rv)},r.period=function(e){return t(n,e)},r}(iv,ov),av=function t(n,e){function r(t){return 1-n*Math.pow(2,-10*(t=+t))*Math.sin((t+i)/e)}var i=Math.asin(1/(n=Math.max(1,n)))*(e/=rv);return r.amplitude=function(n){return t(n,e*rv)},r.period=function(e){return t(n,e)},r}(iv,ov),cv=function t(n,e){function r(t){return((t=2*t-1)<0?n*Math.pow(2,10*t)*Math.sin((i-t)/e):2-n*Math.pow(2,-10*t)*Math.sin((i+t)/e))/2}var i=Math.asin(1/(n=Math.max(1,n)))*(e/=rv);return r.amplitude=function(n){return t(n,e*rv)},r.period=function(e){return t(n,e)},r}(iv,ov),sv=Math.PI,fv=2*sv,lv=1e-6,hv=fv-lv;Mt.prototype=Tt.prototype={constructor:Mt,moveTo:function(t,n){this._.push("M",this._x0=this._x1=+t,",",this._y0=this._y1=+n)},closePath:function(){null!==this._x1&&(this._x1=this._x0,this._y1=this._y0,this._.push("Z"))},lineTo:function(t,n){this._.push("L",this._x1=+t,",",this._y1=+n)},quadraticCurveTo:function(t,n,e,r){this._.push("Q",+t,",",+n,",",this._x1=+e,",",this._y1=+r)},bezierCurveTo:function(t,n,e,r,i,o){this._.push("C",+t,",",+n,",",+e,",",+r,",",this._x1=+i,",",this._y1=+o)},arcTo:function(t,n,e,r,i){t=+t,n=+n,e=+e,r=+r,i=+i;var o=this._x1,u=this._y1,a=e-t,c=r-n,s=o-t,f=u-n,l=s*s+f*f;if(i<0)throw new Error("negative radius: "+i);if(null===this._x1)this._.push("M",this._x1=t,",",this._y1=n);else if(l>lv)if(Math.abs(f*a-c*s)>lv&&i){var h=e-o,p=r-u,d=a*a+c*c,v=h*h+p*p,_=Math.sqrt(d),y=Math.sqrt(l),g=i*Math.tan((sv-Math.acos((d+l-v)/(2*_*y)))/2),m=g/y,x=g/_;Math.abs(m-1)>lv&&this._.push("L",t+m*s,",",n+m*f),this._.push("A",i,",",i,",0,0,",+(f*h>s*p),",",this._x1=t+x*a,",",this._y1=n+x*c)}else this._.push("L",this._x1=t,",",this._y1=n);else;},arc:function(t,n,e,r,i,o){t=+t,n=+n,e=+e;var u=e*Math.cos(r),a=e*Math.sin(r),c=t+u,s=n+a,f=1^o,l=o?r-i:i-r;if(e<0)throw new Error("negative radius: "+e);null===this._x1?this._.push("M",c,",",s):(Math.abs(this._x1-c)>lv||Math.abs(this._y1-s)>lv)&&this._.push("L",c,",",s),e&&(l>hv?this._.push("A",e,",",e,",0,1,",f,",",t-u,",",n-a,"A",e,",",e,",0,1,",f,",",this._x1=c,",",this._y1=s):(l<0&&(l=l%fv+fv),this._.push("A",e,",",e,",0,",+(l>=sv),",",f,",",this._x1=t+e*Math.cos(i),",",this._y1=n+e*Math.sin(i))))},rect:function(t,n,e,r){this._.push("M",this._x0=this._x1=+t,",",this._y0=this._y1=+n,"h",+e,"v",+r,"h",-e,"Z")},toString:function(){return this._.join("")}};var pv=jt.prototype=Ht.prototype;pv.copy=function(){var t,n,e=new Ht(this._x,this._y,this._x0,this._y0,this._x1,this._y1),r=this._root;if(!r)return e;if(!r.length)return e._root=Xt(r),e;for(t=[{source:r,target:e._root=new Array(4)}];r=t.pop();)for(var i=0;i<4;++i)(n=r.source[i])&&(n.length?t.push({source:n,target:r.target[i]=new Array(4)}):r.target[i]=Xt(n));return e},pv.add=kt,pv.addAll=St,pv.cover=At,pv.data=Et,pv.extent=Ct,pv.find=Pt,pv.remove=qt,pv.removeAll=Lt,pv.root=Rt,pv.size=Ut,pv.visit=Dt,pv.visitAfter=Ot,pv.x=It,pv.y=Bt;var dv=[].slice,vv={};Vt.prototype=Qt.prototype={constructor:Vt,defer:function(t){if("function"!=typeof t||this._call)throw new Error;if(null!=this._error)return this;var n=dv.call(arguments,1);return n.push(t),++this._waiting,this._tasks.push(n),Wt(this),this},abort:function(){return null==this._error&&Gt(this,new Error("abort")),this},await:function(t){if("function"!=typeof t||this._call)throw new Error;return this._call=function(n,e){t.apply(null,[n].concat(e))},Jt(this),this},awaitAll:function(t){if("function"!=typeof t||this._call)throw new Error;return this._call=t,Jt(this),this}};var _v=1e-12,yv=Math.PI,gv=yv/2,mv=2*yv;fn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._point=0},lineEnd:function(){(this._line||0!==this._line&&1===this._point)&&this._context.closePath(),this._line=1-this._line;
 },point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1,this._line?this._context.lineTo(t,n):this._context.moveTo(t,n);break;case 1:this._point=2;default:this._context.lineTo(t,n)}}};var xv=xn(ln);mn.prototype={areaStart:function(){this._curve.areaStart()},areaEnd:function(){this._curve.areaEnd()},lineStart:function(){this._curve.lineStart()},lineEnd:function(){this._curve.lineEnd()},point:function(t,n){this._curve.point(n*Math.sin(t),n*-Math.cos(t))}};var bv={draw:function(t,n){var e=Math.sqrt(n/yv);t.moveTo(e,0),t.arc(0,0,e,0,mv)}},wv={draw:function(t,n){var e=Math.sqrt(n/5)/2;t.moveTo(-3*e,-e),t.lineTo(-e,-e),t.lineTo(-e,-3*e),t.lineTo(e,-3*e),t.lineTo(e,-e),t.lineTo(3*e,-e),t.lineTo(3*e,e),t.lineTo(e,e),t.lineTo(e,3*e),t.lineTo(-e,3*e),t.lineTo(-e,e),t.lineTo(-3*e,e),t.closePath()}},Mv=Math.sqrt(1/3),Tv=2*Mv,kv={draw:function(t,n){var e=Math.sqrt(n/Tv),r=e*Mv;t.moveTo(0,-e),t.lineTo(r,0),t.lineTo(0,e),t.lineTo(-r,0),t.closePath()}},Nv=.8908130915292852,Sv=Math.sin(yv/10)/Math.sin(7*yv/10),Av=Math.sin(mv/10)*Sv,Ev=-Math.cos(mv/10)*Sv,Cv={draw:function(t,n){var e=Math.sqrt(n*Nv),r=Av*e,i=Ev*e;t.moveTo(0,-e),t.lineTo(r,i);for(var o=1;o<5;++o){var u=mv*o/5,a=Math.cos(u),c=Math.sin(u);t.lineTo(c*e,-a*e),t.lineTo(a*r-c*i,c*r+a*i)}t.closePath()}},zv={draw:function(t,n){var e=Math.sqrt(n),r=-e/2;t.rect(r,r,e,e)}},Pv=Math.sqrt(3),qv={draw:function(t,n){var e=-Math.sqrt(n/(3*Pv));t.moveTo(0,2*e),t.lineTo(-Pv*e,-e),t.lineTo(Pv*e,-e),t.closePath()}},Lv=-.5,Rv=Math.sqrt(3)/2,Uv=1/Math.sqrt(12),Dv=3*(Uv/2+1),Ov={draw:function(t,n){var e=Math.sqrt(n/Dv),r=e/2,i=e*Uv,o=r,u=e*Uv+e,a=-o,c=u;t.moveTo(r,i),t.lineTo(o,u),t.lineTo(a,c),t.lineTo(Lv*r-Rv*i,Rv*r+Lv*i),t.lineTo(Lv*o-Rv*u,Rv*o+Lv*u),t.lineTo(Lv*a-Rv*c,Rv*a+Lv*c),t.lineTo(Lv*r+Rv*i,Lv*i-Rv*r),t.lineTo(Lv*o+Rv*u,Lv*u-Rv*o),t.lineTo(Lv*a+Rv*c,Lv*c-Rv*a),t.closePath()}},Fv=[bv,wv,kv,zv,Cv,qv,Ov];Sn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._y0=this._y1=NaN,this._point=0},lineEnd:function(){switch(this._point){case 3:Nn(this,this._x1,this._y1);case 2:this._context.lineTo(this._x1,this._y1)}(this._line||0!==this._line&&1===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1,this._line?this._context.lineTo(t,n):this._context.moveTo(t,n);break;case 1:this._point=2;break;case 2:this._point=3,this._context.lineTo((5*this._x0+this._x1)/6,(5*this._y0+this._y1)/6);default:Nn(this,t,n)}this._x0=this._x1,this._x1=t,this._y0=this._y1,this._y1=n}},En.prototype={areaStart:kn,areaEnd:kn,lineStart:function(){this._x0=this._x1=this._x2=this._x3=this._x4=this._y0=this._y1=this._y2=this._y3=this._y4=NaN,this._point=0},lineEnd:function(){switch(this._point){case 1:this._context.moveTo(this._x2,this._y2),this._context.closePath();break;case 2:this._context.moveTo((this._x2+2*this._x3)/3,(this._y2+2*this._y3)/3),this._context.lineTo((this._x3+2*this._x2)/3,(this._y3+2*this._y2)/3),this._context.closePath();break;case 3:this.point(this._x2,this._y2),this.point(this._x3,this._y3),this.point(this._x4,this._y4)}},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1,this._x2=t,this._y2=n;break;case 1:this._point=2,this._x3=t,this._y3=n;break;case 2:this._point=3,this._x4=t,this._y4=n,this._context.moveTo((this._x0+4*this._x1+t)/6,(this._y0+4*this._y1+n)/6);break;default:Nn(this,t,n)}this._x0=this._x1,this._x1=t,this._y0=this._y1,this._y1=n}},zn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._y0=this._y1=NaN,this._point=0},lineEnd:function(){(this._line||0!==this._line&&3===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1;break;case 1:this._point=2;break;case 2:this._point=3;var e=(this._x0+4*this._x1+t)/6,r=(this._y0+4*this._y1+n)/6;this._line?this._context.lineTo(e,r):this._context.moveTo(e,r);break;case 3:this._point=4;default:Nn(this,t,n)}this._x0=this._x1,this._x1=t,this._y0=this._y1,this._y1=n}},qn.prototype={lineStart:function(){this._x=[],this._y=[],this._basis.lineStart()},lineEnd:function(){var t=this._x,n=this._y,e=t.length-1;if(e>0)for(var r,i=t[0],o=n[0],u=t[e]-i,a=n[e]-o,c=-1;++c<=e;)r=c/e,this._basis.point(this._beta*t[c]+(1-this._beta)*(i+r*u),this._beta*n[c]+(1-this._beta)*(o+r*a));this._x=this._y=null,this._basis.lineEnd()},point:function(t,n){this._x.push(+t),this._y.push(+n)}};var Iv=function t(n){function e(t){return 1===n?new Sn(t):new qn(t,n)}return e.beta=function(n){return t(+n)},e}(.85);Rn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._x2=this._y0=this._y1=this._y2=NaN,this._point=0},lineEnd:function(){switch(this._point){case 2:this._context.lineTo(this._x2,this._y2);break;case 3:Ln(this,this._x1,this._y1)}(this._line||0!==this._line&&1===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1,this._line?this._context.lineTo(t,n):this._context.moveTo(t,n);break;case 1:this._point=2,this._x1=t,this._y1=n;break;case 2:this._point=3;default:Ln(this,t,n)}this._x0=this._x1,this._x1=this._x2,this._x2=t,this._y0=this._y1,this._y1=this._y2,this._y2=n}};var Yv=function t(n){function e(t){return new Rn(t,n)}return e.tension=function(n){return t(+n)},e}(0);Un.prototype={areaStart:kn,areaEnd:kn,lineStart:function(){this._x0=this._x1=this._x2=this._x3=this._x4=this._x5=this._y0=this._y1=this._y2=this._y3=this._y4=this._y5=NaN,this._point=0},lineEnd:function(){switch(this._point){case 1:this._context.moveTo(this._x3,this._y3),this._context.closePath();break;case 2:this._context.lineTo(this._x3,this._y3),this._context.closePath();break;case 3:this.point(this._x3,this._y3),this.point(this._x4,this._y4),this.point(this._x5,this._y5)}},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1,this._x3=t,this._y3=n;break;case 1:this._point=2,this._context.moveTo(this._x4=t,this._y4=n);break;case 2:this._point=3,this._x5=t,this._y5=n;break;default:Ln(this,t,n)}this._x0=this._x1,this._x1=this._x2,this._x2=t,this._y0=this._y1,this._y1=this._y2,this._y2=n}};var Bv=function t(n){function e(t){return new Un(t,n)}return e.tension=function(n){return t(+n)},e}(0);Dn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._x2=this._y0=this._y1=this._y2=NaN,this._point=0},lineEnd:function(){(this._line||0!==this._line&&3===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1;break;case 1:this._point=2;break;case 2:this._point=3,this._line?this._context.lineTo(this._x2,this._y2):this._context.moveTo(this._x2,this._y2);break;case 3:this._point=4;default:Ln(this,t,n)}this._x0=this._x1,this._x1=this._x2,this._x2=t,this._y0=this._y1,this._y1=this._y2,this._y2=n}};var jv=function t(n){function e(t){return new Dn(t,n)}return e.tension=function(n){return t(+n)},e}(0);Fn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._x2=this._y0=this._y1=this._y2=NaN,this._l01_a=this._l12_a=this._l23_a=this._l01_2a=this._l12_2a=this._l23_2a=this._point=0},lineEnd:function(){switch(this._point){case 2:this._context.lineTo(this._x2,this._y2);break;case 3:this.point(this,this._x2,this._y2)}(this._line||0!==this._line&&1===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){if(t=+t,n=+n,this._point){var e=this._x2-t,r=this._y2-n;this._l23_a=Math.sqrt(this._l23_2a=Math.pow(e*e+r*r,this._alpha))}switch(this._point){case 0:this._point=1,this._line?this._context.lineTo(t,n):this._context.moveTo(t,n);break;case 1:this._point=2;break;case 2:this._point=3;default:On(this,t,n)}this._l01_a=this._l12_a,this._l12_a=this._l23_a,this._l01_2a=this._l12_2a,this._l12_2a=this._l23_2a,this._x0=this._x1,this._x1=this._x2,this._x2=t,this._y0=this._y1,this._y1=this._y2,this._y2=n}};var Hv=function t(n){function e(t){return n?new Fn(t,n):new Rn(t,0)}return e.alpha=function(n){return t(+n)},e}(.5);In.prototype={areaStart:kn,areaEnd:kn,lineStart:function(){this._x0=this._x1=this._x2=this._x3=this._x4=this._x5=this._y0=this._y1=this._y2=this._y3=this._y4=this._y5=NaN,this._l01_a=this._l12_a=this._l23_a=this._l01_2a=this._l12_2a=this._l23_2a=this._point=0},lineEnd:function(){switch(this._point){case 1:this._context.moveTo(this._x3,this._y3),this._context.closePath();break;case 2:this._context.lineTo(this._x3,this._y3),this._context.closePath();break;case 3:this.point(this._x3,this._y3),this.point(this._x4,this._y4),this.point(this._x5,this._y5)}},point:function(t,n){if(t=+t,n=+n,this._point){var e=this._x2-t,r=this._y2-n;this._l23_a=Math.sqrt(this._l23_2a=Math.pow(e*e+r*r,this._alpha))}switch(this._point){case 0:this._point=1,this._x3=t,this._y3=n;break;case 1:this._point=2,this._context.moveTo(this._x4=t,this._y4=n);break;case 2:this._point=3,this._x5=t,this._y5=n;break;default:On(this,t,n)}this._l01_a=this._l12_a,this._l12_a=this._l23_a,this._l01_2a=this._l12_2a,this._l12_2a=this._l23_2a,this._x0=this._x1,this._x1=this._x2,this._x2=t,this._y0=this._y1,this._y1=this._y2,this._y2=n}};var Xv=function t(n){function e(t){return n?new In(t,n):new Un(t,0)}return e.alpha=function(n){return t(+n)},e}(.5);Yn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._x2=this._y0=this._y1=this._y2=NaN,this._l01_a=this._l12_a=this._l23_a=this._l01_2a=this._l12_2a=this._l23_2a=this._point=0},lineEnd:function(){(this._line||0!==this._line&&3===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){if(t=+t,n=+n,this._point){var e=this._x2-t,r=this._y2-n;this._l23_a=Math.sqrt(this._l23_2a=Math.pow(e*e+r*r,this._alpha))}switch(this._point){case 0:this._point=1;break;case 1:this._point=2;break;case 2:this._point=3,this._line?this._context.lineTo(this._x2,this._y2):this._context.moveTo(this._x2,this._y2);break;case 3:this._point=4;default:On(this,t,n)}this._l01_a=this._l12_a,this._l12_a=this._l23_a,this._l01_2a=this._l12_2a,this._l12_2a=this._l23_2a,this._x0=this._x1,this._x1=this._x2,this._x2=t,this._y0=this._y1,this._y1=this._y2,this._y2=n}};var Vv=function t(n){function e(t){return n?new Yn(t,n):new Dn(t,0)}return e.alpha=function(n){return t(+n)},e}(.5);Bn.prototype={areaStart:kn,areaEnd:kn,lineStart:function(){this._point=0},lineEnd:function(){this._point&&this._context.closePath()},point:function(t,n){t=+t,n=+n,this._point?this._context.lineTo(t,n):(this._point=1,this._context.moveTo(t,n))}},$n.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x0=this._x1=this._y0=this._y1=this._t0=NaN,this._point=0},lineEnd:function(){switch(this._point){case 2:this._context.lineTo(this._x1,this._y1);break;case 3:Wn(this,this._t0,Vn(this,this._t0))}(this._line||0!==this._line&&1===this._point)&&this._context.closePath(),this._line=1-this._line},point:function(t,n){var e=NaN;if(t=+t,n=+n,t!==this._x1||n!==this._y1){switch(this._point){case 0:this._point=1,this._line?this._context.lineTo(t,n):this._context.moveTo(t,n);break;case 1:this._point=2;break;case 2:this._point=3,Wn(this,Vn(this,e=Xn(this,t,n)),e);break;default:Wn(this,this._t0,e=Xn(this,t,n))}this._x0=this._x1,this._x1=t,this._y0=this._y1,this._y1=n,this._t0=e}}},(Zn.prototype=Object.create($n.prototype)).point=function(t,n){$n.prototype.point.call(this,n,t)},Gn.prototype={moveTo:function(t,n){this._context.moveTo(n,t)},closePath:function(){this._context.closePath()},lineTo:function(t,n){this._context.lineTo(n,t)},bezierCurveTo:function(t,n,e,r,i,o){this._context.bezierCurveTo(n,t,r,e,o,i)}},Kn.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x=[],this._y=[]},lineEnd:function(){var t=this._x,n=this._y,e=t.length;if(e)if(this._line?this._context.lineTo(t[0],n[0]):this._context.moveTo(t[0],n[0]),2===e)this._context.lineTo(t[1],n[1]);else for(var r=te(t),i=te(n),o=0,u=1;u<e;++o,++u)this._context.bezierCurveTo(r[0][o],i[0][o],r[1][o],i[1][o],t[u],n[u]);(this._line||0!==this._line&&1===e)&&this._context.closePath(),this._line=1-this._line,this._x=this._y=null},point:function(t,n){this._x.push(+t),this._y.push(+n)}},ee.prototype={areaStart:function(){this._line=0},areaEnd:function(){this._line=NaN},lineStart:function(){this._x=this._y=NaN,this._point=0},lineEnd:function(){0<this._t&&this._t<1&&2===this._point&&this._context.lineTo(this._x,this._y),(this._line||0!==this._line&&1===this._point)&&this._context.closePath(),this._line>=0&&(this._t=1-this._t,this._line=1-this._line)},point:function(t,n){switch(t=+t,n=+n,this._point){case 0:this._point=1,this._line?this._context.lineTo(t,n):this._context.moveTo(t,n);break;case 1:this._point=2;default:if(this._t<=0)this._context.lineTo(this._x,n),this._context.lineTo(t,n);else{var e=this._x*(1-this._t)+t*this._t;this._context.lineTo(e,this._y),this._context.lineTo(e,n)}}this._x=t,this._y=n}};var Wv=Array.prototype.slice,$v=.7,Zv=1/$v,Gv=/^#([0-9a-f]{3})$/,Jv=/^#([0-9a-f]{6})$/,Qv=/^rgb\(\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*\)$/,Kv=/^rgb\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/,t_=/^rgba\(\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+)\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/,n_=/^rgba\(\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/,e_=/^hsl\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*\)$/,r_=/^hsla\(\s*([-+]?\d+(?:\.\d+)?)\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)%\s*,\s*([-+]?\d+(?:\.\d+)?)\s*\)$/,i_={aliceblue:15792383,antiquewhite:16444375,aqua:65535,aquamarine:8388564,azure:15794175,beige:16119260,bisque:16770244,black:0,blanchedalmond:16772045,blue:255,blueviolet:9055202,brown:10824234,burlywood:14596231,cadetblue:6266528,chartreuse:8388352,chocolate:13789470,coral:16744272,cornflowerblue:6591981,cornsilk:16775388,crimson:14423100,cyan:65535,darkblue:139,darkcyan:35723,darkgoldenrod:12092939,darkgray:11119017,darkgreen:25600,darkgrey:11119017,darkkhaki:12433259,darkmagenta:9109643,darkolivegreen:5597999,darkorange:16747520,darkorchid:10040012,darkred:9109504,darksalmon:15308410,darkseagreen:9419919,darkslateblue:4734347,darkslategray:3100495,darkslategrey:3100495,darkturquoise:52945,darkviolet:9699539,deeppink:16716947,deepskyblue:49151,dimgray:6908265,dimgrey:6908265,dodgerblue:2003199,firebrick:11674146,floralwhite:16775920,forestgreen:2263842,fuchsia:16711935,gainsboro:14474460,ghostwhite:16316671,gold:16766720,goldenrod:14329120,gray:8421504,green:32768,greenyellow:11403055,grey:8421504,honeydew:15794160,hotpink:16738740,indianred:13458524,indigo:4915330,ivory:16777200,khaki:15787660,lavender:15132410,lavenderblush:16773365,lawngreen:8190976,lemonchiffon:16775885,lightblue:11393254,lightcoral:15761536,lightcyan:14745599,lightgoldenrodyellow:16448210,lightgray:13882323,lightgreen:9498256,lightgrey:13882323,lightpink:16758465,lightsalmon:16752762,lightseagreen:2142890,lightskyblue:8900346,lightslategray:7833753,lightslategrey:7833753,lightsteelblue:11584734,lightyellow:16777184,lime:65280,limegreen:3329330,linen:16445670,magenta:16711935,maroon:8388608,mediumaquamarine:6737322,mediumblue:205,mediumorchid:12211667,mediumpurple:9662683,mediumseagreen:3978097,mediumslateblue:8087790,mediumspringgreen:64154,mediumturquoise:4772300,mediumvioletred:13047173,midnightblue:1644912,mintcream:16121850,mistyrose:16770273,moccasin:16770229,navajowhite:16768685,navy:128,oldlace:16643558,olive:8421376,olivedrab:7048739,orange:16753920,orangered:16729344,orchid:14315734,palegoldenrod:15657130,palegreen:10025880,paleturquoise:11529966,palevioletred:14381203,papayawhip:16773077,peachpuff:16767673,peru:13468991,pink:16761035,plum:14524637,powderblue:11591910,purple:8388736,rebeccapurple:6697881,red:16711680,rosybrown:12357519,royalblue:4286945,saddlebrown:9127187,salmon:16416882,sandybrown:16032864,seagreen:3050327,seashell:16774638,sienna:10506797,silver:12632256,skyblue:8900331,slateblue:6970061,slategray:7372944,slategrey:7372944,snow:16775930,springgreen:65407,steelblue:4620980,tan:13808780,teal:32896,thistle:14204888,tomato:16737095,turquoise:4251856,violet:15631086,wheat:16113331,white:16777215,whitesmoke:16119285,yellow:16776960,yellowgreen:10145074};ge(xe,be,{displayable:function(){return this.rgb().displayable()},toString:function(){return this.rgb()+""}}),ge(Ne,ke,me(xe,{brighter:function(t){return t=null==t?Zv:Math.pow(Zv,t),new Ne(this.r*t,this.g*t,this.b*t,this.opacity)},darker:function(t){return t=null==t?$v:Math.pow($v,t),new Ne(this.r*t,this.g*t,this.b*t,this.opacity)},rgb:function(){return this},displayable:function(){return 0<=this.r&&this.r<=255&&0<=this.g&&this.g<=255&&0<=this.b&&this.b<=255&&0<=this.opacity&&this.opacity<=1},toString:function(){var t=this.opacity;return t=isNaN(t)?1:Math.max(0,Math.min(1,t)),(1===t?"rgb(":"rgba(")+Math.max(0,Math.min(255,Math.round(this.r)||0))+", "+Math.max(0,Math.min(255,Math.round(this.g)||0))+", "+Math.max(0,Math.min(255,Math.round(this.b)||0))+(1===t?")":", "+t+")")}})),ge(Ce,Ee,me(xe,{brighter:function(t){return t=null==t?Zv:Math.pow(Zv,t),new Ce(this.h,this.s,this.l*t,this.opacity)},darker:function(t){return t=null==t?$v:Math.pow($v,t),new Ce(this.h,this.s,this.l*t,this.opacity)},rgb:function(){var t=this.h%360+360*(this.h<0),n=isNaN(t)||isNaN(this.s)?0:this.s,e=this.l,r=e+(e<.5?e:1-e)*n,i=2*e-r;return new Ne(ze(t>=240?t-240:t+120,i,r),ze(t,i,r),ze(t<120?t+240:t-120,i,r),this.opacity)},displayable:function(){return(0<=this.s&&this.s<=1||isNaN(this.s))&&0<=this.l&&this.l<=1&&0<=this.opacity&&this.opacity<=1}}));var o_=Math.PI/180,u_=180/Math.PI,a_=18,c_=.95047,s_=1,f_=1.08883,l_=4/29,h_=6/29,p_=3*h_*h_,d_=h_*h_*h_;ge(Le,qe,me(xe,{brighter:function(t){return new Le(this.l+a_*(null==t?1:t),this.a,this.b,this.opacity)},darker:function(t){return new Le(this.l-a_*(null==t?1:t),this.a,this.b,this.opacity)},rgb:function(){var t=(this.l+16)/116,n=isNaN(this.a)?t:t+this.a/500,e=isNaN(this.b)?t:t-this.b/200;return t=s_*Ue(t),n=c_*Ue(n),e=f_*Ue(e),new Ne(De(3.2404542*n-1.5371385*t-.4985314*e),De(-.969266*n+1.8760108*t+.041556*e),De(.0556434*n-.2040259*t+1.0572252*e),this.opacity)}})),ge(Ye,Ie,me(xe,{brighter:function(t){return new Ye(this.h,this.c,this.l+a_*(null==t?1:t),this.opacity)},darker:function(t){return new Ye(this.h,this.c,this.l-a_*(null==t?1:t),this.opacity)},rgb:function(){return Pe(this).rgb()}}));var v_=-.14861,__=1.78277,y_=-.29227,g_=-.90649,m_=1.97294,x_=m_*g_,b_=m_*__,w_=__*y_-g_*v_;ge(He,je,me(xe,{brighter:function(t){return t=null==t?Zv:Math.pow(Zv,t),new He(this.h,this.s,this.l*t,this.opacity)},darker:function(t){return t=null==t?$v:Math.pow($v,t),new He(this.h,this.s,this.l*t,this.opacity)},rgb:function(){var t=isNaN(this.h)?0:(this.h+120)*o_,n=+this.l,e=isNaN(this.s)?0:this.s*n*(1-n),r=Math.cos(t),i=Math.sin(t);return new Ne(255*(n+e*(v_*r+__*i)),255*(n+e*(y_*r+g_*i)),255*(n+e*(m_*r)),this.opacity)}}));var M_,T_,k_,N_,S_=function t(n){function e(t,n){var e=r((t=ke(t)).r,(n=ke(n)).r),i=r(t.g,n.g),o=r(t.b,n.b),u=r(t.opacity,n.opacity);return function(n){return t.r=e(n),t.g=i(n),t.b=o(n),t.opacity=u(n),t+""}}var r=Qe(n);return e.gamma=t,e}(1),A_=tr(Ve),E_=tr(We),C_=/[-+]?(?:\d+\.?\d*|\.?\d+)(?:[eE][-+]?\d+)?/g,z_=new RegExp(C_.source,"g"),P_=180/Math.PI,q_={translateX:0,translateY:0,rotate:0,skewX:0,scaleX:1,scaleY:1},L_=pr(lr,"px, ","px)","deg)"),R_=pr(hr,", ",")",")"),U_=Math.SQRT2,D_=2,O_=4,F_=1e-12,I_=gr(Je),Y_=gr(Ke),B_=xr(Je),j_=xr(Ke),H_=br(Je),X_=br(Ke),V_={value:function(){}};Tr.prototype=Mr.prototype={constructor:Tr,on:function(t,n){var e,r=this._,i=kr(t+"",r),o=-1,u=i.length;{if(!(arguments.length<2)){if(null!=n&&"function"!=typeof n)throw new Error("invalid callback: "+n);for(;++o<u;)if(e=(t=i[o]).type)r[e]=Sr(r[e],t.name,n);else if(null==n)for(e in r)r[e]=Sr(r[e],t.name,null);return this}for(;++o<u;)if((e=(t=i[o]).type)&&(e=Nr(r[e],t.name)))return e}},copy:function(){var t={},n=this._;for(var e in n)t[e]=n[e].slice();return new Tr(t)},call:function(t,n){if((e=arguments.length-2)>0)for(var e,r,i=new Array(e),o=0;o<e;++o)i[o]=arguments[o+2];if(!this._.hasOwnProperty(t))throw new Error("unknown type: "+t);for(r=this._[t],o=0,e=r.length;o<e;++o)r[o].value.apply(n,i)},apply:function(t,n,e){if(!this._.hasOwnProperty(t))throw new Error("unknown type: "+t);for(var r=this._[t],i=0,o=r.length;i<o;++i)r[i].value.apply(n,e)}};var W_,$_,Z_=zr(","),G_=Z_.parse,J_=Z_.parseRows,Q_=Z_.format,K_=Z_.formatRows,ty=zr("\t"),ny=ty.parse,ey=ty.parseRows,ry=ty.format,iy=ty.formatRows,oy=Rr("text/html",function(t){return document.createRange().createContextualFragment(t.responseText)}),uy=Rr("application/json",function(t){return JSON.parse(t.responseText)}),ay=Rr("text/plain",function(t){return t.responseText}),cy=Rr("application/xml",function(t){var n=t.responseXML;if(!n)throw new Error("parse error");return n}),sy=Ur("text/csv",G_),fy=Ur("text/tab-separated-values",ny),ly=0,hy=0,py=0,dy=1e3,vy=0,_y=0,yy=0,gy="object"==typeof performance&&performance.now?performance:Date,my="function"==typeof requestAnimationFrame?gy===Date?function(t){requestAnimationFrame(function(){t(gy.now())})}:requestAnimationFrame:function(t){setTimeout(t,17)};Ir.prototype=Yr.prototype={constructor:Ir,restart:function(t,n,e){if("function"!=typeof t)throw new TypeError("callback is not a function");e=(null==e?Or():+e)+(null==n?0:+n),this._next||$_===this||($_?$_._next=this:W_=this,$_=this),this._call=t,this._time=e,Vr()},stop:function(){this._call&&(this._call=null,this._time=1/0,Vr())}};var xy=new Date,by=new Date,wy=Zr(function(){},function(t,n){t.setTime(+t+n)},function(t,n){return n-t});wy.every=function(t){return t=Math.floor(t),isFinite(t)&&t>0?t>1?Zr(function(n){n.setTime(Math.floor(n/t)*t)},function(n,e){n.setTime(+n+e*t)},function(n,e){return(e-n)/t}):wy:null};var My=wy.range,Ty=1e3,ky=6e4,Ny=36e5,Sy=864e5,Ay=6048e5,Ey=Zr(function(t){t.setTime(Math.floor(t/Ty)*Ty)},function(t,n){t.setTime(+t+n*Ty)},function(t,n){return(n-t)/Ty},function(t){return t.getUTCSeconds()}),Cy=Ey.range,zy=Zr(function(t){t.setTime(Math.floor(t/ky)*ky)},function(t,n){t.setTime(+t+n*ky)},function(t,n){return(n-t)/ky},function(t){return t.getMinutes()}),Py=zy.range,qy=Zr(function(t){var n=t.getTimezoneOffset()*ky%Ny;n<0&&(n+=Ny),t.setTime(Math.floor((+t-n)/Ny)*Ny+n)},function(t,n){t.setTime(+t+n*Ny)},function(t,n){return(n-t)/Ny},function(t){return t.getHours()}),Ly=qy.range,Ry=Zr(function(t){t.setHours(0,0,0,0)},function(t,n){t.setDate(t.getDate()+n)},function(t,n){return(n-t-(n.getTimezoneOffset()-t.getTimezoneOffset())*ky)/Sy},function(t){return t.getDate()-1}),Uy=Ry.range,Dy=Gr(0),Oy=Gr(1),Fy=Gr(2),Iy=Gr(3),Yy=Gr(4),By=Gr(5),jy=Gr(6),Hy=Dy.range,Xy=Oy.range,Vy=Fy.range,Wy=Iy.range,$y=Yy.range,Zy=By.range,Gy=jy.range,Jy=Zr(function(t){t.setDate(1),t.setHours(0,0,0,0)},function(t,n){t.setMonth(t.getMonth()+n)},function(t,n){return n.getMonth()-t.getMonth()+12*(n.getFullYear()-t.getFullYear())},function(t){return t.getMonth()}),Qy=Jy.range,Ky=Zr(function(t){t.setMonth(0,1),t.setHours(0,0,0,0)},function(t,n){t.setFullYear(t.getFullYear()+n)},function(t,n){return n.getFullYear()-t.getFullYear()},function(t){return t.getFullYear()});Ky.every=function(t){return isFinite(t=Math.floor(t))&&t>0?Zr(function(n){n.setFullYear(Math.floor(n.getFullYear()/t)*t),n.setMonth(0,1),n.setHours(0,0,0,0)},function(n,e){n.setFullYear(n.getFullYear()+e*t)}):null};var tg=Ky.range,ng=Zr(function(t){t.setUTCSeconds(0,0)},function(t,n){t.setTime(+t+n*ky)},function(t,n){return(n-t)/ky},function(t){return t.getUTCMinutes()}),eg=ng.range,rg=Zr(function(t){t.setUTCMinutes(0,0,0)},function(t,n){t.setTime(+t+n*Ny)},function(t,n){return(n-t)/Ny},function(t){return t.getUTCHours()}),ig=rg.range,og=Zr(function(t){t.setUTCHours(0,0,0,0)},function(t,n){t.setUTCDate(t.getUTCDate()+n)},function(t,n){return(n-t)/Sy},function(t){return t.getUTCDate()-1}),ug=og.range,ag=Jr(0),cg=Jr(1),sg=Jr(2),fg=Jr(3),lg=Jr(4),hg=Jr(5),pg=Jr(6),dg=ag.range,vg=cg.range,_g=sg.range,yg=fg.range,gg=lg.range,mg=hg.range,xg=pg.range,bg=Zr(function(t){t.setUTCDate(1),t.setUTCHours(0,0,0,0)},function(t,n){t.setUTCMonth(t.getUTCMonth()+n)},function(t,n){return n.getUTCMonth()-t.getUTCMonth()+12*(n.getUTCFullYear()-t.getUTCFullYear())},function(t){return t.getUTCMonth()}),wg=bg.range,Mg=Zr(function(t){t.setUTCMonth(0,1),t.setUTCHours(0,0,0,0)},function(t,n){t.setUTCFullYear(t.getUTCFullYear()+n)},function(t,n){return n.getUTCFullYear()-t.getUTCFullYear()},function(t){return t.getUTCFullYear()});Mg.every=function(t){return isFinite(t=Math.floor(t))&&t>0?Zr(function(n){n.setUTCFullYear(Math.floor(n.getUTCFullYear()/t)*t),n.setUTCMonth(0,1),n.setUTCHours(0,0,0,0)},function(n,e){n.setUTCFullYear(n.getUTCFullYear()+e*t)}):null};var Tg,kg=Mg.range,Ng={"":ni,"%":function(t,n){return(100*t).toFixed(n)},b:function(t){return Math.round(t).toString(2)},c:function(t){return t+""},d:function(t){return Math.round(t).toString(10)},e:function(t,n){return t.toExponential(n)},f:function(t,n){return t.toFixed(n)},g:function(t,n){return t.toPrecision(n)},o:function(t){return Math.round(t).toString(8)},p:function(t,n){return ri(100*t,n)},r:ri,s:ei,X:function(t){return Math.round(t).toString(16).toUpperCase()},x:function(t){return Math.round(t).toString(16)}},Sg=/^(?:(.)?([<>=^]))?([+\-\( ])?([$#])?(0)?(\d+)?(,)?(\.\d+)?([a-z%])?$/i;oi.prototype.toString=function(){return this.fill+this.align+this.sign+this.symbol+(this.zero?"0":"")+(null==this.width?"":Math.max(1,0|this.width))+(this.comma?",":"")+(null==this.precision?"":"."+Math.max(0,0|this.precision))+this.type};var Ag,Eg=["y","z","a","f","p","n","µ","m","","k","M","G","T","P","E","Z","Y"];t.format,t.formatPrefix,ci({decimal:".",thousands:",",grouping:[3],currency:["$",""]});var Cg,zg={"-":"",_:" ",0:"0"},Pg=/^\s*\d+/,qg=/^%/,Lg=/[\\\^\$\*\+\?\|\[\]\(\)\.\{\}]/g;t.timeFormat,t.timeParse,t.utcFormat,t.utcParse,so({dateTime:"%x, %X",date:"%-m/%-d/%Y",time:"%-I:%M:%S %p",periods:["AM","PM"],days:["Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday"],shortDays:["Sun","Mon","Tue","Wed","Thu","Fri","Sat"],months:["January","February","March","April","May","June","July","August","September","October","November","December"],shortMonths:["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"]});var Rg="%Y-%m-%dT%H:%M:%S.%LZ",Ug=Date.prototype.toISOString?fo:t.utcFormat(Rg),Dg=+new Date("2000-01-01T00:00:00.000Z")?lo:t.utcParse(Rg),Og=Array.prototype,Fg=Og.map,Ig=Og.slice,Yg={name:"implicit"},Bg=[0,1],jg=1e3,Hg=60*jg,Xg=60*Hg,Vg=24*Xg,Wg=7*Vg,$g=30*Vg,Zg=365*Vg,Gg=Zo("1f77b4ff7f0e2ca02cd627289467bd8c564be377c27f7f7fbcbd2217becf"),Jg=Zo("393b795254a36b6ecf9c9ede6379398ca252b5cf6bcedb9c8c6d31bd9e39e7ba52e7cb94843c39ad494ad6616be7969c7b4173a55194ce6dbdde9ed6"),Qg=Zo("3182bd6baed69ecae1c6dbefe6550dfd8d3cfdae6bfdd0a231a35474c476a1d99bc7e9c0756bb19e9ac8bcbddcdadaeb636363969696bdbdbdd9d9d9"),Kg=Zo("1f77b4aec7e8ff7f0effbb782ca02c98df8ad62728ff98969467bdc5b0d58c564bc49c94e377c2f7b6d27f7f7fc7c7c7bcbd22dbdb8d17becf9edae5"),tm=X_(je(300,.5,0),je(-240,.5,1)),nm=X_(je(-100,.75,.35),je(80,1.5,.8)),em=X_(je(260,.75,.35),je(80,1.5,.8)),rm=je(),im=Jo(Zo("44015444025645045745055946075a46085c460a5d460b5e470d60470e6147106347116447136548146748166848176948186a481a6c481b6d481c6e481d6f481f70482071482173482374482475482576482677482878482979472a7a472c7a472d7b472e7c472f7d46307e46327e46337f463480453581453781453882443983443a83443b84433d84433e85423f854240864241864142874144874045884046883f47883f48893e49893e4a893e4c8a3d4d8a3d4e8a3c4f8a3c508b3b518b3b528b3a538b3a548c39558c39568c38588c38598c375a8c375b8d365c8d365d8d355e8d355f8d34608d34618d33628d33638d32648e32658e31668e31678e31688e30698e306a8e2f6b8e2f6c8e2e6d8e2e6e8e2e6f8e2d708e2d718e2c718e2c728e2c738e2b748e2b758e2a768e2a778e2a788e29798e297a8e297b8e287c8e287d8e277e8e277f8e27808e26818e26828e26828e25838e25848e25858e24868e24878e23888e23898e238a8d228b8d228c8d228d8d218e8d218f8d21908d21918c20928c20928c20938c1f948c1f958b1f968b1f978b1f988b1f998a1f9a8a1e9b8a1e9c891e9d891f9e891f9f881fa0881fa1881fa1871fa28720a38620a48621a58521a68522a78522a88423a98324aa8325ab8225ac8226ad8127ad8128ae8029af7f2ab07f2cb17e2db27d2eb37c2fb47c31b57b32b67a34b67935b77937b87838b9773aba763bbb753dbc743fbc7340bd7242be7144bf7046c06f48c16e4ac16d4cc26c4ec36b50c46a52c56954c56856c66758c7655ac8645cc8635ec96260ca6063cb5f65cb5e67cc5c69cd5b6ccd5a6ece5870cf5773d05675d05477d1537ad1517cd2507fd34e81d34d84d44b86d54989d5488bd6468ed64590d74393d74195d84098d83e9bd93c9dd93ba0da39a2da37a5db36a8db34aadc32addc30b0dd2fb2dd2db5de2bb8de29bade28bddf26c0df25c2df23c5e021c8e020cae11fcde11dd0e11cd2e21bd5e21ad8e219dae319dde318dfe318e2e418e5e419e7e419eae51aece51befe51cf1e51df4e61ef6e620f8e621fbe723fde725")),om=Jo(Zo("00000401000501010601010802010902020b02020d03030f03031204041405041606051806051a07061c08071e0907200a08220b09240c09260d0a290e0b2b100b2d110c2f120d31130d34140e36150e38160f3b180f3d19103f1a10421c10441d11471e114920114b21114e22115024125325125527125829115a2a115c2c115f2d11612f116331116533106734106936106b38106c390f6e3b0f703d0f713f0f72400f74420f75440f764510774710784910784a10794c117a4e117b4f127b51127c52137c54137d56147d57157e59157e5a167e5c167f5d177f5f187f601880621980641a80651a80671b80681c816a1c816b1d816d1d816e1e81701f81721f817320817521817621817822817922827b23827c23827e24828025828125818326818426818627818827818928818b29818c29818e2a81902a81912b81932b80942c80962c80982d80992d809b2e7f9c2e7f9e2f7fa02f7fa1307ea3307ea5317ea6317da8327daa337dab337cad347cae347bb0357bb2357bb3367ab5367ab73779b83779ba3878bc3978bd3977bf3a77c03a76c23b75c43c75c53c74c73d73c83e73ca3e72cc3f71cd4071cf4070d0416fd2426fd3436ed5446dd6456cd8456cd9466bdb476adc4869de4968df4a68e04c67e24d66e34e65e44f64e55064e75263e85362e95462ea5661eb5760ec5860ed5a5fee5b5eef5d5ef05f5ef1605df2625df2645cf3655cf4675cf4695cf56b5cf66c5cf66e5cf7705cf7725cf8745cf8765cf9785df9795df97b5dfa7d5efa7f5efa815ffb835ffb8560fb8761fc8961fc8a62fc8c63fc8e64fc9065fd9266fd9467fd9668fd9869fd9a6afd9b6bfe9d6cfe9f6dfea16efea36ffea571fea772fea973feaa74feac76feae77feb078feb27afeb47bfeb67cfeb77efeb97ffebb81febd82febf84fec185fec287fec488fec68afec88cfeca8dfecc8ffecd90fecf92fed194fed395fed597fed799fed89afdda9cfddc9efddea0fde0a1fde2a3fde3a5fde5a7fde7a9fde9aafdebacfcecaefceeb0fcf0b2fcf2b4fcf4b6fcf6b8fcf7b9fcf9bbfcfbbdfcfdbf")),um=Jo(Zo("00000401000501010601010802010a02020c02020e03021004031204031405041706041907051b08051d09061f0a07220b07240c08260d08290e092b10092d110a30120a32140b34150b37160b39180c3c190c3e1b0c411c0c431e0c451f0c48210c4a230c4c240c4f260c51280b53290b552b0b572d0b592f0a5b310a5c320a5e340a5f3609613809623909633b09643d09653e0966400a67420a68440a68450a69470b6a490b6a4a0c6b4c0c6b4d0d6c4f0d6c510e6c520e6d540f6d550f6d57106e59106e5a116e5c126e5d126e5f136e61136e62146e64156e65156e67166e69166e6a176e6c186e6d186e6f196e71196e721a6e741a6e751b6e771c6d781c6d7a1d6d7c1d6d7d1e6d7f1e6c801f6c82206c84206b85216b87216b88226a8a226a8c23698d23698f24699025689225689326679526679727669827669a28659b29649d29649f2a63a02a63a22b62a32c61a52c60a62d60a82e5fa92e5eab2f5ead305dae305cb0315bb1325ab3325ab43359b63458b73557b93556ba3655bc3754bd3853bf3952c03a51c13a50c33b4fc43c4ec63d4dc73e4cc83f4bca404acb4149cc4248ce4347cf4446d04545d24644d34743d44842d54a41d74b3fd84c3ed94d3dda4e3cdb503bdd513ade5238df5337e05536e15635e25734e35933e45a31e55c30e65d2fe75e2ee8602de9612bea632aeb6429eb6628ec6726ed6925ee6a24ef6c23ef6e21f06f20f1711ff1731df2741cf3761bf37819f47918f57b17f57d15f67e14f68013f78212f78410f8850ff8870ef8890cf98b0bf98c0af98e09fa9008fa9207fa9407fb9606fb9706fb9906fb9b06fb9d07fc9f07fca108fca309fca50afca60cfca80dfcaa0ffcac11fcae12fcb014fcb216fcb418fbb61afbb81dfbba1ffbbc21fbbe23fac026fac228fac42afac62df9c72ff9c932f9cb35f8cd37f8cf3af7d13df7d340f6d543f6d746f5d949f5db4cf4dd4ff4df53f4e156f3e35af3e55df2e661f2e865f2ea69f1ec6df1ed71f1ef75f1f179f2f27df2f482f3f586f3f68af4f88ef5f992f6fa96f8fb9af9fc9dfafda1fcffa4")),am=Jo(Zo("0d088710078813078916078a19068c1b068d1d068e20068f2206902406912605912805922a05932c05942e05952f059631059733059735049837049938049a3a049a3c049b3e049c3f049c41049d43039e44039e46039f48039f4903a04b03a14c02a14e02a25002a25102a35302a35502a45601a45801a45901a55b01a55c01a65e01a66001a66100a76300a76400a76600a76700a86900a86a00a86c00a86e00a86f00a87100a87201a87401a87501a87701a87801a87a02a87b02a87d03a87e03a88004a88104a78305a78405a78606a68707a68808a68a09a58b0aa58d0ba58e0ca48f0da4910ea3920fa39410a29511a19613a19814a099159f9a169f9c179e9d189d9e199da01a9ca11b9ba21d9aa31e9aa51f99a62098a72197a82296aa2395ab2494ac2694ad2793ae2892b02991b12a90b22b8fb32c8eb42e8db52f8cb6308bb7318ab83289ba3388bb3488bc3587bd3786be3885bf3984c03a83c13b82c23c81c33d80c43e7fc5407ec6417dc7427cc8437bc9447aca457acb4679cc4778cc4977cd4a76ce4b75cf4c74d04d73d14e72d24f71d35171d45270d5536fd5546ed6556dd7566cd8576bd9586ada5a6ada5b69db5c68dc5d67dd5e66de5f65de6164df6263e06363e16462e26561e26660e3685fe4695ee56a5de56b5de66c5ce76e5be76f5ae87059e97158e97257ea7457eb7556eb7655ec7754ed7953ed7a52ee7b51ef7c51ef7e50f07f4ff0804ef1814df1834cf2844bf3854bf3874af48849f48948f58b47f58c46f68d45f68f44f79044f79143f79342f89441f89540f9973ff9983ef99a3efa9b3dfa9c3cfa9e3bfb9f3afba139fba238fca338fca537fca636fca835fca934fdab33fdac33fdae32fdaf31fdb130fdb22ffdb42ffdb52efeb72dfeb82cfeba2cfebb2bfebd2afebe2afec029fdc229fdc328fdc527fdc627fdc827fdca26fdcb26fccd25fcce25fcd025fcd225fbd324fbd524fbd724fad824fada24f9dc24f9dd25f8df25f8e125f7e225f7e425f6e626f6e826f5e926f5eb27f4ed27f3ee27f3f027f2f227f1f426f1f525f0f724f0f921")),cm="http://www.w3.org/1999/xhtml",sm={
 svg:"http://www.w3.org/2000/svg",xhtml:cm,xlink:"http://www.w3.org/1999/xlink",xml:"http://www.w3.org/XML/1998/namespace",xmlns:"http://www.w3.org/2000/xmlns/"},fm=0;iu.prototype=ru.prototype={constructor:iu,get:function(t){for(var n=this._;!(n in t);)if(!(t=t.parentNode))return;return t[n]},set:function(t,n){return t[this._]=n},remove:function(t){return this._ in t&&delete t[this._]},toString:function(){return this._}};var lm=function(t){return function(){return this.matches(t)}};if("undefined"!=typeof document){var hm=document.documentElement;if(!hm.matches){var pm=hm.webkitMatchesSelector||hm.msMatchesSelector||hm.mozMatchesSelector||hm.oMatchesSelector;lm=function(t){return function(){return pm.call(this,t)}}}}var dm=lm,vm={};if(t.event=null,"undefined"!=typeof document){var _m=document.documentElement;"onmouseenter"in _m||(vm={mouseenter:"mouseover",mouseleave:"mouseout"})}Tu.prototype={constructor:Tu,appendChild:function(t){return this._parent.insertBefore(t,this._next)},insertBefore:function(t,n){return this._parent.insertBefore(t,n)},querySelector:function(t){return this._parent.querySelector(t)},querySelectorAll:function(t){return this._parent.querySelectorAll(t)}};var ym="$";ia.prototype={add:function(t){var n=this._names.indexOf(t);n<0&&(this._names.push(t),this._node.setAttribute("class",this._names.join(" ")))},remove:function(t){var n=this._names.indexOf(t);n>=0&&(this._names.splice(n,1),this._node.setAttribute("class",this._names.join(" ")))},contains:function(t){return this._names.indexOf(t)>=0}};var gm=[null];qa.prototype=La.prototype={constructor:qa,select:yu,selectAll:xu,filter:bu,data:Au,enter:Mu,exit:Eu,merge:Cu,order:zu,sort:Pu,call:Lu,nodes:Ru,node:Uu,size:Du,empty:Ou,each:Fu,attr:Vu,style:Ju,property:na,classed:fa,text:da,html:ga,raise:xa,lower:wa,append:Ma,insert:ka,remove:Sa,datum:Aa,on:fu,dispatch:Pa};var mm=Mr("start","end","interrupt"),xm=[],bm=0,wm=1,Mm=2,Tm=3,km=4,Nm=5,Sm=La.prototype.constructor,Am=0,Em=La.prototype;Uc.prototype=Dc.prototype={constructor:Uc,select:wc,selectAll:Mc,filter:vc,merge:_c,selection:Tc,transition:Rc,call:Em.call,nodes:Em.nodes,node:Em.node,size:Em.size,empty:Em.empty,each:Em.each,on:mc,attr:rc,attrTween:uc,style:Ec,styleTween:zc,text:Lc,remove:bc,tween:$a,delay:sc,duration:hc,ease:dc};var Cm={time:null,delay:0,duration:250,ease:et};La.prototype.interrupt=Xa,La.prototype.transition=Ic;var zm=[null],Pm=Array.prototype.slice,qm=1,Lm=2,Rm=3,Um=4,Dm=1e-6;ws.prototype=ys.prototype={constructor:ws,each:us,eachAfter:cs,eachBefore:as,sum:ss,sort:fs,path:ls,ancestors:ps,descendants:ds,leaves:vs,links:_s,copy:gs};var Om="$",Fm={depth:-1},Im={};of.prototype=Object.create(ws.prototype);var Ym=(1+Math.sqrt(5))/2,Bm=function t(n){function e(t,e,r,i,o){sf(n,t,e,r,i,o)}return e.ratio=function(n){return t((n=+n)>1?n:1)},e}(Ym),jm=function t(n){function e(t,e,r,i,o){if((u=t._squarify)&&u.ratio===n)for(var u,a,c,s,f,l=-1,h=u.length,p=t.value;++l<h;){for(a=u[l],c=a.children,s=a.value=0,f=c.length;s<f;++s)a.value+=c[s].value;a.dice?Ws(a,e,r,i,r+=(o-r)*a.value/p):cf(a,e,r,e+=(i-e)*a.value/p,o),p-=a.value}else t._squarify=u=sf(n,t,e,r,i,o),u.ratio=n}return e.ratio=function(n){return t((n=+n)>1?n:1)},e}(Ym),Hm=10,Xm=Math.PI*(3-Math.sqrt(5));Pf.prototype.on=function(){var t=this._.on.apply(this._,arguments);return t===this._?this:t},If.prototype={constructor:If,insert:function(t,n){var e,r,i;if(t){if(n.P=t,n.N=t.N,t.N&&(t.N.P=n),t.N=n,t.R){for(t=t.R;t.L;)t=t.L;t.L=n}else t.R=n;e=t}else this._?(t=Hf(this._),n.P=null,n.N=t,t.P=t.L=n,e=t):(n.P=n.N=null,this._=n,e=null);for(n.L=n.R=null,n.U=e,n.C=!0,t=n;e&&e.C;)r=e.U,e===r.L?(i=r.R,i&&i.C?(e.C=i.C=!1,r.C=!0,t=r):(t===e.R&&(Bf(this,e),t=e,e=t.U),e.C=!1,r.C=!0,jf(this,r))):(i=r.L,i&&i.C?(e.C=i.C=!1,r.C=!0,t=r):(t===e.L&&(jf(this,e),t=e,e=t.U),e.C=!1,r.C=!0,Bf(this,r))),e=t.U;this._.C=!1},remove:function(t){t.N&&(t.N.P=t.P),t.P&&(t.P.N=t.N),t.N=t.P=null;var n,e,r,i=t.U,o=t.L,u=t.R;if(e=o?u?Hf(u):o:u,i?i.L===t?i.L=e:i.R=e:this._=e,o&&u?(r=e.C,e.C=t.C,e.L=o,o.U=e,e!==u?(i=e.U,e.U=t.U,t=e.R,i.L=t,e.R=u,u.U=e):(e.U=i,i=e,t=e.R)):(r=t.C,t=e),t&&(t.U=i),!r){if(t&&t.C)return void(t.C=!1);do{if(t===this._)break;if(t===i.L){if(n=i.R,n.C&&(n.C=!1,i.C=!0,Bf(this,i),n=i.R),n.L&&n.L.C||n.R&&n.R.C){n.R&&n.R.C||(n.L.C=!1,n.C=!0,jf(this,n),n=i.R),n.C=i.C,i.C=n.R.C=!1,Bf(this,i),t=this._;break}}else if(n=i.L,n.C&&(n.C=!1,i.C=!0,jf(this,i),n=i.L),n.L&&n.L.C||n.R&&n.R.C){n.L&&n.L.C||(n.R.C=!1,n.C=!0,Bf(this,n),n=i.L),n.C=i.C,i.C=n.L.C=!1,jf(this,i),t=this._;break}n.C=!0,t=i,i=i.U}while(!t.C);t&&(t.C=!1)}}};var Vm,Wm,$m,Zm,Gm,Jm=[],Qm=[],Km=1e-6,tx=1e-12;vl.prototype={constructor:vl,polygons:function(){var t=this.edges;return this.cells.map(function(n){var e=n.halfedges.map(function(e){return Kf(n,t[e])});return e.data=n.site.data,e})},triangles:function(){var t=[],n=this.edges;return this.cells.forEach(function(e,r){for(var i,o=e.site,u=e.halfedges,a=-1,c=u.length,s=n[u[c-1]],f=s.left===o?s.right:s.left;++a<c;)i=f,s=n[u[a]],f=s.left===o?s.right:s.left,r<i.index&&r<f.index&&pl(o,i,f)<0&&t.push([o.data,i.data,f.data])}),t},links:function(){return this.edges.filter(function(t){return t.right}).map(function(t){return{source:t.left.data,target:t.right.data}})}},ml.prototype={constructor:ml,scale:function(t){return 1===t?this:new ml(this.k*t,this.x,this.y)},translate:function(t,n){return 0===t&0===n?this:new ml(this.k,this.x+this.k*t,this.y+this.k*n)},apply:function(t){return[t[0]*this.k+this.x,t[1]*this.k+this.y]},applyX:function(t){return t*this.k+this.x},applyY:function(t){return t*this.k+this.y},invert:function(t){return[(t[0]-this.x)/this.k,(t[1]-this.y)/this.k]},invertX:function(t){return(t-this.x)/this.k},invertY:function(t){return(t-this.y)/this.k},rescaleX:function(t){return t.copy().domain(t.range().map(this.invertX,this).map(t.invert,t))},rescaleY:function(t){return t.copy().domain(t.range().map(this.invertY,this).map(t.invert,t))},toString:function(){return"translate("+this.x+","+this.y+") scale("+this.k+")"}};var nx=new ml(1,0,0);xl.prototype=ml.prototype;var ex={name:"drag"},rx={name:"space"},ix={name:"handle"},ox={name:"center"},ux={name:"x",handles:["e","w"].map(zl),input:function(t,n){return t&&[[t[0],n[0][1]],[t[1],n[1][1]]]},output:function(t){return t&&[t[0][0],t[1][0]]}},ax={name:"y",handles:["n","s"].map(zl),input:function(t,n){return t&&[[n[0][0],t[0]],[n[1][0],t[1]]]},output:function(t){return t&&[t[0][1],t[1][1]]}},cx={name:"xy",handles:["n","e","s","w","nw","ne","se","sw"].map(zl),input:function(t){return t},output:function(t){return t}},sx={overlay:"crosshair",selection:"move",n:"ns-resize",e:"ew-resize",s:"ns-resize",w:"ew-resize",nw:"nwse-resize",ne:"nesw-resize",se:"nwse-resize",sw:"nesw-resize"},fx={e:"w",w:"e",nw:"ne",ne:"nw",se:"sw",sw:"se"},lx={n:"s",s:"n",nw:"sw",ne:"se",se:"ne",sw:"nw"},hx={overlay:1,selection:1,n:null,e:1,s:null,w:-1,nw:-1,ne:1,se:1,sw:-1},px={overlay:1,selection:1,n:-1,e:null,s:1,w:null,nw:-1,ne:-1,se:1,sw:1},dx=Math.cos,vx=Math.sin,_x=Math.PI,yx=_x/2,gx=2*_x,mx=Math.max,xx=Array.prototype.slice;Jl.prototype={constructor:Jl,reset:function(){this.s=this.t=0},add:function(t){Ql(nb,t,this.t),Ql(this,nb.s,this.s),this.s?this.t+=nb.t:this.s=nb.t},valueOf:function(){return this.s}};var bx,wx,Mx,Tx,kx,Nx,Sx,Ax,Ex,Cx,zx,Px,qx,Lx,Rx,Ux,Dx,Ox,Fx,Ix,Yx,Bx,jx,Hx,Xx,Vx,Wx,$x,Zx,Gx,Jx,Qx,Kx,tb,nb=new Jl,eb=1e-6,rb=1e-12,ib=Math.PI,ob=ib/2,ub=ib/4,ab=2*ib,cb=180/ib,sb=ib/180,fb=Math.abs,lb=Math.atan,hb=Math.atan2,pb=Math.cos,db=Math.ceil,vb=Math.exp,_b=Math.log,yb=Math.pow,gb=Math.sin,mb=Math.sign||function(t){return t>0?1:t<0?-1:0},xb=Math.sqrt,bb=Math.tan,wb={Feature:function(t,n){rh(t.geometry,n)},FeatureCollection:function(t,n){for(var e=t.features,r=-1,i=e.length;++r<i;)rh(e[r].geometry,n)}},Mb={Sphere:function(t,n){n.sphere()},Point:function(t,n){t=t.coordinates,n.point(t[0],t[1],t[2])},MultiPoint:function(t,n){for(var e=t.coordinates,r=-1,i=e.length;++r<i;)t=e[r],n.point(t[0],t[1],t[2])},LineString:function(t,n){ih(t.coordinates,n,0)},MultiLineString:function(t,n){for(var e=t.coordinates,r=-1,i=e.length;++r<i;)ih(e[r],n,0)},Polygon:function(t,n){oh(t.coordinates,n)},MultiPolygon:function(t,n){for(var e=t.coordinates,r=-1,i=e.length;++r<i;)oh(e[r],n)},GeometryCollection:function(t,n){for(var e=t.geometries,r=-1,i=e.length;++r<i;)rh(e[r],n)}},Tb={point:eh,lineStart:eh,lineEnd:eh,polygonStart:function(){bx.reset(),Tb.lineStart=ah,Tb.lineEnd=ch},polygonEnd:function(){var t=+bx;wx.add(t<0?ab+t:t),this.lineStart=this.lineEnd=this.point=eh},sphere:function(){wx.add(ab)}},kb={point:mh,lineStart:bh,lineEnd:wh,polygonStart:function(){kb.point=Mh,kb.lineStart=Th,kb.lineEnd=kh,Ux.reset(),Tb.polygonStart()},polygonEnd:function(){Tb.polygonEnd(),kb.point=mh,kb.lineStart=bh,kb.lineEnd=wh,bx<0?(Ax=-(Cx=180),Ex=-(zx=90)):Ux>eb?zx=90:Ux<-eb&&(Ex=-90),Ox[0]=Ax,Ox[1]=Cx}},Nb={sphere:eh,point:Ch,lineStart:Ph,lineEnd:Rh,polygonStart:function(){Nb.lineStart=Uh,Nb.lineEnd=Dh},polygonEnd:function(){Nb.lineStart=Ph,Nb.lineEnd=Rh}};jh.invert=jh;var Sb,Ab,Eb,Cb,zb,Pb,qb,Lb,Rb,Ub,Db,Ob,Fb=1e9,Ib=-Fb,Yb={sphere:eh,point:eh,lineStart:up,lineEnd:eh,polygonStart:eh,polygonEnd:eh},Bb=[null,null],jb={type:"LineString",coordinates:Bb},Hb=Gl(),Xb=Gl(),Vb={point:eh,lineStart:eh,lineEnd:eh,polygonStart:function(){Vb.lineStart=yp,Vb.lineEnd=xp},polygonEnd:function(){Vb.lineStart=Vb.lineEnd=Vb.point=eh,Hb.add(fb(Xb)),Xb.reset()},result:function(){var t=Hb/2;return Hb.reset(),t}},Wb=1/0,$b=Wb,Zb=-Wb,Gb=Zb,Jb={point:bp,lineStart:eh,lineEnd:eh,polygonStart:eh,polygonEnd:eh,result:function(){var t=[[Wb,$b],[Zb,Gb]];return Zb=Gb=-($b=Wb=1/0),t}},Qb=0,Kb=0,tw=0,nw=0,ew=0,rw=0,iw=0,ow=0,uw=0,aw={point:wp,lineStart:Mp,lineEnd:Np,polygonStart:function(){aw.lineStart=Sp,aw.lineEnd=Ap},polygonEnd:function(){aw.point=wp,aw.lineStart=Mp,aw.lineEnd=Np},result:function(){var t=uw?[iw/uw,ow/uw]:rw?[nw/rw,ew/rw]:tw?[Qb/tw,Kb/tw]:[NaN,NaN];return Qb=Kb=tw=nw=ew=rw=iw=ow=uw=0,t}},cw=Gl(),sw=Up(function(){return!0},Fp,Yp,[-ib,-ob]);Xp.prototype={point:function(t,n){this.stream.point(t,n)},sphere:function(){this.stream.sphere()},lineStart:function(){this.stream.lineStart()},lineEnd:function(){this.stream.lineEnd()},polygonStart:function(){this.stream.polygonStart()},polygonEnd:function(){this.stream.polygonEnd()}};var fw=16,lw=pb(30*sb),hw=Hp({point:function(t,n){this.stream.point(t*sb,n*sb)}}),pw=rd(function(t){return xb(2/(1+t))});pw.invert=id(function(t){return 2*th(t/2)});var dw=rd(function(t){return(t=Kl(t))&&t/gb(t)});dw.invert=id(function(t){return t}),ad.invert=function(t,n){return[t,2*lb(vb(n))-ob]},pd.invert=pd,yd.invert=id(lb),md.invert=id(th),bd.invert=id(function(t){return 2+lb(t)}),Md.invert=function(t,n){return[-n,2*lb(vb(t))-ob]},t.version=kd,t.bisect=Sd,t.bisectRight=Sd,t.bisectLeft=Ad,t.ascending=n,t.bisector=e,t.descending=i,t.deviation=a,t.extent=c,t.histogram=v,t.thresholdFreedmanDiaconis=y,t.thresholdScott=g,t.thresholdSturges=d,t.max=m,t.mean=x,t.median=b,t.merge=w,t.min=M,t.pairs=T,t.permute=k,t.quantile=_,t.range=l,t.scan=N,t.shuffle=S,t.sum=A,t.ticks=h,t.tickStep=p,t.transpose=E,t.variance=u,t.zip=z,t.entries=j,t.keys=Y,t.values=B,t.map=q,t.set=I,t.nest=L,t.randomUniform=H,t.randomNormal=X,t.randomLogNormal=V,t.randomBates=$,t.randomIrwinHall=W,t.randomExponential=Z,t.easeLinear=G,t.easeQuad=K,t.easeQuadIn=J,t.easeQuadOut=Q,t.easeQuadInOut=K,t.easeCubic=et,t.easeCubicIn=tt,t.easeCubicOut=nt,t.easeCubicInOut=et,t.easePoly=Id,t.easePolyIn=Od,t.easePolyOut=Fd,t.easePolyInOut=Id,t.easeSin=ot,t.easeSinIn=rt,t.easeSinOut=it,t.easeSinInOut=ot,t.easeExp=ct,t.easeExpIn=ut,t.easeExpOut=at,t.easeExpInOut=ct,t.easeCircle=lt,t.easeCircleIn=st,t.easeCircleOut=ft,t.easeCircleInOut=lt,t.easeBounce=pt,t.easeBounceIn=ht,t.easeBounceOut=pt,t.easeBounceInOut=dt,t.easeBack=ev,t.easeBackIn=tv,t.easeBackOut=nv,t.easeBackInOut=ev,t.easeElastic=av,t.easeElasticIn=uv,t.easeElasticOut=av,t.easeElasticInOut=cv,t.polygonArea=vt,t.polygonCentroid=_t,t.polygonHull=xt,t.polygonContains=bt,t.polygonLength=wt,t.path=Tt,t.quadtree=jt,t.queue=Qt,t.arc=sn,t.area=vn,t.line=dn,t.pie=gn,t.radialArea=Mn,t.radialLine=wn,t.symbol=Tn,t.symbols=Fv,t.symbolCircle=bv,t.symbolCross=wv,t.symbolDiamond=kv,t.symbolSquare=zv,t.symbolStar=Cv,t.symbolTriangle=qv,t.symbolWye=Ov,t.curveBasisClosed=Cn,t.curveBasisOpen=Pn,t.curveBasis=An,t.curveBundle=Iv,t.curveCardinalClosed=Bv,t.curveCardinalOpen=jv,t.curveCardinal=Yv,t.curveCatmullRomClosed=Xv,t.curveCatmullRomOpen=Vv,t.curveCatmullRom=Hv,t.curveLinearClosed=jn,t.curveLinear=ln,t.curveMonotoneX=Jn,t.curveMonotoneY=Qn,t.curveNatural=ne,t.curveStep=re,t.curveStepAfter=oe,t.curveStepBefore=ie,t.stack=se,t.stackOffsetExpand=fe,t.stackOffsetNone=ue,t.stackOffsetSilhouette=le,t.stackOffsetWiggle=he,t.stackOrderAscending=pe,t.stackOrderDescending=ve,t.stackOrderInsideOut=_e,t.stackOrderNone=ae,t.stackOrderReverse=ye,t.color=be,t.rgb=ke,t.hsl=Ee,t.lab=qe,t.hcl=Ie,t.cubehelix=je,t.interpolate=cr,t.interpolateArray=nr,t.interpolateDate=er,t.interpolateNumber=rr,t.interpolateObject=ir,t.interpolateRound=sr,t.interpolateString=ar,t.interpolateTransformCss=L_,t.interpolateTransformSvg=R_,t.interpolateZoom=yr,t.interpolateRgb=S_,t.interpolateRgbBasis=A_,t.interpolateRgbBasisClosed=E_,t.interpolateHsl=I_,t.interpolateHslLong=Y_,t.interpolateLab=mr,t.interpolateHcl=B_,t.interpolateHclLong=j_,t.interpolateCubehelix=H_,t.interpolateCubehelixLong=X_,t.interpolateBasis=Ve,t.interpolateBasisClosed=We,t.quantize=wr,t.dispatch=Mr,t.dsvFormat=zr,t.csvParse=G_,t.csvParseRows=J_,t.csvFormat=Q_,t.csvFormatRows=K_,t.tsvParse=ny,t.tsvParseRows=ey,t.tsvFormat=ry,t.tsvFormatRows=iy,t.request=Pr,t.html=oy,t.json=uy,t.text=ay,t.xml=cy,t.csv=sy,t.tsv=fy,t.now=Or,t.timer=Yr,t.timerFlush=Br,t.timeout=Wr,t.interval=$r,t.timeInterval=Zr,t.timeMillisecond=wy,t.timeMilliseconds=My,t.timeSecond=Ey,t.timeSeconds=Cy,t.timeMinute=zy,t.timeMinutes=Py,t.timeHour=qy,t.timeHours=Ly,t.timeDay=Ry,t.timeDays=Uy,t.timeWeek=Dy;t.timeWeeks=Hy;t.timeSunday=Dy,t.timeSundays=Hy,t.timeMonday=Oy,t.timeMondays=Xy,t.timeTuesday=Fy,t.timeTuesdays=Vy,t.timeWednesday=Iy,t.timeWednesdays=Wy,t.timeThursday=Yy,t.timeThursdays=$y,t.timeFriday=By,t.timeFridays=Zy,t.timeSaturday=jy,t.timeSaturdays=Gy,t.timeMonth=Jy,t.timeMonths=Qy,t.timeYear=Ky,t.timeYears=tg,t.utcMillisecond=wy,t.utcMilliseconds=My,t.utcSecond=Ey,t.utcSeconds=Cy,t.utcMinute=ng,t.utcMinutes=eg,t.utcHour=rg,t.utcHours=ig,t.utcDay=og,t.utcDays=ug,t.utcWeek=ag,t.utcWeeks=dg,t.utcSunday=ag,t.utcSundays=dg,t.utcMonday=cg,t.utcMondays=vg,t.utcTuesday=sg,t.utcTuesdays=_g,t.utcWednesday=fg,t.utcWednesdays=yg,t.utcThursday=lg,t.utcThursdays=gg,t.utcFriday=hg,t.utcFridays=mg,t.utcSaturday=pg,t.utcSaturdays=xg,t.utcMonth=bg,t.utcMonths=wg,t.utcYear=Mg,t.utcYears=kg,t.formatLocale=ai,t.formatDefaultLocale=ci,t.formatSpecifier=ii,t.precisionFixed=si,t.precisionPrefix=fi,t.precisionRound=li,t.isoFormat=Ug,t.isoParse=Dg,t.timeFormatLocale=vi,t.timeFormatDefaultLocale=so,t.scaleBand=po,t.scalePoint=_o,t.scaleIdentity=Eo,t.scaleLinear=Ao,t.scaleLog=Do,t.scaleOrdinal=ho,t.scaleImplicit=Yg,t.scalePow=Fo,t.scaleSqrt=Io,t.scaleQuantile=Yo,t.scaleQuantize=Bo,t.scaleThreshold=jo,t.scaleTime=Wo,t.scaleUtc=$o,t.schemeCategory10=Gg,t.schemeCategory20b=Jg,t.schemeCategory20c=Qg,t.schemeCategory20=Kg,t.scaleSequential=Qo,t.interpolateCubehelixDefault=tm,t.interpolateRainbow=Go,t.interpolateWarm=nm,t.interpolateCool=em,t.interpolateViridis=im,t.interpolateMagma=om,t.interpolateInferno=um,t.interpolatePlasma=am,t.creator=eu,t.customEvent=lu,t.local=ru,t.matcher=dm,t.mouse=du,t.namespace=Ko,t.namespaces=sm,t.select=Ra,t.selectAll=Ua,t.selection=La,t.selector=_u,t.selectorAll=mu,t.touch=Da,t.touches=Oa,t.window=Wu,t.active=Yc,t.interrupt=Ha,t.transition=Dc,t.axisTop=$c,t.axisRight=Zc,t.axisBottom=Gc,t.axisLeft=Jc,t.cluster=os,t.hierarchy=ys,t.pack=Bs,t.packSiblings=Us,t.packEnclose=ks,t.partition=$s,t.stratify=Js,t.tree=af,t.treemap=ff,t.treemapBinary=lf,t.treemapDice=Ws,t.treemapSlice=cf,t.treemapSliceDice=hf,t.treemapSquarify=Bm,t.treemapResquarify=jm,t.forceCenter=pf,t.forceCollide=gf,t.forceLink=xf,t.forceManyBody=Tf,t.forceSimulation=Mf,t.forceX=kf,t.forceY=Nf,t.drag=Uf,t.dragDisable=Ef,t.dragEnable=Cf,t.voronoi=_l,t.zoom=Nl,t.zoomIdentity=nx,t.zoomTransform=xl,t.brush=Fl,t.brushX=Dl,t.brushY=Ol,t.brushSelection=Ul,t.chord=Bl,t.ribbon=Zl,t.geoAlbers=td,t.geoAlbersUsa=ed,t.geoArea=lh,t.geoAzimuthalEqualArea=od,t.geoAzimuthalEqualAreaRaw=pw,t.geoAzimuthalEquidistant=ud,t.geoAzimuthalEquidistantRaw=dw,t.geoBounds=Eh,t.geoCentroid=Ih,t.geoCircle=Jh,t.geoClipExtent=op,t.geoConicConformal=hd,t.geoConicConformalRaw=ld,t.geoConicEqualArea=Kp,t.geoConicEqualAreaRaw=Qp,t.geoConicEquidistant=_d,t.geoConicEquidistantRaw=vd,t.geoDistance=lp,t.geoEquirectangular=dd,t.geoEquirectangularRaw=pd,t.geoGnomonic=gd,t.geoGnomonicRaw=yd,t.geoGraticule=dp,t.geoInterpolate=vp,t.geoLength=fp,t.geoMercator=cd,t.geoMercatorRaw=ad,t.geoOrthographic=xd,t.geoOrthographicRaw=md,t.geoPath=Lp,t.geoProjection=Zp,t.geoProjectionMutator=Gp,t.geoRotation=$h,t.geoStereographic=wd,t.geoStereographicRaw=bd,t.geoStream=uh,t.geoTransform=jp,t.geoTransverseMercator=Td,t.geoTransverseMercatorRaw=Md,Object.defineProperty(t,"__esModule",{value:!0})});
+
 </script>
-    <script type="text/javascript">/**
+
+    <script type="text/javascript">
+/**
  * Simple, lightweight, usable local autocomplete library for modern browsers
  * Because there weren’t enough autocomplete scripts in the world? Because I’m completely insane and have NIH syndrome? Probably both. :P
  * @author Lea Verou http://leaverou.github.io/awesomplete
@@ -956,8 +1026,11 @@ if (typeof module === "object" && module.exports) {
 return _;
 
 }());
+
 </script>
-    <script type="text/javascript">/**
+
+    <script type="text/javascript">
+/**
 * vkBeautify - javascript plugin to pretty-print or minify text in XML, JSON, CSS and SQL formats.
 *
 * Version - 0.99.00.beta
@@ -1086,20 +1159,89 @@ return _;
 
     window.vkbeautify = new vkbeautify();
 
-})();</script>
-    <script type="text/javascript">var modelData = {"tree": {"name": "root", "type": "root", "subsystem_type": "group", "children": [{"name": "design_vars", "type": "subsystem", "subsystem_type": "component", "children": [{"name": "x_aero", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "x_struct", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}, {"name": "aerostruct_cycle", "type": "subsystem", "subsystem_type": "group", "children": [{"name": "aero", "type": "subsystem", "subsystem_type": "component", "children": [{"name": "u", "type": "param", "dtype": "ndarray"}, {"name": "x_aero", "type": "param", "dtype": "ndarray"}, {"name": "Cd", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "Cl", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "w", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}, {"name": "struct", "type": "subsystem", "subsystem_type": "component", "children": [{"name": "w", "type": "param", "dtype": "ndarray"}, {"name": "x_struct", "type": "param", "dtype": "ndarray"}, {"name": "mass", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "u", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}]}, {"name": "objective", "type": "subsystem", "subsystem_type": "component", "children": [{"name": "Cd", "type": "param", "dtype": "ndarray"}, {"name": "Cl", "type": "param", "dtype": "ndarray"}, {"name": "mass", "type": "param", "dtype": "ndarray"}, {"name": "f", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}, {"name": "constraint", "type": "subsystem", "subsystem_type": "component", "children": [{"name": "Cl", "type": "param", "dtype": "ndarray"}, {"name": "g", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}]}, "connections_list": [{"src": "aerostruct_cycle.struct.u", "tgt": "aerostruct_cycle.aero.u", "cycle_arrows": ["aerostruct_cycle.aero aerostruct_cycle.struct"]}, {"src": "design_vars.x_aero", "tgt": "aerostruct_cycle.aero.x_aero"}, {"src": "aerostruct_cycle.aero.w", "tgt": "aerostruct_cycle.struct.w", "cycle_arrows": ["aerostruct_cycle.struct aerostruct_cycle.aero"]}, {"src": "design_vars.x_struct", "tgt": "aerostruct_cycle.struct.x_struct"}, {"src": "aerostruct_cycle.aero.Cl", "tgt": "constraint.Cl"}, {"src": "aerostruct_cycle.aero.Cd", "tgt": "objective.Cd"}, {"src": "aerostruct_cycle.aero.Cl", "tgt": "objective.Cl"}, {"src": "aerostruct_cycle.struct.mass", "tgt": "objective.mass"}]}</script>
-    <script type="text/javascript">//color constants
+})();
+</script>
+
+    <script type="text/javascript">
+var modelData = {"tree": {"name": "root", "type": "root", "component_type": null, "subsystem_type": "group", "is_parallel": false, "linear_solver": "LN: RUNONCE", "nonlinear_solver": "NL: RUNONCE", "children": [{"name": "design_vars", "type": "subsystem", "subsystem_type": "component", "is_parallel": false, "component_type": "indep", "linear_solver": "", "nonlinear_solver": "", "children": [{"name": "x_aero", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "x_struct", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}, {"name": "aerostruct_cycle", "type": "subsystem", "component_type": null, "subsystem_type": "group", "is_parallel": false, "linear_solver": "LN: RUNONCE", "nonlinear_solver": "NL: RUNONCE", "children": [{"name": "aero", "type": "subsystem", "subsystem_type": "component", "is_parallel": false, "component_type": "exec", "linear_solver": "", "nonlinear_solver": "", "children": [{"name": "u", "type": "param", "dtype": "ndarray"}, {"name": "x_aero", "type": "param", "dtype": "ndarray"}, {"name": "Cd", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "Cl", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "w", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}, {"name": "struct", "type": "subsystem", "subsystem_type": "component", "is_parallel": false, "component_type": "exec", "linear_solver": "", "nonlinear_solver": "", "children": [{"name": "w", "type": "param", "dtype": "ndarray"}, {"name": "x_struct", "type": "param", "dtype": "ndarray"}, {"name": "mass", "type": "unknown", "implicit": false, "dtype": "ndarray"}, {"name": "u", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}]}, {"name": "objective", "type": "subsystem", "subsystem_type": "component", "is_parallel": false, "component_type": "exec", "linear_solver": "", "nonlinear_solver": "", "children": [{"name": "Cd", "type": "param", "dtype": "ndarray"}, {"name": "Cl", "type": "param", "dtype": "ndarray"}, {"name": "mass", "type": "param", "dtype": "ndarray"}, {"name": "f", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}, {"name": "constraint", "type": "subsystem", "subsystem_type": "component", "is_parallel": false, "component_type": "exec", "linear_solver": "", "nonlinear_solver": "", "children": [{"name": "Cl", "type": "param", "dtype": "ndarray"}, {"name": "g", "type": "unknown", "implicit": false, "dtype": "ndarray"}]}]}, "sys_pathnames_list": ["aerostruct_cycle.aero", "aerostruct_cycle.struct"], "connections_list": [{"src": "aerostruct_cycle.struct.u", "tgt": "aerostruct_cycle.aero.u", "cycle_arrows": [[0, 1]]}, {"src": "design_vars.x_aero", "tgt": "aerostruct_cycle.aero.x_aero"}, {"src": "aerostruct_cycle.aero.w", "tgt": "aerostruct_cycle.struct.w", "cycle_arrows": [[1, 0]]}, {"src": "design_vars.x_struct", "tgt": "aerostruct_cycle.struct.x_struct"}, {"src": "aerostruct_cycle.aero.Cl", "tgt": "constraint.Cl"}, {"src": "aerostruct_cycle.aero.Cd", "tgt": "objective.Cd"}, {"src": "aerostruct_cycle.aero.Cl", "tgt": "objective.Cl"}, {"src": "aerostruct_cycle.struct.mass", "tgt": "objective.mass"}], "abs2prom": {"input": {"aerostruct_cycle.aero.u": "u", "aerostruct_cycle.aero.x_aero": "x_aero", "aerostruct_cycle.struct.w": "w", "aerostruct_cycle.struct.x_struct": "x_struct", "objective.Cd": "Cd", "objective.Cl": "Cl", "objective.mass": "mass", "constraint.Cl": "Cl"}, "output": {"design_vars.x_aero": "x_aero", "design_vars.x_struct": "x_struct", "aerostruct_cycle.aero.Cd": "Cd", "aerostruct_cycle.aero.Cl": "Cl", "aerostruct_cycle.aero.w": "w", "aerostruct_cycle.struct.mass": "mass", "aerostruct_cycle.struct.u": "u", "objective.f": "f", "constraint.g": "g"}}, "driver": {"name": "Driver", "type": "optimization", "options": {"debug_print": []}, "opt_settings": null}, "design_vars": {}, "responses": {}, "declare_partials_list": [], "options": {"use_declare_partial_info": false}}
+</script>
+
+    <script type="text/javascript">
+// From Isaias Reyes
 var CONNECTION_COLOR = "black",
-    UNKNOWN_IMPLICIT_COLOR = "orange",
-    UNKNOWN_EXPLICIT_COLOR = "#AAA",
-    RED_ARROW_COLOR = "salmon",
-    GREEN_ARROW_COLOR = "seagreen",
-    PARAM_COLOR = "Plum",
-    UNCONNECTED_PARAM_COLOR = "#F42E0C",
-    GROUP_COLOR = "steelblue",
-    COMPONENT_COLOR = "DeepSkyBlue",
-    COLLAPSED_COLOR = "#555";
-HIGHLIGHT_HOVERED_COLOR = "blue"
+   UNKNOWN_IMPLICIT_COLOR = "#c7d06d",
+   UNKNOWN_EXPLICIT_COLOR = "#9ec4c7",
+   N2_COMPONENT_BOX_COLOR = "#555",
+   N2_BACKGROUND_COLOR = "#eee",
+   N2_GRIDLINE_COLOR = "white",
+   PT_STROKE_COLOR = "#eee",
+   UNKNOWN_GROUP_COLOR = "#888",
+   PARAM_COLOR = "#32afad",
+   PARAM_GROUP_COLOR = "Orchid",
+   GROUP_COLOR = "#3476a2",
+   COMPONENT_COLOR = "DeepSkyBlue",
+   COLLAPSED_COLOR = "#555",
+   UNCONNECTED_PARAM_COLOR = "#F42E0C",
+   HIGHLIGHT_HOVERED_COLOR = "blue",
+   RED_ARROW_COLOR = "salmon",
+   GREEN_ARROW_COLOR = "seagreen";
+
+
+// This is how we want to map solvers to colors and CSS classes
+//    Linear             Nonlinear
+//    ---------          ---------
+// 0. None               None
+// 1. LN: LNBJ           NL: NLBJ
+// 2. LN: SCIPY
+// 3. LN: RUNONCE        NL: RUNONCE
+// 4. LN: Direct
+// 5. LN: PETScKrylov
+// 6. LN: LNBGS          NL: NLBGS
+// 7. LN: USER
+// 8.                    NL: Newton
+// 9.                    BROYDEN
+// 10. solve_linear      solve_nonlinear
+// 11. other             other
+
+// Later add these for linesearch ?
+// LS: AG
+// LS: BCHK
+
+// From https://colorbrewer.org
+var colors = ['#8dd3c7','#ffffb3','#bebada','#fb8072','#80b1d3','#fdb462','#b3de69','#fccde5','#d9d9d9','#bc80bd','#ccebc5','#ffed6f'];
+
+var linearSolverColors = {};
+var linearSolverClasses = {} ;
+var nonLinearSolverColors = {};
+var nonLinearSolverClasses = {} ;
+var linearSolverNames = [];
+var nonLinearSolverNames = [] ;
+
+function setSolverColorAndCSSClass(ln_solver, nl_solver, idx){
+    if (ln_solver){
+        linearSolverColors[ln_solver] = colors[idx];
+        linearSolverClasses[ln_solver] = "solver_" + idx;
+        linearSolverNames.push(ln_solver);
+    }
+    if (nl_solver){
+        nonLinearSolverColors[nl_solver] = colors[idx];
+        nonLinearSolverClasses[nl_solver] = "solver_" + idx
+        nonLinearSolverNames.push(nl_solver);
+    }
+}
+
+setSolverColorAndCSSClass( "None", "None", 0);
+setSolverColorAndCSSClass( "LN: LNBJ", "NL: NLBJ", 1);
+setSolverColorAndCSSClass( "LN: SCIPY", "", 2);
+setSolverColorAndCSSClass( "LN: RUNONCE", "NL: RUNONCE", 3);
+setSolverColorAndCSSClass( "LN: Direct", "", 4);
+setSolverColorAndCSSClass( "LN: PETScKrylov", "", 5);
+setSolverColorAndCSSClass( "LN: LNBGS", "NL: NLBGS", 6);
+setSolverColorAndCSSClass( "LN: USER", "", 7);
+setSolverColorAndCSSClass( "", "NL: Newton", 8);
+setSolverColorAndCSSClass( "", "BROYDEN", 9);
+setSolverColorAndCSSClass( "solve_linear", "solve_nonlinear", 10);
+setSolverColorAndCSSClass( "other", "other", 11);
 
 var widthPTreePx = 1,
     kx = 0, ky = 0, kx0 = 0, ky0 = 0,
@@ -1114,8 +1256,21 @@ var widthPTreePx = 1,
     yScalerPTree = d3.scaleLinear().range([0, HEIGHT_PX]),
     xScalerPTree0 = null,
     yScalerPTree0 = null,
-    LEVEL_OF_DETAIL_THRESHOLD = HEIGHT_PX / 3; //3 pixels</script>
-    <script type="text/javascript">///////////////////////////
+    LEVEL_OF_DETAIL_THRESHOLD = HEIGHT_PX / 3; //3 pixels
+
+var widthPSolverTreePx = 1,
+    kSolverx = 0, kSolvery = 0, kSolverx0 = 0, kSolvery0 = 0,
+    xScalerPSolverTree = d3.scaleLinear().range([0, widthPSolverTreePx]),
+    yScalerPSolverTree = d3.scaleLinear().range([0, HEIGHT_PX]),
+    xScalerPSolverTree0 = null,
+    yScalerPSolverTree0 = null;
+
+var showLinearSolverNames = true;
+
+</script>
+
+    <script type="text/javascript">
+///////////////////////////
 //Modal Help Dialog Stuff
 ///////////////////////////
 var parentDiv = document.getElementById("ptN2ContentDivId");
@@ -1136,21 +1291,10 @@ window.onclick = function (event) {
     if (event.target == modal) {
         modal.style.display = "none";
     }
-}</script>
-    <script type="text/javascript">var CONNECTION_COLOR = "black",
-    UNKNOWN_IMPLICIT_COLOR = "orange",
-    UNKNOWN_EXPLICIT_COLOR = "#AAA",
-    N2_COMPONENT_BOX_COLOR = "#555",
-    N2_BACKGROUND_COLOR = "#eee",
-    N2_GRIDLINE_COLOR = "white",
-    PT_STROKE_COLOR = "#eee",
-    UNKNOWN_GROUP_COLOR = "#888",
-    PARAM_COLOR = "Plum",
-    PARAM_GROUP_COLOR = "Orchid",
-    GROUP_COLOR = "steelblue",
-    COMPONENT_COLOR = "DeepSkyBlue",
-    COLLAPSED_COLOR = "#555";
+}
+</script>
 
+    <script type="text/javascript">
 function SaveSvg(parentDiv) {
     //get svg element.
     var svgData = parentDiv.querySelector("#svgId").outerHTML;
@@ -1233,6 +1377,12 @@ function UpdateSvgCss(svgStyleElement, FONT_SIZE_PX){
         "    font-family: helvetica, sans-serif; " +
         "    font-size: " + FONT_SIZE_PX +"px; " +
         "} " +
+        "#svgId"+" g.solver_group > text { " +
+        "    text-anchor: end; " +
+        "    pointer-events: none; " +
+        "    font-family: helvetica, sans-serif; " +
+        "    font-size: " + FONT_SIZE_PX +"px; " +
+        "} " +
         "/* n2 diagram*/  " +
         "g.component_box > rect { " +
         "    stroke: " + N2_COMPONENT_BOX_COLOR + "; " +
@@ -1254,9 +1404,30 @@ function UpdateSvgCss(svgStyleElement, FONT_SIZE_PX){
         "    stroke: " + N2_GRIDLINE_COLOR + "; " +
         "}";
 
+        for (var i = 0; i < linearSolverNames.length; ++i) {
+            var name = linearSolverNames[i];
+            myCssText +=  "g." + linearSolverClasses[name] + " > rect { " +
+            "    cursor: pointer; " +
+            "    fill-opacity: .8; " +
+            "    fill: " + linearSolverColors[name] + "; " +
+            "} " ;
+        }
+        for (var i = 0; i < nonLinearSolverNames.length; ++i) {
+            var name = nonLinearSolverNames[i];
+            myCssText +=  "g." + nonLinearSolverClasses[name] + " > rect { " +
+            "    cursor: pointer; " +
+            "    fill-opacity: .8; " +
+            "    fill: " + nonLinearSolverColors[name] + "; " +
+            "} " ;
+        }
+
+
         svgStyleElement.innerHTML = myCssText;
-    }</script>
-    <script type="text/javascript">var filteredWordForAutoCompleteSuggestions = "", filteredWordForAutoCompleteSuggestionsContainsDot = false;
+    }
+</script>
+
+    <script type="text/javascript">
+var filteredWordForAutoCompleteSuggestions = "", filteredWordForAutoCompleteSuggestionsContainsDot = false;
 var filteredWordForAutoCompleteSuggestionsBaseName = "";
 var wordIndex = 0;
 var searchVals0 = [];
@@ -1266,7 +1437,6 @@ var callSearchFromEnterKeyPressed = false;
 var autoCompleteListNames = [], autoCompleteListPathNames = [];
 var searchCollapsedUndo = [];        
 var autoCompleteSetNames = {}, autoCompleteSetPathNames = {};
-var showParams = true; //default off
 
 window.addEventListener("awesomplete-selectcomplete", function (e) {
     // User made a selection from dropdown.
@@ -1285,7 +1455,6 @@ function DoSearch(d, regexMatch, undoList) {
         }
     }
     if (d === zoomedElement) return didMatch;
-    if (!showParams && d.type === "param") return didMatch;
     if (!didMatch && !d.children && (d.type === "param" || d.type === "unknown")) {
         didMatch = regexMatch.test(d.absPathName);
         if (didMatch) {
@@ -1466,7 +1635,6 @@ function PopulateAutoCompleteList(d) {
         }
     }
     if (d === zoomedElement) return;
-    if (!showParams && d.type === "param") return;
 
     var n = d.name;
     if (d.splitByColon && d.children && d.children.length > 0) n += ":";
@@ -1487,13 +1655,16 @@ function PopulateAutoCompleteList(d) {
         autoCompleteSetPathNames[localPathName] = true;
         autoCompleteListPathNames.push(localPathName);
     }
-}</script>
-    <script type="text/javascript">var showLegend = false; //default off
+}
+</script>
+
+    <script type="text/javascript">
+var showLegend = false; //default off
 
 function SetupLegend(d3, d3ContentDiv) {
-    var numColumns = 2;
+    var numColumns = 3;
     var elementSize = 30, xOffset = 10, columnWidth = 250;
-    var legendWidth = columnWidth * numColumns + 0, legendHeight = 360;
+    var legendWidth = columnWidth * numColumns + 0, legendHeight = 500;
     var u = elementSize * .5;
     var v = u;
 
@@ -1550,7 +1721,7 @@ function SetupLegend(d3, d3ContentDiv) {
 
     //COLUMN TITLES
     {
-        var text = ["Colors", "N^2 Symbols"];
+        var text = ["Systems & Variables", "N^2 Symbols", showLinearSolverNames? " Linear Solvers" : "Nonlinear Solvers"];
         for (var i = 0; i < text.length; ++i) {
             var el = svg_legend.append("g").attr("transform", "translate(" + (columnWidth * i + xOffset) + "," + (60) + ")");
             el.append("svg:text")
@@ -1564,14 +1735,12 @@ function SetupLegend(d3, d3ContentDiv) {
 
     //COLORS
     {
-        var text = ["Group", "Component", "Unknown Explicit", "Unknown Implicit", "Collapsed", "Connection"];
+        var text = ["Group", "Component", "Output Explicit", "Output Implicit", "Collapsed", "Connection"];
         var colors = [GROUP_COLOR, COMPONENT_COLOR, UNKNOWN_EXPLICIT_COLOR, UNKNOWN_IMPLICIT_COLOR, COLLAPSED_COLOR, CONNECTION_COLOR];
-        if (showParams) {
-            text.splice(2, 0, "Param");
-            colors.splice(2, 0, PARAM_COLOR);
-            text.splice(3, 0, "Unconnected Param")
-            colors.splice(3, 0, UNCONNECTED_PARAM_COLOR)
-        }
+        text.splice(2, 0, "Input");
+        colors.splice(2, 0, PARAM_COLOR);
+        text.splice(3, 0, "Unconnected Input")
+        colors.splice(3, 0, UNCONNECTED_PARAM_COLOR)
         for (var i = 0; i < text.length; ++i) {
             var el = svg_legend.append("g").attr("transform", "translate(" + (columnWidth * 0 + xOffset + u) + "," + (80 + 40 * i + v) + ")");
             DrawLegendColor(el, u, v, colors[i], false);
@@ -1581,7 +1750,7 @@ function SetupLegend(d3, d3ContentDiv) {
 
     //N2 SYMBOLS
     {
-        var text = ["Scalar", "Vector", "Group"];
+        var text = ["Scalar", "Vector", "Collapsed variables"];
         var colors = [UNKNOWN_EXPLICIT_COLOR, UNKNOWN_EXPLICIT_COLOR, UNKNOWN_EXPLICIT_COLOR];
         var shapeFunctions = [DrawScalar, DrawVector, DrawGroup];
         for (var i = 0; i < text.length; ++i) {
@@ -1591,6 +1760,26 @@ function SetupLegend(d3, d3ContentDiv) {
             CreateText(el, text[i]);
         }
     }
+
+    //SOLVER COLORS
+    {
+        if (showLinearSolverNames){
+            for (var i = 0; i < linearSolverNames.length; ++i) {
+                var el = svg_legend.append("g").attr("transform", "translate(" + (columnWidth * 2 + xOffset + u) + "," + (80 + 40 * i + v) + ")");
+                var name = linearSolverNames[i];
+                DrawLegendColor(el, u, v, linearSolverColors[name], false);
+                CreateText(el, name);
+            }
+        } else {
+            for (var i = 0; i < nonLinearSolverNames.length; ++i) {
+                var el = svg_legend.append("g").attr("transform", "translate(" + (columnWidth * 2 + xOffset + u) + "," + (80 + 40 * i + v) + ")");
+                var name = nonLinearSolverNames[i];
+                DrawLegendColor(el, u, v, nonLinearSolverColors[name], false);
+                CreateText(el, name);
+            }
+        }
+    }
+
 }
 
 function DrawLegendColor(g, u, v, color, justUpdate) {
@@ -1625,8 +1814,11 @@ function DrawBorder(g, u, v, color, justUpdate) {
     shape2.attr("x", -u).attr("y", -v).attr("width", u * .2).attr("height", v * 2);
     shape3.attr("x", u * .8).attr("y", -v).attr("width", u * .2).attr("height", v * 2);
     shape4.attr("x", -u).attr("y", v * .8).attr("width", u * 2).attr("height", v * .2);
-}</script>
-    <script type="text/javascript">var d3ContentDiv, svgDiv, svg;
+}
+</script>
+
+    <script type="text/javascript">
+var d3ContentDiv, svgDiv, svg;
 var n2ElementsGroup, n2GridLinesGroup, n2ComponentBoxesGroup, n2ArrowsGroup, n2DotsGroup;
 
 var n2Group;
@@ -1704,7 +1896,7 @@ function setD3ContentDiv() {
 }
 
 function setN2Group() {
-    n2Group = svg.append("g");
+    n2Group = svg.append("g").attr('id', 'N2'); // id given just so it is easier to see in Chrome dev tools when debugging
 }
 
 function setN2ElementsGroup() {
@@ -1837,11 +2029,23 @@ function DrawMatrix() {
         return (rt.implicit) ? UNKNOWN_IMPLICIT_COLOR : UNKNOWN_EXPLICIT_COLOR;
     }
 
+    if ( modelData.options.use_declare_partial_info)
+    {
+        symbols_scalarScalar_data = symbols_scalarScalar_declared_partials;
+        symbols_vectorVector_data = symbols_vectorVector_declared_partials;
+        symbols_vectorScalar_data = symbols_vectorScalar_declared_partials;
+        symbols_scalarVector_data = symbols_scalarVector_declared_partials;
+    } else {
+        symbols_scalarScalar_data = symbols_scalarScalar;
+        symbols_vectorVector_data = symbols_vectorVector;
+        symbols_vectorScalar_data = symbols_vectorScalar;
+        symbols_scalarVector_data = symbols_scalarVector;
+    }
     var classes = ["cell_scalar", "cell_vector", "cell_group", "cell_scalarScalar", "cell_scalarVector", "cell_vectorScalar",
         "cell_vectorVector", "cell_scalarGroup", "cell_groupScalar", "cell_vectorGroup", "cell_groupVector", "cell_groupGroup"
     ];
-    var datas = [symbols_scalar, symbols_vector, symbols_group, symbols_scalarScalar, symbols_scalarVector, symbols_vectorScalar,
-        symbols_vectorVector, symbols_scalarGroup, symbols_groupScalar, symbols_vectorGroup, symbols_groupVector, symbols_groupGroup
+    var datas = [symbols_scalar, symbols_vector, symbols_group, symbols_scalarScalar_data, symbols_scalarVector_data, symbols_vectorScalar_data,
+                 symbols_vectorVector_data, symbols_scalarGroup, symbols_groupScalar, symbols_vectorGroup, symbols_groupVector, symbols_groupGroup
     ];
     var drawFunctions = [DrawScalar, DrawVector, DrawGroup, DrawScalar, DrawVector, DrawVector,
         DrawVector, DrawGroup, DrawGroup, DrawGroup, DrawGroup, DrawGroup
@@ -2031,11 +2235,15 @@ function DrawMatrix() {
                 return n2Dy;
             });
     }
-}</script>
-    <script type="text/javascript">function PtN2Diagram(paramParentDiv, paramRootJson, paramConnsJson) {
-    var parentDiv = paramParentDiv;
-    var root = paramRootJson;
-    var conns = paramConnsJson;
+}
+</script>
+
+    <script type="text/javascript">
+function PtN2Diagram(parentDiv, modelData) {
+    var root = modelData.tree;
+    var conns = modelData.connections_list;
+    var abs2prom = modelData.hasOwnProperty("abs2prom") ? modelData.abs2prom : undefined;
+
     var FONT_SIZE_PX = 11;
     var svgStyleElement = document.createElement("style");
     var outputNamingType = "Absolute";
@@ -2045,14 +2253,24 @@ function DrawMatrix() {
     var transitionStartDelay = DEFAULT_TRANSITION_START_DELAY;
     var idCounter = 0;
     var maxDepth = 1;
+
+    var maxSystemDepth = 1; // For use with the right hand side solver tree. Only want max depth of solvers, not params,..
+
     var RIGHT_TEXT_MARGIN_PX = 8; // How much space in px (left and) right of text in partition tree
+
+    var text_width_cache = {}; // used to speed up GetTextWidth using memoization
 
     //N^2 vars
     var backButtonHistory = [], forwardButtonHistory = [];
     var chosenCollapseDepth = -1;
     var updateRecomputesAutoComplete = true; //default
+
     var katexInputDivElement = document.getElementById("katexInputDiv");
     var katexInputElement = document.getElementById("katexInput");
+
+    var tooltip = d3.select("body").append("div").attr("class", "tool-tip")
+        .style("position", "absolute")
+        .style("visibility", "hidden");
 
     mouseOverOnDiagN2 = MouseoverOnDiagN2;
     mouseOverOffDiagN2 = MouseoverOffDiagN2;
@@ -2082,10 +2300,23 @@ function DrawMatrix() {
         .attr("class", "arrowHead");
 
     setN2Group();
-    var pTreeGroup = svg.append("g");
+    var pTreeGroup = svg.append("g").attr("id", "tree"); // id given just so it is easier to see in Chrome dev tools when debugging
+    var pSolverTreeGroup = svg.append("g").attr("id", "solver_tree");
+
+    function InitSubSystemChildren(d){
+        for (var i = 0; i < d.children.length; ++i) {
+            var child = d.children[i];
+            if (child.type === "subsystem"){
+                if (!d.hasOwnProperty("subsystem_children")) {
+                    d.subsystem_children = [];
+                }
+                d.subsystem_children.push(child);
+                InitSubSystemChildren(child);
+            }
+        }
+    }
 
     function updateRootTypes() {
-        if (!showParams) return;
 
         var stack = []
         for (var i = 0; i < root.children.length; ++i) {
@@ -2117,7 +2348,7 @@ function DrawMatrix() {
 
         return false;
     }
-    
+
     function hasOutputConnection(target) {
         for (i = 0; i < conns.length; ++i) {
             if (conns[i].src === target) {
@@ -2144,19 +2375,13 @@ function DrawMatrix() {
 
             text += "<br />self.connect(\"" + unknownName + "\", \"" + paramName + "\")";
         }
-        if(false) {
-             parentDiv.querySelector("#connectionId").innerHTML = text;
-        }
-        else {
-            parentDiv.querySelector("#connectionId").innerHTML = "";
-        }
+        parentDiv.querySelector("#connectionId").innerHTML = "";
     }
     var n2BackgroundRect = n2Group.append("rect")
         .attr("class", "background")
         .attr("width", WIDTH_N2_PX)
         .attr("height", HEIGHT_PX)
         .on("click", function () {
-            if (!showParams) return;
             var coords = d3.mouse(this);
             var c = Math.floor(coords[0] * d3RightTextNodesArrayZoomed.length / WIDTH_N2_PX);
             var r = Math.floor(coords[1] * d3RightTextNodesArrayZoomed.length / HEIGHT_PX);
@@ -2193,7 +2418,6 @@ function DrawMatrix() {
             PrintConnects();
         })
         .on("mousemove", function () {
-            if (!showParams) return;
             var coords = d3.mouse(this);
             var c = Math.floor(coords[0] * d3RightTextNodesArrayZoomed.length / WIDTH_N2_PX);
             var r = Math.floor(coords[1] * d3RightTextNodesArrayZoomed.length / HEIGHT_PX);
@@ -2212,26 +2436,6 @@ function DrawMatrix() {
             var param = d3RightTextNodesArrayZoomed[c],
                 unknown = d3RightTextNodesArrayZoomed[r];
             if (param.type !== "param" && unknown.type !== "unknown") return;
-            if (r > c && false) { //bottom left
-                DrawPathTwoLines(
-                    n2Dx * r, //x1
-                    n2Dy * r + n2Dy * .5, //y1
-                    n2Dx * c + n2Dx * .5, //left x2
-                    n2Dy * r + n2Dy * .5, //left y2
-                    n2Dx * c + n2Dx * .5, //up x3
-                    n2Dy * c + n2Dy - 1e-2, //up y3
-                    "blue", lineWidth, true);
-            }
-            else if (r < c && false) { //top right
-                DrawPathTwoLines(
-                    n2Dx * r + n2Dx, //x1
-                    n2Dy * r + n2Dy * .5, //y1
-                    n2Dx * c + n2Dx * .5, //right x2
-                    n2Dy * r + n2Dy * .5, //right y2
-                    n2Dx * c + n2Dx * .5, //down x3
-                    n2Dy * c + 1e-2, //down y3
-                    "blue", lineWidth, true);
-            }
             var leftTextWidthR = d3RightTextNodesArrayZoomed[r].nameWidthPx,
                 leftTextWidthC = d3RightTextNodesArrayZoomed[c].nameWidthPx;
             DrawRect(-leftTextWidthR - PTREE_N2_GAP_PX, n2Dy * r, leftTextWidthR, n2Dy, "blue"); //highlight var name
@@ -2247,9 +2451,6 @@ function DrawMatrix() {
                     "<b>" + zoomedElement.promotions[unknown.absPathName] + "</b>" :
                     ((zoomedElement === root) ? unknown.absPathName : unknown.absPathName.slice(zoomedElement.absPathName.length + 1));
 
-                if(false) {
-                    parentDiv.querySelector("#connectionId").innerHTML += "<br /><i style=\"color:red;\">self.connect(\"" + unknownName + "\", \"" + paramName + "\")</i>";
-                }
             }
         });
 
@@ -2261,6 +2462,7 @@ function DrawMatrix() {
     FlattenColonGroups(root);
     InitTree(root, null, 1);
     updateRootTypes();
+    InitSubSystemChildren(root);
     ComputeLayout();
     ComputeConnections();
     ComputeMatrixN2();
@@ -2280,10 +2482,10 @@ function DrawMatrix() {
         collapseDepthElement.appendChild(option);
     }
 
-    Update();
+    Update(computeNewTreeLayout=false);
     SetupLegend(d3, d3ContentDiv);
 
-    function Update() {
+    function Update(computeNewTreeLayout=true) {
         parentDiv.querySelector("#currentPathId").innerHTML = "PATH: root" + ((zoomedElement.parent) ? "." : "") + zoomedElement.absPathName;
 
         parentDiv.querySelector("#backButtonId").disabled = (backButtonHistory.length == 0) ? "disabled" : false;
@@ -2292,8 +2494,10 @@ function DrawMatrix() {
         parentDiv.querySelector("#returnToRootButtonId").disabled = (zoomedElement === root) ? "disabled" : false;
 
         // Compute the new tree layout.
-        ComputeLayout(); //updates d3NodesArray
-        ComputeMatrixN2();
+        if (computeNewTreeLayout) {
+            ComputeLayout(); //updates d3NodesArray
+            ComputeMatrixN2();
+        }
 
         for (var i = 2; i <= maxDepth; ++i) {
             parentDiv.querySelector("#idCollapseDepthOption" + i + "").style.display = (i <= zoomedElement.depth) ? "none" : "block";
@@ -2304,6 +2508,11 @@ function DrawMatrix() {
             ky0 = ky;
             xScalerPTree0 = xScalerPTree.copy();
             yScalerPTree0 = yScalerPTree.copy();
+
+            kxSolver0 = kxSolver;
+            kySolver0 = kySolver;
+            xScalerPSolverTree0 = xScalerPSolverTree.copy();
+            yScalerPSolverTree0 = yScalerPSolverTree.copy();
         }
 
         kx = (zoomedElement.x ? widthPTreePx - PARENT_NODE_WIDTH_PX : widthPTreePx) / (1 - zoomedElement.x);
@@ -2311,32 +2520,48 @@ function DrawMatrix() {
         xScalerPTree.domain([zoomedElement.x, 1]).range([zoomedElement.x ? PARENT_NODE_WIDTH_PX : 0, widthPTreePx]);
         yScalerPTree.domain([zoomedElement.y, zoomedElement.y + zoomedElement.height]).range([0, HEIGHT_PX]);
 
+        kxSolver = (zoomedElement.xSolver ? widthPSolverTreePx - PARENT_NODE_WIDTH_PX : widthPSolverTreePx) / (1 - zoomedElement.xSolver);
+        kySolver = HEIGHT_PX / zoomedElement.heightSolver;
+        xScalerPSolverTree.domain([zoomedElement.xSolver, 1]).range([zoomedElement.xSolver ? PARENT_NODE_WIDTH_PX : 0, widthPSolverTreePx]);
+        yScalerPSolverTree.domain([zoomedElement.ySolver, zoomedElement.ySolver + zoomedElement.heightSolver]).range([0, HEIGHT_PX]);
+
         if (xScalerPTree0 == null) { //first run.. duplicate
             kx0 = kx;
             ky0 = ky;
             xScalerPTree0 = xScalerPTree.copy();
             yScalerPTree0 = yScalerPTree.copy();
 
+            kxSolver0 = kxSolver;
+            kySolver0 = kySolver;
+            xScalerPSolverTree0 = xScalerPSolverTree.copy();
+            yScalerPSolverTree0 = yScalerPSolverTree.copy();
+
             //Update svg dimensions before ComputeLayout() changes widthPTreePx
-            svgDiv.style("width", (widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + 2 * SVG_MARGIN) + "px")
-                .style("height", (HEIGHT_PX + 2 * SVG_MARGIN) + "px");
-            svg.attr("width", widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + 2 * SVG_MARGIN)
-                .attr("height", HEIGHT_PX + 2 * SVG_MARGIN);
+            svgDiv.style("width", (widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + widthPSolverTreePx + 2 * SVG_MARGIN + PTREE_N2_GAP_PX) + "px")
+                  .style("height", (HEIGHT_PX + 2 * SVG_MARGIN) + "px");
+            svg.attr("width", widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + widthPSolverTreePx + 2 * SVG_MARGIN + PTREE_N2_GAP_PX)
+               .attr("height", HEIGHT_PX + 2 * SVG_MARGIN);
+
             n2Group.attr("transform", "translate(" + (widthPTreePx + PTREE_N2_GAP_PX + SVG_MARGIN) + "," + SVG_MARGIN + ")");
             pTreeGroup.attr("transform", "translate(" + SVG_MARGIN + "," + SVG_MARGIN + ")");
+
+            pSolverTreeGroup.attr("transform", "translate(" + (widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + SVG_MARGIN + PTREE_N2_GAP_PX) + "," + SVG_MARGIN + ")");
         }
 
         sharedTransition = d3.transition().duration(TRANSITION_DURATION).delay(transitionStartDelay); //do this after intense computation
         transitionStartDelay = DEFAULT_TRANSITION_START_DELAY;
 
         //Update svg dimensions with transition after ComputeLayout() changes widthPTreePx
-        svgDiv.transition(sharedTransition).style("width", (widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + 2 * SVG_MARGIN) + "px")
+        svgDiv.transition(sharedTransition).style("width", (widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + widthPSolverTreePx + 2 * SVG_MARGIN + PTREE_N2_GAP_PX) + "px")
             .style("height", (HEIGHT_PX + 2 * SVG_MARGIN) + "px");
-        svg.transition(sharedTransition).attr("width", widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + 2 * SVG_MARGIN)
+        svg.transition(sharedTransition).attr("width", widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + widthPSolverTreePx + 2 * SVG_MARGIN + PTREE_N2_GAP_PX)
             .attr("height", HEIGHT_PX + 2 * SVG_MARGIN);
+
         n2Group.transition(sharedTransition).attr("transform", "translate(" + (widthPTreePx + PTREE_N2_GAP_PX + SVG_MARGIN) + "," + SVG_MARGIN + ")");
         pTreeGroup.transition(sharedTransition).attr("transform", "translate(" + SVG_MARGIN + "," + SVG_MARGIN + ")");
         n2BackgroundRect.transition(sharedTransition).attr("width", WIDTH_N2_PX).attr("height", HEIGHT_PX);
+
+        pSolverTreeGroup.transition(sharedTransition).attr("transform", "translate(" + (widthPTreePx + PTREE_N2_GAP_PX + WIDTH_N2_PX + SVG_MARGIN + PTREE_N2_GAP_PX) + "," + SVG_MARGIN + ")");
 
         var sel = pTreeGroup.selectAll(".partition_group")
             .data(d3NodesArray, function (d) {
@@ -2351,7 +2576,30 @@ function DrawMatrix() {
                 return "translate(" + xScalerPTree0(d.x0) + "," + yScalerPTree0(d.y0) + ")";
             })
             .on("click", function (d) { LeftClick(d, this); })
-            .on("contextmenu", function (d) { RightClick(d, this); });
+            .on("contextmenu", function (d) { RightClick(d, this); })
+            .on("mouseover", function (d) {
+                if (abs2prom != undefined) {
+                    if (d.type == "param" || d.type == "unconnected_param") {
+                        return tooltip.text(abs2prom.input[d.absPathName])
+                                      .style("visibility", "visible");
+                    }
+                    if (d.type == "unknown") {
+                        return tooltip.text(abs2prom.output[d.absPathName])
+                                      .style("visibility", "visible");
+                    }
+                }
+            })
+            .on("mouseleave", function (d) {
+                if (abs2prom != undefined) {
+                    return tooltip.style("visibility", "hidden");
+                }
+            })
+            .on("mousemove", function(){
+                if (abs2prom != undefined) {
+                    return tooltip.style("top", (d3.event.pageY-30)+"px")
+                                  .style("left",(d3.event.pageX+5)+"px");
+                }
+            });
 
         nodeEnter.append("svg:rect")
             .attr("width", function (d) {
@@ -2423,6 +2671,137 @@ function DrawMatrix() {
                 var anchorX = d.width * kx - RIGHT_TEXT_MARGIN_PX;
                 return "translate(" + anchorX + "," + d.height * ky / 2 + ")";
                 //return "translate(8," + d.height * ky / 2 + ")";
+            })
+            .style("opacity", 0);
+
+
+       var selSolver = pSolverTreeGroup.selectAll(".solver_group")
+            .data(d3SolverNodesArray, function (d) {
+                return d.id;
+            });
+
+        function getSolverClass(showLinearSolverNames, linear_solver_name, nonlinear_solver_name){
+            if (showLinearSolverNames){
+                if (linearSolverNames.indexOf(linear_solver_name) >= 0){
+                    solver_class = linearSolverClasses[linear_solver_name]
+                } else {
+                    solver_class = linearSolverClasses["other"]; // user must have defined their own solver that we do not know about
+                }
+            } else {
+                if (nonLinearSolverNames.indexOf(nonlinear_solver_name) >= 0){
+                    solver_class = nonLinearSolverClasses[nonlinear_solver_name]
+                } else {
+                    solver_class = nonLinearSolverClasses["other"]; // user must have defined their own solver that we do not know about
+                }
+            }
+            return solver_class;
+        }
+
+        var nodeSolverEnter = selSolver.enter().append("svg:g")
+            .attr("class", function (d) {
+                solver_class = getSolverClass(showLinearSolverNames, d.linear_solver, d.nonlinear_solver) ;
+                return solver_class + " " + "solver_group " + GetClass(d) ;
+            })
+            .attr("transform", function (d) {
+                x = 1.0 - d.xSolver0 - d.widthSolver0; // The magic for reversing the blocks on the right side
+                // The solver tree goes from the root on the right and expands to the left
+                return "translate(" + xScalerPSolverTree0(x) + "," + yScalerPSolverTree0(d.ySolver0) + ")";
+            })
+            .on("click", function (d) { LeftClick(d, this); })
+            .on("contextmenu", function (d) { RightClick(d, this); })
+            .on("mouseover", function (d) {
+                if (abs2prom != undefined) {
+                    if (d.type == "param" || d.type == "unconnected_param") {
+                        return tooltip.text(abs2prom.input[d.absPathName])
+                                      .style("visibility", "visible");
+                    }
+                    if (d.type == "unknown") {
+                        return tooltip.text(abs2prom.output[d.absPathName])
+                                      .style("visibility", "visible");
+                    }
+                }
+            })
+            .on("mouseleave", function (d) {
+                if (abs2prom != undefined) {
+                    return tooltip.style("visibility", "hidden");
+                }
+            })
+            .on("mousemove", function(){
+                if (abs2prom != undefined) {
+                    return tooltip.style("top", (d3.event.pageY-30)+"px")
+                                  .style("left",(d3.event.pageX+5)+"px");
+                }
+            });
+
+        nodeSolverEnter.append("svg:rect")
+            .attr("width", function (d) {
+                return d.widthSolver0 * kxSolver0;//0;//
+            })
+            .attr("height", function (d) {
+                return d.heightSolver0 * kySolver0;
+            });
+
+        nodeSolverEnter.append("svg:text")
+            .attr("dy", ".35em")
+            .attr("transform", function (d) {
+                var anchorX = d.widthSolver0 * kxSolver0 - RIGHT_TEXT_MARGIN_PX;
+                return "translate(" + anchorX + "," + d.heightSolver0 * kySolver0 / 2 + ")";
+            })
+            .style("opacity", function (d) {
+                if (d.depth < zoomedElement.depth) return 0;
+                return d.textOpacity0;
+            })
+            .text(GetSolverText);
+
+        var nodeSolverUpdate = nodeSolverEnter.merge(selSolver).transition(sharedTransition)
+            .attr("class", function (d) {
+                solver_class = getSolverClass(showLinearSolverNames, d.linear_solver, d.nonlinear_solver) ;
+                return solver_class + " " + "solver_group " + GetClass(d) ;
+            })
+            .attr("transform", function (d) {
+                x = 1.0 - d.xSolver - d.widthSolver; // The magic for reversing the blocks on the right side
+                return "translate(" + xScalerPSolverTree(x) + "," + yScalerPSolverTree(d.ySolver) + ")";
+            });
+
+        nodeSolverUpdate.select("rect")
+            .attr("width", function (d) {
+                return d.widthSolver * kxSolver;
+            })
+            .attr("height", function (d) {
+                return d.heightSolver * kySolver;
+            });
+
+        nodeSolverUpdate.select("text")
+            .attr("transform", function (d) {
+                var anchorX = d.widthSolver * kxSolver - RIGHT_TEXT_MARGIN_PX;
+                return "translate(" + anchorX + "," + d.heightSolver * kySolver / 2 + ")";
+            })
+            .style("opacity", function (d) {
+                if (d.depth < zoomedElement.depth) return 0;
+                return d.textOpacity;
+            })
+            .text(GetSolverText);
+
+
+        // Transition exiting nodes to the parent's new position.
+        var nodeSolverExit = selSolver.exit().transition(sharedTransition)
+            .attr("transform", function (d) {
+                return "translate(" + xScalerPSolverTree(d.xSolver) + "," + yScalerPSolverTree(d.ySolver) + ")";
+            })
+            .remove();
+
+        nodeSolverExit.select("rect")
+            .attr("width", function (d) {
+                return d.widthSolver * kxSolver;//0;//
+            })
+            .attr("height", function (d) {
+                return d.heightSolver * kySolver;
+            });
+
+        nodeSolverExit.select("text")
+            .attr("transform", function (d) {
+                var anchorX = d.widthSolver * kxSolver - RIGHT_TEXT_MARGIN_PX;
+                return "translate(" + anchorX + "," + d.heightSolver * kySolver / 2 + ")";
             })
             .style("opacity", 0);
 
@@ -2523,6 +2902,11 @@ function DrawMatrix() {
         return retVal;
     }
 
+    function GetSolverText(d) {
+        var retVal = showLinearSolverNames ? d.linear_solver : d.nonlinear_solver;
+        return retVal;
+    }
+
     //Sets parents, depth, and nameWidthPx of all nodes.  Also finds and sets maxDepth.
     function InitTree(d, parent, depth) {
         d.numLeaves = 0; //for nested params
@@ -2553,6 +2937,11 @@ function DrawMatrix() {
             }
         }
         maxDepth = Math.max(depth, maxDepth);
+
+        if (d.type === "subsystem") {
+            maxSystemDepth = Math.max(depth, maxSystemDepth);
+        }
+
         if (d.children) {
             for (var i = 0; i < d.children.length; ++i) {
                 var implicit = InitTree(d.children[i], d, depth + 1);
@@ -2569,6 +2958,9 @@ function DrawMatrix() {
         var columnWidthsPx = new Array(maxDepth + 1).fill(0.0),// since depth is one based
             columnLocationsPx = new Array(maxDepth + 1).fill(0.0);
 
+        var columnSolverWidthsPx = new Array(maxDepth + 1).fill(0.0),// since depth is one based
+            columnSolverLocationsPx = new Array(maxDepth + 1).fill(0.0);
+
         var textWidthGroup = svg.append("svg:g").attr("class", "partition_group");
         var textWidthText = textWidthGroup.append("svg:text")
             .text("")
@@ -2584,7 +2976,6 @@ function DrawMatrix() {
                 }
             }
             if (d === zoomedElement) return;
-            if (!showParams && (d.type === "param" || d.type === "unconnected_param")) return;
 
             var n = d.name;
             if (d.splitByColon && d.children && d.children.length > 0) n += ":";
@@ -2608,16 +2999,34 @@ function DrawMatrix() {
         }
 
         function GetTextWidth(s) {
+            var width ;
+
+            if ( text_width_cache[ s ] != null )
+                return text_width_cache[ s ];
+
             textWidthText.text(s);
-            return textWidthTextNode.getBoundingClientRect().width;
+            width = textWidthTextNode.getBoundingClientRect().width;
+
+            text_width_cache[ s ] = width;
+            return width;
         }
 
         function UpdateTextWidths(d) {
-            if ((!showParams && (d.type === "param" || d.type === "unconnected_param")) || d.varIsHidden) return;
+            if (d.varIsHidden) return;
             d.nameWidthPx = GetTextWidth(GetText(d)) + 2 * RIGHT_TEXT_MARGIN_PX;
             if (d.children) {
                 for (var i = 0; i < d.children.length; ++i) {
                     UpdateTextWidths(d.children[i]);
+                }
+            }
+        }
+
+        function UpdateSolverTextWidths(d) {
+            if ((d.type === "param" || d.type === "unconnected_param") || d.varIsHidden) return;
+            d.nameSolverWidthPx = GetTextWidth(GetSolverText(d)) + 2 * RIGHT_TEXT_MARGIN_PX;
+            if (d.children) {
+                for (var i = 0; i < d.children.length; ++i) {
+                    UpdateSolverTextWidths(d.children[i]);
                 }
             }
         }
@@ -2627,7 +3036,7 @@ function DrawMatrix() {
             var leafWidthsPx = new Array(maxDepth + 1).fill(0.0);
 
             function DoComputeColumnWidths(d) {
-                if ((!showParams && (d.type === "param" || d.type === "unconnected_param")) || d.varIsHidden) return;
+                if (d.varIsHidden) return;
 
                 var heightPx = HEIGHT_PX * d.numLeaves / zoomedElement.numLeaves;
                 d.textOpacity0 = d.hasOwnProperty('textOpacity') ? d.textOpacity : 0;
@@ -2665,9 +3074,50 @@ function DrawMatrix() {
 
         }
 
+        function ComputeSolverColumnWidths(d) {
+            var greatestDepth = 0;
+            var leafSolverWidthsPx = new Array(maxDepth + 1).fill(0.0);
+
+            function DoComputeSolverColumnWidths(d) {
+                var heightPx = HEIGHT_PX * d.numSolverLeaves / zoomedElement.numSolverLeaves;
+                d.textOpacity0 = d.hasOwnProperty('textOpacity') ? d.textOpacity : 0;
+                d.textOpacity = (heightPx > FONT_SIZE_PX) ? 1 : 0;
+                var hasVisibleDetail = (heightPx >= 2.0);
+                var widthPx = 1e-3;
+                if (hasVisibleDetail) widthPx = MIN_COLUMN_WIDTH_PX;
+                if (d.textOpacity > 0.5) widthPx = d.nameSolverWidthPx;
+
+                greatestDepth = Math.max(greatestDepth, d.depth);
+
+                if (d.subsystem_children && !d.isMinimized) { //not leaf
+                    columnSolverWidthsPx[d.depth] = Math.max(columnSolverWidthsPx[d.depth], widthPx);
+                    for (var i = 0; i < d.subsystem_children.length; ++i) {
+                        DoComputeSolverColumnWidths(d.subsystem_children[i]);
+                    }
+                }
+                else { //leaf
+                    leafSolverWidthsPx[d.depth] = Math.max(leafSolverWidthsPx[d.depth], widthPx);
+                }
+            }
+
+            DoComputeSolverColumnWidths(d);
+
+
+            var sum = 0;
+            var lastColumnWidth = 0;
+            for (var i = leafSolverWidthsPx.length - 1; i >= zoomedElement.depth; --i) {
+                sum += columnSolverWidthsPx[i];
+                var lastWidthNeeded = leafSolverWidthsPx[i] - sum;
+                lastColumnWidth = Math.max(lastWidthNeeded, lastColumnWidth);
+            }
+            columnSolverWidthsPx[zoomedElement.depth - 1] = PARENT_NODE_WIDTH_PX;
+            columnSolverWidthsPx[greatestDepth] = lastColumnWidth;
+
+        }
+
 
         function ComputeLeaves(d) {
-            if ((!showParams && (d.type === "param" || d.type === "unconnected_params")) || d.varIsHidden) {
+            if (d.varIsHidden) {
                 d.numLeaves = 0;
                 return;
             }
@@ -2681,12 +3131,28 @@ function DrawMatrix() {
             }
         }
 
+        function ComputeSolverLeaves(d) {
+            if (d.varIsHidden) {
+                d.numSolverLeaves = 0;
+                return;
+            }
+
+            var doRecurse = d.children && !d.isMinimized;
+            d.numSolverLeaves = doRecurse ? 0 : 1; //no children: init to 0 because will be added later
+            if (!doRecurse) return;
+
+            for (var i = 0; i < d.children.length; ++i) {
+                ComputeSolverLeaves(d.children[i]);
+                d.numSolverLeaves += d.children[i].numSolverLeaves;
+            }
+        }
+
         function ComputeNormalizedPositions(d, leafCounter, isChildOfZoomed, earliestMinimizedParent) {
             isChildOfZoomed = (isChildOfZoomed) ? true : (d === zoomedElement);
             if (earliestMinimizedParent == null && isChildOfZoomed) {
-                if ((showParams || (d.type !== "param" && d.type !== "unconnected_param")) && !d.varIsHidden) d3NodesArray.push(d);
+                if (!d.varIsHidden) d3NodesArray.push(d);
                 if (!d.children || d.isMinimized) { //at a "leaf" node
-                    if ((showParams || (d.type !== "param" && d.type !== "unconnected_param")) && !d.varIsHidden) d3RightTextNodesArrayZoomed.push(d);
+                    if (!d.varIsHidden) d3RightTextNodesArrayZoomed.push(d);
                     earliestMinimizedParent = d;
                 }
             }
@@ -2701,7 +3167,7 @@ function DrawMatrix() {
             d.y = leafCounter / root.numLeaves;
             d.width = (d.children && !d.isMinimized) ? (columnWidthsPx[node.depth] / widthPTreePx) : 1 - node.x;//1-d.x;
             d.height = node.numLeaves / root.numLeaves;
-            if ((!showParams && (d.type === "param" || d.type === "unconnected_param")) || d.varIsHidden) { //param or hidden leaf leaving
+            if (d.varIsHidden) { //param or hidden leaf leaving
                 d.x = columnLocationsPx[d.parentComponent.depth + 1] / widthPTreePx;
                 d.y = d.parentComponent.y;
                 d.width = 1e-6;
@@ -2719,14 +3185,62 @@ function DrawMatrix() {
         }
 
 
+        function ComputeSolverNormalizedPositions(d, leafCounter, isChildOfZoomed, earliestMinimizedParent) {
+            isChildOfZoomed = (isChildOfZoomed) ? true : (d === zoomedElement);
+            if (earliestMinimizedParent == null && isChildOfZoomed) {
+                if (d.type === "subsystem" || d.type === "root" ) d3SolverNodesArray.push(d);
+                if (!d.children || d.isMinimized) { //at a "leaf" node
+                    if ((d.type !== "param" && d.type !== "unconnected_param") && !d.varIsHidden) d3SolverRightTextNodesArrayZoomed.push(d);
+                    earliestMinimizedParent = d;
+                }
+            }
+            var node = (earliestMinimizedParent) ? earliestMinimizedParent : d;
+            d.rootIndex0 = d.hasOwnProperty('rootIndex') ? d.rootIndex : leafCounter;
+            d.xSolver0 = d.hasOwnProperty('xSolver') ? d.xSolver : 1e-6;
+            d.ySolver0 = d.hasOwnProperty('ySolver') ? d.ySolver : 1e-6;
+            d.widthSolver0 = d.hasOwnProperty('widthSolver') ? d.widthSolver : 1e-6;
+            d.heightSolver0 = d.hasOwnProperty('heightSolver') ? d.heightSolver : 1e-6;
+            d.xSolver = columnSolverLocationsPx[node.depth] / widthPSolverTreePx;
+            d.ySolver = leafCounter / root.numSolverLeaves;
+            d.widthSolver = (d.subsystem_children && !d.isMinimized) ? (columnSolverWidthsPx[node.depth] / widthPSolverTreePx) : 1 - node.xSolver;//1-d.x;
+
+            d.heightSolver = node.numSolverLeaves / root.numSolverLeaves; 111
+
+            if (d.varIsHidden) { //param or hidden leaf leaving
+                d.xSolver = columnLocationsPx[d.parentComponent.depthqqq + 1] / widthPTreePx;
+                d.ySolver = d.parentComponent.y;
+                d.widthSolver = 1e-6;
+                d.heightSolver = 1e-6;
+            }
+
+            if (d.children) {
+                for (var i = 0; i < d.children.length; ++i) {
+                    ComputeSolverNormalizedPositions(d.children[i], leafCounter, isChildOfZoomed, earliestMinimizedParent);
+                    if (earliestMinimizedParent == null) { //numleaves is only valid passed nonminimized nodes
+                        leafCounter += d.children[i].numSolverLeaves;
+                    }
+                }
+            }
+        }
 
         UpdateTextWidths(zoomedElement);
+
+        UpdateSolverTextWidths(zoomedElement);
+
         ComputeLeaves(root);
+
+        ComputeSolverLeaves(root);
+
         d3NodesArray = [];
         d3RightTextNodesArrayZoomed = [];
 
-        //COLUMN WIDTH COMPUTATION
+        d3SolverNodesArray = [];
+        d3SolverRightTextNodesArrayZoomed = [];
+
         ComputeColumnWidths(zoomedElement);
+
+        ComputeSolverColumnWidths(zoomedElement);
+
         // Now the column_width array is relative to the zoomedElement
         //    and the computation of the widths only includes visible items after the zoom
         widthPTreePx = 0;
@@ -2735,9 +3249,20 @@ function DrawMatrix() {
             widthPTreePx += columnWidthsPx[depth];
         }
 
+        widthPSolverTreePx = 0;
+        for (var depth = 1; depth <= maxDepth; ++depth) {
+            columnSolverLocationsPx[depth] = widthPSolverTreePx;
+            widthPSolverTreePx += columnSolverWidthsPx[depth];
+        }
+
         ComputeNormalizedPositions(root, 0, false, null);
         if (zoomedElement.parent) {
             d3NodesArray.push(zoomedElement.parent);
+        }
+
+        ComputeSolverNormalizedPositions(root, 0, false, null);
+        if (zoomedElement.parent) {
+            d3SolverNodesArray.push(zoomedElement.parent);
         }
 
         if (updateRecomputesAutoComplete) {
@@ -2787,7 +3312,7 @@ function DrawMatrix() {
             TRANSITION_DURATION = TRANSITION_DURATION_FAST;
             lastClickWasLeft = false;
             Toggle(d);
-            Update(d);
+            Update();
         }
     }
 
@@ -2901,31 +3426,6 @@ function DrawMatrix() {
             return null;
         }
 
-        function RemoveDuplicates(d) { //remove redundant elements in every objects' sources and targets arrays
-            if (d.children) {
-                for (var i = 0; i < d.children.length; ++i) {
-                    RemoveDuplicates(d.children[i]);
-                }
-            }
-
-            function unique(elem, pos, arr) {
-                return arr.indexOf(elem) == pos;
-            }
-
-            if (d.targetsParamView) {
-                //numElementsBefore += d.targetsParamView.length;
-                var uniqueArray = d.targetsParamView.filter(unique);
-                d.targetsParamView = uniqueArray;
-                //numElementsAfter += d.targetsParamView.length;
-            }
-            if (d.targetsHideParams) {
-                //numElementsBefore += d.targetsHideParams.length;
-                var uniqueArray = d.targetsHideParams.filter(unique);
-                d.targetsHideParams = uniqueArray;
-                //numElementsAfter += d.targetsHideParams.length;
-            }
-        }
-
         function AddLeaves(d, objArray) {
             if (d.type !== "param" && d.type !== "unconnected_param") {
                 objArray.push(d);
@@ -2938,8 +3438,9 @@ function DrawMatrix() {
         }
 
         function ClearConnections(d) {
-            d.targetsParamView = [];
-            d.targetsHideParams = [];
+            d.targetsParamView = new Set();
+            d.targetsHideParams = new Set();
+
             if (d.children) {
                 for (var i = 0; i < d.children.length; ++i) {
                     ClearConnections(d.children[i]);
@@ -2948,6 +3449,8 @@ function DrawMatrix() {
         }
 
         ClearConnections(root);
+
+        var sys_pathnames = modelData.sys_pathnames_list;
 
         for (var i = 0; i < conns.length; ++i) {
             var srcSplitArray = conns[i].src.split(/\.|:/);
@@ -2993,31 +3496,36 @@ function DrawMatrix() {
 
 
             for (var j = 0; j < srcObjArray.length; ++j) {
-                if (!srcObjArray[j].hasOwnProperty('targetsParamView')) srcObjArray[j].targetsParamView = [];
-                if (!srcObjArray[j].hasOwnProperty('targetsHideParams')) srcObjArray[j].targetsHideParams = [];
-                srcObjArray[j].targetsParamView = srcObjArray[j].targetsParamView.concat(tgtObjArrayParamView);
-                srcObjArray[j].targetsHideParams = srcObjArray[j].targetsHideParams.concat(tgtObjArrayHideParams);
+                if (!srcObjArray[j].hasOwnProperty('targetsParamView')) srcObjArray[j].targetsParamView = new Set();
+                if (!srcObjArray[j].hasOwnProperty('targetsHideParams')) srcObjArray[j].targetsHideParams = new Set();
+
+                tgtObjArrayParamView.forEach(item => srcObjArray[j].targetsParamView.add(item));
+                tgtObjArrayHideParams.forEach(item => srcObjArray[j].targetsHideParams.add(item));
             }
 
             var cycleArrowsArray = [];
             if (conns[i].cycle_arrows && conns[i].cycle_arrows.length > 0) {
                 var cycleArrows = conns[i].cycle_arrows;
                 for (var j = 0; j < cycleArrows.length; ++j) {
-                    var cycleArrowsSplitArray = cycleArrows[j].split(" ");
-                    if (cycleArrowsSplitArray.length != 2) {
-                        alert("error: cycleArrowsSplitArray length not 2: got " + cycleArrowsSplitArray.length);
+                    if (cycleArrows[j].length != 2) {
+                        alert("error: cycleArrowsSplitArray length not 2, got " + cycleArrows[j].length +
+                              ": " + cycleArrows[j]);
                         return;
                     }
-                    var splitArray = cycleArrowsSplitArray[0].split(/\.|:/);
+
+                    var src_pathname = sys_pathnames[cycleArrows[j][0]];
+                    var tgt_pathname = sys_pathnames[cycleArrows[j][1]];
+
+                    var splitArray = src_pathname.split(/\.|:/);
                     var arrowBeginObj = GetObjectInTree(root, splitArray, 0);
                     if (arrowBeginObj == null) {
-                        alert("error: cannot find cycle arrows begin object " + cycleArrowsSplitArray[0]);
+                        alert("error: cannot find cycle arrows begin object " + src_pathname);
                         return;
                     }
-                    splitArray = cycleArrowsSplitArray[1].split(/\.|:/);
+                    splitArray = tgt_pathname.split(/\.|:/);
                     var arrowEndObj = GetObjectInTree(root, splitArray, 0);
                     if (arrowEndObj == null) {
-                        alert("error: cannot find cycle arrows end object " + cycleArrowsSplitArray[1]);
+                        alert("error: cannot find cycle arrows end object " + tgt_pathname);
                         return;
                     }
                     cycleArrowsArray.push({ "begin": arrowBeginObj, "end": arrowEndObj });
@@ -3031,7 +3539,6 @@ function DrawMatrix() {
             }
 
         }
-        RemoveDuplicates(root);
     }
 
     function ComputeMatrixN2() {
@@ -3040,15 +3547,14 @@ function DrawMatrix() {
             for (var si = 0; si < d3RightTextNodesArrayZoomed.length; ++si) {
                 var srcObj = d3RightTextNodesArrayZoomed[si];
                 matrix[si + "_" + si] = { "r": si, "c": si, "obj": srcObj, "id": srcObj.id + "_" + srcObj.id };
-                var targets = (showParams) ? srcObj.targetsParamView : srcObj.targetsHideParams;
-                for (var j = 0; j < targets.length; ++j) {
-                    var tgtObj = targets[j];
+                var targets = srcObj.targetsParamView;
+                for (let tgtObj of targets) {
                     var ti = d3RightTextNodesArrayZoomed.indexOf(tgtObj);
                     if (ti != -1) {
                         matrix[si + "_" + ti] = { "r": si, "c": ti, "obj": srcObj, "id": srcObj.id + "_" + tgtObj.id }; //matrix[si][ti].z = 1;
                     }
                 }
-                if (showParams && (srcObj.type === "param" || srcObj.type === "unconnected_param")) {
+                if (srcObj.type === "param" || srcObj.type === "unconnected_param") {
                     for (var j = si + 1; j < d3RightTextNodesArrayZoomed.length; ++j) {
                         var tgtObj = d3RightTextNodesArrayZoomed[j];
                         if (srcObj.parentComponent !== tgtObj.parentComponent) break;
@@ -3078,6 +3584,10 @@ function DrawMatrix() {
         symbols_vectorGroup = [];
         symbols_groupVector = [];
         symbols_groupGroup = [];
+        symbols_vectorVector_declared_partials = [] ;
+        symbols_scalarScalar_declared_partials = [] ;
+        symbols_vectorScalar_declared_partials = [] ;
+        symbols_scalarVector_declared_partials = [] ;
 
         for (var key in matrix) {
             var d = matrix[key];
@@ -3086,7 +3596,7 @@ function DrawMatrix() {
             if (d.c == d.r) { //on diagonal
                 if (srcObj.type === "subsystem") { //group
                     symbols_group.push(d);
-                } else if (srcObj.type === "unknown" || (showParams && (srcObj.type === "param" || srcObj.type === "unconnected_param"))) {
+                } else if (srcObj.type === "unknown" || (srcObj.type === "param" || srcObj.type === "unconnected_param")) {
                     if (srcObj.dtype === "ndarray") { //vector
                         symbols_vector.push(d);
                     } else { //scalar
@@ -3099,7 +3609,7 @@ function DrawMatrix() {
                 if (tgtObj.type === "subsystem") { //groupGroup
                     symbols_groupGroup.push(d);
                 }
-                else if (tgtObj.type === "unknown" || (showParams && (tgtObj.type === "param" || tgtObj.type === "unconnected_param"))) {
+                else if (tgtObj.type === "unknown" || (tgtObj.type === "param" || tgtObj.type === "unconnected_param")) {
                     if (tgtObj.dtype === "ndarray") {//groupVector
                         symbols_groupVector.push(d);
                     }
@@ -3108,15 +3618,24 @@ function DrawMatrix() {
                     }
                 }
             }
-            else if (srcObj.type === "unknown" || (showParams && (srcObj.type === "param" || srcObj.type === "unconnected_param"))) {
+            else if (srcObj.type === "unknown" || (srcObj.type === "param" || srcObj.type === "unconnected_param")) {
                 if (srcObj.dtype === "ndarray") {
-                    if (tgtObj.type === "unknown" || (showParams && (tgtObj.type === "param" || tgtObj.type === "unconnected_param"))) {
-                        if (tgtObj.dtype === "ndarray" || (showParams && (tgtObj.type === "param" || tgtObj.type === "unconnected_param"))) {//vectorVector
+                    if (tgtObj.type === "unknown" || (tgtObj.type === "param" || tgtObj.type === "unconnected_param")) {
+                        if (tgtObj.dtype === "ndarray" || (tgtObj.type === "param" || tgtObj.type === "unconnected_param")) {//vectorVector
                             symbols_vectorVector.push(d);
+                            var partials_string = tgtObj.absPathName + " > " + srcObj.absPathName;
+                            if (modelData.declare_partials_list.includes(partials_string)){
+                                symbols_vectorVector_declared_partials.push(d);
+                            }
+
                         }
                         else {//vectorScalar
                             symbols_vectorScalar.push(d);
-                        }
+                            var partials_string = tgtObj.absPathName + " > " + srcObj.absPathName;
+                            if (modelData.declare_partials_list.includes(partials_string)){
+                                symbols_vectorScalar_declared_partials.push(d);
+                            }
+                       }
 
                     }
                     else if (tgtObj.type === "subsystem") { //vectorGroup
@@ -3124,20 +3643,26 @@ function DrawMatrix() {
                     }
                 }
                 else { //if (srcObj.dtype !== "ndarray"){
-                    if (tgtObj.type === "unknown" || (showParams && (tgtObj.type === "param" || tgtObj.type === "unconnected_param"))) {
+                    if (tgtObj.type === "unknown" || (tgtObj.type === "param" || tgtObj.type === "unconnected_param")) {
                         if (tgtObj.dtype === "ndarray") {//scalarVector
                             symbols_scalarVector.push(d);
+                            var partials_string = tgtObj.absPathName + " > " + srcObj.absPathName;
+                            if (modelData.declare_partials_list.includes(partials_string)) {
+                                symbols_scalarVector_declared_partials.push(d);
+                            }
                         }
                         else {//scalarScalar
                             symbols_scalarScalar.push(d);
+                            var partials_string = tgtObj.absPathName + " > " + srcObj.absPathName;
+                            if (modelData.declare_partials_list.includes(partials_string)){
+                                symbols_scalarScalar_declared_partials.push(d);
+                            }
                         }
-
                     }
                     else if (tgtObj.type === "subsystem") { //scalarGroup
                         symbols_scalarGroup.push(d);
                     }
                 }
-
             }
         }
 
@@ -3177,12 +3702,6 @@ function DrawMatrix() {
             }
         }
     }
-
-
-    function FindRootOfChangeForShowParams(d) {
-        return (d.hasOwnProperty("parentComponent")) ? d.parentComponent : d;
-    }
-
     function FindRootOfChangeForRightClick(d) {
         return lastRightClickedElement;
     }
@@ -3253,7 +3772,7 @@ function DrawMatrix() {
                 n2Dx * d.c + n2Dx * .5, //left x2
                 n2Dy * d.r + n2Dy * .5, //left y2
                 n2Dx * d.c + n2Dx * .5, //up x3
-                (showParams) ? n2Dy * d.c + n2Dy - 1e-2 : n2Dy * (boxEnd.stopI) + n2Dy - 1e-2, //up y3
+                n2Dy * d.c + n2Dy - 1e-2, //up y3
                 RED_ARROW_COLOR, lineWidth, true);
 
             var targetsWithCycleArrows = [];
@@ -3296,12 +3815,7 @@ function DrawMatrix() {
                             }
 
                             if (firstBeginIndex != firstEndIndex) {
-                                if (showParams) {
-                                    DrawArrowsParamView(firstBeginIndex, firstEndIndex);
-                                }
-                                else {
-                                    DrawArrows(firstBeginIndex, firstEndIndex);
-                                }
+                                DrawArrowsParamView(firstBeginIndex, firstEndIndex);
                             }
                         }
                     }
@@ -3315,7 +3829,7 @@ function DrawMatrix() {
                 n2Dx * d.c + n2Dx * .5, //right x2
                 n2Dy * d.r + n2Dy * .5, //right y2
                 n2Dx * d.c + n2Dx * .5, //down x3
-                (showParams) ? n2Dy * d.c + 1e-2 : n2Dy * boxEnd.startI + 1e-2, //down y3
+                n2Dy * d.c + 1e-2, //down y3
                 RED_ARROW_COLOR, lineWidth, true);
         }
         var leftTextWidthR = d3RightTextNodesArrayZoomed[d.r].nameWidthPx,
@@ -3339,49 +3853,25 @@ function DrawMatrix() {
             var box = d3RightTextNodesArrayZoomedBoxInfo[i];
             if (matrix[hoveredIndexRC + "_" + i] !== undefined) { //if (matrix[hoveredIndexRC][i].z > 0) { //i is column here
                 if (i < hoveredIndexRC) { //column less than hovered
-                    if (showParams) {
-                        DrawPathTwoLines(
-                            n2Dx * hoveredIndexRC, //x1
-                            n2Dy * (hoveredIndexRC + .5), //y1
-                            (i + .5) * n2Dx, //left x2
-                            n2Dy * (hoveredIndexRC + .5), //left y2
-                            (i + .5) * n2Dx, //up x3
-                            (i + 1) * n2Dy, //up y3
-                            GREEN_ARROW_COLOR, lineWidth, true);
-                    }
-                    else if (i == box.startI) {
-                        DrawPathTwoLines(
-                            n2Dx * hoveredIndexRC, //x1
-                            n2Dy * hoveredIndexRC + n2Dy * .5, //y1
-                            (box.startI + (box.stopI - box.startI) * .5) * n2Dx + n2Dx * .5, //left x2
-                            n2Dy * hoveredIndexRC + n2Dy * .5, //left y2
-                            (box.startI + (box.stopI - box.startI) * .5) * n2Dx + n2Dx * .5, //up x3
-                            n2Dy * box.stopI + n2Dy, //up y3
-                            GREEN_ARROW_COLOR, lineWidth, true);
-                    }
+                    DrawPathTwoLines(
+                        n2Dx * hoveredIndexRC, //x1
+                        n2Dy * (hoveredIndexRC + .5), //y1
+                        (i + .5) * n2Dx, //left x2
+                        n2Dy * (hoveredIndexRC + .5), //left y2
+                        (i + .5) * n2Dx, //up x3
+                        (i + 1) * n2Dy, //up y3
+                        GREEN_ARROW_COLOR, lineWidth, true);
                     DrawRect(-leftTextWidthDependency - PTREE_N2_GAP_PX, n2Dy * i, leftTextWidthDependency, n2Dy, GREEN_ARROW_COLOR); //highlight var name
 
                 } else if (i > hoveredIndexRC) { //column greater than hovered
-                    if (showParams) {
-                        DrawPathTwoLines(
-                            n2Dx * hoveredIndexRC + n2Dx, //x1
-                            n2Dy * (hoveredIndexRC + .5), //y1
-                            (i + .5) * n2Dx, //right x2
-                            n2Dy * (hoveredIndexRC + .5), //right y2
-                            (i + .5) * n2Dx, //down x3
-                            n2Dy * i, //down y3
-                            GREEN_ARROW_COLOR, lineWidth, true); //vertical down
-                    }
-                    else if (i == box.startI) {
-                        DrawPathTwoLines(
-                            n2Dx * hoveredIndexRC + n2Dx, //x1
-                            n2Dy * hoveredIndexRC + n2Dy * .5, //y1
-                            (box.startI + (box.stopI - box.startI) * .5) * n2Dx + n2Dx * .5, //right x2
-                            n2Dy * hoveredIndexRC + n2Dy * .5, //right y2
-                            (box.startI + (box.stopI - box.startI) * .5) * n2Dx + n2Dx * .5, //down x3
-                            n2Dy * box.startI, //down y3
-                            GREEN_ARROW_COLOR, lineWidth, true); //vertical down
-                    }
+                    DrawPathTwoLines(
+                        n2Dx * hoveredIndexRC + n2Dx, //x1
+                        n2Dy * (hoveredIndexRC + .5), //y1
+                        (i + .5) * n2Dx, //right x2
+                        n2Dy * (hoveredIndexRC + .5), //right y2
+                        (i + .5) * n2Dx, //down x3
+                        n2Dy * i, //down y3
+                        GREEN_ARROW_COLOR, lineWidth, true); //vertical down
                     DrawRect(-leftTextWidthDependency - PTREE_N2_GAP_PX, n2Dy * i, leftTextWidthDependency, n2Dy, GREEN_ARROW_COLOR); //highlight var name
                 }
             }
@@ -3523,6 +4013,10 @@ function DrawMatrix() {
             var newText = (i == height) ? ("<b>" + i + "px</b>") : (i + "px");
             parentDiv.querySelector("#idVerticalResize" + i + "px").innerHTML = newText;
         }
+        for (var i = 2000; i <= 4000; i += 1000) {
+            var newText = (i == height) ? ("<b>" + i + "px</b>") : (i + "px");
+            parentDiv.querySelector("#idVerticalResize" + i + "px").innerHTML = newText;
+        }
         ClearArrowsAndConnects();
         HEIGHT_PX = height;
         LEVEL_OF_DETAIL_THRESHOLD = HEIGHT_PX / 3;
@@ -3532,19 +4026,12 @@ function DrawMatrix() {
         Update();
     }
 
-    function ShowParamsCheckboxChange() {
-        if (zoomedElement.type === "param" || zoomedElement.type === "unconnected_param") return;
-        showParams = !showParams;
-        parentDiv.querySelector("#showParamsButtonId").className = showParams ? "myButton myButtonToggledOn" : "myButton";
-
-        FindRootOfChangeFunction = FindRootOfChangeForShowParams;
-        lastClickWasLeft = false;
-        TRANSITION_DURATION = TRANSITION_DURATION_SLOW;
-        transitionStartDelay = 500;
+    function ToggleSolverNamesCheckboxChange() {
+        showLinearSolverNames = !showLinearSolverNames;
+        parentDiv.querySelector("#toggleSolverNamesButtonId").className = !showLinearSolverNames ? "myButton myButtonToggledOn" : "myButton";
         SetupLegend(d3, d3ContentDiv);
         Update();
     }
-
 
     function ShowPathCheckboxChange() {
         showPath = !showPath;
@@ -3575,7 +4062,8 @@ function DrawMatrix() {
         div.querySelector("#clearArrowsAndConnectsButtonId").onclick = ClearArrowsAndConnects;
         div.querySelector("#showCurrentPathButtonId").onclick = ShowPathCheckboxChange;
         div.querySelector("#showLegendButtonId").onclick = ToggleLegend;
-        div.querySelector("#showParamsButtonId").onclick = ShowParamsCheckboxChange;
+
+        div.querySelector("#toggleSolverNamesButtonId").onclick = ToggleSolverNamesCheckboxChange;
 
         for (var i = 8; i <= 14; ++i) {
             var f = function (idx) {
@@ -3586,6 +4074,12 @@ function DrawMatrix() {
 
         for (var i = 600; i <= 1000; i += 50) {
             var f = function (idx) {
+                return function () { VerticalResize(idx); };
+            }(i);
+            div.querySelector("#idVerticalResize" + i + "px").onclick = f;
+        }
+        for (var i = 2000; i <= 4000; i += 1000) {
+            var f = function(idx) {
                 return function () { VerticalResize(idx); };
             }(i);
             div.querySelector("#idVerticalResize" + i + "px").onclick = f;
@@ -3611,6 +4105,18 @@ var mouseClickN2;
 var hasInputConn;
 var treeData, connectionList;
 modelData.tree.name = 'model'; //Change 'root' to 'model'
-var app = PtN2Diagram(document.getElementById("ptN2ContentDivId"), modelData['tree'], modelData['connections_list']);
+function ChangeBlankSolverToNone(d) {
+    if (d.linear_solver === "") d.linear_solver = "None";
+    if (d.nonlinear_solver === "") d.nonlinear_solver = "None";
+    if (d.children) {
+        for (var i = 0; i < d.children.length; ++i) {
+            ChangeBlankSolverToNone(d.children[i]);
+        }
+    }
+}
+ChangeBlankSolverToNone(modelData.tree);
+
+var app = PtN2Diagram(document.getElementById("ptN2ContentDivId"), modelData);
+
 
 </script>

--- a/openmdao/docs/theory_manual/total_derivs/aerostruct_n2.py
+++ b/openmdao/docs/theory_manual/total_derivs/aerostruct_n2.py
@@ -2,27 +2,26 @@
 This is not a real run_file. It is only used to make the n2
 diagram for the notional aerostructural problem used for demonstration in the docs.
 """
+import openmdao.api as om
 
-from openmdao.api import Problem, Group, ExecComp, IndepVarComp, view_model, ImplicitComponent
-
-p = Problem()
-dvs = p.model.add_subsystem('design_vars', IndepVarComp(), promotes=['*'])
+p = om.Problem()
+dvs = p.model.add_subsystem('design_vars', om.IndepVarComp(), promotes=['*'])
 dvs.add_output('x_aero')
 dvs.add_output('x_struct')
-aerostruct = p.model.add_subsystem('aerostruct_cycle', Group(), promotes=['*'])
+aerostruct = p.model.add_subsystem('aerostruct_cycle', om.Group(), promotes=['*'])
 #note the equations don't matter... just need a simple way to get inputs and outputs there
 aerostruct.add_subsystem('aero',
-                         ExecComp(['w = u+x_aero', 'Cl=u+x_aero', 'Cd = u + x_aero']),
+                         om.ExecComp(['w = u+x_aero', 'Cl=u+x_aero', 'Cd = u + x_aero']),
                          promotes=['*'])
-aerostruct.add_subsystem('struct', ExecComp(['u = w+x_struct', 'mass=x_struct']),
+aerostruct.add_subsystem('struct', om.ExecComp(['u = w+x_struct', 'mass=x_struct']),
                          promotes=['*'])
 
-p.model.add_subsystem('objective', ExecComp('f=mass+Cl/Cd'), promotes=['*'])
-p.model.add_subsystem('constraint', ExecComp('g=Cl'), promotes=['*'])
+p.model.add_subsystem('objective', om.ExecComp('f=mass+Cl/Cd'), promotes=['*'])
+p.model.add_subsystem('constraint', om.ExecComp('g=Cl'), promotes=['*'])
 
 p.setup()
 
-view_model(p, outfile='aerostruct_n2.html', embeddable=True, show_browser=False)
+om.view_model(p, outfile='aerostruct_n2.html', embeddable=True, show_browser=False)
 
 
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1198,6 +1198,7 @@ class TestDOEDriverFeature(unittest.TestCase):
             pass
 
     def test_uniform(self):
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = om.Problem()

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -61,7 +61,7 @@ class TestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 11
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # TODO: Satadru listed this solution, but I get a way better one.
@@ -74,7 +74,7 @@ class TestSimpleGA(unittest.TestCase):
         np.random.seed(1)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -92,7 +92,7 @@ class TestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution
@@ -103,7 +103,7 @@ class TestSimpleGA(unittest.TestCase):
         np.random.seed(1)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         indep = IndepVarComp()
         indep.add_output('xC', val=7.5)
@@ -124,7 +124,7 @@ class TestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution
@@ -158,7 +158,7 @@ class TestSimpleGA(unittest.TestCase):
                 outputs['weighted'] = obj + pen
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('xc_a1', IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
         model.add_subsystem('xc_a2', IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
@@ -183,7 +183,7 @@ class TestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob['area3'] = 0.0005
         prob.run_driver()
 
@@ -224,7 +224,7 @@ class TestSimpleGA(unittest.TestCase):
                 outputs['weighted'] = obj + pen
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('xc_a1', IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
         model.add_subsystem('xc_a2', IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
@@ -249,7 +249,7 @@ class TestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob['area3'] = 0.0005
         prob.run_driver()
 
@@ -273,7 +273,7 @@ class TestSimpleGA(unittest.TestCase):
                 raise ValueError
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', 0.0))
         model.add_subsystem('comp', ValueErrorComp())
@@ -285,7 +285,7 @@ class TestSimpleGA(unittest.TestCase):
 
         prob.driver = SimpleGADriver(max_gen=75, pop_size=25)
         prob.driver._randomstate = 1
-        prob.setup(check=False)
+        prob.setup()
         # prob.run_driver()
         self.assertRaises(ValueError, prob.run_driver)
 
@@ -342,7 +342,7 @@ class TestSimpleGA(unittest.TestCase):
 
     def test_SimpleGADriver_missing_objective(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('x', IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
@@ -352,7 +352,7 @@ class TestSimpleGA(unittest.TestCase):
         prob.model.add_design_var('x', lower=0)
         prob.model.add_constraint('x', lower=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception) as raises_msg:
             prob.run_driver()
@@ -380,7 +380,7 @@ class TestDriverOptionsSimpleGA(unittest.TestCase):
         driver.options['bits'] = {'x': 8}
         prob.model.add_design_var('x', lower=-10., upper=10.)
         prob.model.add_objective('y')
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
         self.assertEqual(driver.options['Pm'], 0.1)
         self.assertEqual(driver.options['Pc'], 0.01)
@@ -657,7 +657,7 @@ class MPITestSimpleGA(unittest.TestCase):
         np.random.seed(1)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -678,7 +678,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution
@@ -689,7 +689,7 @@ class MPITestSimpleGA(unittest.TestCase):
         np.random.seed(1)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -720,7 +720,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution
@@ -755,7 +755,7 @@ class MPITestSimpleGA(unittest.TestCase):
                 outputs['weighted'] = obj + pen
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('xc_a1', IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
         model.add_subsystem('xc_a2', IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
@@ -780,7 +780,7 @@ class MPITestSimpleGA(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob['area3'] = 0.0005
         prob.run_driver()
 
@@ -802,7 +802,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         np.random.seed(1)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -833,7 +833,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution
@@ -842,7 +842,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
 
     def test_indivisible_error(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('par', ParallelGroup())
 
         prob.driver = SimpleGADriver()
@@ -905,7 +905,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -934,7 +934,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -963,7 +963,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -993,7 +993,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -1078,7 +1078,7 @@ class MPIFeatureTests(unittest.TestCase):
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -1096,7 +1096,7 @@ class MPIFeatureTests(unittest.TestCase):
         prob.driver.options['max_gen'] = 10
         prob.driver.options['run_parallel'] = True
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution
@@ -1115,7 +1115,7 @@ class MPIFeatureTests4(unittest.TestCase):
         from openmdao.test_suite.components.branin import Branin
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('xC', 7.5))
         model.add_subsystem('p2', IndepVarComp('xI', 0.0))
@@ -1146,7 +1146,7 @@ class MPIFeatureTests4(unittest.TestCase):
 
         prob.driver._randomstate = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_driver()
 
         # Optimal solution

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -39,7 +39,7 @@ class TestSimpleGA(unittest.TestCase):
                 outputs['d'] = 19.0 - 14.0*x[0] + 3.0*x[0]**2 - 14.0*x[1] + 6.0*x[0]*x[1] + 3.0*x[1]**2
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', np.array([0.2, -0.2])))
         model.add_subsystem('comp', MyComp())

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -4,15 +4,13 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, ExecComp, \
-    PETScVector, ParallelGroup
-from openmdao.drivers.genetic_algorithm_driver import SimpleGADriver,\
-    GeneticAlgorithm
+import openmdao.api as om
+from openmdao.drivers.genetic_algorithm_driver import GeneticAlgorithm
 from openmdao.test_suite.components.branin import Branin, BraninDiscrete
+from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.three_bar_truss import ThreeBarTruss
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.mpi import MPI
-from openmdao.test_suite.components.paraboloid import Paraboloid
 
 
 class TestSimpleGA(unittest.TestCase):
@@ -20,7 +18,7 @@ class TestSimpleGA(unittest.TestCase):
     def test_simple_test_func(self):
         np.random.seed(11)
 
-        class MyComp(ExplicitComponent):
+        class MyComp(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.zeros((2, )))
@@ -38,12 +36,12 @@ class TestSimpleGA(unittest.TestCase):
                 outputs['c'] = (x[0] + x[1] + 1.0)**2
                 outputs['d'] = 19.0 - 14.0*x[0] + 3.0*x[0]**2 - 14.0*x[1] + 6.0*x[0]*x[1] + 3.0*x[1]**2
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', np.array([0.2, -0.2])))
+        model.add_subsystem('px', om.IndepVarComp('x', np.array([0.2, -0.2])))
         model.add_subsystem('comp', MyComp())
-        model.add_subsystem('obj', ExecComp('f=(30 + a*b)*(1 + c*d)'))
+        model.add_subsystem('obj', om.ExecComp('f=(30 + a*b)*(1 + c*d)'))
 
         model.connect('px.x', 'comp.x')
         model.connect('comp.a', 'obj.a')
@@ -55,7 +53,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('px.x', lower=np.array([0.2, -1.0]), upper=np.array([1.0, -0.2]))
         model.add_objective('obj.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'px.x': 16}
         prob.driver.options['max_gen'] = 75
 
@@ -73,11 +71,11 @@ class TestSimpleGA(unittest.TestCase):
     def test_mixed_integer_branin(self):
         np.random.seed(1)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -87,7 +85,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver(max_gen=75, pop_size=25)
+        prob.driver = om.SimpleGADriver(max_gen=75, pop_size=25)
         prob.driver.options['bits'] = {'p1.xC': 8}
 
         prob.driver._randomstate = 1
@@ -102,10 +100,10 @@ class TestSimpleGA(unittest.TestCase):
     def test_mixed_integer_branin_discrete(self):
         np.random.seed(1)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        indep = IndepVarComp()
+        indep = om.IndepVarComp()
         indep.add_output('xC', val=7.5)
         indep.add_discrete_output('xI', val=0)
 
@@ -119,7 +117,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('p.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver(max_gen=75, pop_size=25)
+        prob.driver = om.SimpleGADriver(max_gen=75, pop_size=25)
         prob.driver.options['bits'] = {'p.xC': 8}
 
         prob.driver._randomstate = 1
@@ -135,7 +133,7 @@ class TestSimpleGA(unittest.TestCase):
     def test_mixed_integer_3bar(self):
         np.random.seed(1)
 
-        class ObjPenalty(ExplicitComponent):
+        class ObjPenalty(om.ExplicitComponent):
             """
             Weight objective with penalty on stress constraint.
             """
@@ -157,15 +155,15 @@ class TestSimpleGA(unittest.TestCase):
 
                 outputs['weighted'] = obj + pen
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('xc_a1', IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a2', IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a3', IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xi_m1', IndepVarComp('mat1', 1), promotes=['*'])
-        model.add_subsystem('xi_m2', IndepVarComp('mat2', 1), promotes=['*'])
-        model.add_subsystem('xi_m3', IndepVarComp('mat3', 1), promotes=['*'])
+        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a3', om.IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 1), promotes=['*'])
+        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 1), promotes=['*'])
+        model.add_subsystem('xi_m3', om.IndepVarComp('mat3', 1), promotes=['*'])
         model.add_subsystem('comp', ThreeBarTruss(), promotes=['*'])
         model.add_subsystem('obj_with_penalty', ObjPenalty(), promotes=['*'])
 
@@ -176,7 +174,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('mat3', lower=1, upper=4)
         model.add_objective('weighted')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'area1': 6,
                                        'area2': 6}
         prob.driver.options['max_gen'] = 75
@@ -201,7 +199,7 @@ class TestSimpleGA(unittest.TestCase):
 
         np.random.seed(1)
 
-        class ObjPenalty(ExplicitComponent):
+        class ObjPenalty(om.ExplicitComponent):
             """
             Weight objective with penalty on stress constraint.
             """
@@ -223,15 +221,15 @@ class TestSimpleGA(unittest.TestCase):
 
                 outputs['weighted'] = obj + pen
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('xc_a1', IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a2', IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a3', IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xi_m1', IndepVarComp('mat1', 1), promotes=['*'])
-        model.add_subsystem('xi_m2', IndepVarComp('mat2', 1), promotes=['*'])
-        model.add_subsystem('xi_m3', IndepVarComp('mat3', 1), promotes=['*'])
+        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a3', om.IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 1), promotes=['*'])
+        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 1), promotes=['*'])
+        model.add_subsystem('xi_m3', om.IndepVarComp('mat3', 1), promotes=['*'])
         model.add_subsystem('comp', ThreeBarTruss(), promotes=['*'])
         model.add_subsystem('obj_with_penalty', ObjPenalty(), promotes=['*'])
 
@@ -242,7 +240,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('mat3', lower=1, upper=4)
         model.add_objective('weighted')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'area1': 6,
                                        'area2': 6}
         prob.driver.options['max_gen'] = 75
@@ -264,7 +262,7 @@ class TestSimpleGA(unittest.TestCase):
     def test_analysis_error(self):
         np.random.seed(1)
 
-        class ValueErrorComp(ExplicitComponent):
+        class ValueErrorComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('x', 1.0)
                 self.add_output('f', 1.0)
@@ -272,10 +270,10 @@ class TestSimpleGA(unittest.TestCase):
             def compute(self, inputs, outputs):
                 raise ValueError
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 0.0))
+        model.add_subsystem('p', om.IndepVarComp('x', 0.0))
         model.add_subsystem('comp', ValueErrorComp())
 
         model.connect('p.x', 'comp.x')
@@ -283,7 +281,7 @@ class TestSimpleGA(unittest.TestCase):
         model.add_design_var('p.x', lower=-5.0, upper=10.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver(max_gen=75, pop_size=25)
+        prob.driver = om.SimpleGADriver(max_gen=75, pop_size=25)
         prob.driver._randomstate = 1
         prob.setup()
         # prob.run_driver()
@@ -314,21 +312,21 @@ class TestSimpleGA(unittest.TestCase):
         np.testing.assert_array_almost_equal(gen[1], ga.encode(x[1], vlb, vub, bits))
 
     def test_vector_desvars_multiobj(self):
-        prob = Problem()
+        prob = om.Problem()
 
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 3)
         indeps.add_output('y', [4.0, -4])
 
         prob.model.add_subsystem('paraboloid1',
-                                 ExecComp('f = (x+5)**2- 3'))
+                                 om.ExecComp('f = (x+5)**2- 3'))
         prob.model.add_subsystem('paraboloid2',
-                                 ExecComp('f = (y[0]-3)**2 + (y[1]-1)**2 - 3',
-                                          y=[0, 0]))
+                                 om.ExecComp('f = (y[0]-3)**2 + (y[1]-1)**2 - 3',
+                                             y=[0, 0]))
         prob.model.connect('indeps.x', 'paraboloid1.x')
         prob.model.connect('indeps.y', 'paraboloid2.y')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
 
         prob.model.add_design_var('indeps.x', lower=-5, upper=5)
         prob.model.add_design_var('indeps.y', lower=[-10, 0], upper=[10, 3])
@@ -341,13 +339,13 @@ class TestSimpleGA(unittest.TestCase):
         np.testing.assert_array_almost_equal(prob['indeps.y'], [3, 1])
 
     def test_SimpleGADriver_missing_objective(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('x', IndepVarComp('x', 2.0), promotes=['*'])
+        model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
 
         prob.model.add_design_var('x', lower=0)
         prob.model.add_constraint('x', lower=0)
@@ -368,12 +366,12 @@ class TestDriverOptionsSimpleGA(unittest.TestCase):
 
     def test_driver_options(self):
         """Tests if Pm and Pc options can be set."""
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        indeps = model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', 1.)
-        model.add_subsystem('model', ExecComp('y=x**2'), promotes=['*'])
-        driver = prob.driver = SimpleGADriver()
+        model.add_subsystem('model', om.ExecComp('y=x**2'), promotes=['*'])
+        driver = prob.driver = om.SimpleGADriver()
         driver.options['Pm'] = 0.1
         driver.options['Pc'] = 0.01
         driver.options['max_gen'] = 5
@@ -390,7 +388,7 @@ class TestMultiObjectiveSimpleGA(unittest.TestCase):
 
     def test_multi_obj(self):
 
-        class Box(ExplicitComponent):
+        class Box(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('length', val=1.)
@@ -412,16 +410,16 @@ class TestMultiObjectiveSimpleGA(unittest.TestCase):
                 outputs['area'] = 2*length*height + 2*length*width + 2*height*width
                 outputs['volume'] = length*height*width
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('box', Box(), promotes=['*'])
 
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('length', 1.5)
         indeps.add_output('width', 1.5)
         indeps.add_output('height', 1.5)
 
         # setup the optimization
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['max_gen'] = 100
         prob.driver.options['bits'] = {'length': 8, 'width': 8, 'height': 8}
         prob.driver.options['multi_obj_exponent'] = 1.
@@ -451,16 +449,16 @@ class TestMultiObjectiveSimpleGA(unittest.TestCase):
 
         # run #2
         # weights changed
-        prob2 = Problem()
+        prob2 = om.Problem()
         prob2.model.add_subsystem('box', Box(), promotes=['*'])
 
-        indeps2 = prob2.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps2 = prob2.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps2.add_output('length', 1.5)
         indeps2.add_output('width', 1.5)
         indeps2.add_output('height', 1.5)
 
         # setup the optimization
-        prob2.driver = SimpleGADriver()
+        prob2.driver = om.SimpleGADriver()
         prob2.driver.options['max_gen'] = 100
         prob2.driver.options['bits'] = {'length': 8, 'width': 8, 'height': 8}
         prob2.driver.options['multi_obj_exponent'] = 1.
@@ -495,7 +493,7 @@ class TestConstrainedSimpleGA(unittest.TestCase):
 
     def test_constrained_with_penalty(self):
 
-        class Cylinder(ExplicitComponent):
+        class Cylinder(om.ExplicitComponent):
             """Main class"""
 
             def setup(self):
@@ -514,15 +512,15 @@ class TestConstrainedSimpleGA(unittest.TestCase):
                 outputs['Area'] = area
                 outputs['Volume'] = volume
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('cylinder', Cylinder(), promotes=['*'])
 
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('radius', 2.)  # height
         indeps.add_output('height', 3.)  # radius
 
         # setup the optimization
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         prob.driver.options['penalty_parameter'] = 3.
         prob.driver.options['penalty_exponent'] = 1.
         prob.driver.options['max_gen'] = 50
@@ -547,7 +545,7 @@ class TestConstrainedSimpleGA(unittest.TestCase):
 
     def test_constrained_without_penalty(self):
 
-        class Cylinder(ExplicitComponent):
+        class Cylinder(om.ExplicitComponent):
             """Main class"""
 
             def setup(self):
@@ -566,15 +564,15 @@ class TestConstrainedSimpleGA(unittest.TestCase):
                 outputs['Area'] = area
                 outputs['Volume'] = volume
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('cylinder', Cylinder(), promotes=['*'])
 
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('radius', 2.)  # height
         indeps.add_output('height', 3.)  # radius
 
         # setup the optimization
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         prob.driver.options['penalty_parameter'] = 0.  # no penalty, same as unconstrained
         prob.driver.options['penalty_exponent'] = 1.
         prob.driver.options['max_gen'] = 50
@@ -599,7 +597,7 @@ class TestConstrainedSimpleGA(unittest.TestCase):
 
     def test_no_constraint(self):
 
-        class Cylinder(ExplicitComponent):
+        class Cylinder(om.ExplicitComponent):
             """Main class"""
 
             def setup(self):
@@ -618,15 +616,15 @@ class TestConstrainedSimpleGA(unittest.TestCase):
                 outputs['Area'] = area
                 outputs['Volume'] = volume
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('cylinder', Cylinder(), promotes=['*'])
 
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('radius', 2.)  # height
         indeps.add_output('height', 3.)  # radius
 
         # setup the optimization
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         prob.driver.options['penalty_parameter'] = 10.  # will have no effect
         prob.driver.options['penalty_exponent'] = 1.
         prob.driver.options['max_gen'] = 50
@@ -648,7 +646,7 @@ class TestConstrainedSimpleGA(unittest.TestCase):
         self.assertAlmostEqual(prob['height'], 0.5, 1)  # it is going to the unconstrained optimum
 
 
-@unittest.skipUnless(PETScVector, "PETSc is required.")
+@unittest.skipUnless(om.PETScVector, "PETSc is required.")
 class MPITestSimpleGA(unittest.TestCase):
 
     N_PROCS = 2
@@ -656,11 +654,11 @@ class MPITestSimpleGA(unittest.TestCase):
     def test_mixed_integer_branin(self):
         np.random.seed(1)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -670,7 +668,7 @@ class MPITestSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['max_gen'] = 50
         prob.driver.options['pop_size'] = 25
@@ -688,12 +686,12 @@ class MPITestSimpleGA(unittest.TestCase):
     def test_two_branin_parallel_model(self):
         np.random.seed(1)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
-        par = model.add_subsystem('par', ParallelGroup())
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
+        par = model.add_subsystem('par', om.ParallelGroup())
 
         par.add_subsystem('comp1', Branin())
         par.add_subsystem('comp2', Branin())
@@ -703,7 +701,7 @@ class MPITestSimpleGA(unittest.TestCase):
         model.connect('p2.xI', 'par.comp2.x0')
         model.connect('p1.xC', 'par.comp2.x1')
 
-        model.add_subsystem('comp', ExecComp('f = f1 + f2'))
+        model.add_subsystem('comp', om.ExecComp('f = f1 + f2'))
         model.connect('par.comp1.f', 'comp.f1')
         model.connect('par.comp2.f', 'comp.f2')
 
@@ -711,7 +709,7 @@ class MPITestSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['max_gen'] = 40
         prob.driver.options['pop_size'] = 25
@@ -732,7 +730,7 @@ class MPITestSimpleGA(unittest.TestCase):
         # was a power of 2.
         np.random.seed(1)
 
-        class ObjPenalty(ExplicitComponent):
+        class ObjPenalty(om.ExplicitComponent):
             """
             Weight objective with penalty on stress constraint.
             """
@@ -754,15 +752,15 @@ class MPITestSimpleGA(unittest.TestCase):
 
                 outputs['weighted'] = obj + pen
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('xc_a1', IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a2', IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xc_a3', IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
-        model.add_subsystem('xi_m1', IndepVarComp('mat1', 1), promotes=['*'])
-        model.add_subsystem('xi_m2', IndepVarComp('mat2', 1), promotes=['*'])
-        model.add_subsystem('xi_m3', IndepVarComp('mat3', 1), promotes=['*'])
+        model.add_subsystem('xc_a1', om.IndepVarComp('area1', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a2', om.IndepVarComp('area2', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xc_a3', om.IndepVarComp('area3', 5.0, units='cm**2'), promotes=['*'])
+        model.add_subsystem('xi_m1', om.IndepVarComp('mat1', 1), promotes=['*'])
+        model.add_subsystem('xi_m2', om.IndepVarComp('mat2', 1), promotes=['*'])
+        model.add_subsystem('xi_m3', om.IndepVarComp('mat3', 1), promotes=['*'])
         model.add_subsystem('comp', ThreeBarTruss(), promotes=['*'])
         model.add_subsystem('obj_with_penalty', ObjPenalty(), promotes=['*'])
 
@@ -773,7 +771,7 @@ class MPITestSimpleGA(unittest.TestCase):
         model.add_design_var('mat3', lower=1, upper=4)
         model.add_objective('weighted')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'area1': 6,
                                        'area2': 6}
         prob.driver.options['max_gen'] = 75
@@ -793,7 +791,7 @@ class MPITestSimpleGA(unittest.TestCase):
         # Material 3 can be anything
 
 
-@unittest.skipUnless(PETScVector, "PETSc is required.")
+@unittest.skipUnless(om.PETScVector, "PETSc is required.")
 class MPITestSimpleGA4Procs(unittest.TestCase):
 
     N_PROCS = 4
@@ -801,12 +799,12 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
     def test_two_branin_parallel_model(self):
         np.random.seed(1)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
-        par = model.add_subsystem('par', ParallelGroup())
+        model.add_subsystem('p1', om.IndepVarComp('xC', 5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
+        par = model.add_subsystem('par', om.ParallelGroup())
 
         par.add_subsystem('comp1', Branin())
         par.add_subsystem('comp2', Branin())
@@ -816,7 +814,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         model.connect('p2.xI', 'par.comp2.x0')
         model.connect('p1.xC', 'par.comp2.x1')
 
-        model.add_subsystem('comp', ExecComp('f = f1 + f2'))
+        model.add_subsystem('comp', om.ExecComp('f = f1 + f2'))
         model.connect('par.comp1.f', 'comp.f1')
         model.connect('par.comp2.f', 'comp.f2')
 
@@ -824,7 +822,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['max_gen'] = 10
         prob.driver.options['pop_size'] = 25
@@ -841,11 +839,11 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
     def test_indivisible_error(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('par', ParallelGroup())
+        model.add_subsystem('par', om.ParallelGroup())
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 3
 
@@ -862,25 +860,25 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         # This test only makes sure we don't lock up if we overallocate our integer desvar space
         # to the next power of 2.
 
-        class GAGroup(Group):
+        class GAGroup(om.Group):
 
             def setup(self):
 
-                self.add_subsystem('p1', IndepVarComp('x', 1.0))
-                self.add_subsystem('p2', IndepVarComp('y', 1.0))
-                self.add_subsystem('p3', IndepVarComp('z', 1.0))
+                self.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+                self.add_subsystem('p2', om.IndepVarComp('y', 1.0))
+                self.add_subsystem('p3', om.IndepVarComp('z', 1.0))
 
-                self.add_subsystem('comp', ExecComp(['f = x + y + z']))
+                self.add_subsystem('comp', om.ExecComp(['f = x + y + z']))
 
                 self.add_design_var('p1.x', lower=-100, upper=100)
                 self.add_design_var('p2.y', lower=-100, upper=100)
                 self.add_design_var('p3.z', lower=-100, upper=100)
                 self.add_objective('comp.f')
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = GAGroup()
 
-        driver = prob.driver = SimpleGADriver()
+        driver = prob.driver = om.SimpleGADriver()
         driver.options['max_gen'] = 5
         driver.options['pop_size'] = 40
         driver.options['run_parallel'] = True
@@ -901,14 +899,14 @@ class TestFeatureSimpleGA(unittest.TestCase):
         os.environ['SimpleGADriver_seed'] = '11'
 
     def test_basic(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver
+        import openmdao.api as om
         from openmdao.test_suite.components.branin import Branin
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -918,7 +916,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
 
         prob.setup()
@@ -930,14 +928,14 @@ class TestFeatureSimpleGA(unittest.TestCase):
         print('p1.xC', prob['p1.xC'])
 
     def test_basic_with_assert(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver
+        import openmdao.api as om
         from openmdao.test_suite.components.branin import Branin
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -947,7 +945,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
 
         prob.driver._randomstate = 1
@@ -959,14 +957,14 @@ class TestFeatureSimpleGA(unittest.TestCase):
         assert_rel_error(self, prob['comp.f'], 0.49399549, 1e-4)
 
     def test_option_max_gen(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver
+        import openmdao.api as om
         from openmdao.test_suite.components.branin import Branin
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -976,7 +974,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['max_gen'] = 5
 
@@ -989,14 +987,14 @@ class TestFeatureSimpleGA(unittest.TestCase):
         print('p1.xC', prob['p1.xC'])
 
     def test_option_pop_size(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver
+        import openmdao.api as om
         from openmdao.test_suite.components.branin import Branin
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -1006,7 +1004,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['pop_size'] = 10
 
@@ -1019,9 +1017,9 @@ class TestFeatureSimpleGA(unittest.TestCase):
         print('p1.xC', prob['p1.xC'])
 
     def test_constrained_with_penalty(self):
-        from openmdao.api import ExplicitComponent, Problem, IndepVarComp, SimpleGADriver
+        import openmdao.api as om
 
-        class Cylinder(ExplicitComponent):
+        class Cylinder(om.ExplicitComponent):
             """Main class"""
 
             def setup(self):
@@ -1040,15 +1038,15 @@ class TestFeatureSimpleGA(unittest.TestCase):
                 outputs['Area'] = area
                 outputs['Volume'] = volume
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('cylinder', Cylinder(), promotes=['*'])
 
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('radius', 2.)  # height
         indeps.add_output('height', 3.)  # radius
 
         # setup the optimization
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['penalty_parameter'] = 3.
         prob.driver.options['penalty_exponent'] = 1.
         prob.driver.options['max_gen'] = 50
@@ -1068,20 +1066,20 @@ class TestFeatureSimpleGA(unittest.TestCase):
         self.assertGreater(prob['height'], 1.)
 
 
-@unittest.skipUnless(PETScVector, "PETSc is required.")
+@unittest.skipUnless(om.PETScVector, "PETSc is required.")
 @unittest.skipUnless(MPI, "MPI is required.")
 class MPIFeatureTests(unittest.TestCase):
     N_PROCS = 2
 
     def test_option_parallel(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver
+        import openmdao.api as om
         from openmdao.test_suite.components.branin import Branin
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
         model.add_subsystem('comp', Branin())
 
         model.connect('p2.xI', 'comp.x0')
@@ -1091,7 +1089,7 @@ class MPIFeatureTests(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['max_gen'] = 10
         prob.driver.options['run_parallel'] = True
@@ -1105,21 +1103,21 @@ class MPIFeatureTests(unittest.TestCase):
         print('p1.xC', prob['p1.xC'])
 
 
-@unittest.skipUnless(PETScVector, "PETSc is required.")
+@unittest.skipUnless(om.PETScVector, "PETSc is required.")
 @unittest.skipUnless(MPI, "MPI is required.")
 class MPIFeatureTests4(unittest.TestCase):
     N_PROCS = 4
 
     def test_option_procs_per_model(self):
-        from openmdao.api import Problem, Group, IndepVarComp, SimpleGADriver, ParallelGroup
+        import openmdao.api as om
         from openmdao.test_suite.components.branin import Branin
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('xC', 7.5))
-        model.add_subsystem('p2', IndepVarComp('xI', 0.0))
-        par = model.add_subsystem('par', ParallelGroup())
+        model.add_subsystem('p1', om.IndepVarComp('xC', 7.5))
+        model.add_subsystem('p2', om.IndepVarComp('xI', 0.0))
+        par = model.add_subsystem('par', om.ParallelGroup())
 
         par.add_subsystem('comp1', Branin())
         par.add_subsystem('comp2', Branin())
@@ -1129,7 +1127,7 @@ class MPIFeatureTests4(unittest.TestCase):
         model.connect('p2.xI', 'par.comp2.x0')
         model.connect('p1.xC', 'par.comp2.x1')
 
-        model.add_subsystem('comp', ExecComp('f = f1 + f2'))
+        model.add_subsystem('comp', om.ExecComp('f = f1 + f2'))
         model.connect('par.comp1.f', 'comp.f1')
         model.connect('par.comp2.f', 'comp.f2')
 
@@ -1137,7 +1135,7 @@ class MPIFeatureTests4(unittest.TestCase):
         model.add_design_var('p1.xC', lower=0.0, upper=15.0)
         model.add_objective('comp.f')
 
-        prob.driver = SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
         prob.driver.options['bits'] = {'p1.xC': 8}
         prob.driver.options['max_gen'] = 10
         prob.driver.options['pop_size'] = 25

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -117,7 +117,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_upper(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -135,7 +135,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -149,7 +149,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_upper_indices(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         size = 3
         model.add_subsystem('p1', IndepVarComp('x', np.array([50.0]*size)))
@@ -179,7 +179,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('comp.f_xy', index=1)
         model.add_constraint('con.c', indices=[1], upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -193,7 +193,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_lower(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -214,7 +214,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -228,7 +228,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_lower_linear(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -248,7 +248,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=15.0, linear=True)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -264,7 +264,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_equality(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -284,7 +284,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', equals=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -298,7 +298,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_equality_linear(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -318,7 +318,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', equals=-15.0, linear=True)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -332,7 +332,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_double_sided_low(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -350,7 +350,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=-11.0, upper=-10.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -363,7 +363,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_double_sided_high(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -394,7 +394,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_array_comp2D(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -413,7 +413,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('c', equals=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -426,7 +426,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_array_comp2D_array_lo_hi(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -445,7 +445,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('c', equals=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -460,7 +460,7 @@ class TestPyoptSparse(unittest.TestCase):
         # This is a slightly modified FanOut
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 1.0))
         model.add_subsystem('p2', IndepVarComp('x', 1.0))
@@ -492,7 +492,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_constraint('con1.c', equals=0.0)
         model.add_constraint('con2.c', equals=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -515,7 +515,7 @@ class TestPyoptSparse(unittest.TestCase):
         # reported by rfalck)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -534,7 +534,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -548,7 +548,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_pyopt_fd_solution(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -569,7 +569,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -588,7 +588,7 @@ class TestPyoptSparse(unittest.TestCase):
                                 " pyopt_fd option has failed.")
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -609,7 +609,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -623,7 +623,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_snopt_fd_option_error(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -644,7 +644,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception) as raises_cm:
             prob.run_driver()
@@ -657,7 +657,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_unsupported_multiple_obj(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -684,7 +684,7 @@ class TestPyoptSparse(unittest.TestCase):
                    ' but the selected optimizer (SLSQP) does not support' \
                    ' multiple objectives.'
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(RuntimeError) as cm:
             prob.final_setup()
@@ -694,7 +694,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_scaled_desvars_fwd(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -726,7 +726,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_desvars_fd(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -748,7 +748,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         model.approx_totals(method='fd')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -760,7 +760,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_desvars_cs(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -782,7 +782,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         model.approx_totals(method='cs')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -795,7 +795,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_scaled_desvars_rev(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -828,7 +828,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_scaled_constraint_fwd(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -860,7 +860,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_constraint_fd(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -882,7 +882,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         model.approx_totals(method='fd')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -894,7 +894,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_constraint_cs(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -916,7 +916,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         model.approx_totals(method='cs')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -929,7 +929,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_scaled_constraint_rev(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -962,7 +962,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_scaled_objective_fwd(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         prob.set_solver_print(level=0)
 
@@ -995,7 +995,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_simple_paraboloid_scaled_objective_rev(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         prob.set_solver_print(level=0)
 
@@ -1170,7 +1170,7 @@ class TestPyoptSparse(unittest.TestCase):
         # attempts to recover.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1192,7 +1192,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -1216,7 +1216,7 @@ class TestPyoptSparse(unittest.TestCase):
         # pyoptsparse to raise.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1241,7 +1241,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         comp.fail_hard = True
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception):
             prob.run_driver()
@@ -1254,7 +1254,7 @@ class TestPyoptSparse(unittest.TestCase):
         # pyopt attempts to recover.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1279,7 +1279,7 @@ class TestPyoptSparse(unittest.TestCase):
         comp.grad_fail_at = 2
         comp.eval_fail_at = 100
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -1307,7 +1307,7 @@ class TestPyoptSparse(unittest.TestCase):
         # pyoptsparse to raise.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1333,7 +1333,7 @@ class TestPyoptSparse(unittest.TestCase):
         comp.grad_fail_at = 2
         comp.eval_fail_at = 100
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception):
             prob.run_driver()
@@ -1343,7 +1343,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_debug_print_option_totals(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1376,7 +1376,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertTrue('Solving variable: con.c' in output)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1411,7 +1411,7 @@ class TestPyoptSparse(unittest.TestCase):
     def test_debug_print_option(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1433,7 +1433,7 @@ class TestPyoptSparse(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed, output = run_driver(prob)
 
@@ -1481,7 +1481,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         # We generally don't hae a working IPOPT install.
         prob.driver.options['optimizer'] = 'IPOPT'
-        prob.setup(check=False)
+        prob.setup()
 
         # Test that we get exception.
         with self.assertRaises(ImportError) as raises_cm:
@@ -1656,7 +1656,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_pyoptsparse_missing_objective(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('x', IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
@@ -1667,7 +1667,7 @@ class TestPyoptSparse(unittest.TestCase):
         prob.model.add_design_var('x', lower=0)
         prob.model.add_constraint('x', lower=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception) as raises_msg:
             prob.run_driver()
@@ -1863,7 +1863,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
     def test_snopt_fd_solution(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1884,7 +1884,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -1903,7 +1903,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                                 " snopt_fd option has failed.")
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1924,7 +1924,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1698,7 +1698,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SLSQP"
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
@@ -1723,7 +1723,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = pyOptSparseDriver(optimizer='SLSQP')
+        prob.driver = om.pyOptSparseDriver(optimizer='SLSQP')
 
         prob.driver.options['print_results'] = False
 
@@ -1749,7 +1749,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SLSQP"
 
         prob.driver.opt_settings['ACC'] = 1e-9
@@ -1776,7 +1776,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SLSQP"
 
         prob.driver.opt_settings['MAXIT'] = 3
@@ -1812,7 +1812,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SNOPT"
 
         prob.driver.opt_settings['Major feasibility tolerance'] = 1e-9
@@ -1839,7 +1839,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = pyOptSparseDriver()
+        prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SNOPT"
 
         # after upgrading to SNOPT 7.5-1.1, this test failed unless iter limit raised from 4 to 5

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -8,12 +8,11 @@ from distutils.version import LooseVersion
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, AnalysisError, ExplicitComponent, \
-    ScipyKrylov, NonlinearBlockGS, LinearBlockGS, DirectSolver
-from openmdao.utils.assert_utils import assert_rel_error
+import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
+from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
 
 # check that pyoptsparse is installed
@@ -24,7 +23,7 @@ if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 
-class ParaboloidAE(ExplicitComponent):
+class ParaboloidAE(om.ExplicitComponent):
     """ Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
     This version raises an analysis error 50% of the time.
     The AE in ParaboloidAE stands for AnalysisError."""
@@ -57,7 +56,7 @@ class ParaboloidAE(ExplicitComponent):
             if self.fail_hard:
                 raise RuntimeError('This should error.')
             else:
-                raise AnalysisError('Try again.')
+                raise om.AnalysisError('Try again.')
 
         x = inputs['x']
         y = inputs['y']
@@ -74,7 +73,7 @@ class ParaboloidAE(ExplicitComponent):
             if self.fail_hard:
                 raise RuntimeError('This should error.')
             else:
-                raise AnalysisError('Try again.')
+                raise om.AnalysisError('Try again.')
 
         x = inputs['x']
         y = inputs['y']
@@ -84,7 +83,7 @@ class ParaboloidAE(ExplicitComponent):
         self.grad_iter_count += 1
 
 
-class DataSave(ExplicitComponent):
+class DataSave(om.ExplicitComponent):
     """ Saves run points so that we can verify that initial point is run."""
 
     def setup(self):
@@ -116,13 +115,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_upper(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -148,18 +147,18 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_upper_indices(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         size = 3
-        model.add_subsystem('p1', IndepVarComp('x', np.array([50.0]*size)))
-        model.add_subsystem('p2', IndepVarComp('y', np.array([50.0]*size)))
-        model.add_subsystem('comp', ExecComp('f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0',
-                                             x=np.zeros(size), y=np.zeros(size),
-                                             f_xy=np.zeros(size)))
-        model.add_subsystem('con', ExecComp('c = - x + y',
-                                            c=np.zeros(size), x=np.zeros(size),
-                                            y=np.zeros(size)))
+        model.add_subsystem('p1', om.IndepVarComp('x', np.array([50.0]*size)))
+        model.add_subsystem('p2', om.IndepVarComp('y', np.array([50.0]*size)))
+        model.add_subsystem('comp', om.ExecComp('f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0',
+                                                x=np.zeros(size), y=np.zeros(size),
+                                                f_xy=np.zeros(size)))
+        model.add_subsystem('con', om.ExecComp('c = - x + y',
+                                               c=np.zeros(size), x=np.zeros(size),
+                                               y=np.zeros(size)))
 
         model.connect('p1.x', 'comp.x')
         model.connect('p2.y', 'comp.y')
@@ -192,13 +191,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_lower(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -227,13 +226,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_lower_linear(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -263,13 +262,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_equality(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -297,13 +296,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_equality_linear(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -331,13 +330,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_double_sided_low(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -362,13 +361,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_double_sided_high(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -393,14 +392,14 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_array_comp2D(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
+        model.add_subsystem('con', om.ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
                             promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
@@ -425,14 +424,14 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_array_comp2D_array_lo_hi(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
+        model.add_subsystem('con', om.ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
                             promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
@@ -459,18 +458,18 @@ class TestPyoptSparse(unittest.TestCase):
         # This tests sparse-response specification.
         # This is a slightly modified FanOut
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 1.0))
-        model.add_subsystem('p2', IndepVarComp('x', 1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+        model.add_subsystem('p2', om.IndepVarComp('x', 1.0))
 
-        model.add_subsystem('comp1', ExecComp('y = 3.0*x'))
-        model.add_subsystem('comp2', ExecComp('y = 5.0*x'))
+        model.add_subsystem('comp1', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('comp2', om.ExecComp('y = 5.0*x'))
 
-        model.add_subsystem('obj', ExecComp('o = i1 + i2'))
-        model.add_subsystem('con1', ExecComp('c = 15.0 - x'))
-        model.add_subsystem('con2', ExecComp('c = 15.0 - x'))
+        model.add_subsystem('obj', om.ExecComp('o = i1 + i2'))
+        model.add_subsystem('con1', om.ExecComp('c = 15.0 - x'))
+        model.add_subsystem('con2', om.ExecComp('c = 15.0 - x'))
 
         # hook up explicitly
         model.connect('p1.x', 'comp1.x')
@@ -514,13 +513,13 @@ class TestPyoptSparse(unittest.TestCase):
         # may do it anyway, so make sure SLSQP doesn't blow up with it (bug
         # reported by rfalck)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -547,15 +546,15 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_pyopt_fd_solution(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -587,15 +586,15 @@ class TestPyoptSparse(unittest.TestCase):
                 raise Exception("OpenMDAO's finite difference has been called."
                                 " pyopt_fd option has failed.")
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', ParaboloidApplyLinear(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -622,15 +621,15 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_snopt_fd_option_error(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -656,16 +655,16 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertEqual(exception.args[0], msg)
 
     def test_unsupported_multiple_obj(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
         model.add_subsystem('comp2', Paraboloid())
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -693,13 +692,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_desvars_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -725,13 +724,13 @@ class TestPyoptSparse(unittest.TestCase):
         assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_fd(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -759,13 +758,13 @@ class TestPyoptSparse(unittest.TestCase):
         assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_cs(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -794,13 +793,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_desvars_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -827,13 +826,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_constraint_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -859,13 +858,13 @@ class TestPyoptSparse(unittest.TestCase):
         assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_fd(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -893,13 +892,13 @@ class TestPyoptSparse(unittest.TestCase):
         assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_cs(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -928,13 +927,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_constraint_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -961,15 +960,15 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_objective_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         prob.set_solver_print(level=0)
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
         prob.driver.options['optimizer'] = OPTIMIZER
@@ -994,15 +993,15 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_objective_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         prob.set_solver_print(level=0)
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
         prob.driver.options['optimizer'] = OPTIMIZER
@@ -1027,7 +1026,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_sellar_mdf(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver()
@@ -1059,7 +1058,7 @@ class TestPyoptSparse(unittest.TestCase):
         # This test makes sure that we call solve_nonlinear first if we have any linear constraints
         # to cache.
 
-        class SellarDis1withDerivatives(ExplicitComponent):
+        class SellarDis1withDerivatives(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('z', val=np.zeros(2))
@@ -1083,7 +1082,7 @@ class TestPyoptSparse(unittest.TestCase):
                 partials['y1', 'x'] = 1.0
 
 
-        class SellarDis2withDerivatives(ExplicitComponent):
+        class SellarDis2withDerivatives(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('z', val=np.zeros(2))
@@ -1111,28 +1110,28 @@ class TestPyoptSparse(unittest.TestCase):
                 J['y2', 'z'] = np.array([[1.0, 1.0]])
 
 
-        class MySellarGroup(Group):
+        class MySellarGroup(om.Group):
 
             def setup(self):
-                self.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-                self.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+                self.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+                self.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
-                self.mda = mda = self.add_subsystem('mda', Group(), promotes=['x', 'z', 'y1', 'y2'])
+                self.mda = mda = self.add_subsystem('mda', om.Group(), promotes=['x', 'z', 'y1', 'y2'])
                 mda.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
                 mda.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                       z=np.array([0.0, 0.0]), x=0.0, y1=0.0, y2=0.0),
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0, y1=0.0, y2=0.0),
                                    promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-                self.linear_solver = DirectSolver()
-                self.nonlinear_solver = NonlinearBlockGS()
+                self.linear_solver = om.DirectSolver()
+                self.nonlinear_solver = om.NonlinearBlockGS()
 
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = MySellarGroup()
 
         prob.driver = pyOptSparseDriver()
@@ -1169,15 +1168,15 @@ class TestPyoptSparse(unittest.TestCase):
         # Component raises an analysis error during some runs, and pyopt
         # attempts to recover.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
         prob.driver.options['optimizer'] = OPTIMIZER
@@ -1215,15 +1214,15 @@ class TestPyoptSparse(unittest.TestCase):
         # Component fails hard this time during execution, so we expect
         # pyoptsparse to raise.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         comp = model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
 
@@ -1253,15 +1252,15 @@ class TestPyoptSparse(unittest.TestCase):
         # Component raises an analysis error during some linearize calls, and
         # pyopt attempts to recover.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         comp = model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
         prob.driver.options['optimizer'] = OPTIMIZER
@@ -1306,14 +1305,14 @@ class TestPyoptSparse(unittest.TestCase):
         # Component fails hard this time during gradient eval, so we expect
         # pyoptsparse to raise.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         comp = model.add_subsystem('comp', ParaboloidAE(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
 
@@ -1342,13 +1341,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_debug_print_option_totals(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -1375,13 +1374,13 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertTrue('Solving variable: comp.f_xy' in output)
         self.assertTrue('Solving variable: con.c' in output)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -1410,13 +1409,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_debug_print_option(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -1462,13 +1461,13 @@ class TestPyoptSparse(unittest.TestCase):
 
     def test_show_exception_bad_opt(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -1498,9 +1497,9 @@ class TestPyoptSparse(unittest.TestCase):
             raise unittest.SkipTest("pyoptsparse is not providing NSGA2")
 
         # Make sure all our opts have run the initial point just once.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', val=1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', val=1.0))
         comp = model.add_subsystem('comp1', DataSave())
         model.connect('p1.x', 'comp1.x')
 
@@ -1525,9 +1524,9 @@ class TestPyoptSparse(unittest.TestCase):
             raise unittest.SkipTest("pyoptsparse is not providing SLSQP")
 
         # Make sure all our opts have run the initial point just once.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', val=1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', val=1.0))
         comp = model.add_subsystem('comp1', DataSave())
         model.connect('p1.x', 'comp1.x')
 
@@ -1551,9 +1550,9 @@ class TestPyoptSparse(unittest.TestCase):
             raise unittest.SkipTest("pyoptsparse is not providing SNOPT")
 
         # Make sure all our opts have run the initial point just once.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', val=1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', val=1.0))
         comp = model.add_subsystem('comp1', DataSave())
         model.connect('p1.x', 'comp1.x')
 
@@ -1580,9 +1579,9 @@ class TestPyoptSparse(unittest.TestCase):
             raise unittest.SkipTest("pyoptsparse is not providing ALPSO")
 
         # Make sure all our opts have run the initial point just once.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', val=1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', val=1.0))
         comp = model.add_subsystem('comp1', DataSave())
         model.connect('p1.x', 'comp1.x')
 
@@ -1606,9 +1605,9 @@ class TestPyoptSparse(unittest.TestCase):
             raise unittest.SkipTest("pyoptsparse is not providing PSQP")
 
         # Make sure all our opts have run the initial point just once.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', val=1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', val=1.0))
         comp = model.add_subsystem('comp1', DataSave())
         model.connect('p1.x', 'comp1.x')
 
@@ -1633,9 +1632,9 @@ class TestPyoptSparse(unittest.TestCase):
             raise unittest.SkipTest("pyoptsparse is not providing CONMIN")
 
         # Make sure all our opts have run the initial point just once.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', val=1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', val=1.0))
         comp = model.add_subsystem('comp1', DataSave())
         model.connect('p1.x', 'comp1.x')
 
@@ -1655,10 +1654,10 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertNotEqual(comp.visited_points[1], 1.0)
 
     def test_pyoptsparse_missing_objective(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('x', IndepVarComp('x', 2.0), promotes=['*'])
+        model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
 
         prob.driver = pyOptSparseDriver()
@@ -1693,10 +1692,10 @@ class TestPyoptSparseFeature(unittest.TestCase):
     def test_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver()
@@ -1718,10 +1717,10 @@ class TestPyoptSparseFeature(unittest.TestCase):
     def test_settings_print(self):
         import numpy as np
 
-        from openmdao.api import Problem, pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver(optimizer='SLSQP')
@@ -1744,10 +1743,10 @@ class TestPyoptSparseFeature(unittest.TestCase):
     def test_slsqp_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver()
@@ -1771,10 +1770,10 @@ class TestPyoptSparseFeature(unittest.TestCase):
     def test_slsqp_maxit(self):
         import numpy as np
 
-        from openmdao.api import Problem, pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver()
@@ -1807,10 +1806,10 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
     def test_snopt_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver()
@@ -1834,10 +1833,10 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
     def test_snopt_maxit(self):
         import numpy as np
 
-        from openmdao.api import Problem, pyOptSparseDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
         prob.driver = pyOptSparseDriver()
@@ -1862,15 +1861,15 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
     def test_snopt_fd_solution(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -1902,15 +1901,15 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                 raise Exception("OpenMDAO's finite difference has been called."
                                 " snopt_fd option has failed.")
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
 
         model.add_subsystem('comp', ParaboloidApplyLinear(), promotes=['*'])
 
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
@@ -1939,7 +1938,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         # One discipline of Sellar will something raise analysis error. This is to test that
         # the iprinting doesn't get out-of-whack.
 
-        class SellarDis1AE(ExplicitComponent):
+        class SellarDis1AE(om.ExplicitComponent):
             def setup(self):
                 self.add_input('z', val=np.zeros(2))
                 self.add_input('x', val=0.)
@@ -1966,13 +1965,13 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                 self.count_iter += 1
                 if self.count_iter in self.fail_deriv:
                     self.failed += 1
-                    raise AnalysisError('Try again.')
+                    raise om.AnalysisError('Try again.')
 
                 partials['y1', 'y2'] = -0.2
                 partials['y1', 'z'] = np.array([[2.0 * inputs['z'][0], 1.0]])
                 partials['y1', 'x'] = 1.0
 
-        class SellarDis2AE(ExplicitComponent):
+        class SellarDis2AE(om.ExplicitComponent):
             def setup(self):
                 self.add_input('z', val=np.zeros(2))
                 self.add_input('y1', val=1.0)
@@ -2001,13 +2000,13 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                 J['y2', 'y1'] = .5*y1**-.5
                 J['y2', 'z'] = np.array([[1.0, 1.0]])
 
-        class SellarMDAAE(Group):
+        class SellarMDAAE(om.Group):
             def setup(self):
-                indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+                indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
                 indeps.add_output('x', 1.0)
                 indeps.add_output('z', np.array([5.0, 2.0]))
 
-                cycle = self.add_subsystem('cycle', Group(), promotes=['*'])
+                cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
 
                 cycle.add_subsystem('d1', SellarDis1AE(),
                                     promotes_inputs=['x', 'z', 'y2'],
@@ -2016,18 +2015,18 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                                     promotes_inputs=['z', 'y1'],
                                     promotes_outputs=['y2'])
 
-                self.linear_solver = LinearBlockGS()
-                cycle.linear_solver = ScipyKrylov()
-                cycle.nonlinear_solver = NonlinearBlockGS()
+                self.linear_solver = om.LinearBlockGS()
+                cycle.linear_solver = om.ScipyKrylov()
+                cycle.nonlinear_solver = om.NonlinearBlockGS()
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                   z=np.array([0.0, 0.0]), x=0.0),
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0),
                                    promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarMDAAE()
 
         prob.driver = pyOptSparseDriver()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -33,7 +33,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         # Make sure 'array' return_format works.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
         model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
@@ -112,7 +112,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_design_var('px.x')
         model.add_objective('px.x')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -128,7 +128,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_scipy_optimizer_simple_paraboloid_unconstrained(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -142,7 +142,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -155,7 +155,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_unconstrained(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -172,7 +172,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -184,7 +184,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_unconstrained_COBYLA(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -201,7 +201,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -214,7 +214,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_upper(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -233,7 +233,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -247,7 +247,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_lower(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -267,7 +267,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -281,7 +281,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_equality(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -300,7 +300,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', equals=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -315,7 +315,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_unsupported_equality(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -334,7 +334,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', equals=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception) as raises_cm:
             prob.run_driver()
@@ -348,7 +348,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_scipy_missing_objective(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('x', IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
@@ -359,7 +359,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.model.add_design_var('x', lower=0)
         # prob.model.add_constraint('x', lower=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(Exception) as raises_msg:
             prob.run_driver()
@@ -373,7 +373,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_double_sided_low(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -392,7 +392,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=-11.0, upper=-10.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -404,7 +404,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_double_sided_high(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -423,7 +423,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=10.0, upper=11.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -435,7 +435,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_array_comp2D(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -455,7 +455,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('c', equals=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -468,7 +468,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_array_comp2D_eq_con(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -486,7 +486,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('areas', equals=np.array([24.0, 21.0, 3.5, 17.5]))
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -499,7 +499,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_array_comp2D_dbl_sided_con(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -517,7 +517,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('areas', lower=np.array([24.0, 21.0, 3.5, 17.5]), upper=np.array([24.0, 21.0, 3.5, 17.5]))
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -530,7 +530,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_array_comp2D_dbl_sided_con_array(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -548,7 +548,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('areas', lower=20.0, upper=20.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -561,7 +561,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_array_comp2D_array_lo_hi(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
@@ -581,7 +581,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('o')
         model.add_constraint('c', equals=0.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -594,7 +594,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_scaled_desvars_fwd(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -625,7 +625,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_scaled_desvars_rev(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -656,7 +656,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_scaled_constraint_fwd(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -687,7 +687,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_scaled_objective_fwd(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         prob.set_solver_print(level=0)
 
@@ -718,7 +718,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_scaled_objective_rev(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         prob.set_solver_print(level=0)
 
@@ -779,7 +779,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         p = Problem(model=SineFitter())
         p.driver = ScipyOptimizeDriver()
 
-        p.setup(check=False)
+        p.setup()
         p.run_driver()
 
         max_defect = np.max(np.abs(p['defect.defect']))
@@ -836,7 +836,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_upper_COBYLA(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -855,7 +855,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -1111,7 +1111,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_lower_linear(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1130,7 +1130,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', lower=15.0, linear=True)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -1146,7 +1146,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_simple_paraboloid_equality_linear(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1165,7 +1165,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', equals=-15.0, linear=True)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed = prob.run_driver()
 
@@ -1179,7 +1179,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_debug_print_option_totals(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1210,7 +1210,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue('Solving variable: con.c' in output)
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1243,7 +1243,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_debug_print_option(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1264,7 +1264,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         failed, output = run_driver(prob)
 
@@ -1325,7 +1325,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         # Make sure we call final setup if our model hasn't been setup.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1344,7 +1344,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', equals=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(RuntimeError) as cm:
             totals = prob.check_totals(method='fd', out_stream=False)
@@ -1361,7 +1361,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1388,7 +1388,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1400,7 +1400,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_driver()
 
@@ -1412,7 +1412,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1425,7 +1425,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_driver()
 
@@ -1437,7 +1437,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1450,7 +1450,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_driver()
 
@@ -1463,7 +1463,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1484,7 +1484,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_driver()
 
@@ -1494,7 +1494,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1515,7 +1515,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         model.add_objective('f_xy')
         model.add_constraint('c', upper=-15.0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_driver()
 
@@ -1546,7 +1546,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
         model.add_objective('c')  # Second objective
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(RuntimeError):
             prob.run_model()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -70,7 +70,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_compute_totals_return_array_non_square(self):
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
         comp = model.add_subsystem('comp', NonSquareArrayComp())

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -8,15 +8,14 @@ from distutils.version import LooseVersion
 import numpy as np
 from scipy import __version__ as scipy_version
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ScipyOptimizeDriver, \
-    ScipyOptimizer, ExplicitComponent, DirectSolver, NonlinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
-from openmdao.utils.general_utils import run_driver
+import openmdao.api as om
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, SellarDerivatives
 from openmdao.test_suite.components.simple_comps import NonSquareArrayComp
 from openmdao.test_suite.groups.sin_fitter import SineFitter
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.general_utils import run_driver
 
 
 class TestScipyOptimizeDriver(unittest.TestCase):
@@ -27,15 +26,15 @@ class TestScipyOptimizeDriver(unittest.TestCase):
               "with OpenMDAO <= 2.2 ; use 'ScipyOptimizeDriver' instead."
 
         with assert_warning(DeprecationWarning, msg):
-            ScipyOptimizer()
+            om.ScipyOptimizer()
 
     def test_compute_totals_basic_return_array(self):
         # Make sure 'array' return_format works.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
@@ -69,10 +68,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_compute_totals_return_array_non_square(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
+        model.add_subsystem('px', om.IndepVarComp(name="x", val=np.ones((2, ))))
         comp = model.add_subsystem('comp', NonSquareArrayComp())
         model.connect('px.x', 'comp.x1')
 
@@ -104,10 +103,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_deriv_wrt_self(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp(name="x", val=np.ones((2, ))))
+        model.add_subsystem('px', om.IndepVarComp(name="x", val=np.ones((2, ))))
 
         model.add_design_var('px.x')
         model.add_objective('px.x')
@@ -127,16 +126,16 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_scipy_optimizer_simple_paraboloid_unconstrained(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizer(optimizer='SLSQP', tol=1e-9, disp=False)
+        prob.driver = om.ScipyOptimizer(optimizer='SLSQP', tol=1e-9, disp=False)
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
         model.add_design_var('y', lower=-50.0, upper=50.0)
@@ -154,16 +153,16 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_unconstrained(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -183,16 +182,16 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
 
     def test_simple_paraboloid_unconstrained_COBYLA(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'COBYLA'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -213,17 +212,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_upper(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -246,17 +245,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_lower(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -280,17 +279,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_equality(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -314,17 +313,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_unsupported_equality(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'COBYLA'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -347,13 +346,13 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_scipy_missing_objective(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('x', IndepVarComp('x', 2.0), promotes=['*'])
+        model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('x', lower=0)
@@ -372,17 +371,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_double_sided_low(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -403,17 +402,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_double_sided_high(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -434,19 +433,20 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_array_comp2D(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
+        model.add_subsystem('con', om.ExecComp('c = areas - 20.0', c=np.zeros((2, 2)),
+                                               areas=np.zeros((2, 2))),
                             promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -467,17 +467,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_array_comp2D_eq_con(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0] + areas[1, 1]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0] + areas[1, 1]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -498,17 +498,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_array_comp2D_dbl_sided_con(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -529,17 +529,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_array_comp2D_dbl_sided_con_array(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -560,19 +560,19 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_array_comp2D_array_lo_hi(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('widths', np.zeros((2, 2))), promotes=['*'])
         model.add_subsystem('comp', TestExplCompArrayDense(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
+        model.add_subsystem('con', om.ExecComp('c = areas - 20.0', c=np.zeros((2, 2)), areas=np.zeros((2, 2))),
                             promotes=['*'])
-        model.add_subsystem('obj', ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
+        model.add_subsystem('obj', om.ExecComp('o = areas[0, 0]', areas=np.zeros((2, 2))),
                             promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -593,17 +593,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_desvars_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -624,17 +624,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_desvars_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -655,17 +655,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_constraint_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -686,17 +686,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_objective_fwd(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         prob.set_solver_print(level=0)
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -717,17 +717,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_scaled_objective_rev(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         prob.set_solver_print(level=0)
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -748,10 +748,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_sellar_mdf(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -776,8 +776,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_bug_in_eq_constraints(self):
         # We were getting extra constraints created because lower and upper are maxfloat instead of
         # None when unused.
-        p = Problem(model=SineFitter())
-        p.driver = ScipyOptimizeDriver()
+        p = om.Problem(model=SineFitter())
+        p.driver = om.ScipyOptimizeDriver()
 
         p.setup()
         p.run_driver()
@@ -786,7 +786,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_rel_error(self, max_defect, 0.0, 1e-10)
 
     def test_reraise_exception_from_callbacks(self):
-        class ReducedActuatorDisc(ExplicitComponent):
+        class ReducedActuatorDisc(om.ExplicitComponent):
 
             def setup(self):
 
@@ -809,8 +809,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
                 J['Vd', 'a'] = -2.0 * Vu
 
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('a', .5)
         indeps.add_output('Vu', 10.0, units='m/s')
 
@@ -818,7 +818,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  promotes_inputs=['a', 'Vu'])
 
         # setup the optimization
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('a', lower=0., upper=1.)
@@ -835,17 +835,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_upper_COBYLA(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'COBYLA'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -868,10 +868,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_sellar_mdf_COBYLA(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'COBYLA'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -902,7 +902,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             x_1 = x[1:]
             return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
 
-        class Rosenbrock(ExplicitComponent):
+        class Rosenbrock(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
@@ -915,14 +915,14 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         x0 = np.array([1.2, 0.8, 1.3])
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
         prob.model.add_subsystem('rosen', Rosenbrock(), promotes=['*'])
-        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.model.add_subsystem('con', om.ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'trust-constr'
         driver.options['tol'] = 1e-8
         driver.options['maxiter'] = 2000
@@ -949,7 +949,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             x_1 = x[1:]
             return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
 
-        class Rosenbrock(ExplicitComponent):
+        class Rosenbrock(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
@@ -962,14 +962,14 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         x0 = np.array([1.2, 0.8, 1.3])
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
         prob.model.add_subsystem('rosen', Rosenbrock(), promotes=['*'])
-        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.model.add_subsystem('con', om.ExecComp('c=sum(x)', x=np.ones(3)), promotes=['*'])
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'trust-constr'
         driver.options['tol'] = 1e-8
         driver.options['maxiter'] = 2000
@@ -997,7 +997,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             x_1 = x[1:]
             return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
 
-        class Rosenbrock(ExplicitComponent):
+        class Rosenbrock(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5, 1.5]))
@@ -1010,16 +1010,16 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         x0 = np.array([0.5, 0.8, 1.4])
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', list(x0))
 
         model.add_subsystem('rosen', Rosenbrock())
-        model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(3)))
+        model.add_subsystem('con', om.ExecComp('c=sum(x)', x=np.ones(3)))
         model.connect('indeps.x', 'rosen.x')
         model.connect('indeps.x', 'con.x')
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'trust-constr'
         driver.options['tol'] = 1e-5
         driver.options['maxiter'] = 2000
@@ -1038,7 +1038,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                          "scipy >= 1.2 is required.")
     def test_trust_constr_inequality_con(self):
 
-        class Sphere(ExplicitComponent):
+        class Sphere(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.array([1.5, 1.5]))
@@ -1051,13 +1051,13 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         x0 = np.array([1.2, 1.5])
 
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
         prob.model.add_subsystem('sphere', Sphere(), promotes=['*'])
-        prob.model.add_subsystem('con', ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
+        prob.model.add_subsystem('con', om.ExecComp('c=sum(x)', x=np.ones(2)), promotes=['*'])
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'trust-constr'
         prob.driver.options['tol'] = 1e-5
         prob.driver.options['maxiter'] = 2000
@@ -1075,7 +1075,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
     def test_trust_constr_bounds(self):
-        class Rosenbrock(ExplicitComponent):
+        class Rosenbrock(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.array([-1.5, -1.5]))
@@ -1088,12 +1088,12 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         x0 = np.array([-1.5, -1.5])
 
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', list(x0))
 
         prob.model.add_subsystem('sphere', Rosenbrock(), promotes=['*'])
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'trust-constr'
         prob.driver.options['tol'] = 1e-7
         prob.driver.options['maxiter'] = 2000
@@ -1110,17 +1110,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_lower_linear(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = x - y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1145,17 +1145,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_simple_paraboloid_equality_linear(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1178,17 +1178,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_debug_print_option_totals(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1209,17 +1209,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue('Solving variable: comp.f_xy' in output)
         self.assertTrue('Solving variable: con.c' in output)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1242,17 +1242,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_debug_print_option(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1292,10 +1292,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_sellar_mdf_linear_con_directsolver(self):
         # This test makes sure that we call solve_nonlinear first if we have any linear constraints
         # to cache.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivatives()
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-3
         prob.driver.options['disp'] = False
@@ -1324,17 +1324,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
     def test_call_final_setup(self):
         # Make sure we call final setup if our model hasn't been setup.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1357,17 +1357,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
     def test_feature_basic(self):
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = True
@@ -1384,17 +1384,17 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
 
     def test_feature_optimizer(self):
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver(optimizer='COBYLA')
+        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYLA')
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
         model.add_design_var('y', lower=-50.0, upper=50.0)
@@ -1408,17 +1408,17 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
 
     def test_feature_maxiter(self):
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['maxiter'] = 20
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
@@ -1433,17 +1433,17 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
 
     def test_feature_tol(self):
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['tol'] = 1.0e-9
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
@@ -1459,20 +1459,20 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
     def test_debug_print_option(self):
 
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver, ExecComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1490,20 +1490,20 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
     def test_debug_print_option_totals(self):
 
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyOptimizeDriver, ExecComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1521,20 +1521,20 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
     def test_multiple_objectives_error(self):
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver, ExecComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', ExecComp('c = - x + y'), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
 
         prob.set_solver_print(level=0)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = False
@@ -1556,9 +1556,9 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
     def test_basinhopping(self):
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
 
-        class Func2d(ExplicitComponent):
+        class Func2d(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.ones(2))
@@ -1576,13 +1576,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 df[1] = 2. * x[1] + 0.2
                 partials['f', 'x'] = df
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(2)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(2)), promotes=['*'])
         model.add_subsystem('func2d', Func2d(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'basinhopping'
         driver.options['disp'] = False
         driver.opt_settings['niter'] = 1000
@@ -1598,9 +1598,9 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
     def test_basinhopping_bounded(self):
         # It should find the local minimum, which is inside the bounds
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
 
-        class Func2d(ExplicitComponent):
+        class Func2d(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.ones(2))
@@ -1618,13 +1618,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 df[1] = 2. * x[1] + 0.2
                 partials['f', 'x'] = df
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(2)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(2)), promotes=['*'])
         model.add_subsystem('func2d', Func2d(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'basinhopping'
         driver.options['disp'] = False
         driver.opt_settings['niter'] = 200
@@ -1641,7 +1641,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                          "scipy >= 1.2 is required.")
     def test_dual_annealing(self):
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
 
         size = 6  # size of the design variable
 
@@ -1650,7 +1650,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
             x_1 = x[1:]
             return sum((1 - x_0) ** 2) + 100 * sum((x_1 - x_0 ** 2) ** 2)
 
-        class Rosenbrock(ExplicitComponent):
+        class Rosenbrock(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', 1.5*np.ones(size))
@@ -1660,13 +1660,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 x = inputs['x']
                 outputs['f'] = rosenbrock(x)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(size)), promotes=['*'])
         model.add_subsystem('rosen', Rosenbrock(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'dual_annealing'
         driver.options['disp'] = False
         driver.options['tol'] = 1e-9
@@ -1684,7 +1684,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
     def test_dual_annealing_rastrigin(self):
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
         # Example from the Scipy documentation
 
         size = 3  # size of the design variable
@@ -1693,7 +1693,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
             a = 10  # constant
             return np.sum(np.square(x) - a * np.cos(2 * np.pi * x)) + a * np.size(x)
 
-        class Rastrigin(ExplicitComponent):
+        class Rastrigin(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', 0.5 * np.ones(size))
@@ -1703,13 +1703,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 x = inputs['x']
                 outputs['f'] = rastrigin(x)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(size)), promotes=['*'])
         model.add_subsystem('rastrigin', Rastrigin(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'dual_annealing'
         driver.options['disp'] = False
         driver.options['tol'] = 1e-9
@@ -1728,7 +1728,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         # Source of example:
         # https://scipy.github.io/devdocs/generated/scipy.optimize.dual_annealing.html
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
 
         size = 3  # size of the design variable
 
@@ -1736,7 +1736,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
             a = 10  # constant
             return np.sum(np.square(x) - a * np.cos(2 * np.pi * x)) + a * np.size(x)
 
-        class Rastrigin(ExplicitComponent):
+        class Rastrigin(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', 0.5 * np.ones(size))
@@ -1746,13 +1746,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 x = inputs['x']
                 outputs['f'] = rastrigin(x)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(size)), promotes=['*'])
         model.add_subsystem('rastrigin', Rastrigin(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'differential_evolution'
         driver.options['disp'] = False
         driver.options['tol'] = 1e-9
@@ -1769,7 +1769,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         # https://scipy.github.io/devdocs/generated/scipy.optimize.dual_annealing.html
         # In this example the minimum is not the unbounded global minimum.
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
 
         size = 3  # size of the design variable
 
@@ -1777,7 +1777,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
             a = 10  # constant
             return np.sum(np.square(x) - a * np.cos(2 * np.pi * x)) + a * np.size(x)
 
-        class Rastrigin(ExplicitComponent):
+        class Rastrigin(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', 0.5 * np.ones(size))
@@ -1787,13 +1787,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 x = inputs['x']
                 outputs['f'] = rastrigin(x)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(size)), promotes=['*'])
         model.add_subsystem('rastrigin', Rastrigin(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'differential_evolution'
         driver.options['disp'] = False
         driver.options['tol'] = 1e-9
@@ -1812,7 +1812,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         # Source of example:
         # https://scipy.github.io/devdocs/generated/scipy.optimize.dual_annealing.html
 
-        from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+        import openmdao.api as om
 
         size = 3  # size of the design variable
 
@@ -1820,7 +1820,7 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
             a = 10  # constant
             return np.sum(np.square(x) - a*np.cos(2*np.pi*x)) + a*np.size(x)
 
-        class Rastrigin(ExplicitComponent):
+        class Rastrigin(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', np.ones(size))
@@ -1830,13 +1830,13 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
                 x = inputs['x']
                 outputs['f'] = rastrigin(x)
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)), promotes=['*'])
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(size)), promotes=['*'])
         model.add_subsystem('rastrigin', Rastrigin(), promotes=['*'])
 
-        prob.driver = driver = ScipyOptimizeDriver()
+        prob.driver = driver = om.ScipyOptimizeDriver()
         driver.options['optimizer'] = 'shgo'
         driver.options['disp'] = False
         driver.options['maxiter'] = 100

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -248,7 +248,7 @@ class TestJacobian(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
 
@@ -315,7 +315,7 @@ class TestJacobian(unittest.TestCase):
         prob = Problem()
         comp = ExplicitSetItemComp(dtype, value, shape, constructor)
         prob.model.add_subsystem('C1', comp)
-        prob.setup(check=False)
+        prob.setup()
 
         prob.set_solver_print(level=0)
         prob.run_model()
@@ -400,7 +400,7 @@ class TestJacobian(unittest.TestCase):
 
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', np.array([1.0, 1.0])), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -450,7 +450,7 @@ class TestJacobian(unittest.TestCase):
         prob.model.connect('C1.c', 'C2.b')
         prob.model.connect('C2.d', 'C3.a')
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
         assert_rel_error(self, prob['C3.ee'], 8.0, 0000.1)
 
@@ -476,7 +476,7 @@ class TestJacobian(unittest.TestCase):
         prob.model.connect('indeps.y', 'G1.C1.x')
         prob.model.connect('indeps.z', 'G1.C2.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['G1.C1.y'], 50.0)
@@ -507,7 +507,7 @@ class TestJacobian(unittest.TestCase):
         prob.model.connect('indeps.y', 'G1.C1.x')
         prob.model.connect('indeps.z', 'G1.C2.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['G1.C1.y'], 50.0)
@@ -723,7 +723,7 @@ class TestJacobian(unittest.TestCase):
 
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', val=1.0))
         model.add_subsystem('comp', Undeclared())
@@ -754,7 +754,7 @@ class TestJacobian(unittest.TestCase):
         prob.model.connect('indeps.x', 'G1.C1.x', src_indices=[0,1])
         prob.model.connect('indeps.x', 'G1.C1.y', src_indices=[2,3])
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         J = prob.compute_totals(of=['G1.C1.z'], wrt=['indeps.x'])

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -223,7 +223,7 @@ class TestJacobian(unittest.TestCase):
         self._check_rev(self.prob, rev_check)
 
     def _setup_model(self, assembled_jac, comp_jac_class, nested, lincalls):
-        self.prob = prob = Problem(model=Group())
+        self.prob = prob = Problem()
         if nested:
             top = prob.model.add_subsystem('G1', Group())
         else:
@@ -312,7 +312,7 @@ class TestJacobian(unittest.TestCase):
         shape, constructor, expected_shape = shapes
         dtype, value = dtypes
 
-        prob = Problem(model=Group())
+        prob = Problem()
         comp = ExplicitSetItemComp(dtype, value, shape, constructor)
         prob.model.add_subsystem('C1', comp)
         prob.setup(check=False)

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -117,7 +117,6 @@ class DistributedRecorderTest(unittest.TestCase):
 
     def test_distrib_record_system(self):
         prob = Problem()
-        prob.model = Group()
 
         try:
             prob.model.add_recorder(self.recorder)
@@ -129,7 +128,6 @@ class DistributedRecorderTest(unittest.TestCase):
 
     def test_distrib_record_solver(self):
         prob = Problem()
-        prob.model = Group()
         try:
             prob.model.nonlinear_solver.add_recorder(self.recorder)
         except RuntimeError as err:
@@ -141,7 +139,6 @@ class DistributedRecorderTest(unittest.TestCase):
     def test_distrib_record_driver(self):
         size = 100  # how many items in the array
         prob = Problem()
-        prob.model = Group()
 
         prob.model.add_subsystem('des_vars', IndepVarComp('x', np.ones(size)), promotes=['x'])
         prob.model.add_subsystem('plus', DistributedAdder(size), promotes=['x', 'y'])
@@ -156,7 +153,7 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.model.add_design_var('x')
         prob.model.add_objective('sum')
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['x'] = np.ones(size)
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1634,7 +1634,7 @@ class TestSqliteCaseReader(unittest.TestCase):
     def test_simple_paraboloid_scaled_desvars(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 50.0), promotes=['*'])
         model.add_subsystem('p2', IndepVarComp('y', 50.0), promotes=['*'])
@@ -1944,7 +1944,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         model.comp.add_recorder(self.recorder)
         model.add_recorder(self.recorder)
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['px.x'] = 2.0
         prob['comp.y'] = 0.0

--- a/openmdao/solvers/linear/tests/linear_test_base.py
+++ b/openmdao/solvers/linear/tests/linear_test_base.py
@@ -32,7 +32,7 @@ class LinearSolverTests(object):
             group.linear_solver.options['maxiter'] = 2
 
             p = Problem(group)
-            p.setup(check=False)
+            p.setup()
             p.set_solver_print(level=0)
 
             # Conclude setup but don't run model.
@@ -58,7 +58,7 @@ class LinearSolverTests(object):
             # Tests derivatives on a simple comp that defines compute_jacvec.
             # Note, For DirectSolver, assemble_jac must be False for mat-vec.
             prob = Problem()
-            model = prob.model = Group()
+            model = prob.model
             model.add_subsystem('x_param', IndepVarComp('length', 3.0),
                                 promotes=['length'])
             model.add_subsystem('mycomp', TestExplCompSimpleJacVec(),
@@ -93,7 +93,7 @@ class LinearSolverTests(object):
             # Tests derivatives on a group that contains a simple comp that
             # defines compute_jacvec.
             prob = Problem()
-            model = prob.model = Group()
+            model = prob.model
             model.add_subsystem('x_param', IndepVarComp('length', 3.0),
                                 promotes=['length'])
             sub = model.add_subsystem('sub', Group(),
@@ -131,7 +131,7 @@ class LinearSolverTests(object):
             # defines compute_jacvec. For this one, the indepvarcomp is also
             # in the subsystem.
             prob = Problem()
-            model = prob.model = Group()
+            model = prob.model
             sub = model.add_subsystem('sub', Group(),
                                       promotes=['length', 'width', 'area'])
             sub.add_subsystem('x_param', IndepVarComp('length', 3.0),

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -7,8 +7,7 @@ from six import assertRaisesRegex, iteritems
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, NewtonSolver, ExecComp, \
-     NewtonSolver, BalanceComp, ExplicitComponent, ImplicitComponent
+import openmdao.api as om
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
 from openmdao.test_suite.components.sellar import SellarDerivatives
@@ -16,7 +15,7 @@ from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-class NanComp(ExplicitComponent):
+class NanComp(om.ExplicitComponent):
     def setup(self):
         self.add_input('x', 1.0)
         self.add_output('y', 1.0)
@@ -32,7 +31,7 @@ class NanComp(ExplicitComponent):
         J['y', 'x'] = np.NaN
 
 
-class SingularComp(ImplicitComponent):
+class SingularComp(om.ImplicitComponent):
     def setup(self):
         self.add_input('x', 1.0)
         self.add_output('y', 1.0)
@@ -46,7 +45,7 @@ class SingularComp(ImplicitComponent):
         J['y', 'y'] = 0.0
 
 
-class NanComp2(ExplicitComponent):
+class NanComp2(om.ExplicitComponent):
     def setup(self):
         self.add_input('x', 1.0)
         self.add_output('y', 1.0)
@@ -64,7 +63,7 @@ class NanComp2(ExplicitComponent):
         J['y', 'x'] = np.NaN
         J['y2', 'x'] = 2.0
 
-class DupPartialsComp(ExplicitComponent):
+class DupPartialsComp(om.ExplicitComponent):
     def setup(self):
         self.add_input('c', np.zeros(19))
         self.add_output('x', np.zeros(11))
@@ -82,12 +81,12 @@ class DupPartialsComp(ExplicitComponent):
 
 class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
-    linear_solver_class = DirectSolver
+    linear_solver_class = om.DirectSolver
 
     # DirectSolver doesn't iterate.
     def test_solve_linear_maxiter(self):
         # Test that using options that should not exist in class cause an error
-        solver = DirectSolver()
+        solver = om.DirectSolver()
 
         msg = "\"Option '%s' cannot be set because it has not been declared.\""
 
@@ -100,13 +99,13 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
     def test_solve_on_subsystem(self):
         """solve an implicit system with DirectSolver attached to a subsystem"""
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        dv = model.add_subsystem('des_vars', IndepVarComp())
+        dv = model.add_subsystem('des_vars', om.IndepVarComp())
         # just need a dummy variable so the sizes don't match between root and g1
         dv.add_output('dummy', val=1.0, shape=10)
 
-        g1 = model.add_subsystem('g1', TestImplicitGroup(lnSolverClass=DirectSolver))
+        g1 = model.add_subsystem('g1', TestImplicitGroup(lnSolverClass=om.DirectSolver))
 
         p.setup()
 
@@ -142,8 +141,9 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_rev_mode_bug(self):
 
-        prob = Problem()
-        prob.model = SellarDerivatives(nonlinear_solver=NewtonSolver(), linear_solver=DirectSolver())
+        prob = om.Problem()
+        prob.model = SellarDerivatives(nonlinear_solver=om.NewtonSolver(),
+                                       linear_solver=om.DirectSolver())
 
         prob.setup(check=False, mode='rev')
         prob.set_solver_print(level=0)
@@ -175,16 +175,16 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         assert_rel_error(self, prob['y2'], 12.05848819, .00001)
 
     def test_multi_dim_src_indices(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
         size = 5
 
-        model.add_subsystem('indeps', IndepVarComp('x', np.arange(5).reshape((1,size,1))))
-        model.add_subsystem('comp', ExecComp('y = x * 2.', x=np.zeros((size,)), y=np.zeros((size,))))
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.arange(5).reshape((1,size,1))))
+        model.add_subsystem('comp', om.ExecComp('y = x * 2.', x=np.zeros((size,)), y=np.zeros((size,))))
         src_indices = [[0, i, 0] for i in range(size)]
         model.connect('indeps.x', 'comp.x', src_indices=src_indices)
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
         prob.setup()
         prob.run_model()
 
@@ -192,18 +192,18 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         np.testing.assert_almost_equal(J, np.eye(size) * 2.)
 
     def test_raise_error_on_singular(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        comp = IndepVarComp()
+        comp = om.IndepVarComp()
         comp.add_output('dXdt:TAS', val=1.0)
         comp.add_output('accel_target', val=2.0)
         model.add_subsystem('des_vars', comp, promotes=['*'])
 
-        teg = model.add_subsystem('thrust_equilibrium_group', subsys=Group())
-        teg.add_subsystem('dynamics', ExecComp('z = 2.0*thrust'), promotes=['*'])
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
 
-        thrust_bal = BalanceComp()
+        thrust_bal = om.BalanceComp()
         thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
                                rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
 
@@ -211,9 +211,9 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                           promotes_inputs=['dXdt:TAS', 'accel_target'],
                           promotes_outputs=['thrust'])
 
-        teg.linear_solver = DirectSolver(assemble_jac=False)
+        teg.linear_solver = om.DirectSolver(assemble_jac=False)
 
-        teg.nonlinear_solver = NewtonSolver()
+        teg.nonlinear_solver = om.NewtonSolver()
         teg.nonlinear_solver.options['solve_subsystems'] = True
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
@@ -229,13 +229,13 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_raise_error_on_dup_partials(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('des_vars', IndepVarComp('x', 1.0), promotes=['*'])
+        model.add_subsystem('des_vars', om.IndepVarComp('x', 1.0), promotes=['*'])
         model.add_subsystem('dupcomp', DupPartialsComp())
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         with self.assertRaises(Exception) as cm:
             prob.setup()
@@ -245,18 +245,18 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_raise_error_on_singular_with_densejac(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        comp = IndepVarComp()
+        comp = om.IndepVarComp()
         comp.add_output('dXdt:TAS', val=1.0)
         comp.add_output('accel_target', val=2.0)
         model.add_subsystem('des_vars', comp, promotes=['*'])
 
-        teg = model.add_subsystem('thrust_equilibrium_group', subsys=Group())
-        teg.add_subsystem('dynamics', ExecComp('z = 2.0*thrust'), promotes=['*'])
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
 
-        thrust_bal = BalanceComp()
+        thrust_bal = om.BalanceComp()
         thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
                                rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
 
@@ -264,10 +264,10 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                           promotes_inputs=['dXdt:TAS', 'accel_target'],
                           promotes_outputs=['thrust'])
 
-        teg.linear_solver = DirectSolver(assemble_jac=True)
+        teg.linear_solver = om.DirectSolver(assemble_jac=True)
         teg.options['assembled_jac_type'] = 'dense'
 
-        teg.nonlinear_solver = NewtonSolver()
+        teg.nonlinear_solver = om.NewtonSolver()
         teg.nonlinear_solver.options['solve_subsystems'] = True
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
@@ -283,18 +283,18 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_raise_error_on_singular_with_sparsejac(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        comp = IndepVarComp()
+        comp = om.IndepVarComp()
         comp.add_output('dXdt:TAS', val=1.0)
         comp.add_output('accel_target', val=2.0)
         model.add_subsystem('des_vars', comp, promotes=['*'])
 
-        teg = model.add_subsystem('thrust_equilibrium_group', subsys=Group())
-        teg.add_subsystem('dynamics', ExecComp('z = 2.0*thrust'), promotes=['*'])
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
 
-        thrust_bal = BalanceComp()
+        thrust_bal = om.BalanceComp()
         thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
                                rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
 
@@ -302,9 +302,9 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                           promotes_inputs=['dXdt:TAS', 'accel_target'],
                           promotes_outputs=['thrust'])
 
-        teg.linear_solver = DirectSolver(assemble_jac=True)
+        teg.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        teg.nonlinear_solver = NewtonSolver()
+        teg.nonlinear_solver = om.NewtonSolver()
         teg.nonlinear_solver.options['solve_subsystems'] = True
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
@@ -320,18 +320,18 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_raise_no_error_on_singular(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        comp = IndepVarComp()
+        comp = om.IndepVarComp()
         comp.add_output('dXdt:TAS', val=1.0)
         comp.add_output('accel_target', val=2.0)
         model.add_subsystem('des_vars', comp, promotes=['*'])
 
-        teg = model.add_subsystem('thrust_equilibrium_group', subsys=Group())
-        teg.add_subsystem('dynamics', ExecComp('z = 2.0*thrust'), promotes=['*'])
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
 
-        thrust_bal = BalanceComp()
+        thrust_bal = om.BalanceComp()
         thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
                                rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
 
@@ -339,9 +339,9 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                           promotes_inputs=['dXdt:TAS', 'accel_target'],
                           promotes_outputs=['thrust'])
 
-        teg.linear_solver = DirectSolver(assemble_jac=False)
+        teg.linear_solver = om.DirectSolver(assemble_jac=False)
 
-        teg.nonlinear_solver = NewtonSolver()
+        teg.nonlinear_solver = om.NewtonSolver()
         teg.nonlinear_solver.options['solve_subsystems'] = True
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
@@ -354,17 +354,17 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_raise_error_on_nan(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0))
-        model.add_subsystem('c1', ExecComp('y = 4.0*x'))
-        sub = model.add_subsystem('sub', Group())
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x'))
+        sub = model.add_subsystem('sub', om.Group())
         sub.add_subsystem('c2', NanComp())
-        model.add_subsystem('c3', ExecComp('y = 4.0*x'))
+        model.add_subsystem('c3', om.ExecComp('y = 4.0*x'))
         model.add_subsystem('c4', NanComp2())
-        model.add_subsystem('c5', ExecComp('y = 3.0*x'))
-        model.add_subsystem('c6', ExecComp('y = 2.0*x'))
+        model.add_subsystem('c5', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('c6', om.ExecComp('y = 2.0*x'))
 
         model.connect('p.x', 'c1.x')
         model.connect('c1.y', 'sub.c2.x')
@@ -373,7 +373,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.connect('c4.y', 'c5.x')
         model.connect('c4.y2', 'c6.x')
 
-        model.linear_solver = DirectSolver(assemble_jac=False)
+        model.linear_solver = om.DirectSolver(assemble_jac=False)
 
         prob.setup()
         prob.run_model()
@@ -387,17 +387,17 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_raise_error_on_nan_sparse(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0))
-        model.add_subsystem('c1', ExecComp('y = 4.0*x'))
-        sub = model.add_subsystem('sub', Group())
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x'))
+        sub = model.add_subsystem('sub', om.Group())
         sub.add_subsystem('c2', NanComp())
-        model.add_subsystem('c3', ExecComp('y = 4.0*x'))
+        model.add_subsystem('c3', om.ExecComp('y = 4.0*x'))
         model.add_subsystem('c4', NanComp2())
-        model.add_subsystem('c5', ExecComp('y = 3.0*x'))
-        model.add_subsystem('c6', ExecComp('y = 2.0*x'))
+        model.add_subsystem('c5', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('c6', om.ExecComp('y = 2.0*x'))
 
         model.connect('p.x', 'c1.x')
         model.connect('c1.y', 'sub.c2.x')
@@ -406,7 +406,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.connect('c4.y', 'c5.x')
         model.connect('c4.y2', 'c6.x')
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
         prob.run_model()
@@ -420,17 +420,17 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_raise_error_on_nan_dense(self):
 
-        prob = Problem(model=Group(assembled_jac_type='dense'))
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'))
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0))
-        model.add_subsystem('c1', ExecComp('y = 4.0*x'))
-        sub = model.add_subsystem('sub', Group())
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x'))
+        sub = model.add_subsystem('sub', om.Group())
         sub.add_subsystem('c2', NanComp())
-        model.add_subsystem('c3', ExecComp('y = 4.0*x'))
+        model.add_subsystem('c3', om.ExecComp('y = 4.0*x'))
         model.add_subsystem('c4', NanComp2())
-        model.add_subsystem('c5', ExecComp('y = 3.0*x'))
-        model.add_subsystem('c6', ExecComp('y = 2.0*x'))
+        model.add_subsystem('c5', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('c6', om.ExecComp('y = 2.0*x'))
 
         model.connect('p.x', 'c1.x')
         model.connect('c1.y', 'sub.c2.x')
@@ -439,7 +439,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.connect('c4.y', 'c5.x')
         model.connect('c4.y2', 'c6.x')
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
         prob.run_model()
@@ -452,14 +452,14 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_error_on_NaN_bug(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0*np.ones((2, 2))))
-        model.add_subsystem('c1', ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c2', ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c3', ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c4', ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0*np.ones((2, 2))))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c2', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c3', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c4', om.ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
         model.add_subsystem('c5', NanComp())
 
         model.connect('p.x', 'c1.x')
@@ -468,7 +468,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.connect('c3.y', 'c4.x')
         model.connect('c4.y', 'c5.x', src_indices=([0]))
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
         prob.run_model()
@@ -481,14 +481,14 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_error_on_singular_with_sparsejac_bug(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0*np.ones((2, 2))))
-        model.add_subsystem('c1', ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c2', ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c3', ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c4', ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0*np.ones((2, 2))))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c2', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c3', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c4', om.ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
         model.add_subsystem('c5', SingularComp())
 
         model.connect('p.x', 'c1.x')
@@ -497,7 +497,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.connect('c3.y', 'c4.x')
         model.connect('c4.y', 'c5.x', src_indices=([0]))
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.setup()
         prob.run_model()
@@ -510,14 +510,14 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_error_on_singular_with_densejac_bug(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p', IndepVarComp('x', 2.0*np.ones((2, 2))))
-        model.add_subsystem('c1', ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c2', ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c3', ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
-        model.add_subsystem('c4', ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0*np.ones((2, 2))))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c2', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c3', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c4', om.ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
         model.add_subsystem('c5', SingularComp())
 
         model.connect('p.x', 'c1.x')
@@ -526,7 +526,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.connect('c3.y', 'c4.x')
         model.connect('c4.y', 'c5.x', src_indices=([0]))
 
-        model.linear_solver = DirectSolver(assemble_jac=True)
+        model.linear_solver = om.DirectSolver(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -541,7 +541,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_raise_error_on_underdetermined_csc(self):
 
-        class DCgenerator(ImplicitComponent):
+        class DCgenerator(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('V_bus', val=1.0)
@@ -563,7 +563,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                 J['P_out', 'V_out'] = outputs['I_out']
                 J['P_out', 'I_out'] = inputs['V_out']
 
-        class RectifierCalcs(ImplicitComponent):
+        class RectifierCalcs(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('P_out', val=1.0)
@@ -583,17 +583,17 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
                 resids['V_out'] = 1.0 - outputs['V_out']
                 resids['Q_in'] = outputs['P_in'] - outputs['Q_in']
 
-        class Rectifier(Group):
+        class Rectifier(om.Group):
 
             def setup(self):
                 self.add_subsystem('gen', DCgenerator(), promotes=[('V_bus', 'Vm_dc'), 'P_out'])
 
                 self.add_subsystem('calcs', RectifierCalcs(), promotes=['P_out', ('V_out', 'Vm_dc')])
 
-                self.nonlinear_solver = NewtonSolver()
-                self.linear_solver = DirectSolver()
+                self.nonlinear_solver = om.NewtonSolver()
+                self.linear_solver = om.DirectSolver()
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('sub', Rectifier())
 
         prob.setup()
@@ -607,9 +607,9 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_matvec_error_raised(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('x_param', IndepVarComp('length', 3.0),
+        model.add_subsystem('x_param', om.IndepVarComp('length', 3.0),
                             promotes=['length'])
         model.add_subsystem('mycomp', TestExplCompSimpleJacVec(),
                             promotes=['length', 'width', 'area'])
@@ -630,13 +630,13 @@ class TestDirectSolverFeature(unittest.TestCase):
 
     def test_specify_solver(self):
 
-        from openmdao.api import Problem, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivatives()
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
         prob.setup()
         prob.run_model()

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -481,7 +481,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_error_on_singular_with_sparsejac_bug(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', 2.0*np.ones((2, 2))))
@@ -510,7 +510,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(expected_msg, str(cm.exception))
 
     def test_error_on_singular_with_densejac_bug(self):
-        prob = Problem(model=Group())
+        prob = Problem()
         model = prob.model
 
         model.add_subsystem('p', IndepVarComp('x', 2.0*np.ones((2, 2))))

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -108,7 +108,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         g1 = model.add_subsystem('g1', TestImplicitGroup(lnSolverClass=DirectSolver))
 
-        p.setup(check=False)
+        p.setup()
 
         g1.linear_solver.options['assemble_jac'] = False
 
@@ -218,7 +218,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         with self.assertRaises(RuntimeError) as cm:
@@ -238,7 +238,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         model.linear_solver = DirectSolver(assemble_jac=True)
 
         with self.assertRaises(Exception) as cm:
-            prob.setup(check=False)
+            prob.setup()
 
         expected_msg = "dupcomp: declare_partials has been called with rows and cols that specify the following duplicate subjacobian entries: [(4, 11), (10, 2)]."
 
@@ -272,7 +272,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         with self.assertRaises(RuntimeError) as cm:
@@ -309,7 +309,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         with self.assertRaises(RuntimeError) as cm:
@@ -346,7 +346,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         teg.nonlinear_solver.options['max_sub_solves'] = 1
         teg.nonlinear_solver.options['atol'] = 1e-4
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         teg.linear_solver.options['err_on_singular'] = False
@@ -596,7 +596,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         prob = Problem()
         prob.model.add_subsystem('sub', Rectifier())
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         with self.assertRaises(RuntimeError) as cm:
@@ -608,7 +608,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_matvec_error_raised(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('x_param', IndepVarComp('length', 3.0),
                             promotes=['length'])
         model.add_subsystem('mycomp', TestExplCompSimpleJacVec(),

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -42,7 +42,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
                             promotes=['length', 'width', 'area'])
 
         model.linear_solver = self.linear_solver_class(assemble_jac=True)
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(RuntimeError) as context:
             prob.run_model()
@@ -55,7 +55,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         # as long as we slot a non-lgs linear solver on that component.
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
         model.add_subsystem('p', IndepVarComp('a', 5.0))
         comp = model.add_subsystem('comp', SimpleImp())
         model.connect('p.a', 'comp.a')
@@ -71,7 +71,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_implicit_cycle(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 1.0))
         model.add_subsystem('d1', SellarImplicitDis1())
@@ -83,7 +83,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         model.nonlinear_solver.options['maxiter'] = 5
         model.linear_solver = self.linear_solver_class()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob.run_model()
@@ -94,7 +94,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
 
     def test_implicit_cycle_precon(self):
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 1.0))
         model.add_subsystem('d1', SellarImplicitDis1())
@@ -108,7 +108,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         model.linear_solver = ScipyKrylov()
         model.linear_solver.precon = self.linear_solver_class()
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob['d1.y1'] = 4.0
         prob.set_solver_print()
@@ -131,7 +131,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # We don't call run_driver() here because we don't
         # actually want the optimizer to run
@@ -186,7 +186,7 @@ class TestBGSSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -223,7 +223,7 @@ class TestBGSSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -260,7 +260,7 @@ class TestBGSSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -5,17 +5,16 @@ import unittest
 
 import numpy as np
 
+import openmdao.api as om
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
-from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.api import LinearBlockGS, Problem, Group, ImplicitComponent, IndepVarComp, \
-    DirectSolver, NewtonSolver, ScipyKrylov, ExecComp, NonlinearBlockGS, BoundsEnforceLS
 from openmdao.test_suite.components.sellar import SellarImplicitDis1, SellarImplicitDis2, \
     SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
 from openmdao.test_suite.components.sellar import SellarDerivatives
+from openmdao.utils.assert_utils import assert_rel_error
 
 
-class SimpleImp(ImplicitComponent):
+class SimpleImp(om.ImplicitComponent):
     def setup(self):
         self.add_input('a', val=1.)
         self.add_output('x', val=0.)
@@ -31,12 +30,12 @@ class SimpleImp(ImplicitComponent):
 
 
 class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
-    linear_solver_class = LinearBlockGS
+    linear_solver_class = om.LinearBlockGS
 
     def test_globaljac_err(self):
-        prob = Problem()
-        model = prob.model = Group(assembled_jac_type='dense')
-        model.add_subsystem('x_param', IndepVarComp('length', 3.0),
+        prob = om.Problem()
+        model = prob.model = om.Group(assembled_jac_type='dense')
+        model.add_subsystem('x_param', om.IndepVarComp('length', 3.0),
                             promotes=['length'])
         model.add_subsystem('mycomp', TestExplCompSimpleDense(),
                             promotes=['length', 'width', 'area'])
@@ -54,14 +53,14 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         # This verifies that we can perform lgs around an implicit comp and get the right answer
         # as long as we slot a non-lgs linear solver on that component.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('p', IndepVarComp('a', 5.0))
+        model.add_subsystem('p', om.IndepVarComp('a', 5.0))
         comp = model.add_subsystem('comp', SimpleImp())
         model.connect('p.a', 'comp.a')
 
         model.linear_solver = self.linear_solver_class()
-        comp.linear_solver = DirectSolver()
+        comp.linear_solver = om.DirectSolver()
 
         prob.setup(check=False, mode='fwd')
         prob.run_model()
@@ -70,16 +69,16 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertEqual(deriv['comp.x', 'p.a'], -1.5)
 
     def test_implicit_cycle(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 1.0))
         model.add_subsystem('d1', SellarImplicitDis1())
         model.add_subsystem('d2', SellarImplicitDis2())
         model.connect('d1.y1', 'd2.y1')
         model.connect('d2.y2', 'd1.y2')
 
-        model.nonlinear_solver = NewtonSolver()
+        model.nonlinear_solver = om.NewtonSolver()
         model.nonlinear_solver.options['maxiter'] = 5
         model.linear_solver = self.linear_solver_class()
 
@@ -93,19 +92,19 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertLess(res, 2.0e-2)
 
     def test_implicit_cycle_precon(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 1.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 1.0))
         model.add_subsystem('d1', SellarImplicitDis1())
         model.add_subsystem('d2', SellarImplicitDis2())
         model.connect('d1.y1', 'd2.y1')
         model.connect('d2.y2', 'd1.y2')
 
-        model.nonlinear_solver = NewtonSolver()
+        model.nonlinear_solver = om.NewtonSolver()
         model.nonlinear_solver.options['maxiter'] = 5
-        model.nonlinear_solver.linesearch = BoundsEnforceLS()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver.linesearch = om.BoundsEnforceLS()
+        model.linear_solver = om.ScipyKrylov()
         model.linear_solver.precon = self.linear_solver_class()
 
         prob.setup()
@@ -119,12 +118,12 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         self.assertLess(res, 2.0e-2)
 
     def test_full_desvar_with_index_obj_relevance_bug(self):
-        prob = Problem()
+        prob = om.Problem()
         sub = prob.model.add_subsystem('sub', SellarDerivatives())
-        prob.model.nonlinear_solver = NonlinearBlockGS()
-        prob.model.linear_solver = LinearBlockGS()
-        sub.nonlinear_solver = NonlinearBlockGS()
-        sub.linear_solver = LinearBlockGS()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
+        prob.model.linear_solver = om.LinearBlockGS()
+        sub.nonlinear_solver = om.NonlinearBlockGS()
+        sub.linear_solver = om.LinearBlockGS()
 
         prob.model.add_design_var('sub.z', lower=-100, upper=100)
         prob.model.add_objective('sub.z', index=1)
@@ -147,27 +146,27 @@ class TestBGSSolverFeature(unittest.TestCase):
     def test_specify_solver(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockGS, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
         prob.run_model()
@@ -182,28 +181,28 @@ class TestBGSSolverFeature(unittest.TestCase):
     def test_feature_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockGS, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
         model.linear_solver.options['maxiter'] = 2
 
         prob.setup()
@@ -219,28 +218,28 @@ class TestBGSSolverFeature(unittest.TestCase):
     def test_feature_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockGS, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
         model.linear_solver.options['atol'] = 1.0e-3
 
         prob.setup()
@@ -256,28 +255,28 @@ class TestBGSSolverFeature(unittest.TestCase):
     def test_feature_rtol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockGS, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
         model.linear_solver.options['rtol'] = 1.0e-3
 
         prob.setup()

--- a/openmdao/solvers/linear/tests/test_linear_block_jac.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_jac.py
@@ -27,7 +27,7 @@ class TestLinearBlockJacSolver(LinearSolverTests.LinearSolverTestCase):
                             promotes=['length', 'width', 'area'])
 
         model.linear_solver = LinearBlockJac(assemble_jac=True)
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(RuntimeError) as context:
             prob.run_model()
@@ -44,7 +44,7 @@ class TestBJacSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -79,7 +79,7 @@ class TestBJacSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -116,7 +116,7 @@ class TestBJacSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -153,7 +153,7 @@ class TestBJacSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])

--- a/openmdao/solvers/linear/tests/test_linear_block_jac.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_jac.py
@@ -6,8 +6,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, Problem, LinearBlockJac, \
-    ExecComp, NonlinearBlockGS
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
@@ -16,17 +15,17 @@ from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
 
 class TestLinearBlockJacSolver(LinearSolverTests.LinearSolverTestCase):
 
-    linear_solver_class = LinearBlockJac
+    linear_solver_class = om.LinearBlockJac
 
     def test_globaljac_err(self):
-        prob = Problem()
-        model = prob.model = Group(assembled_jac_type='dense')
-        model.add_subsystem('x_param', IndepVarComp('length', 3.0),
+        prob = om.Problem()
+        model = prob.model = om.Group(assembled_jac_type='dense')
+        model.add_subsystem('x_param', om.IndepVarComp('length', 3.0),
                             promotes=['length'])
         model.add_subsystem('mycomp', TestExplCompSimpleDense(),
                             promotes=['length', 'width', 'area'])
 
-        model.linear_solver = LinearBlockJac(assemble_jac=True)
+        model.linear_solver = om.LinearBlockJac(assemble_jac=True)
         prob.setup()
 
         with self.assertRaises(RuntimeError) as context:
@@ -40,27 +39,27 @@ class TestBJacSolverFeature(unittest.TestCase):
     def test_specify_solver(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockJac, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
-        model.linear_solver = LinearBlockJac()
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        model.linear_solver = om.LinearBlockJac()
 
         prob.setup()
         prob.run_model()
@@ -75,28 +74,28 @@ class TestBJacSolverFeature(unittest.TestCase):
     def test_feature_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockJac, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = LinearBlockJac()
+        model.linear_solver = om.LinearBlockJac()
         model.linear_solver.options['maxiter'] = 5
 
         prob.setup()
@@ -112,28 +111,28 @@ class TestBJacSolverFeature(unittest.TestCase):
     def test_feature_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockJac, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = LinearBlockJac()
+        model.linear_solver = om.LinearBlockJac()
         model.linear_solver.options['atol'] = 1.0e-3
 
         prob.setup(mode='rev')
@@ -149,28 +148,28 @@ class TestBJacSolverFeature(unittest.TestCase):
     def test_feature_rtol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockJac, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = LinearBlockJac()
+        model.linear_solver = om.LinearBlockJac()
         model.linear_solver.options['rtol'] = 1.0e-3
 
         prob.setup(mode='rev')

--- a/openmdao/solvers/linear/tests/test_linear_runonce.py
+++ b/openmdao/solvers/linear/tests/test_linear_runonce.py
@@ -2,24 +2,23 @@
 
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp
-from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.solvers.linear.linear_runonce import LinearRunOnce
+import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.groups.parallel_groups import ConvergeDivergeGroups
+from openmdao.utils.assert_utils import assert_rel_error
 
 
 class TestLinearRunOnceSolver(unittest.TestCase):
 
     def test_converge_diverge_groups(self):
         # Test derivatives for converge-diverge-groups topology.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = ConvergeDivergeGroups()
 
-        model.linear_solver = LinearRunOnce()
-        model.g1.linear_solver = LinearRunOnce()
-        model.g1.g2.linear_solver = LinearRunOnce()
-        model.g3.linear_solver = LinearRunOnce()
+        model.linear_solver = om.LinearRunOnce()
+        model.g1.linear_solver = om.LinearRunOnce()
+        model.g1.g2.linear_solver = om.LinearRunOnce()
+        model.g3.linear_solver = om.LinearRunOnce()
 
         prob.set_solver_print(level=0)
         prob.setup(check=False, mode='fwd')
@@ -42,7 +41,7 @@ class TestLinearRunOnceSolver(unittest.TestCase):
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class cause an error
-        solver = LinearRunOnce()
+        solver = om.LinearRunOnce()
 
         msg = "\"Option '%s' cannot be set because it has not been declared.\""
 
@@ -54,17 +53,17 @@ class TestLinearRunOnceSolver(unittest.TestCase):
 
 
     def test_feature_solver(self):
-        from openmdao.api import Problem, Group, IndepVarComp, LinearRunOnce
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
-        model.linear_solver = LinearRunOnce()
+        model.linear_solver = om.LinearRunOnce()
 
         prob.setup(check=False, mode='fwd')
 

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -44,7 +44,7 @@ class TestPETScKrylov(unittest.TestCase):
             group = TestImplicitGroup(lnSolverClass=PetscKSP)
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -75,7 +75,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver.options['ksp_type'] = 'gmres'
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -106,7 +106,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver.options['maxiter'] = 2
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -135,7 +135,7 @@ class TestPETScKrylov(unittest.TestCase):
         precon = group.linear_solver.precon = LinearBlockGS()
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -165,7 +165,7 @@ class TestPETScKrylov(unittest.TestCase):
 
         # test the direct solver and make sure KSP correctly recurses for _linearize
         precon = group.linear_solver.precon = DirectSolver(assemble_jac=False)
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -199,7 +199,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver.options['ksp_type'] = 'richardson'
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -230,7 +230,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver.options['precon_side'] = 'left'
         group.linear_solver.options['ksp_type'] = 'richardson'
 
-        p.setup(check=False)
+        p.setup()
 
         # Conclude setup but don't run model.
         p.final_setup()
@@ -281,7 +281,7 @@ class TestPETScKrylov(unittest.TestCase):
 
         g1 = model.add_subsystem('g1', TestImplicitGroup(lnSolverClass=PETScKrylov))
 
-        p.setup(check=False)
+        p.setup()
 
         p.set_solver_print(level=0)
 
@@ -372,7 +372,7 @@ class TestPETScKrylov(unittest.TestCase):
     def test_error_under_cs(self):
         """Verify that PETScKrylov abides by the 'maxiter' option."""
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -413,7 +413,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -451,7 +451,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
              SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -488,7 +488,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -525,7 +525,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -562,7 +562,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -601,7 +601,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
              SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -637,7 +637,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
              SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -7,10 +7,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, Problem, ExecComp, NonlinearBlockGS, BoundsEnforceLS
-from openmdao.solvers.linear.linear_block_gs import LinearBlockGS
-from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov, ScipyIterativeSolver
-from openmdao.solvers.nonlinear.newton import NewtonSolver
+import openmdao.api as om
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
 from openmdao.test_suite.components.misc_components import Comp4LinearCacheTest
@@ -22,7 +19,7 @@ from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 # use this to fake out the TestImplicitGroup so it'll use the solver we want.
 def krylov_factory(solver):
     def f(junk=None):
-        return ScipyKrylov(solver=solver)
+        return om.ScipyKrylov(solver=solver)
     return f
 
 
@@ -34,7 +31,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
     def test_options(self):
         """Verify that the SciPy solver specific options are declared."""
 
-        group = Group()
+        group = om.Group()
         group.linear_solver = self.linear_solver_class()
 
         self.assertEqual(group.linear_solver.options['solver'], self.linear_solver_name)
@@ -47,9 +44,9 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         msg = "ScipyIterativeSolver is deprecated.  Use ScipyKrylov instead."
 
         with assert_warning(DeprecationWarning, msg):
-            group = TestImplicitGroup(lnSolverClass=lambda : ScipyIterativeSolver(solver=self.linear_solver_name))
+            group = TestImplicitGroup(lnSolverClass=lambda : om.ScipyIterativeSolver(solver=self.linear_solver_name))
 
-        p = Problem(group)
+        p = om.Problem(group)
         p.setup()
         p.set_solver_print(level=0)
 
@@ -78,7 +75,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         group = TestImplicitGroup(lnSolverClass=self.linear_solver_class)
         group.linear_solver.options['maxiter'] = 2
 
-        p = Problem(group)
+        p = om.Problem(group)
         p.setup()
         p.set_solver_print(level=0)
 
@@ -104,9 +101,9 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
     def test_solve_on_subsystem(self):
         """solve an implicit system with GMRES attached to a subsystem"""
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
-        dv = model.add_subsystem('des_vars', IndepVarComp())
+        dv = model.add_subsystem('des_vars', om.IndepVarComp())
         # just need a dummy variable so the sizes don't match between root and g1
         dv.add_output('dummy', val=1.0, shape=10)
 
@@ -150,7 +147,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
 
         # check deprecation on setter & getter
         with assert_warning(DeprecationWarning, msg):
-            group.linear_solver.preconditioner = LinearBlockGS()
+            group.linear_solver.preconditioner = om.LinearBlockGS()
 
         with assert_warning(DeprecationWarning, msg):
             group.linear_solver.preconditioner
@@ -162,14 +159,14 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
 
         # Forward mode
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('d1', Comp4LinearCacheTest(), promotes=['x', 'y'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        model.linear_solver = om.ScipyKrylov()
 
         model.add_design_var('x', cache_linear_solution=True)
         model.add_objective('y', cache_linear_solution=True)
@@ -188,14 +185,14 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
 
         # Reverse mode
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('d1', Comp4LinearCacheTest(), promotes=['x', 'y'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        model.linear_solver = om.ScipyKrylov()
 
         model.add_design_var('x', cache_linear_solution=True)
         model.add_objective('y', cache_linear_solution=True)
@@ -218,18 +215,18 @@ class TestScipyKrylovFeature(unittest.TestCase):
     def test_feature_simple(self):
         """Tests feature for adding a Scipy GMRES solver and calculating the
         derivatives."""
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
 
         # Tests derivatives on a simple comp that defines compute_jacvec.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('x_param', IndepVarComp('length', 3.0),
+        model.add_subsystem('x_param', om.IndepVarComp('length', 3.0),
                             promotes=['length'])
         model.add_subsystem('mycomp', TestExplCompSimpleDense(),
                             promotes=['length', 'width', 'area'])
 
-        model.linear_solver = ScipyKrylov()
+        model.linear_solver = om.ScipyKrylov()
         prob.set_solver_print(level=0)
 
         prob.setup(check=False, mode='fwd')
@@ -245,30 +242,29 @@ class TestScipyKrylovFeature(unittest.TestCase):
     def test_specify_solver(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyKrylov, \
-             NonlinearBlockGS, ExecComp
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, \
              SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = ScipyKrylov()
+        model.linear_solver = om.ScipyKrylov()
 
         prob.setup()
         prob.run_model()
@@ -283,28 +279,28 @@ class TestScipyKrylovFeature(unittest.TestCase):
     def test_feature_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyKrylov, NonlinearBlockGS, ExecComp
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = ScipyKrylov()
+        model.linear_solver = om.ScipyKrylov()
         model.linear_solver.options['maxiter'] = 3
 
         prob.setup()
@@ -320,28 +316,28 @@ class TestScipyKrylovFeature(unittest.TestCase):
     def test_feature_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ScipyKrylov, NonlinearBlockGS, ExecComp
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
-        model.linear_solver = ScipyKrylov()
+        model.linear_solver = om.ScipyKrylov()
         model.linear_solver.options['atol'] = 1.0e-20
 
         prob.setup()
@@ -357,35 +353,33 @@ class TestScipyKrylovFeature(unittest.TestCase):
     def test_specify_precon(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, ScipyKrylov, NewtonSolver, LinearBlockGS, \
-             DirectSolver, ExecComp, PETScKrylov
-
+        import openmdao.api as om
         from openmdao.test_suite.components.quad_implicit import QuadraticComp
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        sub1 = model.add_subsystem('sub1', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
         sub1.add_subsystem('q1', QuadraticComp())
-        sub1.add_subsystem('z1', ExecComp('y = -6.0 + .01 * x'))
-        sub2 = model.add_subsystem('sub2', Group())
+        sub1.add_subsystem('z1', om.ExecComp('y = -6.0 + .01 * x'))
+        sub2 = model.add_subsystem('sub2', om.Group())
         sub2.add_subsystem('q2', QuadraticComp())
-        sub2.add_subsystem('z2', ExecComp('y = -6.0 + .01 * x'))
+        sub2.add_subsystem('z2', om.ExecComp('y = -6.0 + .01 * x'))
 
         model.connect('sub1.q1.x', 'sub1.z1.x')
         model.connect('sub1.z1.y', 'sub2.q2.c')
         model.connect('sub2.q2.x', 'sub2.z2.x')
         model.connect('sub2.z2.y', 'sub1.q1.c')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         prob.setup()
 
-        model.sub1.linear_solver = DirectSolver()
-        model.sub2.linear_solver = DirectSolver()
+        model.sub1.linear_solver = om.DirectSolver()
+        model.sub2.linear_solver = om.DirectSolver()
 
-        model.linear_solver.precon = LinearBlockGS()
+        model.linear_solver.precon = om.LinearBlockGS()
 
         prob.set_solver_print(level=2)
         prob.run_model()

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -50,7 +50,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
             group = TestImplicitGroup(lnSolverClass=lambda : ScipyIterativeSolver(solver=self.linear_solver_name))
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -79,7 +79,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         group.linear_solver.options['maxiter'] = 2
 
         p = Problem(group)
-        p.setup(check=False)
+        p.setup()
         p.set_solver_print(level=0)
 
         # Conclude setup but don't run model.
@@ -105,7 +105,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         """solve an implicit system with GMRES attached to a subsystem"""
 
         p = Problem()
-        model = p.model = Group()
+        model = p.model
         dv = model.add_subsystem('des_vars', IndepVarComp())
         # just need a dummy variable so the sizes don't match between root and g1
         dv.add_output('dummy', val=1.0, shape=10)
@@ -113,7 +113,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         grp = TestImplicitGroup(lnSolverClass=self.linear_solver_class)
         g1 = model.add_subsystem('g1', grp)
 
-        p.setup(check=False)
+        p.setup()
 
         p.set_solver_print(level=0)
 

--- a/openmdao/solvers/linear/tests/test_user_defined.py
+++ b/openmdao/solvers/linear/tests/test_user_defined.py
@@ -6,10 +6,8 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Group, Problem, ImplicitComponent, PETScKrylov, LinearRunOnce, \
-     IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.solvers.linear.user_defined import LinearUserDefined
 from openmdao.utils.array_utils import evenly_distrib_idxs
 
 try:
@@ -18,7 +16,7 @@ except ImportError:
     PETScVector = None
 
 
-class DistribStateImplicit(ImplicitComponent):
+class DistribStateImplicit(om.ImplicitComponent):
 
     def setup(self):
 
@@ -33,8 +31,8 @@ class DistribStateImplicit(ImplicitComponent):
         self.add_output('out_var', shape=1)
         self.local_size = sizes[rank]
 
-        self.linear_solver = PETScKrylov()
-        self.linear_solver.precon = LinearUserDefined(self.mysolve)
+        self.linear_solver = om.PETScKrylov()
+        self.linear_solver.precon = om.LinearUserDefined(self.mysolve)
 
     def solve_nonlinear(self, i, o):
         o['states'] = i['a']
@@ -121,16 +119,16 @@ class DistribStateImplicit(ImplicitComponent):
 class TestUserDefinedSolver(unittest.TestCase):
 
     def test_method(self):
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('des_vars', IndepVarComp('a', val=10., units='m'), promotes=['*'])
+        p.model.add_subsystem('des_vars', om.IndepVarComp('a', val=10., units='m'), promotes=['*'])
 
         p.model.add_subsystem('icomp', DistribStateImplicit(), promotes=['*'])
 
         model = p.model
 
-        model.linear_solver = PETScKrylov()
-        model.linear_solver.precon = LinearRunOnce()
+        model.linear_solver = om.PETScKrylov()
+        model.linear_solver.precon = om.LinearRunOnce()
 
         p.setup(mode='rev', check=False)
         p.run_model()
@@ -147,7 +145,7 @@ class TestUserDefinedSolver(unittest.TestCase):
                 raise ValueError('This value should be unscaled.')
 
 
-        class ScaledComp(ImplicitComponent):
+        class ScaledComp(om.ImplicitComponent):
 
             def setup(self):
 
@@ -157,12 +155,12 @@ class TestUserDefinedSolver(unittest.TestCase):
                 self.add_output('out_var', val=20.0, ref=12.0)
 
 
-        p = Problem()
-        p.model.add_subsystem('des_vars', IndepVarComp('a', val=10., units='m'), promotes=['*'])
+        p = om.Problem()
+        p.model.add_subsystem('des_vars', om.IndepVarComp('a', val=10., units='m'), promotes=['*'])
         p.model.add_subsystem('icomp', ScaledComp(), promotes=['*'])
         model = p.model
 
-        model.linear_solver = LinearUserDefined(custom_method)
+        model.linear_solver = om.LinearUserDefined(custom_method)
 
         p.setup(mode='rev', check=False)
         p.run_model()
@@ -170,20 +168,20 @@ class TestUserDefinedSolver(unittest.TestCase):
 
     def test_method_default(self):
         # Uses `solve_linear` by default
-        p = Problem()
+        p = om.Problem()
 
-        p.model.add_subsystem('des_vars', IndepVarComp('a', val=10., units='m'), promotes=['*'])
+        p.model.add_subsystem('des_vars', om.IndepVarComp('a', val=10., units='m'), promotes=['*'])
 
         p.model.add_subsystem('icomp', DistribStateImplicit(), promotes=['*'])
 
         model = p.model
 
-        model.linear_solver = PETScKrylov()
-        model.linear_solver.precon = LinearRunOnce()
+        model.linear_solver = om.PETScKrylov()
+        model.linear_solver.precon = om.LinearRunOnce()
 
         p.setup(mode='rev', check=False)
 
-        model.icomp.linear_solver.precon = LinearUserDefined()
+        model.icomp.linear_solver.precon = om.LinearUserDefined()
 
         p.run_model()
         jac = p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
@@ -193,10 +191,10 @@ class TestUserDefinedSolver(unittest.TestCase):
     def test_feature(self):
         import numpy as np
 
-        from openmdao.api import Problem, ImplicitComponent, IndepVarComp, LinearRunOnce, PETScKrylov, PETScVector, LinearUserDefined
+        import openmdao.api as om
         from openmdao.utils.array_utils import evenly_distrib_idxs
 
-        class CustomSolveImplicit(ImplicitComponent):
+        class CustomSolveImplicit(om.ImplicitComponent):
 
             def setup(self):
 
@@ -211,8 +209,8 @@ class TestUserDefinedSolver(unittest.TestCase):
                 self.add_output('out_var', shape=1)
                 self.local_size = sizes[rank]
 
-                self.linear_solver = PETScKrylov()
-                self.linear_solver.precon = LinearUserDefined(solve_function=self.mysolve)
+                self.linear_solver = om.PETScKrylov()
+                self.linear_solver.precon = om.LinearUserDefined(solve_function=self.mysolve)
 
             def solve_nonlinear(self, i, o):
                 o['states'] = i['a']
@@ -289,16 +287,16 @@ class TestUserDefinedSolver(unittest.TestCase):
                 elif mode == 'rev':
                     d_residuals.set_vec(d_outputs)
 
-        prob = Problem()
+        prob = om.Problem()
 
 
-        prob.model.add_subsystem('des_vars', IndepVarComp('a', val=10., units='m'), promotes=['*'])
+        prob.model.add_subsystem('des_vars', om.IndepVarComp('a', val=10., units='m'), promotes=['*'])
         prob.model.add_subsystem('icomp', CustomSolveImplicit(), promotes=['*'])
 
         model = prob.model
 
-        model.linear_solver = PETScKrylov()
-        model.linear_solver.precon = LinearRunOnce()
+        model.linear_solver = om.PETScKrylov()
+        model.linear_solver.precon = om.LinearRunOnce()
 
         prob.setup(mode='rev', check=False)
         prob.run_model()

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -33,7 +33,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         top.model.nonlinear_solver.options['maxiter'] = 10
         top.model.linear_solver = ScipyKrylov()
 
-        top.setup(check=False)
+        top.setup()
 
         self.top = top
 
@@ -60,7 +60,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         ls.options['alpha'] = 1.0
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bound: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -84,7 +84,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         ls.options['alpha'] = 10.0
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bound: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -108,7 +108,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         ls.options['alpha'] = 10.0
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bound: should stop just short of the lower bound
         top['px.x'] = 2.0
@@ -185,7 +185,7 @@ class TestAnalysisErrorExplicit(unittest.TestCase):
     def test_retry(self):
         # Test the behavior with the switch turned on.
         top = self.top
-        top.setup(check=False)
+        top.setup()
         self.ls.options['retry_on_analysis_error'] = True
 
         # Test lower bound: should go as far as it can without going past 1.75 and triggering an
@@ -201,7 +201,7 @@ class TestAnalysisErrorExplicit(unittest.TestCase):
         self.ls.options['retry_on_analysis_error'] = False
 
         top = self.top
-        top.setup(check=False)
+        top.setup()
 
         top['px.x'] = 2.0
         top['comp.y'] = 0.0
@@ -292,7 +292,7 @@ class TestAnalysisErrorImplicit(unittest.TestCase):
         ls.options['retry_on_analysis_error'] = True
         ls.options['c'] = 10000.0
 
-        top.setup(check=False)
+        top.setup()
         top.set_solver_print(level=2)
 
         stdout = sys.stdout
@@ -342,7 +342,7 @@ class TestAnalysisErrorImplicit(unittest.TestCase):
         ls.options['retry_on_analysis_error'] = True
         ls.options['c'] = 10000.0
 
-        top.setup(check=False)
+        top.setup()
         top.set_solver_print(level=2)
 
         stdout = sys.stdout
@@ -379,7 +379,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top.model.linear_solver = ScipyKrylov()
 
         top.set_solver_print(level=0)
-        top.setup(check=False)
+        top.setup()
 
         self.top = top
         self.ub = np.array([2.6, 2.5, 2.65])
@@ -391,7 +391,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         ls.options['print_bound_enforce'] = True
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -428,7 +428,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='wall')
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -452,7 +452,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar')
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should stop just short of the lower bound
         top['px.x'] = 2.0
@@ -515,7 +515,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
         top.set_solver_print(level=0)
 
-        top.setup(check=False)
+        top.setup()
 
         # Make sure we don't raise an error when we reach the final debug print.
         top.run_model()
@@ -564,7 +564,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top.model.linear_solver = ScipyKrylov()
 
         top.set_solver_print(level=0)
-        top.setup(check=False)
+        top.setup()
 
         self.top = top
         self.ub = np.array([2.6, 2.5, 2.65])
@@ -576,7 +576,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         ls.options['c'] = .1
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -600,7 +600,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -624,7 +624,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='scalar')
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should stop just short of the lower bound
         top['px.x'] = 2.0
@@ -765,7 +765,7 @@ class TestFeatureLineSearch(unittest.TestCase):
 
         top.model.nonlinear_solver.linesearch = BoundsEnforceLS()
 
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -795,7 +795,7 @@ class TestFeatureLineSearch(unittest.TestCase):
 
         top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS()
 
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -825,7 +825,7 @@ class TestFeatureLineSearch(unittest.TestCase):
 
         top.model.nonlinear_solver.linesearch = BoundsEnforceLS()
 
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -856,7 +856,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
         ls.options['bound_enforcement'] = 'vector'
 
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -887,7 +887,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='wall')
         ls.options['bound_enforcement'] = 'wall'
 
-        top.setup(check=False)
+        top.setup()
 
         # Test upper bounds: should go to the upper bound and stall
         top['px.x'] = 0.5
@@ -918,7 +918,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar')
         ls.options['bound_enforcement'] = 'scalar'
 
-        top.setup(check=False)
+        top.setup()
         top.run_model()
 
         # Test lower bounds: should stop just short of the lower bound
@@ -982,7 +982,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='vector')
         ls.options['bound_enforcement'] = 'vector'
 
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bounds: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -1013,7 +1013,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
         ls.options['bound_enforcement'] = 'wall'
 
-        top.setup(check=False)
+        top.setup()
 
         # Test upper bounds: should go to the upper bound and stall
         top['px.x'] = 0.5
@@ -1044,7 +1044,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='scalar')
         ls.options['bound_enforcement'] = 'scalar'
 
-        top.setup(check=False)
+        top.setup()
         top.run_model()
 
         # Test lower bounds: should stop just short of the lower bound

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -9,29 +9,24 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, AnalysisError, \
-    ExplicitComponent, ImplicitComponent
-from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.solvers.linesearch.backtracking import ArmijoGoldsteinLS, BoundsEnforceLS
-from openmdao.solvers.nonlinear.newton import NewtonSolver
-from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov
+import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.implicit_newton_linesearch \
     import ImplCompTwoStates, ImplCompTwoStatesArrays
+from openmdao.utils.assert_utils import assert_rel_error
 
 
 class TestArmejoGoldsteinBounds(unittest.TestCase):
 
     def setUp(self):
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', 1.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 1.0))
         top.model.add_subsystem('comp', ImplCompTwoStates())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
         top.setup()
 
@@ -55,7 +50,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
     def test_linesearch_bounds_vector(self):
         top = self.top
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='vector')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
         ls.options['maxiter'] = 10
         ls.options['alpha'] = 1.0
 
@@ -79,7 +74,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
     def test_linesearch_bounds_wall(self):
         top = self.top
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='wall')
         ls.options['maxiter'] = 10
         ls.options['alpha'] = 10.0
 
@@ -103,7 +98,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
     def test_linesearch_bounds_scalar(self):
         top = self.top
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='scalar')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='scalar')
         ls.options['maxiter'] = 10
         ls.options['alpha'] = 10.0
 
@@ -125,7 +120,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         self.assertTrue(2.4 <= top['comp.z'] <= 2.5)
 
 
-class ParaboloidAE(ExplicitComponent):
+class ParaboloidAE(om.ExplicitComponent):
     """ Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
     This version raises an analysis error if x < 2.0
     The AE in ParaboloidAE stands for AnalysisError."""
@@ -146,7 +141,7 @@ class ParaboloidAE(ExplicitComponent):
         y = inputs['y']
 
         if x < 1.75:
-            raise AnalysisError('Try Again.')
+            raise om.AnalysisError('Try Again.')
 
         outputs['f_xy'] = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
 
@@ -162,19 +157,18 @@ class ParaboloidAE(ExplicitComponent):
 class TestAnalysisErrorExplicit(unittest.TestCase):
 
     def setUp(self):
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', 1.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 1.0))
         top.model.add_subsystem('comp', ImplCompTwoStates())
         top.model.add_subsystem('par', ParaboloidAE())
         top.model.connect('px.x', 'comp.x')
         top.model.connect('comp.z', 'par.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 1
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='vector')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
         ls.options['maxiter'] = 10
         ls.options['alpha'] = 1.0
         top.set_solver_print(level=0)
@@ -207,13 +201,13 @@ class TestAnalysisErrorExplicit(unittest.TestCase):
         top['comp.y'] = 0.0
         top['comp.z'] = 2.1
 
-        with self.assertRaises(AnalysisError) as context:
+        with self.assertRaises(om.AnalysisError) as context:
             top.run_model()
 
         self.assertEqual(str(context.exception), 'Try Again.')
 
 
-class ImplCompTwoStatesAE(ImplicitComponent):
+class ImplCompTwoStatesAE(om.ImplicitComponent):
 
     def setup(self):
         self.add_input('x', 0.5)
@@ -241,7 +235,7 @@ class ImplCompTwoStatesAE(ImplicitComponent):
 
         self.counter += 1
         if self.counter > 5 and self.counter < 11:
-            raise AnalysisError('catch me')
+            raise om.AnalysisError('catch me')
 
     def linearize(self, inputs, outputs, jac):
         """
@@ -268,25 +262,24 @@ class TestAnalysisErrorImplicit(unittest.TestCase):
 
     def test_deep_analysis_error_iprint(self):
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', 7.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 7.0))
 
-        sub = top.model.add_subsystem('sub', Group())
+        sub = top.model.add_subsystem('sub', om.Group())
         sub.add_subsystem('comp', ImplCompTwoStatesAE())
 
         top.model.connect('px.x', 'sub.comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 2
         top.model.nonlinear_solver.options['solve_subsystems'] = True
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        sub.nonlinear_solver = NewtonSolver()
+        sub.nonlinear_solver = om.NewtonSolver()
         sub.nonlinear_solver.options['maxiter'] = 2
-        sub.linear_solver = ScipyKrylov()
+        sub.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='wall')
         ls.options['maxiter'] = 5
         ls.options['alpha'] = 10.0
         ls.options['retry_on_analysis_error'] = True
@@ -318,25 +311,24 @@ class TestAnalysisErrorImplicit(unittest.TestCase):
         # this tests for a bug in which guess_nonlinear failed due to the output
         # vector being left in a read only state after the AnalysisError
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', 7.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 7.0))
 
-        sub = top.model.add_subsystem('sub', Group())
+        sub = top.model.add_subsystem('sub', om.Group())
         sub.add_subsystem('comp', ImplCompTwoStatesGuess())
 
         top.model.connect('px.x', 'sub.comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 2
         top.model.nonlinear_solver.options['solve_subsystems'] = True
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        sub.nonlinear_solver = NewtonSolver()
+        sub.nonlinear_solver = om.NewtonSolver()
         sub.nonlinear_solver.options['maxiter'] = 2
-        sub.linear_solver = ScipyKrylov()
+        sub.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='wall')
         ls.options['maxiter'] = 5
         ls.options['alpha'] = 10.0
         ls.options['retry_on_analysis_error'] = True
@@ -368,15 +360,14 @@ class TestAnalysisErrorImplicit(unittest.TestCase):
 class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
 
     def setUp(self):
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
         top.set_solver_print(level=0)
         top.setup()
@@ -387,7 +378,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
     def test_linesearch_vector_bound_enforcement(self):
         top = self.top
 
-        ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
+        ls = top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='vector')
         ls.options['print_bound_enforce'] = True
 
         # Setup again because we assigned a new linesearch
@@ -425,7 +416,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
     def test_linesearch_wall_bound_enforcement_wall(self):
         top = self.top
 
-        top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='wall')
+        top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='wall')
 
         # Setup again because we assigned a new linesearch
         top.setup()
@@ -449,7 +440,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
     def test_linesearch_wall_bound_enforcement_scalar(self):
         top = self.top
 
-        top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar')
+        top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='scalar')
 
         # Setup again because we assigned a new linesearch
         top.setup()
@@ -473,7 +464,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
     def test_error_handling(self):
         # Make sure the debug_print doesn't bomb out.
 
-        class Bad(ExplicitComponent):
+        class Bad(om.ExplicitComponent):
 
             def setup(self):
                 self.add_input('x', val=0.0)
@@ -501,18 +492,17 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
                 partials['f_xy', 'x'] = 2.0*x - 6.0 + y
                 partials['f_xy', 'y'] = 2.0*y + 8.0 + x
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', 1.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 1.0))
         top.model.add_subsystem('comp', ImplCompTwoStates())
         top.model.add_subsystem('par', Bad())
         top.model.connect('px.x', 'comp.x')
         top.model.connect('comp.z', 'par.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 3
 
-        top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
+        top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='vector')
         top.set_solver_print(level=0)
 
         top.setup()
@@ -526,25 +516,25 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         # atol, rtol, maxiter, and err_on_maxiter are not used in BoundsEnforceLS
 
         with self.assertRaises(KeyError) as context:
-            BoundsEnforceLS(bound_enforcement='scalar', atol=1.0)
+            om.BoundsEnforceLS(bound_enforcement='scalar', atol=1.0)
 
         self.assertEqual(str(context.exception), "\"Option 'atol' cannot be set because it "
                                                  "has not been declared.\"")
 
         with self.assertRaises(KeyError) as context:
-            BoundsEnforceLS(bound_enforcement='scalar', rtol=2.0)
+            om.BoundsEnforceLS(bound_enforcement='scalar', rtol=2.0)
 
         self.assertEqual(str(context.exception), "\"Option 'rtol' cannot be set because it "
                                                  "has not been declared.\"")
 
         with self.assertRaises(KeyError) as context:
-            BoundsEnforceLS(bound_enforcement='scalar', maxiter=1)
+            om.BoundsEnforceLS(bound_enforcement='scalar', maxiter=1)
 
         self.assertEqual(str(context.exception), "\"Option 'maxiter' cannot be set because it "
                                                  "has not been declared.\"")
 
         with self.assertRaises(KeyError) as context:
-            BoundsEnforceLS(bound_enforcement='scalar', err_on_maxiter=True)
+            om.BoundsEnforceLS(bound_enforcement='scalar', err_on_maxiter=True)
 
         self.assertEqual(str(context.exception), "\"Option 'err_on_maxiter' cannot be set because it "
                                                  "has not been declared.\"")
@@ -553,15 +543,14 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
 class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
 
     def setUp(self):
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
         top.set_solver_print(level=0)
         top.setup()
@@ -572,7 +561,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
     def test_linesearch_vector_bound_enforcement(self):
         top = self.top
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='vector')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
         ls.options['c'] = .1
 
         # Setup again because we assigned a new linesearch
@@ -597,7 +586,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
     def test_linesearch_wall_bound_enforcement_wall(self):
         top = self.top
 
-        top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
+        top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='wall')
 
         # Setup again because we assigned a new linesearch
         top.setup()
@@ -621,7 +610,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
     def test_linesearch_wall_bound_enforcement_scalar(self):
         top = self.top
 
-        top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='scalar')
+        top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='scalar')
 
         # Setup again because we assigned a new linesearch
         top.setup()
@@ -643,25 +632,25 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
             self.assertTrue(2.4 <= top['comp.z'][ind] <= self.ub[ind])
 
     def test_with_subsolves(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = DoubleSellar()
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver()
+        g1.nonlinear_solver = om.NewtonSolver()
         g1.nonlinear_solver.options['rtol'] = 1.0e-5
-        g1.linear_solver = DirectSolver()
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver()
+        g2.nonlinear_solver = om.NewtonSolver()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver()
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 4
-        ls = model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='vector')
+        ls = model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
 
         # This is pretty bogus, but it ensures that we get a few LS iterations.
         ls.options['c'] = 100.0
@@ -677,7 +666,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
 
-class CompAtan(ImplicitComponent):
+class CompAtan(om.ImplicitComponent):
     """
     A simple implicit component with the following equation:
 
@@ -716,14 +705,13 @@ class CompAtan(ImplicitComponent):
 class TestFeatureLineSearch(unittest.TestCase):
 
     def test_feature_specification(self):
-        from openmdao.api import Problem, IndepVarComp, NewtonSolver, BoundsEnforceLS
-        from openmdao.api import DirectSolver
+        import openmdao.api as om
         from openmdao.solvers.linesearch.tests.test_backtracking import CompAtan
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', -100.0))
+        model.add_subsystem('px', om.IndepVarComp('x', -100.0))
         model.add_subsystem('comp', CompAtan())
 
         model.connect('px.x', 'comp.x')
@@ -733,14 +721,14 @@ class TestFeatureLineSearch(unittest.TestCase):
         # Initial value for the state:
         prob['comp.y'] = 12.0
 
-        # You can change the NewtonSolver settings after setup is called
-        newton = prob.model.nonlinear_solver = NewtonSolver()
-        prob.model.linear_solver = DirectSolver()
+        # You can change the om.NewtonSolver settings after setup is called
+        newton = prob.model.nonlinear_solver = om.NewtonSolver()
+        prob.model.linear_solver = om.DirectSolver()
         newton.options['iprint'] = 2
         newton.options['rtol'] = 1e-8
         newton.options['solve_subsystems'] = True
 
-        newton.linesearch = BoundsEnforceLS()
+        newton.linesearch = om.BoundsEnforceLS()
         newton.linesearch.options['iprint'] = 2
 
         prob.run_model()
@@ -750,20 +738,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_boundsenforcels_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, BoundsEnforceLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        top.model.nonlinear_solver.linesearch = BoundsEnforceLS()
+        top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS()
 
         top.setup()
 
@@ -780,20 +767,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_armijogoldsteinls_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, ArmijoGoldsteinLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS()
+        top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS()
 
         top.setup()
 
@@ -810,20 +796,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_boundscheck_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, BoundsEnforceLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        top.model.nonlinear_solver.linesearch = BoundsEnforceLS()
+        top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS()
 
         top.setup()
 
@@ -840,20 +825,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_boundscheck_vector(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, BoundsEnforceLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
+        ls = top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='vector')
         ls.options['bound_enforcement'] = 'vector'
 
         top.setup()
@@ -871,20 +855,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_boundscheck_wall(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, BoundsEnforceLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='wall')
+        ls = top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='wall')
         ls.options['bound_enforcement'] = 'wall'
 
         top.setup()
@@ -902,20 +885,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_boundscheck_scalar(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, BoundsEnforceLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='scalar')
+        ls = top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='scalar')
         ls.options['bound_enforcement'] = 'scalar'
 
         top.setup()
@@ -934,20 +916,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_print_bound_enforce(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, BoundsEnforceLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        newt = top.model.nonlinear_solver = NewtonSolver()
+        newt = top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 2
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = newt.linesearch = BoundsEnforceLS(bound_enforcement='vector')
+        ls = newt.linesearch = om.BoundsEnforceLS(bound_enforcement='vector')
         ls.options['print_bound_enforce'] = True
 
         top.set_solver_print(level=2)
@@ -966,20 +947,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_armijo_boundscheck_vector(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, ArmijoGoldsteinLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='vector')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
         ls.options['bound_enforcement'] = 'vector'
 
         top.setup()
@@ -997,20 +977,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_armijo_boundscheck_wall(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, ArmijoGoldsteinLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='wall')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='wall')
         ls.options['bound_enforcement'] = 'wall'
 
         top.setup()
@@ -1028,20 +1007,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_armijo_boundscheck_scalar(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, ArmijoGoldsteinLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = ArmijoGoldsteinLS(bound_enforcement='scalar')
+        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='scalar')
         ls.options['bound_enforcement'] = 'scalar'
 
         top.setup()
@@ -1060,20 +1038,19 @@ class TestFeatureLineSearch(unittest.TestCase):
     def test_feature_armijo_print_bound_enforce(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, ArmijoGoldsteinLS
+        import openmdao.api as om
         from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays
 
-        top = Problem()
-        top.model = Group()
-        top.model.add_subsystem('px', IndepVarComp('x', np.ones((3, 1))))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', np.ones((3, 1))))
         top.model.add_subsystem('comp', ImplCompTwoStatesArrays())
         top.model.connect('px.x', 'comp.x')
 
-        newt = top.model.nonlinear_solver = NewtonSolver()
+        newt = top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 2
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
-        ls = newt.linesearch = ArmijoGoldsteinLS()
+        ls = newt.linesearch = om.ArmijoGoldsteinLS()
         ls.options['print_bound_enforce'] = True
 
         top.set_solver_print(level=2)

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -134,7 +134,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.options['state_vars'] = ['junk']
 
@@ -151,7 +151,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         with self.assertRaises(ValueError) as context:
             prob.run_model()
@@ -166,7 +166,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.options['state_vars'] = ['state_eq.y2_command']
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -183,7 +183,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarDerivatives(nonlinear_solver=BroydenSolver(),
                                                linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.options['state_vars'] = ['y1']
         model.nonlinear_solver.options['compute_jacobian'] = True
@@ -203,7 +203,7 @@ class TestBryoden(unittest.TestCase):
                                                    linear_solver=LinearRunOnce())
         prob.model.approx_totals(method='fd')
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.options['state_vars'] = ['state_eq.y2_command']
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -232,7 +232,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
 
@@ -254,7 +254,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
 
@@ -278,7 +278,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
 
-        prob.setup(check=False)
+        prob.setup()
 
         msg = "The following states are not covered by a solver, and may have been " \
               "omitted from the BroydenSolver 'state_vars': mixed.x3, mixed.x45"
@@ -300,7 +300,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
 
-        prob.setup(check=False)
+        prob.setup()
 
         msg = "The following states are not covered by a solver, and may have been " \
               "omitted from the BroydenSolver 'state_vars': x3, x45"
@@ -324,7 +324,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
 
@@ -348,7 +348,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.linear_solver = DirectSolver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
 
@@ -367,7 +367,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.options['state_vars'] = ['state_eq.y2_command']
         model.nonlinear_solver.linear_solver = DirectSolver(assemble_jac=False)
@@ -388,7 +388,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.linear_solver = DirectSolver(assemble_jac=True)
 
@@ -408,7 +408,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.options['assembled_jac_type'] = 'dense'
         model.nonlinear_solver.linear_solver = DirectSolver(assemble_jac=True)
@@ -429,7 +429,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.linear_solver = DirectSolver()
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -450,7 +450,7 @@ class TestBryoden(unittest.TestCase):
         model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
                                                    linear_solver=LinearRunOnce())
 
-        prob.setup(check=False)
+        prob.setup()
 
         model.nonlinear_solver.linear_solver = DirectSolver()
 
@@ -481,7 +481,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['diverge_limit'] = np.inf
         model.nonlinear_solver.linear_solver = DirectSolver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.set_solver_print(level=2)
         prob.run_model()
@@ -505,7 +505,7 @@ class TestBryoden(unittest.TestCase):
         model.nonlinear_solver.options['diverge_limit'] = 0.5
         model.nonlinear_solver.linear_solver = DirectSolver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.set_solver_print(level=2)
         prob.run_model()
@@ -525,11 +525,11 @@ class TestBryoden(unittest.TestCase):
 
         top.model.linear_solver = DirectSolver()
 
-        top.setup(check=False)
+        top.setup()
         top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
 
         # Setup again because we assigned a new linesearch
-        top.setup(check=False)
+        top.setup()
 
         top.set_solver_print(level=2)
         # Test lower bound: should go to the lower bound and stall

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -2,21 +2,18 @@
 from __future__ import print_function
 
 from six import iteritems
-
 import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, LinearRunOnce, ImplicitComponent, IndepVarComp, DirectSolver, \
-     BoundsEnforceLS, LinearBlockGS, Group, ExecComp
-from openmdao.solvers.nonlinear.broyden import BroydenSolver
+import openmdao.api as om
 from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStates
 from openmdao.test_suite.components.sellar import SellarStateConnection, SellarDerivatives, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 
 
-class VectorEquation(ImplicitComponent):
+class VectorEquation(om.ImplicitComponent):
     """Equation with 5 states in a single vector. Should converge to x=[0,0,0,0,0]"""
 
     def setup(self):
@@ -32,7 +29,7 @@ class VectorEquation(ImplicitComponent):
         residuals['x'] = -d*x - c*x**3
 
 
-class MixedEquation(ImplicitComponent):
+class MixedEquation(om.ImplicitComponent):
     """Equation with 5 states split between 3 vars. Should converge to x=[0,0,0,0,0]"""
 
     def setup(self):
@@ -75,7 +72,7 @@ class MixedEquation(ImplicitComponent):
         jacobian['x45', 'c'] = -3.0 * x45**2
 
 
-class SpedicatoHuang(ImplicitComponent):
+class SpedicatoHuang(om.ImplicitComponent):
 
     cite = """
            @article{spedicato_hwang,
@@ -130,9 +127,9 @@ class TestBryoden(unittest.TestCase):
     def test_error_badname(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
@@ -147,9 +144,9 @@ class TestBryoden(unittest.TestCase):
     def test_error_need_direct_solver(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
@@ -162,9 +159,9 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
@@ -179,9 +176,9 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar_cycle(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarDerivatives(nonlinear_solver=BroydenSolver(),
-                                               linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarDerivatives(nonlinear_solver=om.BroydenSolver(),
+                                               linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
@@ -198,9 +195,9 @@ class TestBryoden(unittest.TestCase):
     def test_sellar_state_connection_fd_system(self):
         # Sellar model closes loop with state connection instead of a cycle.
         # This test is just fd.
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
         prob.model.approx_totals(method='fd')
 
         prob.setup()
@@ -219,15 +216,15 @@ class TestBryoden(unittest.TestCase):
     def test_vector(self):
         # Testing Broyden on a 5 state single vector case.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('c', 0.01))
+        model.add_subsystem('p1', om.IndepVarComp('c', 0.01))
         model.add_subsystem('vec', VectorEquation())
 
         model.connect('p1.c', 'vec.c')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['vec.x']
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -241,15 +238,15 @@ class TestBryoden(unittest.TestCase):
     def test_mixed(self):
         # Testing Broyden on a 5 state case split among 3 vars.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('c', 0.01))
+        model.add_subsystem('p1', om.IndepVarComp('c', 0.01))
         model.add_subsystem('mixed', MixedEquation())
 
         model.connect('p1.c', 'mixed.c')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['mixed.x12', 'mixed.x3', 'mixed.x45']
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -265,15 +262,15 @@ class TestBryoden(unittest.TestCase):
     def test_missing_state_warning(self):
         # Testing Broyden on a 5 state case split among 3 vars.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('c', 0.01))
+        model.add_subsystem('p1', om.IndepVarComp('c', 0.01))
         model.add_subsystem('mixed', MixedEquation())
 
         model.connect('p1.c', 'mixed.c')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['mixed.x12']
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -287,15 +284,15 @@ class TestBryoden(unittest.TestCase):
             prob.run_model()
 
         # Try again with promoted names.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('c', 0.01))
+        model.add_subsystem('p1', om.IndepVarComp('c', 0.01))
         model.add_subsystem('mixed', MixedEquation(), promotes=['*'])
 
         model.connect('p1.c', 'c')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['x12']
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -311,15 +308,15 @@ class TestBryoden(unittest.TestCase):
     def test_mixed_promoted_vars(self):
         # Testing Broyden on a 5 state case split among 3 vars.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('c', 0.01))
+        model.add_subsystem('p1', om.IndepVarComp('c', 0.01))
         model.add_subsystem('mixed', MixedEquation(), promotes_outputs=['x12', 'x3', 'x45'])
 
         model.connect('p1.c', 'mixed.c')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['x12', 'x3', 'x45']
         model.nonlinear_solver.options['maxiter'] = 15
         model.nonlinear_solver.options['compute_jacobian'] = False
@@ -335,18 +332,18 @@ class TestBryoden(unittest.TestCase):
     def test_mixed_jacobian(self):
         # Testing Broyden on a 5 state case split among 3 vars.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('c', 0.01))
+        model.add_subsystem('p1', om.IndepVarComp('c', 0.01))
         model.add_subsystem('mixed', MixedEquation())
 
         model.connect('p1.c', 'mixed.c')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['mixed.x12', 'mixed.x3', 'mixed.x45']
         model.nonlinear_solver.options['maxiter'] = 15
-        model.nonlinear_solver.linear_solver = DirectSolver()
+        model.nonlinear_solver.linear_solver = om.DirectSolver()
 
         prob.setup()
 
@@ -363,14 +360,14 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar_jacobian(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
         model.nonlinear_solver.options['state_vars'] = ['state_eq.y2_command']
-        model.nonlinear_solver.linear_solver = DirectSolver(assemble_jac=False)
+        model.nonlinear_solver.linear_solver = om.DirectSolver(assemble_jac=False)
 
         prob.run_model()
 
@@ -384,13 +381,13 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar_jacobian_assembled(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
-        model.nonlinear_solver.linear_solver = DirectSolver(assemble_jac=True)
+        model.nonlinear_solver.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.run_model()
 
@@ -404,14 +401,14 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar_jacobian_assembled_dense(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
         model.options['assembled_jac_type'] = 'dense'
-        model.nonlinear_solver.linear_solver = DirectSolver(assemble_jac=True)
+        model.nonlinear_solver.linear_solver = om.DirectSolver(assemble_jac=True)
 
         prob.run_model()
 
@@ -425,13 +422,13 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar_full(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
-        model.nonlinear_solver.linear_solver = DirectSolver()
+        model.nonlinear_solver.linear_solver = om.DirectSolver()
         model.nonlinear_solver.options['compute_jacobian'] = False
 
         prob.run_model()
@@ -446,13 +443,13 @@ class TestBryoden(unittest.TestCase):
     def test_simple_sellar_full_jacobian(self):
         # Test top level Sellar (i.e., not grouped).
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
-        model.nonlinear_solver.linear_solver = DirectSolver()
+        model.nonlinear_solver.linear_solver = om.DirectSolver()
 
         prob.run_model()
 
@@ -466,20 +463,20 @@ class TestBryoden(unittest.TestCase):
     def test_jacobian_update_converge_limit(self):
         # This model needs jacobian updates to converge.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', np.array([0, 20.0])))
+        model.add_subsystem('p1', om.IndepVarComp('x', np.array([0, 20.0])))
         model.add_subsystem('comp', SpedicatoHuang())
 
         model.connect('p1.x', 'comp.x')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['comp.y']
         model.nonlinear_solver.options['maxiter'] = 20
         model.nonlinear_solver.options['max_converge_failures'] = 1
         model.nonlinear_solver.options['diverge_limit'] = np.inf
-        model.nonlinear_solver.linear_solver = DirectSolver()
+        model.nonlinear_solver.linear_solver = om.DirectSolver()
 
         prob.setup()
 
@@ -491,19 +488,19 @@ class TestBryoden(unittest.TestCase):
     def test_jacobian_update_diverge_limit(self):
         # This model needs jacobian updates to converge.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', np.array([0, 20.0])))
+        model.add_subsystem('p1', om.IndepVarComp('x', np.array([0, 20.0])))
         model.add_subsystem('comp', SpedicatoHuang())
 
         model.connect('p1.x', 'comp.x')
 
-        model.nonlinear_solver = BroydenSolver()
+        model.nonlinear_solver = om.BroydenSolver()
         model.nonlinear_solver.options['state_vars'] = ['comp.y']
         model.nonlinear_solver.options['maxiter'] = 20
         model.nonlinear_solver.options['diverge_limit'] = 0.5
-        model.nonlinear_solver.linear_solver = DirectSolver()
+        model.nonlinear_solver.linear_solver = om.DirectSolver()
 
         prob.setup()
 
@@ -513,20 +510,20 @@ class TestBryoden(unittest.TestCase):
         assert_rel_error(self, prob['comp.y'], np.array([-36.26230985,  10.20857237, -54.17658612]), 1e-6)
 
     def test_backtracking(self):
-        top = Problem()
-        top.model.add_subsystem('px', IndepVarComp('x', 1.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 1.0))
         top.model.add_subsystem('comp', ImplCompTwoStates())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = BroydenSolver()
+        top.model.nonlinear_solver = om.BroydenSolver()
         top.model.nonlinear_solver.options['maxiter'] = 25
         top.model.nonlinear_solver.options['diverge_limit'] = 0.5
         top.model.nonlinear_solver.options['state_vars'] = ['comp.y', 'comp.z']
 
-        top.model.linear_solver = DirectSolver()
+        top.model.linear_solver = om.DirectSolver()
 
         top.setup()
-        top.model.nonlinear_solver.linesearch = BoundsEnforceLS(bound_enforcement='vector')
+        top.model.nonlinear_solver.linesearch = om.BoundsEnforceLS(bound_enforcement='vector')
 
         # Setup again because we assigned a new linesearch
         top.setup()
@@ -549,26 +546,28 @@ class TestBryoden(unittest.TestCase):
     def test_cs_around_broyden(self):
         # Basic sellar test.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        sub = model.add_subsystem('sub', Group(), promotes=['*'])
+        sub = model.add_subsystem('sub', om.Group(), promotes=['*'])
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'),
+                            promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'),
+                            promotes=['con2', 'y2'])
 
-        sub.nonlinear_solver = BroydenSolver()
-        sub.linear_solver = DirectSolver()
-        model.linear_solver = DirectSolver()
+        sub.nonlinear_solver = om.BroydenSolver()
+        sub.linear_solver = om.DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -589,26 +588,26 @@ class TestBryoden(unittest.TestCase):
     def test_cs_around_broyden_compute_jac(self):
         # Basic sellar test.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        sub = model.add_subsystem('sub', Group(), promotes=['*'])
+        sub = model.add_subsystem('sub', om.Group(), promotes=['*'])
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        sub.nonlinear_solver = BroydenSolver()
-        sub.linear_solver = DirectSolver(assemble_jac=False)
-        model.linear_solver = DirectSolver(assemble_jac=False)
+        sub.nonlinear_solver = om.BroydenSolver()
+        sub.linear_solver = om.DirectSolver(assemble_jac=False)
+        model.linear_solver = om.DirectSolver(assemble_jac=False)
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -631,26 +630,26 @@ class TestBryoden(unittest.TestCase):
     def test_cs_around_broyden_compute_jac_dense(self):
         # Basic sellar test.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        sub = model.add_subsystem('sub', Group(), promotes=['*'])
+        sub = model.add_subsystem('sub', om.Group(), promotes=['*'])
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         sub.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        sub.nonlinear_solver = BroydenSolver()
-        sub.linear_solver = DirectSolver()
-        model.linear_solver = DirectSolver()
+        sub.nonlinear_solver = om.BroydenSolver()
+        sub.linear_solver = om.DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
         prob.model.add_design_var('x', lower=-100, upper=100)
         prob.model.add_design_var('z', lower=-100, upper=100)
@@ -674,12 +673,12 @@ class TestBryoden(unittest.TestCase):
 class TestBryodenFeature(unittest.TestCase):
 
     def test_sellar(self):
-        from openmdao.api import Problem, LinearRunOnce, IndepVarComp, BroydenSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarStateConnection
 
-        prob = Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=BroydenSolver(),
-                                                   linear_solver=LinearRunOnce())
+        prob = om.Problem()
+        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                                   linear_solver=om.LinearRunOnce())
 
         prob.setup()
 
@@ -693,15 +692,14 @@ class TestBryodenFeature(unittest.TestCase):
         assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
 
     def test_circuit(self):
-        from openmdao.api import Group, BroydenSolver, DirectSolver, Problem, IndepVarComp, LinearBlockGS
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -709,14 +707,14 @@ class TestBryodenFeature(unittest.TestCase):
 
         p.setup()
 
-        # Replace existing solver with BroydenSolver
-        model.circuit.nonlinear_solver = BroydenSolver()
+        # Replace existing solver with om.BroydenSolver
+        model.circuit.nonlinear_solver = om.BroydenSolver()
         model.circuit.nonlinear_solver.options['maxiter'] = 20
 
         # Specify states for Broyden to solve
         model.circuit.nonlinear_solver.options['state_vars'] = ['n1.V', 'n2.V']
 
-        model.nonlinear_solver.linear_solver = LinearBlockGS()
+        model.nonlinear_solver.linear_solver = om.LinearBlockGS()
 
         # set some initial guesses
         p['circuit.n1.V'] = 10.
@@ -732,15 +730,14 @@ class TestBryodenFeature(unittest.TestCase):
         assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_options(self):
-        from openmdao.api import Group, BroydenSolver, DirectSolver, Problem, IndepVarComp
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -749,7 +746,7 @@ class TestBryodenFeature(unittest.TestCase):
         p.setup()
 
         # Replace existing solver with BroydenSolver
-        model.circuit.nonlinear_solver = BroydenSolver()
+        model.circuit.nonlinear_solver = om.BroydenSolver()
         model.circuit.nonlinear_solver.options['maxiter'] = 20
         model.circuit.nonlinear_solver.options['converge_limit'] = 0.1
         model.circuit.nonlinear_solver.options['max_converge_failures'] = 1
@@ -771,15 +768,14 @@ class TestBryodenFeature(unittest.TestCase):
         assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_full(self):
-        from openmdao.api import Group, BroydenSolver, DirectSolver, Problem, IndepVarComp
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -788,9 +784,9 @@ class TestBryodenFeature(unittest.TestCase):
         p.setup()
 
         # Replace existing solver with BroydenSolver
-        model.circuit.nonlinear_solver = BroydenSolver()
+        model.circuit.nonlinear_solver = om.BroydenSolver()
         model.circuit.nonlinear_solver.options['maxiter'] = 20
-        model.circuit.nonlinear_solver.linear_solver = DirectSolver()
+        model.circuit.nonlinear_solver.linear_solver = om.DirectSolver()
 
         # set some initial guesses
         p['circuit.n1.V'] = 10.
@@ -804,6 +800,7 @@ class TestBryodenFeature(unittest.TestCase):
 
         # sanity check: should sum to .1 Amps
         assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -45,7 +45,7 @@ class TestNewton(unittest.TestCase):
 
         prob = Problem(model=SellarDerivatives(nonlinear_solver=NewtonSolver()))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)
@@ -56,7 +56,7 @@ class TestNewton(unittest.TestCase):
 
         prob = Problem(model=SellarDerivativesGrouped(nonlinear_solver=NewtonSolver()))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -71,7 +71,7 @@ class TestNewton(unittest.TestCase):
 
         prob = Problem(model=SellarNoDerivatives(nonlinear_solver=NewtonSolver()))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)
@@ -102,7 +102,7 @@ class TestNewton(unittest.TestCase):
         ls.options['maxiter'] = 10
         ls.options['alpha'] = 1.0
 
-        top.setup(check=False)
+        top.setup()
 
         # Test lower bound: should go to the lower bound and stall
         top['px.x'] = 2.0
@@ -126,7 +126,7 @@ class TestNewton(unittest.TestCase):
         prob = Problem()
         prob.model = SellarDerivatives(nonlinear_solver=NewtonSolver(), linear_solver=LinearBlockGS())
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -148,7 +148,7 @@ class TestNewton(unittest.TestCase):
 
         prob = Problem(model=SellarDerivatives(nonlinear_solver=NewtonSolver()))
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -164,7 +164,7 @@ class TestNewton(unittest.TestCase):
         prob = Problem(model=SellarStateConnection(nonlinear_solver=NewtonSolver()))
 
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)
@@ -180,7 +180,7 @@ class TestNewton(unittest.TestCase):
 
         prob.model.approx_totals(method='fd')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -233,7 +233,7 @@ class TestNewton(unittest.TestCase):
         model.nonlinear_solver.linear_solver = ScipyKrylov()
 
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)
@@ -287,7 +287,7 @@ class TestNewton(unittest.TestCase):
         model.nonlinear_solver.linear_solver = DirectSolver()
 
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)
@@ -744,7 +744,7 @@ class TestNewton(unittest.TestCase):
         nlsolver.options['err_on_maxiter'] = True
         nlsolver.options['maxiter'] = 1
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         with self.assertRaises(AnalysisError) as context:
@@ -789,7 +789,7 @@ class TestNewton(unittest.TestCase):
         model.nonlinear_solver = NewtonSolver()
         model.linear_solver = ScipyKrylov()
 
-        prob.setup(check=False)
+        prob.setup()
 
         prob.run_model()
 

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -4,11 +4,8 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Group, Problem, IndepVarComp, LinearBlockGS, \
-    NewtonSolver, ExecComp, ScipyKrylov, ImplicitComponent, \
-    DirectSolver, AnalysisError
+import openmdao.api as om
 from openmdao.core.tests.test_discrete import InternalDiscreteGroup
-from openmdao.solvers.linesearch.backtracking import ArmijoGoldsteinLS
 from openmdao.test_suite.components.double_sellar import DoubleSellar, DoubleSellarImplicit, \
      SubSellar
 from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStates
@@ -22,14 +19,14 @@ class TestNewton(unittest.TestCase):
 
     def test_specify_newton_linear_solver_in_system(self):
 
-        my_newton = NewtonSolver()
-        my_newton.linear_solver = DirectSolver()
+        my_newton = om.NewtonSolver()
+        my_newton.linear_solver = om.DirectSolver()
 
-        prob = Problem(model=SellarDerivatives(nonlinear_solver=my_newton))
+        prob = om.Problem(model=SellarDerivatives(nonlinear_solver=my_newton))
 
         prob.setup()
 
-        self.assertIsInstance(prob.model.nonlinear_solver.linear_solver, DirectSolver)
+        self.assertIsInstance(prob.model.nonlinear_solver.linear_solver, om.DirectSolver)
 
         prob.run_model()
 
@@ -40,10 +37,10 @@ class TestNewton(unittest.TestCase):
         """ Feature test for slotting a Newton solver and using it to solve
         Sellar.
         """
-        from openmdao.api import Problem, NewtonSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem(model=SellarDerivatives(nonlinear_solver=NewtonSolver()))
+        prob = om.Problem(model=SellarDerivatives(nonlinear_solver=om.NewtonSolver()))
 
         prob.setup()
         prob.run_model()
@@ -54,7 +51,7 @@ class TestNewton(unittest.TestCase):
     def test_sellar_grouped(self):
         # Tests basic Newton solution on Sellar in a subgroup
 
-        prob = Problem(model=SellarDerivativesGrouped(nonlinear_solver=NewtonSolver()))
+        prob = om.Problem(model=SellarDerivativesGrouped(nonlinear_solver=om.NewtonSolver()))
 
         prob.setup()
         prob.set_solver_print(level=0)
@@ -69,7 +66,7 @@ class TestNewton(unittest.TestCase):
     def test_sellar(self):
         # Just tests Newton on Sellar with FD derivs.
 
-        prob = Problem(model=SellarNoDerivatives(nonlinear_solver=NewtonSolver()))
+        prob = om.Problem(model=SellarNoDerivatives(nonlinear_solver=om.NewtonSolver()))
 
         prob.setup()
         prob.run_model()
@@ -81,20 +78,20 @@ class TestNewton(unittest.TestCase):
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
 
     def test_line_search_deprecated(self):
-        top = Problem()
-        top.model.add_subsystem('px', IndepVarComp('x', 1.0))
+        top = om.Problem()
+        top.model.add_subsystem('px', om.IndepVarComp('x', 1.0))
         top.model.add_subsystem('comp', ImplCompTwoStates())
         top.model.connect('px.x', 'comp.x')
 
-        top.model.nonlinear_solver = NewtonSolver()
+        top.model.nonlinear_solver = om.NewtonSolver()
         top.model.nonlinear_solver.options['maxiter'] = 10
-        top.model.linear_solver = ScipyKrylov()
+        top.model.linear_solver = om.ScipyKrylov()
 
         msg = "The 'line_search' attribute provides backwards compatibility with OpenMDAO 1.x ; " \
               "use 'linesearch' instead."
 
         with assert_warning(DeprecationWarning, msg):
-            top.model.nonlinear_solver.line_search = ArmijoGoldsteinLS(bound_enforcement='vector')
+            top.model.nonlinear_solver.line_search = om.ArmijoGoldsteinLS(bound_enforcement='vector')
 
         with assert_warning(DeprecationWarning, msg):
             ls = top.model.nonlinear_solver.line_search
@@ -123,8 +120,9 @@ class TestNewton(unittest.TestCase):
         # Also, piggybacked testing that makes sure we only call apply_nonlinear
         # on the head component behind the cycle break.
 
-        prob = Problem()
-        prob.model = SellarDerivatives(nonlinear_solver=NewtonSolver(), linear_solver=LinearBlockGS())
+        prob = om.Problem()
+        prob.model = SellarDerivatives(nonlinear_solver=om.NewtonSolver(),
+                                       linear_solver=om.LinearBlockGS())
 
         prob.setup()
         prob.set_solver_print(level=0)
@@ -146,7 +144,7 @@ class TestNewton(unittest.TestCase):
 
     def test_sellar_derivs_with_Lin_GS(self):
 
-        prob = Problem(model=SellarDerivatives(nonlinear_solver=NewtonSolver()))
+        prob = om.Problem(model=SellarDerivatives(nonlinear_solver=om.NewtonSolver()))
 
         prob.setup()
         prob.set_solver_print(level=0)
@@ -161,7 +159,7 @@ class TestNewton(unittest.TestCase):
     def test_sellar_state_connection(self):
         # Sellar model closes loop with state connection instead of a cycle.
 
-        prob = Problem(model=SellarStateConnection(nonlinear_solver=NewtonSolver()))
+        prob = om.Problem(model=SellarStateConnection(nonlinear_solver=om.NewtonSolver()))
 
         prob.set_solver_print(level=0)
         prob.setup()
@@ -176,7 +174,7 @@ class TestNewton(unittest.TestCase):
     def test_sellar_state_connection_fd_system(self):
         # Sellar model closes loop with state connection instead of a cycle.
         # This test is just fd.
-        prob = Problem(model=SellarStateConnection(nonlinear_solver=NewtonSolver()))
+        prob = om.Problem(model=SellarStateConnection(nonlinear_solver=om.NewtonSolver()))
 
         prob.model.approx_totals(method='fd')
 
@@ -192,18 +190,18 @@ class TestNewton(unittest.TestCase):
 
     def test_sellar_specify_linear_solver(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         proms = ['x', 'z', 'y1', 'state_eq.y2_actual', 'state_eq.y2_command', 'd1.y2', 'd2.y2']
-        sub = model.add_subsystem('sub', Group(), promotes=proms)
+        sub = model.add_subsystem('sub', om.Group(), promotes=proms)
 
-        subgrp = sub.add_subsystem('state_eq_group', Group(),
+        subgrp = sub.add_subsystem('state_eq_group', om.Group(),
                                    promotes=['state_eq.y2_actual', 'state_eq.y2_command'])
-        subgrp.linear_solver = ScipyKrylov()
+        subgrp.linear_solver = om.ScipyKrylov()
         subgrp.add_subsystem('state_eq', StateConnection())
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1'])
@@ -212,25 +210,25 @@ class TestNewton(unittest.TestCase):
         model.connect('state_eq.y2_command', 'd1.y2')
         model.connect('d2.y2', 'state_eq.y2_actual')
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                z=np.array([0.0, 0.0]), x=0.0, y1=0.0, y2=0.0),
                            promotes=['x', 'z', 'y1', 'obj'])
         model.connect('d2.y2', 'obj_cmp.y2')
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
         model.connect('d2.y2', 'con_cmp2.y2')
 
-        model.nonlinear_solver = NewtonSolver()
+        model.nonlinear_solver = om.NewtonSolver()
 
         # Use bad settings for this one so that problem doesn't converge.
         # That way, we test that we are really using Newton's Lin Solver
         # instead.
-        model.linear_solver = ScipyKrylov()
+        model.linear_solver = om.ScipyKrylov()
         model.linear_solver.options['maxiter'] = 1
 
         # The good solver
-        model.nonlinear_solver.linear_solver = ScipyKrylov()
+        model.nonlinear_solver.linear_solver = om.ScipyKrylov()
 
         prob.set_solver_print(level=0)
         prob.setup()
@@ -246,18 +244,18 @@ class TestNewton(unittest.TestCase):
 
     def test_sellar_specify_linear_direct_solver(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         proms = ['x', 'z', 'y1', 'state_eq.y2_actual', 'state_eq.y2_command', 'd1.y2', 'd2.y2']
-        sub = model.add_subsystem('sub', Group(), promotes=proms)
+        sub = model.add_subsystem('sub', om.Group(), promotes=proms)
 
-        subgrp = sub.add_subsystem('state_eq_group', Group(),
+        subgrp = sub.add_subsystem('state_eq_group', om.Group(),
                                    promotes=['state_eq.y2_actual', 'state_eq.y2_command'])
-        subgrp.linear_solver = ScipyKrylov()
+        subgrp.linear_solver = om.ScipyKrylov()
         subgrp.add_subsystem('state_eq', StateConnection())
 
         sub.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1'])
@@ -266,25 +264,25 @@ class TestNewton(unittest.TestCase):
         model.connect('state_eq.y2_command', 'd1.y2')
         model.connect('d2.y2', 'state_eq.y2_actual')
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                z=np.array([0.0, 0.0]), x=0.0, y1=0.0, y2=0.0),
                            promotes=['x', 'z', 'y1', 'obj'])
         model.connect('d2.y2', 'obj_cmp.y2')
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2'])
         model.connect('d2.y2', 'con_cmp2.y2')
 
-        model.nonlinear_solver = NewtonSolver()
+        model.nonlinear_solver = om.NewtonSolver()
 
         # Use bad settings for this one so that problem doesn't converge.
         # That way, we test that we are really using Newton's Lin Solver
         # instead.
-        sub.linear_solver = ScipyKrylov()
+        sub.linear_solver = om.ScipyKrylov()
         sub.linear_solver.options['maxiter'] = 1
 
         # The good solver
-        model.nonlinear_solver.linear_solver = DirectSolver()
+        model.nonlinear_solver.linear_solver = om.DirectSolver()
 
         prob.set_solver_print(level=0)
         prob.setup()
@@ -298,23 +296,23 @@ class TestNewton(unittest.TestCase):
         self.assertEqual(model.linear_solver._iter_count, 0)
 
     def test_solve_subsystems_basic(self):
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver()
+        g1.nonlinear_solver = om.NewtonSolver()
         g1.nonlinear_solver.options['rtol'] = 1.0e-5
-        g1.linear_solver = DirectSolver(assemble_jac=True)
+        g1.linear_solver = om.DirectSolver(assemble_jac=True)
         g1.options['assembled_jac_type'] = 'dense'
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver()
+        g2.nonlinear_solver = om.NewtonSolver()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver(assemble_jac=True)
+        g2.linear_solver = om.DirectSolver(assemble_jac=True)
         g2.options['assembled_jac_type'] = 'dense'
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         model.nonlinear_solver.options['solve_subsystems'] = True
@@ -328,21 +326,21 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_csc(self):
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
         g1.options['assembled_jac_type'] = 'dense'
-        g1.linear_solver = DirectSolver(assemble_jac=True)
+        g1.linear_solver = om.DirectSolver(assemble_jac=True)
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver(assemble_jac=True)
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver(assemble_jac=True)
         g2.options['assembled_jac_type'] = 'dense'
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
 
         prob.setup()
         prob.run_model()
@@ -353,19 +351,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_dense_jac(self):
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -377,19 +375,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_dense_jac_scaling(self):
-        prob = Problem(model=DoubleSellar(units=None, scaling=True))
+        prob = om.Problem(model=DoubleSellar(units=None, scaling=True))
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -401,19 +399,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_dense_jac_units_scaling(self):
-        prob = Problem(model=DoubleSellar(units=True, scaling=True))
+        prob = om.Problem(model=DoubleSellar(units=True, scaling=True))
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -425,19 +423,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top(self):
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -449,19 +447,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_csc(self):
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
 
         prob.setup()
         prob.run_model()
@@ -472,19 +470,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_implicit(self):
-        prob = Problem(model=DoubleSellarImplicit())
+        prob = om.Problem(model=DoubleSellarImplicit())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -496,19 +494,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_implicit_scaling(self):
-        prob = Problem(model=DoubleSellarImplicit(scaling=True))
+        prob = om.Problem(model=DoubleSellarImplicit(scaling=True))
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -520,19 +518,19 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_implicit_scaling_units(self):
-        prob = Problem(model=DoubleSellarImplicit(units=True, scaling=True))
+        prob = om.Problem(model=DoubleSellarImplicit(units=True, scaling=True))
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver()
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver(solve_subsystems=True)
-        model.linear_solver = ScipyKrylov(assemble_jac=True)
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         prob.setup()
@@ -544,20 +542,20 @@ class TestNewton(unittest.TestCase):
         assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_subgroup(self):
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g1.linear_solver = DirectSolver(assemble_jac=True)
+        g1.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g1.linear_solver = om.DirectSolver(assemble_jac=True)
         model.options['assembled_jac_type'] = 'dense'
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver(rtol=1.0e-5)
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver(rtol=1.0e-5)
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         prob.setup()
         prob.run_model()
@@ -571,7 +569,7 @@ class TestNewton(unittest.TestCase):
         # Here we test that this feature is doing what it should do by counting the
         # number of calls in various places.
 
-        class CountNewton(NewtonSolver):
+        class CountNewton(om.NewtonSolver):
             """ This version of Newton also counts how many times it runs in total."""
 
             def __init__(self, **kwargs):
@@ -582,7 +580,7 @@ class TestNewton(unittest.TestCase):
                 super(CountNewton, self)._single_iteration()
                 self.total_count += 1
 
-        class CountDS(DirectSolver):
+        class CountDS(om.DirectSolver):
             """ This version of Newton also counts how many times it linearizes"""
 
             def __init__(self, **kwargs):
@@ -593,7 +591,7 @@ class TestNewton(unittest.TestCase):
                 super(CountDS, self)._linearize()
                 self.lin_count += 1
 
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         # each SubSellar group converges itself
@@ -605,11 +603,11 @@ class TestNewton(unittest.TestCase):
         g2 = model.g2
         g2.nonlinear_solver = CountNewton()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver()
+        g2.linear_solver = om.DirectSolver()
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         # Enfore behavior: max_sub_solves = 0 means we run once during init
 
@@ -626,7 +624,7 @@ class TestNewton(unittest.TestCase):
         self.assertEqual(g2.nonlinear_solver.total_count, 2)
         self.assertEqual(g1.linear_solver.lin_count, 2)
 
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         # each SubSellar group converges itself
@@ -638,11 +636,11 @@ class TestNewton(unittest.TestCase):
         g2 = model.g2
         g2.nonlinear_solver = CountNewton()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver()
+        g2.linear_solver = om.DirectSolver()
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         # Enforce Behavior: baseline
 
@@ -659,7 +657,7 @@ class TestNewton(unittest.TestCase):
         self.assertEqual(g2.nonlinear_solver.total_count, 5)
         self.assertEqual(g1.linear_solver.lin_count, 5)
 
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         # each SubSellar group converges itself
@@ -671,11 +669,11 @@ class TestNewton(unittest.TestCase):
         g2 = model.g2
         g2.nonlinear_solver = CountNewton()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver()
+        g2.linear_solver = om.DirectSolver()
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         # Enfore behavior: max_sub_solves = 1 means we run during init and first iteration of iter_execute
 
@@ -696,7 +694,7 @@ class TestNewton(unittest.TestCase):
         # Fix bug when maxiter was set to 1.
         # This bug caused linearize to run before apply in this case.
 
-        class ImpComp(ImplicitComponent):
+        class ImpComp(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('a', val=1.)
@@ -721,13 +719,13 @@ class TestNewton(unittest.TestCase):
                 if not self.applied:
                     raise RuntimeError("Bug! Linearize called before Apply!")
 
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
-        root.add_subsystem('p1', IndepVarComp('a', 1.0))
+        root.add_subsystem('p1', om.IndepVarComp('a', 1.0))
         root.add_subsystem('comp', ImpComp())
         root.connect('p1.a', 'comp.a')
 
-        root.nonlinear_solver = NewtonSolver()
+        root.nonlinear_solver = om.NewtonSolver()
         root.nonlinear_solver.options['maxiter'] = 1
         prob.set_solver_print(level=0)
 
@@ -737,9 +735,10 @@ class TestNewton(unittest.TestCase):
     def test_err_on_maxiter(self):
         # Raise AnalysisError when it fails to converge
 
-        prob = Problem()
-        nlsolver = NewtonSolver()
-        prob.model = SellarDerivatives(nonlinear_solver=nlsolver, linear_solver=LinearBlockGS())
+        prob = om.Problem()
+        nlsolver = om.NewtonSolver()
+        prob.model = SellarDerivatives(nonlinear_solver=nlsolver,
+                                       linear_solver=om.LinearBlockGS())
 
         nlsolver.options['err_on_maxiter'] = True
         nlsolver.options['maxiter'] = 1
@@ -747,7 +746,7 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.set_solver_print(level=0)
 
-        with self.assertRaises(AnalysisError) as context:
+        with self.assertRaises(om.AnalysisError) as context:
             prob.run_driver()
 
         msg = "Solver 'NL: Newton' on system '' failed to converge in 1 iterations."
@@ -755,7 +754,7 @@ class TestNewton(unittest.TestCase):
 
     def test_relevancy_for_newton(self):
 
-        class TestImplCompSimple(ImplicitComponent):
+        class TestImplCompSimple(om.ImplicitComponent):
 
             def setup(self):
                 self.add_input('a', val=1.)
@@ -773,12 +772,12 @@ class TestNewton(unittest.TestCase):
                 jacobian['x', 'a'] = -2 * inputs['a'] * outputs['x']**2
 
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
         model.add_subsystem('icomp', TestImplCompSimple())
-        model.add_subsystem('ecomp', ExecComp('y = x*p', p=1.0))
+        model.add_subsystem('ecomp', om.ExecComp('y = x*p', p=1.0))
 
         model.connect('p1.x', 'ecomp.x')
         model.connect('icomp.x', 'ecomp.p')
@@ -786,8 +785,8 @@ class TestNewton(unittest.TestCase):
         model.add_design_var('p1.x', 3.0)
         model.add_objective('ecomp.y')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         prob.setup()
 
@@ -802,28 +801,28 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, NewtonSolver, LinearBlockGS, ExecComp, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver()
+        model.nonlinear_solver = om.NewtonSolver()
 
         prob.setup()
 
@@ -835,28 +834,28 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, LinearBlockGS, ExecComp, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
-        nlgbs = model.nonlinear_solver = NewtonSolver()
+        nlgbs = model.nonlinear_solver = om.NewtonSolver()
         nlgbs.options['maxiter'] = 2
 
         prob.setup()
@@ -869,28 +868,28 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_rtol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, LinearBlockGS, ExecComp, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
-        nlgbs = model.nonlinear_solver = NewtonSolver()
+        nlgbs = model.nonlinear_solver = om.NewtonSolver()
         nlgbs.options['rtol'] = 1e-3
 
         prob.setup()
@@ -903,28 +902,28 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, LinearBlockGS, ExecComp, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
-        nlgbs = model.nonlinear_solver = NewtonSolver()
+        nlgbs = model.nonlinear_solver = om.NewtonSolver()
         nlgbs.options['atol'] = 1e-4
 
         prob.setup()
@@ -937,32 +936,31 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_linear_solver(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, LinearBlockGS, \
-             ExecComp, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, \
              SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
-        nlgbs = model.nonlinear_solver = NewtonSolver()
+        nlgbs = model.nonlinear_solver = om.NewtonSolver()
 
-        nlgbs.linear_solver = DirectSolver()
+        nlgbs.linear_solver = om.DirectSolver()
 
         prob.setup()
 
@@ -974,10 +972,10 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_max_sub_solves(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, LinearBlockGS, ExecComp, DirectSolver, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.double_sellar import SubSellar
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
         model.add_subsystem('g1', SubSellar())
@@ -987,21 +985,21 @@ class TestNewtonFeatures(unittest.TestCase):
         model.connect('g2.y2', 'g1.x')
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = DirectSolver()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.DirectSolver()
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver()
+        g1.nonlinear_solver = om.NewtonSolver()
         g1.nonlinear_solver.options['rtol'] = 1.0e-5
-        g1.linear_solver = DirectSolver()
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver()
+        g2.nonlinear_solver = om.NewtonSolver()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver()
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
@@ -1012,29 +1010,28 @@ class TestNewtonFeatures(unittest.TestCase):
     def test_feature_err_on_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, LinearBlockGS, \
-                                 ExecComp, AnalysisError, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                 z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
-        nlgbs = model.nonlinear_solver = NewtonSolver()
+        nlgbs = model.nonlinear_solver = om.NewtonSolver()
         nlgbs.options['maxiter'] = 1
         nlgbs.options['err_on_maxiter'] = True
 
@@ -1042,28 +1039,28 @@ class TestNewtonFeatures(unittest.TestCase):
 
         try:
             prob.run_model()
-        except AnalysisError:
+        except om.AnalysisError:
             pass
 
     def test_solve_subsystems_basic(self):
-        from openmdao.api import Problem, NewtonSolver, DirectSolver, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.double_sellar import DoubleSellar
 
-        prob = Problem(model=DoubleSellar())
+        prob = om.Problem(model=DoubleSellar())
         model = prob.model
 
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver()
+        g1.nonlinear_solver = om.NewtonSolver()
         g1.nonlinear_solver.options['rtol'] = 1.0e-5
-        g1.linear_solver = DirectSolver()
+        g1.linear_solver = om.DirectSolver()
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver()
+        g2.nonlinear_solver = om.NewtonSolver()
         g2.nonlinear_solver.options['rtol'] = 1.0e-5
-        g2.linear_solver = DirectSolver()
+        g2.linear_solver = om.DirectSolver()
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
 
         model.nonlinear_solver.options['solve_subsystems'] = True
 

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
@@ -4,8 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, NonlinearBlockGS, Group, ScipyKrylov, IndepVarComp, \
-    ExecComp, AnalysisError
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives, \
@@ -17,26 +16,26 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_feature_set_options(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
 
         nlgbs.options['maxiter'] = 20
         nlgbs.options['atol'] = 1e-6
@@ -52,26 +51,26 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_feature_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
 
@@ -83,26 +82,26 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_feature_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
         nlgbs.options['maxiter'] = 2
 
         prob.setup()
@@ -115,26 +114,26 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_feature_rtol(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives, SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
         nlgbs.options['rtol'] = 1e-3
 
         prob.setup()
@@ -147,26 +146,26 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_feature_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp, ExecComp, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
         nlgbs.options['atol'] = 1e-4
 
         prob.setup()
@@ -179,23 +178,23 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_sellar(self):
         # Basic sellar test.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
         prob.set_solver_print(level=0)
@@ -212,23 +211,23 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         # With run_apply_linear, we execute the components more times.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                    z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                                 promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
         nlgbs.options['use_apply_nonlinear'] = True
 
         prob.setup()
@@ -247,23 +246,23 @@ class TestNLBGaussSeidel(unittest.TestCase):
     def test_sellar_analysis_error(self):
         # Tests Sellar behavior when AnalysisError is raised.
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockGS()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockGS()
         nlgbs.options['maxiter'] = 2
         nlgbs.options['err_on_maxiter'] = True
 
@@ -272,7 +271,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         try:
             prob.run_model()
-        except AnalysisError as err:
+        except om.AnalysisError as err:
             self.assertEqual(str(err), "Solver 'NL: NLBGS' on system '' failed to converge in 2 iterations.")
         else:
             self.fail("expected AnalysisError")
@@ -282,7 +281,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
         # solver couples them together through variable x.
 
         # This version has the indepvarcomps removed so we can connect them together.
-        class SellarModified(Group):
+        class SellarModified(om.Group):
             """ Group containing the Sellar MDA. This version uses the disciplines
             with derivatives."""
 
@@ -292,12 +291,12 @@ class TestNLBGaussSeidel(unittest.TestCase):
                 self.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
                 self.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-                self.nonlinear_solver = NonlinearBlockGS()
-                self.linear_solver = ScipyKrylov()
+                self.nonlinear_solver = om.NonlinearBlockGS()
+                self.linear_solver = om.ScipyKrylov()
 
-        prob = Problem()
+        prob = om.Problem()
         root = prob.model
-        root.nonlinear_solver = NonlinearBlockGS()
+        root.nonlinear_solver = om.NonlinearBlockGS()
         root.nonlinear_solver.options['maxiter'] = 20
         root.add_subsystem('g1', SellarModified())
         root.add_subsystem('g2', SellarModified())
@@ -317,9 +316,9 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
     def test_NLBGS_Aitken(self):
 
-        prob = Problem(model=SellarDerivatives())
+        prob = om.Problem(model=SellarDerivatives())
         model = prob.model
-        model.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.setup()
         model.nonlinear_solver.options['use_aitken'] = True
@@ -331,7 +330,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
     def test_NLBGS_Aitken_cs(self):
 
-        prob = Problem(model=SellarDerivatives())
+        prob = om.Problem(model=SellarDerivatives())
 
         model = prob.model
         model.approx_totals(method='cs', step=1e-10)
@@ -352,7 +351,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
     def test_NLBGS_cs(self):
 
-        prob = Problem(model=SellarDerivatives())
+        prob = om.Problem(model=SellarDerivatives())
 
         model = prob.model
         model.approx_totals(method='cs')
@@ -381,16 +380,16 @@ class TestNLBGaussSeidel(unittest.TestCase):
                 super(ContrivedSellarDis1, self).compute(inputs, outputs)
                 outputs['highly_nonlinear'] = 10*np.sin(10*inputs['y2'])
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', ContrivedSellarDis1(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2(), promotes=['z', 'y1', 'y2'])
 
-        nlbgs = model.nonlinear_solver = NonlinearBlockGS()
+        nlbgs = model.nonlinear_solver = om.NonlinearBlockGS()
 
         nlbgs.options['maxiter'] = 20
         nlbgs.options['atol'] = 1e-6

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
@@ -197,7 +197,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         nlgbs = model.nonlinear_solver = NonlinearBlockGS()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -231,7 +231,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
         nlgbs = model.nonlinear_solver = NonlinearBlockGS()
         nlgbs.options['use_apply_nonlinear'] = True
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
         prob.run_model()
 
@@ -267,7 +267,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
         nlgbs.options['maxiter'] = 2
         nlgbs.options['err_on_maxiter'] = True
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         try:
@@ -305,7 +305,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
         root.connect('g1.y2', 'g2.x')
         root.connect('g2.y2', 'g1.x')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         prob.run_model()

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
@@ -27,7 +27,7 @@ class TestNLBlockJacobi(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -59,7 +59,7 @@ class TestNLBlockJacobi(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -93,7 +93,7 @@ class TestNLBlockJacobi(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -127,7 +127,7 @@ class TestNLBlockJacobi(unittest.TestCase):
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
         model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
@@ -182,7 +182,7 @@ class TestNonlinearBlockJacobiMPI(unittest.TestCase):
 
         prob.driver = AEDriver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         handled = prob.run_driver()
         self.assertTrue(handled)

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
@@ -163,7 +163,7 @@ class TestNonlinearBlockJacobiMPI(unittest.TestCase):
     @unittest.skipUnless(MPI, "MPI is not active.")
     def test_reraise_analylsis_error(self):
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 0.5))
         model.add_subsystem('p2', IndepVarComp('x', 3.0))

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
@@ -4,9 +4,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, LinearBlockGS, ExplicitComponent, \
-     AnalysisError, ParallelGroup, ExecComp
-from openmdao.solvers.nonlinear.nonlinear_block_jac import NonlinearBlockJac
+import openmdao.api as om
 from openmdao.test_suite.components.ae_tests import AEComp, AEDriver
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.utils.assert_utils import assert_rel_error
@@ -23,27 +21,27 @@ class TestNLBlockJacobi(unittest.TestCase):
     def test_feature_basic(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockJac, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
-        model.nonlinear_solver = NonlinearBlockJac()
+        model.linear_solver = om.LinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockJac()
 
         prob.setup()
 
@@ -55,28 +53,28 @@ class TestNLBlockJacobi(unittest.TestCase):
     def test_feature_maxiter(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockJac, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockJac()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockJac()
         nlgbs.options['maxiter'] = 4
 
         prob.setup()
@@ -89,28 +87,28 @@ class TestNLBlockJacobi(unittest.TestCase):
     def test_feature_rtol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockJac, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockJac()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockJac()
         nlgbs.options['rtol'] = 1e-3
 
         prob.setup()
@@ -123,28 +121,28 @@ class TestNLBlockJacobi(unittest.TestCase):
     def test_feature_atol(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockJac, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        model.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
         model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
 
-        model.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                z=np.array([0.0, 0.0]), x=0.0),
+        model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                   z=np.array([0.0, 0.0]), x=0.0),
                             promotes=['obj', 'x', 'z', 'y1', 'y2'])
 
-        model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        model.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        model.linear_solver = LinearBlockGS()
+        model.linear_solver = om.LinearBlockGS()
 
-        nlgbs = model.nonlinear_solver = NonlinearBlockJac()
+        nlgbs = model.nonlinear_solver = om.NonlinearBlockJac()
         nlgbs.options['atol'] = 1e-2
 
         prob.setup()
@@ -162,18 +160,18 @@ class TestNonlinearBlockJacobiMPI(unittest.TestCase):
 
     @unittest.skipUnless(MPI, "MPI is not active.")
     def test_reraise_analylsis_error(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 0.5))
-        model.add_subsystem('p2', IndepVarComp('x', 3.0))
-        sub = model.add_subsystem('sub', ParallelGroup())
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.5))
+        model.add_subsystem('p2', om.IndepVarComp('x', 3.0))
+        sub = model.add_subsystem('sub', om.ParallelGroup())
 
         sub.add_subsystem('c1', AEComp())
         sub.add_subsystem('c2', AEComp())
-        sub.nonlinear_solver = NonlinearBlockJac()
+        sub.nonlinear_solver = om.NonlinearBlockJac()
 
-        model.add_subsystem('obj', ExecComp(['val = x1 + x2']))
+        model.add_subsystem('obj', om.ExecComp(['val = x1 + x2']))
 
         model.connect('p1.x', 'sub.c1.x')
         model.connect('p2.x', 'sub.c2.x')

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -78,17 +78,17 @@ class TestNonlinearRunOnceSolverMPI(unittest.TestCase):
 
     @unittest.skipUnless(MPI, "MPI is not active.")
     def test_reraise_analylsis_error(self):
-        prob = om.om.Problem()
+        prob = om.Problem()
         model = prob.model
 
         model.add_subsystem('p1', om.IndepVarComp('x', 0.5))
         model.add_subsystem('p2', om.IndepVarComp('x', 3.0))
-        sub = model.add_subsystem('sub', ParallelGroup())
+        sub = model.add_subsystem('sub', om.ParallelGroup())
 
         sub.add_subsystem('c1', AEComp())
         sub.add_subsystem('c2', AEComp())
 
-        model.add_subsystem('obj', ExecComp(['val = x1 + x2']))
+        model.add_subsystem('obj', om.ExecComp(['val = x1 + x2']))
 
         model.connect('p1.x', 'sub.c1.x')
         model.connect('p2.x', 'sub.c2.x')

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -99,7 +99,7 @@ class TestNonlinearRunOnceSolverMPI(unittest.TestCase):
 
         prob.driver = AEDriver()
 
-        prob.setup(check=False)
+        prob.setup()
 
         handled = prob.run_driver()
         self.assertTrue(handled)

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -2,9 +2,7 @@
 
 import unittest
 
-from openmdao.api import Problem, ScipyKrylov, IndepVarComp, Group, ExplicitComponent, \
-     AnalysisError, ParallelGroup, ExecComp
-from openmdao.solvers.nonlinear.nonlinear_runonce import NonlinearRunOnce
+import openmdao.api as om
 from openmdao.test_suite.components.ae_tests import AEComp, AEDriver
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.groups.parallel_groups import ConvergeDivergeGroups
@@ -21,15 +19,15 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
 
     def test_converge_diverge_groups(self):
         # Test derivatives for converge-diverge-groups topology.
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = ConvergeDivergeGroups()
 
-        model.linear_solver = ScipyKrylov()
-        model.nonlinear_solver = NonlinearRunOnce()
+        model.linear_solver = om.ScipyKrylov()
+        model.nonlinear_solver = om.NonlinearRunOnce()
 
-        model.g1.nonlinear_solver = NonlinearRunOnce()
-        model.g1.g2.nonlinear_solver = NonlinearRunOnce()
-        model.g3.nonlinear_solver = NonlinearRunOnce()
+        model.g1.nonlinear_solver = om.NonlinearRunOnce()
+        model.g1.g2.nonlinear_solver = om.NonlinearRunOnce()
+        model.g3.nonlinear_solver = om.NonlinearRunOnce()
 
         prob.set_solver_print(level=0)
         prob.setup(check=False, mode='fwd')
@@ -40,7 +38,7 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class cause an error
-        solver = NonlinearRunOnce()
+        solver = om.NonlinearRunOnce()
 
         msg = "\"Option '%s' cannot be set because it has not been declared.\""
 
@@ -51,17 +49,17 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
             self.assertEqual(str(context.exception), msg % option)
 
     def test_feature_solver(self):
-        from openmdao.api import Problem, Group, NonlinearRunOnce, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
-        model.nonlinear_solver = NonlinearRunOnce()
+        model.nonlinear_solver = om.NonlinearRunOnce()
 
         prob.setup(check=False, mode='fwd')
 
@@ -80,11 +78,11 @@ class TestNonlinearRunOnceSolverMPI(unittest.TestCase):
 
     @unittest.skipUnless(MPI, "MPI is not active.")
     def test_reraise_analylsis_error(self):
-        prob = Problem()
+        prob = om.om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 0.5))
-        model.add_subsystem('p2', IndepVarComp('x', 3.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.5))
+        model.add_subsystem('p2', om.IndepVarComp('x', 3.0))
         sub = model.add_subsystem('sub', ParallelGroup())
 
         sub.add_subsystem('c1', AEComp())

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -243,7 +243,7 @@ class TestNonlinearSolversIsolated(unittest.TestCase):
         teg.nonlinear_solver.options['atol'] = 1e-4
         teg.nonlinear_solver.options['debug_print'] = True
 
-        prob.setup(check=False)
+        prob.setup()
         prob.set_solver_print(level=0)
 
         stdout = sys.stdout

--- a/openmdao/solvers/tests/test_solver_features.py
+++ b/openmdao/solvers/tests/test_solver_features.py
@@ -2,12 +2,7 @@
 
 import unittest
 
-from openmdao.api import Problem
-from openmdao.solvers.nonlinear.newton import NewtonSolver
-from openmdao.solvers.nonlinear.nonlinear_block_gs import NonlinearBlockGS
-from openmdao.solvers.linear.direct import DirectSolver
-from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov
-from openmdao.solvers.linear.linear_block_gs import LinearBlockGS
+import openmdao.api as om
 
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.test_suite.components.sellar import SellarDerivatives
@@ -17,19 +12,19 @@ from openmdao.test_suite.components.double_sellar import DoubleSellar
 class TestSolverFeatures(unittest.TestCase):
 
     def test_specify_solver(self):
-        from openmdao.api import Problem, NewtonSolver, ScipyKrylov, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = SellarDerivatives()
 
-        model.nonlinear_solver = newton = NewtonSolver()
+        model.nonlinear_solver = newton = om.NewtonSolver()
 
         # using a different linear solver for Newton with a looser tolerance
-        newton.linear_solver = ScipyKrylov(atol=1e-4)
+        newton.linear_solver = om.ScipyKrylov(atol=1e-4)
 
         # used for analytic derivatives
-        model.linear_solver = DirectSolver()
+        model.linear_solver = om.DirectSolver()
 
         prob.setup()
         prob.run_model()
@@ -38,25 +33,25 @@ class TestSolverFeatures(unittest.TestCase):
         assert_rel_error(self, prob['y2'], 12.05848819, .00001)
 
     def test_specify_subgroup_solvers(self):
-        from openmdao.api import Problem, NewtonSolver, ScipyKrylov, DirectSolver, NonlinearBlockGS, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.double_sellar import DoubleSellar
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model = DoubleSellar()
 
         # each SubSellar group converges itself
         g1 = model.g1
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = DirectSolver()  # used for derivatives
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.DirectSolver()  # used for derivatives
 
         g2 = model.g2
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = DirectSolver()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.DirectSolver()
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        model.nonlinear_solver = NonlinearBlockGS(rtol=1.0e-5)
-        model.linear_solver = ScipyKrylov()
-        model.linear_solver.precon = LinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS(rtol=1.0e-5)
+        model.linear_solver = om.ScipyKrylov()
+        model.linear_solver.precon = om.LinearBlockGS()
 
         prob.setup()
         prob.run_model()

--- a/openmdao/solvers/tests/test_solver_iprint.py
+++ b/openmdao/solvers/tests/test_solver_iprint.py
@@ -134,7 +134,7 @@ class TestSolverPrint(unittest.TestCase):
 
         prob.set_solver_print(level=2)
 
-        prob.setup(check=False)
+        prob.setup()
 
         output = run_model(prob)
         # TODO: check output
@@ -161,7 +161,7 @@ class TestSolverPrint(unittest.TestCase):
 
         prob.set_solver_print(level=2)
 
-        prob.setup(check=False)
+        prob.setup()
 
         output = run_model(prob)
         # TODO: check output
@@ -190,7 +190,7 @@ class TestSolverPrint(unittest.TestCase):
 
         prob.set_solver_print(level=2)
 
-        prob.setup(check=False)
+        prob.setup()
 
         output = run_model(prob)
         # TODO: check output
@@ -348,7 +348,7 @@ class MPITests(unittest.TestCase):
 
         prob.set_solver_print(level=2)
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Conclude setup but don't run model.
         prob.final_setup()

--- a/openmdao/solvers/tests/test_solver_iprint.py
+++ b/openmdao/solvers/tests/test_solver_iprint.py
@@ -6,8 +6,7 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem, NewtonSolver, ScipyKrylov, Group, PETScVector, \
-    IndepVarComp, NonlinearBlockGS, NonlinearBlockJac, LinearBlockGS
+import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import SubSellar
 from openmdao.test_suite.components.sellar import SellarDerivatives
 
@@ -18,16 +17,16 @@ from openmdao.utils.mpi import MPI
 class TestSolverPrint(unittest.TestCase):
 
     def test_feature_iprint_neg1(self):
-        from openmdao.api import Problem, NewtonSolver, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
 
         prob.setup()
 
-        newton = prob.model.nonlinear_solver = NewtonSolver()
-        scipy = prob.model.linear_solver = ScipyKrylov()
+        newton = prob.model.nonlinear_solver = om.NewtonSolver()
+        scipy = prob.model.linear_solver = om.ScipyKrylov()
 
         newton.options['maxiter'] = 2
 
@@ -40,16 +39,16 @@ class TestSolverPrint(unittest.TestCase):
         prob.run_model()
 
     def test_feature_iprint_0(self):
-        from openmdao.api import Problem, NewtonSolver, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
 
         prob.setup()
 
-        newton = prob.model.nonlinear_solver = NewtonSolver()
-        scipy = prob.model.linear_solver = ScipyKrylov()
+        newton = prob.model.nonlinear_solver = om.NewtonSolver()
+        scipy = prob.model.linear_solver = om.ScipyKrylov()
 
         newton.options['maxiter'] = 1
 
@@ -62,16 +61,16 @@ class TestSolverPrint(unittest.TestCase):
         prob.run_model()
 
     def test_feature_iprint_1(self):
-        from openmdao.api import Problem, NewtonSolver, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
 
         prob.setup()
 
-        newton = prob.model.nonlinear_solver = NewtonSolver()
-        scipy = prob.model.linear_solver = ScipyKrylov()
+        newton = prob.model.nonlinear_solver = om.NewtonSolver()
+        scipy = prob.model.linear_solver = om.ScipyKrylov()
 
         newton.options['maxiter'] = 20
 
@@ -83,16 +82,16 @@ class TestSolverPrint(unittest.TestCase):
         prob.run_model()
 
     def test_feature_iprint_2(self):
-        from openmdao.api import Problem, NewtonSolver, ScipyKrylov
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarDerivatives()
 
         prob.setup()
 
-        newton = prob.model.nonlinear_solver = NewtonSolver()
-        scipy = prob.model.linear_solver = ScipyKrylov()
+        newton = prob.model.nonlinear_solver = om.NewtonSolver()
+        scipy = prob.model.linear_solver = om.ScipyKrylov()
 
         newton.options['maxiter'] = 20
 
@@ -105,13 +104,13 @@ class TestSolverPrint(unittest.TestCase):
 
     def test_hierarchy_iprint(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -119,17 +118,17 @@ class TestSolverPrint(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
 
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = LinearBlockGS()
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.LinearBlockGS()
 
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = ScipyKrylov()
-        g2.linear_solver.precon = LinearBlockGS()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.ScipyKrylov()
+        g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
         prob.set_solver_print(level=2)
@@ -141,13 +140,13 @@ class TestSolverPrint(unittest.TestCase):
 
     def test_hierarchy_iprint2(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -155,9 +154,9 @@ class TestSolverPrint(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NonlinearBlockGS()
-        g1.nonlinear_solver = NonlinearBlockGS()
-        g2.nonlinear_solver = NonlinearBlockGS()
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        g1.nonlinear_solver = om.NonlinearBlockGS()
+        g2.nonlinear_solver = om.NonlinearBlockGS()
 
         prob.set_solver_print(level=2)
 
@@ -168,13 +167,13 @@ class TestSolverPrint(unittest.TestCase):
 
     def test_hierarchy_iprint3(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -182,11 +181,11 @@ class TestSolverPrint(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NonlinearBlockJac()
-        sub1.nonlinear_solver = NonlinearBlockJac()
-        sub2.nonlinear_solver = NonlinearBlockJac()
-        g1.nonlinear_solver = NonlinearBlockJac()
-        g2.nonlinear_solver = NonlinearBlockJac()
+        model.nonlinear_solver = om.NonlinearBlockJac()
+        sub1.nonlinear_solver = om.NonlinearBlockJac()
+        sub2.nonlinear_solver = om.NonlinearBlockJac()
+        g1.nonlinear_solver = om.NonlinearBlockJac()
+        g2.nonlinear_solver = om.NonlinearBlockJac()
 
         prob.set_solver_print(level=2)
 
@@ -198,16 +197,16 @@ class TestSolverPrint(unittest.TestCase):
     def test_feature_set_solver_print1(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.double_sellar import SubSellar
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -215,17 +214,17 @@ class TestSolverPrint(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
 
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = LinearBlockGS()
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.LinearBlockGS()
 
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = ScipyKrylov()
-        g2.linear_solver.precon = LinearBlockGS()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.ScipyKrylov()
+        g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
         prob.set_solver_print(level=2)
@@ -236,16 +235,16 @@ class TestSolverPrint(unittest.TestCase):
     def test_feature_set_solver_print2(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.double_sellar import SubSellar
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -253,17 +252,17 @@ class TestSolverPrint(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
 
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = LinearBlockGS()
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.LinearBlockGS()
 
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = ScipyKrylov()
-        g2.linear_solver.precon = LinearBlockGS()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.ScipyKrylov()
+        g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
         prob.set_solver_print(level=2)
@@ -275,16 +274,16 @@ class TestSolverPrint(unittest.TestCase):
     def test_feature_set_solver_print3(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, NewtonSolver, ScipyKrylov, LinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.double_sellar import SubSellar
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -292,17 +291,17 @@ class TestSolverPrint(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
 
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = LinearBlockGS()
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.LinearBlockGS()
 
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = ScipyKrylov()
-        g2.linear_solver.precon = LinearBlockGS()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.ScipyKrylov()
+        g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
         prob.set_solver_print(level=0)
@@ -312,20 +311,20 @@ class TestSolverPrint(unittest.TestCase):
         prob.run_model()
 
 
-@unittest.skipUnless(PETScVector, "PETSc is required.")
+@unittest.skipUnless(om.PETScVector, "PETSc is required.")
 class MPITests(unittest.TestCase):
 
     N_PROCS = 2
 
     @unittest.skipUnless(MPI, "MPI is not active.")
     def test_hierarchy_iprint(self):
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])))
+        model.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])))
 
-        sub1 = model.add_subsystem('sub1', Group())
-        sub2 = sub1.add_subsystem('sub2', Group())
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = sub1.add_subsystem('sub2', om.Group())
         g1 = sub2.add_subsystem('g1', SubSellar())
         g2 = model.add_subsystem('g2', SubSellar())
 
@@ -333,17 +332,17 @@ class MPITests(unittest.TestCase):
         model.connect('sub1.sub2.g1.y2', 'g2.x')
         model.connect('g2.y2', 'sub1.sub2.g1.x')
 
-        model.nonlinear_solver = NewtonSolver()
-        model.linear_solver = ScipyKrylov()
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov()
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 0
 
-        g1.nonlinear_solver = NewtonSolver()
-        g1.linear_solver = LinearBlockGS()
+        g1.nonlinear_solver = om.NewtonSolver()
+        g1.linear_solver = om.LinearBlockGS()
 
-        g2.nonlinear_solver = NewtonSolver()
-        g2.linear_solver = ScipyKrylov()
-        g2.linear_solver.precon = LinearBlockGS()
+        g2.nonlinear_solver = om.NewtonSolver()
+        g2.linear_solver = om.ScipyKrylov()
+        g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
         prob.set_solver_print(level=2)

--- a/openmdao/solvers/tests/test_solver_parametric_suite.py
+++ b/openmdao/solvers/tests/test_solver_parametric_suite.py
@@ -55,7 +55,7 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
             prob.model.linear_solver = DirectSolver(assemble_jac=jac in ('csc','dense'))
             prob.set_solver_print(level=0)
 
-            prob.setup(check=False)
+            prob.setup()
 
             prob.run_model()
             assert_rel_error(self, prob['y'], [-1., 1.])
@@ -80,7 +80,7 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
         """
         prob = Problem(model=TestImplicitGroup(lnSolverClass=DirectSolver))
 
-        prob.setup(check=False)
+        prob.setup()
 
         # Set this to False because we have matrix-free component(s).
         prob.model.linear_solver.options['assemble_jac'] = False

--- a/openmdao/surrogate_models/tests/test_map.py
+++ b/openmdao/surrogate_models/tests/test_map.py
@@ -29,7 +29,7 @@ class TestMap(unittest.TestCase):
         # add compressor map to problem
         p = Problem()
         p.model.add_subsystem('compmap', c)
-        p.setup(check=False)
+        p.setup()
 
         # train metamodel
         Nc = np.array([0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0, 1.1])

--- a/openmdao/test_suite/components/ae_tests.py
+++ b/openmdao/test_suite/components/ae_tests.py
@@ -2,11 +2,11 @@
 Some classes that are used to test Analysis Errors on multiple processes.
 """
 
-from openmdao.api import ExplicitComponent, AnalysisError
+import openmdao.api as om
 from openmdao.core.driver import Driver
 
 
-class AEComp(ExplicitComponent):
+class AEComp(om.ExplicitComponent):
 
     def setup(self):
         self.add_input('x', val=0.0)
@@ -19,7 +19,7 @@ class AEComp(ExplicitComponent):
         x = inputs['x']
 
         if x > 2.0:
-            raise AnalysisError('Try again.')
+            raise om.AnalysisError('Try again.')
 
         outputs['y'] = x*x + 2.0
 

--- a/openmdao/test_suite/components/ae_tests.py
+++ b/openmdao/test_suite/components/ae_tests.py
@@ -23,6 +23,7 @@ class AEComp(om.ExplicitComponent):
 
         outputs['y'] = x*x + 2.0
 
+
 class AEDriver(Driver):
     """
     Handle an Analysis Error from below.
@@ -34,7 +35,7 @@ class AEDriver(Driver):
         """
         try:
             self._problem.model.run_solve_nonlinear()
-        except AnalysisError:
+        except om.AnalysisError:
             return True
 
         return False

--- a/openmdao/test_suite/components/array_comp.py
+++ b/openmdao/test_suite/components/array_comp.py
@@ -1,7 +1,9 @@
 import numpy as np
-from openmdao.api import ExplicitComponent
 
-class ArrayComp(ExplicitComponent):
+import openmdao.api as om
+
+
+class ArrayComp(om.ExplicitComponent):
 
     def setup(self):
 

--- a/openmdao/test_suite/components/branin.py
+++ b/openmdao/test_suite/components/branin.py
@@ -16,10 +16,10 @@ The global minimum can be found at f(x) = 0.397887
 """
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class Branin(ExplicitComponent):
+class Branin(om.ExplicitComponent):
     """
     The Branin test problem. This version is the standard version and
     contains two continuous parameters.
@@ -74,7 +74,7 @@ class Branin(ExplicitComponent):
         partials['f', 'x0'] = 2.0*a*(x1 - b*x0**2 + c*x0 - d)*(-2.*b*x0 + c) - e*(1.-f)*np.sin(x0)
 
 
-class BraninDiscrete(ExplicitComponent):
+class BraninDiscrete(om.ExplicitComponent):
     """
     The Branin test problem. This version defines a Discrete Variable in OpenMDAO.
 

--- a/openmdao/test_suite/components/double_sellar.py
+++ b/openmdao/test_suite/components/double_sellar.py
@@ -1,14 +1,12 @@
-from openmdao.core.group import Group
-from openmdao.solvers.nonlinear.newton import NewtonSolver
-from openmdao.solvers.linear.direct import DirectSolver
+import openmdao.api as om
+
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.components.sellar import SellarImplicitDis1
-
 # TODO -- Need to convert these over to use `setup` after we have two setup
 # phases split up and have the ability to change driver settings
 
 
-class SubSellar(Group):
+class SubSellar(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
         super(SubSellar, self).__init__(**kwargs)
@@ -19,7 +17,7 @@ class SubSellar(Group):
                            promotes=['z', 'y1', 'y2'])
 
 
-class DoubleSellar(Group):
+class DoubleSellar(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
         super(DoubleSellar, self).__init__(**kwargs)
@@ -31,11 +29,11 @@ class DoubleSellar(Group):
         self.connect('g2.y2', 'g1.x')
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        self.nonlinear_solver = NewtonSolver()
-        self.linear_solver = DirectSolver()
+        self.nonlinear_solver = om.NewtonSolver()
+        self.linear_solver = om.DirectSolver()
 
 
-class SubSellarImplicit(Group):
+class SubSellarImplicit(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
         super(SubSellarImplicit, self).__init__(**kwargs)
@@ -46,7 +44,7 @@ class SubSellarImplicit(Group):
                            promotes=['z', 'y1', 'y2'])
 
 
-class DoubleSellarImplicit(Group):
+class DoubleSellarImplicit(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
         super(DoubleSellarImplicit, self).__init__(**kwargs)
@@ -58,5 +56,5 @@ class DoubleSellarImplicit(Group):
         self.connect('g2.y2', 'g1.x')
 
         # Converge the outer loop with Gauss Seidel, with a looser tolerance.
-        self.nonlinear_solver = NewtonSolver()
-        self.linear_solver = DirectSolver()
+        self.nonlinear_solver = om.NewtonSolver()
+        self.linear_solver = om.DirectSolver()

--- a/openmdao/test_suite/components/expl_comp_array.py
+++ b/openmdao/test_suite/components/expl_comp_array.py
@@ -4,10 +4,10 @@ from __future__ import division, print_function
 import numpy as np
 import scipy.sparse
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class TestExplCompArray(ExplicitComponent):
+class TestExplCompArray(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('thickness', default=1.)

--- a/openmdao/test_suite/components/impl_comp_array.py
+++ b/openmdao/test_suite/components/impl_comp_array.py
@@ -5,10 +5,10 @@ from __future__ import division, print_function
 import numpy as np
 import scipy.sparse
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 
-class TestImplCompArray(ImplicitComponent):
+class TestImplCompArray(om.ImplicitComponent):
 
     def initialize(self):
         self.mtx = np.array([

--- a/openmdao/test_suite/components/impl_comp_simple.py
+++ b/openmdao/test_suite/components/impl_comp_simple.py
@@ -5,10 +5,10 @@ import numpy as np
 import scipy.sparse
 import scipy.optimize
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 
-class TestImplCompSimple(ImplicitComponent):
+class TestImplCompSimple(om.ImplicitComponent):
 
     def setup(self):
         self.add_input('a', val=1.)

--- a/openmdao/test_suite/components/implicit_newton_linesearch.py
+++ b/openmdao/test_suite/components/implicit_newton_linesearch.py
@@ -1,13 +1,13 @@
 """Components used mainly for testing Newton and line searches."""
+from math import exp
 
 import numpy as np
 import unittest
-from math import exp
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 
-class ImplCompOneState(ImplicitComponent):
+class ImplCompOneState(om.ImplicitComponent):
     """
     A Simple Implicit Component
 
@@ -44,7 +44,7 @@ class ImplCompOneState(ImplicitComponent):
         J[('y', 'y')] = y + 2.0 - 32.0*y*exp(-16.0*y*y) - 10.0*exp(-5.0*y)
 
 
-class ImplCompTwoStates(ImplicitComponent):
+class ImplCompTwoStates(om.ImplicitComponent):
     """
     A Simple Implicit Component with an additional output equation.
 
@@ -100,7 +100,7 @@ class ImplCompTwoStates(ImplicitComponent):
         jac[('z', 'x')] = outputs['z']
 
 
-class ImplCompTwoStatesArrays(ImplicitComponent):
+class ImplCompTwoStatesArrays(om.ImplicitComponent):
     """
     A Simple Implicit Component with an additional output equation.
 

--- a/openmdao/test_suite/components/matmultcomp.py
+++ b/openmdao/test_suite/components/matmultcomp.py
@@ -1,14 +1,15 @@
 """
 A simple component used for derivative testing.
 """
-
 from __future__ import division, print_function
 import time
+
 import numpy as np
-from openmdao.core.explicitcomponent import ExplicitComponent
+
+import openmdao.api as om
 
 
-class MatMultComp(ExplicitComponent):
+class MatMultComp(om.ExplicitComponent):
     def __init__(self, mat, approx_method='exact', sleep_time=0.1, **kwargs):
         super(MatMultComp, self).__init__(**kwargs)
         self.mat = mat
@@ -30,7 +31,8 @@ class MatMultComp(ExplicitComponent):
 
 if __name__ == '__main__':
     import sys
-    from openmdao.api import Problem, IndepVarComp
+
+    import openmdao.api as om
     from openmdao.utils.mpi import MPI
 
     if len(sys.argv) > 1:
@@ -52,9 +54,9 @@ if __name__ == '__main__':
 
     print("mat shape:", mat.shape)
 
-    p = Problem()
+    p = om.Problem()
     model = p.model
-    model.add_subsystem('indep', IndepVarComp('x', val=np.ones(mat.shape[1])))
+    model.add_subsystem('indep', om.IndepVarComp('x', val=np.ones(mat.shape[1])))
     comp = model.add_subsystem('comp', MatMultComp(mat, approx_method='fd', num_par_fd=5))
 
     model.connect('indep.x', 'comp.x')

--- a/openmdao/test_suite/components/misc_components.py
+++ b/openmdao/test_suite/components/misc_components.py
@@ -9,10 +9,10 @@ from __future__ import division, print_function
 
 import numpy as np
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 
-class Comp4LinearCacheTest(ImplicitComponent):
+class Comp4LinearCacheTest(om.ImplicitComponent):
     """
     Component needed for testing cached linear solutions.
 

--- a/openmdao/test_suite/components/options_feature_array.py
+++ b/openmdao/test_suite/components/options_feature_array.py
@@ -4,9 +4,10 @@ the array is given as an option of type 'numpy.ndarray'.
 """
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class ArrayMultiplyComp(ExplicitComponent):
+
+class ArrayMultiplyComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('array', types=np.ndarray)

--- a/openmdao/test_suite/components/options_feature_function.py
+++ b/openmdao/test_suite/components/options_feature_function.py
@@ -5,9 +5,10 @@ is a function given as an option.
 
 from types import FunctionType
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class UnitaryFunctionComp(ExplicitComponent):
+
+class UnitaryFunctionComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('func', types=FunctionType)

--- a/openmdao/test_suite/components/options_feature_lincomb.py
+++ b/openmdao/test_suite/components/options_feature_lincomb.py
@@ -4,9 +4,10 @@ are given as an option of type 'numpy.ScalarType'.
 """
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class LinearCombinationComp(ExplicitComponent):
+
+class LinearCombinationComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('a', default=1., types=np.ScalarType)

--- a/openmdao/test_suite/components/options_feature_vector.py
+++ b/openmdao/test_suite/components/options_feature_vector.py
@@ -4,9 +4,10 @@ size of the vector is given as an option of type 'int'.
 """
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
-class VectorDoublingComp(ExplicitComponent):
+
+class VectorDoublingComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('size', types=int)

--- a/openmdao/test_suite/components/paraboloid.py
+++ b/openmdao/test_suite/components/paraboloid.py
@@ -2,10 +2,11 @@
 (x-3)^2 + xy + (y+4)^2 = 3
 """
 from __future__ import division, print_function
-from openmdao.core.explicitcomponent import ExplicitComponent
+
+import openmdao.api as om
 
 
-class Paraboloid(ExplicitComponent):
+class Paraboloid(om.ExplicitComponent):
     """
     Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.
     """
@@ -41,10 +42,9 @@ class Paraboloid(ExplicitComponent):
 
 
 if __name__ == "__main__":
-    from openmdao.api import Problem, Group, ScipyOptimizeDriver, ExecComp, IndepVarComp
 
-    model = Group()
-    ivc = IndepVarComp()
+    model = om.Group()
+    ivc = om.IndepVarComp()
     ivc.add_output('x', 3.0)
     ivc.add_output('y', -4.0)
     model.add_subsystem('des_vars', ivc)
@@ -53,8 +53,8 @@ if __name__ == "__main__":
     model.connect('des_vars.x', 'parab_comp.x')
     model.connect('des_vars.y', 'parab_comp.y')
 
-    prob = Problem(model)
-    prob.driver = ScipyOptimizeDriver()  # so 'openmdao cite' will report it for cite docs
+    prob = om.Problem(model)
+    prob.driver = om.ScipyOptimizeDriver()  # so 'openmdao cite' will report it for cite docs
     prob.setup()
     prob.run_model()
     print(prob['parab_comp.f_xy'])

--- a/openmdao/test_suite/components/paraboloid_feature.py
+++ b/openmdao/test_suite/components/paraboloid_feature.py
@@ -2,10 +2,11 @@
 Demonstration of a model using the Paraboloid component.
 """
 from __future__ import division, print_function
-from openmdao.api import ExplicitComponent
+
+import openmdao.api as om
 
 
-class Paraboloid(ExplicitComponent):
+class Paraboloid(om.ExplicitComponent):
     """
     Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.
     """
@@ -32,12 +33,9 @@ class Paraboloid(ExplicitComponent):
 
 
 if __name__ == "__main__":
-    from openmdao.core.problem import Problem
-    from openmdao.core.group import Group
-    from openmdao.core.indepvarcomp import IndepVarComp
 
-    model = Group()
-    ivc = IndepVarComp()
+    model = om.Group()
+    ivc = om.IndepVarComp()
     ivc.add_output('x', 3.0)
     ivc.add_output('y', -4.0)
     model.add_subsystem('des_vars', ivc)
@@ -46,7 +44,7 @@ if __name__ == "__main__":
     model.connect('des_vars.x', 'parab_comp.x')
     model.connect('des_vars.y', 'parab_comp.y')
 
-    prob = Problem(model)
+    prob = om.Problem(model)
     prob.setup()
     prob.run_model()
     print(prob['parab_comp.f_xy'])

--- a/openmdao/test_suite/components/quad_implicit.py
+++ b/openmdao/test_suite/components/quad_implicit.py
@@ -1,6 +1,7 @@
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
-class QuadraticComp(ImplicitComponent):
+
+class QuadraticComp(om.ImplicitComponent):
     """
     A Simple Implicit Component representing a Quadratic Equation.
 

--- a/openmdao/test_suite/components/sellar_feature.py
+++ b/openmdao/test_suite/components/sellar_feature.py
@@ -104,7 +104,7 @@ class SellarMDA(om.Group):
                             promotes_outputs=['y2'])
 
         # Nonlinear Block Gauss Seidel is a gradient free solver
-        cycle.nonlinear_solver = NonlinearBlockGS()
+        cycle.nonlinear_solver = om.NonlinearBlockGS()
 
         self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                   z=np.array([0.0, 0.0]), x=0.0),
@@ -235,8 +235,8 @@ class SellarNoDerivativesCS(om.Group):
         self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
         self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
-        self.nonlinear_solver = NonlinearBlockGS()
-        self.linear_solver = ScipyKrylov()
+        self.nonlinear_solver = om.NonlinearBlockGS()
+        self.linear_solver = om.ScipyKrylov()
 
 
 class SellarIDF(om.Group):

--- a/openmdao/test_suite/components/sellar_feature.py
+++ b/openmdao/test_suite/components/sellar_feature.py
@@ -7,15 +7,15 @@ From Sellar's analytic problem.
     Optimization for Multidisciplinary System Design," Proceedings References 79 of the 34th AIAA
     Aerospace Sciences Meeting and Exhibit, Reno, NV, January 1996.
 """
-
 import numpy as np
-from openmdao.api import Group, ExplicitComponent, ExecComp, IndepVarComp, \
-                         NonlinearBlockGS, ScipyKrylov, DirectSolver, EQConstraintComp, NewtonSolver
+
+import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, \
                          SellarDis2withDerivatives
 from openmdao.test_suite.components.double_sellar import SubSellar
 
-class SellarDis1(ExplicitComponent):
+
+class SellarDis1(om.ExplicitComponent):
     """
     Component containing Discipline 1 -- no derivatives version.
     """
@@ -50,7 +50,7 @@ class SellarDis1(ExplicitComponent):
         outputs['y1'] = z1**2 + z2 + x1 - 0.2*y2
 
 
-class SellarDis2(ExplicitComponent):
+class SellarDis2(om.ExplicitComponent):
     """
     Component containing Discipline 2 -- no derivatives version.
     """
@@ -87,57 +87,61 @@ class SellarDis2(ExplicitComponent):
         outputs['y2'] = y1**.5 + z1 + z2
 
 
-class SellarMDA(Group):
+class SellarMDA(om.Group):
     """
     Group containing the Sellar MDA.
     """
 
     def setup(self):
-        indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', 1.0)
         indeps.add_output('z', np.array([5.0, 2.0]))
 
-        cycle = self.add_subsystem('cycle', Group(), promotes=['*'])
-        cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'], promotes_outputs=['y1'])
-        cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'], promotes_outputs=['y2'])
+        cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
+        cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'],
+                            promotes_outputs=['y1'])
+        cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'],
+                            promotes_outputs=['y2'])
 
         # Nonlinear Block Gauss Seidel is a gradient free solver
         cycle.nonlinear_solver = NonlinearBlockGS()
 
-        self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                           z=np.array([0.0, 0.0]), x=0.0),
+        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                  z=np.array([0.0, 0.0]), x=0.0),
                            promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-        self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
 
-class SellarMDALinearSolver(Group):
+class SellarMDALinearSolver(om.Group):
     """
     Group containing the Sellar MDA.
     """
 
     def setup(self):
-        indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', 1.0)
         indeps.add_output('z', np.array([5.0, 2.0]))
 
-        cycle = self.add_subsystem('cycle', Group(), promotes=['*'])
-        d1 = cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'], promotes_outputs=['y1'])
-        d2 = cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'], promotes_outputs=['y2'])
+        cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
+        d1 = cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'],
+                                 promotes_outputs=['y1'])
+        d2 = cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'],
+                                 promotes_outputs=['y2'])
 
-        cycle.nonlinear_solver = NonlinearBlockGS()
-        cycle.linear_solver = DirectSolver()
+        cycle.nonlinear_solver = om.NonlinearBlockGS()
+        cycle.linear_solver = om.DirectSolver()
 
-        self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                            z=np.array([0.0, 0.0]), x=0.0),
                            promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-        self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
 
-class SellarDis1CS(ExplicitComponent):
+class SellarDis1CS(om.ExplicitComponent):
     """
     Component containing Discipline 1 -- no derivatives version.
     Uses Complex Step
@@ -173,7 +177,7 @@ class SellarDis1CS(ExplicitComponent):
         outputs['y1'] = z1**2 + z2 + x1 - 0.2*y2
 
 
-class SellarDis2CS(ExplicitComponent):
+class SellarDis2CS(om.ExplicitComponent):
     """
     Component containing Discipline 2 -- no derivatives version.
     Uses Complex Step
@@ -211,37 +215,37 @@ class SellarDis2CS(ExplicitComponent):
         outputs['y2'] = y1**.5 + z1 + z2
 
 
-class SellarNoDerivativesCS(Group):
+class SellarNoDerivativesCS(om.Group):
     """
     Group containing the Sellar MDA. This version uses the disciplines without derivatives.
     """
 
     def setup(self):
-        self.add_subsystem('px', IndepVarComp('x', 1.0), promotes=['x'])
-        self.add_subsystem('pz', IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+        self.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+        self.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
-        cycle = self.add_subsystem('cycle', Group(), promotes=['x', 'z', 'y1', 'y2'])
+        cycle = self.add_subsystem('cycle', om.Group(), promotes=['x', 'z', 'y1', 'y2'])
         d1 = cycle.add_subsystem('d1', SellarDis1CS(), promotes=['x', 'z', 'y1', 'y2'])
         d2 = cycle.add_subsystem('d2', SellarDis2CS(), promotes=['z', 'y1', 'y2'])
 
-        self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                           z=np.array([0.0, 0.0]), x=0.0),
+        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                  z=np.array([0.0, 0.0]), x=0.0),
                            promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-        self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-        self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
+        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
 
         self.nonlinear_solver = NonlinearBlockGS()
         self.linear_solver = ScipyKrylov()
 
 
-class SellarIDF(Group):
+class SellarIDF(om.Group):
     """
     Individual Design Feasible (IDF) architecture for the Sellar problem.
     """
     def setup(self):
         # construct the Sellar model with `y1` and `y2` as independent variables
-        dv = IndepVarComp()
+        dv = om.IndepVarComp()
         dv.add_output('x', 5.)
         dv.add_output('y1', 5.)
         dv.add_output('y2', 5.)
@@ -251,11 +255,11 @@ class SellarIDF(Group):
         self.add_subsystem('d1', SellarDis1withDerivatives())
         self.add_subsystem('d2', SellarDis2withDerivatives())
 
-        self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                            x=0., z=np.array([0., 0.])))
 
-        self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'))
-        self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'))
+        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'))
+        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'))
 
         self.connect('dv.x', ['d1.x', 'obj_cmp.x'])
         self.connect('dv.y1', ['d2.y1', 'obj_cmp.y1', 'con_cmp1.y1'])
@@ -265,7 +269,7 @@ class SellarIDF(Group):
         # rather than create a cycle by connecting d1.y1 to d2.y1 and d2.y2 to d1.y2
         # we will constrain y1 and y2 to be equal for the two disciplines
 
-        equal = EQConstraintComp()
+        equal = om.EQConstraintComp()
         self.add_subsystem('equal', equal)
 
         equal.add_eq_output('y1', add_constraint=True)

--- a/openmdao/test_suite/components/simple_comps.py
+++ b/openmdao/test_suite/components/simple_comps.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class DoubleArrayComp(ExplicitComponent):
+class DoubleArrayComp(om.ExplicitComponent):
     """
     A fairly simple array component.
     """
@@ -51,7 +51,7 @@ class DoubleArrayComp(ExplicitComponent):
         partials[('y2', 'x2')] = self.JJ[2:4, 2:4]
 
 
-class NonSquareArrayComp(ExplicitComponent):
+class NonSquareArrayComp(om.ExplicitComponent):
     """
     A fairly simple array component.
     """
@@ -97,7 +97,7 @@ class NonSquareArrayComp(ExplicitComponent):
         partials[('y2', 'x2')] = self.JJ[3:4, 2:4]
 
 
-class TestExplCompDeprecated(ExplicitComponent):
+class TestExplCompDeprecated(om.ExplicitComponent):
     """
     A component that adds variables in the __init__ function.
     """

--- a/openmdao/test_suite/components/three_bar_truss.py
+++ b/openmdao/test_suite/components/three_bar_truss.py
@@ -10,7 +10,7 @@ The global optima is 3,3,x (x can be anything), with mass = 5.28 kg
 
 import numpy as np
 
-from openmdao.core.explicitcomponent import ExplicitComponent
+import openmdao.api as om
 
 
 def stress_calc(A, E):
@@ -64,7 +64,7 @@ def stress_calc(A, E):
     return sigma
 
 
-class ThreeBarTruss(ExplicitComponent):
+class ThreeBarTruss(om.ExplicitComponent):
     """
     3 Bar truss problem with 3 continuous design variables and 3 discrete
     material choices. Material chosen as follows:
@@ -156,7 +156,7 @@ class ThreeBarTruss(ExplicitComponent):
         outputs['stress'] = (np.abs(sigma)/sigma_y)
 
 
-class ThreeBarTrussVector(ExplicitComponent):
+class ThreeBarTrussVector(om.ExplicitComponent):
     """
     3 Bar truss problem with 3 continuous design variables and 3 discrete
     material choices. Material chosen as follows:

--- a/openmdao/test_suite/components/unit_conv.py
+++ b/openmdao/test_suite/components/unit_conv.py
@@ -2,10 +2,10 @@
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent, Group, IndepVarComp
+import openmdao.api as om
 
 
-class SrcComp(ExplicitComponent):
+class SrcComp(om.ExplicitComponent):
     """Source provides degrees Celsius."""
 
     def setup(self):
@@ -37,7 +37,7 @@ class SrcCompFD(SrcComp):
         pass
 
 
-class TgtCompF(ExplicitComponent):
+class TgtCompF(om.ExplicitComponent):
     """Target expressed in degrees F."""
 
     def setup(self):
@@ -69,7 +69,7 @@ class TgtCompFFD(TgtCompF):
         pass
 
 
-class TgtCompC(ExplicitComponent):
+class TgtCompC(om.ExplicitComponent):
     """Target expressed in degrees Celsius."""
 
     def setup(self):
@@ -101,7 +101,7 @@ class TgtCompCFD(TgtCompC):
         pass
 
 
-class TgtCompK(ExplicitComponent):
+class TgtCompK(om.ExplicitComponent):
     """Target expressed in degrees Kelvin."""
 
     def setup(self):
@@ -133,7 +133,7 @@ class TgtCompKFD(TgtCompK):
         pass
 
 
-class TgtCompFMulti(ExplicitComponent):
+class TgtCompFMulti(om.ExplicitComponent):
     """Contains some extra inputs that might trip things up."""
 
     def setup(self):
@@ -163,7 +163,7 @@ class TgtCompFMulti(ExplicitComponent):
         J['x3_', 'x2_'] = 0.0
 
 
-class UnitConvGroup(Group):
+class UnitConvGroup(om.Group):
     """Group containing a degC source that feeds into three targets with
     units degF, degC, and degK respectively. Good for testing unit
     conversion."""
@@ -171,7 +171,7 @@ class UnitConvGroup(Group):
     def __init__(self, **kwargs):
         super(UnitConvGroup, self).__init__(**kwargs)
 
-        self.add_subsystem('px1', IndepVarComp('x1', 100.0))
+        self.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
         self.add_subsystem('src', SrcComp())
         self.add_subsystem('tgtF', TgtCompF())
         self.add_subsystem('tgtC', TgtCompC())
@@ -183,7 +183,7 @@ class UnitConvGroup(Group):
         self.connect('src.x2', 'tgtK.x2')
 
 
-class UnitConvGroupImplicitConns(Group):
+class UnitConvGroupImplicitConns(om.Group):
     """ Group containing a defF source that feeds into three targets with
     units degF, degC, and degK respectively. Good for testing unit
     conversion.
@@ -194,7 +194,7 @@ class UnitConvGroupImplicitConns(Group):
     def __init__(self):
         super(UnitConvGroupImplicitConns, self).__init__()
 
-        self.add_subsystem('px1', IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
+        self.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
         self.add_subsystem('src', SrcComp(), promotes_inputs=['x1'], promotes_outputs=['x2'])
         self.add_subsystem('tgtF', TgtCompF(), promotes_inputs=['x2'])
         self.add_subsystem('tgtC', TgtCompC(), promotes_inputs=['x2'])

--- a/openmdao/test_suite/groups/cycle_group.py
+++ b/openmdao/test_suite/groups/cycle_group.py
@@ -28,12 +28,13 @@ depend on particular values of 'theta' (or 'x_i'/'y_i' values) without taking th
 
 from __future__ import print_function, division
 from six.moves import range
+
 import numpy as np
 
-from openmdao.api import IndepVarComp
-from openmdao.test_suite.groups.parametric_group import ParametericTestGroup
+import openmdao.api as om
 from openmdao.test_suite.components.cycle_comps import PSI, \
     ExplicitCycleComp, ExplicitFirstComp, ExplicitLastComp
+from openmdao.test_suite.groups.parametric_group import ParametericTestGroup
 
 
 class CycleGroup(ParametericTestGroup):
@@ -118,8 +119,8 @@ class CycleGroup(ParametericTestGroup):
             'num_comp': self.options['num_comp']
         }
 
-        self.add_subsystem('psi_comp', IndepVarComp('psi', PSI))
-        indep_var_comp = self.add_subsystem('x0_comp', IndepVarComp())
+        self.add_subsystem('psi_comp', om.IndepVarComp('psi', PSI))
+        indep_var_comp = self.add_subsystem('x0_comp', om.IndepVarComp())
         for i in range(num_var):
             indep_var_comp.add_output('x_{0}'.format(i), np.ones(var_shape))
 

--- a/openmdao/test_suite/groups/implicit_group.py
+++ b/openmdao/test_suite/groups/implicit_group.py
@@ -2,11 +2,10 @@
 
 from __future__ import division, print_function
 
-from openmdao.api import Group, ImplicitComponent
-from openmdao.api import LinearBlockGS, NonlinearBlockGS
+import openmdao.api as om
 
 
-class Comp(ImplicitComponent):
+class Comp(om.ImplicitComponent):
 
     def setup(self):
         self.add_input('a')
@@ -74,13 +73,13 @@ class Comp(ImplicitComponent):
             out_vec[var] = in_vec[var]
 
 
-class TestImplicitGroup(Group):
+class TestImplicitGroup(om.Group):
     """
     A `Group` with two interconnected <ImplicitComponent>s.
     """
 
-    def __init__(self, lnSolverClass=LinearBlockGS,
-                       nlSolverClass=NonlinearBlockGS):
+    def __init__(self, lnSolverClass=om.LinearBlockGS,
+                       nlSolverClass=om.NonlinearBlockGS):
 
         super(TestImplicitGroup, self).__init__()
 

--- a/openmdao/test_suite/groups/parallel_groups.py
+++ b/openmdao/test_suite/groups/parallel_groups.py
@@ -2,13 +2,9 @@
 
 from __future__ import division, print_function
 
-from openmdao.core.group import Group
-from openmdao.core.parallel_group import ParallelGroup
-from openmdao.core.indepvarcomp import IndepVarComp
-from openmdao.components.exec_comp import ExecComp
+import openmdao.api as om
 
-
-class FanOut(Group):
+class FanOut(om.Group):
     """
     Topology where one comp broadcasts an output to two target
     components.
@@ -17,17 +13,17 @@ class FanOut(Group):
     def __init__(self):
         super(FanOut, self).__init__()
 
-        self.add_subsystem('p', IndepVarComp('x', 1.0))
-        self.add_subsystem('comp1', ExecComp(['y=3.0*x']))
-        self.add_subsystem('comp2', ExecComp(['y=-2.0*x']))
-        self.add_subsystem('comp3', ExecComp(['y=5.0*x']))
+        self.add_subsystem('p', om.IndepVarComp('x', 1.0))
+        self.add_subsystem('comp1', om.ExecComp(['y=3.0*x']))
+        self.add_subsystem('comp2', om.ExecComp(['y=-2.0*x']))
+        self.add_subsystem('comp3', om.ExecComp(['y=5.0*x']))
 
         self.connect("p.x", "comp1.x")
         self.connect("comp1.y", "comp2.x")
         self.connect("comp1.y", "comp3.x")
 
 
-class FanOutGrouped(Group):
+class FanOutGrouped(om.Group):
     """
     Topology where one component broadcasts an output to two target
     components.
@@ -36,15 +32,15 @@ class FanOutGrouped(Group):
     def __init__(self):
         super(FanOutGrouped, self).__init__()
 
-        self.add_subsystem('iv', IndepVarComp('x', 1.0))
-        self.add_subsystem('c1', ExecComp(['y=3.0*x']))
+        self.add_subsystem('iv', om.IndepVarComp('x', 1.0))
+        self.add_subsystem('c1', om.ExecComp(['y=3.0*x']))
 
-        self.sub = self.add_subsystem('sub', ParallelGroup())
-        self.sub.add_subsystem('c2', ExecComp(['y=-2.0*x']))
-        self.sub.add_subsystem('c3', ExecComp(['y=5.0*x']))
+        self.sub = self.add_subsystem('sub', om.ParallelGroup())
+        self.sub.add_subsystem('c2', om.ExecComp(['y=-2.0*x']))
+        self.sub.add_subsystem('c3', om.ExecComp(['y=5.0*x']))
 
-        self.add_subsystem('c2', ExecComp(['y=x']))
-        self.add_subsystem('c3', ExecComp(['y=x']))
+        self.add_subsystem('c2', om.ExecComp(['y=x']))
+        self.add_subsystem('c3', om.ExecComp(['y=x']))
 
         self.connect('iv.x', 'c1.x')
 
@@ -55,7 +51,7 @@ class FanOutGrouped(Group):
         self.connect('sub.c3.y', 'c3.x')
 
 
-class FanIn(Group):
+class FanIn(om.Group):
     """
     Topology where two comps feed a single comp.
     """
@@ -63,11 +59,11 @@ class FanIn(Group):
     def __init__(self):
         super(FanIn, self).__init__()
 
-        self.add_subsystem('p1', IndepVarComp('x1', 1.0))
-        self.add_subsystem('p2', IndepVarComp('x2', 1.0))
-        self.add_subsystem('comp1', ExecComp(['y=-2.0*x']))
-        self.add_subsystem('comp2', ExecComp(['y=5.0*x']))
-        self.add_subsystem('comp3', ExecComp(['y=3.0*x1+7.0*x2']))
+        self.add_subsystem('p1', om.IndepVarComp('x1', 1.0))
+        self.add_subsystem('p2', om.IndepVarComp('x2', 1.0))
+        self.add_subsystem('comp1', om.ExecComp(['y=-2.0*x']))
+        self.add_subsystem('comp2', om.ExecComp(['y=5.0*x']))
+        self.add_subsystem('comp3', om.ExecComp(['y=3.0*x1+7.0*x2']))
 
         self.connect("comp1.y", "comp3.x1")
         self.connect("comp2.y", "comp3.x2")
@@ -75,7 +71,7 @@ class FanIn(Group):
         self.connect("p2.x2", "comp2.x")
 
 
-class FanInGrouped(Group):
+class FanInGrouped(om.Group):
     """
     Topology where two components in a Group feed a single component
     outside of that Group.
@@ -84,16 +80,16 @@ class FanInGrouped(Group):
     def __init__(self):
         super(FanInGrouped, self).__init__()
 
-        iv = self.add_subsystem('iv', IndepVarComp())
+        iv = self.add_subsystem('iv', om.IndepVarComp())
         iv.add_output('x1', 1.0)
         iv.add_output('x2', 1.0)
         iv.add_output('x3', 1.0)
 
-        self.sub = self.add_subsystem('sub', ParallelGroup())
-        self.sub.add_subsystem('c1', ExecComp(['y=-2.0*x']))
-        self.sub.add_subsystem('c2', ExecComp(['y=5.0*x']))
+        self.sub = self.add_subsystem('sub', om.ParallelGroup())
+        self.sub.add_subsystem('c1', om.ExecComp(['y=-2.0*x']))
+        self.sub.add_subsystem('c2', om.ExecComp(['y=5.0*x']))
 
-        self.add_subsystem('c3', ExecComp(['y=3.0*x1+7.0*x2']))
+        self.add_subsystem('c3', om.ExecComp(['y=3.0*x1+7.0*x2']))
 
         self.connect("sub.c1.y", "c3.x1")
         self.connect("sub.c2.y", "c3.x2")
@@ -101,7 +97,8 @@ class FanInGrouped(Group):
         self.connect("iv.x1", "sub.c1.x")
         self.connect("iv.x2", "sub.c2.x")
 
-class FanInGrouped2(Group):
+
+class FanInGrouped2(om.Group):
     """
     Topology where two components in a Group feed a single component
     outside of that Group. This is slightly different than FanInGrouped
@@ -113,14 +110,14 @@ class FanInGrouped2(Group):
     def __init__(self):
         super(FanInGrouped2, self).__init__()
 
-        p1 = self.add_subsystem('p1', IndepVarComp('x', 1.0))
-        p2 = self.add_subsystem('p2', IndepVarComp('x', 1.0))
+        p1 = self.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+        p2 = self.add_subsystem('p2', om.IndepVarComp('x', 1.0))
 
-        self.sub = self.add_subsystem('sub', ParallelGroup())
-        self.sub.add_subsystem('c1', ExecComp(['y=-2.0*x']))
-        self.sub.add_subsystem('c2', ExecComp(['y=5.0*x']))
+        self.sub = self.add_subsystem('sub', om.ParallelGroup())
+        self.sub.add_subsystem('c1', om.ExecComp(['y=-2.0*x']))
+        self.sub.add_subsystem('c2', om.ExecComp(['y=5.0*x']))
 
-        self.add_subsystem('c3', ExecComp(['y=3.0*x1+7.0*x2']))
+        self.add_subsystem('c3', om.ExecComp(['y=3.0*x1+7.0*x2']))
 
         self.connect("sub.c1.y", "c3.x1")
         self.connect("sub.c2.y", "c3.x2")
@@ -129,7 +126,7 @@ class FanInGrouped2(Group):
         self.connect("p2.x", "sub.c2.x")
 
 
-class DiamondFlat(Group):
+class DiamondFlat(om.Group):
     """
     Topology: one - two - one.
 
@@ -138,20 +135,18 @@ class DiamondFlat(Group):
     def __init__(self):
         super(DiamondFlat, self).__init__()
 
-        self.add_subsystem('iv', IndepVarComp('x', 2.0))
+        self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
-        self.add_subsystem('c1', ExecComp([
-            'y1 = 2.0*x1**2',
-            'y2 = 3.0*x1'
-        ]))
+        self.add_subsystem('c1', om.ExecComp(['y1 = 2.0*x1**2',
+                                              'y2 = 3.0*x1'
+                                              ]))
 
-        self.add_subsystem('c2', ExecComp('y1 = 0.5*x1'))
-        self.add_subsystem('c3', ExecComp('y1 = 3.5*x1'))
+        self.add_subsystem('c2', om.ExecComp('y1 = 0.5*x1'))
+        self.add_subsystem('c3', om.ExecComp('y1 = 3.5*x1'))
 
-        self.add_subsystem('c4', ExecComp([
-            'y1 = x1 + 2.0*x2',
-            'y2 = 3.0*x1 - 5.0*x2'
-        ]))
+        self.add_subsystem('c4', om.ExecComp(['y1 = x1 + 2.0*x2',
+                                              'y2 = 3.0*x1 - 5.0*x2'
+                                              ]))
 
         # make connections
         self.connect('iv.x', 'c1.x1')
@@ -161,7 +156,7 @@ class DiamondFlat(Group):
         self.connect('c3.y1', 'c4.x2')
 
 
-class Diamond(Group):
+class Diamond(om.Group):
     """
     Topology: one - two - one.
     """
@@ -169,21 +164,19 @@ class Diamond(Group):
     def __init__(self):
         super(Diamond, self).__init__()
 
-        self.add_subsystem('iv', IndepVarComp('x', 2.0))
+        self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
-        self.add_subsystem('c1', ExecComp([
-            'y1 = 2.0*x1**2',
-            'y2 = 3.0*x1'
-        ]))
+        self.add_subsystem('c1', om.ExecComp(['y1 = 2.0*x1**2',
+                                              'y2 = 3.0*x1'
+                                              ]))
 
-        sub = self.add_subsystem('sub', ParallelGroup())
-        sub.add_subsystem('c2', ExecComp('y1 = 0.5*x1'))
-        sub.add_subsystem('c3', ExecComp('y1 = 3.5*x1'))
+        sub = self.add_subsystem('sub', om.ParallelGroup())
+        sub.add_subsystem('c2', om.ExecComp('y1 = 0.5*x1'))
+        sub.add_subsystem('c3', om.ExecComp('y1 = 3.5*x1'))
 
-        self.add_subsystem('c4', ExecComp([
-            'y1 = x1 + 2.0*x2',
-            'y2 = 3.0*x1 - 5.0*x2'
-        ]))
+        self.add_subsystem('c4', om.ExecComp(['y1 = x1 + 2.0*x2',
+                                              'y2 = 3.0*x1 - 5.0*x2'
+                                              ]))
 
         # make connections
         self.connect('iv.x', 'c1.x1')
@@ -195,7 +188,7 @@ class Diamond(Group):
         self.connect('sub.c3.y1', 'c4.x2')
 
 
-class ConvergeDivergeFlat(Group):
+class ConvergeDivergeFlat(om.Group):
     """
     Topology one - two - one - two - one. This model was critical in
     testing parallel reverse scatters. This version is perfectly flat.
@@ -204,24 +197,22 @@ class ConvergeDivergeFlat(Group):
     def __init__(self):
         super(ConvergeDivergeFlat, self).__init__()
 
-        self.add_subsystem('iv', IndepVarComp('x', 2.0))
+        self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
-        self.add_subsystem('c1', ExecComp([
-            'y1 = 2.0*x1**2',
-            'y2 = 3.0*x1'
-        ]))
+        self.add_subsystem('c1', om.ExecComp(['y1 = 2.0*x1**2',
+                                              'y2 = 3.0*x1'
+                                              ]))
 
-        self.add_subsystem('c2', ExecComp('y1 = 0.5*x1'))
-        self.add_subsystem('c3', ExecComp('y1 = 3.5*x1'))
+        self.add_subsystem('c2', om.ExecComp('y1 = 0.5*x1'))
+        self.add_subsystem('c3', om.ExecComp('y1 = 3.5*x1'))
 
-        self.add_subsystem('c4', ExecComp([
-            'y1 = x1 + 2.0*x2',
-            'y2 = 3.0*x1 - 5.0*x2'
-        ]))
+        self.add_subsystem('c4', om.ExecComp(['y1 = x1 + 2.0*x2',
+                                              'y2 = 3.0*x1 - 5.0*x2'
+                                              ]))
 
-        self.add_subsystem('c5', ExecComp('y1 = 0.8*x1'))
-        self.add_subsystem('c6', ExecComp('y1 = 0.5*x1'))
-        self.add_subsystem('c7', ExecComp('y1 = x1 + 3.0*x2'))
+        self.add_subsystem('c5', om.ExecComp('y1 = 0.8*x1'))
+        self.add_subsystem('c6', om.ExecComp('y1 = 0.5*x1'))
+        self.add_subsystem('c7', om.ExecComp('y1 = x1 + 3.0*x2'))
 
         # make connections
         self.connect('iv.x', 'c1.x1')
@@ -239,7 +230,7 @@ class ConvergeDivergeFlat(Group):
         self.connect('c6.y1', 'c7.x2')
 
 
-class ConvergeDiverge(Group):
+class ConvergeDiverge(om.Group):
     """
     Topology: one - two - one - two - one.
 
@@ -249,27 +240,25 @@ class ConvergeDiverge(Group):
     def __init__(self):
         super(ConvergeDiverge, self).__init__()
 
-        self.add_subsystem('iv', IndepVarComp('x', 2.0))
+        self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
-        self.add_subsystem('c1', ExecComp([
-            'y1 = 2.0*x1**2',
-            'y2 = 3.0*x1'
-        ]))
+        self.add_subsystem('c1', om.ExecComp(['y1 = 2.0*x1**2',
+                                              'y2 = 3.0*x1'
+                                              ]))
 
-        g1 = self.add_subsystem('g1', ParallelGroup())
-        g1.add_subsystem('c2', ExecComp('y1 = 0.5*x1'))
-        g1.add_subsystem('c3', ExecComp('y1 = 3.5*x1'))
+        g1 = self.add_subsystem('g1', om.ParallelGroup())
+        g1.add_subsystem('c2', om.ExecComp('y1 = 0.5*x1'))
+        g1.add_subsystem('c3', om.ExecComp('y1 = 3.5*x1'))
 
-        self.add_subsystem('c4', ExecComp([
-            'y1 = x1 + 2.0*x2',
-            'y2 = 3.0*x1 - 5.0*x2'
-        ]))
+        self.add_subsystem('c4', om.ExecComp(['y1 = x1 + 2.0*x2',
+                                              'y2 = 3.0*x1 - 5.0*x2'
+                                              ]))
 
-        g2 = self.add_subsystem('g2', ParallelGroup())
-        g2.add_subsystem('c5', ExecComp('y1 = 0.8*x1'))
-        g2.add_subsystem('c6', ExecComp('y1 = 0.5*x1'))
+        g2 = self.add_subsystem('g2', om.ParallelGroup())
+        g2.add_subsystem('c5', om.ExecComp('y1 = 0.8*x1'))
+        g2.add_subsystem('c6', om.ExecComp('y1 = 0.5*x1'))
 
-        self.add_subsystem('c7', ExecComp('y1 = x1 + 3.0*x2'))
+        self.add_subsystem('c7', om.ExecComp('y1 = x1 + 3.0*x2'))
 
         # make connections
         self.connect('iv.x', 'c1.x1')
@@ -287,7 +276,7 @@ class ConvergeDiverge(Group):
         self.connect('g2.c6.y1', 'c7.x2')
 
 
-class ConvergeDivergeGroups(Group):
+class ConvergeDivergeGroups(om.Group):
     """
     Topology: one - two - one - two - one.
 
@@ -298,28 +287,26 @@ class ConvergeDivergeGroups(Group):
     def __init__(self):
         super(ConvergeDivergeGroups, self).__init__()
 
-        self.add_subsystem('iv', IndepVarComp('x', 2.0))
+        self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
-        g1 = self.add_subsystem('g1', ParallelGroup())
-        g1.add_subsystem('c1', ExecComp([
-            'y1 = 2.0*x1**2',
-            'y2 = 3.0*x1'
-        ]))
+        g1 = self.add_subsystem('g1', om.ParallelGroup())
+        g1.add_subsystem('c1', om.ExecComp(['y1 = 2.0*x1**2',
+                                            'y2 = 3.0*x1'
+                                            ]))
 
-        g2 = g1.add_subsystem('g2', ParallelGroup())
-        g2.add_subsystem('c2', ExecComp('y1 = 0.5*x1'))
-        g2.add_subsystem('c3', ExecComp('y1 = 3.5*x1'))
+        g2 = g1.add_subsystem('g2', om.ParallelGroup())
+        g2.add_subsystem('c2', om.ExecComp('y1 = 0.5*x1'))
+        g2.add_subsystem('c3', om.ExecComp('y1 = 3.5*x1'))
 
-        g1.add_subsystem('c4', ExecComp([
-            'y1 = x1 + 2.0*x2',
-            'y2 = 3.0*x1 - 5.0*x2'
-        ]))
+        g1.add_subsystem('c4', om.ExecComp(['y1 = x1 + 2.0*x2',
+                                            'y2 = 3.0*x1 - 5.0*x2'
+                                            ]))
 
-        g3 = self.add_subsystem('g3', ParallelGroup())
-        g3.add_subsystem('c5', ExecComp('y1 = 0.8*x1'))
-        g3.add_subsystem('c6', ExecComp('y1 = 0.5*x1'))
+        g3 = self.add_subsystem('g3', om.ParallelGroup())
+        g3.add_subsystem('c5', om.ExecComp('y1 = 0.8*x1'))
+        g3.add_subsystem('c6', om.ExecComp('y1 = 0.5*x1'))
 
-        self.add_subsystem('c7', ExecComp('y1 = x1 + 3.0*x2'))
+        self.add_subsystem('c7', om.ExecComp('y1 = x1 + 3.0*x2'))
 
         # make connections
         self.connect('iv.x', 'g1.c1.x1')
@@ -337,25 +324,25 @@ class ConvergeDivergeGroups(Group):
         self.connect('g3.c6.y1', 'c7.x2')
 
 
-class FanInSubbedIDVC(Group):
+class FanInSubbedIDVC(om.Group):
     """
     Classic Fan In with indepvarcomps buried below the parallel group, and a summation
     component.
     """
 
     def setup(self):
-        sub = self.add_subsystem('sub', ParallelGroup())
-        sub1 = sub.add_subsystem('sub1', Group())
-        sub2 = sub.add_subsystem('sub2', Group())
+        sub = self.add_subsystem('sub', om.ParallelGroup())
+        sub1 = sub.add_subsystem('sub1', om.Group())
+        sub2 = sub.add_subsystem('sub2', om.Group())
 
-        sub1.add_subsystem('p1', IndepVarComp('x', 3.0))
-        sub2.add_subsystem('p2', IndepVarComp('x', 5.0))
-        sub1.add_subsystem('c1', ExecComp(['y = 2.0*x']))
-        sub2.add_subsystem('c2', ExecComp(['y = 4.0*x']))
+        sub1.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        sub2.add_subsystem('p2', om.IndepVarComp('x', 5.0))
+        sub1.add_subsystem('c1', om.ExecComp(['y = 2.0*x']))
+        sub2.add_subsystem('c2', om.ExecComp(['y = 4.0*x']))
         sub1.connect('p1.x', 'c1.x')
         sub2.connect('p2.x', 'c2.x')
 
-        self.add_subsystem('sum', ExecComp(['y = z1 + z2']))
+        self.add_subsystem('sum',om. ExecComp(['y = z1 + z2']))
         self.connect('sub.sub1.c1.y', 'sum.z1')
         self.connect('sub.sub2.c2.y', 'sum.z2')
 

--- a/openmdao/test_suite/scripts/beam_opt.py
+++ b/openmdao/test_suite/scripts/beam_opt.py
@@ -1,7 +1,6 @@
 import numpy as np
 
-from openmdao.api import Problem, ScipyOptimizeDriver
-
+import openmdao.api as om
 from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 
 if __name__ == '__main__':
@@ -13,8 +12,8 @@ if __name__ == '__main__':
 
     num_elements = 50
 
-    prob = Problem(model=BeamGroup(E=E, L=L, b=b, volume=volume, num_elements=num_elements),
-                   driver=ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=True))
+    prob = om.Problem(model=BeamGroup(E=E, L=L, b=b, volume=volume, num_elements=num_elements),
+                      driver=om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=True))
     prob.setup()
     prob.run_driver()
 

--- a/openmdao/test_suite/scripts/circle_opt.py
+++ b/openmdao/test_suite/scripts/circle_opt.py
@@ -1,12 +1,13 @@
 
-from openmdao.api import Problem, IndepVarComp, ExecComp, ScipyOptimizeDriver
 import numpy as np
+
+import openmdao.api as om
 
 # note: size must be an even number
 SIZE = 10
-p = Problem()
+p = om.Problem()
 
-indeps = p.model.add_subsystem('indeps', IndepVarComp(), promotes_outputs=['*'])
+indeps = p.model.add_subsystem('indeps', om.IndepVarComp(), promotes_outputs=['*'])
 
 # the following were randomly generated using np.random.random(10)*2-1 to randomly
 # disperse them within a unit circle centered at the origin.
@@ -16,23 +17,24 @@ indeps.add_output('y', np.array([ 0.52577864,  0.30894559,  0.8420792 ,  0.35039
                                   -0.86236787, -0.97500023,  0.47739414,  0.51174103,  0.10052582]))
 indeps.add_output('r', .7)
 
-p.model.add_subsystem('arctan_yox', ExecComp('g=arctan(y/x)', vectorize=True,
+p.model.add_subsystem('arctan_yox', om.ExecComp('g=arctan(y/x)', vectorize=True,
                                                 g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
-p.model.add_subsystem('circle', ExecComp('area=pi*r**2'))
+p.model.add_subsystem('circle', om.ExecComp('area=pi*r**2'))
 
-p.model.add_subsystem('r_con', ExecComp('g=x**2 + y**2 - r', vectorize=True,
-                                        g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
+p.model.add_subsystem('r_con', om.ExecComp('g=x**2 + y**2 - r', vectorize=True,
+                                           g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)))
 
 thetas = np.linspace(0, np.pi/4, SIZE)
-p.model.add_subsystem('theta_con', ExecComp('g = x - theta', vectorize=True,
-                                            g=np.ones(SIZE), x=np.ones(SIZE),
-                                            theta=thetas))
-p.model.add_subsystem('delta_theta_con', ExecComp('g = even - odd', vectorize=True,
-                                                    g=np.ones(SIZE//2), even=np.ones(SIZE//2),
-                                                    odd=np.ones(SIZE//2)))
+p.model.add_subsystem('theta_con', om.ExecComp('g = x - theta', vectorize=True,
+                                               g=np.ones(SIZE), x=np.ones(SIZE),
+                                               theta=thetas))
+p.model.add_subsystem('delta_theta_con', om.ExecComp('g = even - odd', vectorize=True,
+                                                     g=np.ones(SIZE//2), even=np.ones(SIZE//2),
+                                                     odd=np.ones(SIZE//2)))
 
-p.model.add_subsystem('l_conx', ExecComp('g=x-1', vectorize=True, g=np.ones(SIZE), x=np.ones(SIZE)))
+p.model.add_subsystem('l_conx', om.ExecComp('g=x-1', vectorize=True, g=np.ones(SIZE),
+                                            x=np.ones(SIZE)))
 
 IND = np.arange(SIZE, dtype=int)
 ODD_IND = IND[1::2]  # all odd indices
@@ -45,7 +47,7 @@ p.model.connect('arctan_yox.g', 'theta_con.x')
 p.model.connect('arctan_yox.g', 'delta_theta_con.even', src_indices=EVEN_IND)
 p.model.connect('arctan_yox.g', 'delta_theta_con.odd', src_indices=ODD_IND)
 
-p.driver = ScipyOptimizeDriver()
+p.driver = om.ScipyOptimizeDriver()
 p.driver.options['optimizer'] = 'SLSQP'
 p.driver.options['disp'] = False
 

--- a/openmdao/test_suite/scripts/circuit.py
+++ b/openmdao/test_suite/scripts/circuit.py
@@ -1,8 +1,7 @@
-from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-
+import openmdao.api as om
 from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node
 
-class Circuit(Group):
+class Circuit(om.Group):
 
     def setup(self):
         self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])
@@ -20,16 +19,16 @@ class Circuit(Group):
         self.connect('R2.I', 'n2.I_in:0')
         self.connect('D1.I', 'n2.I_out:0')
 
-        self.nonlinear_solver = NewtonSolver()
+        self.nonlinear_solver = om.NewtonSolver()
         self.nonlinear_solver.options['iprint'] = 2
         self.nonlinear_solver.options['maxiter'] = 20
-        self.linear_solver = DirectSolver()
+        self.linear_solver = om.DirectSolver()
 
-p = Problem()
+p = om.Problem()
 model = p.model
 
-model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
 model.add_subsystem('circuit', Circuit())
 
 model.connect('source.I', 'circuit.I_in')

--- a/openmdao/test_suite/scripts/circuit.py
+++ b/openmdao/test_suite/scripts/circuit.py
@@ -38,7 +38,7 @@ model.add_design_var('ground.V')
 model.add_design_var('source.I')
 model.add_objective('circuit.D1.I')
 
-p.setup(check=False)
+p.setup()
 
 # set some initial guesses
 p['circuit.n1.V'] = 10.

--- a/openmdao/test_suite/scripts/circuit_analysis.py
+++ b/openmdao/test_suite/scripts/circuit_analysis.py
@@ -1,14 +1,13 @@
 from __future__ import print_function, division, absolute_import
-import numpy as np
-
 import unittest
 
-from openmdao.api import ExplicitComponent, ImplicitComponent, Group, NewtonSolver, DirectSolver
+import numpy as np
 
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
-class Resistor(ExplicitComponent):
+class Resistor(om.ExplicitComponent):
     """Computes current across a resistor using Ohm's law."""
 
     def initialize(self):
@@ -27,7 +26,7 @@ class Resistor(ExplicitComponent):
         outputs['I'] = deltaV / self.options['R']
 
 
-class Diode(ExplicitComponent):
+class Diode(om.ExplicitComponent):
     """Computes current across a diode using the Shockley diode equation."""
 
     def initialize(self):
@@ -49,7 +48,7 @@ class Diode(ExplicitComponent):
         outputs['I'] = Is * np.exp(deltaV / Vt - 1)
 
 
-class Node(ImplicitComponent):
+class Node(om.ImplicitComponent):
     """Computes voltage residual across a node based on incoming and outgoing current."""
 
     def initialize(self):
@@ -80,7 +79,7 @@ class Node(ImplicitComponent):
 
 
 # note: This is defined twice in the file. Once so you can import it, and once inside a test that gets included in the docs.
-class Circuit(Group):
+class Circuit(om.Group):
 
     def setup(self):
         self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])
@@ -98,29 +97,29 @@ class Circuit(Group):
         self.connect('R2.I', 'n2.I_in:0')
         self.connect('D1.I', 'n2.I_out:0')
 
-        self.nonlinear_solver = NewtonSolver()
+        self.nonlinear_solver = om.NewtonSolver()
         self.nonlinear_solver.options['iprint'] = 2
         self.nonlinear_solver.options['maxiter'] = 20
-        self.linear_solver = DirectSolver()
+        self.linear_solver = om.DirectSolver()
 
 
 if __name__ == "__main__":
-    from openmdao.api import ArmijoGoldsteinLS, Problem, IndepVarComp, BalanceComp, ExecComp
-    from openmdao.api import NewtonSolver, DirectSolver, NonlinearRunOnce, LinearRunOnce
+    import openmdao.api as om
 
-    p = Problem()
+    p = om.Problem()
     model = p.model
 
-    model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
+    model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
 
     # replacing the fixed current source with a BalanceComp to represent a fixed Voltage source
     # model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
-    model.add_subsystem('batt', IndepVarComp('V', 1.5, units='V'))
-    bal = model.add_subsystem('batt_balance', BalanceComp())
+    model.add_subsystem('batt', om.IndepVarComp('V', 1.5, units='V'))
+    bal = model.add_subsystem('batt_balance', om.BalanceComp())
     bal.add_balance('I', units='A', eq_units='V')
 
     model.add_subsystem('circuit', Circuit())
-    model.add_subsystem('batt_deltaV', ExecComp('dV = V1 - V2', V1={'units':'V'}, V2={'units':'V'}, dV={'units':'V'}))
+    model.add_subsystem('batt_deltaV', om.ExecComp('dV = V1 - V2', V1={'units':'V'},
+                                                   V2={'units':'V'}, dV={'units':'V'}))
 
     # current into the circuit is now the output state from the batt_balance comp
     model.connect('batt_balance.I', 'circuit.I_in')
@@ -139,16 +138,16 @@ if __name__ == "__main__":
 
     # change the circuit solver to RunOnce because we're
     # going to converge at the top level of the model with newton instead
-    p.model.circuit.nonlinear_solver = NonlinearRunOnce()
-    p.model.circuit.linear_solver = LinearRunOnce()
+    p.model.circuit.nonlinear_solver = om.NonlinearRunOnce()
+    p.model.circuit.linear_solver = om.LinearRunOnce()
 
     # Put Newton at the top so it can also converge the new BalanceComp residual
-    newton = p.model.nonlinear_solver = NewtonSolver()
-    p.model.linear_solver = DirectSolver()
+    newton = p.model.nonlinear_solver = om.NewtonSolver()
+    p.model.linear_solver = om.DirectSolver()
     newton.options['iprint'] = 2
     newton.options['maxiter'] = 20
     newton.options['solve_subsystems'] = True
-    newton.linesearch = ArmijoGoldsteinLS()
+    newton.linesearch = om.ArmijoGoldsteinLS()
     newton.linesearch.options['maxiter'] = 10
     newton.linesearch.options['iprint'] = 2
 

--- a/openmdao/test_suite/scripts/circuit_with_unconnected_input.py
+++ b/openmdao/test_suite/scripts/circuit_with_unconnected_input.py
@@ -1,8 +1,7 @@
-from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-
+import openmdao.api as om
 from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node
 
-class Circuit(Group):
+class Circuit(om.Group):
 
     def setup(self):
         self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])
@@ -21,16 +20,16 @@ class Circuit(Group):
         # self.connect('D1.I', 'n2.I_out:0') # commented out so there is an unconnected input
                                              # example for docs for the N2 diagram
 
-        self.nonlinear_solver = NewtonSolver()
+        self.nonlinear_solver = om.NewtonSolver()
         self.nonlinear_solver.options['iprint'] = 2
         self.nonlinear_solver.options['maxiter'] = 20
-        self.linear_solver = DirectSolver()
+        self.linear_solver = om.DirectSolver()
 
-p = Problem()
+p = om.Problem()
 model = p.model
 
-model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
 model.add_subsystem('circuit', Circuit())
 
 model.connect('source.I', 'circuit.I_in')

--- a/openmdao/test_suite/scripts/multipoint_beam_opt.py
+++ b/openmdao/test_suite/scripts/multipoint_beam_opt.py
@@ -2,7 +2,8 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-from openmdao.api import Problem, ScipyOptimizeDriver
+
+import openmdao.api as om
 from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
@@ -23,11 +24,11 @@ if __name__ == '__main__' and PETScVector is not None:
     num_elements = 50
     num_load_cases = 2
 
-    prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
-                                             num_elements=num_elements, num_cp=num_cp,
-                                             num_load_cases=num_load_cases))
+    prob = om.Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
+                                                num_elements=num_elements, num_cp=num_cp,
+                                                num_load_cases=num_load_cases))
 
-    prob.driver = ScipyOptimizeDriver()
+    prob.driver = om.ScipyOptimizeDriver()
     prob.driver.options['optimizer'] = 'SLSQP'
     prob.driver.options['tol'] = 1e-9
     prob.driver.options['disp'] = True

--- a/openmdao/test_suite/scripts/sellar.py
+++ b/openmdao/test_suite/scripts/sellar.py
@@ -1,16 +1,17 @@
 import numpy as np
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockGS, ScipyOptimizeDriver
+
+import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
 
 
-class SellarMDAConnect(Group):
+class SellarMDAConnect(om.Group):
 
     def setup(self):
-        indeps = self.add_subsystem('indeps', IndepVarComp())
+        indeps = self.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 1.0)
         indeps.add_output('z', np.array([5.0, 2.0]))
 
-        cycle = self.add_subsystem('cycle', Group())
+        cycle = self.add_subsystem('cycle', om.Group())
         cycle.add_subsystem('d1', SellarDis1())
         cycle.add_subsystem('d2', SellarDis2())
         cycle.connect('d1.y1', 'd2.y1')
@@ -21,13 +22,13 @@ class SellarMDAConnect(Group):
         #cycle.connect('d2.y2', 'd1.y2')
 
         # Nonlinear Block Gauss Seidel is a gradient free solver
-        cycle.nonlinear_solver = NonlinearBlockGS()
+        cycle.nonlinear_solver = om.NonlinearBlockGS()
 
-        self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                               z=np.array([0.0, 0.0]), x=0.0))
+        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                  z=np.array([0.0, 0.0]), x=0.0))
 
-        self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'))
-        self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'))
+        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'))
+        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'))
 
         self.connect('indeps.x', ['cycle.d1.x', 'obj_cmp.x'])
         self.connect('indeps.z', ['cycle.d1.z', 'cycle.d2.z', 'obj_cmp.z'])
@@ -35,11 +36,11 @@ class SellarMDAConnect(Group):
         self.connect('cycle.d2.y2', ['obj_cmp.y2', 'con_cmp2.y2'])
 
 
-prob = Problem()
+prob = om.Problem()
 
 prob.model = SellarMDAConnect()
 
-prob.driver = ScipyOptimizeDriver()
+prob.driver = om.ScipyOptimizeDriver()
 prob.driver.options['optimizer'] = 'SLSQP'
 # prob.driver.options['maxiter'] = 100
 prob.driver.options['tol'] = 1e-8

--- a/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
+++ b/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
@@ -3,22 +3,20 @@ from __future__ import print_function, division, absolute_import
 import unittest
 
 from openmdao.utils.assert_utils import assert_rel_error
-
-from openmdao.api import Problem, ScipyOptimizeDriver, ExecComp, IndepVarComp
-
 from openmdao.test_suite.components.paraboloid import Paraboloid
+
 
 class BasicOptParaboloid(unittest.TestCase):
 
     def test_unconstrainted(self):
-        from openmdao.api import Problem, ScipyOptimizeDriver, IndepVarComp
+        import openmdao.api as om
 
         # We'll use the component that was defined in the last tutorial
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         # build the model
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 3.0)
         indeps.add_output('y', -4.0)
 
@@ -28,7 +26,7 @@ class BasicOptParaboloid(unittest.TestCase):
         prob.model.connect('indeps.y', 'paraboloid.y')
 
         # setup the optimization
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'COBYLA'
 
         prob.model.add_design_var('indeps.x', lower=-50, upper=50)
@@ -47,27 +45,27 @@ class BasicOptParaboloid(unittest.TestCase):
 
 
     def test_constrained(self):
-        from openmdao.api import Problem, ScipyOptimizeDriver, ExecComp, IndepVarComp
+        import openmdao.api as om
 
         # We'll use the component that was defined in the last tutorial
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         # build the model
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 3.0)
         indeps.add_output('y', -4.0)
 
         prob.model.add_subsystem('parab', Paraboloid())
 
         # define the component whose output will be constrained
-        prob.model.add_subsystem('const', ExecComp('g = x + y'))
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y'))
 
         prob.model.connect('indeps.x', ['parab.x', 'const.x'])
         prob.model.connect('indeps.y', ['parab.y', 'const.y'])
 
         # setup the optimization
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'COBYLA'
 
         prob.model.add_design_var('indeps.x', lower=-50, upper=50)

--- a/openmdao/test_suite/test_examples/beam_optimization/beam_group.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/beam_group.py
@@ -1,7 +1,7 @@
 from __future__ import division
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp
+import openmdao.api as om
 
 from openmdao.test_suite.test_examples.beam_optimization.components.moment_comp import MomentOfInertiaComp
 from openmdao.test_suite.test_examples.beam_optimization.components.local_stiffness_matrix_comp import LocalStiffnessMatrixComp
@@ -11,7 +11,7 @@ from openmdao.test_suite.test_examples.beam_optimization.components.compliance_c
 from openmdao.test_suite.test_examples.beam_optimization.components.volume_comp import VolumeComp
 
 
-class BeamGroup(Group):
+class BeamGroup(om.Group):
 
     def initialize(self):
         self.options.declare('E')
@@ -31,7 +31,7 @@ class BeamGroup(Group):
         force_vector = np.zeros(2 * num_nodes)
         force_vector[-2] = -1.
 
-        inputs_comp = IndepVarComp()
+        inputs_comp = om.IndepVarComp()
         inputs_comp.add_output('h', shape=num_elements)
         self.add_subsystem('inputs_comp', inputs_comp)
 

--- a/openmdao/test_suite/test_examples/beam_optimization/components/compliance_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/compliance_comp.py
@@ -3,10 +3,10 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class ComplianceComp(ExplicitComponent):
+class ComplianceComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)
@@ -29,7 +29,7 @@ class ComplianceComp(ExplicitComponent):
         outputs['compliance'] = np.dot(force_vector, inputs['displacements'])
 
 
-class MultiComplianceComp(ExplicitComponent):
+class MultiComplianceComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/components/displacements_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/displacements_comp.py
@@ -3,10 +3,10 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class DisplacementsComp(ExplicitComponent):
+class DisplacementsComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)
@@ -29,7 +29,7 @@ class DisplacementsComp(ExplicitComponent):
         outputs['displacements'] = inputs['d'][:2 * num_nodes]
 
 
-class MultiDisplacementsComp(ExplicitComponent):
+class MultiDisplacementsComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
@@ -3,6 +3,7 @@ import numpy as np
 
 import openmdao.api as om
 
+
 class LocalStiffnessMatrixComp(om.ExplicitComponent):
 
     def initialize(self):

--- a/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
@@ -1,9 +1,9 @@
 from __future__ import division
 import numpy as np
-from openmdao.api import ExplicitComponent
 
+import openmdao.api as om
 
-class LocalStiffnessMatrixComp(ExplicitComponent):
+class LocalStiffnessMatrixComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/components/moment_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/moment_comp.py
@@ -1,9 +1,11 @@
 from __future__ import division
+
 import numpy as np
-from openmdao.api import ExplicitComponent
+
+import openmdao.api as om
 
 
-class MomentOfInertiaComp(ExplicitComponent):
+class MomentOfInertiaComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/components/states_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/states_comp.py
@@ -5,10 +5,10 @@ import numpy as np
 from scipy.sparse import coo_matrix
 from scipy.sparse.linalg import splu
 
-from openmdao.api import ImplicitComponent
+import openmdao.api as om
 
 
-class StatesComp(ImplicitComponent):
+class StatesComp(om.ImplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)
@@ -120,7 +120,7 @@ class StatesComp(ImplicitComponent):
         return coo_matrix((data, (rows, cols)), shape=(n_K, n_K)).tocsc()
 
 
-class MultiStatesComp(ImplicitComponent):
+class MultiStatesComp(om.ImplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/components/stress_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/stress_comp.py
@@ -10,10 +10,10 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import ExplicitComponent
+import openmdao.api as om
 
 
-class MultiStressComp(ExplicitComponent):
+class MultiStressComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/components/volume_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/volume_comp.py
@@ -1,9 +1,10 @@
 from __future__ import division
 import numpy as np
-from openmdao.api import ExplicitComponent
+
+import openmdao.api as om
 
 
-class VolumeComp(ExplicitComponent):
+class VolumeComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare('num_elements', types=int)

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_group.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_group.py
@@ -8,8 +8,7 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, ParallelGroup, ExecComp
-from openmdao.components.bsplines_comp import BsplinesComp
+import openmdao.api as om
 
 from openmdao.test_suite.test_examples.beam_optimization.components.compliance_comp import MultiComplianceComp
 from openmdao.test_suite.test_examples.beam_optimization.components.displacements_comp import MultiDisplacementsComp
@@ -51,7 +50,7 @@ def divide_cases(ncases, nprocs):
     return data
 
 
-class MultipointBeamGroup(Group):
+class MultipointBeamGroup(om.Group):
 
     def initialize(self):
         self.options.declare('E')
@@ -72,12 +71,12 @@ class MultipointBeamGroup(Group):
         num_cp = self.options['num_cp']
         num_load_cases = self.options['num_load_cases']
 
-        inputs_comp = IndepVarComp()
+        inputs_comp = om.IndepVarComp()
         inputs_comp.add_output('h_cp', shape=num_cp)
         self.add_subsystem('inputs_comp', inputs_comp)
 
-        comp = BsplinesComp(num_control_points=num_cp, num_points=num_elements, in_name='h_cp',
-                            out_name='h')
+        comp = om.BsplinesComp(num_control_points=num_cp, num_points=num_elements,
+                               in_name='h_cp', out_name='h')
         self.add_subsystem('interp', comp)
 
         I_comp = MomentOfInertiaComp(num_elements=num_elements, b=b)
@@ -87,7 +86,7 @@ class MultipointBeamGroup(Group):
         self.add_subsystem('local_stiffness_matrix_comp', comp)
 
         # Parallel Subsystem for load cases.
-        par = self.add_subsystem('parallel', ParallelGroup())
+        par = self.add_subsystem('parallel', om.ParallelGroup())
 
         # Determine how to split cases up over the available procs.
         nprocs = self.comm.size
@@ -98,7 +97,7 @@ class MultipointBeamGroup(Group):
             num_rhs = len(this_proc)
 
             name = 'sub_%d' % j
-            sub = par.add_subsystem(name, Group())
+            sub = par.add_subsystem(name, om.Group())
 
             # Load is a sinusoidal distributed force of varying spatial frequency.
             force_vector = np.zeros((2 * num_nodes, num_rhs))
@@ -139,7 +138,7 @@ class MultipointBeamGroup(Group):
         comp = VolumeComp(num_elements=num_elements, b=b, L=L)
         self.add_subsystem('volume_comp', comp)
 
-        comp = ExecComp(['obj = ' + ' + '.join(['compliance_%d' % i for i in range(num_load_cases)])])
+        comp = om.ExecComp(['obj = ' + ' + '.join(['compliance_%d' % i for i in range(num_load_cases)])])
         self.add_subsystem('obj_sum', comp)
 
         for j, src in enumerate(obj_srcs):

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
@@ -10,8 +10,6 @@ from six.moves import range
 import numpy as np
 
 import openmdao.api as om
-from openmdao.components.bsplines_comp import BsplinesComp
-from openmdao.components.ks_comp import KSComp
 
 from openmdao.test_suite.test_examples.beam_optimization.components.displacements_comp import MultiDisplacementsComp
 from openmdao.test_suite.test_examples.beam_optimization.components.local_stiffness_matrix_comp import LocalStiffnessMatrixComp
@@ -85,8 +83,8 @@ class MultipointBeamGroup(om.Group):
         inputs_comp.add_output('h_cp', shape=num_cp)
         self.add_subsystem('inputs_comp', inputs_comp)
 
-        comp = BsplinesComp(num_control_points=num_cp, num_points=num_elements, in_name='h_cp',
-                            out_name='h')
+        comp = om.BsplinesComp(num_control_points=num_cp, num_points=num_elements, in_name='h_cp',
+                               out_name='h')
         self.add_subsystem('interp', comp)
 
         I_comp = MomentOfInertiaComp(num_elements=num_elements, b=b)
@@ -142,7 +140,7 @@ class MultipointBeamGroup(om.Group):
                     'displacements_comp.displacements_%d' % k,
                     'stress_comp.displacements_%d' % k)
 
-                comp = KSComp(width=num_elements)
+                comp = om.KSComp(width=num_elements)
                 comp.options['upper'] = max_bending
                 sub.add_subsystem('KS_%d' % k, comp)
 

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
@@ -9,7 +9,7 @@ from six.moves import range
 
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, ParallelGroup, ExecComp
+import openmdao.api as om
 from openmdao.components.bsplines_comp import BsplinesComp
 from openmdao.components.ks_comp import KSComp
 
@@ -53,7 +53,7 @@ def divide_cases(ncases, nprocs):
     return data
 
 
-class MultipointBeamGroup(Group):
+class MultipointBeamGroup(om.Group):
     """
     System setup for minimization of volume (i.e., mass) subject to KS aggregated bending stress constraints.
     """
@@ -81,7 +81,7 @@ class MultipointBeamGroup(Group):
         num_load_cases = self.options['num_load_cases']
         parallel_derivs = self.options['parallel_derivs']
 
-        inputs_comp = IndepVarComp()
+        inputs_comp = om.IndepVarComp()
         inputs_comp.add_output('h_cp', shape=num_cp)
         self.add_subsystem('inputs_comp', inputs_comp)
 
@@ -96,7 +96,7 @@ class MultipointBeamGroup(Group):
         self.add_subsystem('local_stiffness_matrix_comp', comp)
 
         # Parallel Subsystem for load cases.
-        par = self.add_subsystem('parallel', ParallelGroup())
+        par = self.add_subsystem('parallel', om.ParallelGroup())
 
         # Determine how to split cases up over the available procs.
         nprocs = self.comm.size
@@ -106,7 +106,7 @@ class MultipointBeamGroup(Group):
             num_rhs = len(this_proc)
 
             name = 'sub_%d' % j
-            sub = par.add_subsystem(name, Group())
+            sub = par.add_subsystem(name, om.Group())
 
             # Load is a sinusoidal distributed force of varying spatial frequency.
             force_vector = np.zeros((2 * num_nodes, num_rhs))

--- a/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
@@ -4,7 +4,7 @@ import unittest
 
 from openmdao.utils.assert_utils import assert_rel_error
 
-from openmdao.api import Problem, ScipyOptimizeDriver
+import openmdao.api as om
 from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
@@ -19,8 +19,7 @@ class TestCase(unittest.TestCase):
     def test(self):
         import numpy as np
 
-        from openmdao.api import Problem, ScipyOptimizeDriver
-
+        import openmdao.api as om
         from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 
         E = 1.
@@ -30,9 +29,9 @@ class TestCase(unittest.TestCase):
 
         num_elements = 50
 
-        prob = Problem(model=BeamGroup(E=E, L=L, b=b, volume=volume, num_elements=num_elements))
+        prob = om.Problem(model=BeamGroup(E=E, L=L, b=b, volume=volume, num_elements=num_elements))
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = True
@@ -55,8 +54,7 @@ class TestCase(unittest.TestCase):
     def test_multipoint(self):
         import numpy as np
 
-        from openmdao.api import Problem, ScipyOptimizeDriver
-
+        import openmdao.api as om
         from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
         E = 1.
@@ -68,11 +66,13 @@ class TestCase(unittest.TestCase):
         num_elements = 50
         num_load_cases = 2
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        model = MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
+                                    num_elements=num_elements, num_cp=num_cp,
+                                    num_load_cases=num_load_cases)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob = om.Problem(model=model)
+
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = True
@@ -95,8 +95,7 @@ class TestCase(unittest.TestCase):
     def test_multipoint_stress(self):
         import numpy as np
 
-        from openmdao.api import Problem, ScipyOptimizeDriver
-
+        import openmdao.api as om
         from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_stress import MultipointBeamGroup
 
         E = 1.
@@ -109,11 +108,13 @@ class TestCase(unittest.TestCase):
         num_elements = 25
         num_load_cases = 2
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume, max_bending = max_bending,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        model = MultipointBeamGroup(E=E, L=L, b=b, volume=volume, max_bending = max_bending,
+                                    num_elements=num_elements, num_cp=num_cp,
+                                    num_load_cases=num_load_cases)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob = om.Problem(model=model)
+
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = True
@@ -138,8 +139,7 @@ class TestParallelGroups(unittest.TestCase):
     def test_multipoint(self):
         import numpy as np
 
-        from openmdao.api import Problem, ScipyOptimizeDriver
-
+        import openmdao.api as om
         from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
         E = 1.
@@ -151,11 +151,13 @@ class TestParallelGroups(unittest.TestCase):
         num_elements = 50
         num_load_cases = 2
 
-        prob = Problem(model=MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
-                                                 num_elements=num_elements, num_cp=num_cp,
-                                                 num_load_cases=num_load_cases))
+        model = MultipointBeamGroup(E=E, L=L, b=b, volume=volume,
+                                    num_elements=num_elements, num_cp=num_cp,
+                                    num_load_cases=num_load_cases)
 
-        prob.driver = ScipyOptimizeDriver()
+        prob = om.Problem(model=model)
+
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         prob.driver.options['tol'] = 1e-9
         prob.driver.options['disp'] = True

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -5,12 +5,12 @@ import unittest
 
 import scipy
 
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
-from openmdao.api import Problem, ScipyOptimizeDriver, IndepVarComp, ExplicitComponent
 
 # duplicate definition here so it can be included in docs by itself
-class ActuatorDisc(ExplicitComponent):
+class ActuatorDisc(om.ExplicitComponent):
     """Simple wind turbine model based on actuator disc theory"""
 
     def setup(self):
@@ -90,14 +90,15 @@ class ActuatorDisc(ExplicitComponent):
         J['power', 'rho'] = 2.0 * a_times_area * Vu ** 3 * (one_minus_a)**2
         J['power', 'Vu'] = 6.0 * Area * Vu**2 * a * rho * one_minus_a**2
 
+
 class TestBetzLimit(unittest.TestCase):
 
     def test_betz(self):
         from distutils.version import LooseVersion
         import scipy
-        from openmdao.api import Problem, ScipyOptimizeDriver, IndepVarComp, ExplicitComponent
+        import openmdao.api as om
 
-        class ActuatorDisc(ExplicitComponent):
+        class ActuatorDisc(om.ExplicitComponent):
             """Simple wind turbine model based on actuator disc theory"""
 
             def setup(self):
@@ -180,8 +181,8 @@ class TestBetzLimit(unittest.TestCase):
 
 
         # build the model
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('a', .5)
         indeps.add_output('Area', 10.0, units='m**2')
         indeps.add_output('rho', 1.225, units='kg/m**3')
@@ -191,7 +192,7 @@ class TestBetzLimit(unittest.TestCase):
                                 promotes_inputs=['a', 'Area', 'rho', 'Vu'])
 
         # setup the optimization
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('a', lower=0., upper=1.)
@@ -213,16 +214,15 @@ class TestBetzLimit(unittest.TestCase):
             raise unittest.SkipTest(msg)
 
     def test_betz_derivatives(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
 
         from openmdao.test_suite.test_examples.test_betz_limit import ActuatorDisc
 
-        prob = Problem()
+        prob = om.Problem()
 
         prob.model.add_subsystem('a_disk', ActuatorDisc())
 
         prob.setup()
-
         prob.check_partials(compact_print=True)
 
 

--- a/openmdao/test_suite/test_examples/test_circuit_analysis.py
+++ b/openmdao/test_suite/test_examples/test_circuit_analysis.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import unittest
 
-from openmdao.api import ExplicitComponent, ImplicitComponent, Group, NewtonSolver, DirectSolver
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
@@ -11,11 +11,10 @@ class TestCircuit(unittest.TestCase):
 
     def test_circuit_plain_newton_assembled(self):
 
-        from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node
 
-        class Circuit(Group):
+        class Circuit(om.Group):
 
             def setup(self):
                 self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])
@@ -33,20 +32,20 @@ class TestCircuit(unittest.TestCase):
                 self.connect('R2.I', 'n2.I_in:0')
                 self.connect('D1.I', 'n2.I_out:0')
 
-                self.nonlinear_solver = NewtonSolver()
+                self.nonlinear_solver = om.NewtonSolver()
                 self.nonlinear_solver.options['iprint'] = 2
                 self.nonlinear_solver.options['maxiter'] = 20
                 ##################################################################
                 # Assemble at the group level. Default assembled jac type is 'csc'
                 ##################################################################
                 self.options['assembled_jac_type'] = 'csc'
-                self.linear_solver = DirectSolver(assemble_jac=True)
+                self.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -71,11 +70,10 @@ class TestCircuit(unittest.TestCase):
 
     def test_circuit_plain_newton(self):
 
-        from openmdao.api import Group, NewtonSolver, DirectSolver, Problem, IndepVarComp
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node
 
-        class Circuit(Group):
+        class Circuit(om.Group):
 
             def setup(self):
                 self.add_subsystem('n1', Node(n_in=1, n_out=2), promotes_inputs=[('I_in:0', 'I_in')])
@@ -93,16 +91,16 @@ class TestCircuit(unittest.TestCase):
                 self.connect('R2.I', 'n2.I_in:0')
                 self.connect('D1.I', 'n2.I_out:0')
 
-                self.nonlinear_solver = NewtonSolver()
+                self.nonlinear_solver = om.NewtonSolver()
                 self.nonlinear_solver.options['iprint'] = 2
                 self.nonlinear_solver.options['maxiter'] = 20
-                self.linear_solver = DirectSolver()
+                self.linear_solver = om.DirectSolver()
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -127,15 +125,14 @@ class TestCircuit(unittest.TestCase):
 
     def test_circuit_plain_newton_many_iter(self):
 
-        from openmdao.api import Problem, IndepVarComp
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -160,15 +157,14 @@ class TestCircuit(unittest.TestCase):
         assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], 0.09987447, 1e-6)
 
     def test_circuit_advanced_newton(self):
-        from openmdao.api import ArmijoGoldsteinLS, Problem, IndepVarComp
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
-        model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
         model.add_subsystem('circuit', Circuit())
 
         model.connect('source.I', 'circuit.I_in')
@@ -181,7 +177,7 @@ class TestCircuit(unittest.TestCase):
         newton.options['iprint'] = 2
         newton.options['maxiter'] = 10
         newton.options['solve_subsystems'] = True
-        newton.linesearch = ArmijoGoldsteinLS()
+        newton.linesearch = om.ArmijoGoldsteinLS()
         newton.linesearch.options['maxiter'] = 10
         newton.linesearch.options['iprint'] = 2
 
@@ -201,24 +197,23 @@ class TestCircuit(unittest.TestCase):
         assert_rel_error(self, p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_voltage_source(self):
-        from openmdao.api import ArmijoGoldsteinLS, Problem, IndepVarComp, BalanceComp, ExecComp
-        from openmdao.api import NewtonSolver, DirectSolver, NonlinearRunOnce, LinearRunOnce
-
+        import openmdao.api as om
         from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-        p = Problem()
+        p = om.Problem()
         model = p.model
 
-        model.add_subsystem('ground', IndepVarComp('V', 0., units='V'))
+        model.add_subsystem('ground', om.IndepVarComp('V', 0., units='V'))
 
         # replacing the fixed current source with a BalanceComp to represent a fixed Voltage source
-        # model.add_subsystem('source', IndepVarComp('I', 0.1, units='A'))
-        model.add_subsystem('batt', IndepVarComp('V', 1.5, units='V'))
-        bal = model.add_subsystem('batt_balance', BalanceComp())
+        # model.add_subsystem('source', om.IndepVarComp('I', 0.1, units='A'))
+        model.add_subsystem('batt', om.IndepVarComp('V', 1.5, units='V'))
+        bal = model.add_subsystem('batt_balance', om.BalanceComp())
         bal.add_balance('I', units='A', eq_units='V')
 
         model.add_subsystem('circuit', Circuit())
-        model.add_subsystem('batt_deltaV', ExecComp('dV = V1 - V2', V1={'units':'V'}, V2={'units':'V'}, dV={'units':'V'}))
+        model.add_subsystem('batt_deltaV', om.ExecComp('dV = V1 - V2', V1={'units':'V'},
+                                                       V2={'units':'V'}, dV={'units':'V'}))
 
         # current into the circuit is now the output state from the batt_balance comp
         model.connect('batt_balance.I', 'circuit.I_in')
@@ -237,16 +232,16 @@ class TestCircuit(unittest.TestCase):
 
         # change the circuit solver to RunOnce because we're
         # going to converge at the top level of the model with newton instead
-        p.model.circuit.nonlinear_solver = NonlinearRunOnce()
-        p.model.circuit.linear_solver = LinearRunOnce()
+        p.model.circuit.nonlinear_solver = om.NonlinearRunOnce()
+        p.model.circuit.linear_solver = om.LinearRunOnce()
 
         # Put Newton at the top so it can also converge the new BalanceComp residual
-        newton = p.model.nonlinear_solver = NewtonSolver()
-        p.model.linear_solver = DirectSolver()
+        newton = p.model.nonlinear_solver = om.NewtonSolver()
+        p.model.linear_solver = om.DirectSolver()
         newton.options['iprint'] = 2
         newton.options['maxiter'] = 20
         newton.options['solve_subsystems'] = True
-        newton.linesearch = ArmijoGoldsteinLS()
+        newton.linesearch = om.ArmijoGoldsteinLS()
         newton.linesearch.options['maxiter'] = 10
         newton.linesearch.options['iprint'] = 2
 

--- a/openmdao/test_suite/test_examples/test_hohmann_transfer.py
+++ b/openmdao/test_suite/test_examples/test_hohmann_transfer.py
@@ -134,7 +134,7 @@ class TestHohmannTransfer(unittest.TestCase):
         from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ScipyOptimizeDriver
         from openmdao.test_suite.test_examples.test_hohmann_transfer import  VCircComp, TransferOrbitComp, DeltaVComp
 
-        prob = Problem(model=Group())
+        prob = Problem()
 
         model = prob.model
 

--- a/openmdao/test_suite/test_examples/test_hohmann_transfer.py
+++ b/openmdao/test_suite/test_examples/test_hohmann_transfer.py
@@ -3,15 +3,14 @@ Find the minimum delta-V for an impulsive Hohmann Transer from
 Low Earth Orbit (LEO) to Geostationary Orbit (GEO)
 """
 from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np
-from openmdao.api import Problem, Group, ExplicitComponent, IndepVarComp, \
-    ExecComp, ScipyOptimizeDriver
+
+import openmdao.api as om
 
 
-class VCircComp(ExplicitComponent):
+class VCircComp(om.ExplicitComponent):
     """
     Computes the circular orbit velocity given a radius and gravitational
     parameter.
@@ -54,7 +53,7 @@ class VCircComp(ExplicitComponent):
         partials['vcirc', 'r'] = -0.5 * mu / (vcirc * r ** 2)
 
 
-class DeltaVComp(ExplicitComponent):
+class DeltaVComp(om.ExplicitComponent):
     """
     Compute the delta-V performed given the magnitude of two velocities
     and the angle between them.
@@ -95,7 +94,7 @@ class DeltaVComp(ExplicitComponent):
         partials['delta_v', 'dinc'] = 0.5 / delta_v * (2 * v1 * v2 * np.sin(dinc))
 
 
-class TransferOrbitComp(ExplicitComponent):
+class TransferOrbitComp(om.ExplicitComponent):
     def initialize(self):
         pass
 
@@ -131,14 +130,14 @@ class TransferOrbitComp(ExplicitComponent):
 class TestHohmannTransfer(unittest.TestCase):
 
     def test_dv_at_apogee(self):
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ScipyOptimizeDriver
+        import openmdao.api as om
         from openmdao.test_suite.test_examples.test_hohmann_transfer import  VCircComp, TransferOrbitComp, DeltaVComp
 
-        prob = Problem()
+        prob = om.Problem()
 
         model = prob.model
 
-        ivc = model.add_subsystem('ivc', IndepVarComp(), promotes_outputs=['*'])
+        ivc = model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
         ivc.add_output('mu', val=0.0, units='km**3/s**2')
         ivc.add_output('r1', val=0.0, units='km')
         ivc.add_output('r2', val=0.0, units='km')
@@ -168,26 +167,26 @@ class TestHohmannTransfer(unittest.TestCase):
         model.connect('dinc2', 'dv2.dinc')
 
         model.add_subsystem('dv_total',
-                            subsys=ExecComp('delta_v=dv1+dv2',
-                                            delta_v={'units': 'km/s'},
-                                            dv1={'units': 'km/s'},
-                                            dv2={'units': 'km/s'}),
+                            subsys=om.ExecComp('delta_v=dv1+dv2',
+                                               delta_v={'units': 'km/s'},
+                                               dv1={'units': 'km/s'},
+                                               dv2={'units': 'km/s'}),
                             promotes=['delta_v'])
 
         model.connect('dv1.delta_v', 'dv_total.dv1')
         model.connect('dv2.delta_v', 'dv_total.dv2')
 
         model.add_subsystem('dinc_total',
-                            subsys=ExecComp('dinc=dinc1+dinc2',
-                                            dinc={'units': 'deg'},
-                                            dinc1={'units': 'deg'},
-                                            dinc2={'units': 'deg'}),
+                            subsys=om.ExecComp('dinc=dinc1+dinc2',
+                                               dinc={'units': 'deg'},
+                                               dinc1={'units': 'deg'},
+                                               dinc2={'units': 'deg'}),
                             promotes=['dinc'])
 
         model.connect('dinc1', 'dinc_total.dinc1')
         model.connect('dinc2', 'dinc_total.dinc2')
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
 
         model.add_design_var('dinc1', lower=0, upper=28.5)
         model.add_design_var('dinc2', lower=0, upper=28.5)

--- a/openmdao/test_suite/test_examples/test_keplers_equation.py
+++ b/openmdao/test_suite/test_examples/test_keplers_equation.py
@@ -5,8 +5,8 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, BalanceComp, \
-    ExecComp, DirectSolver, NewtonSolver
+import openmdao.api as om
+
 
 class TestKeplersEquation(unittest.TestCase):
 
@@ -14,12 +14,11 @@ class TestKeplersEquation(unittest.TestCase):
         import numpy as np
         from numpy.testing import assert_almost_equal
 
-        from openmdao.api import Problem, Group, IndepVarComp, BalanceComp, \
-            ExecComp, DirectSolver, NewtonSolver
+        import openmdao.api as om
 
-        prob = Problem()
+        prob = om.Problem()
 
-        ivc = IndepVarComp()
+        ivc = om.IndepVarComp()
 
         ivc.add_output(name='M',
                        val=0.0,
@@ -31,7 +30,7 @@ class TestKeplersEquation(unittest.TestCase):
                        units=None,
                        desc='orbit eccentricity')
 
-        bal = BalanceComp()
+        bal = om.BalanceComp()
 
         bal.add_balance(name='E', val=0.0, units='rad', eq_units='rad', rhs_name='M')
 
@@ -42,10 +41,10 @@ class TestKeplersEquation(unittest.TestCase):
         bal.options['guess_func'] = guess_function
 
         # ExecComp used to compute the LHS of Kepler's equation.
-        lhs_comp = ExecComp('lhs=E - ecc * sin(E)',
-                            lhs={'value': 0.0, 'units': 'rad'},
-                            E={'value': 0.0, 'units': 'rad'},
-                            ecc={'value': 0.0})
+        lhs_comp = om.ExecComp('lhs=E - ecc * sin(E)',
+                               lhs={'value': 0.0, 'units': 'rad'},
+                               E={'value': 0.0, 'units': 'rad'},
+                               ecc={'value': 0.0})
 
         prob.model.add_subsystem(name='ivc', subsys=ivc,
                                  promotes_outputs=['M', 'ecc'])
@@ -61,8 +60,8 @@ class TestKeplersEquation(unittest.TestCase):
         prob.model.connect('lhs_comp.lhs', 'balance.lhs:E')
 
         # Set up solvers
-        prob.model.linear_solver = DirectSolver()
-        prob.model.nonlinear_solver = NewtonSolver(maxiter=100, iprint=0)
+        prob.model.linear_solver = om.DirectSolver()
+        prob.model.nonlinear_solver = om.NewtonSolver(maxiter=100, iprint=0)
 
         prob.setup()
 

--- a/openmdao/test_suite/test_examples/test_sellar_mda_promote_connect.py
+++ b/openmdao/test_suite/test_examples/test_sellar_mda_promote_connect.py
@@ -1,48 +1,51 @@
 from __future__ import print_function, division
 import unittest
+
 import numpy as np
 
-from openmdao.api import Group, IndepVarComp, ExecComp, NonlinearBlockGS
+import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
-
 from openmdao.utils.assert_utils import assert_rel_error
-
 
 
 class TestSellarMDAPromoteConnect(unittest.TestCase):
 
     def test_sellar_mda_promote(self):
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockGS
+
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
 
-        class SellarMDA(Group):
+        class SellarMDA(om.Group):
             """
             Group containing the Sellar MDA.
             """
 
             def setup(self):
-                indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+                indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
                 indeps.add_output('x', 1.0)
                 indeps.add_output('z', np.array([5.0, 2.0]))
 
-                cycle = self.add_subsystem('cycle', Group(), promotes=['*'])
-                cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'], promotes_outputs=['y1'])
-                cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'], promotes_outputs=['y2'])
+                cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
+                cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'],
+                                    promotes_outputs=['y1'])
+                cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'],
+                                    promotes_outputs=['y2'])
 
                 # Nonlinear Block Gauss Seidel is a gradient free solver
-                cycle.nonlinear_solver = NonlinearBlockGS()
+                cycle.nonlinear_solver =om. NonlinearBlockGS()
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                   z=np.array([0.0, 0.0]), x=0.0),
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0),
                                    promotes=['x', 'z', 'y1', 'y2', 'obj'])
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'),
+                                   promotes=['con1', 'y1'])
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'),
+                                   promotes=['con2', 'y2'])
 
 
-        prob = Problem()
-
+        prob = om.Problem()
         prob.model = SellarMDA()
 
         prob.setup()
@@ -58,41 +61,41 @@ class TestSellarMDAPromoteConnect(unittest.TestCase):
 
     def test_sellar_mda_connect(self):
         import numpy as np
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockGS
+
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
 
-        class SellarMDAConnect(Group):
+        class SellarMDAConnect(om.Group):
             """
             Group containing the Sellar MDA. This version uses the disciplines without derivatives.
             """
 
             def setup(self):
-                indeps = self.add_subsystem('indeps', IndepVarComp())
+                indeps = self.add_subsystem('indeps', om.IndepVarComp())
                 indeps.add_output('x', 1.0)
                 indeps.add_output('z', np.array([5.0, 2.0]))
 
-                cycle = self.add_subsystem('cycle', Group())
+                cycle = self.add_subsystem('cycle', om.Group())
                 cycle.add_subsystem('d1', SellarDis1())
                 cycle.add_subsystem('d2', SellarDis2())
                 cycle.connect('d1.y1', 'd2.y1')
                 cycle.connect('d2.y2', 'd1.y2')
 
                 # Nonlinear Block Gauss Seidel is a gradient free solver
-                cycle.nonlinear_solver = NonlinearBlockGS()
+                cycle.nonlinear_solver = om.NonlinearBlockGS()
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                       z=np.array([0.0, 0.0]), x=0.0))
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0))
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'))
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'))
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'))
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'))
 
                 self.connect('indeps.x', ['cycle.d1.x', 'obj_cmp.x'])
                 self.connect('indeps.z', ['cycle.d1.z', 'cycle.d2.z', 'obj_cmp.z'])
                 self.connect('cycle.d1.y1', ['obj_cmp.y1', 'con_cmp1.y1'])
                 self.connect('cycle.d2.y2', ['obj_cmp.y2', 'con_cmp2.y2'])
 
-        prob = Problem()
-
+        prob = om.Problem()
         prob.model = SellarMDAConnect()
 
         prob.setup()
@@ -109,33 +112,33 @@ class TestSellarMDAPromoteConnect(unittest.TestCase):
     def test_sellar_mda_promote_connect(self):
         import numpy as np
 
-        from openmdao.api import Problem, Group, IndepVarComp, ExecComp, NonlinearBlockGS
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
 
-        class SellarMDAPromoteConnect(Group):
+        class SellarMDAPromoteConnect(om.Group):
             """
             Group containing the Sellar MDA. This version uses the disciplines without derivatives.
             """
 
             def setup(self):
-                indeps = self.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+                indeps = self.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
                 indeps.add_output('x', 1.0)
                 indeps.add_output('z', np.array([5.0, 2.0]))
 
-                cycle = self.add_subsystem('cycle', Group(), promotes=['*'])
+                cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
                 cycle.add_subsystem('d1', SellarDis1())
                 cycle.add_subsystem('d2', SellarDis2())
                 cycle.connect('d1.y1', 'd2.y1')
                 cycle.connect('d2.y2', 'd1.y2')
 
                 # Nonlinear Block Gauss Seidel is a gradient free solver
-                cycle.nonlinear_solver = NonlinearBlockGS()
+                cycle.nonlinear_solver = om.NonlinearBlockGS()
 
-                self.add_subsystem('obj_cmp', ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
-                                                       z=np.array([0.0, 0.0]), x=0.0))
+                self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
+                                                          z=np.array([0.0, 0.0]), x=0.0))
 
-                self.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1'))
-                self.add_subsystem('con_cmp2', ExecComp('con2 = y2 - 24.0'))
+                self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'))
+                self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'))
 
                 self.connect('x', ['d1.x', 'obj_cmp.x'])
                 self.connect('z', ['d1.z', 'd2.z', 'obj_cmp.z'])
@@ -143,8 +146,7 @@ class TestSellarMDAPromoteConnect(unittest.TestCase):
                 self.connect('d2.y2', ['con_cmp2.y2', 'obj_cmp.y2'])
 
 
-        prob = Problem()
-
+        prob = om.Problem()
         prob.model = SellarMDAPromoteConnect()
 
         prob.setup()

--- a/openmdao/test_suite/test_examples/test_sellar_opt.py
+++ b/openmdao/test_suite/test_examples/test_sellar_opt.py
@@ -2,21 +2,20 @@ from __future__ import print_function, division, absolute_import
 
 import unittest
 
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
-
-from openmdao.api import Problem, ScipyOptimizeDriver, ExecComp, IndepVarComp, DirectSolver
 
 
 class TestSellarOpt(unittest.TestCase):
 
     def test_sellar_opt(self):
-        from openmdao.api import Problem, ScipyOptimizeDriver, ExecComp, IndepVarComp, DirectSolver
+        import openmdao.api as om
         from openmdao.test_suite.components.sellar_feature import SellarMDA
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarMDA()
 
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
         # prob.driver.options['maxiter'] = 100
         prob.driver.options['tol'] = 1e-8

--- a/openmdao/test_suite/test_examples/test_tldr_paraboloid_b.py
+++ b/openmdao/test_suite/test_examples/test_tldr_paraboloid_b.py
@@ -8,21 +8,21 @@ from openmdao.utils.assert_utils import assert_rel_error
 class TestParaboloidTLDR(unittest.TestCase):
 
     def test_tldr(self):
-        from openmdao.api import Problem, ScipyOptimizeDriver, ExecComp, IndepVarComp
+        import openmdao.api as om
 
         # build the model
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 3.0)
         indeps.add_output('y', -4.0)
 
-        prob.model.add_subsystem('paraboloid', ExecComp('f = (x-3)**2 + x*y + (y+4)**2 - 3'))
+        prob.model.add_subsystem('paraboloid', om.ExecComp('f = (x-3)**2 + x*y + (y+4)**2 - 3'))
 
         prob.model.connect('indeps.x', 'paraboloid.x')
         prob.model.connect('indeps.y', 'paraboloid.y')
 
         # setup the optimization
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('indeps.x', lower=-50, upper=50)

--- a/openmdao/test_suite/test_examples/tldr_paraboloid.py
+++ b/openmdao/test_suite/test_examples/tldr_paraboloid.py
@@ -8,21 +8,21 @@ from openmdao.utils.assert_utils import assert_rel_error
 class TestParaboloidTLDR(unittest.TestCase):
 
     def test_tldr(self):
-        from openmdao.api import Problem, ScipyOptimizeDriver, ExecComp, IndepVarComp
+        import openmdao.api as om
 
         # build the model
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 3.0)
         indeps.add_output('y', -4.0)
 
-        prob.model.add_subsystem('paraboloid', ExecComp('f = (x-3)**2 + x*y + (y+4)**2 - 3'))
+        prob.model.add_subsystem('paraboloid', om.ExecComp('f = (x-3)**2 + x*y + (y+4)**2 - 3'))
 
         prob.model.connect('indeps.x', 'paraboloid.x')
         prob.model.connect('indeps.y', 'paraboloid.y')
 
         # setup the optimization
-        prob.driver = ScipyOptimizeDriver()
+        prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
 
         prob.model.add_design_var('indeps.x', lower=-50, upper=50)

--- a/openmdao/test_suite/tests/test_feature_sellar.py
+++ b/openmdao/test_suite/tests/test_feature_sellar.py
@@ -13,7 +13,7 @@ class TestSellarFeature(unittest.TestCase):
         prob = om.Problem()
         prob.model = SellarMDA()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['y1'], 25.58830273, .00001)
@@ -28,7 +28,7 @@ class TestSellarFeature(unittest.TestCase):
         prob = om.Problem()
         prob.model = SellarMDALinearSolver()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.model.cycle.nonlinear_solver.options['use_apply_nonlinear'] = True
         prob.run_model()
 

--- a/openmdao/test_suite/tests/test_feature_sellar.py
+++ b/openmdao/test_suite/tests/test_feature_sellar.py
@@ -2,15 +2,15 @@
 
 import unittest
 
-from openmdao.api import Problem
+import openmdao.api as om
+from openmdao.test_suite.components.sellar_feature import SellarMDA, SellarMDALinearSolver
 from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.test_suite.components.sellar_feature import SellarMDA, SellarMDALinearSolver, IndepVarComp
 
 
 class TestSellarFeature(unittest.TestCase):
 
     def test_sellar(self):
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarMDA()
 
         prob.setup(check=False)
@@ -25,7 +25,7 @@ class TestSellarFeature(unittest.TestCase):
 
     def test_sellar_linear_solver(self):
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model = SellarMDALinearSolver()
 
         prob.setup(check=False)
@@ -46,6 +46,7 @@ class TestSellarFeature(unittest.TestCase):
         assert_rel_error(self, jac['con1', 'z'][0], [-9.61002284, -0.78449158], 1e-4)
         assert_rel_error(self, jac['con2', 'x'][0], 0.09692762, 1e-4)
         assert_rel_error(self, jac['con2', 'z'][0], [1.94989079, 1.0775421], 1e-4)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/test_suite/tests/test_paraboloid_feature.py
+++ b/openmdao/test_suite/tests/test_paraboloid_feature.py
@@ -12,7 +12,7 @@ class TestSellarFeature(unittest.TestCase):
     def test_paraboloid_feature(self):
 
         prob = Problem()
-        model = prob.model = Group()
+        model = prob.model
 
         model.add_subsystem('p1', IndepVarComp('x', 3.0))
         model.add_subsystem('p2', IndepVarComp('y', -4.0))
@@ -21,7 +21,7 @@ class TestSellarFeature(unittest.TestCase):
         model.connect('p1.x', 'comp.x')
         model.connect('p2.y', 'comp.y')
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         assert_rel_error(self, prob['comp.f_xy'], -15.0)

--- a/openmdao/test_suite/tests/test_paraboloid_feature.py
+++ b/openmdao/test_suite/tests/test_paraboloid_feature.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.test_suite.components.paraboloid_feature import Paraboloid
 
@@ -11,11 +11,11 @@ class TestSellarFeature(unittest.TestCase):
 
     def test_paraboloid_feature(self):
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', IndepVarComp('x', 3.0))
-        model.add_subsystem('p2', IndepVarComp('y', -4.0))
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
         model.add_subsystem('comp', Paraboloid())
 
         model.connect('p1.x', 'comp.x')

--- a/openmdao/test_suite/tests/test_quad_implicit.py
+++ b/openmdao/test_suite/tests/test_quad_implicit.py
@@ -2,9 +2,8 @@ import unittest
 
 import numpy as np
 
-from openmdao.api import Problem
+import openmdao.api as om
 from openmdao.test_suite.components.quad_implicit import QuadraticComp
-
 
 
 class TestQuadImplicit(unittest.TestCase):
@@ -13,10 +12,10 @@ class TestQuadImplicit(unittest.TestCase):
 
     def test_check_partials_for_docs(self):
 
-        from openmdao.api import Problem
+        import openmdao.api as om
         from openmdao.test_suite.components.quad_implicit import QuadraticComp
 
-        p = Problem()
+        p = om.Problem()
 
         p.model.add_subsystem('quad', QuadraticComp())
 
@@ -25,7 +24,7 @@ class TestQuadImplicit(unittest.TestCase):
         p.check_partials(compact_print=True)
 
     def test_check_partials(self):
-        p = Problem()
+        p = om.Problem()
 
         p.model.add_subsystem('quad', QuadraticComp())
 

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -241,5 +241,6 @@ def _calltree_exec(options):
 
 
 if __name__ == '__main__':
-    from openmdao.api import LinearBlockGS
-    get_nested_calls(LinearBlockGS, 'solve')
+    import openmdao.api as om
+
+    get_nested_calls(om.LinearBlockGS, 'solve')

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -39,7 +39,7 @@ class TestAssertUtils(unittest.TestCase):
         prob.model = MyComp()
 
         prob.set_solver_print(level=0)
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -71,7 +71,7 @@ class TestAssertUtils(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -124,7 +124,7 @@ class TestAssertUtils(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.setup(check=False)
+        prob.setup()
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
@@ -141,7 +141,7 @@ class TestAssertUtils(unittest.TestCase):
         prob = Problem()
         prob.model = SellarNoDerivativesCS()
 
-        prob.setup(check=False)
+        prob.setup()
 
         try:
             assert_no_approx_partials(prob.model, include_self=True, recurse=True)
@@ -163,7 +163,7 @@ class TestAssertUtils(unittest.TestCase):
         prob = Problem()
         prob.model = DoubleSellar()
 
-        prob.setup(check=False)
+        prob.setup()
 
         assert_no_approx_partials(prob.model, include_self=True, recurse=True)
 
@@ -172,7 +172,7 @@ class TestAssertUtils(unittest.TestCase):
         prob = Problem()
         prob.model = SellarNoDerivativesCS()
 
-        prob.setup(check=False)
+        prob.setup()
         prob.model.cycle._jacobian = DictionaryJacobian(prob.model.cycle)
 
         try:
@@ -199,6 +199,6 @@ class TestAssertUtils(unittest.TestCase):
         prob = Problem(model)
         prob.model.linear_solver = DirectSolver(assemble_jac=True)
 
-        prob.setup(check=False)
+        prob.setup()
 
         assert_no_dict_jacobians(prob.model, include_self=True, recurse=True)

--- a/openmdao/utils/tests/test_find_citations.py
+++ b/openmdao/utils/tests/test_find_citations.py
@@ -17,7 +17,6 @@ class TestFindCite(unittest.TestCase):
 
         p = Problem()
 
-        p.model = Group()
         p.model.cite = "foobar model"
         p.model.nonlinear_solver.cite = "foobar nonlinear_solver"
         p.model.linear_solver.cite = "foobar linear_solver"
@@ -139,8 +138,6 @@ class TestFindCitePar(unittest.TestCase):
 
         p = Problem()
 
-        p.model = Group()
-        
         p.model.cite = "foobar model"
         p.model.nonlinear_solver.cite = "foobar nonlinear_solver"
         p.model.linear_solver.cite = "foobar linear_solver"

--- a/openmdao/utils/tests/test_options_dictionary_feature.py
+++ b/openmdao/utils/tests/test_options_dictionary_feature.py
@@ -1,18 +1,20 @@
-from openmdao.api import ExplicitComponent
 import unittest
 from six import PY3, assertRegex
+
 import numpy as np
+
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 
 class TestOptionsDictionaryFeature(unittest.TestCase):
 
     def test_simple(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.options_feature_vector import VectorDoublingComp
 
-        prob = Problem()
-        prob.model.add_subsystem('inputs', IndepVarComp('x', shape=3))
+        prob = om.Problem()
+        prob.model.add_subsystem('inputs', om.IndepVarComp('x', shape=3))
         prob.model.add_subsystem('double', VectorDoublingComp(size=3))  # 'size' is an option
         prob.model.connect('inputs.x', 'double.x')
 
@@ -24,11 +26,11 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
         assert_rel_error(self, prob['double.y'], [2., 4., 6.])
 
     def test_simple_fail(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.options_feature_vector import VectorDoublingComp
 
-        prob = Problem()
-        prob.model.add_subsystem('inputs', IndepVarComp('x', shape=3))
+        prob = om.Problem()
+        prob.model.add_subsystem('inputs', om.IndepVarComp('x', shape=3))
         prob.model.add_subsystem('double', VectorDoublingComp())  # 'size' not specified
         prob.model.connect('inputs.x', 'double.x')
 
@@ -38,11 +40,11 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
             self.assertEqual(str(err), "Option 'size' is required but has not been set.")
 
     def test_with_default(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.options_feature_lincomb import LinearCombinationComp
 
-        prob = Problem()
-        prob.model.add_subsystem('inputs', IndepVarComp('x'))
+        prob = om.Problem()
+        prob.model.add_subsystem('inputs', om.IndepVarComp('x'))
         prob.model.add_subsystem('linear', LinearCombinationComp(a=2.))  # 'b' not specified
         prob.model.connect('inputs.x', 'linear.x')
 
@@ -56,11 +58,11 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
     def test_simple_array(self):
         import numpy as np
 
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.options_feature_array import ArrayMultiplyComp
 
-        prob = Problem()
-        prob.model.add_subsystem('inputs', IndepVarComp('x', 1.))
+        prob = om.Problem()
+        prob.model.add_subsystem('inputs', om.IndepVarComp('x', 1.))
         prob.model.add_subsystem('a_comp', ArrayMultiplyComp(array=np.array([1, 2, 3])))
         prob.model.connect('inputs.x', 'a_comp.x')
 
@@ -73,14 +75,14 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
         assert_rel_error(self, prob['a_comp.y'], [5., 10., 15.])
 
     def test_simple_function(self):
-        from openmdao.api import Problem, IndepVarComp
+        import openmdao.api as om
         from openmdao.test_suite.components.options_feature_function import UnitaryFunctionComp
 
         def my_func(x):
             return x*2
 
-        prob = Problem()
-        prob.model.add_subsystem('inputs', IndepVarComp('x', 1.))
+        prob = om.Problem()
+        prob.model.add_subsystem('inputs', om.IndepVarComp('x', 1.))
         prob.model.add_subsystem('f_comp', UnitaryFunctionComp(func=my_func))
         prob.model.connect('inputs.x', 'f_comp.x')
 

--- a/openmdao/utils/tests/test_visualization.py
+++ b/openmdao/utils/tests/test_visualization.py
@@ -51,7 +51,7 @@ class TestVisualization(unittest.TestCase):
                 partials[('y1', 'x1')] = self.JJ + error
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
         model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))), promotes=['x1'])
         model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
         prob.setup(check=False, mode='fwd')
@@ -175,7 +175,7 @@ class TestFeatureVisualization(unittest.TestCase):
                 partials[('y1', 'x1')] = self.JJ + error
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
         model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))), promotes=['x1'])
         model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
         prob.setup(check=False, mode='fwd')
@@ -220,7 +220,7 @@ class TestFeatureVisualization(unittest.TestCase):
                 partials[('y1', 'x1')] = self.JJ + error
 
         prob = Problem()
-        prob.model = model = Group()
+        model = prob.model
         model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))), promotes=['x1'])
         model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
         prob.setup(check=False, mode='fwd')

--- a/openmdao/utils/tests/test_visualization.py
+++ b/openmdao/utils/tests/test_visualization.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     matplotlib = None
 
-from openmdao.api import Problem, IndepVarComp, ExplicitComponent, Group, partial_deriv_plot
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_rel_error
 
 @unittest.skipUnless(matplotlib, "Matplotlib is required.")
@@ -20,7 +20,7 @@ class TestVisualization(unittest.TestCase):
 
     def test_partial_deriv_plot(self):
 
-        class ArrayComp2D(ExplicitComponent):
+        class ArrayComp2D(om.ExplicitComponent):
             """
             A fairly simple array component with an intentional error in compute_partials.
             """
@@ -50,15 +50,15 @@ class TestVisualization(unittest.TestCase):
                 error[1][2] = - 2.0 * err
                 partials[('y1', 'x1')] = self.JJ + error
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))), promotes=['x1'])
+        model.add_subsystem('x_param1', om.IndepVarComp('x1', np.ones((4))), promotes=['x1'])
         model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
         prob.setup(check=False, mode='fwd')
         check_partials_data = prob.check_partials(out_stream=None)
 
         # plot with defaults
-        fig, ax = partial_deriv_plot('y1', 'x1', check_partials_data, title="Defaults")
+        fig, ax = om.partial_deriv_plot('y1', 'x1', check_partials_data, title="Defaults")
         # Instead of seeing if the images created by matplotlib match what we expect, which
         # is a fragile thing to do in testing, check a data structure inside matplotlib's
         # objects. We will assume matplotlib draws the correct thing.
@@ -82,8 +82,8 @@ class TestVisualization(unittest.TestCase):
         assert_rel_error(self, expected_array, actual_array, 1e-8)
 
         # plot with specified jac_method
-        fig, ax = partial_deriv_plot('y1', 'x1', check_partials_data, jac_method = "J_rev",
-                           title="specified jac_method")
+        fig, ax = om.partial_deriv_plot('y1', 'x1', check_partials_data, jac_method = "J_rev",
+                                        title="specified jac_method")
         expected_array = np.array([[1., 0., 0., 1.],
                                    [0., 1., 0., 0.],
                                    [1., 0., 1., 0.],
@@ -104,8 +104,8 @@ class TestVisualization(unittest.TestCase):
         assert_rel_error(self, expected_array, actual_array, 1e-8)
 
         # plot in non-binary mode
-        fig, ax = partial_deriv_plot('y1', 'x1', check_partials_data, binary = False,
-                                     title="non-binary")
+        fig, ax = om.partial_deriv_plot('y1', 'x1', check_partials_data, binary = False,
+                                        title="non-binary")
         expected_array = np.array([[ 1. ,  0. ,  0. ,  7. ],
                                    [ 0. ,  2.5,  0. ,  0. ],
                                    [-1. ,  0. ,  8. ,  0. ],
@@ -127,10 +127,10 @@ class TestVisualization(unittest.TestCase):
 
         # plot with different tol values
         # Not obvious how to test this other than image matching
-        partial_deriv_plot('y1', 'x1', check_partials_data, tol=1e-5,
-                                     title="tol greater than err")
-        partial_deriv_plot('y1', 'x1', check_partials_data, tol=1e-10,
-                                     title="tol less than err")
+        om.partial_deriv_plot('y1', 'x1', check_partials_data, tol=1e-5,
+                              title="tol greater than err")
+        om.partial_deriv_plot('y1', 'x1', check_partials_data, tol=1e-10,
+                              title="tol less than err")
 
 
 @unittest.skipUnless(matplotlib, "Matplotlib is required.")
@@ -141,8 +141,9 @@ class TestFeatureVisualization(unittest.TestCase):
 
     def test_partial_deriv_plot(self):
         import numpy as np
-        from openmdao.api import ExplicitComponent, Problem, Group, IndepVarComp
-        class ArrayComp2D(ExplicitComponent):
+        import openmdao.api as om
+
+        class ArrayComp2D(om.ExplicitComponent):
             """
             A fairly simple array component with an intentional error in compute_partials.
             """
@@ -174,20 +175,21 @@ class TestFeatureVisualization(unittest.TestCase):
                 error[1][2] = - 2.0 * err
                 partials[('y1', 'x1')] = self.JJ + error
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))), promotes=['x1'])
+        model.add_subsystem('x_param1', om.IndepVarComp('x1', np.ones((4))), promotes=['x1'])
         model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
         prob.setup(check=False, mode='fwd')
         check_partials_data = prob.check_partials(out_stream=None)
 
         # plot with defaults
-        partial_deriv_plot('y1', 'x1', check_partials_data)
+        om.partial_deriv_plot('y1', 'x1', check_partials_data)
 
     def test_partial_deriv_non_binary_plot(self):
         import numpy as np
-        from openmdao.api import ExplicitComponent, Problem, Group, IndepVarComp
-        class ArrayComp2D(ExplicitComponent):
+        import openmdao.api as om
+
+        class ArrayComp2D(om.ExplicitComponent):
             """
             A fairly simple array component with an intentional error in compute_partials.
             """
@@ -219,15 +221,15 @@ class TestFeatureVisualization(unittest.TestCase):
                 error[1][2] = - 2.0 * err
                 partials[('y1', 'x1')] = self.JJ + error
 
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
-        model.add_subsystem('x_param1', IndepVarComp('x1', np.ones((4))), promotes=['x1'])
+        model.add_subsystem('x_param1', om.IndepVarComp('x1', np.ones((4))), promotes=['x1'])
         model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
         prob.setup(check=False, mode='fwd')
         check_partials_data = prob.check_partials(out_stream=None)
 
         # plot in non-binary mode
-        partial_deriv_plot('y1', 'x1', check_partials_data, binary = False)
+        om.partial_deriv_plot('y1', 'x1', check_partials_data, binary = False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. Fully replaced in test files that contained some linked features tests.  Did not touch other tests.
2. Fully replaced in all loose examples.
3. Also globally got rid of redundant creation of model Group().
4. Also globally got rid of redundant specification of check=False.