### PR TITLE
Get rid of warnings on Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,7 +111,7 @@ install:
     pip install .[all];
     conda list;
 
-- cmd: if %PYTHON% GTR 3 (set CONDA="C:\Miniconda3%PYTHON:~2%-x64") else (set CONDA="C:\Miniconda-x64")
+- cmd: if %PYTHON% GTR 3 (set CONDA=C:\Miniconda3%PYTHON:~2%-x64) else (set CONDA=C:\Miniconda-x64)
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
 - cmd: conda install numpy=%NUMPY% scipy=%SCIPY% pip --quiet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -111,7 +111,7 @@ install:
     pip install .[all];
     conda list;
 
-- cmd: if %PYTHON% GTR 3 (set CONDA="C:\\Miniconda3%PYTHON:~2%-x64") else (set CONDA="C:\\Miniconda-x64")
+- cmd: if %PYTHON% GTR 3 (set CONDA="C:\Miniconda3%PYTHON:~2%-x64") else (set CONDA="C:\Miniconda-x64")
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
 - cmd: conda install numpy=%NUMPY% scipy=%SCIPY% pip --quiet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,5 +120,4 @@ install:
 
 test_script:
 - sh: testflo openmdao -n 1;
-- cmd: echo %PATH%
 - cmd: testflo openmdao -n 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -120,4 +120,5 @@ install:
 
 test_script:
 - sh: testflo openmdao -n 1;
+- cmd: echo %PATH%
 - cmd: testflo openmdao -n 1


### PR DESCRIPTION
Get rid of warnings like the following on Appveyor:
```
WARNING: The script pycodestyle.exe is installed in 'C:\Miniconda-x64\Scripts' which is not on PATH.
Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```