### PR TITLE
some coloring tweaks

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -162,14 +162,9 @@ class Driver(object):
         self.iter_count = 0
         self.cite = ""
 
-        self._coloring_info = {
-            'coloring': None,
-            'show_summary': True,
-            'show_sparsity': False,
-            'tol': 1e-15,
-            'orders': 20,
-            'num_full_jacs': 3,
-        }
+        self._coloring_info = coloring_mod._DEF_COMP_SPARSITY_ARGS.copy()
+        self._coloring_info['coloring'] = None
+
         self._total_jac_sparsity = None
         self._res_jacs = {}
         self._total_jac = None

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -146,7 +146,7 @@ def run_opt(driver_class, mode, assemble_type=None, color_info=None, sparsity=No
         del options['method']
 
     if 'dynamic_total_coloring' in options:
-        p.driver.declare_coloring()
+        p.driver.declare_coloring(tol=1e-15)
         del options['dynamic_total_coloring']
 
     p.driver.options.update(options)

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -254,7 +254,7 @@ def _get_viewer_data(data_source):
                 edges_list = [
                     (sys_pathnames_dict[s], sys_pathnames_dict[t]) for s, t in G.edges(strong_comp)
                     if exe_low <= orders[s] <= exe_high and exe_low <= orders[t] <= exe_high and
-                            not (s == src and t == tgt) and t in sys_pathnames_dict
+                            not (s == src and t == tgt)
                 ]
                 for vsrc, vtgtlist in iteritems(G.get_edge_data(src, tgt)['conns']):
                     for vtgt in vtgtlist:

--- a/openmdao/devtools/problem_viewer/problem_viewer.py
+++ b/openmdao/devtools/problem_viewer/problem_viewer.py
@@ -254,7 +254,7 @@ def _get_viewer_data(data_source):
                 edges_list = [
                     (sys_pathnames_dict[s], sys_pathnames_dict[t]) for s, t in G.edges(strong_comp)
                     if exe_low <= orders[s] <= exe_high and exe_low <= orders[t] <= exe_high and
-                            not (s == src and t == tgt)
+                            not (s == src and t == tgt) and t in sys_pathnames_dict
                 ]
                 for vsrc, vtgtlist in iteritems(G.get_edge_data(src, tgt)['conns']):
                     for vtgt in vtgtlist:


### PR DESCRIPTION
- changed default drop tol to 1e-25 and by default the tol sweep will no longer be performed (orders=None)
- set a random seed to make results consistent
- changed normalization of composite jacobian back to use max jacobian value
- default values for tol and orders are now only set in one place.
- investigated changes to the jacobian randomization, but didn't find anything that improved robustness of the process to determine the sparsity.