### PR TITLE
Implement `get_val` on Case object, similar to function on `Problem`

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -229,7 +229,6 @@ class Case(object):
 
         raise KeyError('Variable name "%s" not found.' % name)
 
-
     def get_val(self, name, units=None, indices=None):
         """
         Get an output/input variable.

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -294,21 +294,9 @@ class Case(object):
         proms = self._prom2abs
 
         if name in proms['output']:
-            abs_list = proms['output'][name]
-            if len(abs_list) == 1:
-                abs_name = abs_list[0]
-                return meta[abs_name]['units']
-            else:
-                # TODO: looks like aliased input, must access the connected output?
-                print('------')
-                print('abs_list:')
-                from pprint import pprint
-                pprint(abs_list)
-                print('------')
-                abs_name = None
-                return meta[abs_name]['units']
+            abs_name = proms['output'][name][0]
+            return meta[abs_name]['units']
         elif name in proms['input']:
-            # TODO: check for unconnected non-unique inputs, and raise error?
             abs_name = proms['input'][name]
             return meta[abs_name]['units']
 

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -294,10 +294,21 @@ class Case(object):
         proms = self._prom2abs
 
         if name in proms['output']:
-            abs_name = proms['output'][name]
-            return meta[abs_name]['units']
+            abs_list = proms['output'][name]
+            if len(abs_list) == 1:
+                abs_name = abs_list[0]
+                return meta[abs_name]['units']
+            else:
+                # TODO: looks like aliased input, must access the connected output?
+                print('------')
+                print('abs_list:')
+                from pprint import pprint
+                pprint(abs_list)
+                print('------')
+                abs_name = None
+                return meta[abs_name]['units']
         elif name in proms['input']:
-            # TODO: check for unconnected non-unique inputs, and raise error
+            # TODO: check for unconnected non-unique inputs, and raise error?
             abs_name = proms['input'][name]
             return meta[abs_name]['units']
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1110,16 +1110,12 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_get_var(self):
         indep = om.IndepVarComp()
-        indep.add_output('distance', val=6., units='m')
-        indep.add_output('time', val=3., units='s')
+        indep.add_output('distance', val=6., units='km')
+        indep.add_output('time', val=2., units='h')
 
         model = om.Group()
-        model.add_subsystem('c1', indep)
-        model.add_subsystem('c2', SpeedComp())
-        model.add_subsystem('c3', om.ExecComp('f=speed', speed={'units': 'm/s'}, f={'units': 'm/s'}))
-        model.connect('c1.distance', 'c2.distance')
-        model.connect('c1.time', 'c2.time')
-        model.connect('c2.speed', 'c3.speed')
+        model.add_subsystem('c1', indep, promotes=['*'])
+        model.add_subsystem('c2', SpeedComp(), promotes=['*'])
 
         model.add_recorder(self.recorder)
 
@@ -1131,8 +1127,8 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         case = cr.get_case(0)
 
-        np.testing.assert_almost_equal(case.get_val('c3.f'), 2.)  # m/s
-        np.testing.assert_almost_equal(case.get_val('c3.f', units='mi/h'), 2*2.237, decimal=3)
+        np.testing.assert_almost_equal(case.get_val('speed'), 3.)  # km/h
+        np.testing.assert_almost_equal(case.get_val('speed', units='m/h'), 3000.)
 
     def test_get_vars(self):
         prob = SellarProblem()

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -4,7 +4,8 @@ import os
 import unittest
 
 # from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, add_unit, add_offset_unit
+from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, \
+    add_unit, add_offset_unit, get_conversion
 
 
 class TestNumberDict(unittest.TestCase):
@@ -243,6 +244,16 @@ class TestPhysicalUnit(unittest.TestCase):
         self.assertEqual(y.name(), 'm**2')
         y = x2 / (x1**2)
         self.assertEqual(y.name(), 'kg/m**2')
+
+    def test_get_conversion(self):
+        self.assertEqual(get_conversion('km', 'm'), (1000., 0.))
+
+        try:
+            get_conversion('km', 1.0)
+        except RuntimeError as err:
+            self.assertEqual(str(err), "Cannot convert to new units: 1.0")
+        else:
+            self.fail("Expecting RuntimeError")
 
 
 class TestModuleFunctions(unittest.TestCase):

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -998,7 +998,11 @@ def get_conversion(old_units, new_units):
     (float, float)
         Conversion factor and offset
     """
-    return _find_unit(old_units).conversion_tuple_to(_find_unit(new_units))
+    new_physical_units = _find_unit(new_units)
+    if new_physical_units is None:
+        raise RuntimeError("Cannot convert to new units: %s" % str(new_units))
+
+    return _find_unit(old_units).conversion_tuple_to(new_physical_units)
 
 
 def convert_units(val, old_units, new_units=None):


### PR DESCRIPTION
User can call `get_val` for data on CaseReader inputs and outputs to specify a specific unit they want the value returned in