### PR TITLE
Implement `get_val` on Case object, similar to function on `Problem`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -159,7 +159,7 @@ after_success:
 # again, only run coverage operations on the upload machine after success.
 - if [ "$UPLOAD_DOCS" ]; then
     coveralls --rcfile=../../.coveragerc --output=coveralls.json;
-    sed 's/\/home\/travis\/miniconda\/lib\/python'"$PY"'\/site-packages\///g' < coveralls.json > coveralls-upd.json;
+    sed 's/\/home\/travis\/miniconda\/envs\/PY$PY\/lib\/python'"$PY"'\/site-packages\///g' < coveralls.json > coveralls-upd.json;
     coveralls --upload=coveralls-upd.json;
   fi
 

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -229,7 +229,6 @@ class Case(object):
 
         raise KeyError('Variable name "%s" not found.' % name)
 
-
     def get_val(self, name, units=None, indices=None):
         """
         Get an output/input variable.

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -302,7 +302,7 @@ class Case(object):
                 # The promoted name maps to multiple absolute names, require absolute name.
                 msg = "Can't get units for the promoted name '%s' because it refers to " + \
                       "multiple inputs: %s. Access the units using an absolute path name."
-                raise NameError(msg % (name, str(proms['input'][name])))
+                raise RuntimeError(msg % (name, str(proms['input'][name])))
 
             abs_name = proms['input'][name][0]
             return meta[abs_name]['units']
@@ -851,7 +851,7 @@ class PromAbsDict(dict):
                 msg = "The promoted name '%s' is invalid because it refers to multiple " + \
                       "inputs: %s. Access the value using an absolute path name or the " + \
                       "connected output variable instead."
-                raise NameError(msg % (key, str(self._prom2abs['input'][key])))
+                raise RuntimeError(msg % (key, str(self._prom2abs['input'][key])))
             else:
                 return val
 

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -285,6 +285,8 @@ class Case(object):
         str
             Unit string.
         """
+        from pprint import pprint
+
         meta = self._abs2meta
 
         if name in meta:
@@ -296,7 +298,14 @@ class Case(object):
             abs_name = proms['output'][name][0]
             return meta[abs_name]['units']
         elif name in proms['input']:
-            abs_name = proms['input'][name]
+            if len(proms['input'][name]) > 1:
+                print(name, ':', proms['input'][name])
+                # looks like an aliased input
+                for abs_name in proms['input'][name]:
+                    print(abs_name, self[abs_name], self._get_units(abs_name))
+
+            # get units for the first abs_name
+            abs_name = proms['input'][name][0]
             return meta[abs_name]['units']
 
         raise KeyError('Variable name "{}" not found.'.format(name))

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -294,21 +294,9 @@ class Case(object):
         proms = self._prom2abs
 
         if name in proms['output']:
-            abs_list = proms['output'][name]
-            if len(abs_list) == 1:
-                abs_name = abs_list[0]
-                return meta[abs_name]['units']
-            else:
-                # TODO: looks like aliased input, must access the connected output?
-                print('------')
-                print('abs_list:')
-                from pprint import pprint
-                pprint(abs_list)
-                print('------')
-                abs_name = None
-                return meta[abs_name]['units']
+            abs_name = proms['output'][name][0]
+            return meta[abs_name]['units']
         elif name in proms['input']:
-            # TODO: check for unconnected non-unique inputs, and raise error?
             abs_name = proms['input'][name]
             return meta[abs_name]['units']
 

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -294,10 +294,21 @@ class Case(object):
         proms = self._prom2abs
 
         if name in proms['output']:
-            abs_name = proms['output'][name]
-            return meta[abs_name]['units']
+            abs_list = proms['output'][name]
+            if len(abs_list) == 1:
+                abs_name = abs_list[0]
+                return meta[abs_name]['units']
+            else:
+                # TODO: looks like aliased input, must access the connected output?
+                print('------')
+                print('abs_list:')
+                from pprint import pprint
+                pprint(abs_list)
+                print('------')
+                abs_name = None
+                return meta[abs_name]['units']
         elif name in proms['input']:
-            # TODO: check for unconnected non-unique inputs, and raise error
+            # TODO: check for unconnected non-unique inputs, and raise error?
             abs_name = proms['input'][name]
             return meta[abs_name]['units']
 

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -12,7 +12,7 @@ from six import PY2, PY3, iteritems, string_types
 from six.moves import range
 
 from openmdao.recorders.base_case_reader import BaseCaseReader
-from openmdao.recorders.case import Case, PromotedToAbsoluteMap
+from openmdao.recorders.case import Case, PromAbsDict
 
 from openmdao.utils.general_utils import simple_warning
 from openmdao.utils.record_util import check_valid_sqlite3_db, convert_to_np_array
@@ -157,8 +157,8 @@ class SqliteCaseReader(BaseCaseReader):
         con.close()
 
         # create maps to facilitate accessing variable metadata using absolute or promoted name
-        self._output2meta = PromotedToAbsoluteMap(self._abs2meta, self._prom2abs, self._abs2prom, 1)
-        self._input2meta = PromotedToAbsoluteMap(self._abs2meta, self._prom2abs, self._abs2prom, 0)
+        self._output2meta = PromAbsDict(self._abs2meta, self._prom2abs, self._abs2prom, 1)
+        self._input2meta = PromAbsDict(self._abs2meta, self._prom2abs, self._abs2prom, 0)
 
         # create helper objects for accessing cases from the three iteration tables and
         # the problem cases table

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2642,6 +2642,7 @@ class TestFeatureSqliteReader(unittest.TestCase):
         stream = cStringIO()
         case.list_inputs(values=True,
                          units=True,
+                         prom_name=True,
                          hierarchical=False,
                          print_arrays=False,
                          out_stream=stream)
@@ -2650,12 +2651,12 @@ class TestFeatureSqliteReader(unittest.TestCase):
         self.assertEqual(1, text.count('mult.x'))
         num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
         self.assertEqual(5, num_non_empty_lines)
+        self.assertEqual(1, text.count('mult.x   |10.0|  inch   x'))
 
         # out_stream - hierarchical - extras - no print_arrays
         stream = cStringIO()
         case.list_inputs(values=True,
                          units=True,
-                         prom_name=True,
                          shape=True,
                          hierarchical=True,
                          print_arrays=False,
@@ -2666,7 +2667,7 @@ class TestFeatureSqliteReader(unittest.TestCase):
         self.assertEqual(7, num_non_empty_lines)
         self.assertEqual(1, text.count('top'))
         self.assertEqual(1, text.count('  mult'))
-        self.assertEqual(1, text.count('    x    |10.0|  inch   (100,)  x '))
+        self.assertEqual(1, text.count('    x    |10.0|  inch   (100'))
 
         # logging outputs
         # out_stream - not hierarchical - extras - no print_arrays

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1110,16 +1110,12 @@ class TestSqliteCaseReader(unittest.TestCase):
 
     def test_get_var(self):
         indep = om.IndepVarComp()
-        indep.add_output('distance', val=6., units='m')
-        indep.add_output('time', val=3., units='s')
+        indep.add_output('distance', val=6., units='km')
+        indep.add_output('time', val=2., units='h')
 
         model = om.Group()
-        model.add_subsystem('c1', indep)
-        model.add_subsystem('c2', SpeedComp())
-        model.add_subsystem('c3', om.ExecComp('f=speed', speed={'units': 'm/s'}, f={'units': 'm/s'}))
-        model.connect('c1.distance', 'c2.distance')
-        model.connect('c1.time', 'c2.time')
-        model.connect('c2.speed', 'c3.speed')
+        model.add_subsystem('c1', indep, promotes=['*'])
+        model.add_subsystem('c2', SpeedComp(), promotes=['*'])
 
         model.add_recorder(self.recorder)
 
@@ -1131,8 +1127,8 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         case = cr.get_case(0)
 
-        np.testing.assert_almost_equal(case.get_val('c3.f'), 2.)  # m/s
-        np.testing.assert_almost_equal(case.get_val('c3.f', units='mi/h'), 2*2.237, decimal=3)
+        np.testing.assert_almost_equal(case.get_val('speed'), 3.)  # km/h
+        np.testing.assert_almost_equal(case.get_val('speed', units='m/h'), 3000.)
 
     def test_get_vars(self):
         prob = SellarProblem()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -283,7 +283,6 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # Test values from cases
         case = cr.get_case('rank0:Driver|0|root._solve_nonlinear|0')
-
         np.testing.assert_almost_equal(case.inputs['d1.y2'], [12.05848815, ])
         np.testing.assert_almost_equal(case.outputs['obj'], [28.58830817, ])
         np.testing.assert_almost_equal(case.residuals['obj'], [0.0, ],)
@@ -1196,29 +1195,29 @@ class TestSqliteCaseReader(unittest.TestCase):
               " ['G2.C1.m', 'G2.C2.f']. Access the value using an absolute path name " + \
               "or the connected output variable instead."
 
-        with self.assertRaises(NameError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             case['a']
         self.assertEquals(str(cm.exception), msg)
 
-        with self.assertRaises(NameError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             case.get_val('a')
         self.assertEquals(str(cm.exception), msg)
 
-        with self.assertRaises(NameError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             case.get_val('a', units='m')
         self.assertEquals(str(cm.exception), msg)
 
-        with self.assertRaises(NameError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             case.get_val('a', units='ft')
         self.assertEquals(str(cm.exception), msg)
 
         # 'a' is ambiguous.. which input's units do you want when accessing 'a'?
-        # (test the underlying function, currently only called inside get_val)
+        # (test the underlying function, currently only called from inside get_val)
         msg = "Can't get units for the promoted name 'a' because it refers to " + \
               "multiple inputs: ['G2.C1.m', 'G2.C2.f']. Access the units using " + \
               "an absolute path name."
 
-        with self.assertRaises(NameError) as cm:
+        with self.assertRaises(RuntimeError) as cm:
             case._get_units('a')
         self.assertEquals(str(cm.exception), msg)
 

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -4,7 +4,8 @@ import os
 import unittest
 
 # from openmdao.utils.assert_utils import assert_rel_error
-from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, add_unit, add_offset_unit
+from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, \
+    add_unit, add_offset_unit, get_conversion
 
 
 class TestNumberDict(unittest.TestCase):
@@ -243,6 +244,16 @@ class TestPhysicalUnit(unittest.TestCase):
         self.assertEqual(y.name(), 'm**2')
         y = x2 / (x1**2)
         self.assertEqual(y.name(), 'kg/m**2')
+
+    def test_get_conversion(self):
+        self.assertEqual(get_conversion('km', 'm'), (1000., 0.))
+
+        try:
+            get_conversion('km', 1.0)
+        except RuntimeError as err:
+            self.assertEqual(str(err), "Cannot convert to new units: 1.0")
+        else:
+            self.fail("Expecting RuntimeError")
 
 
 class TestModuleFunctions(unittest.TestCase):

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -998,7 +998,11 @@ def get_conversion(old_units, new_units):
     (float, float)
         Conversion factor and offset
     """
-    return _find_unit(old_units).conversion_tuple_to(_find_unit(new_units))
+    new_physical_units = _find_unit(new_units)
+    if new_physical_units is None:
+        raise RuntimeError("Cannot convert to new units: %s" % str(new_units))
+
+    return _find_unit(old_units).conversion_tuple_to(new_physical_units)
 
 
 def convert_units(val, old_units, new_units=None):


### PR DESCRIPTION
User can call get_val for data on CaseReader inputs and outputs to specify a specific unit they want the value returned in

Also:
- fix coveralls upload in travis.yml
- raise an error for ambiguous input names in Case `__getitem__`
- implement `prom_name` and `shape` args for Case `list_inputs`
- rename PromotedToAbsoluteMap to something shorter (and slightly more accurate)
- catch & respond with better message when bad arg passed to units `get_conversion`
