### PR TITLE
Fix xdsm docstrings and also bug in test_lint_attributes.py

### DIFF
--- a/openmdao/code_review/test_lint_attributes.py
+++ b/openmdao/code_review/test_lint_attributes.py
@@ -143,14 +143,13 @@ class LintAttributesTestCase(unittest.TestCase):
                                     found_in_pc = False
                                     for pc in parent_classes:
                                         pc_class_doc = inspect.getdoc(pc)
-                                        if not pc_class_doc:
-                                            found_in_pc = False
-                                        else:
+                                        if pc_class_doc:
                                             pc_classdoc_matches = classdoc_re.findall(pc_class_doc)
                                             pc_classdoc_varnames_matches = classdoc_varnames_re.findall(pc_classdoc_matches[0]) if(len(pc_classdoc_matches) == 1) else []
                                             if v in pc_classdoc_varnames_matches:
                                                 if(print_info): print("    Documented member `%s` in base class `%s`" % (v, pc.__name__))
                                                 found_in_pc = True
+                                                break
                                     if not found_in_pc:
                                         new_failures.append('Member `{0}` not documented in Attributes section of own class or parent class docstrings'.format(v))
                                 else:

--- a/openmdao/code_review/test_lint_attributes.py
+++ b/openmdao/code_review/test_lint_attributes.py
@@ -143,11 +143,14 @@ class LintAttributesTestCase(unittest.TestCase):
                                     found_in_pc = False
                                     for pc in parent_classes:
                                         pc_class_doc = inspect.getdoc(pc)
-                                        pc_classdoc_matches = classdoc_re.findall(pc_class_doc)
-                                        pc_classdoc_varnames_matches = classdoc_varnames_re.findall(pc_classdoc_matches[0]) if(len(pc_classdoc_matches) == 1) else []
-                                        if v in pc_classdoc_varnames_matches:
-                                            if(print_info): print("    Documented member `%s` in base class `%s`" % (v, pc.__name__))
-                                            found_in_pc = True
+                                        if not pc_class_doc:
+                                            found_in_pc = False
+                                        else:
+                                            pc_classdoc_matches = classdoc_re.findall(pc_class_doc)
+                                            pc_classdoc_varnames_matches = classdoc_varnames_re.findall(pc_classdoc_matches[0]) if(len(pc_classdoc_matches) == 1) else []
+                                            if v in pc_classdoc_varnames_matches:
+                                                if(print_info): print("    Documented member `%s` in base class `%s`" % (v, pc.__name__))
+                                                found_in_pc = True
                                     if not found_in_pc:
                                         new_failures.append('Member `{0}` not documented in Attributes section of own class or parent class docstrings'.format(v))
                                 else:

--- a/openmdao/visualization/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/visualization/xdsm_viewer/xdsm_writer.py
@@ -649,6 +649,8 @@ else:
             If true, display components with numbers.
         has_legend : bool
             If true, a legend will be added to the diagram.
+        class_names : bool
+            If true, appends class name of groups/components to the component blocks of diagram.
         extension : str
             Output file saved with this extension. Value fixed at 'pdf' for this class.
         type_map : str
@@ -681,8 +683,11 @@ else:
             number_alignment : str
                 Position of number relative to the component label. Possible values
                 are: 'horizontal', 'vertical'.
-            legend : str
+            legend : bool
                 If true, a legend will be added to the diagram.
+            class_names : bool, optional
+                If true, appends class name of groups/components to the component blocks of diagram.
+                Defaults to False.
             add_component_indices : bool
                 If true, display components with numbers.
             """
@@ -744,10 +749,11 @@ else:
                     if step is not None:
                         i = self._make_loop_str(first=i, last=step, start_index=_START_INDEX)
                     # Add the number
-                    label = self.finalize_label(i, label, self.number_alignment, cls=comp['class'])
+                    label = self.finalize_label(i, label, self.number_alignment,
+                                                class_name=comp['class'])
                 else:
                     label = self.finalize_label(None, label, self.number_alignment,
-                                                cls=comp['class'])
+                                                class_name=comp['class'])
                 # Convert from math mode to regular text
                 comp['label'] = self._textify(label)
                 # Now the label is finished.
@@ -995,7 +1001,7 @@ else:
             txt = '{}, {}$ \\rightarrow $ {}'
             return txt.format(first + i, last + i, first + i + 1)
 
-        def finalize_label(self, number, txt, alignment, cls=None):
+        def finalize_label(self, number, txt, alignment, class_name=None):
             """
             Add an index to the label either above or on the left side.
 
@@ -1007,7 +1013,7 @@ else:
                 Text appended to the number string.
             alignment : str
                 Indicates alignment of label. Either 'horizontal' or 'vertical'.
-            cls : str or None, optional
+            class_name : str or None, optional
                 Class name.
                 Defaults to None.
 
@@ -1019,8 +1025,8 @@ else:
             def multi_ln(txt, number=None):
                 # Converts text to a multiline block, if an index or class name is added in
                 # separate row.
-                if self.class_names and (cls is not None):
-                    cls_name = '\\textit{%s}' % cls  # Makes it italic
+                if self.class_names and (class_name is not None):
+                    cls_name = '\\textit{%s}' % class_name  # Makes it italic
                     txt = '} \\\\ \\text{'.join([txt, cls_name])  # Formatting for multi-line array
                 elif number is None:
                     return txt  # No number, no classname, just flows through


### PR DESCRIPTION
The test_lint_attributes.py code didn't properly handle classes that had parents with no docstring.

Also had to change the name of a variable from 'cls' because that confuses Sphinx.