### PR TITLE
Backtracking step length parameter bugfix

### DIFF
--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -172,7 +172,7 @@ class ArmijoGoldsteinLS(LinesearchSolver):
 
     def _line_search_objective(self):
         """
-        Calculate the objective function of the line search
+        Calculate the objective function of the line search.
 
         Returns
         -------

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -50,6 +50,7 @@ class LinesearchSolver(NonlinearSolver):
     _do_subsolve : bool
         Dictionary holding input and output vectors at start of iteration, if requested.
     """
+
     def __init__(self, **kwargs):
         """
         Initialize all attributes.
@@ -70,12 +71,6 @@ class BoundsEnforceLS(LinesearchSolver):
 
     Not so much a linesearch; just check the bounds and if they are violated, then pull back to a
     non-violating point and evaluate.
-
-    Attributes
-    ----------
-    _do_subsolve : bool
-        Flag used by parent solver to tell the line search whether to solve subsystems while
-        backtracking.
     """
 
     SOLVER = 'LS: BCHK'

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -48,7 +48,8 @@ class LinesearchSolver(NonlinearSolver):
     Attributes
     ----------
     _do_subsolve : bool
-        Dictionary holding input and output vectors at start of iteration, if requested.
+        Flag used by parent solver to tell the line search whether to solve subsystems while
+        backtracking.
     """
 
     def __init__(self, **kwargs):

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -1,4 +1,4 @@
-""" Test for the Backktracking Line Search"""
+""" Test for the Backtracking Line Search"""
 
 import sys
 import unittest

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -100,7 +100,7 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
 
         ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='scalar')
         ls.options['maxiter'] = 10
-        ls.options['alpha'] = 10.0
+        ls.options['alpha'] = 1.0
 
         # Setup again because we assigned a new linesearch
         top.setup()
@@ -110,14 +110,16 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         top['comp.y'] = 0.0
         top['comp.z'] = 1.6
         top.run_model()
-        self.assertTrue(1.5 <= top['comp.z'] <= 1.6)
+        self.assertGreaterEqual(top['comp.z'], 1.5)
+        self.assertLessEqual(top['comp.z'], 1.6)
 
         # Test lower bound: should stop just short of the upper bound
         top['px.x'] = 0.5
         top['comp.y'] = 0.0
         top['comp.z'] = 2.4
         top.run_model()
-        self.assertTrue(2.4 <= top['comp.z'] <= 2.5)
+        self.assertGreaterEqual(top['comp.z'], 2.5)
+        self.assertLessEqual(top['comp.z'], 2.5)
 
 
 class ParaboloidAE(om.ExplicitComponent):
@@ -451,7 +453,8 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
         for ind in range(3):
-            self.assertTrue(1.5 <= top['comp.z'][ind] <= 1.6)
+            self.assertGreaterEqual(top['comp.z'][ind], 1.5)
+            self.assertLessEqual(top['comp.z'][ind], 1.6)
 
         # Test upper bounds: should stop just short of the minimum upper bound
         top['px.x'] = 0.5
@@ -760,9 +763,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_armijogoldsteinls_basic(self):
         import numpy as np
@@ -789,9 +791,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_boundscheck_basic(self):
         import numpy as np
@@ -818,9 +819,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_boundscheck_vector(self):
         import numpy as np
@@ -848,9 +848,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_boundscheck_wall(self):
         import numpy as np
@@ -909,10 +908,6 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        print(top['comp.z'][0])
-        print(top['comp.z'][1])
-        print(top['comp.z'][2])
-
     def test_feature_print_bound_enforce(self):
         import numpy as np
 
@@ -940,9 +935,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_armijo_boundscheck_vector(self):
         import numpy as np
@@ -970,9 +964,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_armijo_boundscheck_wall(self):
         import numpy as np
@@ -1031,10 +1024,6 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        print(top['comp.z'][0])
-        print(top['comp.z'][1])
-        print(top['comp.z'][2])
-
     def test_feature_armijo_print_bound_enforce(self):
         import numpy as np
 
@@ -1062,9 +1051,8 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [1.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [1.5], 1e-8)
+        for ind in range(3):
+            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
1. The step length parameter _alpha_ was declared twice in `_iter_initialize()`, this way the user option was always ignored and alpha was set to 1.

2. Some clean-up and refactoring of the code and tests.