### PR TITLE
Import Iterable from collections.abc, if available

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2,7 +2,11 @@
 
 from __future__ import division
 
-from collections import OrderedDict, Iterable, Counter, defaultdict
+from collections import OrderedDict, Counter, defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from itertools import product
 from six import string_types, iteritems, itervalues
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2,7 +2,11 @@
 from __future__ import division
 
 import os
-from collections import Iterable, Counter, OrderedDict, defaultdict
+from collections import Counter, OrderedDict, defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from itertools import product, chain
 from numbers import Number
 import inspect

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4,7 +4,11 @@ from __future__ import division
 import sys
 import os
 from contextlib import contextmanager
-from collections import OrderedDict, Iterable, defaultdict
+from collections import OrderedDict, defaultdict
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from fnmatch import fnmatchcase
 import sys
 import os

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -11,7 +11,10 @@ import unittest
 from fnmatch import fnmatchcase
 from six import string_types, PY2, reraise
 from six.moves import range, cStringIO as StringIO
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 import numbers
 import json
 import importlib


### PR DESCRIPTION
From Python 3.7 (or even earlier), a `DeprecationWarning` is raised when importing `Iterable` directly from the `collections` module, e.g.:
```sh
...\lib\site-packages\openmdao\core\component.py:5: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
This patch changes the imports accordingly. The `collections.abc` module was introduced in Python 3.3, so a fallback is present to maintain compatibility with Python 2.7.