### PR TITLE
P168431589 user can set specific slices of variables using the set_val method on problem

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -1,7 +1,7 @@
 """Key OpenMDAO classes can be imported from here."""
 
 # Core
-from openmdao.core.problem import Problem
+from openmdao.core.problem import Problem, slicer
 from openmdao.core.group import Group
 from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.explicitcomponent import ExplicitComponent

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2161,3 +2161,29 @@ def _format_error(error, tol):
     if np.isnan(error) or error < tol:
         return '{:.6e}'.format(error)
     return '{:.6e} *'.format(error)
+
+
+class Slicer(object):
+    """
+    Helper class that can be used with the indices argument for Problem set_val and get_val.
+    """
+
+    def __getitem__(self, val):
+        """
+        Pass through indices or slice.
+
+        Parameters
+        ----------
+        val : int or slice object or tuples of slice objects
+            Indices or slice to return.
+
+        Returns
+        -------
+        indices : int or slice object or tuples of slice objects
+            Indices or slice to return.
+        """
+        return val
+
+
+# instance of the Slicer class to be used by users for the set_val and get_val methods of Problem
+slicer = Slicer()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1012,19 +1012,6 @@ class TestProblem(unittest.TestCase):
         import numpy as np
         import openmdao.api as om
 
-        # 1D array
-        prob = om.Problem()
-        prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
-                                                     x={'value': np.array([100.0, 33.3]),},
-                                                     y={'shape': (2, ), }))
-
-        prob.setup()
-        prob.run_model()
-
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0]), 100.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:1]), 100.0, 1e-6)
-
-        # 2D array
         prob = om.Problem()
         prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
                                                      x={'value': np.array([[1., 2.], [3., 4.]]),},
@@ -1033,13 +1020,12 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0,0]), 1.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:1,[1]]), [[2.0],], 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:,0]), [1., 3.], 1e-6)
 
-        prob.set_val('comp.x', 50.0, indices=om.slicer[0,0])
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0,0]), 50.0, 1e-6)
-        prob.set_val('comp.x', 60.0, indices=om.slicer[:1])
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:1]), [[60.0, 60.0]], 1e-6)
+        prob.set_val('comp.x', [5., 6.], indices=om.slicer[:,0])
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:,0]), [5., 6.], 1e-6)
+        prob.run_model()
+        assert_rel_error(self, prob.get_val('comp.y', indices=om.slicer[:,0]), [6., 7.], 1e-6)
 
     def test_feature_set_get_array(self):
         import numpy as np

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1014,18 +1014,20 @@ class TestProblem(unittest.TestCase):
 
         prob = om.Problem()
         prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
-                                                     x={'value': np.array([[1., 2.], [3., 4.]]),},
+                                                     x={'value': np.array([[1., 2.], [3., 4.]]), },
                                                      y={'shape': (2, 2), }))
 
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:,0]), [1., 3.], 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:, 0]), [1., 3.], 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0, 1]), 2., 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[1, -1]), 4., 1e-6)
 
         prob.set_val('comp.x', [5., 6.], indices=om.slicer[:,0])
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:,0]), [5., 6.], 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:, 0]), [5., 6.], 1e-6)
         prob.run_model()
-        assert_rel_error(self, prob.get_val('comp.y', indices=om.slicer[:,0]), [6., 7.], 1e-6)
+        assert_rel_error(self, prob.get_val('comp.y', indices=om.slicer[:, 0]), [6., 7.], 1e-6)
 
     def test_feature_set_get_array(self):
         import numpy as np

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1008,6 +1008,39 @@ class TestProblem(unittest.TestCase):
         assert_rel_error(self, prob.get_val('comp.x'), np.array([1.0, 5.0]), 1e-6)
         assert_rel_error(self, prob.get_val('comp.x', 'm', indices=1), 5.0e-2, 1e-6)
 
+    def test_feature_get_set_array_with_slicer(self):
+        import numpy as np
+        import openmdao.api as om
+
+        # 1D array
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
+                                                     x={'value': np.array([100.0, 33.3]),},
+                                                     y={'shape': (2, ), }))
+
+        prob.setup()
+        prob.run_model()
+
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0]), 100.0, 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:1]), 100.0, 1e-6)
+
+        # 2D array
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x+1.',
+                                                     x={'value': np.array([[1., 2.], [3., 4.]]),},
+                                                     y={'shape': (2, 2), }))
+
+        prob.setup()
+        prob.run_model()
+
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0,0]), 1.0, 1e-6)
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:1,[1]]), [[2.0],], 1e-6)
+
+        prob.set_val('comp.x', 50.0, indices=om.slicer[0,0])
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0,0]), 50.0, 1e-6)
+        prob.set_val('comp.x', 60.0, indices=om.slicer[:1])
+        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:1]), [[60.0, 60.0]], 1e-6)
+
     def test_feature_set_get_array(self):
         import numpy as np
 

--- a/openmdao/docs/features/core_features/running/set_get.rst
+++ b/openmdao/docs/features/core_features/running/set_get.rst
@@ -58,7 +58,6 @@ In other words, the shape of the list has to match the shape of the actual data.
     :layout: interleave
 
 
-
 Residuals
 ---------
 
@@ -96,9 +95,16 @@ peform the conversion for you. This is done with the `Problem` methods `get_val`
 .. embed-code:: openmdao.core.tests.test_problem.TestProblem.test_feature_get_set_with_units
     :layout: interleave
 
-When dealing with arrays, you can set or get specific indices or index ranges by adding the "index" argument to the calls:
+When dealing with arrays, you can set or get specific indices or index ranges by adding the "indices" argument to the calls:
 
 .. embed-code:: openmdao.core.tests.test_problem.TestProblem.test_feature_get_set_array_with_units
+    :layout: interleave
+
+An alternate method of specifying the indices is by making use of the :code:`slicer` object. This object serves as a
+helper function allowing the user to specify the indices value using the same syntax as you would when
+accessing a numpy array.
+
+.. embed-code:: openmdao.core.tests.test_problem.TestProblem.test_feature_get_set_array_with_slicer
     :layout: interleave
 
 

--- a/openmdao/docs/features/core_features/running/set_get.rst
+++ b/openmdao/docs/features/core_features/running/set_get.rst
@@ -58,6 +58,7 @@ In other words, the shape of the list has to match the shape of the actual data.
     :layout: interleave
 
 
+
 Residuals
 ---------
 

--- a/openmdao/docs/features/core_features/running/set_get.rst
+++ b/openmdao/docs/features/core_features/running/set_get.rst
@@ -102,7 +102,7 @@ When dealing with arrays, you can set or get specific indices or index ranges by
 
 An alternate method of specifying the indices is by making use of the :code:`slicer` object. This object serves as a
 helper function allowing the user to specify the indices value using the same syntax as you would when
-accessing a numpy array.
+accessing a numpy array. This example shows that usage.
 
 .. embed-code:: openmdao.core.tests.test_problem.TestProblem.test_feature_get_set_array_with_slicer
     :layout: interleave


### PR DESCRIPTION
User wants a way to input slices using the same syntax as you would when accessing a numpy array, e.g.,  arr[2:10, :99]. Based on that, we could provide a helper class, maybe called Slicer or something, that would define a __getitem__ method that would simply return the arg it was passed, allowing things like prob.get_val('comp.x', 'm', indices=Slicer[2:10, :99])

