### PR TITLE
fixes a bug in the coloring config check

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1357,10 +1357,9 @@ class Component(System):
         if self._first_call_to_linearize:
             self._first_call_to_linearize = False  # only do this once
             if coloring_mod._use_partial_sparsity:
-                is_dynamic = self._coloring_info['coloring'] is coloring_mod._DYN_COLORING
                 coloring = self._get_coloring()
                 if coloring is not None:
-                    if not is_dynamic:
+                    if not self._coloring_info['dynamic']:
                         coloring._check_config_partial(self)
                     self._update_subjac_sparsity(coloring.get_subjac_sparsity())
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -164,7 +164,8 @@ class Driver(object):
 
         self._coloring_info = coloring_mod._DEF_COMP_SPARSITY_ARGS.copy()
         self._coloring_info['coloring'] = None
-        self._coloring_info['orig_coloring'] = None
+        self._coloring_info['dynamic'] = False
+        self._coloring_info['static'] = None
 
         self._total_jac_sparsity = None
         self._res_jacs = {}
@@ -299,7 +300,8 @@ class Driver(object):
         # set up simultaneous deriv coloring
         if coloring_mod._use_total_sparsity:
             # reset the coloring
-            self._coloring_info['coloring'] = self._coloring_info['orig_coloring']
+            if self._coloring_info['dynamic'] or self._coloring_info['static'] is not None:
+                self._coloring_info['coloring'] = None
 
             coloring = self._get_static_coloring()
             if coloring is not None and self.supports['simultaneous_derivatives']:
@@ -1031,8 +1033,11 @@ class Driver(object):
         self._coloring_info['tol'] = tol
         self._coloring_info['orders'] = orders
         self._coloring_info['perturb_size'] = perturb_size
-        self._coloring_info['coloring'] = coloring_mod._DYN_COLORING
-        self._coloring_info['orig_coloring'] = coloring_mod._DYN_COLORING
+        if self._coloring_info['static'] is None:
+            self._coloring_info['dynamic'] = True
+        else:
+            self._coloring_info['dynamic'] = False
+        self._coloring_info['coloring'] = None
         self._coloring_info['show_summary'] = show_summary
         self._coloring_info['show_sparsity'] = show_sparsity
 
@@ -1050,9 +1055,13 @@ class Driver(object):
         if self.supports['simultaneous_derivatives']:
             if coloring_mod._force_dyn_coloring and coloring is coloring_mod._STD_COLORING_FNAME:
                 # force the generation of a dynamic coloring this time
-                coloring = coloring_mod._DYN_COLORING
-            self._coloring_info['coloring'] = coloring
-            self._coloring_info['orig_coloring'] = coloring
+                self._coloring_info['dynamic'] = True
+                self._coloring_info['static'] = None
+            else:
+                self._coloring_info['static'] = coloring
+                self._coloring_info['dynamic'] = False
+
+            self._coloring_info['coloring'] = None
         else:
             raise RuntimeError("Driver '%s' does not support simultaneous derivatives." %
                                self._get_name())
@@ -1093,16 +1102,22 @@ class Driver(object):
             The pre-existing or loaded Coloring, or None
         """
         info = self._coloring_info
-        coloring = info['coloring']
+        static = info['static']
 
-        if isinstance(coloring, coloring_mod.Coloring):
+        if isinstance(static, coloring_mod.Coloring):
+            coloring = static
+            info['coloring'] = coloring
+        else:
+            coloring = info['coloring']
+
+        if coloring is not None:
             return coloring
 
-        if coloring is coloring_mod._STD_COLORING_FNAME or isinstance(coloring, string_types):
-            if coloring is coloring_mod._STD_COLORING_FNAME:
+        if static is coloring_mod._STD_COLORING_FNAME or isinstance(static, string_types):
+            if static is coloring_mod._STD_COLORING_FNAME:
                 fname = self._get_total_coloring_fname()
             else:
-                fname = coloring
+                fname = static
             print("loading total coloring from file %s" % fname)
             coloring = info['coloring'] = coloring_mod.Coloring.load(fname)
             info.update(coloring._meta)

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -164,6 +164,7 @@ class Driver(object):
 
         self._coloring_info = coloring_mod._DEF_COMP_SPARSITY_ARGS.copy()
         self._coloring_info['coloring'] = None
+        self._coloring_info['orig_coloring'] = None
 
         self._total_jac_sparsity = None
         self._res_jacs = {}
@@ -297,6 +298,9 @@ class Driver(object):
 
         # set up simultaneous deriv coloring
         if coloring_mod._use_total_sparsity:
+            # reset the coloring
+            self._coloring_info['coloring'] = self._coloring_info['orig_coloring']
+
             coloring = self._get_static_coloring()
             if coloring is not None and self.supports['simultaneous_derivatives']:
                 if model._owns_approx_jac:
@@ -1028,6 +1032,7 @@ class Driver(object):
         self._coloring_info['orders'] = orders
         self._coloring_info['perturb_size'] = perturb_size
         self._coloring_info['coloring'] = coloring_mod._DYN_COLORING
+        self._coloring_info['orig_coloring'] = coloring_mod._DYN_COLORING
         self._coloring_info['show_summary'] = show_summary
         self._coloring_info['show_sparsity'] = show_sparsity
 
@@ -1047,6 +1052,7 @@ class Driver(object):
                 # force the generation of a dynamic coloring this time
                 coloring = coloring_mod._DYN_COLORING
             self._coloring_info['coloring'] = coloring
+            self._coloring_info['orig_coloring'] = coloring
         else:
             raise RuntimeError("Driver '%s' does not support simultaneous derivatives." %
                                self._get_name())

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -921,11 +921,12 @@ class Problem(object):
 
         driver._setup_driver(self)
 
-        coloring = driver._coloring_info['coloring']
-        if coloring is coloring_mod._STD_COLORING_FNAME:
+        info = driver._coloring_info
+        coloring = info['coloring']
+        if coloring is None and info['static'] is not None:
             coloring = driver._get_static_coloring()
-        if (coloring and coloring is not coloring_mod._DYN_COLORING and
-                coloring_mod._use_total_sparsity):
+
+        if coloring and coloring_mod._use_total_sparsity:
             # if we're using simultaneous total derivatives then our effective size is less
             # than the full size
             if coloring._fwd and coloring._rev:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -35,7 +35,7 @@ from openmdao.utils.general_utils import make_set, var_name_match_includes_exclu
 from openmdao.utils.graph_utils import all_connected_nodes
 from openmdao.utils.name_maps import rel_name2abs_name
 from openmdao.utils.coloring import _compute_coloring, Coloring, \
-    _STD_COLORING_FNAME, _DYN_COLORING, _DEF_COMP_SPARSITY_ARGS
+    _STD_COLORING_FNAME, _DEF_COMP_SPARSITY_ARGS
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.general_utils import determine_adder_scaler, find_matches, \
     format_as_float_or_array, warn_deprecation, ContainsAll, all_ancestors, \
@@ -65,10 +65,9 @@ _DEFAULT_COLORING_META = {
     'method': 'fd',
     'wrt_matches': None,
     'per_instance': False,
-    'coloring': None,
-    'orig_coloring': None,
-    'dynamic': False,
-    'static': None,
+    'coloring': None,  # this will contain the actual Coloring object
+    'dynamic': False,  # True if dynamic coloring is being used
+    'static': None,    # either _STD_COLORING_FNAME or a filename if use_fixed_coloring was called
 }
 
 _DEFAULT_COLORING_META.update(_DEF_COMP_SPARSITY_ARGS)
@@ -802,8 +801,9 @@ class System(object):
         # save a ref to the problem level options.
         self._problem_options = prob_options
 
-        # reset any coloring to exactly what the user specified
-        self._coloring_info['coloring'] = self._coloring_info['orig_coloring']
+        # reset any coloring if a Coloring object was not set explicitly
+        if self._coloring_info['dynamic'] or self._coloring_info['static'] is not None:
+            self._coloring_info['coloring'] = None
 
         # 1. Full setup that must be called in the root system.
         if setup_mode == 'full':
@@ -929,29 +929,23 @@ class System(object):
             If True, set fixed coloring in all subsystems that declare a coloring. Ignored
             if a specific coloring is passed in.
         """
-        self._coloring_info['orig_coloring'] = coloring
+        if coloring_mod._force_dyn_coloring and coloring is _STD_COLORING_FNAME:
+            self._coloring_info['dynamic'] = True
+            return  # don't use static this time
 
-        if coloring not in (_STD_COLORING_FNAME, _DYN_COLORING):
+        self._coloring_info['static'] = coloring
+        self._coloring_info['dynamic'] = False
+
+        if coloring is not _STD_COLORING_FNAME:
             if recurse:
                 simple_warning("%s: recurse was passed to use_fixed_coloring but a specific "
                                "coloring was set, so recurse was ignored." % self.pathname)
-            self._coloring_info['coloring'] = coloring
             if isinstance(coloring, Coloring):
                 approx = self._get_approx_scheme(coloring._meta['method'])
                 # force regen of approx groups on next call to compute_approximations
                 approx._colored_approx_groups = None
                 approx._approx_groups = None
             return
-
-        if coloring_mod._force_dyn_coloring and coloring is _STD_COLORING_FNAME:
-            # force the generation of a dynamic coloring this time
-            coloring = _DYN_COLORING
-
-        if self._coloring_info['coloring'] is None:
-            simple_warning('%s: use_fixed_coloring() ignored because no coloring was declared.' %
-                           self.pathname)
-        else:
-            self._coloring_info['coloring'] = coloring
 
         if recurse:
             for s in self._subsystems_myproc:
@@ -1012,16 +1006,11 @@ class System(object):
         options = _DEFAULT_COLORING_META.copy()
         options.update(approx.DEFAULT_OPTIONS)
 
-        if self._coloring_info['orig_coloring'] is None:
-            options['orig_coloring'] = _DYN_COLORING
-
-        if self._coloring_info['coloring'] is None:
-            # calling declare_coloring turns on dynamic coloring.  Calling use_fixed_coloring
-            # will switch it to use a static coloring.
-            options['coloring'] = _DYN_COLORING
+        if self._coloring_info['static'] is None:
+            options['dynamic'] = True
         else:
-            # this will handle cases where use_fixed_coloring was called before declare_coloring
-            options['coloring'] = self._coloring_info['coloring']
+            options['dynamic'] = False
+            options['static'] = self._coloring_info['static']
 
         options['wrt_patterns'] = [wrt] if isinstance(wrt, string_types) else wrt
         options['method'] = method
@@ -1032,6 +1021,7 @@ class System(object):
         options['perturb_size'] = perturb_size
         options['show_summary'] = show_summary
         options['show_sparsity'] = show_sparsity
+        options['coloring'] = self._coloring_info['coloring']
         if form is not None:
             options['form'] = form
         if step is not None:
@@ -1077,6 +1067,7 @@ class System(object):
 
         # don't override metadata if it's already declared
         info = self._coloring_info
+
         info.update(**overrides)
         if isinstance(info['wrt_patterns'], string_types):
             info['wrt_patterns'] = [info['wrt_patterns']]
@@ -1119,8 +1110,8 @@ class System(object):
 
         starting_resids = self._residuals._data.copy()
 
-        if self._coloring_info['coloring'] is None:
-            self._coloring_info['coloring'] = coloring_mod._DYN_COLORING
+        if self._coloring_info['coloring'] is None and self._coloring_info['static'] is None:
+            self._coloring_info['dynamic'] = True
 
         # for groups, this does some setup of approximations
         self._setup_approx_coloring()
@@ -1305,15 +1296,15 @@ class System(object):
         """
         info = self._coloring_info
         coloring = info['coloring']
+        if coloring is not None:
+            return coloring
 
-        if coloring is _DYN_COLORING:
-            return None
-
-        if coloring is _STD_COLORING_FNAME or isinstance(coloring, string_types):
-            if coloring is _STD_COLORING_FNAME:
+        static = info['static']
+        if static is _STD_COLORING_FNAME or isinstance(static, string_types):
+            if static is _STD_COLORING_FNAME:
                 fname = self.get_approx_coloring_fname()
             else:
-                fname = coloring
+                fname = static
             print("%s: loading coloring from file %s" % (self.msginfo, fname))
             info['coloring'] = coloring = Coloring.load(fname)
             if info['wrt_patterns'] != coloring._meta['wrt_patterns']:
@@ -1326,6 +1317,13 @@ class System(object):
             # force regen of approx groups during next compute_approximations
             approx._colored_approx_groups = None
             approx._approx_groups = None
+        elif isinstance(static, coloring_mod.Coloring):
+            info['coloring'] = coloring = static
+
+        if coloring is not None:
+            info['dynamic'] = False
+
+        info['static'] = coloring
 
         return coloring
 
@@ -1341,7 +1339,7 @@ class System(object):
             Coloring object, possible loaded from a file or dynamically generated, or None
         """
         coloring = self._get_static_coloring()
-        if coloring is None and self._coloring_info['coloring'] is _DYN_COLORING:
+        if coloring is None and self._coloring_info['dynamic']:
             self._coloring_info['coloring'] = coloring = self._compute_approx_coloring()[0]
             self._coloring_info.update(coloring._meta)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -67,7 +67,8 @@ _DEFAULT_COLORING_META = {
     'per_instance': False,
     'coloring': None,  # this will contain the actual Coloring object
     'dynamic': False,  # True if dynamic coloring is being used
-    'static': None,    # either _STD_COLORING_FNAME or a filename if use_fixed_coloring was called
+    'static': None,    # either _STD_COLORING_FNAME, a filename, or a Coloring object
+                       # if use_fixed_coloring was called
 }
 
 _DEFAULT_COLORING_META.update(_DEF_COMP_SPARSITY_ARGS)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -66,6 +66,9 @@ _DEFAULT_COLORING_META = {
     'wrt_matches': None,
     'per_instance': False,
     'coloring': None,
+    'orig_coloring': None,
+    'dynamic': False,
+    'static': None,
 }
 
 _DEFAULT_COLORING_META.update(_DEF_COMP_SPARSITY_ARGS)
@@ -799,6 +802,9 @@ class System(object):
         # save a ref to the problem level options.
         self._problem_options = prob_options
 
+        # reset any coloring to exactly what the user specified
+        self._coloring_info['coloring'] = self._coloring_info['orig_coloring']
+
         # 1. Full setup that must be called in the root system.
         if setup_mode == 'full':
             recurse = True
@@ -923,6 +929,8 @@ class System(object):
             If True, set fixed coloring in all subsystems that declare a coloring. Ignored
             if a specific coloring is passed in.
         """
+        self._coloring_info['orig_coloring'] = coloring
+
         if coloring not in (_STD_COLORING_FNAME, _DYN_COLORING):
             if recurse:
                 simple_warning("%s: recurse was passed to use_fixed_coloring but a specific "
@@ -1003,6 +1011,9 @@ class System(object):
         # start with defaults
         options = _DEFAULT_COLORING_META.copy()
         options.update(approx.DEFAULT_OPTIONS)
+
+        if self._coloring_info['orig_coloring'] is None:
+            options['orig_coloring'] = _DYN_COLORING
 
         if self._coloring_info['coloring'] is None:
             # calling declare_coloring turns on dynamic coloring.  Calling use_fixed_coloring

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -1216,8 +1216,6 @@ class TestStaticColoringParallelCS(unittest.TestCase):
         model.add_design_var('indeps.x0')
         model.add_design_var('indeps.x1')
 
-        #import wingdbstub
-
         prob.setup(check=False, mode='fwd')
         prob.set_solver_print(level=0)
         prob.run_model()

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -1216,6 +1216,8 @@ class TestStaticColoringParallelCS(unittest.TestCase):
         model.add_design_var('indeps.x0')
         model.add_design_var('indeps.x1')
 
+        #import wingdbstub
+
         prob.setup(check=False, mode='fwd')
         prob.set_solver_print(level=0)
         prob.run_model()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -223,7 +223,7 @@ class pyOptSparseDriver(Driver):
 
         # compute dynamic simul deriv coloring or just sparsity if option is set
         if coloring_mod._use_total_sparsity:
-            if self._coloring_info['coloring'] is coloring_mod._DYN_COLORING:
+            if self._coloring_info['coloring'] is None and self._coloring_info['dynamic']:
                 coloring_mod.dynamic_total_coloring(self, run_model=not model_ran,
                                                     fname=self._get_total_coloring_fname())
                 self._setup_tot_jac_sparsity()

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -416,7 +416,7 @@ class ScipyOptimizeDriver(Driver):
 
         # compute dynamic simul deriv coloring if option is set
         if coloring_mod._use_total_sparsity:
-            if self._coloring_info['coloring'] is coloring_mod._DYN_COLORING:
+            if self._coloring_info['coloring'] is None and self._coloring_info['dynamic']:
                 coloring_mod.dynamic_total_coloring(self, run_model=False,
                                                     fname=self._get_total_coloring_fname())
             elif self.options['dynamic_simul_derivs']:

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -63,8 +63,6 @@ _force_dyn_coloring = False
 # path or system pathname
 _STD_COLORING_FNAME = object()
 
-# used to indicate that we should dynamically generate a coloring
-_DYN_COLORING = object()
 
 # default values related to the computation of a sparsity matrix
 _DEF_COMP_SPARSITY_ARGS = {


### PR DESCRIPTION
The coloring system was incorrectly raising an exception if a Problem was setup then later resized and setup again.  The system was incorrectly trying to load a static coloring instead of just regenerating a new dynamic coloring.  That static coloring had different var sizes than the current model, so an exception was being raised.