### PR TITLE
Retarget webview entry_point to openmdao.utils.webview

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -154,8 +154,8 @@ setup(
     entry_points="""
     [console_scripts]
     wingproj=openmdao.devtools.wingproj:run_wing
-    run_test=openmdao.devtools.run_test:run_test
     webview=openmdao.utils.webview:webview_argv
+    run_test=openmdao.devtools.run_test:run_test
     openmdao=openmdao.utils.om:openmdao_cmd
     """,
     extras_require=optional_dependencies,

--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,7 @@ setup(
     [console_scripts]
     wingproj=openmdao.devtools.wingproj:run_wing
     run_test=openmdao.devtools.run_test:run_test
+    webview=openmdao.utils.webview:webview_argv
     openmdao=openmdao.utils.om:openmdao_cmd
     """,
     extras_require=optional_dependencies,

--- a/setup.py
+++ b/setup.py
@@ -154,7 +154,6 @@ setup(
     entry_points="""
     [console_scripts]
     wingproj=openmdao.devtools.wingproj:run_wing
-    webview=openmdao.devtools.webview:webview_argv
     run_test=openmdao.devtools.run_test:run_test
     openmdao=openmdao.utils.om:openmdao_cmd
     """,


### PR DESCRIPTION
Congratulations on the release!

However, it appears `webview` no longer exists, but is still listed as an `entry_point`.

c/f:
- https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=76975&view=logs&jobId=1bf226d3-0e2f-52d8-fa93-7d9e633347b3&taskId=ec8d466d-e3b4-5115-4f06-222398f91e6c&lineStart=2130&lineEnd=2131&colStart=1&colEnd=1
- https://github.com/conda-forge/openmdao-feedstock/pull/1