### PR TITLE
added support for passing args to user scripts when using 'openmdao' commands.

### DIFF
--- a/openmdao/devtools/iprof_mem.py
+++ b/openmdao/devtools/iprof_mem.py
@@ -137,13 +137,14 @@ def _mem_prof_setup_parser(parser):
     parser.add_argument('file', metavar='file', nargs=1, help='Python file to profile.')
 
 
-def _mem_prof_exec(options):
+def _mem_prof_exec(options, user_args):
     """
     Process command line args and perform memory profiling on a specified python file.
     """
 
     progname = options.file[0]
     sys.path.insert(0, os.path.dirname(progname))
+
 
     globals_dict = {
         '__file__': progname,
@@ -163,6 +164,9 @@ def _mem_prof_exec(options):
 
     if options.nogc:
         gc.disable()
+
+    # update sys.argv in case python script takes cmd line args
+    sys.argv[:] = [progname] + user_args
 
     exec (code, globals_dict)
 
@@ -224,7 +228,7 @@ def _mempost_setup_parser(parser):
     parser.add_argument('file', metavar='file', nargs=1, help='Memory dump file to process.')
 
 
-def _mempost_exec(options):
+def _mempost_exec(options, user_args):
     """
     Process command line args and perform postprocessing on the specified memory dump file.
     """

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -396,7 +396,7 @@ def _iprof_totals_exec(options):
             out_stream.close()
 
 
-def _iprof_py_file(options):
+def _iprof_py_file(options, user_args):
     """
     Run instance-based profiling on the given python script.
 
@@ -404,12 +404,17 @@ def _iprof_py_file(options):
     ----------
     options : argparse Namespace
         Command line options.
+    user_args : list of str
+        Command line options after '--' (if any).  Passed to user script.
     """
     if not func_group:
         _setup_func_group()
 
     progname = options.file[0]
     sys.path.insert(0, os.path.dirname(progname))
+
+    # update sys.argv in case python script takes cmd line args
+    sys.argv[:] = [progname] + user_args
 
     with open(progname, 'rb') as fp:
         code = compile(fp.read(), progname, 'exec')

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -349,7 +349,7 @@ def _iprof_totals_setup_parser(parser):
                         help='Raw profile data files or a python file.')
 
 
-def _iprof_totals_exec(options):
+def _iprof_totals_exec(options, user_args):
     """
     Called from the command line (openmdao prof_totals command) to create a file containing total
     elapsed times and number of calls for all profiled functions.
@@ -368,7 +368,7 @@ def _iprof_totals_exec(options):
         if len(options.file) > 1:
             print("iprofview can only process a single python file.", file=sys.stderr)
             sys.exit(-1)
-        _iprof_py_file(options)
+        _iprof_py_file(options, user_args)
         if MPI:
             options.file = ['iprof.%d' % i for i in range(MPI.COMM_WORLD.size)]
         else:

--- a/openmdao/devtools/iprofile_app/iprofile_app.py
+++ b/openmdao/devtools/iprofile_app/iprofile_app.py
@@ -118,7 +118,7 @@ def _iprof_setup_parser(parser):
 
 
 if tornado is None:
-    def _iprof_exec(options):
+    def _iprof_exec(options, user_args):
         """
         Called from a command line to instance based profile data in a web page.
         """
@@ -202,7 +202,8 @@ else:
             self.set_header('Content-Type', 'application/json')
             self.write(dump)
 
-    def _iprof_exec(options):
+
+    def _iprof_exec(options, user_args):
         """
         Called from a command line to instance based profile data in a web page.
         """
@@ -210,7 +211,8 @@ else:
             if len(options.file) > 1:
                 print("iprofview can only process a single python file.", file=sys.stderr)
                 sys.exit(-1)
-            _iprof_py_file(options)
+
+            _iprof_py_file(options, user_args)
             if MPI:
                 options.file = ['iprof.%d' % i for i in range(MPI.COMM_WORLD.size)]
             else:

--- a/openmdao/devtools/itrace.py
+++ b/openmdao/devtools/itrace.py
@@ -385,7 +385,7 @@ def _itrace_setup_parser(parser):
                              'expression can be added for each class.')
 
 
-def _itrace_exec(options):
+def _itrace_exec(options, user_args):
     """
     Process command line args and perform tracing on a specified python file.
     """
@@ -405,4 +405,5 @@ def _itrace_exec(options):
     _setup(options)
     start()
 
+    sys.argv[:] = [progname] + user_args
     exec (code, globals_dict)

--- a/openmdao/devtools/itrace.py
+++ b/openmdao/devtools/itrace.py
@@ -9,7 +9,7 @@ import warnings
 from contextlib import contextmanager
 from collections import defaultdict, OrderedDict
 
-from six import string_types
+from six import string_types, PY2
 from six.moves import cStringIO
 from numpy import ndarray
 try:
@@ -81,8 +81,12 @@ def _get_printer(stream, rank=-1):
 
     # rank < 0 means output on all ranks
     if not MPI or rank < 0 or MPI.COMM_WORLD.rank == rank:
-        def prt(*args, **kwargs):
-            print(*args, file=stream, flush=True, **kwargs)
+        if PY2:  # python 2 doesn't like the flush arg
+            def prt(*args, **kwargs):
+                print(*args, file=stream, **kwargs)
+        else:
+            def prt(*args, **kwargs):
+                print(*args, file=stream, flush=True, **kwargs)
     else:
         def prt(*args, **kwargs):
             pass

--- a/openmdao/docs/other/om_command.rst
+++ b/openmdao/docs/other/om_command.rst
@@ -7,11 +7,17 @@ Command Line Tools
 OpenMDAO has a number of debugging/viewing command line tools that are available via the `openmdao`
 command.  There are two types of commands available, those that perform some sort of viewing or
 configuration checking on the Problem after its setup is complete, and those that are used to
-collect information about the entire run of the Problem, things like profilers and tracers.
+collect information about the entire run of the Problem, like profilers and tracers.
 
 .. note::
     The `openmdao` sub-commands, as well as any other console scripts associated with OpenMDAO, will
     only be available if you have installed OpenMDAO using *pip*. See :ref:`Getting Started <GettingStarted>`
+
+
+.. note::
+    When using a command line tool on a script that takes its own command line arguments, those
+    arguments must be placed after a :code:`--` on the command line.  Anything to the right of the
+    :code:`--` will be ignored by the openmdao command line parser and passed on to the user script.
 
 
 All available :code:`openmdao` sub-commands can be shown using the following command:
@@ -20,25 +26,23 @@ All available :code:`openmdao` sub-commands can be shown using the following com
     :cmd: openmdao -h
 
 
-To get further info on any sub-command,
-for example, for :code:`tree`, follow the command with a *-h*.  For example:
+To get further info on any sub-command, follow the command with a *-h*.  For example:
 
 .. embed-shell-cmd::
-    :cmd: openmdao tree -h
+    :cmd: openmdao n2 -h
 
 .. note::
-    Several of the example commands below make use of a file :code:`circuit.py`. This file is located in the
-    openmdao/test_suite/scripts directory.
+    Several of the example commands below make use of a files :code:`circuit.py` and
+    :code:`circle_opt.py`. These files are located in the openmdao/test_suite/scripts directory.
 
 
-Post-setup Commands
--------------------
+Viewing and Checking Commands
+-----------------------------
 
-The following commands all register a function that will run at the end of a Problem's
-:code:`final_setup` function.  After the registered function completes, the program will exit, rather than
-continuing to the end of the user's run script. This makes it convenient to view or check the
-configuration of a model in any run script without having to wait around for the entire script
-to run.
+Usually these commands will exit after executing, rather than continuing to the end of the user's
+run script. This makes it convenient to view or check the configuration of a model in any
+run script without having to wait around for the entire script to run.
+
 
 .. _om-command-check:
 
@@ -109,7 +113,7 @@ Below is an example of a connection viewer for a pycycle propulsor model obtaine
 
 .. code-block:: none
 
-    openmdao view_connections propulsor.py
+    openmdao view_connections -v propulsor.py
 
 
 .. figure:: view_connections.png
@@ -170,7 +174,7 @@ openmdao summary
 The :code:`openmdao summary` command prints a high level summary of the model.  For example:
 
 .. embed-shell-cmd::
-    :cmd: openmdao summary circuit.py
+    :cmd: openmdao summary circle_opt.py
     :dir: ../test_suite/scripts
 
 

--- a/openmdao/docs/other/om_command.rst
+++ b/openmdao/docs/other/om_command.rst
@@ -18,6 +18,8 @@ collect information about the entire run of the Problem, like profilers and trac
     When using a command line tool on a script that takes its own command line arguments, those
     arguments must be placed after a :code:`--` on the command line.  Anything to the right of the
     :code:`--` will be ignored by the openmdao command line parser and passed on to the user script.
+    For example: :code:`openmdao n2 -o foo.html myscript.py -- -x --myarg=bar` would pass
+    :code:`-x` and :code:`--myarg=bar` as args to :code:`myscript.py`.
 
 
 All available :code:`openmdao` sub-commands can be shown using the following command:
@@ -32,7 +34,7 @@ To get further info on any sub-command, follow the command with a *-h*.  For exa
     :cmd: openmdao n2 -h
 
 .. note::
-    Several of the example commands below make use of a files :code:`circuit.py` and
+    Several of the example commands below make use of the files :code:`circuit.py` and
     :code:`circle_opt.py`. These files are located in the openmdao/test_suite/scripts directory.
 
 

--- a/openmdao/test_suite/scripts/circle_coloring_dynpartials.py
+++ b/openmdao/test_suite/scripts/circle_coloring_dynpartials.py
@@ -1,0 +1,11 @@
+
+import os
+
+COLOR_TYPE = os.environ.get('COLOR_TYPE', 'auto')
+
+from openmdao.api import ScipyOptimizeDriver
+from openmdao.core.tests.test_coloring import run_opt
+
+
+p_color = run_opt(ScipyOptimizeDriver, COLOR_TYPE, optimizer='SLSQP', disp=False, dynamic_total_coloring=True, partial_coloring=True)
+

--- a/openmdao/test_suite/scripts/circle_coloring_dynpartials.py
+++ b/openmdao/test_suite/scripts/circle_coloring_dynpartials.py
@@ -6,6 +6,7 @@ COLOR_TYPE = os.environ.get('COLOR_TYPE', 'auto')
 from openmdao.api import ScipyOptimizeDriver
 from openmdao.core.tests.test_coloring import run_opt
 
-
-p_color = run_opt(ScipyOptimizeDriver, COLOR_TYPE, optimizer='SLSQP', disp=False, dynamic_total_coloring=True, partial_coloring=True)
+if __name__ == '__main__':
+    p_color = run_opt(ScipyOptimizeDriver, COLOR_TYPE, optimizer='SLSQP', disp=False,
+                      dynamic_total_coloring=True, partial_coloring=True)
 

--- a/openmdao/test_suite/scripts/circle_coloring_needs_args.py
+++ b/openmdao/test_suite/scripts/circle_coloring_needs_args.py
@@ -1,0 +1,15 @@
+
+import os
+import sys
+
+COLOR_TYPE = os.environ.get('COLOR_TYPE', 'auto')
+
+from openmdao.api import ScipyOptimizeDriver
+from openmdao.core.tests.test_coloring import run_opt
+
+if len(sys.argv) != 3 or sys.argv[1] != '-f':
+    print("usage: python circle_coloring_needs_args.py -f bar")
+    sys.exit(2)
+
+p_color = run_opt(ScipyOptimizeDriver, COLOR_TYPE, optimizer='SLSQP', disp=False, dynamic_total_coloring=True, partial_coloring=False)
+

--- a/openmdao/test_suite/scripts/circle_coloring_needs_args.py
+++ b/openmdao/test_suite/scripts/circle_coloring_needs_args.py
@@ -7,9 +7,12 @@ COLOR_TYPE = os.environ.get('COLOR_TYPE', 'auto')
 from openmdao.api import ScipyOptimizeDriver
 from openmdao.core.tests.test_coloring import run_opt
 
-if len(sys.argv) != 3 or sys.argv[1] != '-f':
-    print("usage: python circle_coloring_needs_args.py -f bar")
-    sys.exit(2)
+if __name__ == '__main__':
 
-p_color = run_opt(ScipyOptimizeDriver, COLOR_TYPE, optimizer='SLSQP', disp=False, dynamic_total_coloring=True, partial_coloring=False)
+    if len(sys.argv) != 3 or sys.argv[1] != '-f':
+        print("usage: python circle_coloring_needs_args.py -f bar")
+        sys.exit(2)
+
+    p_color = run_opt(ScipyOptimizeDriver, COLOR_TYPE, optimizer='SLSQP', disp=False,
+                      dynamic_total_coloring=True, partial_coloring=False)
 

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -216,7 +216,7 @@ def _calltree_setup_parser(parser):
                         default='stdout', help='Output file.  Defaults to stdout.')
 
 
-def _calltree_exec(options):
+def _calltree_exec(options, user_args):
     """
     Process command line args and call get_nested_calls on the specified class method.
     """

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -2072,7 +2072,7 @@ def _view_coloring_setup_parser(parser):
                         'for a particular variable.')
 
 
-def _view_coloring_exec(options):
+def _view_coloring_exec(options, user_args):
     """
     Execute the 'openmdao view_coloring' command.
 
@@ -2080,6 +2080,8 @@ def _view_coloring_exec(options):
     ----------
     options : argparse Namespace
         Command line options.
+    user_args : list of str
+        Command line options after '--' (if any).  Passed to user script.
     """
     coloring = Coloring.load(options.file[0])
     if options.show_sparsity_text:

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -376,7 +376,7 @@ def _config_summary_cmd(options):
     """
     def summary(prob):
         config_summary(prob)
-        exit()
+        sys.exit(0)
 
     hooks._register_hook('final_setup', 'Problem', post=summary)
 

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -63,7 +63,7 @@ def _n2_setup_parser(parser):
                         help="use declare partial info for internal connectivity.")
 
 
-def _n2_cmd(options):
+def _n2_cmd(options, user_args):
     """
     Process command line args and call n2 on the specified file.
 
@@ -71,6 +71,8 @@ def _n2_cmd(options):
     ----------
     options : argparse Namespace
         Command line options.
+    user_args : list of str
+        Command line options after '--' (if any).  Passed to user script.
     """
     filename = options.file[0]
 
@@ -86,7 +88,7 @@ def _n2_cmd(options):
 
         hooks._register_hook('final_setup', 'Problem', pre=_viewmod)
 
-        _simple_exec(options)
+        _simple_exec(options, user_args)
     else:
         # assume the file is a recording, run standalone
         n2(filename, outfile=options.outfile, title=options.title,
@@ -94,9 +96,9 @@ def _n2_cmd(options):
            use_declare_partial_info=options.use_declare_partial_info)
 
 
-def _view_model_cmd(options):
+def _view_model_cmd(options, user_args):
     warn_deprecation("The 'view_model' command has been deprecated. Use 'n2' instead.")
-    _n2_cmd(options)
+    _n2_cmd(options, user_args)
 
 
 def _xdsm_setup_parser(parser):
@@ -156,7 +158,7 @@ def _xdsm_setup_parser(parser):
                              'component blocks of the diagram..')
 
 
-def _xdsm_cmd(options):
+def _xdsm_cmd(options, user_args):
     """
     Process command line args and call xdsm on the specified file.
 
@@ -164,6 +166,8 @@ def _xdsm_cmd(options):
     ----------
     options : argparse Namespace
         Command line options.
+    user_args : list of str
+        Command line options after '--' (if any).  Passed to user script.
     """
     filename = options.file[0]
 
@@ -193,7 +197,7 @@ def _xdsm_cmd(options):
 
         hooks._register_hook('setup', 'Problem', post=_xdsm)
 
-        _simple_exec(options)
+        _simple_exec(options, user_args)
     else:
         # assume the file is a recording, run standalone
         write_xdsm(filename, filename=options.outfile, model_path=options.model_path,
@@ -584,7 +588,7 @@ def _cite_cmd(options):
     return _cite
 
 
-def _simple_exec(options):
+def _simple_exec(options, user_args):
     """
     Use this as executor for commands that run as Problem commands.
 
@@ -596,6 +600,8 @@ def _simple_exec(options):
     progname = options.file[0]
 
     sys.path.insert(0, os.path.dirname(progname))
+
+    sys.argv[:] = [progname] + user_args
 
     with open(progname, 'rb') as fp:
         code = compile(fp.read(), progname, 'exec')
@@ -672,8 +678,20 @@ def openmdao_cmd():
     """
     Wrap a number of Problem viewing/debugging command line functions.
     """
+    # pre-parse sys.argv to split between before and after '--'
+    if '--' in sys.argv:
+        idx = sys.argv.index('--')
+        sys_args = sys.argv[:idx]
+        user_args = sys.argv[idx + 1:]
+        sys.argv[:] = sys_args
+    else:
+        user_args = []
+
     parser = argparse.ArgumentParser(description='OpenMDAO Command Line Tools',
-                                     epilog='Use -h after any sub-command for sub-command help.')
+                                     epilog='Use -h after any sub-command for sub-command help.'
+                                     ' If using a tool on a script that takes its own command line'
+                                     ' arguments, place those arguments after a "--". For example:'
+                                     ' openmdao n2 -o foo.html myscript.py -- -x --myarg=bar')
 
     # setting 'dest' here will populate the Namespace with the active subparser name
     subs = parser.add_subparsers(title='Tools', metavar='', dest="subparser_name")
@@ -685,7 +703,7 @@ def openmdao_cmd():
     # handle case where someone just runs `openmdao <script> [dashed-args]`
     args = [a for a in sys.argv[1:] if not a.startswith('-')]
     if not set(args).intersection(subs.choices) and len(args) == 1 and os.path.isfile(args[0]):
-        _simple_exec(_Options(file=[args[0]], func=None))
+        _simple_exec(_Options(file=[args[0]], func=None), user_args)
     else:
         hooks.use_hooks = True
         # we do a parse_known_args here instead of parse_args so that we can associate errors with
@@ -702,8 +720,9 @@ def openmdao_cmd():
                 print(sub.format_usage(), file=sys.stderr)
                 print(msg, file=sys.stderr)
             parser.exit(2)
+
         if hasattr(options, 'executor'):
-            options.executor(options)
+            options.executor(options, user_args)
         else:
             print("\nNothing to do.")
 

--- a/openmdao/utils/scaffold.py
+++ b/openmdao/utils/scaffold.py
@@ -49,7 +49,7 @@ def _get_template(fname, **kwargs):
     return template
 
 
-def _scaffold_exec(options):
+def _scaffold_exec(options, user_args):
     """
     Execute the 'openmdao scaffold' command.
 
@@ -57,6 +57,8 @@ def _scaffold_exec(options):
     ----------
     options : argparse Namespace
         Command line options.
+    user_args : list of str
+        Command line options after '--' (if any).  Passed to user script.
     """
     if options.file is None:
         outfile = _camel_case_split(options.class_name)

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -1,0 +1,57 @@
+
+import os
+import unittest
+import subprocess
+
+from openmdao.utils.testing_utils import use_tempdirs
+
+try:
+    from parameterized import parameterized
+except ImportError:
+    from openmdao.utils.assert_utils import SkipParameterized as parameterized
+
+dname = os.path.dirname
+
+scriptdir = os.path.join(dname(dname(dname(os.path.abspath(__file__)))), 'test_suite', 'scripts')
+
+counter = 0
+
+def _test_func_name(func, num, param):
+    return func.__name__ + '_' + '_'.join(param.args[0].split()[1:-1])
+
+
+@use_tempdirs
+class CmdlineTestCase(unittest.TestCase):
+    @parameterized.expand([
+        'openmdao call_tree openmdao.components.exec_comp.ExecComp.setup',
+        'openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao check {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao cite {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao iprof --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao iprof_totals {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao mem {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao mem --tree {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao n2 --no_browser {} -- -f bar'.format(os.path.join(scriptdir, 'circle_coloring_needs_args.py')),
+        'openmdao partial_coloring {}'.format(os.path.join(scriptdir, 'circle_coloring_dynpartials.py')),
+        'openmdao scaffold -e -c Foo',
+        'openmdao scaffold -i -c Foo',
+        'openmdao total_coloring {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao trace {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao tree -c {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao view_connections --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao view_model --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        'openmdao xdsm --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    ], name_func=_test_func_name)
+    def test_cmd(self, cmd):
+        # this only tests that a given command line tool returns a 0 return code. It doesn't
+        # check the expected output at all.  The underlying functions that implement the
+        # commands should be tested seperately.
+        try:
+            output = subprocess.check_output(cmd.split())
+        except subprocess.CalledProcessError as err:
+            self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -19,30 +19,42 @@ counter = 0
 def _test_func_name(func, num, param):
     return func.__name__ + '_' + '_'.join(param.args[0].split()[1:-1])
 
+cmd_tests = [
+    'openmdao call_tree openmdao.components.exec_comp.ExecComp.setup',
+    'openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao check {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao cite {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao iprof --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao iprof_totals {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao n2 --no_browser {} -- -f bar'.format(os.path.join(scriptdir, 'circle_coloring_needs_args.py')),
+    'openmdao partial_coloring {}'.format(os.path.join(scriptdir, 'circle_coloring_dynpartials.py')),
+    'openmdao scaffold -e -c Foo',
+    'openmdao scaffold -i -c Foo',
+    'openmdao total_coloring {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao trace {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao tree -c {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao view_connections --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao view_model --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao xdsm --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+]
+
+
+mem_cmd_tests = [
+    'openmdao mem {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao mem --tree {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+    'openmdao trace -m {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+]
+
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
 
 @use_tempdirs
 class CmdlineTestCase(unittest.TestCase):
-    @parameterized.expand([
-        'openmdao call_tree openmdao.components.exec_comp.ExecComp.setup',
-        'openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao check {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao cite {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao iprof --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao iprof_totals {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao mem {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao mem --tree {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao n2 --no_browser {} -- -f bar'.format(os.path.join(scriptdir, 'circle_coloring_needs_args.py')),
-        'openmdao partial_coloring {}'.format(os.path.join(scriptdir, 'circle_coloring_dynpartials.py')),
-        'openmdao scaffold -e -c Foo',
-        'openmdao scaffold -i -c Foo',
-        'openmdao total_coloring {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao trace {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao tree -c {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao view_connections --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao view_model --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-        'openmdao xdsm --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    ], name_func=_test_func_name)
+    @parameterized.expand(cmd_tests, name_func=_test_func_name)
     def test_cmd(self, cmd):
         # this only tests that a given command line tool returns a 0 return code. It doesn't
         # check the expected output at all.  The underlying functions that implement the
@@ -52,6 +64,16 @@ class CmdlineTestCase(unittest.TestCase):
         except subprocess.CalledProcessError as err:
             self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
 
+    @parameterized.expand(mem_cmd_tests, name_func=_test_func_name)
+    @unittest.skipIf(psutil is None, 'psutil must be installed to run mem commands')
+    def test_cmd(self, cmd):
+        # this only tests that a given command line tool returns a 0 return code. It doesn't
+        # check the expected output at all.  The underlying functions that implement the
+        # commands should be tested seperately.
+        try:
+            output = subprocess.check_output(cmd.split())
+        except subprocess.CalledProcessError as err:
+            self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- any args to the left of '--' (if it exists) on the command line will be processed normally.  Anything to the right will be passed to the user script.