### PR TITLE
fix issue causing test failures on cluster

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -101,8 +101,7 @@ from openmdao.visualization.partial_deriv_plot import partial_deriv_plot
 import os
 if os.environ.get('OPENMDAO_TRACE'):
     from openmdao.devtools.itrace import setup, start
-    ret = bool(os.environ.get('OPENMDAO_TRACE_RETURN'))
-    setup(os.environ['OPENMDAO_TRACE'], show_return=ret)
+    setup(os.environ['OPENMDAO_TRACE'])
     start()
 elif os.environ.get('OPENMDAO_PROF_MEM'):
     from openmdao.devtools.iprof_mem import setup, start

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -3,10 +3,13 @@
 from __future__ import division
 
 from collections import OrderedDict, Counter, defaultdict
+
+# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
+
 from itertools import product
 from six import string_types, iteritems, itervalues
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3,10 +3,13 @@ from __future__ import division
 
 import os
 from collections import Counter, OrderedDict, defaultdict
+
+# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
+
 from itertools import product, chain
 from numbers import Number
 import inspect

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -2,6 +2,7 @@
 
 from __future__ import division
 
+# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable
 except ImportError:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5,10 +5,13 @@ import sys
 import os
 from contextlib import contextmanager
 from collections import OrderedDict, defaultdict
+
+# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
+
 from fnmatch import fnmatchcase
 import sys
 import os

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -4,6 +4,8 @@ from __future__ import division, print_function
 
 import unittest
 import itertools
+
+# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable
 except ImportError:

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -4,6 +4,10 @@ from __future__ import division, print_function
 
 import unittest
 import itertools
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import numpy as np
 
@@ -39,11 +43,14 @@ class Noisy(ConvergeDiverge):
 def _test_func_name(func, num, param):
     args = []
     for p in param.args:
-        try:
-            arg = p.__name__
-        except:
-            arg = str(p)
-        args.append(arg)
+        if not isinstance(p, Iterable):
+            p = {p}
+        for item in p:
+            try:
+                arg = item.__name__
+            except:
+                arg = str(item)
+            args.append(arg)
     return func.__name__ + '_' + '_'.join(args)
 
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -11,10 +11,13 @@ import unittest
 from fnmatch import fnmatchcase
 from six import string_types, PY2, reraise
 from six.moves import range, cStringIO as StringIO
+
+# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable
 except ImportError:
     from collections import Iterable
+
 import numbers
 import json
 import importlib


### PR DESCRIPTION
process items within tuples when assigning parameterized test names
remove attempt to pass invalid arg to itrace setup()