### PR TITLE
XDSM v2 component type update

### DIFF
--- a/openmdao/visualization/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/visualization/xdsm_viewer/xdsm_writer.py
@@ -678,6 +678,8 @@ else:
             Index of last components in a process.
         _nr_comps : int
             Number of components.
+        _pyxdsm_version : str
+            Version of the installed pyXDSM package.
         """
 
         def __init__(self, name='pyxdsm', box_stacking=_DEFAULT_BOX_STACKING,
@@ -733,8 +735,8 @@ else:
 
             try:
                 type_map_name = self.name
-                if LooseVersion(pyxdsm_version) <= LooseVersion('1.0.0'):
-                    type_map_name += ' ' + pyxdsm_version
+                if LooseVersion(pyxdsm_version) < LooseVersion('2.0.0'):
+                    type_map_name += ' 1.0'
                 self.type_map = _COMPONENT_TYPE_MAP[type_map_name]
             except KeyError:
                 self.type_map = _COMPONENT_TYPE_MAP[_DEFAULT_WRITER]


### PR DESCRIPTION
Added the new component type mapping based on pyXDSM 2.0. The current implementation sets as default the new version. This might break the code for users of 1.0. If someone really wants, they can change the "pyxdsm_version" of the XDSMWriter, and pass it as a custom writer. It can be made friendlier after https://github.com/mdolab/pyXDSM/pull/14.

Fixed a small bug, which caused to place the output blocks incorrectly in some cases, when mixed left & right outputs sides were set.

Currently ImplicitGroups are not considered.

![image](https://user-images.githubusercontent.com/34424189/69914297-e6280180-1442-11ea-8766-a88ecc85f8c1.png)
