### PR TITLE
Use running python executable

### DIFF
--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -65,7 +65,7 @@ class TestExternalCodeComp(unittest.TestCase):
 
     def test_normal(self):
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out'
+            sys.executable, 'extcode_example.py', 'extcode.out'
         ]
 
         self.extcode.options['external_input_files'] = ['extcode_example.py']
@@ -108,7 +108,7 @@ class TestExternalCodeComp(unittest.TestCase):
 
     def test_timeout_raise(self):
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out', '--delay', '3'
+            sys.executable, 'extcode_example.py', 'extcode.out', '--delay', '3'
         ]
         self.extcode.options['timeout'] = 1.0
 
@@ -124,7 +124,7 @@ class TestExternalCodeComp(unittest.TestCase):
 
     def test_error_code_raise(self):
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out', '--delay', '-3'
+            sys.executable, 'extcode_example.py', 'extcode.out', '--delay', '-3'
         ]
         self.extcode.options['timeout'] = 1.0
 
@@ -142,7 +142,7 @@ class TestExternalCodeComp(unittest.TestCase):
 
     def test_error_code_soft(self):
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out', '--delay', '-3'
+            sys.executable, 'extcode_example.py', 'extcode.out', '--delay', '-3'
         ]
         self.extcode.options['timeout'] = 1.0
         self.extcode.options['fail_hard'] = False
@@ -163,7 +163,7 @@ class TestExternalCodeComp(unittest.TestCase):
     def test_allowed_return_code(self):
         self.extcode.options['allowed_return_codes'] = set(range(5))
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out', '--return_code', '4'
+            sys.executable, 'extcode_example.py', 'extcode.out', '--return_code', '4'
         ]
 
         self.extcode.options['external_input_files'] = ['extcode_example.py']
@@ -174,7 +174,7 @@ class TestExternalCodeComp(unittest.TestCase):
     def test_disallowed_return_code(self):
         self.extcode.options['allowed_return_codes'] = list(range(5))
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out', '--return_code', '7'
+            sys.executable, 'extcode_example.py', 'extcode.out', '--return_code', '7'
         ]
 
         self.extcode.options['external_input_files'] = ['extcode_example.py']
@@ -220,7 +220,7 @@ class TestExternalCodeComp(unittest.TestCase):
     def test_env_vars(self):
         self.extcode.options['env_vars'] = {'TEST_ENV_VAR': 'SOME_ENV_VAR_VALUE'}
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out', '--write_test_env_var'
+            sys.executable, 'extcode_example.py', 'extcode.out', '--write_test_env_var'
         ]
 
         self.prob.setup(check=True)
@@ -274,7 +274,7 @@ class ParaboloidExternalCodeComp(om.ExternalCodeComp):
         self.options['external_output_files'] = [self.output_file]
 
         self.options['command'] = [
-            'python', 'extcode_paraboloid.py', self.input_file, self.output_file
+            sys.executable, 'extcode_paraboloid.py', self.input_file, self.output_file
         ]
 
     def compute(self, inputs, outputs):
@@ -311,7 +311,7 @@ class ParaboloidExternalCodeCompFD(om.ExternalCodeComp):
         self.options['external_output_files'] = [self.output_file]
 
         self.options['command'] = [
-            'python', 'extcode_paraboloid.py', self.input_file, self.output_file
+            sys.executable, 'extcode_paraboloid.py', self.input_file, self.output_file
         ]
 
         # this external code does not provide derivatives, use finite difference
@@ -352,7 +352,7 @@ class ParaboloidExternalCodeCompDerivs(om.ExternalCodeComp):
         self.options['external_output_files'] = [self.output_file, self.derivs_file]
 
         self.options['command'] = [
-            'python', 'extcode_paraboloid_derivs.py',
+            sys.executable, 'extcode_paraboloid_derivs.py',
             self.input_file, self.output_file, self.derivs_file
         ]
 
@@ -548,7 +548,7 @@ class TestDeprecatedExternalCode(unittest.TestCase):
 
     def test_normal(self):
         self.extcode.options['command'] = [
-            'python', 'extcode_example.py', 'extcode.out'
+            sys.executable, 'extcode_example.py', 'extcode.out'
         ]
 
         self.extcode.options['external_input_files'] = ['extcode_example.py']
@@ -610,10 +610,10 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
                 self.options['external_output_files'] = [self.output_file]
 
                 self.options['command_apply'] = [
-                    'python', 'extcode_mach.py', self.input_file, self.output_file,
+                    sys.executable, 'extcode_mach.py', self.input_file, self.output_file,
                 ]
                 self.options['command_solve'] = [
-                    'python', 'extcode_mach.py', self.input_file, self.output_file,
+                    sys.executable, 'extcode_mach.py', self.input_file, self.output_file,
                 ]
 
             def apply_nonlinear(self, inputs, outputs, residuals):

--- a/openmdao/docs/_utils/docutil.py
+++ b/openmdao/docs/_utils/docutil.py
@@ -697,7 +697,7 @@ def run_code(code_to_run, path, module=None, cls=None, shows_plot=False, imports
             env['OPENMDAO_CURRENT_MODULE'] = module.__name__
             env['OPENMDAO_CODE_TO_RUN'] = code_to_run
 
-            p = subprocess.Popen(['mpirun', '-n', str(N_PROCS), 'python', _sub_runner],
+            p = subprocess.Popen(['mpirun', '-n', str(N_PROCS), sys.executable, _sub_runner],
                                  env=env)
             p.wait()
 
@@ -715,7 +715,7 @@ def run_code(code_to_run, path, module=None, cls=None, shows_plot=False, imports
                 with os.fdopen(fd, 'w') as tmp:
                     tmp.write(code_to_run)
                 try:
-                    p = subprocess.Popen(['python', code_to_run_path],
+                    p = subprocess.Popen([sys.executable, code_to_run_path],
                                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=os.environ)
                     output, _ = p.communicate()
                     if p.returncode != 0:
@@ -729,7 +729,7 @@ def run_code(code_to_run, path, module=None, cls=None, shows_plot=False, imports
                 env['OPENMDAO_CURRENT_MODULE'] = module.__name__
                 env['OPENMDAO_CODE_TO_RUN'] = code_to_run
 
-                p = subprocess.Popen(['python', _sub_runner],
+                p = subprocess.Popen([sys.executable, _sub_runner],
                                      stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=env)
                 output, _ = p.communicate()
                 if p.returncode != 0:

--- a/openmdao/test_suite/test_examples/test_circuit_with_unconnected_input.py
+++ b/openmdao/test_suite/test_examples/test_circuit_with_unconnected_input.py
@@ -1,6 +1,7 @@
 import unittest
 import subprocess
 import os
+import sys
 
 import openmdao.test_suite.scripts
 
@@ -22,7 +23,7 @@ class TestCircuitWithUnconnectedInputScript(unittest.TestCase):
         script_path = os.path.join(os.path.dirname(openmdao.test_suite.scripts.__file__),
                               'circuit_with_unconnected_input.py')
 
-        output = self._run_command('python {}'.format(script_path))
+        output = self._run_command('{} {}'.format(sys.executable, script_path))
 
         self.assertTrue('The following inputs are not connected' in output,
                         msg="Should have gotten error about unconnected input")


### PR DESCRIPTION
Currently it uses the system-default version of Python, which may not be the one running the code and may not have openMDAO installed.