### PR TITLE
Skip signal test if pyoptsparse does not have _version_, or version is less than 1.1.

### DIFF
--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1686,6 +1686,11 @@ class TestPyoptSparse(unittest.TestCase):
         if local_opt != 'SNOPT':
             raise unittest.SkipTest("pyoptsparse is not providing SNOPT")
 
+        import pyoptsparse
+        if not hasattr(pyoptsparse, '__version__') or \
+           LooseVersion(pyoptsparse.__version__) < LooseVersion('1.1.0'):
+            raise unittest.SkipTest("pyoptsparse needs to be updated to 1.1.0")
+
         class ParaboloidSIG(om.ExplicitComponent):
 
             def setup(self):


### PR DESCRIPTION
Note: Companion PR will add version number to pyoptsparse base module at mdolab.