### PR TITLE
Description can be listed in list_inputs/list_outputs

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3137,6 +3137,8 @@ class System(object):
             When True, display/return units. Default is False.
         shape : bool, optional
             When True, display/return the shape of the value. Default is False.
+        desc : bool, optional
+            When True, display/return description. Default is False.
         hierarchical : bool, optional
             When True, human readable output shows variables in hierarchical format.
         print_arrays : bool, optional
@@ -3299,6 +3301,8 @@ class System(object):
             When True, display/return bounds (lower and upper). Default is False.
         scaling : bool, optional
             When True, display/return scaling (ref, ref0, and res_ref). Default is False.
+        desc : bool, optional
+            When True, display/return description. Default is False.
         hierarchical : bool, optional
             When True, human readable output shows variables in hierarchical format.
         print_arrays : bool, optional
@@ -3387,7 +3391,8 @@ class System(object):
                 var_meta['ref'] = meta[var_name]['ref']
                 var_meta['ref0'] = meta[var_name]['ref0']
                 var_meta['res_ref'] = meta[var_name]['res_ref']
-
+            if desc:
+                var_meta['desc'] = meta[var_name]['desc']
             if var_name in states:
                 impl_outputs.append((var_name, var_meta))
             else:
@@ -3522,10 +3527,6 @@ class System(object):
                                 var_dict[name]['resids'] = \
                                     np.append(var_dict[name]['resids'],
                                               proc_vars[name]['resids'])
-                            if 'desc' in var_dict[name]:
-                                var_dict[name]['desc'] = \
-                                    np.append(var_dict[name]['desc'],
-                                              proc_vars[name]['desc'])
 
         inputs = var_type is 'input'
         outputs = not inputs

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3112,6 +3112,7 @@ class System(object):
                     prom_name=False,
                     units=False,
                     shape=False,
+                    desc=False,
                     hierarchical=True,
                     print_arrays=False,
                     tags=None,
@@ -3207,6 +3208,8 @@ class System(object):
                 var_meta['units'] = meta[var_name]['units']
             if shape:
                 var_meta['shape'] = val.shape
+            if desc:
+                var_meta['desc'] = meta[var_name]['desc']
 
             inputs.append((var_name, var_meta))
 
@@ -3257,6 +3260,7 @@ class System(object):
                      shape=False,
                      bounds=False,
                      scaling=False,
+                     desc=False,
                      hierarchical=True,
                      print_arrays=False,
                      tags=None,
@@ -3518,6 +3522,10 @@ class System(object):
                                 var_dict[name]['resids'] = \
                                     np.append(var_dict[name]['resids'],
                                               proc_vars[name]['resids'])
+                            if 'desc' in var_dict[name]:
+                                var_dict[name]['desc'] = \
+                                    np.append(var_dict[name]['desc'],
+                                              proc_vars[name]['desc'])
 
         inputs = var_type is 'input'
         outputs = not inputs

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -257,7 +257,7 @@ class TestSystem(unittest.TestCase):
         assert_rel_error(self, prob['double.y'], [2., 4., 6.])
 
     def test_list_inputs_output_with_includes_excludes(self):
-        from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node, Circuit
+        from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
         p = Problem()
         model = p.model
@@ -274,40 +274,40 @@ class TestSystem(unittest.TestCase):
 
         # Inputs with no includes or excludes
         inputs = model.list_inputs(out_stream=None)
-        self.assertEqual( len(inputs), 11)
+        self.assertEqual(len(inputs), 11)
 
         # Inputs with includes
         inputs = model.list_inputs(includes=['*V_out*'], out_stream=None)
-        self.assertEqual( len(inputs), 3)
+        self.assertEqual(len(inputs), 3)
 
         # Inputs with includes matching a promoted name
         inputs = model.list_inputs(includes=['*Vg*'], out_stream=None)
-        self.assertEqual( len(inputs), 2)
+        self.assertEqual(len(inputs), 2)
 
         # Inputs with excludes
         inputs = model.list_inputs(excludes=['*V_out*'], out_stream=None)
-        self.assertEqual( len(inputs), 8)
+        self.assertEqual(len(inputs), 8)
 
         # Inputs with excludes matching a promoted name
         inputs = model.list_inputs(excludes=['*Vg*'], out_stream=None)
-        self.assertEqual( len(inputs), 9)
+        self.assertEqual(len(inputs), 9)
 
         # Inputs with includes and excludes
         inputs = model.list_inputs(includes=['*V_out*'], excludes=['*Vg*'], out_stream=None)
-        self.assertEqual( len(inputs), 1)
-
+        self.assertEqual(len(inputs), 1)
 
         # Outputs with no includes or excludes. Explicit only
         outputs = model.list_outputs(implicit=False, out_stream=None)
-        self.assertEqual( len(outputs), 5)
+        self.assertEqual(len(outputs), 5)
 
         # Outputs with includes. Explicit only
         outputs = model.list_outputs(includes=['*I'], implicit=False, out_stream=None)
-        self.assertEqual( len(outputs), 4)
+        self.assertEqual(len(outputs), 4)
 
         # Outputs with excludes. Explicit only
         outputs = model.list_outputs(excludes=['circuit*'], implicit=False, out_stream=None)
-        self.assertEqual( len(outputs), 2)
+        self.assertEqual(len(outputs), 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/variable_table.py
+++ b/openmdao/utils/variable_table.py
@@ -68,10 +68,10 @@ def write_var_table(pathname, var_list, var_type, var_dict,
     # Need an ordered list of possible output values for the two cases: inputs and outputs
     #  so that we do the column output in the correct order
     if var_type is 'input':
-        out_types = ('value', 'units', 'shape', 'prom_name')
+        out_types = ('value', 'units', 'shape', 'prom_name', 'desc')
     else:
         out_types = ('value', 'resids', 'units', 'shape', 'lower', 'upper', 'ref',
-                     'ref0', 'res_ref', 'prom_name')
+                     'ref0', 'res_ref', 'prom_name', 'desc')
 
     # Figure out which columns will be displayed
     # Look at any one of the outputs, they should all be the same


### PR DESCRIPTION
Optional, turned off by default.

An example output with the actuator disc:

list_inputs(desc=True):
```
varname   value         desc                                      
--------  ------------  ------------------------------------------
top
  a_disk
    a     [0.33335528]  Induced Velocity Factor                   
    Area  [1.]          Rotor disc area                           
    rho   [1.225]       air density                               
    Vu    [10.]         Freestream air velocity, upstream of rotor
```

list_outputs(desc=True):

```
varname     value           desc                                        
----------  --------------  --------------------------------------------
top
  indeps
    a       [0.33335528]                                                
    Area    [1.]                                                        
    rho     [1.225]                                                     
    Vu      [10.]                                                       
  a_disk
    Vr      [6.6664472]     Air velocity at rotor exit plane            
    Vd      [3.33289439]    Slipstream air velocity, downstream of rotor
    Ct      [0.88891815]    Thrust Coefficient                          
    thrust  [54.44623668]   Thrust produced by the rotor                
    Cp      [0.59259259]    Power Coefficient                           
    power   [362.96296178]  Power produced by the rotor                 
0 Implicit Output(s) in 'model'
-------------------------------

```