### PR TITLE
Fixed bug in scipy optimizer where it was computing gradient of linear constraints for a non-gradient optimizer.

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -319,7 +319,7 @@ class ScipyOptimizeDriver(Driver):
                 upper = meta['upper']
                 lower = meta['lower']
                 equals = meta['equals']
-                if 'linear' in meta and meta['linear']:
+                if opt in _gradient_optimizers and 'linear' in meta and meta['linear']:
                     lincons.append(name)
                     self._con_idx[name] = lin_i
                     lin_i += size

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1355,6 +1355,35 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         self.assertEqual(expected_msg, str(cm.exception))
 
+    def test_cobyla_linear_constraint(self):
+        # Bug where scipyoptimizer tried to compute and cache the constraint derivatives for the
+        # lower and upper bounds of the desvars even though we were using a non-gradient optimizer.
+        # This causd a KeyError.
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
+        indeps.add_output('x', 3.0)
+        indeps.add_output('y', -4.0)
+
+        prob.model.add_subsystem('parab', Paraboloid())
+
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y'))
+
+        prob.model.connect('indeps.x', ['parab.x', 'const.x'])
+        prob.model.connect('indeps.y', ['parab.y', 'const.y'])
+
+        prob.driver = om.ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'COBYLA'
+
+        prob.model.add_constraint('const.g', lower=0, upper=10.)
+        prob.model.add_design_var('indeps.x', **{'ref0': 0, 'ref': 2, 'lower': -50, 'upper': 50})
+        prob.model.add_design_var('indeps.y', **{'ref0': 0, 'ref': 2, 'lower': -50, 'upper': 50})
+        prob.model.add_objective('parab.f_xy', scaler = 4.0)
+        prob.setup()
+        prob.run_driver()
+
+        # minimum value
+        assert_rel_error(self, prob['parab.f_xy'], -27, 1e-6)
+
 
 class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 


### PR DESCRIPTION
closes #942 