### PR TITLE
Bugfix for DOEDriver full factorial array inputs

### DIFF
--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -262,7 +262,10 @@ class DOEDriver(Driver):
                         recorder._record_on_proc = True
                     else:
                         size = self._comm.size // procs_per_model
-                        recorder._record_on_proc = self._comm.rank < size
+                        if self._comm.rank < size:
+                            recorder._record_on_proc = True
+                        else:
+                            recorder._record_on_proc = False
 
         super(DOEDriver, self)._setup_recording()
 

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -262,10 +262,7 @@ class DOEDriver(Driver):
                         recorder._record_on_proc = True
                     else:
                         size = self._comm.size // procs_per_model
-                        if self._comm.rank < size:
-                            recorder._record_on_proc = True
-                        else:
-                            recorder._record_on_proc = False
+                        recorder._record_on_proc = self._comm.rank < size
 
         super(DOEDriver, self)._setup_recording()
 

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -320,12 +320,6 @@ class _pyDOE_Generator(DOEGenerator):
         """
         sizes = [meta['size'] for name, meta in iteritems(design_vars)]
 
-        if isinstance(self._levels, int):
-            self._level_lst = [self._levels] * len(sizes)
-        else:
-            default = self._levels.get('default', _LEVELS)
-            self._level_lst = [self._levels.get(name, default) for name in design_vars.keys()]
-
         size = sum(sizes)
 
         doe = self._generate_design(size)
@@ -353,18 +347,22 @@ class _pyDOE_Generator(DOEGenerator):
                 row += 1
 
         # yield values for doe generated indices
+        print(doe.astype('int'))
+        print("\nValues:\n")
+        print(values)
+        print("\n")
         for idxs in doe.astype('int'):
             retval = []
             row = 0
             for var, (name, meta) in enumerate(iteritems(design_vars)):
                 size = meta['size']
                 val = np.empty(size)
+                ids = idxs[var + k]
                 for k in range(size):
                     idx = idxs[var + k]
                     val[k] = values[row + k][idx]
                 retval.append((name, val))
                 row += size
-
             yield retval
 
     def _generate_design(self, sizes):

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -293,7 +293,7 @@ class _pyDOE_Generator(DOEGenerator):
 
         Parameters
         ----------
-        levels : int or dict(str, int), optional
+        levels : int, optional
             The number of evenly spaced levels between each design variable
             lower and upper bound. Defaults to 2.
         """
@@ -318,9 +318,7 @@ class _pyDOE_Generator(DOEGenerator):
         list
             list of name, value tuples for the design variables.
         """
-        sizes = [meta['size'] for name, meta in iteritems(design_vars)]
-
-        size = sum(sizes)
+        size = sum([meta['size'] for name, meta in iteritems(design_vars)])
 
         doe = self._generate_design(size)
 
@@ -427,6 +425,7 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
         doe = pyDOE2.pbdesign(size)
 
         doe[doe < 0] = 0  # replace -1 with zero
+
         return doe
 
 

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -15,7 +15,7 @@ import pyDOE2
 
 from openmdao.utils.name_maps import prom_name2abs_name
 
-_LEVELS = 2
+_LEVELS = 2  # default number of levels for pyDOE generators
 
 
 class DOEGenerator(object):

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -360,13 +360,13 @@ class _pyDOE_Generator(DOEGenerator):
                 row += size
             yield retval
 
-    def _generate_design(self, sizes):
+    def _generate_design(self, size):
         """
         Generate DOE design.
 
         Parameters
         ----------
-        sizes : list(int)
+        size : int
             The number of factors for the design.
 
         Returns

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -350,7 +350,7 @@ class _pyDOE_Generator(DOEGenerator):
         for idxs in doe.astype('int'):
             retval = []
             row = 0
-            for var, (name, meta) in enumerate(iteritems(design_vars)):
+            for name, meta in iteritems(design_vars):
                 size = meta['size']
                 val = np.empty(size)
                 for k in range(size):

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -93,15 +93,15 @@ class ListGenerator(DOEGenerator):
         """
         for case in self._data:
             if not isinstance(case, list):
-                msg = "Invalid DOE case found, expecting a list of name/value pairs:\n{}"
-                raise RuntimeError(msg.format(case))
+                msg = "Invalid DOE case found, expecting a list of name/value pairs:\n%s"
+                raise RuntimeError(msg % str(case))
 
             name_map = {}
 
             for tup in case:
-                if not isinstance(tup, (tuple, list)) or len(tup) != 2:
-                    msg = "Invalid DOE case found, expecting a list of name/value pairs:\n{}"
-                    raise RuntimeError(msg.format(case))
+                if type(tup) not in (tuple, list) or len(tup) != 2:
+                    msg = "Invalid DOE case found, expecting a list of name/value pairs:\n%s"
+                    raise RuntimeError(msg % str(case))
 
                 name = tup[0]
                 if name in design_vars:
@@ -115,11 +115,11 @@ class ListGenerator(DOEGenerator):
             invalid_desvars = [name for name, _ in case if name not in name_map]
             if invalid_desvars:
                 if len(invalid_desvars) > 1:
-                    msg = "Invalid DOE case found, {} are not valid design variables:\n{}"
-                    raise RuntimeError(msg.format(invalid_desvars, case))
+                    msg = "Invalid DOE case found, %s are not valid design variables:\n%s"
+                    raise RuntimeError(msg % (str(invalid_desvars), str(case)))
                 else:
-                    msg = "Invalid DOE case found, '{}' is not a valid design variable:\n{}"
-                    raise RuntimeError(msg.format(invalid_desvars[0], case))
+                    msg = "Invalid DOE case found, '%s' is not a valid design variable:\n%s"
+                    raise RuntimeError(msg % (str(invalid_desvars[0]), str(case)))
 
             yield [(name_map[name], val) for name, val in case]
 
@@ -151,10 +151,10 @@ class CSVGenerator(DOEGenerator):
         super(CSVGenerator, self).__init__()
 
         if not isinstance(filename, str):
-            raise RuntimeError("'{}' is not a valid file name.".format(filename))
+            raise RuntimeError("'%s' is not a valid file name." % str(filename))
 
         if not os.path.isfile(filename):
-            raise RuntimeError("File not found: {}".format(filename))
+            raise RuntimeError("File not found: %s" % filename)
 
         self._filename = filename
 
@@ -192,11 +192,11 @@ class CSVGenerator(DOEGenerator):
             invalid_desvars = [name for name in names if name not in name_map]
             if invalid_desvars:
                 if len(invalid_desvars) > 1:
-                    msg = "Invalid DOE case file, {} are not valid design variables."
-                    raise RuntimeError(msg.format(invalid_desvars))
+                    msg = "Invalid DOE case file, %s are not valid design variables."
+                    raise RuntimeError(msg % str(invalid_desvars))
                 else:
-                    msg = "Invalid DOE case file, '{}' is not a valid design variable."
-                    raise RuntimeError(msg.format(invalid_desvars[0]))
+                    msg = "Invalid DOE case file, '%s' is not a valid design variable."
+                    raise RuntimeError(msg % str(invalid_desvars[0]))
 
         # read cases from file, parse values into numpy arrays
         with open(self._filename, 'r') as f:

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -347,19 +347,14 @@ class _pyDOE_Generator(DOEGenerator):
                 row += 1
 
         # yield values for doe generated indices
-        print(doe.astype('int'))
-        print("\nValues:\n")
-        print(values)
-        print("\n")
         for idxs in doe.astype('int'):
             retval = []
             row = 0
             for var, (name, meta) in enumerate(iteritems(design_vars)):
                 size = meta['size']
                 val = np.empty(size)
-                ids = idxs[var + k]
                 for k in range(size):
-                    idx = idxs[var + k]
+                    idx = idxs[row + k]
                     val[k] = values[row + k][idx]
                 retval.append((name, val))
                 row += size

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -328,7 +328,7 @@ class _pyDOE_Generator(DOEGenerator):
 
         size = sum(sizes)
 
-        doe = self._generate_design(sizes)
+        doe = self._generate_design(size)
 
         # generate values for each level for each design variable
         # over the range of that variable's lower to upper bound
@@ -389,13 +389,13 @@ class FullFactorialGenerator(_pyDOE_Generator):
     DOE case generator implementing the Full Factorial method.
     """
 
-    def _generate_design(self, sizes):
+    def _generate_design(self, size):
         """
         Generate a full factorial DOE design.
 
         Parameters
         ----------
-        sizes : list(int)
+        size : int
             The number of factors for the design.
 
         Returns
@@ -403,11 +403,7 @@ class FullFactorialGenerator(_pyDOE_Generator):
         ndarray
             The design matrix as a size x levels array of indices.
         """
-        if isinstance(self._levels, int):
-            levels = [self._levels] * sum(sizes)
-        else:  # _levels is a dictionary
-            raise NotImplementedError()
-        return pyDOE2.fullfact(levels)
+        return pyDOE2.fullfact([self._levels] * size)
 
 
 class PlackettBurmanGenerator(_pyDOE_Generator):
@@ -421,13 +417,13 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
         """
         super(PlackettBurmanGenerator, self).__init__(levels=2)
 
-    def _generate_design(self, sizes):
+    def _generate_design(self, size):
         """
         Generate a Plackett-Burman DOE design.
 
         Parameters
         ----------
-        sizes : list(int)
+        size : int
             The number of factors for the design.
 
         Returns
@@ -435,7 +431,6 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
         ndarray
             The design matrix as a size x levels array of indices.
         """
-        size = sum(sizes)
         doe = pyDOE2.pbdesign(size)
 
         doe[doe < 0] = 0  # replace -1 with zero
@@ -464,13 +459,13 @@ class BoxBehnkenGenerator(_pyDOE_Generator):
         super(BoxBehnkenGenerator, self).__init__(levels=3)
         self._center = center
 
-    def _generate_design(self, sizes):
+    def _generate_design(self, size):
         """
         Generate a Box-Behnken DOE design.
 
         Parameters
         ----------
-        sizes : list(int)
+        size : int
             The number of factors for the design.
 
         Returns
@@ -478,7 +473,6 @@ class BoxBehnkenGenerator(_pyDOE_Generator):
         ndarray
             The design matrix as a size x levels array of indices.
         """
-        size = sum(sizes)
         if size < 3:
             raise RuntimeError("Total size of design variables is %d,"
                                "but must be at least 3 when using %s. " %

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -439,7 +439,6 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
         doe = pyDOE2.pbdesign(size)
 
         doe[doe < 0] = 0  # replace -1 with zero
-
         return doe
 
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import tempfile
 import csv
+import json
 
 import numpy as np
 
@@ -19,6 +20,8 @@ from openmdao.test_suite.groups.parallel_groups import FanInGrouped
 
 from openmdao.utils.assert_utils import assert_rel_error
 from openmdao.utils.general_utils import run_driver, printoptions
+
+from openmdao.utils.mpi import MPI
 
 
 class ParaboloidArray(om.ExplicitComponent):
@@ -1467,6 +1470,7 @@ class TestParallelDOEFeature2(unittest.TestCase):
 
     def setUp(self):
         import os
+        import shutil
         import tempfile
 
         from mpi4py import MPI
@@ -1547,9 +1551,8 @@ class TestParallelDOEFeature2(unittest.TestCase):
                 outputs = cr.get_case(case).outputs
                 values.append((outputs['iv.x1'], outputs['iv.x2'], outputs['c3.y']))
 
-            self.assertEqual("\n"+"\n".join(["iv.x1: %5.2f, iv.x2: %5.2f, c3.y: %6.2f"
-                                             % vals_i for vals_i in values]),
-                             self.expect_text)
+            self.assertEqual("\n"+"\n".join(["iv.x1: %5.2f, iv.x2: %5.2f, c3.y: %6.2f" % (x1, x2, y) for x1, x2, y in values]),
+                self.expect_text)
 
 
 if __name__ == "__main__":

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1227,6 +1227,7 @@ class TestDOEDriverFeature(unittest.TestCase):
             f.write(self.expected_json)
 
     def tearDown(self):
+        import os
         import shutil
 
         os.chdir(self.startdir)
@@ -1236,6 +1237,7 @@ class TestDOEDriverFeature(unittest.TestCase):
             pass
 
     def test_uniform(self):
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = om.Problem()
@@ -1269,6 +1271,7 @@ class TestDOEDriverFeature(unittest.TestCase):
         print("\n".join(["x: %5.2f, y: %5.2f, f_xy: %6.2f" % vals_i for vals_i in values]))
 
     def test_csv(self):
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = om.Problem()
@@ -1308,6 +1311,7 @@ class TestDOEDriverFeature(unittest.TestCase):
                          self.expected_text)
 
     def test_list(self):
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         import json
@@ -1409,6 +1413,7 @@ class TestParallelDOEFeature(unittest.TestCase):
             pass
 
     def test_full_factorial(self):
+        import openmdao.api as om
         from openmdao.test_suite.components.paraboloid import Paraboloid
 
         from mpi4py import MPI
@@ -1504,6 +1509,7 @@ class TestParallelDOEFeature2(unittest.TestCase):
             pass
 
     def test_fan_in_grouped(self):
+        import openmdao.api as om
         from openmdao.test_suite.groups.parallel_groups import FanInGrouped
 
         from mpi4py import MPI

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1176,6 +1176,7 @@ class TestDOEDriverFeature(unittest.TestCase):
         import json
         import os
         import tempfile
+        import numpy as np
 
         self.startdir = os.getcwd()
         self.tempdir = tempfile.mkdtemp(prefix='TestDOEDriverFeature-')
@@ -1368,6 +1369,8 @@ class TestParallelDOEFeature(unittest.TestCase):
     def setUp(self):
         import os
         import tempfile
+        import numpy as np
+
         from mpi4py import MPI
         rank = MPI.COMM_WORLD.rank
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -28,9 +28,7 @@ class ParaboloidArray(om.ExplicitComponent):
     Where x and y are xy[0] and xy[1] respectively.
     """
 
-    def __init__(self):
-        super(ParaboloidArray, self).__init__()
-
+    def setup(self):
         self.add_input('xy', val=np.array([0., 0.]))
         self.add_output('f_xy', val=0.0)
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -505,7 +505,7 @@ class TestDOEDriver(unittest.TestCase):
         model.add_subsystem('p1', om.IndepVarComp('xy', np.array([0., 0.])), promotes=['*'])
         model.add_subsystem('comp', ParaboloidArray(), promotes=['*'])
 
-        model.add_design_var('xy', lower=np.array([-50., -50.]), upper=np.array([50., 50.]))
+        model.add_design_var('xy', lower=np.array([-10., -50.]), upper=np.array([10., 50.]))
         model.add_objective('f_xy')
 
         prob.driver = om.DOEDriver(om.FullFactorialGenerator(levels=3))
@@ -516,17 +516,17 @@ class TestDOEDriver(unittest.TestCase):
         prob.cleanup()
 
         expected = [
-            {'xy': np.array([-50., -50.])},
+            {'xy': np.array([-10., -50.])},
             {'xy': np.array([0., -50.])},
-            {'xy': np.array([50., -50.])},
+            {'xy': np.array([10., -50.])},
 
-            {'xy': np.array([-50.,   0.])},
+            {'xy': np.array([-10.,   0.])},
             {'xy': np.array([0.,   0.])},
-            {'xy': np.array([50.,   0.])},
+            {'xy': np.array([10.,   0.])},
 
-            {'xy': np.array([-50.,  50.])},
+            {'xy': np.array([-10.,  50.])},
             {'xy': np.array([0.,  50.])},
-            {'xy': np.array([50.,  50.])},
+            {'xy': np.array([10.,  50.])},
         ]
 
         cr = om.CaseReader("cases.sql")

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1174,6 +1174,7 @@ class TestDOEDriverFeature(unittest.TestCase):
 
     def setUp(self):
         import json
+        import os
         import tempfile
 
         self.startdir = os.getcwd()
@@ -1365,6 +1366,8 @@ class TestParallelDOEFeature(unittest.TestCase):
     N_PROCS = 2
 
     def setUp(self):
+        import os
+        import tempfile
         from mpi4py import MPI
         rank = MPI.COMM_WORLD.rank
 
@@ -1457,6 +1460,9 @@ class TestParallelDOEFeature2(unittest.TestCase):
     N_PROCS = 4
 
     def setUp(self):
+        import os
+        import tempfile
+
         from mpi4py import MPI
         rank = MPI.COMM_WORLD.rank
 

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -321,18 +321,18 @@ class TestDOEDriver(unittest.TestCase):
         expected = [
             {'p1.x': np.array([0., 0.]), 'p2.y': np.array([0., 0.])},
             {'p1.x': np.array([1., 0.]), 'p2.y': np.array([0., 0.])},
+            {'p1.x': np.array([0., 1.]), 'p2.y': np.array([0., 0.])},
+            {'p1.x': np.array([1., 1.]), 'p2.y': np.array([0., 0.])},
+            {'p1.x': np.array([0., 0.]), 'p2.y': np.array([1., 0.])},
+            {'p1.x': np.array([1., 0.]), 'p2.y': np.array([1., 0.])},
             {'p1.x': np.array([0., 1.]), 'p2.y': np.array([1., 0.])},
             {'p1.x': np.array([1., 1.]), 'p2.y': np.array([1., 0.])},
             {'p1.x': np.array([0., 0.]), 'p2.y': np.array([0., 1.])},
             {'p1.x': np.array([1., 0.]), 'p2.y': np.array([0., 1.])},
-            {'p1.x': np.array([0., 1.]), 'p2.y': np.array([1., 1.])},
-            {'p1.x': np.array([1., 1.]), 'p2.y': np.array([1., 1.])},
-            {'p1.x': np.array([0., 0.]), 'p2.y': np.array([0., 0.])},
-            {'p1.x': np.array([1., 0.]), 'p2.y': np.array([0., 0.])},
-            {'p1.x': np.array([0., 1.]), 'p2.y': np.array([1., 0.])},
-            {'p1.x': np.array([1., 1.]), 'p2.y': np.array([1., 0.])},
-            {'p1.x': np.array([0., 0.]), 'p2.y': np.array([0., 1.])},
-            {'p1.x': np.array([1., 0.]), 'p2.y': np.array([0., 1.])},
+            {'p1.x': np.array([0., 1.]), 'p2.y': np.array([0., 1.])},
+            {'p1.x': np.array([1., 1.]), 'p2.y': np.array([0., 1.])},
+            {'p1.x': np.array([0., 0.]), 'p2.y': np.array([1., 1.])},
+            {'p1.x': np.array([1., 0.]), 'p2.y': np.array([1., 1.])},
             {'p1.x': np.array([0., 1.]), 'p2.y': np.array([1., 1.])},
             {'p1.x': np.array([1., 1.]), 'p2.y': np.array([1., 1.])},
         ]
@@ -498,6 +498,52 @@ class TestDOEDriver(unittest.TestCase):
             for name in ('x', 'y', 'f_xy'):
                 self.assertEqual(outputs[name], expected_case[name])
 
+    def test_full_factorial_factoring(self):
+
+        class Digits2Num(om.ExplicitComponent):
+            """
+            Makes from two vectors with 2 elements a 4 digit number.
+            For singe digit integers always gives a unique output number.
+            """
+
+            def setup(self):
+                self.add_input('x', val=np.array([0., 0.]))
+                self.add_input('y', val=np.array([0., 0.]))
+                self.add_output('f', val=0.0)
+
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                y = inputs['y']
+                outputs['f'] = x[0] * 1000 + x[1] * 100 + y[0] * 10 + y[1]
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', np.array([0.0, 0.0])), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', np.array([0.0, 0.0])), promotes=['*'])
+        model.add_subsystem('comp', Digits2Num(), promotes=['*'])
+
+        model.add_design_var('x', lower=0.0, upper=np.array([1.0, 2.0]))
+        model.add_design_var('y', lower=0.0, upper=np.array([3.0, 4.0]))
+        model.add_objective('f')
+
+        prob.driver = om.DOEDriver(generator=om.FullFactorialGenerator(levels=2))
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader("cases.sql")
+        cases = cr.list_cases('driver')
+
+        objs = [int(cr.get_case(case).outputs['f']) for case in cases]
+
+        self.assertEqual(len(objs), 16)
+        # Testing uniqueness. If all elements are unique, it should be the same length as the
+        # number of cases
+        self.assertEqual(len(set(objs)), 16)
+
     def test_full_factorial_array(self):
         prob = om.Problem()
         model = prob.model
@@ -538,47 +584,6 @@ class TestDOEDriver(unittest.TestCase):
             outputs = cr.get_case(case).outputs
             self.assertEqual(outputs['xy'][0], expected_case['xy'][0])
             self.assertEqual(outputs['xy'][1], expected_case['xy'][1])
-
-    @unittest.expectedFailure
-    def test_full_factorial_dict_input(self):
-        prob = om.Problem()
-        model = prob.model
-
-        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
-        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
-        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
-
-        model.add_design_var('x', lower=0.0, upper=1.0)
-        model.add_design_var('y', lower=0.0, upper=1.0)
-        model.add_objective('f_xy')
-
-        prob.driver = om.DOEDriver(generator=om.FullFactorialGenerator(levels={'x': 2, 'y': 3}))
-        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
-
-        prob.setup()
-        prob.run_driver()
-        prob.cleanup()
-
-        expected = [
-            {'x': np.array([0.]), 'y': np.array([0.]), 'f_xy': np.array([22.00])},
-            {'x': np.array([1.]), 'y': np.array([0.]), 'f_xy': np.array([17.00])},
-
-            {'x': np.array([0.]), 'y': np.array([.5]), 'f_xy': np.array([26.25])},
-            {'x': np.array([1.]), 'y': np.array([.5]), 'f_xy': np.array([21.75])},
-
-            {'x': np.array([0.]), 'y': np.array([1.]), 'f_xy': np.array([31.00])},
-            {'x': np.array([1.]), 'y': np.array([1.]), 'f_xy': np.array([27.00])},
-        ]
-
-        cr = om.CaseReader("cases.sql")
-        cases = cr.list_cases('driver')
-
-        self.assertEqual(len(cases), 6)
-
-        for case, expected_case in zip(cases, expected):
-            outputs = cr.get_case(case).outputs
-            for name in ('x', 'y', 'f_xy'):
-                self.assertEqual(outputs[name], expected_case[name])
 
     def test_plackett_burman(self):
         prob = om.Problem()

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -571,6 +571,7 @@ class TestDOEDriver(unittest.TestCase):
             self.assertEqual(outputs['xy'][0], expected[n]['xy'][0])
             self.assertEqual(outputs['xy'][1], expected[n]['xy'][1])
 
+    @unittest.expectedFailure
     def test_full_factorial_array_input(self):
         prob = om.Problem()
         model = prob.model


### PR DESCRIPTION
This PR fixes a bug of the `FullFactorialGenerator` in the `DOEDriver`

**Bug:**
Wrong factoring, if there exists at least one array design variable with array size larger than one, and it is not the last one. The array test of this class was testing with only one design variable, therefore it was not caught before.

**Fix:**
Corrected a wrong indexing in `doe_generators.py`. Location in the comments
Added a new test.

I also made some other small changes for performance and readability

The only test so far, where it was used with multiple array inputs, was in `test_csv_array()`. Here the expected result was not really a full factorial, since it included non-unique cases (each repeated twice), as the figure below shows. 

![image](https://user-images.githubusercontent.com/34424189/73134685-dccda680-4039-11ea-941b-701c6ecd5e2a.png)
