### PR TITLE
fix typos in documentation

### DIFF
--- a/openmdao/docs/advanced_guide/implicit_comps/defining_icomps.rst
+++ b/openmdao/docs/advanced_guide/implicit_comps/defining_icomps.rst
@@ -66,18 +66,18 @@ Notice that we still define *V* as an output of the :code:`Node` component, albe
 .. embed-code::
      openmdao.test_suite.scripts.circuit_analysis.Node
 
-Every state variable must have exactly one corresponding residual which is defined in the :code:`apply_nonlinear` method. The :code:`residuals` equations 
-in an implicit component are not analogous to the :code:`outputs` equations in the :code:`compute` method of an explicit component. 
-Instead of defining an explicit equation for the output, :code:`residuals['example_output']` defines an equation for the residual *associated with* the 
-output (state variable) :code:`example_output`. In our example, :code:`residuals['V']` defines the equation of the residual associated with the state variable *V*. There will be no explicit 
-equation defining *V*, instead, the residual equation sums the currents associated with *V* so the sum can be driven to zero. 
+Every state variable must have exactly one corresponding residual which is defined in the :code:`apply_nonlinear` method. The :code:`residuals` equations
+in an implicit component are not analogous to the :code:`outputs` equations in the :code:`compute` method of an explicit component.
+Instead of defining an explicit equation for the output, :code:`residuals['example_output']` defines an equation for the residual *associated with* the
+output (state variable) :code:`example_output`. In our example, :code:`residuals['V']` defines the equation of the residual associated with the state variable *V*. There will be no explicit
+equation defining *V*, instead, the residual equation sums the currents associated with *V* so the sum can be driven to zero.
 
-An implicit component varies its outputs (state variables, in this case *V*) to drive the residual equation to zero. In our model, *V* does not show up directly in the residual 
-equation. Instead, our explicit components :code:`Resistor` and :code:`Diode` create a dependence of the currents on *V*, so by using a solver on a higher level of the model 
-hierarchy, we can vary *V* to have an effect on current, and we can drive the residuals to zero. 
+An implicit component varies its outputs (state variables, in this case *V*) to drive the residual equation to zero. In our model, *V* does not show up directly in the residual
+equation. Instead, our explicit components :code:`Resistor` and :code:`Diode` create a dependence of the currents on *V*, so by using a solver on a higher level of the model
+hierarchy, we can vary *V* to have an effect on current, and we can drive the residuals to zero.
 
-All implicit components must define the :code:`apply_nonlinear` method, but it is not a requirement that every :ref:`ImplicitComponent <comp-type-3-implicitcomp>`  define the 
-:code:`solve_nonlinear` method. (The :code:`solve_nonlinear` method provides a way to explicitly define an output within an implicit component.) In fact, for the :code:`Node` 
+All implicit components must define the :code:`apply_nonlinear` method, but it is not a requirement that every :ref:`ImplicitComponent <comp-type-3-implicitcomp>`  define the
+:code:`solve_nonlinear` method. (The :code:`solve_nonlinear` method provides a way to explicitly define an output within an implicit component.) In fact, for the :code:`Node`
 component, it is not even possible to define a :code:`solve_nonlinear` because *V* does not show up directly in the residual function.
 So the implicit function represented by instances of the :code:`Node` component must be converged at a higher level in the model hierarchy.
 

--- a/openmdao/docs/advanced_guide/implicit_comps/implicit_with_balancecomp.rst
+++ b/openmdao/docs/advanced_guide/implicit_comps/implicit_with_balancecomp.rst
@@ -70,7 +70,7 @@ as follows:
     openmdao n2 <your_python_script>
 
 
-You can do the same thing programmatically by calling the 
+You can do the same thing programmatically by calling the
 :func:`n2 <openmdao.visualization.n2_viewer.n2_viewer.n2>`
 function in your python script (after setup):
 

--- a/openmdao/docs/basic_guide/basic_recording.rst
+++ b/openmdao/docs/basic_guide/basic_recording.rst
@@ -4,7 +4,7 @@
 Recording and Reading Data
 **************************
 
-One of the most useful features in OpenMDAO is :ref:`Case Recording <case_recording>`. 
+One of the most useful features in OpenMDAO is :ref:`Case Recording <case_recording>`.
 With case recording you can record variables and their values over the course of an optimization
 and store the information in a local database file.  The data can then be read back later using
 a case reader.
@@ -22,7 +22,7 @@ In the following example we add a recorder to the :ref:`Sellar<sellar>` Problem:
     openmdao.recorders.tests.test_sqlite_recorder.TestFeatureBasicRecording.record_cases
     :layout: code
 
-Note that cases haved been saved to a database file named `cases.sql`.
+Note that cases have been saved to a database file named `cases.sql`.
 
 
 Creating a Case Reader and Reading Data

--- a/openmdao/docs/basic_guide/first_mdao.rst
+++ b/openmdao/docs/basic_guide/first_mdao.rst
@@ -4,7 +4,7 @@ Optimizing the Sellar Problem
 
 In the previous tutorials we showed you how to define the Sellar model and run it directly.
 Now let's see how we can optimize the Sellar problem to minimize the objective function.
-Here is the mathematical problem formulation for the Sellar optimziation problem:
+Here is the mathematical problem formulation for the Sellar optimization problem:
 
 .. math::
 

--- a/openmdao/docs/examples/beam_optimization/beam_optimization_stress.rst
+++ b/openmdao/docs/examples/beam_optimization/beam_optimization_stress.rst
@@ -14,7 +14,7 @@ to insert an `ExecComp` component that converts the stress into a form where a n
 a positive value means it is violated.
 
 The problem presented here is also an example of a multi-point implementation, where we create a separate instance of the
-parts of the calculation that are impacted by different loadcases. This enables our model to take advantage of multiple
+parts of the calculation that are impacted by different load cases. This enables our model to take advantage of multiple
 processors when run in parallel.
 
 If we allow the optimizer to vary the thickness of each element, then we have a design variable vector that is as wide as the

--- a/openmdao/docs/examples/keplers_equation/keplers_equation.rst
+++ b/openmdao/docs/examples/keplers_equation/keplers_equation.rst
@@ -1,6 +1,6 @@
 .. _`keplers_eqn_tutorial`:
 
-Kepler's Equation Example - Solving an Implicit Equaiton
+Kepler's Equation Example - Solving an Implicit Equation
 ========================================================
 
 This example will demonstrate the use of OpenMDAO for solving
@@ -27,17 +27,17 @@ to the balance, it solves the following equation:
      lhs(var) \cdot mult(var) = rhs(var)
 
 The :math:`mult` term is an optional multiplier than can be applied to the
-left-hand side (LHS) of the equation.  For our example, we will assign the 
-right-hand side (RHS) to the mean anomaly (:math:`M`), and the left-hand 
+left-hand side (LHS) of the equation.  For our example, we will assign the
+right-hand side (RHS) to the mean anomaly (:math:`M`), and the left-hand
 side to :math:`E - e \sin{E}`
 
 In this implementation, we rely on an ExecComp to compute the value of the LHS.
 
 BalanceComp also provides a way to supply the starting value for the implicit
-state variable (:math:`E` in this case), via the `guess_func` argument.  The 
-supplied function should have a similar signature to the *guess_nonlinear* 
+state variable (:math:`E` in this case), via the `guess_func` argument.  The
+supplied function should have a similar signature to the *guess_nonlinear*
 function of :ref:`ImplicitComponent <comp-type-3-implicitcomp>`. When solving
-Kepler's equation, using :math:`M` as the initial guess for :math:`E` is a 
+Kepler's equation, using :math:`M` as the initial guess for :math:`E` is a
 good starting point.
 
 In summary, the recipe for solving Kepler's equation is as follows:

--- a/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
@@ -15,7 +15,7 @@ Using the AddSubtractComp
 ---------------------------------------------------
 
 The `add_equation` method is used to set up a system of inputs to be added/subtracted (with scaling factors).
-Each time the user adds an equation, all of the inputs and outputs must be of identical shape (this is a requirement for elementwise addition/subtraction).
+Each time the user adds an equation, all of the inputs and outputs must be of identical shape (this is a requirement for element-wise addition/subtraction).
 The units must also be compatible between all inputs and the output of each equation.
 
 AddSubtractComp Example

--- a/openmdao/docs/features/building_blocks/components/balance_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/balance_comp.rst
@@ -7,7 +7,7 @@ BalanceComp
 ***********
 
 `BalanceComp` is a specialized implementation of :ref:`ImplicitComponent <comp-type-3-implicitcomp>`
-that is intended to provide a simple way to implement most implicit equations without the need to 
+that is intended to provide a simple way to implement most implicit equations without the need to
 define your own residuals.
 
 BalanceComp Options
@@ -119,9 +119,9 @@ they need not be connected.
 Example:  Providing an Initial Guess for a State Variable
 ---------------------------------------------------------
 
-`BalanceComp` has a :code:`guess_func` option that can be used to supply an initial guess 
-value for the state variables.  This option provides the same functionality as the 
-:meth:`guess_nonlinear <openmdao.core.implicitcomponent.ImplicitComponent.guess_nonlinear>` 
+`BalanceComp` has a :code:`guess_func` option that can be used to supply an initial guess
+value for the state variables.  This option provides the same functionality as the
+:meth:`guess_nonlinear <openmdao.core.implicitcomponent.ImplicitComponent.guess_nonlinear>`
 method of `ImplicitComponent`.
 
 The Kepler example script shows how :code:`guess_func` can be used.

--- a/openmdao/docs/features/building_blocks/components/bsplines_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/bsplines_comp.rst
@@ -43,15 +43,15 @@ BsplinesComp Option Examples
 
 **distribution**
 
-The :code:`distribution` option can be used to change the spacing of the spline control points. 
-A "uniform" distribution yields a set of evenly distributed control points, while a "sine" 
+The :code:`distribution` option can be used to change the spacing of the spline control points.
+A "uniform" distribution yields a set of evenly distributed control points, while a "sine"
 distribution places more points towards the edges.
 
-For example, let's say we have a spatial distributed variable, like the beam thickness 
-in the :ref:`beam optimization <beam_optimization_example_part_2>` example, that has 100 nodes. 
-We would like to reduce that to a more reasonable number like 20, so we use the BsplineComp. 
-Our initial value for this variable is roughly a sine wave. When we create the BsplineComp 
-with a "uniform" distribution, our control points are evenly spaced over the domain, as seen 
+For example, let's say we have a spatial distributed variable, like the beam thickness
+in the :ref:`beam optimization <beam_optimization_example_part_2>` example, that has 100 nodes.
+We would like to reduce that to a more reasonable number like 20, so we use the BsplineComp.
+Our initial value for this variable is roughly a sine wave. When we create the BsplineComp
+with a "uniform" distribution, our control points are evenly spaced over the domain, as seen
 in the figure below.
 
 .. embed-code::

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -53,7 +53,7 @@ Constrained Optimization
 
 The SimpleGADriver supports both constrained and unconstrained optimization. If you have constraints,
 the constraints are added to the objective after they have been weighted using a user-tunable
-penalty mutiplier and exponent.
+penalty multiplier and exponent.
 
         All constraints are converted to the form of :math:`g(x)_i \leq 0` for
         inequality constraints and :math:`h(x)_i = 0` for equality constraints.

--- a/openmdao/docs/features/building_blocks/solvers/backtracking/armijo_goldstein.rst
+++ b/openmdao/docs/features/building_blocks/solvers/backtracking/armijo_goldstein.rst
@@ -98,7 +98,7 @@ Here are examples of each acceptable value for the **bound_enforcement** option:
 **alpha**
 
   The "alpha" option is used to specify the initial length of the Newton step. Since NewtonSolver assumes a
-  stepsize of 1.0, this value usually shouldn't be changed.
+  step size of 1.0, this value usually shouldn't be changed.
 
 **rho**
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/broyden.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/broyden.rst
@@ -5,14 +5,14 @@ BroydenSolver
 *************
 
 BroydenSolver is a quasi-Newton solver that implements Broyden's second method to solve for values of the model's states that
-drive their residuals to zero. It does so by maintaning an approximation to the inverse of the Jacobian of the model or a subset
+drive their residuals to zero. It does so by maintaining an approximation to the inverse of the Jacobian of the model or a subset
 of the model. In some cases this can be more efficient than NewtonSolver because updating the approximated inverse Jacobian is
 cheaper than solving the linear system. It may take more iterations because the search direction depends on an approximation,
 but the iterations take fewer operations.
 
 The BroydenSolver has two different modes of operation. It can operate on the entire model and solve for every state in the containing
 system and all subsystems. Alternatively, it can operate on a subset of the model and only solve for a list of states that you provide.
-The advanatage of full-model mode is that you don't have to worry about forgetting a state, particularly in large models where you might
+The advantage of full-model mode is that you don't have to worry about forgetting a state, particularly in large models where you might
 not be familiar with every component or variable. The disadvantage is that you are computing the inverse of a larger matrix every time
 you recalculate the inverse jacobian, though ideally you are not recomputing this very often. Operating on a subset of states is more
 efficient in both the linear solve and the Broyden update, but you do run the risk of missing a state. The BroydenSolver will print a

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -51,7 +51,7 @@ Residual Calculation
 The `Unified Derivatives Equations` are formulated so that explicit equations (via `ExplicitComponent`) are also expressed
 as implicit relationships, and their residual is also calculated in "apply_linear", which runs the component a second time and
 saves the difference in the output vector as the residual. However, this would require an extra call to `compute`, which is
-inefficient for slower components. To elimimate the inefficiency of running the model twice every iteration the NonlinearBlockGS
+inefficient for slower components. To eliminate the inefficiency of running the model twice every iteration the NonlinearBlockGS
 driver saves a copy of the output vector and uses that to calculate the residual without rerunning the model. This does require
 a little more memory, so if you are solving a model where memory is more of a concern than execution time, you can set the
 "use_apply_nonlinear" option to True to use the original formulation that calls "apply_linear" on the subsystem.

--- a/openmdao/docs/features/core_features/defining_components/implicitcomp.rst
+++ b/openmdao/docs/features/core_features/defining_components/implicitcomp.rst
@@ -8,7 +8,7 @@ Implicit variables are those that are computed as an implicit function of other 
 For instance, :math:`y` would be an implicit variable, given that it is computed by solving :math:`\cos(x \cdot y) - z \cdot y = 0`.
 In OpenMDAO, implicit variables are defined as the outputs of components that inherit from :ref:`ImplicitComponent <openmdao.core.implicitcomponent.py>`.
 
-In the above implict expression, :math:`y` is the implicit variable while :math:`x` and :math:`z` would be considered inputs.
+In the above implicit expression, :math:`y` is the implicit variable while :math:`x` and :math:`z` would be considered inputs.
 
 ImplicitComponent Methods
 -------------------------
@@ -87,19 +87,19 @@ The implementation of each method will be illustrated using a simple implicit co
 
 - :code:`guess_nonlinear(self, inputs, outputs, residuals)` :
 
-  [Optional] This method allows the user to calculate and specify an initial guess for implicit states. 
+  [Optional] This method allows the user to calculate and specify an initial guess for implicit states.
   It is called at the start of the solve loop from certain nonlinear solvers (i.e. NewtonSolver and BroydenSolver),
   so it is useful for when you would like to "reset" the initial conditions on an inner-nested solve whenever an
   outer loop solver or driver changes other values.
 
   Since it is a hook for custom code, you could also use it to monitor variables in the input, output, or residual
-  vectors and change the initial guess when some condition is met. 
+  vectors and change the initial guess when some condition is met.
 
   Here is a simple example where we use NewtonSolver to find one of the roots of a second-order quadratic equation.
   Which root you get depends on the initial guess.
 
   .. embed-code::
       openmdao.core.tests.test_impl_comp.ImplicitCompGuessTestCase.test_guess_nonlinear_feature
-      :layout: code, output      
+      :layout: code, output
 
 .. tags:: Component, ImplicitComponent

--- a/openmdao/docs/features/core_features/grouping_components/add_subsystem.rst
+++ b/openmdao/docs/features/core_features/grouping_components/add_subsystem.rst
@@ -21,8 +21,8 @@ Add a Component to a Group
 
 .. note::
 
-    Group names must be Pythonic, so they can only contain alphanumeric characters plus the underscore. 
-    In addition, the first character in the group name must be a letter of the alphabet. 
+    Group names must be Pythonic, so they can only contain alphanumeric characters plus the underscore.
+    In addition, the first character in the group name must be a letter of the alphabet.
     Also, the system name should not duplicate any method or attribute of the `System` API.
 
 Promote the input and output of a Component

--- a/openmdao/docs/features/core_features/grouping_components/configure_method.rst
+++ b/openmdao/docs/features/core_features/grouping_components/configure_method.rst
@@ -5,10 +5,10 @@ Modifying Children of a Group with Configure Method
 ***************************************************
 
 Most of the time, the :code:`setup` method is the only one you need to define on a group.
-The main exception is the case where you want to modify a solver that was set in one of 
+The main exception is the case where you want to modify a solver that was set in one of
 your children groups. When you call :code:`add_subsystem`, the system you add is instantiated
 but its :code:`setup` method is not called until after the parent group's :code:`setup` method
-is finished with its execution. That means that anything you do with that subsystem 
+is finished with its execution. That means that anything you do with that subsystem
 (e.g., changing the nonlinear solver) will potentially be overwritten by the child system's
 :code:`setup` if it is assigned there as well.
 
@@ -20,7 +20,7 @@ system in the hierarchy takes precedence over all lower ones for any modificatio
 Configuring Solvers
 -------------------
 
-Here is a simple example where a lower system sets a solver, but we want to change it to a 
+Here is a simple example where a lower system sets a solver, but we want to change it to a
 different one in the top-most system.
 
 .. embed-code::
@@ -33,7 +33,7 @@ Configuring Setup-Dependent I/O
 -------------------------------
 
 Another situation in which the :code:`configure` method might be useful is if the inputs
-and outputs of a component or subsystem are dependent on the :code:`setup` of another system.  
+and outputs of a component or subsystem are dependent on the :code:`setup` of another system.
 The following example is a variation on the model used to illustrate use of an
 :ref:`AddSubtractComp <addsubtractcomp_feature>`.  Here we assume the component that
 provides the vectorized data must be :code:`setup` before the shape of that data is known:

--- a/openmdao/docs/features/core_features/grouping_components/guess_method.rst
+++ b/openmdao/docs/features/core_features/grouping_components/guess_method.rst
@@ -4,7 +4,7 @@
 Providing an Initial Guess for Implicit States in a Group
 *********************************************************
 
-In the documentation for :ref:`ImplicitComponent <comp-type-3-implicitcomp>`, 
+In the documentation for :ref:`ImplicitComponent <comp-type-3-implicitcomp>`,
 you saw that you can provide an initial guess for implicit states within the
 component using it's *guess_nonlinear* method.
 
@@ -13,8 +13,8 @@ the starting value for implicit state variables in any of it's subsystems.
 
 The following example demonstrates the capability of setting the initial guess
 value at the group level, using the input from one component to compute the guess
-for another.  In this case, a `Discipline` group solves a system of equations 
-using a :ref:`BalanceComp <balancecomp_feature>`. It answers the question: 
+for another.  In this case, a `Discipline` group solves a system of equations
+using a :ref:`BalanceComp <balancecomp_feature>`. It answers the question:
 "What is :math:`x` such that :math:`x^2` is equal to twice our input value".
 
 .. figure:: guess_example.png
@@ -23,7 +23,7 @@ using a :ref:`BalanceComp <balancecomp_feature>`. It answers the question:
    :alt: Group guess_nonlinear Example
 
 Given our knowledge of the relationship between the two equations, we can supply
-an initial guess for the implicit state variable, :math:`x`, that makes it 
+an initial guess for the implicit state variable, :math:`x`, that makes it
 unnecessary for the solver to iterate.
 
 .. embed-code::

--- a/openmdao/docs/features/core_features/grouping_components/parallel_group.rst
+++ b/openmdao/docs/features/core_features/grouping_components/parallel_group.rst
@@ -1,4 +1,4 @@
-.. _feature_parallel_group: 
+.. _feature_parallel_group:
 
 ***************
 Parallel Groups

--- a/openmdao/docs/features/core_features/running/set_get.rst
+++ b/openmdao/docs/features/core_features/running/set_get.rst
@@ -91,7 +91,7 @@ Specifying Units
 ----------------
 
 You can also set an input or request the value of any variable in a different unit than its declared unit, and OpenMDAO will
-peform the conversion for you. This is done with the `Problem` methods `get_val` and `set_val`.
+perform the conversion for you. This is done with the `Problem` methods `get_val` and `set_val`.
 
 .. embed-code:: openmdao.core.tests.test_problem.TestProblem.test_feature_get_set_with_units
     :layout: interleave

--- a/openmdao/docs/features/core_features/working_with_derivatives/approximating_partials.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/approximating_partials.rst
@@ -7,7 +7,7 @@ Approximating Partial Derivatives
 OpenMDAO allows you to specify analytic derivatives for your models, but it is not a requirement.
 If certain partial derivatives are not available, you can ask the framework to approximate the
 derivatives by using the :code:`declare_partials` method inside :code:`setup`, and give it a
-method that is either 'fd' for finite diffference or 'cs' for complex step.
+method that is either 'fd' for finite difference or 'cs' for complex step.
 
 .. automethod:: openmdao.core.component.Component.declare_partials
     :noindex:

--- a/openmdao/docs/features/core_features/working_with_derivatives/approximating_totals.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/approximating_totals.rst
@@ -61,18 +61,18 @@ You can also complex step your model or group, though there are some important r
   (with the exception of `PetscKSP`) support the solution of such a system.  However, when you linearize the submodel
   to determine derivatives around a complex point, the application of complex step loses some of its robust properties
   when compared to real-valued finite difference (in particular, you get subtractive cancelation which causes
-  increased inaccuracy for smaller stepsizes.) When OpenMDAO encounters this situation, it will warn the user, and the
+  increased inaccuracy for smaller step sizes.) When OpenMDAO encounters this situation, it will warn the user, and the
   inner approximation will automatically switch over to using finite difference with default settings.
 
 **Care must be taken with iterative solver tolerances; you may need to adjust the stepsize for complex step:**
-  If you are using an interative nonlinear solver, and you don't converge it tightly, then the complex stepped
+  If you are using an iterative nonlinear solver, and you don't converge it tightly, then the complex stepped
   linear system may have trouble converging as well. You may need to tighten the convergence of your solvers
   and increase the step size used for complex step. To prevent the nonlinear solvers from ignoring a tiny
   complex step, a tiny offset is added to the states to nudge it off the solution, allowing it to reconverge
   with the complex step. You can also turn this behavior off by setting the "cs_reconverge" to False.
 
   Similarly, an iterative linear solver may also require
-  adjusting the stepsize, particularly if you are using the `ScipyKrylov` solver.
+  adjusting the step size, particularly if you are using the `ScipyKrylov` solver.
 
 .. embed-code::
     openmdao.core.tests.test_approx_derivs.ApproxTotalsFeature.test_basic_cs

--- a/openmdao/docs/features/core_features/working_with_derivatives/check_partials_subset.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/check_partials_subset.rst
@@ -9,7 +9,7 @@ Includes and Excludes
 
 When you have a model with a large number of components, you may want to reduce the number of components you
 check so that the output is small and readable. The `check_partials` method has two arguments: "includes" and
-"excludes" that help you specify a reduced set. Both of these arugments are lists of strings that default to None. If you
+"excludes" that help you specify a reduced set. Both of these arguments are lists of strings that default to None. If you
 specify "includes", and give it a list containing strings, then only the components whose full pathnames match one of the patterns in those strings
 are included in the check. Wildcards are acceptable in the string patterns. Likewise, if you specify excludes, then components whose pathname matches
 the given patterns will be excluded from the check.

--- a/openmdao/docs/features/core_features/working_with_derivatives/check_total_derivatives.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/check_total_derivatives.rst
@@ -55,7 +55,7 @@ Display the results in a compact format:
 ----
 
 Use complex step instead of finite difference for a more accurate check. We also tighten the tolerance
-on the nonlinear Gauss-Seidel solver so that we get more accuracate converged values.
+on the nonlinear Gauss-Seidel solver so that we get more accurate converged values.
 
 .. embed-code::
     openmdao.core.tests.test_problem.TestProblem.test_feature_check_totals_cs

--- a/openmdao/docs/features/core_features/working_with_derivatives/parallel_fd.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/parallel_fd.rst
@@ -1,13 +1,13 @@
 .. _feature_parallel_fd:
 
 ************************************************************************************************
-Speeding up Derivative Approximations with Parallel Finite Difference and Parrallel Complex Step
+Speeding up Derivative Approximations with Parallel Finite Difference and Parallel Complex Step
 ************************************************************************************************
 
 If you have multiple processors available to you, it's possible to speed up the calculation of
 approximated partials or totals by computing multiple columns of the approximated Jacobian matrix
 simultaneously across multiple processes.  Setting up *parallel* finite difference or *parallel*
-complex step is identical to setting up for serial execution, except for the additon of a single
+complex step is identical to setting up for serial execution, except for the addition of a single
 __init__ arg that sets *num_par_fd* on the System(s) where you want to compute the approximate
 derivatives. The *num_par_fd* arg specifies the number of approximated jacobian columns that will be
 computed in parallel, assuming that enough processes are provided when the problem script is

--- a/openmdao/docs/features/core_features/working_with_derivatives/simul_derivs.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/simul_derivs.rst
@@ -144,7 +144,7 @@ command line.
 
 The total_coloring command also generates summary information that can sometimes be useful.
 The tolerance that was actually used to determine if an entry in the total jacobian is
-considered to be non-zerois displayed, along with the number of zero entries found in this
+considered to be non-zero is displayed, along with the number of zero entries found in this
 case, and how many times that number of zero entries occurred when sweeping over different tolerances
 between +- a number of orders of magnitude around the given tolerance.  If no tolerance is given, the default
 is 1e-15.  If the number of occurrences is only 1, an exception will be raised, and you should
@@ -305,7 +305,7 @@ If matplotlib is not available, a text-based version of the jacobian can be prin
 
 If you run *openmdao total_coloring* and it turns out there is no simultaneous total coloring
 available, or that you don't gain very much by coloring, don't be surprised.  Not all total
-Jacobians are sparse enough to benefit signficantly from simultaneous derivatives.
+Jacobians are sparse enough to benefit significantly from simultaneous derivatives.
 
 
 Checking that it works

--- a/openmdao/docs/features/core_features/working_with_derivatives/total_compute_jacvec_product.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/total_compute_jacvec_product.rst
@@ -6,7 +6,7 @@ Matrix Free Total Derivatives
 *****************************
 
 The :code:`compute_jacvec_product` method of :code:`Problem` can be used to compute a matrix
-free total jacobian vector product.  It's analagous to the way that the :code:`compute_jacvec_product`
+free total jacobian vector product.  It's analogous to the way that the :code:`compute_jacvec_product`
 method of :code:`System` can be used to compute partial jacobian vector products.
 
 
@@ -50,4 +50,3 @@ The code for :code:`SubProbComp` is shown below:
 
 .. embed-code::
     openmdao.core.tests.test_compute_jacvec_prod.SubProbComp
-

--- a/openmdao/docs/features/debugging/listing_variables.rst
+++ b/openmdao/docs/features/debugging/listing_variables.rst
@@ -191,9 +191,9 @@ scaling (res, res0, and res_ref) for the variables.
 ~~~~~~~~~~~~~~~~~~~~
 
 The :code:`list_inputs()` and :code:`list_outputs()` methods both have a :code:`print_arrays` option.
-By default, this option is set to False and only the norm of the array will appear in the tabular display. 
-The norm value is surrounded by vertical bars to indicate that it is a norm. 
-When the option is set to True, the complete value of the array will also be a displayed below the row. 
+By default, this option is set to False and only the norm of the array will appear in the tabular display.
+The norm value is surrounded by vertical bars to indicate that it is a norm.
+When the option is set to True, the complete value of the array will also be a displayed below the row.
 The format is affected by the values set with :code:`numpy.set_printoptions`.
 
 .. embed-code::
@@ -205,9 +205,9 @@ The format is affected by the values set with :code:`numpy.set_printoptions`.
 
    It is normally required to run the model before :code:`list_inputs()` and :code:`list_outputs()` can be used.
    This is because the final setup that occurs just before execution determines the hierarchy and builds the
-   data structures and connections.  In some cases however, it can be useful to call these functions on a 
+   data structures and connections.  In some cases however, it can be useful to call these functions on a
    component prior to execution to assist in configuring your model. This capability does not apply to groups,
-   but basic metadata about a component's inputs and outputs is available.  
+   but basic metadata about a component's inputs and outputs is available.
    See the documentation for the :ref:`configure() method<feature_configure_IO>` for one such use case.
 
 

--- a/openmdao/docs/features/index.rst
+++ b/openmdao/docs/features/index.rst
@@ -5,7 +5,7 @@ Features
 ********
 
 OpenMDAO's fully-supported features are documented here, each in a self-contained context.
-Any feature documented here, with the exception of those in the *Experimental Featuers* section,
+Any feature documented here, with the exception of those in the *Experimental Features* section,
 has been thoroughly tested, and should be considered fully functional.
 
 .. toctree::

--- a/openmdao/docs/features/model_visualization/meta_model_basics.rst
+++ b/openmdao/docs/features/model_visualization/meta_model_basics.rst
@@ -8,7 +8,7 @@ When evaluating meta models, it can be useful to determine their fit of the trai
 OpenMDAO has a visualization package to view the training data and meta models generated from it.
 This page explains how to use `view_mm` in the command line.
 
-The metamodel viewer allows a user the ability of reducing a high dimentional input space down
+The metamodel viewer allows a user the ability of reducing a high dimensional input space down
 to three dimensions to enable the user to determine the fit of a meta model to the given
 training data.
 

--- a/openmdao/docs/features/model_visualization/n2_details.rst
+++ b/openmdao/docs/features/model_visualization/n2_details.rst
@@ -108,7 +108,7 @@ the Solver Structure box for that System has the text `NL: Newton (sub_solve)`.
 Toolbar
 -------
 
-The tool bar above the N2 diagram provides many useful capabilites.
+The tool bar above the N2 diagram provides many useful capabilities.
 
 Zoomed Element
 **************
@@ -292,7 +292,3 @@ the sections in the legend:
     * Finally, there is a column describing the colors for the items in the solver hierarchy on the right of the
       diagram. The colors indicate
       the type of solver, either linear or nonlinear, depending what is being displayed.
-
-
-
-

--- a/openmdao/docs/features/recording/reading_data.rst
+++ b/openmdao/docs/features/recording/reading_data.rst
@@ -79,7 +79,7 @@ This example shows both methods of getting variable data by name.
 .. embed-code::
     openmdao.recorders.tests.test_sqlite_reader.TestFeatureSqliteReader.test_feature_get_val
     :layout: interleave
-    
+
 Getting Derivative Data from a Case
 -----------------------------------
 

--- a/openmdao/docs/features/recording/reading_metadata.rst
+++ b/openmdao/docs/features/recording/reading_metadata.rst
@@ -5,7 +5,7 @@ Accessing Recorded Metadata
 ***************************
 
 In addition to the cases themselves, a :ref:`CaseReader<case_reader>` may also record
-certain metadata about the model and it's consituent systems and solvers.
+certain metadata about the model and its constituent systems and solvers.
 
 Problem Metadata
 ----------------
@@ -39,7 +39,7 @@ for every system in the model.
 .. note::
     Each system object must have a recorder explicitly attached in order for its metadata and options to be recorded.
 
-   
+
 Solver Metadata
 ---------------
 

--- a/openmdao/docs/features/recording/saving_data.rst
+++ b/openmdao/docs/features/recording/saving_data.rst
@@ -9,7 +9,7 @@ Driver Recording
 
 A :class:`CaseRecorder<openmdao.recorders.case_recorder.CaseRecorder>` is commonly attached to
 the problem's :class:`Driver` in order to gain insight into the convergence of the model as the driver
-finds a solution.  By default, a recorder attached to a driver will record the design variables, 
+finds a solution.  By default, a recorder attached to a driver will record the design variables,
 constraints and objectives.
 
 Driver Recording Options
@@ -32,7 +32,7 @@ Driver Recording Example
 Problem Recording
 -----------------
 
-You might also want to attach a recorder to the problem itself. This allows you to record an 
+You might also want to attach a recorder to the problem itself. This allows you to record an
 arbitrary case at a point of your choosing.  This feature can be useful if you only record a
 limited number of variables during the run but would like to see a more complete list of values
 after the run.
@@ -115,11 +115,11 @@ differentiate the cases.  This prefix can be specified when calling :code:`run_m
     :layout: interleave
 
 .. note::
-    A recorder can be attached to more than one object. Also, more than one recorder can be 
+    A recorder can be attached to more than one object. Also, more than one recorder can be
     attached to an object.
 
 .. note::
-    In this example, we have disabled the saving of data needed by the standalone :math:`N^2` 
+    In this example, we have disabled the saving of data needed by the standalone :math:`N^2`
     visualizer and debugging tool by setting :code:`record_viewer_data` to :code:`False`.
 
 Recording Options Include and Exclude Matching

--- a/openmdao/docs/other/api_translation.rst
+++ b/openmdao/docs/other/api_translation.rst
@@ -12,7 +12,7 @@ Build a Model
 -------------
 
 Define an Explicit Component
-===========================
+============================
 
 .. content-container ::
 

--- a/openmdao/docs/other/api_translation.rst
+++ b/openmdao/docs/other/api_translation.rst
@@ -231,7 +231,7 @@ Specify Finite Difference for all Component Derivatives
 
 
 Specify FD Form and Step Size on Specific Derivatives
-====================================================
+=====================================================
 
 .. content-container ::
 

--- a/openmdao/docs/other/api_translation.rst
+++ b/openmdao/docs/other/api_translation.rst
@@ -11,7 +11,7 @@ It is not a comprehensive guide to using OpenMDAO 2, but focuses only on the thi
 Build a Model
 -------------
 
-Define an Explcit Component
+Define an Explicit Component
 ===========================
 
 .. content-container ::
@@ -230,7 +230,7 @@ Specify Finite Difference for all Component Derivatives
         self.deriv_options['type'] = 'fd'
 
 
-Specify FD Form and Stepsize on Specific Derivatives
+Specify FD Form and Step Size on Specific Derivatives
 ====================================================
 
 .. content-container ::

--- a/openmdao/docs/other/om_command.rst
+++ b/openmdao/docs/other/om_command.rst
@@ -136,7 +136,7 @@ or promoted *input* column.
 When showing promoted output and promoted input columns, if the promoted output name equals the
 promoted input name, that means the connection is an implicit connection.  Otherwise the
 connection is explicit, meaning somewhere in the model there is an explicit call to `connect`
-that producted the connection.
+that produced the connection.
 
 In OpenMDAO, multiple inputs can be promoted to the same name, and by sorting the promoted inputs
 column, all such inputs will be grouped together.  This can make it much easier to spot either

--- a/openmdao/docs/theory_manual/class_structure.rst
+++ b/openmdao/docs/theory_manual/class_structure.rst
@@ -7,7 +7,7 @@ a model and a driver. You saw how a model can be built from components of differ
 a driver is used to perform an optimization. Then in the :ref:`Advanced User Guide<AdvancedUserGuide>`,
 you learned about solvers and methods for computing derivatives.
 
-The following diagram shows the relationship between these various object types (classes) and the 
+The following diagram shows the relationship between these various object types (classes) and the
 functionality that is assigned to each.
 
 .. figure:: openmdao_class_structure.jpg
@@ -20,22 +20,22 @@ Problem
 -------
 The Problem class defines a top-level container, holding all other objects. A problem instance
 contains the system and its subsystems that constitute the model hierarchy, and also contains a
-single driver instance. In addition to serving as a container, the problem also provides the user 
+single driver instance. In addition to serving as a container, the problem also provides the user
 interface for model setup and execution.
 
 System
 ------
 A :code:`System` can be a :code:`Group` or a :code:`Component`.
 
-A :code:`Group` contains components, other groups, or a mix of both. The containment relationships 
-between groups and components form a hierarchy tree, where a top-level group contains other groups, 
+A :code:`Group` contains components, other groups, or a mix of both. The containment relationships
+between groups and components form a hierarchy tree, where a top-level group contains other groups,
 which contain other groups, and so on, until we reach the bottom of the tree, which is composed
-only of components. In addition to managing the data dependencies between its subsystems, groups 
-serve three purposes: 
+only of components. In addition to managing the data dependencies between its subsystems, groups
+serve three purposes:
 
 #. They help to package sets of components together, e.g., the components for a given discipline.
 #. They help create namespaces (since all components and variables are named based on their ancestors
-   in the tree). 
+   in the tree).
 #. They facilitate the use of hierarchical nonlinear and linear solvers.
 
 Instances of the :code:`Component` class provide the lowest-level functionality representing basic calculations.
@@ -51,12 +51,12 @@ Solver
 Every system may contain two solvers, a :code:`NonlinearSolver` and a :code:`LinearSolver`, which share
 a common :code:`Solver` base class. Nonlinear solvers are used to converge implicit components or groups
 with cycles and linear solvers are used when computing derivatives across the model (see :ref:`Setting
-Nonlinear and Linear Solvers <set-solvers>`). Additional details about the different kinds of solvers 
+Nonlinear and Linear Solvers <set-solvers>`). Additional details about the different kinds of solvers
 can be found in the :ref:`OpenMDAO Solvers<theory_solver_api>` section.
 
 Driver
 ------
 The :code:`Driver` class defines algorithms that iteratively call the model. There are different types
 of drivers, for example one driver might implement an optimization algorithm while another would execute
-a design of experiments (DOE). The driver types that are included with OpenMDAO are described in 
+a design of experiments (DOE). The driver types that are included with OpenMDAO are described in
 :ref:`Drivers`.

--- a/openmdao/docs/theory_manual/scaling.rst
+++ b/openmdao/docs/theory_manual/scaling.rst
@@ -14,7 +14,7 @@ or a portion of its data into a scaled or unscaled state when requested. Doing s
 addition with a vector of adders.  There is a small amount of cost to this, so OpenMDAO tries to scale/unscale only when necessary and only over
 as tight a scope as required.
 
-Scaling is used primarily as an aid to solver convergence (both linear and nonlinear). Whenver a user interacts with OpenMDAO, or whenever a component
+Scaling is used primarily as an aid to solver convergence (both linear and nonlinear). Whenever a user interacts with OpenMDAO, or whenever a component
 calls a user-written function like "compute", the vectors will always be in an unscaled state. The following tables summarize this:
 
 **outputs and residuals (linear and nonlinear) are in an unscaled state**
@@ -30,7 +30,7 @@ calls a user-written function like "compute", the vectors will always be in an u
 
  - During solver iteration (computing next step, determining convergence)
  - When data is passed from outputs to inputs
- - When OpenMDAO loops over the model hieararchy
+ - When OpenMDAO loops over the model hierarchy
 
 The scaling system is also used to handle unit conversion. This proves to be a good fit because every unit in the unit library can be represented
 as a multiplication and an addition.  Unit conversion happens upon the passing of data from outputs to inputs. You cannot specify scaling for


### PR DESCRIPTION
This MR fixes some spelling mistakes and trailing white space in the documentation.