### PR TITLE
P170974030 decorators on tests that are used in embed-code generate errors

### DIFF
--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -197,7 +197,7 @@ class ExternalCodeDelegate(object):
         comp = self._comp
 
         if isinstance(command, str):
-            program_to_execute = re.findall("^([\w\-]+)", command)[0]
+            program_to_execute = re.findall(r"^([\w\-]+)", command)[0]
         else:
             program_to_execute = command[0]
 

--- a/openmdao/docs/_exts/embed_code.py
+++ b/openmdao/docs/_exts/embed_code.py
@@ -14,7 +14,8 @@ from openmdao.docs._utils.docutil import get_source_code, remove_docstrings, \
     remove_initial_empty_lines, replace_asserts_with_prints, \
     strip_header, dedent, insert_output_start_stop_indicators, run_code, \
     get_skip_output_node, get_interleaved_io_nodes, get_output_block_node, \
-    split_source_into_input_blocks, extract_output_blocks, consolidate_input_blocks, node_setup
+    split_source_into_input_blocks, extract_output_blocks, consolidate_input_blocks, node_setup, \
+    strip_decorators
 
 
 _plot_count = 0
@@ -117,7 +118,11 @@ class EmbedCodeDirective(Directive):
 
         if is_test:
             try:
-                source = replace_asserts_with_prints(dedent(strip_header(source)))
+                source = dedent(source)  # strip_decorators needs dedented code to work
+                source = strip_decorators(source)
+                source = strip_header(source)
+                source = dedent(source)  # need to do this again if there were decorators
+                source = replace_asserts_with_prints(source)
                 source = remove_initial_empty_lines(source)
 
                 class_name = class_.__name__

--- a/openmdao/docs/_utils/docutil.py
+++ b/openmdao/docs/_utils/docutil.py
@@ -13,6 +13,8 @@ import subprocess
 import tempfile
 import unittest
 import traceback
+import ast
+
 from docutils import nodes
 
 from collections import namedtuple
@@ -574,6 +576,52 @@ def extract_output_blocks(run_output):
         output_blocks['Trailing'] = output_block
 
     return output_blocks
+
+def strip_decorators(src):
+    """
+    Remove any decorators from the source code of the method or function.
+
+    Parameters
+    ----------
+    src : str
+        Source code
+
+    Returns
+    -------
+    str
+        Source code minus any decorators
+    """
+    class Parser(ast.NodeVisitor):
+        def __init__(self):
+            self.function_node = None
+
+        def visit_FunctionDef(self, node):
+            self.function_node = node
+
+        def get_function(self):
+            return self.function_node
+
+    tree = ast.parse(src)
+    parser = Parser()
+    parser.visit(tree)
+
+    # get node for the first function
+    function_node = parser.get_function()
+    if not function_node.decorator_list:  # no decorators so no changes needed
+        return src
+
+    # Unfortunately, the ast library, for a decorated function, returns the line
+    #   number for the first decorator when asking for the line number of the function
+    # So using the line number for the argument for of the function, which is always
+    #   correct. But we assume that the argument is on the same line as the function.
+    # We also assume there IS an argument. If not, we raise an error.
+    if function_node.args.args:
+        function_lineno = function_node.args.args[0].lineno
+    else:
+        raise RuntimeError("Cannot determine line number for decorated function without args")
+    lines = src.splitlines()
+    lines_minus_decorator = lines[function_lineno - 1:]
+    return '\n'.join(lines_minus_decorator)
 
 
 def strip_header(src):

--- a/openmdao/docs/debug_build_docs.py
+++ b/openmdao/docs/debug_build_docs.py
@@ -1,10 +1,10 @@
 # using this file to build the docs allows you run the doc build in a debugger.
 if __name__ == '__main__':
     import sys
-    import os
-    import sphinx
+    # import os
+    from sphinx.cmd.build import main
     #os.system('make clean')
     testargs = '-b html -d _build/doctrees . _build/html -t "usr"'.split(' ')
     sys.argv.extend(testargs)
 
-    sys.exit(sphinx.main())
+    sys.exit(main())


### PR DESCRIPTION
If a test has a decorator like

@unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
"scipy >= 1.2 is required.")

and it is used in an embed-code like

.. embed-code::
openmdao.drivers.tests.test_scipy_optimizer.TestScipyOptimizeDriverFeatures.test_feature_shgo_rastrigin
:layout: interleave

then when building the docs, you get an error.

Fixed the source code processing so decorators are handled.