### PR TITLE
a fix to some regex to get rid of warnings from new pycodestyle

### DIFF
--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -197,7 +197,7 @@ class ExternalCodeDelegate(object):
         comp = self._comp
 
         if isinstance(command, str):
-            program_to_execute = re.findall("^([\w\-]+)", command)[0]
+            program_to_execute = re.findall(r"^([\w\-]+)", command)[0]
         else:
             program_to_execute = command[0]
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -807,7 +807,7 @@ class Group(System):
                     for rank in range(self.comm.size):
                         if sizes[rank, i] > 0:
                             owns[name] = rank
-                            if type_ is 'output' and not abs2meta[name]['distributed']:
+                            if type_ == 'output' and not abs2meta[name]['distributed']:
                                 self._owned_sizes[rank + 1:, i] = 0  # zero out all dups
                             break
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3532,7 +3532,7 @@ class System(object):
                                     np.append(var_dict[name]['resids'],
                                               proc_vars[name]['resids'])
 
-        inputs = var_type is 'input'
+        inputs = var_type == 'input'
         outputs = not inputs
         var_list = self._get_vars_exec_order(inputs=inputs, outputs=outputs, variables=var_dict)
 

--- a/openmdao/docs/features/debugging/controlling_mpi.rst
+++ b/openmdao/docs/features/debugging/controlling_mpi.rst
@@ -25,3 +25,39 @@ can be modified by setting the environment variable
   * MPI is disallowed (e.g. certain HPC cluster head nodes)
   * Loading mpi4py causes unacceptable overhead
   * Displaying the warning message is undesirable
+
+
+*******************
+MPI Troubleshooting
+*******************
+
+This section describes how to fix certain MPI related problems.
+
+
+The following errors may occur when using certain versions of Open MPI:
+
+Fix the **There are not enough slots available in the system...** error by defining
+
+    **OMPI_MCA_rmaps_base_oversubscribe=1**
+
+in your environment.
+
+
+Fix the **A system call failed during shared memory initialization that should not have...**
+error by setting
+
+    **OMPI_MCA_btl=self,tcp**
+
+in your environment.
+
+
+***********
+MPI Testing
+***********
+
+Running OpenMDAO's MPI tests requires the use of the
+`testflo <https://github.com/OpenMDAO/testflo>`_  package.  You must have a working
+MPI library installed, for example *openmpi* or *MVAPICH*, and the
+*mpi4py*, *petsc4py*, and *pyoptsparse* python packages must be installed in your python
+environment.
+

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ optional_dependencies = {
     'test': [
         'parameterized',
         'numpydoc>=0.9.1',
-        'pycodestyle==2.3.1',
+        'pycodestyle==2.4.0',
         'pydocstyle==2.0.0',
         'testflo>=1.3.5',
     ] + (gui_test_deps if sys.version_info > (3, 5) else [])

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ optional_dependencies = {
     'test': [
         'parameterized',
         'numpydoc>=0.9.1',
-        'pycodestyle==2.4.0',
+        'pycodestyle>=2.4.0',
         'pydocstyle==2.0.0',
         'testflo>=1.3.5',
     ] + (gui_test_deps if sys.version_info > (3, 5) else [])


### PR DESCRIPTION
- also pinned to a newer version,  2.4.0, of pycodestyle
- added some docs describing how to fix a couple of MPI errors when using newer versions of OpenMPI (3+).