### PR TITLE
update versions tested on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,13 @@ language: generic
 
 env:
   matrix:
-    # pinning Python 3.7.3, seems to be an issue with the python 3.7.4 installed by conda
-     - PY=3.7.3 NUMPY=1.16 SCIPY=1.2   PETSc=3.11
-     - PY=3.6   NUMPY=1.15 SCIPY=1.1
-     - PY=3.6   NUMPY=1.14 SCIPY=1.0.1 PETSc=3.10.1 UPLOAD_DOCS=1
-     - PY=2.7   NUMPY=1.13 SCIPY=1.1   PETSc=3.9.1
-     - PY=2.7   NUMPY=1.12 SCIPY=1.1
+    # test with the latest version of Python 3.x; due to issues with PETSc 3.12, stick to 3.11 and
+    # install from maint-3.11 to get this fix: https://bitbucket.org/petsc/petsc4py/commits/a013d13
+    - PY=3   NUMPY=1.18 SCIPY=1.4 PETSc=git+https://bitbucket.org/petsc/petsc4py.git@maint-3.11 UPLOAD_DOCS=1
+    - PY=3.7 NUMPY=1.17 SCIPY=1.3
+    - PY=3.6 NUMPY=1.16 SCIPY=1.2 PETSc=3.10.1
+    - PY=2.7 NUMPY=1.15 SCIPY=1.2 PETSc=3.9
+    - PY=2.7 NUMPY=1.14 SCIPY=1.1
 
 git:
   depth: 99999
@@ -81,7 +82,8 @@ install:
   fi
 
 # if we don't have a cached conda environment then build one, otherwise just activate the cached one
-- if [ "$CACHED_ENV" ]; then
+- |
+  if [ "$CACHED_ENV" ]; then
     echo ">>> Using cached environment";
     export PATH=$HOME/miniconda/bin:$PATH;
     source $HOME/miniconda/bin/activate PY$PY;
@@ -125,8 +127,11 @@ install:
 
     if [ "$PETSc" ]; then
       echo " >> Installing parallel processing dependencies";
-      pip install mpi4py;
-      pip install petsc4py==$PETSc;
+      if [[ "$PETSc" == "git"* ]]; then
+        pip install $PETSc;
+      else
+        pip install petsc4py==$PETSc;
+      fi
     fi
 
   fi
@@ -142,6 +147,8 @@ install:
 script:
 # prevent OpenMPI warning messages
 - export OMPI_MCA_btl=^openib
+# newer versions of OpenMPI require this
+- export OMPI_MCA_rmaps_base_oversubscribe=1
 
 # make docs first
 - cd openmdao/docs;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,34 +6,20 @@ branches:
 
 environment:
   matrix:
+    #
+    # test with the latest Python 3.x/2.x and numpy/scipy releases
+    #
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON: 2.7
-      NUMPY: 1.15
-      SCIPY: 1.0.1
+      PYTHON: 3
 
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON: 3.6
-      NUMPY: 1.15
-      SCIPY: 1.0.1
+      PYTHON: 2
 
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
-    #   PYTHON: 2.7
-    #   NUMPY: 1.13
-    #   SCIPY: 1.0.1
-    #   PETSc: 3.9.1    # 3.9.1  released 2018-05-02
-
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
-    #   PYTHON: 3.6
-    #   NUMPY: 1.15
-    #   SCIPY: 1.0.1
-    #   PETSc: 3.10.1  # 3.10.1  released 2019-01-27
-
-    # - APPVEYOR_BUILD_WORKER_IMAGE: Previous Ubuntu
-    #   PYTHON: 3.7
-    #   NUMPY: 1.15
-    #   SCIPY: 1.0.1
-    #   PETSc: 3.11    # 3.11.0  released 2019-04-14
-
+    # - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+    #   # test with the latest version of Python 3.x; due to issues with PETSc 3.12, stay with 3.11 and
+    #   # install from maint-3.11 to get this fix: https://bitbucket.org/petsc/petsc4py/commits/a013d13
+    #   PYTHON: 3
+    #   PETSc: git+https://bitbucket.org/petsc/petsc4py.git@maint-3.11
 
   encrypted_74d70a284b7d_key:
     secure: 7u/kPupG0BmwqAJOLeyGMPakwj3lqukKHXsxEP4+6aX+Huu8VH2ZkDNq6GYlaw6HGJHi2JTAal9VDgOpZc9RMlweOrXJiNFWS3Iu0chy+L4=
@@ -45,7 +31,7 @@ environment:
     secure: BMuN2XRyyMclCtx+SGQCMNgbtSplR5GnBKRZVvotqd1SO6aNpMyh+Hqv+23+vBMFcN7te93hDiAE5+joj4R+H4sGGyeRb+khsu/sILHZaLQ=
 
 install:
-- sh:
+- sh: |
     if [ "$encrypted_74d70a284b7d_key" ]; then
       openssl aes-256-cbc -K $encrypted_74d70a284b7d_key -iv $encrypted_74d70a284b7d_iv -in travis_deploy_rsa.enc -out /tmp/travis_deploy_rsa -d;
       eval "$(ssh-agent -s)";
@@ -76,7 +62,7 @@ install:
     source $HOME/miniconda/bin/activate PY$PYTHON;
 
     echo " >> Installing non-pure Python dependencies from conda";
-    conda install --yes numpy=$NUMPY scipy=$SCIPY cython swig;
+    conda install --yes numpy scipy cython swig;
 
     pip install --upgrade pip;
 
@@ -101,8 +87,11 @@ install:
 
     if [ "$PETSc" ]; then
       echo " >> Installing parallel processing dependencies";
-      pip install mpi4py;
-      pip install petsc4py==$PETSc;
+      if [[ "$PETSc" == "git"* ]]; then
+        pip install $PETSc;
+      else
+        pip install petsc4py==$PETSc;
+      fi
     fi
 
     echo ">>> Installing OpenMDAO";
@@ -112,7 +101,7 @@ install:
 - cmd: if %PYTHON% GTR 3 (set CONDA=C:\Miniconda3%PYTHON:~2%-x64) else (set CONDA=C:\Miniconda-x64)
 - cmd: set PATH=%CONDA%;%CONDA%\Scripts;%PATH%
 - cmd: conda config --set always_yes yes
-- cmd: conda create -n PY%PYTHON% numpy=%NUMPY% scipy=%SCIPY% pip --quiet
+- cmd: conda create -n PY%PYTHON% numpy scipy pip --quiet
 - cmd: activate PY%PYTHON%
 - cmd: pip install -e .[all]
 - cmd: conda list


### PR DESCRIPTION
- Update the Python, NumPy and SciPy versions being testing on Travis
  - Test the latest version of Python 3.x (currently 3.8)
  - Publish docs from the build with the latest versions
  - Drop testing of old NumPy (1.12, 1.13) and SciPy (1.0.1) versions
- Test the latest versions of Python 2.x/3.x, NumPy and SciPy on AppVeyor
