### PR TITLE
POEM012 - Story 170977646 - test_sin_metamodel_preset_data fails with recent versions of scipy

### DIFF
--- a/openmdao/docs/features/building_blocks/surrogates/kriging.rst
+++ b/openmdao/docs/features/building_blocks/surrogates/kriging.rst
@@ -16,7 +16,7 @@ Here is a simple example where a Kriging model is used to approximate the output
     openmdao.components.tests.test_meta_model_unstructured_comp.MetaModelUnstructuredSurrogatesFeatureTestCase.test_kriging
     :layout: code, output
 
-Note: `FloatKriginSurrogate` implements the same surrogate model as `KrigingSurrogate` with `eval_rmse` set to False,
+Note: `FloatKrigingSurrogate` implements the same surrogate model as `KrigingSurrogate` with `eval_rmse` set to False,
 so that it only predicts the mean of the approximated output. This is deprecated and provided for backwards compatibility.
 
 

--- a/openmdao/surrogate_models/kriging.py
+++ b/openmdao/surrogate_models/kriging.py
@@ -24,6 +24,10 @@ class KrigingSurrogate(SurrogateModel):
         Reduced likelihood parameter: alpha
     L : ndarray
         Reduced likelihood parameter: L
+    lapack_driver : str, optional
+        Which lapack driver should be used for scipy's linalg.svd. Options are
+        'gesdd' which is faster but not as robust, or 'gesvd' which is slower but
+        more reliable
     n_dims : int
         Number of independents in the surrogate
     n_samples : int
@@ -46,16 +50,23 @@ class KrigingSurrogate(SurrogateModel):
         Standard deviation of training model response values, normalized.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, lapack_driver='gesvd', **kwargs):
         """
         Initialize all attributes.
 
         Parameters
         ----------
+        lapack_driver : str, optional
+            Which lapack driver should be used for scipy's linalg.svd. Options are
+            'gesdd' which is faster but not as robust, or 'gesvd' which is slower but
+            more reliable. 'gesvd' is the default.
+
         **kwargs : dict
             options dictionary.
         """
         super(KrigingSurrogate, self).__init__(**kwargs)
+
+        self.lapack_driver = lapack_driver
 
         self.n_dims = 0                 # number of independent
         self.n_samples = 0              # number of training points
@@ -159,6 +170,7 @@ class KrigingSurrogate(SurrogateModel):
             Given input correlation coefficients. If none given, uses self.thetas
             from training.
 
+
         Returns
         -------
         ndarray
@@ -181,7 +193,7 @@ class KrigingSurrogate(SurrogateModel):
         R = np.exp(-thetas.dot(np.square(distances)))
         R[np.diag_indices_from(R)] = 1. + self.options['nugget']
 
-        [U, S, Vh] = linalg.svd(R)
+        [U, S, Vh] = linalg.svd(R, lapack_driver=self.lapack_driver)
 
         # Penrose-Moore Pseudo-Inverse:
         # Given A = USV^* and Ax=b, the least-squares solution is


### PR DESCRIPTION
If

numpy==1.18.1
scipy==1.4.1

is installed, then test_sin_metamodel_preset_data fails with

Traceback (most recent call last):
File "/Users/hschilli/anaconda/envs/py37/lib/python3.7/site-packages/testflo/test.py", line 473, in _try_call
func()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/components/tests/test_meta_model_unstructured_comp.py", line 126, in test_sin_metamodel_preset_data
prob.run_model()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/core/problem.py", line 554, in run_model
self.model.run_solve_nonlinear()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/core/system.py", line 3605, in run_solve_nonlinear
self._solve_nonlinear()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/core/group.py", line 1644, in _solve_nonlinear
self._nonlinear_solver.solve()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/solvers/nonlinear/nonlinear_runonce.py", line 40, in solve
self._gs_iter()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/solvers/solver.py", line 677, in _gs_iter
subsys._solve_nonlinear()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/core/explicitcomponent.py", line 271, in _solve_nonlinear
self.compute(self._inputs, self._outputs)
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/components/meta_model_unstructured_comp.py", line 348, in compute
self._train()
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/components/meta_model_unstructured_comp.py", line 610, in _train
self._training_output[name])
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/surrogate_models/kriging.py", line 138, in train
bounds=bounds)
File "/Users/hschilli/anaconda/envs/py37/lib/python3.7/site-packages/scipy/optimize/_minimize.py", line 608, in minimize
constraints, callback=callback, *options)
File "/Users/hschilli/anaconda/envs/py37/lib/python3.7/site-packages/scipy/optimize/slsqp.py", line 399, in _minimize_slsqp
fx = func(x)
File "/Users/hschilli/anaconda/envs/py37/lib/python3.7/site-packages/scipy/optimize/optimize.py", line 326, in function_wrapper
return function((wrapper_args + args))
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/surrogate_models/kriging.py", line 131, in _calcll
loglike = self._calculate_reduced_likelihood_params(np.exp(thetas))[0]
File "/Users/hschilli/Documents/OpenMDAO/dev/OpenMDAO/openmdao/surrogate_models/kriging.py", line 184, in _calculate_reduced_likelihood_params
[U, S, Vh] = linalg.svd(R)
File "/Users/hschilli/anaconda/envs/py37/lib/python3.7/site-packages/scipy/linalg/decomp_svd.py", line 132, in svd
raise LinAlgError("SVD did not converge")
numpy.linalg.LinAlgError: SVD did not converge
