### PR TITLE
MPI coloring fixes

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -835,15 +835,24 @@ class Component(System):
         if not self.options['distributed']:
             return
 
+        iproc = self.comm.rank
         abs2meta = self._var_abs2meta
+        sizes = np.zeros(self.comm.size, dtype=INT_DTYPE)
+        tmp = np.zeros(1, dtype=INT_DTYPE)
+
         for iname in self._var_allprocs_abs_names['input']:
             if iname in abs2meta and iname in abs_in2out:
                 if abs2meta[iname]['src_indices'] is None:
+                    metadata = abs2meta[iname]
+                    tmp[0] = metadata['size']
+                    self.comm.Allgather(tmp, sizes)
+                    offset = np.sum(sizes[:iproc])
+                    end = offset + sizes[iproc]
                     simple_warning("{}: Component is distributed but input '{}' was added without "
-                                    "src_indices. Setting "
-                                    "src_indices to range({}).".format(self.msginfo, name,
-                                                                        metadata['size']))
-                    metadata['src_indices'] = np.arange(metadata['size'], dtype=INT_DTYPE)
+                                   "src_indices. Setting "
+                                   "src_indices to range({}, {}).".format(self.msginfo, iname,
+                                                                          offset, end))
+                    metadata['src_indices'] = np.arange(offset, end, dtype=INT_DTYPE)
 
     def _approx_partials(self, of, wrt, method='fd', **kwargs):
         """

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -542,14 +542,7 @@ class Component(System):
             'tags': make_set(tags),
         }
 
-        if src_indices is None:
-            if distributed:
-                simple_warning("{}: Component is distributed but input '{}' was added without "
-                               "src_indices. Setting "
-                               "src_indices to range({}).".format(self.msginfo, name,
-                                                                  metadata['size']))
-                metadata['src_indices'] = np.arange(metadata['size'], dtype=INT_DTYPE)
-        else:
+        if src_indices is not None:
             metadata['src_indices'] = np.asarray(src_indices, dtype=INT_DTYPE)
 
         # We may not know the pathname yet, so we have to use name for now, instead of abs_name.
@@ -829,6 +822,28 @@ class Component(System):
         var_rel2meta[name] = self._var_discrete['output'][name] = metadata
 
         return metadata
+
+    def _update_dist_src_indices(self, abs_in2out):
+        """
+        Set default src_indices on distributed components for any inputs where they aren't set.
+
+        Parameters
+        ----------
+        abs_in2out : dict
+            Mapping of connected inputs to their source.  Names are absolute.
+        """
+        if not self.options['distributed']:
+            return
+
+        abs2meta = self._var_abs2meta
+        for iname in self._var_allprocs_abs_names['input']:
+            if iname in abs2meta and iname in abs_in2out:
+                if abs2meta[iname]['src_indices'] is None:
+                    simple_warning("{}: Component is distributed but input '{}' was added without "
+                                    "src_indices. Setting "
+                                    "src_indices to range({}).".format(self.msginfo, name,
+                                                                        metadata['size']))
+                    metadata['src_indices'] = np.arange(metadata['size'], dtype=INT_DTYPE)
 
     def _approx_partials(self, of, wrt, method='fd', **kwargs):
         """

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -936,10 +936,10 @@ class Group(System):
                 if isinstance(subsys, Group):
                     if subsys.name in new_conns:
                         subsys._setup_global_connections(recurse=recurse,
-                                                        conns=new_conns[subsys.name])
+                                                         conns=new_conns[subsys.name])
                     else:
                         subsys._setup_global_connections(recurse=recurse)
-                elif subsys.options['distributed']:
+                elif subsys.options['distributed'] and subsys.comm.size > 1:
                     distcomps.append(subsys)
 
         # Compute global_abs_in2out by first adding this group's contributions,
@@ -1207,12 +1207,12 @@ class Group(System):
                                     for i in arr.flat:
                                         if abs(i) >= d_size:
                                             msg = ("%s: The source indices do not specify "
-                                                "a valid index for the connection "
-                                                "'%s' to '%s'. Index "
-                                                "'%d' is out of range for source "
-                                                "dimension of size %d.")
-                                            raise ValueError(msg % (self.msginfo, abs_out, abs_in, i,
-                                                                    d_size))
+                                                   "a valid index for the connection "
+                                                   "'%s' to '%s'. Index "
+                                                   "'%d' is out of range for source "
+                                                   "dimension of size %d.")
+                                            raise ValueError(msg % (self.msginfo, abs_out, abs_in,
+                                                                    i, d_size))
 
     def _transfer(self, vec_name, mode, isub=None):
         """
@@ -1234,7 +1234,7 @@ class Group(System):
 
         if mode == 'fwd':
             if xfer is not None:
-                if vec_inputs._do_scaling:
+                if self._has_input_scaling:
                     vec_inputs.scale('norm')
                     xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
                     vec_inputs.scale('phys')
@@ -1245,7 +1245,7 @@ class Group(System):
 
         else:  # rev
             if xfer is not None:
-                if vec_inputs._do_scaling:
+                if self._has_input_scaling:
                     vec_inputs.scale('phys')
                     xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
                     vec_inputs.scale('norm')

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1234,7 +1234,7 @@ class Group(System):
 
         if mode == 'fwd':
             if xfer is not None:
-                if self._has_input_scaling:
+                if vec_inputs._do_scaling:
                     vec_inputs.scale('norm')
                     xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
                     vec_inputs.scale('phys')
@@ -1245,7 +1245,7 @@ class Group(System):
 
         else:  # rev
             if xfer is not None:
-                if self._has_input_scaling:
+                if vec_inputs._do_scaling:
                     vec_inputs.scale('phys')
                     xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
                     vec_inputs.scale('norm')

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1202,15 +1202,17 @@ class Group(System):
                             # when running under MPI, there is a value for each proc
                             d_size = out_shape[d] * self.comm.size
                             if src_indices.size > 0:
-                                for i in src_indices[..., d].flat:
-                                    if abs(i) >= d_size:
-                                        msg = ("%s: The source indices do not specify "
-                                               "a valid index for the connection "
-                                               "'%s' to '%s'. Index "
-                                               "'%d' is out of range for source "
-                                               "dimension of size %d.")
-                                        raise ValueError(msg % (self.msginfo, abs_out, abs_in, i,
-                                                                d_size))
+                                arr = src_indices[..., d]
+                                if np.any(arr >= d_size) or np.any(arr <= -d_size):
+                                    for i in arr.flat:
+                                        if abs(i) >= d_size:
+                                            msg = ("%s: The source indices do not specify "
+                                                "a valid index for the connection "
+                                                "'%s' to '%s'. Index "
+                                                "'%d' is out of range for source "
+                                                "dimension of size %d.")
+                                            raise ValueError(msg % (self.msginfo, abs_out, abs_in, i,
+                                                                    d_size))
 
     def _transfer(self, vec_name, mode, isub=None):
         """

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -851,11 +851,11 @@ class MatMultMultipointTestCase(unittest.TestCase):
         p.driver = pyOptSparseDriver()
         p.driver.options['optimizer'] = OPTIMIZER
         p.driver.declare_coloring()
-        if OPTIMIZER == 'SLSQP':
+        if OPTIMIZER == 'SNOPT':
             p.driver.opt_settings['Major iterations limit'] = 100
             p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
             p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
-            p.driver.opt_settings['iSumm'] = 6
+            # p.driver.opt_settings['iSumm'] = 6
 
         model = p.model
         for i in range(num_pts):
@@ -927,10 +927,10 @@ class SimulColoringVarOutputTestClass(unittest.TestCase):
         p.driver.options['optimizer'] = 'SLSQP'
         p.driver.declare_coloring()
         p.driver.options['debug_print'] = ['totals']
-        # if OPTIMIZER == 'SLSQP':
-        #     p.driver.opt_settings['Major iterations limit'] = 100
-        #     p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
-        #     p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
+        if OPTIMIZER == 'SNOPT':
+            p.driver.opt_settings['Major iterations limit'] = 100
+            p.driver.opt_settings['Major feasibility tolerance'] = 1.0E-6
+            p.driver.opt_settings['Major optimality tolerance'] = 1.0E-6
         #     p.driver.opt_settings['iSumm'] = 6
 
         model = p.model

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -885,25 +885,35 @@ class MatMultMultipointTestCase(unittest.TestCase):
 
         model.add_objective('obj.y')
 
-        try:
-            p.setup()
+        p.setup()
 
-            p.run_driver()
+        p.run_driver()
 
-            J = p.compute_totals()
+        J = p.compute_totals()
 
-            for i in range(num_pts):
-                vname = 'par2.comp%d.A' % i
-                if vname in model._var_abs_names['input']:
-                    norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] -
-                                          getattr(par2, 'comp%d'%i)._inputs['A'].dot(getattr(par1, 'comp%d'%i)._inputs['A']))
-                    self.assertLess(norm, 1.e-7)
-                elif vname not in model._var_allprocs_abs_names['input']:
-                    self.fail("Can't find variable par2.comp%d.A" % i)
+        for i in range(num_pts):
+            cname = 'par2.comp%d' % i
+            vname = cname + '.A'
+            if vname in model._var_abs_names['input']:
+                A1 = p.get_val('par1.comp%d.A'%i)
+                A2 = p.get_val('par2.comp%d.A'%i)
+                norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] - A2.dot(A1))
+                self.assertLess(norm, 1.e-7)
 
-            print("final obj:", p['obj.y'])
-        except Exception as err:
-            print(str(err))
+        print("final obj:", p['obj.y'])
+
+
+# use_tempdirs is inherited
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class MatMultMultipointMPI2TestCase(MatMultMultipointTestCase):
+    N_PROCS = 2
+
+
+# use_tempdirs is inherited
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class MatMultMultipointMPI4TestCase(MatMultMultipointTestCase):
+    N_PROCS = 4
+
 
 class SimulColoringVarOutputTestClass(unittest.TestCase):
     def test_multi_variable_coloring_debug_print_totals(self):
@@ -1071,7 +1081,6 @@ class SimulColoringConfigCheckTestCase(unittest.TestCase):
                               sizes=[3, 4, 5], color='partial', fixed=False)
         p.run_driver()
 
-        print('++++++++++++')
         p = self._build_model(ofnames=['w', 'x', 'y', 'z'], wrtnames=['a', 'b', 'c', 'd'],
                                 sizes=[3, 4, 5, 6], color='partial', fixed=True)
 
@@ -1154,4 +1163,3 @@ class SimulColoringConfigCheckTestCase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -177,8 +177,8 @@ class DistribInputDistribOutputComp(om.ExplicitComponent):
         start = offsets[rank]
         end = start + sizes[rank]
 
-        self.add_input('invec', np.ones(sizes[rank], float),
-                       src_indices=np.arange(start, end, dtype=int))
+        # don't set src_indices on the input and just use default behavior
+        self.add_input('invec', np.ones(sizes[rank], float))
         self.add_output('outvec', np.ones(sizes[rank], float))
 
 

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -54,23 +54,6 @@ def _get_which_procs(group):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-class ProcTestCase1(unittest.TestCase):
-
-    N_PROCS = 1
-
-    def test_4_subs(self):
-        p = _build_model(nsubs=4)
-        all_inds = _get_which_procs(p.model.par)
-        self.assertEqual(all_inds, [[0,1,2,3]])
-
-        p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
-
-        J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
-
-
-@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class ProcTestCase2(unittest.TestCase):
 
     N_PROCS = 2

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -243,7 +243,12 @@ class _TotalJacInfo(object):
         # create scratch array for jac scatters
         self.jac_scratch = None
         if self.comm.size > 1:
-            self.jac_scratch = np.empty(max(J.shape), dtype=J.dtype)
+            scratch = np.empty(max(J.shape), dtype=J.dtype)
+            self.jac_scratch = {}
+            if 'fwd' in modes:
+                self.jac_scratch['fwd'] = scratch[:J.shape[0]]
+            if 'rev' in modes:
+                self.jac_scratch['rev'] = scratch[:J.shape[1]]
 
         if not approx:
             self.sol2jac_map = {}
@@ -1137,7 +1142,7 @@ class _TotalJacInfo(object):
                                 addv=False, mode=False)
                 self.J[:, i] = self.tgt_petsc[mode].array
         else:  # rev
-            scratch = self.jac_scratch[:self.J[i].size]
+            scratch = self.jac_scratch['rev']
             scratch[:] = self.J[i]
             self.comm.Allreduce(scratch, self.J[i], op=MPI.SUM)
 
@@ -1199,7 +1204,7 @@ class _TotalJacInfo(object):
         if self.jac_scratch is None:
             reduced_derivs = deriv_val[deriv_idxs['linear']]
         else:
-            reduced_derivs = self.jac_scratch[:scratch_size]
+            reduced_derivs = self.jac_scratch[mode]
             reduced_derivs[:] = 0.0
             reduced_derivs[jac_idxs['linear']] = deriv_val[deriv_idxs['linear']]
 

--- a/openmdao/devtools/run_test.py
+++ b/openmdao/devtools/run_test.py
@@ -9,14 +9,22 @@ To specify the test to run, use the following forms:
 
 <modpath>:<testcase name>.<funcname>   OR   <modpath>:<funcname>
 
+where <modpath> is either the dotted module name or the full filesystem path of the python file.
+
 for example:
 
     mpirun -n 4 run_test mypackage.mysubpackage.mymod:MyTestCase.test_foo
 
+    OR
+
+    mpirun -n 4 run_test /foo/bar/mypackage/mypackage/mysubpackage/mymod.py:MyTestCase.test_foo
 """
 from __future__ import print_function
 
 import sys
+import importlib
+from openmdao.utils.file_utils import get_module_path
+
 
 def run_test():
     """
@@ -35,9 +43,10 @@ def run_test():
         sys.exit(-1)
 
     modpath, funcpath = parts
+    if modpath.endswith('.py'):
+        modpath = get_module_path(modpath)
 
-    __import__(modpath)
-    mod = sys.modules[modpath]
+    mod = importlib.import_module(modpath)
 
     parts = funcpath.split('.', 1)
     if len(parts) == 2:

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -383,7 +383,7 @@ def _flatten_src_indices(src_indices, shape_in, shape_out, size_out):
         return convert_neg(src_indices.flatten(), size_out)
 
     entries = [list(range(x)) for x in shape_in]
-    cols = np.vstack(src_indices[i] for i in product(*entries))
+    cols = np.vstack([src_indices[i] for i in product(*entries)])
     dimidxs = [convert_neg(cols[:, i], shape_out[i]) for i in range(cols.shape[1])]
     return np.ravel_multi_index(dimidxs, shape_out)
 


### PR DESCRIPTION
### Summary

Some fixes for when we use coloring under MPI.
Also,
- fixes default behavior for when src_indices are not defined for a distributed input.
- fixes a very slow check for valid src_indices
- adds a couple of MPI coloring tests
- gets rid of a numpy deprecation warning involving vstack
- gets rid of a comm.size==1 MPI test that never runs
- updated the `run_om_test` command to accept either dotted module path or file system path.

### Related Issues

- Resolves #

### Backwards incompatibilities

Default behavior of undefined src_indices for distributed inputs is now different.  Before, on all procs the range was from 0 to local_size.  Now it's from distributed_offset (based on sizes on other procs) to distributed_offset + local_size.

### New Dependencies

None
