### PR TITLE
fix solver options for benchmark case

### DIFF
--- a/benchmark/benchmark_param_cycle.py
+++ b/benchmark/benchmark_param_cycle.py
@@ -44,6 +44,7 @@ class BM(unittest.TestCase):
     def benchmark_comp200_var5_nlbs_lbgs(self):
         suite = _build(
             solver_class=om.NonlinearBlockGS, linear_solver_class=om.LinearBlockGS,
+            solver_options={'maxiter': 100},
             assembled_jac=False,
             jacobian_type='dense',
             connection_type='explicit',


### PR DESCRIPTION
### Summary

The default solver options for `ParameterizedInstance` include `solve_subsystems` which is not a valid option if you change the solver to something like `NonlinearBlockGS`.

This PR fixes one instance where the solver has been changed by providing solver options that do not include `solve_subsystems`.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
