### PR TITLE
Removing Futures imports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ env:
     - PY=3   NUMPY=1.18 SCIPY=1.4 PETSc=git+https://bitbucket.org/petsc/petsc4py.git@maint-3.11 UPLOAD_DOCS=1
     - PY=3.7 NUMPY=1.17 SCIPY=1.3
     - PY=3.6 NUMPY=1.16 SCIPY=1.2 PETSc=3.10.1
-    - PY=2.7 NUMPY=1.15 SCIPY=1.2 PETSc=3.9
-    - PY=2.7 NUMPY=1.14 SCIPY=1.1
 
 git:
   depth: 99999

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,6 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       PYTHON: 3
 
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      PYTHON: 2
-
     # - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
     #   # test with the latest version of Python 3.x; due to issues with PETSc 3.12, stay with 3.11 and
     #   # install from maint-3.11 to get this fix: https://bitbucket.org/petsc/petsc4py/commits/a013d13

--- a/benchmark/benchmark_multipoint.py
+++ b/benchmark/benchmark_multipoint.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import time
 import unittest
 from six.moves import range

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -1,6 +1,4 @@
 """Base class used to define the interface for derivative approximation schemes."""
-from __future__ import print_function, division
-
 from six import iteritems
 from collections import defaultdict
 from scipy.sparse import coo_matrix

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -1,6 +1,4 @@
 """Complex Step derivative approximations."""
-from __future__ import division, print_function
-
 from six import iteritems, itervalues
 from six.moves import range
 from collections import defaultdict

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -1,6 +1,4 @@
 """Finite difference derivative approximations."""
-from __future__ import division, print_function
-
 from collections import namedtuple, defaultdict
 from six import iteritems
 from six.moves import range, zip

--- a/openmdao/code_review/test_lint_attributes.py
+++ b/openmdao/code_review/test_lint_attributes.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import os.path
 import importlib

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import ast
 import unittest
 import os.path
@@ -314,13 +312,7 @@ class LintTestCase(unittest.TestCase):
         dedented_src = textwrap.dedent(method_src)
 
         f = ReturnFinder()
-        try:
-            f.visit(ast.parse(dedented_src))
-        except SyntaxError:
-            # ast.parse in python 2 will fail if we use certain print function syntax in
-            # our function.
-            dedented_src = 'from __future__ import print_function\n' + dedented_src
-            f.visit(ast.parse(dedented_src))
+        f.visit(ast.parse(dedented_src))
 
         # If the function does nothing but pass, return
         if f.passes:

--- a/openmdao/code_review/test_lint_peps.py
+++ b/openmdao/code_review/test_lint_peps.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import unittest
 import os
 from fnmatch import fnmatch, filter as fnfilter

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -1,7 +1,5 @@
 """Define the BalanceComp class."""
 
-from __future__ import print_function, division, absolute_import
-
 from types import FunctionType
 from numbers import Number
 from six import iteritems

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -1,7 +1,5 @@
 """Define the EQConstraintComp class."""
 
-from __future__ import print_function, division, absolute_import
-
 from numbers import Number
 from six import iteritems
 

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -1,6 +1,4 @@
 """Define the ExternalCodeComp and ExternalCodeImplicitComp classes."""
-from __future__ import print_function
-
 import os
 import sys
 import re

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -4,7 +4,6 @@ Base class for interpolation methods that calculate values for each dimension in
 Based on Tables in NPSS, and was added to bridge the gap between some of the slower scipy
 implementations.
 """
-from __future__ import division, print_function, absolute_import
 from six.moves import range
 
 import numpy as np

--- a/openmdao/components/interp_util/interp_akima.py
+++ b/openmdao/components/interp_util/interp_akima.py
@@ -3,7 +3,6 @@ Interpolate using am Akima spline.
 
 Based on NPSS implementation, with improvements from Andrew Ning (BYU).
 """
-from __future__ import division, print_function, absolute_import
 from six.moves import range
 
 import numpy as np

--- a/openmdao/components/interp_util/interp_algorithm.py
+++ b/openmdao/components/interp_util/interp_algorithm.py
@@ -1,8 +1,6 @@
 """
 Base class for interpolation methods.  New methods should inherit from this class.
 """
-from __future__ import division, print_function, absolute_import
-
 from openmdao.utils.options_dictionary import OptionsDictionary
 
 

--- a/openmdao/components/interp_util/interp_bsplines.py
+++ b/openmdao/components/interp_util/interp_bsplines.py
@@ -1,8 +1,6 @@
 """
 Interpolation usng simple B-splines.
 """
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 from scipy.sparse import csc_matrix, csr_matrix
 

--- a/openmdao/components/interp_util/interp_cubic.py
+++ b/openmdao/components/interp_util/interp_cubic.py
@@ -3,7 +3,6 @@ Interpolate using a cubic spline polynomial.
 
 Based on NPSS implementation.
 """
-from __future__ import division, print_function, absolute_import
 from six.moves import range
 
 import numpy as np

--- a/openmdao/components/interp_util/interp_lagrange2.py
+++ b/openmdao/components/interp_util/interp_lagrange2.py
@@ -3,8 +3,6 @@ Interpolate using a second order Lagrange polynomial.
 
 Based on NPSS implementation.
 """
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 from openmdao.components.interp_util.interp_algorithm import InterpAlgorithm

--- a/openmdao/components/interp_util/interp_lagrange3.py
+++ b/openmdao/components/interp_util/interp_lagrange3.py
@@ -3,8 +3,6 @@ Interpolate using a third order Lagrange polynomial.
 
 Based on NPSS implementation.
 """
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 from openmdao.components.interp_util.interp_algorithm import InterpAlgorithm

--- a/openmdao/components/interp_util/interp_scipy.py
+++ b/openmdao/components/interp_util/interp_scipy.py
@@ -1,6 +1,4 @@
 """Grid interpolation using scipy splines."""
-from __future__ import division, print_function, absolute_import
-
 from six.moves import range
 
 from scipy import __version__ as scipy_version

--- a/openmdao/components/interp_util/interp_slinear.py
+++ b/openmdao/components/interp_util/interp_slinear.py
@@ -3,8 +3,6 @@ Interpolate using a linear polynomial.
 
 Based on NPSS implementation.
 """
-from __future__ import division, print_function, absolute_import
-
 import numpy as np
 
 from openmdao.components.interp_util.interp_algorithm import InterpAlgorithm

--- a/openmdao/components/interp_util/outofbounds_error.py
+++ b/openmdao/components/interp_util/outofbounds_error.py
@@ -1,5 +1,4 @@
 """Exception rasied by grid interpolators when they go out of bounds."""
-from __future__ import division, print_function, absolute_import
 
 
 class OutOfBoundsError(Exception):

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -1,7 +1,6 @@
 """
 Unit tests for the spline interpolator component.
 """
-from __future__ import division, print_function, absolute_import
 from copy import deepcopy
 import unittest
 

--- a/openmdao/components/linear_system_comp.py
+++ b/openmdao/components/linear_system_comp.py
@@ -1,6 +1,4 @@
 """Define the LinearSystemComp class."""
-from __future__ import division, print_function
-
 from six.moves import range
 
 import numpy as np

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -1,6 +1,4 @@
 """Define the MetaModelStructured class."""
-from __future__ import division, print_function, absolute_import
-
 from six import raise_from, iteritems, itervalues
 from six.moves import range
 

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -1,8 +1,6 @@
 """
 Unit tests for the BalanceComp.
 """
-from __future__ import print_function, division, absolute_import
-
 import os
 import unittest
 import warnings

--- a/openmdao/components/tests/test_bsplines_comp.py
+++ b/openmdao/components/tests/test_bsplines_comp.py
@@ -1,8 +1,6 @@
 """
 Test the B-spline interpolation component.
 """
-from __future__ import print_function
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_demux_comp.py
+++ b/openmdao/components/tests/test_demux_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -1,8 +1,6 @@
 """
 Unit test for DotProductComp.
 """
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import itertools
 import unittest
 import math

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -1,6 +1,4 @@
 """ Test the ExternalCodeComp. """
-from __future__ import print_function
-
 import os
 import sys
 import shutil

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -1,6 +1,4 @@
 """ Test the KSFunction component. """
-from __future__ import print_function
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1,7 +1,6 @@
 """
 Unit tests for the structured metamodel component.
 """
-from __future__ import division, print_function, absolute_import
 import unittest
 from six import assertRaisesRegex
 

--- a/openmdao/components/tests/test_mux_comp.py
+++ b/openmdao/components/tests/test_mux_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/components/tests/test_vector_magnitude_comp.py
+++ b/openmdao/components/tests/test_vector_magnitude_comp.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1,7 +1,5 @@
 """Define the Component class."""
 
-from __future__ import division
-
 from collections import OrderedDict, Counter, defaultdict
 
 # note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1,6 +1,4 @@
 """Define a base class for all Drivers in OpenMDAO."""
-from __future__ import print_function
-
 from collections import OrderedDict
 import pprint
 import sys

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -1,7 +1,5 @@
 """Define the ExplicitComponent class."""
 
-from __future__ import division
-
 import numpy as np
 from six import itervalues, iteritems
 from six.moves import range

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1,6 +1,4 @@
 """Define the Group class."""
-from __future__ import division
-
 import os
 from collections import Counter, OrderedDict, defaultdict
 

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -1,7 +1,5 @@
 """Define the ImplicitComponent class."""
 
-from __future__ import division
-
 import numpy as np
 from six import itervalues, iteritems
 from six.moves import range

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -1,7 +1,5 @@
 """Define the IndepVarComp class."""
 
-from __future__ import division
-
 # note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
 try:
     from collections.abc import Iterable

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1,7 +1,5 @@
 """Define the Problem class and a FakeComm class for non-MPI users."""
 
-from __future__ import division, print_function
-
 import sys
 import pprint
 import os

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1,6 +1,4 @@
 """Define the base System class."""
-from __future__ import division
-
 import sys
 import os
 from contextlib import contextmanager

--- a/openmdao/core/tests/test_add_var.py
+++ b/openmdao/core/tests/test_add_var.py
@@ -1,5 +1,4 @@
 """Acceptance and developer tests for add_input and add_output."""
-from __future__ import division
 import unittest
 
 import numpy as np

--- a/openmdao/core/tests/test_aviary_mpi_bug.py
+++ b/openmdao/core/tests/test_aviary_mpi_bug.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import unittest
 import numpy as np
 

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import os
 import sys

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -1,6 +1,4 @@
 """Component unittests."""
-from __future__ import division
-
 import numpy as np
 import unittest
 

--- a/openmdao/core/tests/test_core_simple.py
+++ b/openmdao/core/tests/test_core_simple.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import unittest
 

--- a/openmdao/core/tests/test_deriv_transfers.py
+++ b/openmdao/core/tests/test_deriv_transfers.py
@@ -1,6 +1,4 @@
 
-from __future__ import division, print_function
-
 import unittest
 import itertools
 

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -1,6 +1,4 @@
 """ Unit tests for the design_variable and response interface to system."""
-from __future__ import print_function
-
 from six.moves import range
 
 import unittest

--- a/openmdao/core/tests/test_direct_nondistrib_comp.py
+++ b/openmdao/core/tests/test_direct_nondistrib_comp.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import unittest
 
 import numpy as np

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import unittest
 import time

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -1,6 +1,5 @@
 """ Unit tests for the Driver base class."""
 
-from __future__ import print_function
 
 from distutils.version import LooseVersion
 from six import StringIO

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -1,6 +1,4 @@
 """Simple example demonstrating how to implement an explicit component."""
-from __future__ import division
-
 from six import assertRaisesRegex
 
 from six.moves import cStringIO

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -1,6 +1,4 @@
 """Test for a feature doc showing how to use cache_linear_solution"""
-from __future__ import division
-
 from distutils.version import LooseVersion
 import unittest
 from copy import deepcopy

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1,7 +1,6 @@
 """
 Unit tests for Group.
 """
-from __future__ import print_function
 
 import itertools
 import unittest

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -1,6 +1,4 @@
 """Simple example demonstrating how to implement an implicit component."""
-from __future__ import division
-
 import unittest
 
 from six import iteritems

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -1,6 +1,4 @@
 """IndepVarComp tests used in the IndepVarComp feature doc."""
-from __future__ import division
-
 import unittest
 
 import openmdao.api as om

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/core/tests/test_mwe_matmat.py
+++ b/openmdao/core/tests/test_mwe_matmat.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import unittest
 
 from openmdao.api import ExplicitComponent

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -1,6 +1,5 @@
 """ Test out some specialized parallel derivatives features"""
 
-from __future__ import print_function
 
 from six.moves import cStringIO as StringIO
 import sys

--- a/openmdao/core/tests/test_parallel_fd.py
+++ b/openmdao/core/tests/test_parallel_fd.py
@@ -1,5 +1,4 @@
 
-from __future__ import print_function
 
 import time
 import itertools

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -1,7 +1,5 @@
 """Test the parallel groups."""
 
-from __future__ import division, print_function
-
 import unittest
 import itertools
 

--- a/openmdao/core/tests/test_parallel_src_indices.py
+++ b/openmdao/core/tests/test_parallel_src_indices.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import unittest
 import numpy as np
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import unittest
 

--- a/openmdao/core/tests/test_reconf.py
+++ b/openmdao/core/tests/test_reconf.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import unittest
 

--- a/openmdao/core/tests/test_reconf_connections.py
+++ b/openmdao/core/tests/test_reconf_connections.py
@@ -6,8 +6,6 @@ Tests for absolute and promoted connections, for different nonlinear solvers.
 # FIXME With NonlinearRunOnce run_model() fails with ValueError (P.O.)
 # FIXME With Newton solver and NLBGS variable sizes are not updated. (P.O.)
 
-from __future__ import division
-
 import numpy as np
 import unittest
 

--- a/openmdao/core/tests/test_reconf_dynamic.py
+++ b/openmdao/core/tests/test_reconf_dynamic.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import unittest
 

--- a/openmdao/core/tests/test_reconf_group.py
+++ b/openmdao/core/tests/test_reconf_group.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import unittest
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp

--- a/openmdao/core/tests/test_reconf_parallel_group.py
+++ b/openmdao/core/tests/test_reconf_parallel_group.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import unittest
 

--- a/openmdao/core/tests/test_remote_vois.py
+++ b/openmdao/core/tests/test_remote_vois.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import unittest
 import numpy as np

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -1,6 +1,4 @@
 """Define the units/scaling tests."""
-from __future__ import division, print_function
-
 import unittest
 from copy import deepcopy
 from six import assertRaisesRegex

--- a/openmdao/core/tests/test_simple_impl_comp.py
+++ b/openmdao/core/tests/test_simple_impl_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 import unittest
 import scipy.sparse.linalg

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1,8 +1,6 @@
 """
 Helper class for total jacobian computation.
 """
-from __future__ import print_function, division
-
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
 import pprint

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -1,6 +1,5 @@
 """Various debugging functions."""
 
-from __future__ import print_function
 
 import sys
 import os

--- a/openmdao/devtools/docs_experiment/experimental_guide/examples/bezier_plot.py
+++ b/openmdao/devtools/docs_experiment/experimental_guide/examples/bezier_plot.py
@@ -1,5 +1,4 @@
 # Adding a comment and a future import to make sure it works.
-from __future__ import print_function
 import matplotlib.path as mpath
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt

--- a/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
+++ b/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
@@ -1,5 +1,4 @@
 """Define a base class for all Drivers in OpenMDAO."""
-from __future__ import print_function
 from collections import OrderedDict
 import warnings
 

--- a/openmdao/devtools/dump_sqlite_recorder_file.py
+++ b/openmdao/devtools/dump_sqlite_recorder_file.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import pprint
 import sqlite3
 import sys

--- a/openmdao/devtools/iprof_mem.py
+++ b/openmdao/devtools/iprof_mem.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import sys
 import os

--- a/openmdao/devtools/iprof_utils.py
+++ b/openmdao/devtools/iprof_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import os
 import sys

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import os
 import sys

--- a/openmdao/devtools/iprofile_app/iprofile_app.py
+++ b/openmdao/devtools/iprofile_app/iprofile_app.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import os
 import sys

--- a/openmdao/devtools/itrace.py
+++ b/openmdao/devtools/itrace.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import os
 import sys

--- a/openmdao/devtools/memory.py
+++ b/openmdao/devtools/memory.py
@@ -1,7 +1,5 @@
 """Various debugging functions."""
 
-from __future__ import print_function, division
-
 import sys
 import os
 import functools

--- a/openmdao/devtools/run_test.py
+++ b/openmdao/devtools/run_test.py
@@ -14,7 +14,6 @@ for example:
     mpirun -n 4 run_test mypackage.mysubpackage.mymod:MyTestCase.test_foo
 
 """
-from __future__ import print_function
 
 import sys
 

--- a/openmdao/devtools/wingproj.py
+++ b/openmdao/devtools/wingproj.py
@@ -1,6 +1,5 @@
 """A script wrapper for the Wing IDE."""
 
-from __future__ import print_function
 
 import os
 import os.path

--- a/openmdao/docs/_utils/docutil.py
+++ b/openmdao/docs/_utils/docutil.py
@@ -1,7 +1,6 @@
 """
 A collection of functions for modifying source code that is embeded into the Sphinx documentation.
 """
-from __future__ import print_function
 
 import sys
 import os

--- a/openmdao/docs/basic_guide/first_analysis.rst
+++ b/openmdao/docs/basic_guide/first_analysis.rst
@@ -37,7 +37,6 @@ Preamble
 ---------
 ::
 
-    from __future__ import division, print_function
     import openmdao.api as om
 
 At the top of any script you'll see these lines (or lines very similar to these) which import needed classes and functions.

--- a/openmdao/docs/other/file_wrap.rst
+++ b/openmdao/docs/other/file_wrap.rst
@@ -477,8 +477,7 @@ precision. Consider a variable with 15 digits of precision.
 ::
 
     >>> # Python 3 compatibility
-    >>> from __future__ import print_function
-    >>> val = 3.1415926535897932
+    >>>     >>> val = 3.1415926535897932
     >>>
     >>> val
     3.141592653589793...

--- a/openmdao/docs/theory_manual/sequence_diagrams/scaling_basic_compute_totals_direct.py
+++ b/openmdao/docs/theory_manual/sequence_diagrams/scaling_basic_compute_totals_direct.py
@@ -3,7 +3,6 @@ Figure built manually in SVG.
 
 Note, these require the svgwrite package (and optionally, the svglib package to convert to pdf).
 """
-from __future__ import print_function
 import subprocess
 
 from svgwrite import Drawing

--- a/openmdao/docs/theory_manual/sequence_diagrams/scaling_basic_compute_totals_gmres.py
+++ b/openmdao/docs/theory_manual/sequence_diagrams/scaling_basic_compute_totals_gmres.py
@@ -3,7 +3,6 @@ Figure built manually in SVG.
 
 Note, these require the svgwrite package (and optionally, the svglib package to convert to pdf).
 """
-from __future__ import print_function
 import subprocess
 
 from svgwrite import Drawing

--- a/openmdao/docs/theory_manual/sequence_diagrams/scaling_basic_run_model.py
+++ b/openmdao/docs/theory_manual/sequence_diagrams/scaling_basic_run_model.py
@@ -3,7 +3,6 @@ Figure built manually in SVG.
 
 Note, these require the svgwrite package (and optionally, the svglib package to convert to pdf).
 """
-from __future__ import print_function
 import subprocess
 
 from svgwrite import Drawing

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -1,7 +1,6 @@
 """
 Design-of-Experiments Driver.
 """
-from __future__ import print_function
 
 import traceback
 import inspect

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -5,7 +5,6 @@ pyoptsparse is based on pyOpt, which is an object-oriented framework for
 formulating and solving nonlinear constrained optimization problems, with
 additional MPI capability.
 """
-from __future__ import print_function
 
 from collections import OrderedDict
 import json

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -2,7 +2,6 @@
 OpenMDAO Wrapper for the scipy.optimize.minimize family of local optimizers.
 """
 
-from __future__ import print_function
 
 import sys
 from collections import OrderedDict

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1,8 +1,6 @@
 """
 Test DOE Driver and Generators.
 """
-from __future__ import print_function, division
-
 import unittest
 
 import os

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -1,5 +1,4 @@
 """A module containing various configuration checks for an OpenMDAO Problem."""
-from __future__ import print_function
 
 from collections import defaultdict
 from six import iteritems

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -1,6 +1,4 @@
 """Define the AssembledJacobian class."""
-from __future__ import division, print_function
-
 import sys
 from collections import defaultdict, OrderedDict
 

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -1,6 +1,4 @@
 """Define the DictionaryJacobian class."""
-from __future__ import division
-
 import numpy as np
 from six.moves import range
 from scipy.sparse import csc_matrix

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -1,5 +1,4 @@
 """Define the base Jacobian class."""
-from __future__ import division
 import weakref
 
 import numpy as np

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -1,7 +1,6 @@
 """
 Unit and feature doc tests for partial derivative specifiation.
 """
-from __future__ import print_function, division
 import itertools
 import unittest
 from six import iteritems

--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -1,6 +1,4 @@
 """Define the COOmatrix class."""
-from __future__ import division, print_function
-
 from collections import Counter, defaultdict
 import numpy as np
 from numpy import ndarray

--- a/openmdao/matrices/dense_matrix.py
+++ b/openmdao/matrices/dense_matrix.py
@@ -1,5 +1,4 @@
 """Define the DenseMatrix class."""
-from __future__ import division, print_function
 import numpy as np
 from numpy import ndarray
 from six import iteritems

--- a/openmdao/matrices/matrix.py
+++ b/openmdao/matrices/matrix.py
@@ -1,5 +1,4 @@
 """Define the base Matrix class."""
-from __future__ import division
 import numpy as np
 from scipy.sparse import coo_matrix, csr_matrix, csc_matrix
 

--- a/openmdao/proc_allocators/default_allocator.py
+++ b/openmdao/proc_allocators/default_allocator.py
@@ -1,6 +1,4 @@
 """Define the DefaultAllocator class."""
-from __future__ import division, print_function
-
 import warnings
 
 import numpy as np

--- a/openmdao/proc_allocators/proc_allocator.py
+++ b/openmdao/proc_allocators/proc_allocator.py
@@ -1,5 +1,4 @@
 """Define the base ProcAllocator class."""
-from __future__ import division
 import numpy as np
 from six.moves import range
 

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -1,8 +1,6 @@
 """
 Definition of the SqliteCaseReader.
 """
-from __future__ import print_function, absolute_import
-
 import sqlite3
 from collections import OrderedDict
 

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1,5 +1,4 @@
 """ Unit tests for the SqliteCaseReader. """
-from __future__ import print_function
 
 import errno
 import os

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -1,7 +1,5 @@
 """LinearSolver that uses linalg.solve or LU factor/solve."""
 
-from __future__ import division, print_function
-
 import sys
 import warnings
 from six import reraise, PY2

--- a/openmdao/solvers/linear/linear_block_gs.py
+++ b/openmdao/solvers/linear/linear_block_gs.py
@@ -1,5 +1,4 @@
 """Define the LinearBlockGS class."""
-from __future__ import print_function
 
 from six import iteritems
 from six.moves import range

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -1,6 +1,5 @@
 """LinearSolver that uses PetSC KSP to solve for a system's derivatives."""
 
-from __future__ import division, print_function
 import numpy as np
 
 try:

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -1,7 +1,5 @@
 """Define the scipy iterative solver class."""
 
-from __future__ import division, print_function
-
 from distutils.version import LooseVersion
 import numpy as np
 import scipy

--- a/openmdao/solvers/linear/tests/linear_test_base.py
+++ b/openmdao/solvers/linear/tests/linear_test_base.py
@@ -1,6 +1,5 @@
 """Common tests for linear solvers."""
 
-from __future__ import division, print_function
 from six import iteritems
 
 import unittest

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -1,7 +1,5 @@
 """Test the DirectSolver linear solver class."""
 
-from __future__ import division, print_function
-
 import unittest
 from six import assertRaisesRegex, iteritems
 

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -1,6 +1,5 @@
 """Test the LinearBlockGS linear solver class."""
 
-from __future__ import division, print_function
 import unittest
 
 import numpy as np

--- a/openmdao/solvers/linear/tests/test_linear_block_jac.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_jac.py
@@ -1,7 +1,5 @@
 """Test the LinearBlockJac class."""
 
-from __future__ import division, print_function
-
 import unittest
 
 import numpy as np

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -1,7 +1,5 @@
 """Test the PetsKSP linear solver class."""
 
-from __future__ import division, print_function
-
 import unittest
 
 import numpy as np

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -1,7 +1,5 @@
 """Test the ScipyKrylov linear solver class."""
 
-from __future__ import division, print_function
-
 from six import iteritems
 import unittest
 

--- a/openmdao/solvers/linear/tests/test_user_defined.py
+++ b/openmdao/solvers/linear/tests/test_user_defined.py
@@ -1,7 +1,5 @@
 """Test the LinearUserDefined linear solver class."""
 
-from __future__ import division, print_function
-
 import unittest
 
 import numpy as np

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -5,7 +5,6 @@ BoundsEnforceLS - Only checks bounds and enforces them by one of three methods.
 ArmijoGoldsteinLS -- Like above, but terminates with the ArmijoGoldsteinLS condition.
 
 """
-from __future__ import print_function
 
 import sys
 import numpy as np

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -3,7 +3,6 @@ Define the BroydenSolver class.
 
 Based on implementation in Scipy via OpenMDAO 0.8x with improvements based on NPSS solver.
 """
-from __future__ import print_function
 from six.moves import range
 
 import numpy as np

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -1,6 +1,5 @@
 """Define the NewtonSolver class."""
 
-from __future__ import print_function
 
 import numpy as np
 

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -1,5 +1,4 @@
 """Test the Broyden nonlinear solver. """
-from __future__ import print_function
 
 import os
 from six import iteritems

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1,7 +1,5 @@
 """Define the base Solver, NonlinearSolver, and LinearSolver classes."""
 
-from __future__ import division, print_function
-
 from six import iteritems, reraise
 from collections import OrderedDict
 import os

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -1,7 +1,5 @@
 """Tests the `debug_print` option for Nonlinear solvers."""
 
-from __future__ import division, print_function
-
 from six import StringIO
 
 import os

--- a/openmdao/solvers/tests/test_solver_parametric_suite.py
+++ b/openmdao/solvers/tests/test_solver_parametric_suite.py
@@ -1,7 +1,5 @@
 """Runs a parametric test over several of the linear solvers."""
 
-from __future__ import division, print_function
-
 import numpy as np
 import unittest
 from six import iterkeys

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -1,7 +1,6 @@
 """
 Various functions to make it easier to build test models.
 """
-from __future__ import print_function
 
 import time
 import numpy

--- a/openmdao/test_suite/components/cycle_comps.py
+++ b/openmdao/test_suite/components/cycle_comps.py
@@ -1,6 +1,4 @@
 """Components for use in `CycleGroup`. For details, see `CycleGroup`."""
-from __future__ import division, print_function
-
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/components/exec_comp_for_test.py
+++ b/openmdao/test_suite/components/exec_comp_for_test.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import time
 import os

--- a/openmdao/test_suite/components/expl_comp_array.py
+++ b/openmdao/test_suite/components/expl_comp_array.py
@@ -1,6 +1,4 @@
 """Define the explicit test component (array)."""
-from __future__ import division, print_function
-
 import numpy as np
 import scipy.sparse
 

--- a/openmdao/test_suite/components/expl_comp_simple.py
+++ b/openmdao/test_suite/components/expl_comp_simple.py
@@ -1,6 +1,4 @@
 """Define the explicit test component (simple)."""
-from __future__ import division, print_function
-
 import scipy.sparse
 
 from openmdao.core.explicitcomponent import ExplicitComponent

--- a/openmdao/test_suite/components/impl_comp_array.py
+++ b/openmdao/test_suite/components/impl_comp_array.py
@@ -1,7 +1,5 @@
 """Define the implicit test component (array)."""
 
-from __future__ import division, print_function
-
 import numpy as np
 import scipy.sparse
 

--- a/openmdao/test_suite/components/impl_comp_simple.py
+++ b/openmdao/test_suite/components/impl_comp_simple.py
@@ -1,6 +1,4 @@
 """Define the implicit test component (simple)."""
-from __future__ import division, print_function
-
 import numpy as np
 import scipy.sparse
 import scipy.optimize

--- a/openmdao/test_suite/components/matmultcomp.py
+++ b/openmdao/test_suite/components/matmultcomp.py
@@ -1,7 +1,6 @@
 """
 A simple component used for derivative testing.
 """
-from __future__ import division, print_function
 import time
 
 import numpy as np

--- a/openmdao/test_suite/components/misc_components.py
+++ b/openmdao/test_suite/components/misc_components.py
@@ -5,8 +5,6 @@ Contains some general test components that are used in multiple places for testi
 featured as examples, and are not meant to be showcased as the proper way to write components
 in OpenMDAO.
 """
-from __future__ import division, print_function
-
 import numpy as np
 
 import openmdao.api as om

--- a/openmdao/test_suite/components/paraboloid.py
+++ b/openmdao/test_suite/components/paraboloid.py
@@ -1,8 +1,6 @@
 """ Definition of the Paraboloid component, which evaluates the equation
 (x-3)^2 + xy + (y+4)^2 = 3
 """
-from __future__ import division, print_function
-
 import openmdao.api as om
 
 

--- a/openmdao/test_suite/components/paraboloid_feature.py
+++ b/openmdao/test_suite/components/paraboloid_feature.py
@@ -1,8 +1,6 @@
 """
 Demonstration of a model using the Paraboloid component.
 """
-from __future__ import division, print_function
-
 import openmdao.api as om
 
 

--- a/openmdao/test_suite/groups/cycle_group.py
+++ b/openmdao/test_suite/groups/cycle_group.py
@@ -26,7 +26,6 @@ Note: 'theta' is unique only up to equivalence mod (2*pi)/(num_comp - 1). Test a
 depend on particular values of 'theta' (or 'x_i'/'y_i' values) without taking this in to account.
 """
 
-from __future__ import print_function, division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/groups/implicit_group.py
+++ b/openmdao/test_suite/groups/implicit_group.py
@@ -1,7 +1,5 @@
 """Define a `Group` with two interconnected `ImplicitComponent`s for testing"""
 
-from __future__ import division, print_function
-
 import openmdao.api as om
 
 

--- a/openmdao/test_suite/groups/parallel_groups.py
+++ b/openmdao/test_suite/groups/parallel_groups.py
@@ -1,7 +1,5 @@
 """Define `Group`s with parallel topologies for testing"""
 
-from __future__ import division, print_function
-
 import openmdao.api as om
 
 class FanOut(om.Group):

--- a/openmdao/test_suite/groups/parametric_group.py
+++ b/openmdao/test_suite/groups/parametric_group.py
@@ -1,6 +1,4 @@
 """Define the test group classes."""
-from __future__ import division, print_function
-
 from openmdao.core.group import Group
 
 

--- a/openmdao/test_suite/groups/sin_fitter.py
+++ b/openmdao/test_suite/groups/sin_fitter.py
@@ -2,7 +2,6 @@
     Optimize locations of Legendre-Gauss-Lobatto points to match a sine curve.
 """
 
-from __future__ import print_function, division, absolute_import
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/parametric_suite.py
+++ b/openmdao/test_suite/parametric_suite.py
@@ -1,5 +1,3 @@
-from __future__ import division, print_function
-
 import itertools
 from six.moves import zip
 from six import iteritems, iterkeys, itervalues, string_types

--- a/openmdao/test_suite/scripts/circuit_analysis.py
+++ b/openmdao/test_suite/scripts/circuit_analysis.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np

--- a/openmdao/test_suite/scripts/multipoint_beam_opt.py
+++ b/openmdao/test_suite/scripts/multipoint_beam_opt.py
@@ -1,6 +1,4 @@
 
-from __future__ import print_function, division, absolute_import
-
 import numpy as np
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
+++ b/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 from openmdao.utils.assert_utils import assert_rel_error

--- a/openmdao/test_suite/test_examples/beam_optimization/beam_group.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/beam_group.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/beam_optimization/components/compliance_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/compliance_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/beam_optimization/components/moment_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/moment_comp.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import numpy as np
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/beam_optimization/components/multi_compliance_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/multi_compliance_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/components/multi_states_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/multi_states_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/components/multi_stress_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/multi_stress_comp.py
@@ -5,7 +5,6 @@ Simple calculation of beam bending stress assuming small angular displacments.
 Vectorized for multiple load cases.
 """
 
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/components/states_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/states_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/components/volume_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/volume_comp.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import numpy as np
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_group.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_group.py
@@ -3,7 +3,6 @@ This is a multipoint implementation of the beam optimization problem.
 
 
 """
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
@@ -4,7 +4,6 @@ This is a multipoint implementation of the beam optimization problem.
 This version minimizes volume while satisfying a max bending stress constraint in each element
 for each loadcase.
 """
-from __future__ import division
 from six.moves import range
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 from distutils.version import LooseVersion
 import unittest
 

--- a/openmdao/test_suite/test_examples/test_circuit_analysis.py
+++ b/openmdao/test_suite/test_examples/test_circuit_analysis.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division, absolute_import
 import numpy as np
 
 import unittest

--- a/openmdao/test_suite/test_examples/test_hohmann_transfer.py
+++ b/openmdao/test_suite/test_examples/test_hohmann_transfer.py
@@ -2,7 +2,6 @@
 Find the minimum delta-V for an impulsive Hohmann Transer from
 Low Earth Orbit (LEO) to Geostationary Orbit (GEO)
 """
-from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/test_keplers_equation.py
+++ b/openmdao/test_suite/test_examples/test_keplers_equation.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/test_sellar_mda_promote_connect.py
+++ b/openmdao/test_suite/test_examples/test_sellar_mda_promote_connect.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division
 import unittest
 
 import numpy as np

--- a/openmdao/test_suite/test_examples/test_sellar_opt.py
+++ b/openmdao/test_suite/test_examples/test_sellar_opt.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import openmdao.api as om

--- a/openmdao/test_suite/test_examples/test_tldr_paraboloid_b.py
+++ b/openmdao/test_suite/test_examples/test_tldr_paraboloid_b.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 from openmdao.utils.assert_utils import assert_rel_error

--- a/openmdao/test_suite/test_examples/tldr_paraboloid.py
+++ b/openmdao/test_suite/test_examples/tldr_paraboloid.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 from openmdao.utils.assert_utils import assert_rel_error

--- a/openmdao/test_suite/tot_jac_builder.py
+++ b/openmdao/test_suite/tot_jac_builder.py
@@ -1,7 +1,6 @@
 """
 A tool to make it easier to investigate coloring of jacobians with different sparsity structures.
 """
-from __future__ import print_function
 
 import sys
 import numpy as np

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1,8 +1,6 @@
 """
 Utils for dealing with arrays.
 """
-from __future__ import print_function, division
-
 import sys
 import six
 from six.moves import range

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -1,8 +1,6 @@
 """
 Routines to compute coloring for use with simultaneous derivatives.
 """
-from __future__ import division, print_function
-
 import os
 import sys
 import time

--- a/openmdao/utils/entry_points.py
+++ b/openmdao/utils/entry_points.py
@@ -1,7 +1,6 @@
 """
 Various functions for working with entry points.
 """
-from __future__ import print_function
 
 import sys
 import traceback

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -1,7 +1,6 @@
 """
 Utilities for working with files.
 """
-from __future__ import print_function
 
 import sys
 import os

--- a/openmdao/utils/file_wrap.py
+++ b/openmdao/utils/file_wrap.py
@@ -4,7 +4,6 @@ A collection of utilities for file wrapping.
 Note: This is a work in progress.
 """
 
-from __future__ import print_function
 
 import re
 from six.moves import range

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1,6 +1,4 @@
 """Some miscellaneous utility functions."""
-from __future__ import division
-
 from contextlib import contextmanager
 import os
 import re

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -1,7 +1,6 @@
 """
 A console script wrapper for multiple openmdao functions.
 """
-from __future__ import print_function
 
 import sys
 import os

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -1,6 +1,4 @@
 """Define the OptionsDictionary class."""
-from __future__ import division, print_function
-
 from six import iteritems, string_types
 
 from openmdao.utils.general_utils import warn_deprecation

--- a/openmdao/utils/tests/test_array_utils.py
+++ b/openmdao/utils/tests/test_array_utils.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, division, absolute_import
 import unittest
 
 import numpy as np

--- a/openmdao/utils/tests/test_hooks.py
+++ b/openmdao/utils/tests/test_hooks.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division
-
 import unittest
 import numpy as np
 

--- a/openmdao/utils/tests/test_visualization.py
+++ b/openmdao/utils/tests/test_visualization.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, division, absolute_import
-
 import unittest
 
 import numpy as np

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -9,9 +9,6 @@ in Scientific Python, by Konrad Hinsen. Modifications by
 Justin Gray.
 """
 
-from __future__ import division, print_function
-
-
 import sys
 
 import re

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -1,7 +1,5 @@
 """Define the default Transfer class."""
 
-from __future__ import division
-
 from itertools import product, chain
 from collections import defaultdict
 from six import iteritems, itervalues

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -1,6 +1,4 @@
 """Define the default Vector class."""
-from __future__ import division
-
 from copy import deepcopy
 import numbers
 

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -1,6 +1,4 @@
 """Define the PETSc Transfer class."""
-from __future__ import division
-
 import numpy as np
 from petsc4py import PETSc
 from six import iteritems, itervalues

--- a/openmdao/vectors/petsc_vector.py
+++ b/openmdao/vectors/petsc_vector.py
@@ -1,6 +1,4 @@
 """Define the PETSc Vector classe."""
-from __future__ import division
-
 import sys
 import numpy as np
 from petsc4py import PETSc

--- a/openmdao/vectors/transfer.py
+++ b/openmdao/vectors/transfer.py
@@ -1,7 +1,5 @@
 """Define the Transfer base class."""
 
-from __future__ import division
-
 
 class Transfer(object):
     """

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -1,6 +1,4 @@
 """Define the base Vector and Transfer classes."""
-from __future__ import division, print_function
-
 from six import iteritems, PY3
 from copy import deepcopy
 import os

--- a/openmdao/visualization/n2_viewer/tests/gui_test_models/bug_arrow.py
+++ b/openmdao/visualization/n2_viewer/tests/gui_test_models/bug_arrow.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 
 import numpy as np
 

--- a/openmdao/visualization/n2_viewer/tests/test_parallel_n2.py
+++ b/openmdao/visualization/n2_viewer/tests/test_parallel_n2.py
@@ -1,7 +1,5 @@
 """Test N2 with MPI and more than one process."""
 
-from __future__ import division, print_function
-
 import os
 import unittest
 import openmdao.api as om

--- a/openmdao/visualization/xdsm_viewer/xdsm_writer.py
+++ b/openmdao/visualization/xdsm_viewer/xdsm_writer.py
@@ -14,7 +14,6 @@ The pyXDSM package is available at https://github.com/mdolab/pyXDSM.
 XDSMjs is available at https://github.com/OneraHub/XDSMjs.
 """
 
-from __future__ import print_function
 
 import json
 import os


### PR DESCRIPTION
### Summary

Removed Six imports in preparation for dropping Python 2.x support

### Related Issues

- Resolves #

### Backwards incompatibilities

Python 2.x

### New Dependencies

Python 3.6+
