### PR TITLE
Enable CI for 2.10 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 branches:
   only:
   - master
+  - 2.10
 
 sudo: false
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,7 @@ build: off
 branches:
   only:
     - master
+    - 2.10
 
 environment:
   matrix:


### PR DESCRIPTION
### Summary

Enable CI for the `2.10` branch of OpenMDAO.

This branch maintains Python 2.x compatibility and may receive bug fixes from time to time.

### Related Issues

- Resolves #1201

### Backwards incompatibilities

None

### New Dependencies

None
