### PR TITLE
add -dev suffix to version

### DIFF
--- a/openmdao/__init__.py
+++ b/openmdao/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.0.0'
+__version__ = '3.0.0-dev'
 
 INF_BOUND = 1.0E30


### PR DESCRIPTION
### Summary

add `-dev` suffix to version to reduce confusion for users who pull intermediate versions between releases

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
