### PR TITLE
mark version on master with `-dev` suffix to indicate that its an intermediate version

### DIFF
--- a/openmdao/__init__.py
+++ b/openmdao/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.0.0'
+__version__ = '3.0.0-dev'
 
 INF_BOUND = 1.0E30

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from subprocess import check_call
 import distutils.spawn
 
 __version__ = re.findall(
-    r"""__version__ = ["']+([0-9\.]*)["']+""",
+    r"""__version__ = ["']+([0-9\.\-dev]*)["']+""",
     open('openmdao/__init__.py').read(),
 )[0]
 
@@ -68,7 +68,6 @@ setup(
     author='OpenMDAO Team',
     author_email='openmdao@openmdao.org',
     url='http://openmdao.org',
-    download_url='http://github.com/OpenMDAO/OpenMDAO/tarball/'+__version__,
     license='Apache License, Version 2.0',
     packages=[
         'openmdao',


### PR DESCRIPTION
### Summary

Mark version on master with `-dev` suffix to indicate that its an intermediate version

Also, remove `download_url` from `setup.py` per the following issue:
https://github.com/pypa/packaging.python.org/issues/293

### Related Issues

- Resolves #1245

### Backwards incompatibilities

None

### New Dependencies

None
