### PR TITLE
changed global_names to use_abs_names everywhere and added a deprecation warning

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1302,7 +1302,7 @@ class Problem(object):
         return data['']
 
     def compute_totals(self, of=None, wrt=None, return_format='flat_dict', debug_print=False,
-                       driver_scaling=False, global_names=False):
+                       driver_scaling=False, use_abs_names=False):
         """
         Compute derivatives of desired quantities with respect to desired inputs.
 
@@ -1324,7 +1324,7 @@ class Problem(object):
             When True, return derivatives that are scaled according to either the adder and scaler
             or the ref and ref0 values that were specified when add_design_var, add_objective, and
             add_constraint were called on the model. Default is False, which is unscaled.
-        global_names : bool
+        use_abs_names : bool
             Set to True when passing in absolute names to skip some translation steps.
 
         Returns
@@ -1336,11 +1336,11 @@ class Problem(object):
             self.final_setup()
 
         if self.model._owns_approx_jac:
-            total_info = _TotalJacInfo(self, of, wrt, global_names, return_format,
+            total_info = _TotalJacInfo(self, of, wrt, use_abs_names, return_format,
                                        approx=True, driver_scaling=driver_scaling)
             return total_info.compute_totals_approx(initialize=True)
         else:
-            total_info = _TotalJacInfo(self, of, wrt, global_names, return_format,
+            total_info = _TotalJacInfo(self, of, wrt, use_abs_names, return_format,
                                        debug_print=debug_print, driver_scaling=driver_scaling)
             return total_info.compute_totals()
 

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -150,7 +150,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        prob.driver._compute_totals(of=['parab.f_xy'], wrt=['px.x'], global_names=True)
+        prob.driver._compute_totals(of=['parab.f_xy'], wrt=['px.x'], use_abs_names=True)
 
         # 1. run_model; 2. step x
         self.assertEqual(model.parab.count, 2)

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import openmdao
 from openmdao.api import Problem, IndepVarComp, Group, ExecComp, ScipyOptimizeDriver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_rel_error, assert_warning
 from openmdao.utils.general_utils import printoptions
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp, NonSquareArrayComp
@@ -144,8 +144,9 @@ class TestDriver(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        derivs = prob.driver._compute_totals(of=['comp.y1'], wrt=['px.x'],
-                                             return_format='dict')
+        with assert_warning(DeprecationWarning, "'global_names' is deprecated in calls to _compute_totals. Use 'use_abs_names' instead."):
+            derivs = prob.driver._compute_totals(of=['comp.y1'], wrt=['px.x'], global_names=True,
+                                                 return_format='dict')
 
         oscale = np.array([1.0/(7.0-5.2), 1.0/(11.0-6.3)])
         iscale = np.array([2.0-0.5, 3.0-1.5])

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -77,7 +77,7 @@ class _TotalJacInfo(object):
         Contains all data necessary to simultaneously solve for groups of total derivatives.
     """
 
-    def __init__(self, problem, of, wrt, global_names, return_format, approx=False,
+    def __init__(self, problem, of, wrt, use_abs_names, return_format, approx=False,
                  debug_print=False, driver_scaling=True):
         """
         Initialize object.
@@ -90,8 +90,8 @@ class _TotalJacInfo(object):
             Response names.
         wrt : iter of str
             Design variable names.
-        global_names : bool
-            If True, names in of and wrt are global names.
+        use_abs_names : bool
+            If True, names in of and wrt are absolute names.
         return_format : str
             Indicates the desired return format of the total jacobian. Can have value of
             'array', 'dict', or 'flat_dict'.
@@ -142,7 +142,7 @@ class _TotalJacInfo(object):
                                    "for compute_totals.")
         else:
             prom_wrt = wrt
-            if not global_names:
+            if not use_abs_names:
                 wrt = [prom2abs[name][0] for name in prom_wrt]
 
         if of is None:
@@ -153,7 +153,7 @@ class _TotalJacInfo(object):
                                    "for compute_totals.")
         else:
             prom_of = of
-            if not global_names:
+            if not use_abs_names:
                 of = [prom2abs[name][0] for name in prom_of]
 
         # raise an exception if we depend on any discrete outputs

--- a/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
+++ b/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
@@ -558,7 +558,7 @@ class ExperimentalDriver(object):
 
         return new_derivs
 
-    def _compute_totals(self, of=None, wrt=None, return_format='flat_dict', global_names=True):
+    def _compute_totals(self, of=None, wrt=None, return_format='flat_dict', use_abs_names=True):
         """
         Compute derivatives of desired quantities with respect to desired inputs.
 
@@ -576,7 +576,7 @@ class ExperimentalDriver(object):
             Format to return the derivatives. Default is a 'flat_dict', which
             returns them in a dictionary whose keys are tuples of form (of, wrt). For
             the scipy optimizer, 'array' is also supported.
-        global_names : bool
+        use_abs_names : bool
             Set to True when passing in global names to skip some translation steps.
 
         Returns
@@ -589,10 +589,10 @@ class ExperimentalDriver(object):
         # Compute the derivatives in dict format...
         if prob.model._owns_approx_jac:
             derivs = prob._compute_totals_approx(of=of, wrt=wrt, return_format='dict',
-                                                 global_names=global_names)
+                                                 use_abs_names=use_abs_names)
         else:
             derivs = prob._compute_totals(of=of, wrt=wrt, return_format='dict',
-                                          global_names=global_names)
+                                          use_abs_names=use_abs_names)
 
         # ... then convert to whatever the driver needs.
         if return_format in ('dict', 'array'):

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -309,10 +309,10 @@ class TestPETScKrylov(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False,
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False,
                                         return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False,
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False,
                                         return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
@@ -337,10 +337,10 @@ class TestPETScKrylov(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False,
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False,
                                         return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False,
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False,
                                         return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -152,9 +152,9 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False, return_format='flat_dict')
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False, return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False, return_format='flat_dict')
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False, return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
         # Should take less iterations when starting from previous solution.
@@ -178,9 +178,9 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False, return_format='flat_dict')
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False, return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], global_names=False, return_format='flat_dict')
+        J = prob.driver._compute_totals(of=['y'], wrt=['x'], use_abs_names=False, return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
         # Should take less iterations when starting from previous solution.


### PR DESCRIPTION

### Related Issues

Earlier version of this PR was already merged, but merge happened before I could update global_names to use_abs_names based on discussion with @robfalck .

### Backwards incompatibilities

Use of global_names with Driver._compute_totals is now deprecated and use_abs_names replaces it.  This is really an internal method so shouldn't impact many users.

### New Dependencies

None
