### PR TITLE
Added ability to deprecate options in OptionsDictionary

### DIFF
--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -1,5 +1,7 @@
 """Define the OptionsDictionary class."""
 
+from openmdao.utils.general_utils import warn_deprecation
+
 # unique object to check if default is given
 _undefined = object()
 
@@ -24,6 +26,10 @@ class OptionsDictionary(object):
         If True, no options can be set after declaration.
     _all_recordable : bool
         Flag to determine if all options in UserOptions are recordable.
+    _setitem_warning_issued : list
+        Option names that are deprecated and a warning has been issued for their use in _setitem.
+    _getitem_warning_issued : list
+        Option names that are deprecated and a warning has been issued for their use in _getitem.
     """
 
     def __init__(self, parent_name=None, read_only=False):
@@ -42,6 +48,9 @@ class OptionsDictionary(object):
         self._read_only = read_only
 
         self._all_recordable = True
+
+        self._setitem_warning_issued = []
+        self._getitem_warning_issued = []
 
     def __getstate__(self):
         """
@@ -281,7 +290,8 @@ class OptionsDictionary(object):
             meta['check_valid'](name, value)
 
     def declare(self, name, default=_undefined, values=None, types=None, desc='',
-                upper=None, lower=None, check_valid=None, allow_none=False, recordable=True):
+                upper=None, lower=None, check_valid=None, allow_none=False, recordable=True,
+                deprecation=True):
         r"""
         Declare an option.
 
@@ -312,6 +322,9 @@ class OptionsDictionary(object):
             If True, allow None as a value regardless of values or types.
         recordable : bool
             If True, add to recorder
+        deprecation : str or None
+            If None, it is not deprecated. If a str, use as a DeprecationWarning
+            during __setitem__ and __getitem__
         """
         if values is not None and not isinstance(values, (set, list, tuple)):
             self._raise("In declaration of option '%s', the 'values' arg must be of type None,"
@@ -343,6 +356,7 @@ class OptionsDictionary(object):
             'has_been_set': default_provided,
             'allow_none': allow_none,
             'recordable': recordable,
+            'deprecation': deprecation,
         }
 
         # If a default is given, check for validity
@@ -419,6 +433,10 @@ class OptionsDictionary(object):
             msg = "Option '{}' cannot be set because it has not been declared."
             self._raise(msg.format(name), exc_type=KeyError)
 
+        if meta['deprecation'] is not None and name not in self._setitem_warning_issued:
+            warn_deprecation(meta['deprecation'])
+            self._setitem_warning_issued.append(name)
+
         if self._read_only:
             self._raise("Tried to set read-only option '{}'.".format(name), exc_type=KeyError)
 
@@ -444,6 +462,9 @@ class OptionsDictionary(object):
         # If the option has been set in this system, return the set value
         try:
             meta = self._dict[name]
+            if meta['deprecation'] is not None and name not in self._getitem_warning_issued:
+                warn_deprecation(meta['deprecation'])
+                self._getitem_warning_issued.append(name)
             if meta['has_been_set']:
                 return meta['value']
             else:

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -26,10 +26,8 @@ class OptionsDictionary(object):
         If True, no options can be set after declaration.
     _all_recordable : bool
         Flag to determine if all options in UserOptions are recordable.
-    _setitem_warning_issued : list
-        Option names that are deprecated and a warning has been issued for their use in _setitem.
-    _getitem_warning_issued : list
-        Option names that are deprecated and a warning has been issued for their use in _getitem.
+    _deprecation_warning_issued : list
+        Option names that are deprecated and a warning has been issued for their use.
     """
 
     def __init__(self, parent_name=None, read_only=False):
@@ -49,8 +47,7 @@ class OptionsDictionary(object):
 
         self._all_recordable = True
 
-        self._setitem_warning_issued = []
-        self._getitem_warning_issued = []
+        self._deprecation_warning_issued = []
 
     def __getstate__(self):
         """
@@ -433,9 +430,9 @@ class OptionsDictionary(object):
             msg = "Option '{}' cannot be set because it has not been declared."
             self._raise(msg.format(name), exc_type=KeyError)
 
-        if meta['deprecation'] is not None and name not in self._setitem_warning_issued:
+        if meta['deprecation'] is not None and name not in self._deprecation_warning_issued:
             warn_deprecation(meta['deprecation'])
-            self._setitem_warning_issued.append(name)
+            self._deprecation_warning_issued.append(name)
 
         if self._read_only:
             self._raise("Tried to set read-only option '{}'.".format(name), exc_type=KeyError)
@@ -462,9 +459,9 @@ class OptionsDictionary(object):
         # If the option has been set in this system, return the set value
         try:
             meta = self._dict[name]
-            if meta['deprecation'] is not None and name not in self._getitem_warning_issued:
+            if meta['deprecation'] is not None and name not in self._deprecation_warning_issued:
                 warn_deprecation(meta['deprecation'])
-                self._getitem_warning_issued.append(name)
+                self._deprecation_warning_issued.append(name)
             if meta['has_been_set']:
                 return meta['value']
             else:

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -2,7 +2,7 @@ from openmdao.api import OptionsDictionary
 
 import unittest
 
-from openmdao.utils.assert_utils import assert_warning
+from openmdao.utils.assert_utils import assert_warning, assert_no_warning
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 
@@ -248,6 +248,23 @@ class TestOptionsDict(unittest.TestCase):
         expected_msg = "\"Option 'test' cannot be found\""
         self.assertEqual(expected_msg, str(context.exception))
 
+    def test_deprecated(self):
+        msg = 'Option "test" is deprecated.'
+        self.dict.declare('test', deprecation=msg)
+
+        # First setting option
+        with assert_warning(DeprecationWarning, msg):
+            self.dict['test'] = None
+        # Should only generate warning first time through
+        with assert_no_warning(DeprecationWarning, msg):
+            self.dict['test'] = None
+
+        # Second getting option
+        with assert_warning(DeprecationWarning, msg):
+            option = self.dict['test']
+        # Should only generate warning first time through
+        with assert_no_warning(DeprecationWarning, msg):
+            option = self.dict['test']
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -248,23 +248,26 @@ class TestOptionsDict(unittest.TestCase):
         expected_msg = "\"Option 'test' cannot be found\""
         self.assertEqual(expected_msg, str(context.exception))
 
-    def test_deprecated(self):
-        msg = 'Option "test" is deprecated.'
-        self.dict.declare('test', deprecation=msg)
+    def test_deprecated_option(self):
+        msg = 'Option "test1" is deprecated.'
+        self.dict.declare('test1', deprecation=msg)
 
-        # First setting option
+        # test double set
         with assert_warning(DeprecationWarning, msg):
-            self.dict['test'] = None
-        # Should only generate warning first time through
+            self.dict['test1'] = None
+        # Should only generate warning first time
         with assert_no_warning(DeprecationWarning, msg):
-            self.dict['test'] = None
+            self.dict['test1'] = None
 
-        # Second getting option
+        # Also test set and then get
+        msg = 'Option "test2" is deprecated.'
+        self.dict.declare('test2', deprecation=msg)
+
         with assert_warning(DeprecationWarning, msg):
-            option = self.dict['test']
-        # Should only generate warning first time through
+            self.dict['test2'] = None
+        # Should only generate warning first time
         with assert_no_warning(DeprecationWarning, msg):
-            option = self.dict['test']
+            option = self.dict['test2']
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

OptionsDictionary options which are deprecated currently must be handled during setup. This change will raise a deprecation warning any time a deprecated option's __setitem__ or __getitem__ method is called.

### Related Issues

- Resolves #1252

### Backwards incompatibilities

None

### New Dependencies

None
