### PR TITLE
Wrong default for deprecation option in OptionsDictionary

### DIFF
--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -288,7 +288,7 @@ class OptionsDictionary(object):
 
     def declare(self, name, default=_undefined, values=None, types=None, desc='',
                 upper=None, lower=None, check_valid=None, allow_none=False, recordable=True,
-                deprecation=True):
+                deprecation=None):
         r"""
         Declare an option.
 


### PR DESCRIPTION
### Summary

Wrong default for deprecation option in OptionsDictionary.

### Related Issues

- Resolves #1252

### Backwards incompatibilities

None

### New Dependencies

None
