### PR TITLE
Improvement to reporting of ill-conditioned jacobians in DirectSolver

### DIFF
--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -116,6 +116,11 @@ def format_singular_csc_error(system, matrix):
     if zero_cols.size <= zero_rows.size:
 
         if zero_rows.size == 0:
+            u, s, v = np.linalg.svd(dense)
+            idx1 = np.where(np.abs(u[:, -1]) > 1e-15)[0]
+            idx2 = np.where(np.abs(v[-1, :]) > 1e-15)[0]
+            idx = set(idx1).intersection(idx2)
+
             # Underdetermined: duplicate columns or rows.
             msg = "Identical rows or columns found in jacobian in '{}'. Problem is " + \
                   "underdetermined."

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -25,7 +25,7 @@ def index_to_varname(system, loc):
     Returns
     -------
     str
-        Sting containing variable absolute name (and promoted name if there is one) and index.
+        String containing variable absolute name (and promoted name if there is one) and index.
     """
     start = end = 0
     varsizes = np.sum(system._owned_sizes, axis=0)

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -132,25 +132,24 @@ def format_singular_csc_error(system, matrix):
             # In this case, some row is a linear combination of the other rows.
 
             # SVD gives us some information that may help locate the source of the problem.
-            u, _, v = np.linalg.svd(dense)
+            u, _, _ = np.linalg.svd(dense)
 
-            # Compare left and right singular vector for lowest singular value.
-            # Nonzero elements in these vectors occur at the rows/cols that contribute strongly to
+            # Nonzero elements in the left singular vector show the rows that contribute strongly to
             # the singular subspace. Note that sometimes extra rows/cols are included in the set,
-            # but taking the intersection of the left and right singular vector seems to remove
-            # these.
+            # currently don't have a good way to pare them down.
             tol = 1e-15
-            left_idx = np.where(np.abs(u[:, -1]) > tol)[0]
-            right_idx = np.where(np.abs(v[-1, :]) > tol)[0]
-            idx = set(left_idx).intersection(right_idx)
+            u_sing = np.abs(u[:, -1])
+            left_idx = np.where(u_sing > tol)[0]
 
-            # Underdetermined: duplicate columns or rows.
             msg = "Jacobian in '{}' is not full rank. The following set of states/residuals " + \
                   "contains one or more equations that is a linear combination of the others: \n"
 
             for loc in left_idx:
                 name = index_to_varname(system, loc)
                 msg += ' ' + name + '\n'
+
+            if len(left_idx) > 2:
+                msg += "Note that the problem may be in a single Component."
 
             return msg.format(system.pathname)
 

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -543,7 +543,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         self.assertEqual(expected_msg, str(cm.exception))
 
-    def test_raise_error_on_underdetermined_csc(self):
+    def test_error_msg_underdetermined_1(self):
 
         class DCgenerator(om.ImplicitComponent):
 
@@ -606,9 +606,168 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.run_model()
 
-        expected_msg = "Identical rows or columns found in jacobian in 'sub'. Problem is underdetermined."
+        expected = "Jacobian in 'sub' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'gen.I_out' ('sub.gen.I_out') index 0.\n"
+        expected += " 'Vm_dc' ('sub.calcs.V_out') index 0.\n"
 
-        self.assertEqual(expected_msg, str(cm.exception))
+        self.assertEqual(expected, str(cm.exception))
+
+    def test_error_msg_underdetermined_2(self):
+
+        class E1(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('a', 1.0)
+                self.add_input('aa', 1.0)
+                self.add_input('y', 1.0)
+                self.add_input('z', 1.0)
+                self.add_output('x', 1.0)
+
+                self.declare_partials('x', 'x', val=1.0)
+                self.declare_partials('x', 'y', val=1.0)
+                self.declare_partials('x', 'z', val=1.0)
+                self.declare_partials('x', 'a', val=-1.0)
+                self.declare_partials('x', 'aa', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['x'] = outputs['x'] + inputs['y'] + inputs['z'] - inputs['a'] - inputs['aa']
+
+
+        class E2(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('x', 1.0)
+                self.add_output('y', 1.0)
+
+                self.declare_partials('y', 'x', val=2.063e-4)
+                self.declare_partials('y', 'y')
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['y'] = 2.063e-4 * inputs['x'] - outputs['y'] ** 2
+
+            def linearize(self, inputs, outputs, jacobian):
+                jacobian['y', 'y'] = -2.0 * outputs['y']
+
+
+        class E3(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('a', 1.0)
+                self.add_input('aa', 1.0)
+                self.add_input('x', 1.0)
+                self.add_input('y', 1.0)
+                self.add_output('z', 1.0)
+
+                self.declare_partials('z', 'x', val=2.0)
+                self.declare_partials('z', 'y', val=1.0)
+                self.declare_partials('z', 'z', val=-4.0)
+                self.declare_partials('z', 'a', val=-1.0)
+                self.declare_partials('z', 'aa', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['z'] = 2.0 * inputs['x'] + inputs['y'] - 4.0 * outputs['z'] - inputs['a'] - inputs['aa']
+
+
+        class E3bad(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('a', 1.0)
+                self.add_input('aa', 1.0)
+                self.add_input('x', 1.0)
+                self.add_input('y', 1.0)
+                self.add_output('z', 1.0)
+
+                self.declare_partials('z', 'x', val=1.0)
+                self.declare_partials('z', 'y', val=1.0)
+                self.declare_partials('z', 'z', val=1.0)
+                self.declare_partials('z', 'a', val=-1.0)
+                self.declare_partials('z', 'aa', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['z'] = 2.0 * inputs['x'] + inputs['y'] - 4.0 * outputs['z'] - inputs['a'] - inputs['aa']
+
+        # Configuration 1
+        p = om.Problem()
+        model = p.model
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('aa', 1.0)
+        model.add_subsystem('p', ivc, promotes=['aa'])
+
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = model.add_subsystem('sub2', om.Group())
+        sub3 = model.add_subsystem('sub3', om.Group())
+
+        sub1.add_subsystem('e1', E1(), promotes=['*'])
+        sub1.add_subsystem('e2', E2(), promotes=['*'])
+        sub1.add_subsystem('e3', E3(), promotes=['*'])
+
+        sub2.add_subsystem('e1', E1(), promotes=['*'])
+        sub2.add_subsystem('e2', E2(), promotes=['*'])
+        sub2.add_subsystem('e3', E3bad(), promotes=['*'])
+
+        sub3.add_subsystem('e1', E1(), promotes=['*'])
+        sub3.add_subsystem('e2', E2(), promotes=['*'])
+        sub3.add_subsystem('e3', E3(), promotes=['*'])
+
+        model.connect('sub1.z', 'sub2.a')
+        model.connect('sub2.z', 'sub3.a')
+        model.connect('sub3.z', 'sub1.a')
+        model.linear_solver = om.DirectSolver()
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+        p.setup()
+        with self.assertRaises(RuntimeError) as cm:
+            p.run_model()
+
+        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
+        expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
+
+        self.assertEqual(expected, str(cm.exception))
+
+        # Configuration 2
+        p = om.Problem()
+        model = p.model
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('aa', 1.0)
+        model.add_subsystem('p', ivc, promotes=['aa'])
+
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = model.add_subsystem('sub2', om.Group())
+        sub3 = model.add_subsystem('sub3', om.Group())
+
+        sub1.add_subsystem('e1', E1(), promotes=['*'])
+        sub1.add_subsystem('e2', E2(), promotes=['*'])
+        sub1.add_subsystem('e3', E3(), promotes=['aa', 'x', 'y', 'z'])
+
+        sub2.add_subsystem('e1', E1(), promotes=['*'])
+        sub2.add_subsystem('e2', E2(), promotes=['*'])
+        sub2.add_subsystem('e3', E3bad(), promotes=['aa', 'x', 'y', 'z'])
+
+        sub3.add_subsystem('e1', E1(), promotes=['*'])
+        sub3.add_subsystem('e2', E2(), promotes=['*'])
+        sub3.add_subsystem('e3', E3(), promotes=['aa', 'x', 'y', 'z'])
+
+        model.connect('sub1.z', 'sub2.a')
+        model.connect('sub2.z', 'sub3.a')
+        model.linear_solver = om.DirectSolver()
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+        p.setup()
+        with self.assertRaises(RuntimeError) as cm:
+            p.run_model()
+
+        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'sub1.x' ('sub1.e1.x') index 0.\n"
+        expected += " 'sub1.y' ('sub1.e2.y') index 0.\n"
+        expected += " 'sub1.z' ('sub1.e3.z') index 0.\n"
+        expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
+        expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
+        expected += "Note that the problem may be in a single Component."
+
+        self.assertEqual(expected, str(cm.exception))
 
     def test_matvec_error_raised(self):
         prob = om.Problem()


### PR DESCRIPTION
### Summary

1. Previously, when the splu solver reported a singularity, and we did not find a zero row or column, then we raised a general exception.  This generally occurs because a row (equation) is a linear combination of other rows (equations).  Now, we return a set of likely residual equation names.  These are determined by looking at the non-zero elements of the singular vector associated with the lowest singular value determined by np.linalg.svd.

NOTE: The singular vector sometimes includes some related equations that aren't part of the immediate problem. I have not found a way to tighten this down yet, and would like to see feedback on this version applied to some real models.

2. Previously, when the lu solver (which is used for dense assembled jacobians) encountered a similar problem, the "index" returned from numpy is not correct.  This has been fixed by ignoring that index and recomputing it using the same function used for sparse matrices, so we can correctly identify where to look for zero rows/cols and for under-determined subsets.

### Related Issues

- Resolves #1192 

### Backwards incompatibilities

None

### New Dependencies

None
