### PR TITLE
Fix check_totals output to show cs:None instead of fd:None when method is cs

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1292,7 +1292,7 @@ class Problem(object):
             data[''][key] = {}
             data[''][key]['J_fwd'] = val
             data[''][key]['J_fd'] = Jfd[key]
-        fd_args['method'] = 'fd'
+        fd_args['method'] = method
 
         if out_stream == _DEFAULT_OUT_STREAM:
             out_stream = sys.stdout

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -1871,6 +1871,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         self.assertTrue('9.80614' in lines[4], "'9.80614' not found in '%s'" % lines[4])
         self.assertTrue('9.80614' in lines[5], "'9.80614' not found in '%s'" % lines[5])
+        self.assertTrue('cs:None' in lines[5], "'cs:None not found in '%s'" % lines[5])
 
         assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fwd'], [[0.09692762]], 1e-5)
         assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fd'], [[0.09692762]], 1e-5)


### PR DESCRIPTION
### Summary

Method was always assigned to 'fd' in check_totals prior to calling _assemble_derivative_data. Changed it to assign to method arg and added output test.

### Related Issues

- Resolves #1249

### Backwards incompatibilities

None

### New Dependencies

None
