### PR TITLE
Changed the error message format to be similar to others

### DIFF
--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -1875,6 +1875,18 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fwd'], [[0.09692762]], 1e-5)
         assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fd'], [[0.09692762]], 1e-5)
 
+        # Test compact_print output
+        compact_stream = StringIO()
+        compact_totals = prob.check_totals(method='fd', out_stream=compact_stream,
+            compact_print=True)
+
+        compact_lines = compact_stream.getvalue().splitlines()
+
+        self.assertTrue('<output>' in compact_lines[3],
+            "'<output>' not found in '%s'" % compact_lines[4])
+        self.assertTrue('9.7743e+00' in compact_lines[11],
+            "'9.7743e+00' not found in '%s'" % compact_lines[11])
+
     def test_desvar_as_obj(self):
         prob = om.Problem()
         prob.model = SellarDerivatives()

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -182,9 +182,8 @@ class Jacobian(object):
                 else:
                     # Sparse subjac
                     if subjac.shape != (1,) and subjac.shape != rows.shape:
-                        raise ValueError("{}: Sub-jacobian for key %s has "
-                                         "the wrong shape (%s), expected (%s)." %
-                                         (self.msginfo, abs_key, subjac.shape, rows.shape))
+                        msg = '{}: Sub-jacobian for key {} has the wrong shape ({}), expected ({}).'
+                        raise ValueError(msg.format(self.msginfo, abs_key, subjac.shape, rows.shape))
 
                 subjacs_info['value'][:] = subjac
 

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -183,7 +183,8 @@ class Jacobian(object):
                     # Sparse subjac
                     if subjac.shape != (1,) and subjac.shape != rows.shape:
                         msg = '{}: Sub-jacobian for key {} has the wrong shape ({}), expected ({}).'
-                        raise ValueError(msg.format(self.msginfo, abs_key, subjac.shape, rows.shape))
+                        raise ValueError(msg.format(self.msginfo, abs_key,
+                                                    subjac.shape, rows.shape))
 
                 subjacs_info['value'][:] = subjac
 


### PR DESCRIPTION
### Summary

The error message at line 184 of jacobian.py had the wrong number of arguments and was formatted differently than other exceptions. The format has been updated to be similar to messages elsewhere in the file.

### Related Issues

- Resolves #1256

### Backwards incompatibilities

None

### New Dependencies

None
