### PR TITLE
Fix for a bug in Akima when using a 4-point spline.

### DIFF
--- a/openmdao/components/interp_util/interp_akima.py
+++ b/openmdao/components/interp_util/interp_akima.py
@@ -304,6 +304,10 @@ class InterpAkima(InterpAlgorithm):
         if compute_local_train:
             dm3_dv = (deriv_dv[..., idx_val4, :] - deriv_dv[..., idx_val3, :]) / \
                 (grid[idx + 1] - grid[idx])
+            dm1_dv = 0
+            dm2_dv = 0
+            dm4_dv = 0
+            dm5_dv = 0
 
         if idx >= 2:
             m1 = (val2 - val1) / (grid[idx - 1] - grid[idx - 2])

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -116,6 +116,11 @@ def format_singular_csc_error(system, matrix):
     if zero_cols.size <= zero_rows.size:
 
         if zero_rows.size == 0:
+            u, s, v = np.linalg.svd(dense)
+            idx1 = np.where(np.abs(u[:, -1]) > 1e-15)[0]
+            idx2 = np.where(np.abs(v[-1, :]) > 1e-15)[0]
+            idx = set(idx1).intersection(idx2)
+
             # Underdetermined: duplicate columns or rows.
             msg = "Identical rows or columns found in jacobian in '{}'. Problem is " + \
                   "underdetermined."


### PR DESCRIPTION
### Summary

Fixed a bug where certain sub-partials were undefined when using a 4-point akima spline.

### Related Issues

- Resolves #1262

### Backwards incompatibilities

None

### New Dependencies

None
