### PR TITLE
Deprecated assert_rel_error(), replaced with assert_near_equal()

### DIFF
--- a/benchmark/benchmark_param_cycle.py
+++ b/benchmark/benchmark_param_cycle.py
@@ -3,7 +3,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.test_suite.parametric_suite import ParameterizedInstance
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 def _build(solver_class=om.NewtonSolver, linear_solver_class=om.ScipyKrylov,
@@ -30,17 +30,17 @@ def _check_results(testcase, test, error_bound):
     expected_values = root.expected_values
     if expected_values:
         actual = {key: problem[key] for key in expected_values}
-        assert_rel_error(testcase, actual, expected_values, 1e-8)
+        assert_near_equal(actual, expected_values, 1e-8)
 
     expected_totals = root.expected_totals
     if expected_totals:
         # Forward Derivatives Check
         totals = test.compute_totals('fwd')
-        assert_rel_error(testcase, totals, expected_totals, error_bound)
+        assert_near_equal(totals, expected_totals, error_bound)
 
         # Reverse Derivatives Check
         totals = test.compute_totals('rev')
-        assert_rel_error(testcase, totals, expected_totals, error_bound)
+        assert_near_equal(totals, expected_totals, error_bound)
 
 
 class BM(unittest.TestCase):

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_array_equal
 
 from openmdao.components.interp_util.interp import InterpND
 from openmdao.components.interp_util.outofbounds_error import OutOfBoundsError
-from openmdao.utils.assert_utils import assert_rel_error, assert_equal_arrays
+from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays
 
 def rel_error(actual, computed):
     return np.linalg.norm(actual - computed) / np.linalg.norm(actual)
@@ -47,7 +47,7 @@ class InterpNDStandaloneFeatureTestcase(unittest.TestCase):
                             20.96983509, 21.37579297, 21.94811407, 22.66809748, 23.51629844,
                             24.47327219, 25.51957398, 26.63575905, 27.80238264, 29.        ]])
 
-        assert_rel_error(self, akima_y.flatten(), y.flatten(), tolerance=1e-6)
+        assert_near_equal(akima_y.flatten(), y.flatten(), tolerance=1e-6)
 
     def test_interp_spline_akima_derivs(self):
         import numpy as np
@@ -73,7 +73,7 @@ class InterpNDStandaloneFeatureTestcase(unittest.TestCase):
                         [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
                             0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
 
-        assert_rel_error(self, deriv, dy_dycp, tolerance=1e-6)
+        assert_near_equal(deriv, dy_dycp, tolerance=1e-6)
 
     def test_interp_spline_bsplines(self):
         import numpy as np
@@ -100,7 +100,7 @@ class InterpNDStandaloneFeatureTestcase(unittest.TestCase):
                               20.4965297 , 21.13578243, 21.8400867 , 22.61430372, 23.46329467,
                               24.39192074, 25.40504312, 26.507523  , 27.70422156, 29.        ]])
 
-        assert_rel_error(self, akima_y.flatten(), y.flatten(), tolerance=1e-6)
+        assert_near_equal(akima_y.flatten(), y.flatten(), tolerance=1e-6)
 
     def test_table_interp(self):
         import numpy as np
@@ -124,8 +124,8 @@ class InterpNDStandaloneFeatureTestcase(unittest.TestCase):
         actual = np.array([6.73306794])
         deriv_actual = np.array([[ 0.06734927, 0.323 , -2.14]])
 
-        assert_rel_error(self, f, actual, tolerance=1e-7)
-        assert_rel_error(self, df_dx, deriv_actual, tolerance=1e-7)
+        assert_near_equal(f, actual, tolerance=1e-7)
+        assert_near_equal(df_dx, deriv_actual, tolerance=1e-7)
 
 
 class TestInterpNDPython(unittest.TestCase):
@@ -332,7 +332,7 @@ class TestInterpNDPython(unittest.TestCase):
             interp._xi = x
             dy = np.array([0.997901, 0.08915])
             interp._d_dx = dy
-            assert_rel_error(self, interp.gradient(x), dy, tolerance=1e-7)
+            assert_near_equal(interp.gradient(x), dy, tolerance=1e-7)
 
     def test_akima_interpolating_spline(self):
         n_cp = 80
@@ -457,7 +457,7 @@ class TestInterpNDPython(unittest.TestCase):
                           [ 0.00000000e+00,  0.00000000e+00,  0.00000000e+00,
                             0.00000000e+00,  0.00000000e+00,  1.00000000e+00]])
 
-        assert_rel_error(self, deriv, dy_dycp, tolerance=1e-6)
+        assert_near_equal(deriv, dy_dycp, tolerance=1e-6)
 
     def test_scipy_auto_reduce_spline_order(self):
         # if a spline method is used and spline_dim_error=False and a dimension
@@ -481,7 +481,7 @@ class TestInterpNDPython(unittest.TestCase):
         # should operate as normal
         x = np.array([0.5, 0, 1001])
         result = interp.interpolate(x)
-        assert_rel_error(self, result, -0.046325695741704434, tolerance=1e-5)
+        assert_near_equal(result, -0.046325695741704434, tolerance=1e-5)
 
         interp = InterpND(method='scipy_slinear', points=points, values=values)
         value1 = interp.interpolate(x)

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 
 class TestAddSubtractCompScalars(unittest.TestCase):
@@ -38,7 +38,7 @@ class TestAddSubtractCompScalars(unittest.TestCase):
         b = self.p['b']
         out = self.p['add_subtract_comp.adder_output']
         expected = a + b
-        assert_rel_error(self, out, expected,1e-16)
+        assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
         partials = self.p.check_partials(method='fd', out_stream=None)
@@ -79,7 +79,7 @@ class TestAddSubtractCompNx1(unittest.TestCase):
         b = self.p['b']
         out = self.p['add_subtract_comp.adder_output']
         expected = a + b
-        assert_rel_error(self, out, expected,1e-16)
+        assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
         partials = self.p.check_partials(method='fd', out_stream=None)
@@ -120,7 +120,7 @@ class TestAddSubtractCompNx3(unittest.TestCase):
         b = self.p['b']
         out = self.p['add_subtract_comp.adder_output']
         expected = a + b
-        assert_rel_error(self, out, expected,1e-16)
+        assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
         partials = self.p.check_partials(method='fd', out_stream=None)
@@ -165,7 +165,7 @@ class TestAddSubtractMultipleInputs(unittest.TestCase):
         c = self.p['c']
         out = self.p['add_subtract_comp.adder_output']
         expected = a + b + c
-        assert_rel_error(self, out, expected,1e-16)
+        assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
         partials = self.p.check_partials(method='fd', out_stream=None)
@@ -210,7 +210,7 @@ class TestAddSubtractScalingFactors(unittest.TestCase):
         c = self.p['c']
         out = self.p['add_subtract_comp.adder_output']
         expected = 2*a + b - c
-        assert_rel_error(self, out, expected,1e-16)
+        assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
         partials = self.p.check_partials(method='fd', out_stream=None)
@@ -256,7 +256,7 @@ class TestAddSubtractUnits(unittest.TestCase):
         out = self.p['add_subtract_comp.adder_output']
         m_to_ft = 3.280839895
         expected = a + b*m_to_ft + c*m_to_ft
-        assert_rel_error(self, out, expected,1e-8)
+        assert_near_equal(out, expected,1e-8)
 
     def test_partials(self):
         partials = self.p.check_partials(method='fd', out_stream=None)
@@ -342,7 +342,7 @@ class TestFeature(unittest.TestCase):
 
         # Verify the results
         expected_i = np.array([[100, 200, 300], [0, -1, -2]]).T
-        assert_rel_error(self, p.get_val('totalforcecomp.total_force', units='kN'), expected_i)
+        assert_near_equal(p.get_val('totalforcecomp.total_force', units='kN'), expected_i)
 
 
 if __name__ == '__main__':

--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestCrossProductCompNx3(unittest.TestCase):
@@ -208,7 +208,7 @@ class TestUnits(unittest.TestCase):
             c_i = self.p.get_val('cross_prod_comp.c', units='ft*lbf')[i, :]
             expected_i = np.cross(a_i, b_i)
 
-            assert_rel_error(self, c_i, expected_i, tolerance=1.0E-12)
+            assert_near_equal(c_i, expected_i, tolerance=1.0E-12)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -227,7 +227,7 @@ class TestFeature(unittest.TestCase):
         import numpy as np
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         n = 100
 
@@ -261,7 +261,7 @@ class TestFeature(unittest.TestCase):
             a_i = p['r'][i, :]
             b_i = p['F'][i, :]
             expected_i = np.cross(a_i, b_i) * 0.73756215
-            assert_rel_error(self,
+            assert_near_equal(
                              p.get_val('cross_prod_comp.torque', units='ft*lbf')[i, :],
                              expected_i, tolerance=1.0E-8)
 

--- a/openmdao/components/tests/test_demux_comp.py
+++ b/openmdao/components/tests/test_demux_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 
 class TestDemuxCompOptions(unittest.TestCase):
@@ -91,10 +91,10 @@ class TestDemuxComp1D(unittest.TestCase):
         for i in range(self.nn):
             in_i = self.p['a'][i]
             out_i = self.p['demux_comp.a_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
             in_i = self.p['b'][i]
             out_i = self.p['demux_comp.b_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -138,11 +138,11 @@ class TestDemuxComp2D(unittest.TestCase):
         for i in range(self.nn):
             in_i = np.take(self.p['a'], indices=i, axis=0)
             out_i = self.p['demux_comp.a_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
             in_i = np.take(self.p['b'], indices=i, axis=1)
             out_i = self.p['demux_comp.b_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -159,7 +159,7 @@ class TestFeature(unittest.TestCase):
         import numpy as np
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         # The number of elements to be demuxed
         n = 3
@@ -200,7 +200,7 @@ class TestFeature(unittest.TestCase):
         p.run_model()
 
         expected = np.arctan(p['pos_ecef'][:, 1] / p['pos_ecef'][:, 0])
-        assert_rel_error(self, p.get_val('longitude_comp.long'), expected)
+        assert_near_equal(p.get_val('longitude_comp.long'), expected)
 
 
 if __name__ == '__main__':

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -165,7 +165,7 @@ class TestFeature(unittest.TestCase):
         import numpy as np
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         n = 100
 
@@ -201,7 +201,7 @@ class TestFeature(unittest.TestCase):
             a_i = p['force'][i, :]
             b_i = p['vel'][i, :]
             expected_i = np.dot(a_i, b_i) / 1000.0
-            assert_rel_error(self, p.get_val('dot_prod_comp.P', units='kW')[i], expected_i)
+            assert_near_equal(p.get_val('dot_prod_comp.P', units='kW')[i], expected_i)
 
 
 if __name__ == '__main__':

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
 from openmdao.test_suite.components.sellar_feature import SellarIDF
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 
 class TestEQConstraintComp(unittest.TestCase):
@@ -32,10 +32,10 @@ class TestEQConstraintComp(unittest.TestCase):
         # check results
         prob.run_driver()
 
-        assert_rel_error(self, prob['dv.x'], 0., 1e-5)
-        assert_rel_error(self, prob['dv.z'], [1.977639, 0.], 1e-5)
+        assert_near_equal(prob['dv.x'], 0., 1e-5)
+        assert_near_equal(prob['dv.z'], [1.977639, 0.], 1e-5)
 
-        assert_rel_error(self, prob['obj_cmp.obj'], 3.18339395045, 1e-5)
+        assert_near_equal(prob['obj_cmp.obj'], 3.18339395045, 1e-5)
 
         assert_almost_equal(prob['dv.y1'], 3.16)
         assert_almost_equal(prob['d1.y1'], 3.16)
@@ -163,7 +163,7 @@ class TestEQConstraintComp(unittest.TestCase):
         lhs = prob['f.y']
         rhs = prob['g.y']
         diff = lhs - rhs
-        assert_rel_error(self, prob['equal.y'], diff)
+        assert_near_equal(prob['equal.y'], diff)
 
         prob.driver = om.ScipyOptimizeDriver(disp=False)
 
@@ -293,7 +293,7 @@ class TestEQConstraintComp(unittest.TestCase):
         lhs = prob['f.y']
         rhs = prob['g.y']
         diff = lhs - rhs
-        assert_rel_error(self, prob['equal.y'], diff)
+        assert_near_equal(prob['equal.y'], diff)
 
         prob.run_driver()
 
@@ -333,9 +333,9 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
-        assert_rel_error(self, prob['equal.y'], 0., 1e-6)
-        assert_rel_error(self, prob['indep.x'], 2., 1e-6)
-        assert_rel_error(self, prob['f.y'], 4., 1e-6)
+        assert_near_equal(prob['equal.y'], 0., 1e-6)
+        assert_near_equal(prob['indep.x'], 2., 1e-6)
+        assert_near_equal(prob['f.y'], 4., 1e-6)
 
         cpd = prob.check_partials(out_stream=None)
         for (of, wrt) in cpd['equal']:
@@ -401,9 +401,9 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
-        assert_rel_error(self, prob['equal.y'], np.zeros(n), 1e-6)
-        assert_rel_error(self, prob['indep.x'], np.ones(n)*2., 1e-6)
-        assert_rel_error(self, prob['f.y'], np.ones(n)*4., 1e-6)
+        assert_near_equal(prob['equal.y'], np.zeros(n), 1e-6)
+        assert_near_equal(prob['indep.x'], np.ones(n)*2., 1e-6)
+        assert_near_equal(prob['f.y'], np.ones(n)*4., 1e-6)
 
         cpd = prob.check_partials(out_stream=None)
         for (of, wrt) in cpd['equal']:
@@ -437,9 +437,9 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
-        assert_rel_error(self, prob['equal.y'], np.zeros(n), 1e-6)
-        assert_rel_error(self, prob['indep.x'], np.ones(n)*2., 1e-6)
-        assert_rel_error(self, prob['f.y'], np.ones(n)*4., 1e-6)
+        assert_near_equal(prob['equal.y'], np.zeros(n), 1e-6)
+        assert_near_equal(prob['indep.x'], np.ones(n)*2., 1e-6)
+        assert_near_equal(prob['f.y'], np.ones(n)*4., 1e-6)
 
         cpd = prob.check_partials(out_stream=None)
         for (of, wrt) in cpd['equal']:
@@ -467,9 +467,9 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
-        assert_rel_error(self, prob['equal.y'], 0., 1e-6)
-        assert_rel_error(self, prob['indep.x'], 2., 1e-6)
-        assert_rel_error(self, prob['f.y'], 4., 1e-6)
+        assert_near_equal(prob['equal.y'], 0., 1e-6)
+        assert_near_equal(prob['indep.x'], 2., 1e-6)
+        assert_near_equal(prob['f.y'], 4., 1e-6)
 
         cpd = prob.check_partials(out_stream=None)
 
@@ -504,9 +504,9 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.driver = om.ScipyOptimizeDriver(disp=False)
         prob.run_driver()
 
-        assert_rel_error(self, prob['equal.y'], np.zeros(n), 1e-6)
-        assert_rel_error(self, prob['indep.x'], np.ones(n)*2., 1e-6)
-        assert_rel_error(self, prob['f.y'], np.ones(n)*4., 1e-6)
+        assert_near_equal(prob['equal.y'], np.zeros(n), 1e-6)
+        assert_near_equal(prob['indep.x'], np.ones(n)*2., 1e-6)
+        assert_near_equal(prob['f.y'], np.ones(n)*4., 1e-6)
 
         cpd = prob.check_partials(out_stream=None)
         for (of, wrt) in cpd['equal']:
@@ -529,7 +529,7 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['equal.y'], np.ones(shape) - rhs, 1e-6)
+        assert_near_equal(prob['equal.y'], np.ones(shape) - rhs, 1e-6)
 
         cpd = prob.check_partials(out_stream=None)
         for (of, wrt) in cpd['equal']:
@@ -585,14 +585,14 @@ class TestFeatureEQConstraintComp(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['dv.x'], 0., 1e-5)
+        assert_near_equal(prob['dv.x'], 0., 1e-5)
 
-        assert_rel_error(self, [prob['dv.y1'], prob['d1.y1']], [[3.16], [3.16]], 1e-5)
-        assert_rel_error(self, [prob['dv.y2'], prob['d2.y2']], [[3.7552778], [3.7552778]], 1e-5)
+        assert_near_equal([prob['dv.y1'], prob['d1.y1']], [[3.16], [3.16]], 1e-5)
+        assert_near_equal([prob['dv.y2'], prob['d2.y2']], [[3.7552778], [3.7552778]], 1e-5)
 
-        assert_rel_error(self, prob['dv.z'], [1.977639, 0.], 1e-5)
+        assert_near_equal(prob['dv.z'], [1.977639, 0.], 1e-5)
 
-        assert_rel_error(self, prob['obj_cmp.obj'], 3.18339395045, 1e-5)
+        assert_near_equal(prob['obj_cmp.obj'], 3.18339395045, 1e-5)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -13,7 +13,7 @@ except ImportError:
 
 import openmdao.api as om
 from openmdao.components.exec_comp import _expr_dict
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 _ufunc_test_data = {
     'abs': {
@@ -333,7 +333,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 45.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], 45.0, 0.00001)
 
     def test_simple(self):
         prob = om.Problem()
@@ -350,7 +350,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 3.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], 3.0, 0.00001)
 
     def test_for_spaces(self):
         prob = om.Problem()
@@ -368,7 +368,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 2 * math.pi, 0.00001)
+        assert_near_equal(C1._outputs['y'], 2 * math.pi, 0.00001)
 
     def test_units(self):
         prob = om.Problem()
@@ -384,7 +384,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 4.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], 4.0, 0.00001)
 
     def test_units_varname(self):
         prob = om.Problem()
@@ -437,7 +437,7 @@ class TestExecComp(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 4.0, 0.00001)
+        assert_near_equal(prob['comp.y'], 4.0, 0.00001)
 
     def test_common_units_no_meta(self):
         # make sure common units are assigned when no metadata is provided
@@ -451,7 +451,7 @@ class TestExecComp(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 2001., 0.00001)
+        assert_near_equal(prob['comp.y'], 2001., 0.00001)
 
     def test_conflicting_units(self):
         prob = om.Problem()
@@ -587,7 +587,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], math.sin(2.0), 0.00001)
+        assert_near_equal(C1._outputs['y'], math.sin(2.0), 0.00001)
 
     def test_np(self):
         prob = om.Problem()
@@ -645,7 +645,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 2.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], 2.0, 0.00001)
 
     def test_array_lhs(self):
         prob = om.Problem()
@@ -664,7 +664,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], np.array([2., 1.]), 0.00001)
+        assert_near_equal(C1._outputs['y'], np.array([2., 1.]), 0.00001)
 
     def test_simple_array_model(self):
         prob = om.Problem()
@@ -681,12 +681,12 @@ class TestExecComp(unittest.TestCase):
 
         data = prob.check_partials(out_stream=None)
 
-        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][2], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['abs error'][0], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['abs error'][1], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['abs error'][2], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['rel error'][0], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['rel error'][1], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_simple_array_model2(self):
         prob = om.Problem()
@@ -703,12 +703,12 @@ class TestExecComp(unittest.TestCase):
 
         data = prob.check_partials(out_stream=None)
 
-        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['abs error'][2], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][0], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][1], 0.0, 1e-5)
-        assert_rel_error(self, data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['abs error'][0], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['abs error'][1], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['abs error'][2], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['rel error'][0], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['rel error'][1], 0.0, 1e-5)
+        assert_near_equal(data['comp'][('y', 'x')]['rel error'][2], 0.0, 1e-5)
 
     def test_complex_step(self):
         prob = om.Problem()
@@ -725,11 +725,11 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 5.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], 5.0, 0.00001)
 
         C1._linearize()
 
-        assert_rel_error(self, C1._jacobian[('y', 'x')], [[2.0]], 0.00001)
+        assert_near_equal(C1._jacobian[('y', 'x')], [[2.0]], 0.00001)
 
     def test_complex_step2(self):
         prob = om.Problem(om.Group())
@@ -742,13 +742,13 @@ class TestExecComp(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(['comp.y'], ['p1.x'], return_format='flat_dict')
-        assert_rel_error(self, J['comp.y', 'p1.x'], np.array([[6.0]]), 0.00001)
+        assert_near_equal(J['comp.y', 'p1.x'], np.array([[6.0]]), 0.00001)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(['comp.y'], ['p1.x'], return_format='flat_dict')
-        assert_rel_error(self, J['comp.y', 'p1.x'], np.array([[6.0]]), 0.00001)
+        assert_near_equal(J['comp.y', 'p1.x'], np.array([[6.0]]), 0.00001)
 
     def test_abs_complex_step(self):
         prob = om.Problem()
@@ -758,20 +758,20 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], 4.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], 4.0, 0.00001)
 
         # any positive C1.x should give a 2.0 derivative for dy/dx
         C1._inputs['x'] = 1.0e-10
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y', 'x'], [[2.0]], 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], [[2.0]], 0.00001)
 
         C1._inputs['x'] = -3.0
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y', 'x'], [[-2.0]], 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], [[-2.0]], 0.00001)
 
         C1._inputs['x'] = 0.0
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y', 'x'], [[2.0]], 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], [[2.0]], 0.00001)
 
     def test_abs_array_complex_step(self):
         prob = om.Problem()
@@ -782,20 +782,20 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, C1._outputs['y'], np.ones(3)*4.0, 0.00001)
+        assert_near_equal(C1._outputs['y'], np.ones(3)*4.0, 0.00001)
 
         # any positive C1.x should give a 2.0 derivative for dy/dx
         C1._inputs['x'] = np.ones(3)*1.0e-10
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y', 'x'], np.eye(3)*2.0, 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], np.eye(3)*2.0, 0.00001)
 
         C1._inputs['x'] = np.ones(3)*-3.0
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y', 'x'], np.eye(3)*-2.0, 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], np.eye(3)*-2.0, 0.00001)
 
         C1._inputs['x'] = np.zeros(3)
         C1._linearize()
-        assert_rel_error(self, C1._jacobian['y', 'x'], np.eye(3)*2.0, 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], np.eye(3)*2.0, 0.00001)
 
         C1._inputs['x'] = np.array([1.5, -0.6, 2.4])
         C1._linearize()
@@ -804,7 +804,7 @@ class TestExecComp(unittest.TestCase):
         expect[1, 1] = -2.0
         expect[2, 2] = 2.0
 
-        assert_rel_error(self, C1._jacobian['y', 'x'], expect, 0.00001)
+        assert_near_equal(C1._jacobian['y', 'x'], expect, 0.00001)
 
     def test_has_diag_partials_error(self):
         p = om.Problem()
@@ -935,7 +935,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 3.0, 0.00001)
+        assert_near_equal(prob['comp.y'], 3.0, 0.00001)
 
     def test_feature_multi_output(self):
         import openmdao.api as om
@@ -953,8 +953,8 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y1'], 3.0, 0.00001)
-        assert_rel_error(self, prob['comp.y2'], 1.0, 0.00001)
+        assert_near_equal(prob['comp.y1'], 3.0, 0.00001)
+        assert_near_equal(prob['comp.y2'], 1.0, 0.00001)
 
     def test_feature_array(self):
         import numpy as np
@@ -975,7 +975,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 2.0, 0.00001)
+        assert_near_equal(prob['comp.y'], 2.0, 0.00001)
 
     def test_feature_math(self):
         import numpy as np
@@ -997,7 +997,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.z'], 1.0, 0.00001)
+        assert_near_equal(prob['comp.z'], 1.0, 0.00001)
 
     def test_feature_numpy(self):
         import numpy as np
@@ -1016,7 +1016,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 6.0, 0.00001)
+        assert_near_equal(prob['comp.y'], 6.0, 0.00001)
 
     def test_feature_metadata(self):
         import openmdao.api as om
@@ -1038,7 +1038,7 @@ class TestExecComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.z'], 24.0, 0.00001)
+        assert_near_equal(prob['comp.z'], 24.0, 0.00001)
 
     def test_feature_options(self):
         import openmdao.api as om
@@ -1059,7 +1059,7 @@ class TestExecComp(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], [2., 4.], 0.00001)
+        assert_near_equal(prob['comp.y'], [2., 4.], 0.00001)
 
 
 class TestExecCompParameterized(unittest.TestCase):

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -10,7 +10,7 @@ from scipy.optimize import fsolve
 import openmdao.api as om
 from openmdao.components.external_code_comp import STDOUT
 
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 DIRECTORY = os.path.dirname((os.path.abspath(__file__)))
 
@@ -472,8 +472,8 @@ class TestExternalCodeCompFeature(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['p1.x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['p2.y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['p1.x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['p2.y'], -7.3333333, 1e-6)
 
     def test_optimize_derivs(self):
         import openmdao.api as om
@@ -506,8 +506,8 @@ class TestExternalCodeCompFeature(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['p1.x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['p2.y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['p1.x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['p2.y'], -7.3333333, 1e-6)
 
 
 class TestExternalCodeImplicitCompFeature(unittest.TestCase):
@@ -617,14 +617,14 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
         prob['area_ratio'] = area_ratio
         mach_comp.options['super_sonic'] = super_sonic
         prob.run_model()
-        assert_rel_error(self, prob['mach'], mach_solve(area_ratio, super_sonic=super_sonic), 1e-8)
+        assert_near_equal(prob['mach'], mach_solve(area_ratio, super_sonic=super_sonic), 1e-8)
 
         area_ratio = 1.3
         super_sonic = True
         prob['area_ratio'] = area_ratio
         mach_comp.options['super_sonic'] = super_sonic
         prob.run_model()
-        assert_rel_error(self, prob['mach'], mach_solve(area_ratio, super_sonic=super_sonic), 1e-8)
+        assert_near_equal(prob['mach'], mach_solve(area_ratio, super_sonic=super_sonic), 1e-8)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -6,7 +6,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_stress import MultipointBeamGroup
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 class TestKSFunction(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestKSFunction(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, max(prob['comp.y2']), prob['ks.KS'][0])
+        assert_near_equal(max(prob['comp.y2']), prob['ks.KS'][0])
 
     def test_vectorized(self):
         prob = om.Problem()
@@ -49,14 +49,14 @@ class TestKSFunction(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['ks.KS'][0], 17.0)
-        assert_rel_error(self, prob['ks.KS'][1], 34.0)
-        assert_rel_error(self, prob['ks.KS'][2], 51.0)
+        assert_near_equal(prob['ks.KS'][0], 17.0)
+        assert_near_equal(prob['ks.KS'][1], 34.0)
+        assert_near_equal(prob['ks.KS'][2], 51.0)
 
         partials = prob.check_partials(includes=['ks'], out_stream=None)
 
         for (of, wrt) in partials['ks']:
-            assert_rel_error(self, partials['ks'][of, wrt]['abs error'][0], 0.0, 1e-6)
+            assert_near_equal(partials['ks'][of, wrt]['abs error'][0], 0.0, 1e-6)
 
     def test_partials_no_compute(self):
         prob = om.Problem()
@@ -77,14 +77,14 @@ class TestKSFunction(unittest.TestCase):
         partials = {}
 
         ks_comp.compute_partials(inputs, partials)
-        assert_rel_error(self, partials[('KS', 'g')], np.array([1., 0.]), 1e-6)
+        assert_near_equal(partials[('KS', 'g')], np.array([1., 0.]), 1e-6)
 
         # swap inputs and call compute partials again, without calling compute
         inputs['g'][0][0] = 4
         inputs['g'][0][1] = 5
 
         ks_comp.compute_partials(inputs, partials)
-        assert_rel_error(self, partials[('KS', 'g')], np.array([0., 1.]), 1e-6)
+        assert_near_equal(partials[('KS', 'g')], np.array([0., 1.]), 1e-6)
 
     def test_beam_stress(self):
         E = 1.
@@ -114,8 +114,8 @@ class TestKSFunction(unittest.TestCase):
         stress1 = prob['parallel.sub_0.stress_comp.stress_1']
 
         # Test that the the maximum constraint prior to aggregation is close to "active".
-        assert_rel_error(self, max(stress0), 100.0, tolerance=5e-2)
-        assert_rel_error(self, max(stress1), 100.0, tolerance=5e-2)
+        assert_near_equal(max(stress0), 100.0, tolerance=5e-2)
+        assert_near_equal(max(stress1), 100.0, tolerance=5e-2)
 
         # Test that no original constraint is violated.
         self.assertTrue(np.all(stress0 < 100.0))
@@ -137,7 +137,7 @@ class TestKSFunction(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['ks.KS'][0], -1.0)
+        assert_near_equal(prob['ks.KS'][0], -1.0)
 
     def test_lower_flag(self):
 
@@ -155,7 +155,7 @@ class TestKSFunction(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['ks.KS'][0], -12.0)
+        assert_near_equal(prob['ks.KS'][0], -12.0)
 
 
 class TestKSFunctionFeatures(unittest.TestCase):
@@ -179,7 +179,7 @@ class TestKSFunctionFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['ks.KS'][0], 15.0)
+        assert_near_equal(prob['ks.KS'][0], 15.0)
 
     def test_vectorized(self):
         import numpy as np
@@ -200,8 +200,8 @@ class TestKSFunctionFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['ks.KS'][0], 15.0)
-        assert_rel_error(self, prob['ks.KS'][1], 30.0)
+        assert_near_equal(prob['ks.KS'][0], 15.0)
+        assert_near_equal(prob['ks.KS'][1], 30.0)
 
     def test_upper(self):
         import numpy as np
@@ -223,7 +223,7 @@ class TestKSFunctionFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['ks.KS'][0], -1.0)
+        assert_near_equal(prob['ks.KS'][0], -1.0)
 
     def test_lower_flag(self):
         import numpy as np
@@ -245,7 +245,7 @@ class TestKSFunctionFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['ks.KS'][0], -12.0)
+        assert_near_equal(prob['ks.KS'][0], -12.0)
 
 
 if __name__ == "__main__":

--- a/openmdao/components/tests/test_linear_system_comp.py
+++ b/openmdao/components/tests/test_linear_system_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestLinearSystemComp(unittest.TestCase):
@@ -37,14 +37,14 @@ class TestLinearSystemComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['lin.x'], x, .0001)
-        assert_rel_error(self, prob.model._residuals.get_norm(), 0.0, 1e-10)
+        assert_near_equal(prob['lin.x'], x, .0001)
+        assert_near_equal(prob.model._residuals.get_norm(), 0.0, 1e-10)
 
         model.run_apply_nonlinear()
 
         with model._scaled_context_all():
             val = model.lingrp.lin._residuals['x']
-            assert_rel_error(self, val, np.zeros((3, )), tolerance=1e-8)
+            assert_near_equal(val, np.zeros((3, )), tolerance=1e-8)
 
     def test_vectorized(self):
         """Check against the scipy solver."""
@@ -72,14 +72,14 @@ class TestLinearSystemComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['lin.x'], x, .0001)
-        assert_rel_error(self, prob.model._residuals.get_norm(), 0.0, 1e-10)
+        assert_near_equal(prob['lin.x'], x, .0001)
+        assert_near_equal(prob.model._residuals.get_norm(), 0.0, 1e-10)
 
         model.run_apply_nonlinear()
 
         with model._scaled_context_all():
             val = model.lingrp.lin._residuals['x']
-            assert_rel_error(self, val, np.zeros((2, 3)), tolerance=1e-8)
+            assert_near_equal(val, np.zeros((2, 3)), tolerance=1e-8)
 
     def test_vectorized_A(self):
         """Check against the scipy solver."""
@@ -108,14 +108,14 @@ class TestLinearSystemComp(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['lin.x'], x, .0001)
-        assert_rel_error(self, prob.model._residuals.get_norm(), 0.0, 1e-10)
+        assert_near_equal(prob['lin.x'], x, .0001)
+        assert_near_equal(prob.model._residuals.get_norm(), 0.0, 1e-10)
 
         model.run_apply_nonlinear()
 
         with model._scaled_context_all():
             val = model.lingrp.lin._residuals['x']
-            assert_rel_error(self, val, np.zeros((2, 3)), tolerance=1e-8)
+            assert_near_equal(val, np.zeros((2, 3)), tolerance=1e-8)
 
     def test_solve_linear(self):
         """Check against solve_linear."""
@@ -158,17 +158,17 @@ class TestLinearSystemComp(unittest.TestCase):
         d_residuals['lin.x'] = b
         lingrp.run_solve_linear(['linear'], 'fwd')
         sol = d_outputs['lin.x']
-        assert_rel_error(self, sol, x, .0001)
+        assert_near_equal(sol, x, .0001)
 
         # Reverse mode with RHS of self.b_T
         d_outputs['lin.x'] = b_T
         lingrp.run_solve_linear(['linear'], 'rev')
         sol = d_residuals['lin.x']
-        assert_rel_error(self, sol, x, .0001)
+        assert_near_equal(sol, x, .0001)
 
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b', 'lin.x'], return_format='flat_dict')
-        assert_rel_error(self, J['lin.x', 'p1.A'], dx_dA, .0001)
-        assert_rel_error(self, J['lin.x', 'p2.b'], dx_db, .0001)
+        assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
+        assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
         data = prob.check_partials(out_stream=None)
 
@@ -221,17 +221,17 @@ class TestLinearSystemComp(unittest.TestCase):
         d_residuals['lin.x'] = b
         lingrp.run_solve_linear(['linear'], 'fwd')
         sol = d_outputs['lin.x']
-        assert_rel_error(self, sol, x, .0001)
+        assert_near_equal(sol, x, .0001)
 
         # Reverse mode with RHS of self.b_T
         d_outputs['lin.x'] = b_T
         lingrp.run_solve_linear(['linear'], 'rev')
         sol = d_residuals['lin.x']
-        assert_rel_error(self, sol, x, .0001)
+        assert_near_equal(sol, x, .0001)
 
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b'], return_format='flat_dict')
-        assert_rel_error(self, J['lin.x', 'p1.A'], dx_dA, .0001)
-        assert_rel_error(self, J['lin.x', 'p2.b'], dx_db, .0001)
+        assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
+        assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
         data = prob.check_partials(out_stream=None)
 
@@ -292,17 +292,17 @@ class TestLinearSystemComp(unittest.TestCase):
         d_residuals['lin.x'] = b
         lingrp.run_solve_linear(['linear'], 'fwd')
         sol = d_outputs['lin.x']
-        assert_rel_error(self, sol, x, .0001)
+        assert_near_equal(sol, x, .0001)
 
         # Reverse mode with RHS of self.b_T
         d_outputs['lin.x'] = b_T
         lingrp.run_solve_linear(['linear'], 'rev')
         sol = d_residuals['lin.x']
-        assert_rel_error(self, sol, x, .0001)
+        assert_near_equal(sol, x, .0001)
 
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b'], return_format='flat_dict')
-        assert_rel_error(self, J['lin.x', 'p1.A'], dx_dA, .0001)
-        assert_rel_error(self, J['lin.x', 'p2.b'], dx_db, .0001)
+        assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
+        assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
         data = prob.check_partials(out_stream=None)
 
@@ -337,7 +337,7 @@ class TestLinearSystemComp(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['lin.x'], np.array([0.36423841, -0.00662252, -0.4205298 ]), .0001)
+        assert_near_equal(prob['lin.x'], np.array([0.36423841, -0.00662252, -0.4205298 ]), .0001)
 
     def test_feature_vectorized(self):
         import numpy as np
@@ -365,7 +365,7 @@ class TestLinearSystemComp(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['lin.x'], np.array([[ 0.10596026, -0.16556291,  0.48675497],
+        assert_near_equal(prob['lin.x'], np.array([[ 0.10596026, -0.16556291,  0.48675497],
                                                         [ 0.19205298, -0.11258278, -0.14900662]]),
                          .0001)
 
@@ -396,7 +396,7 @@ class TestLinearSystemComp(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['lin.x'], np.array([[-0.78807947,  0.66887417,  0.47350993],
+        assert_near_equal(prob['lin.x'], np.array([[-0.78807947,  0.66887417,  0.47350993],
                                                         [ 0.7       , -1.8       ,  0.75      ]]),
                          .0001)
 

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestMatrixVectorProductComp3x3(unittest.TestCase):
@@ -137,7 +137,7 @@ class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
         b_i = self.p['mat_vec_product_comp.b']
 
         expected = np.dot(np.reshape(A_i, (3, 3)), np.reshape(x_i, (3,)))
-        assert_rel_error(self, b_i, expected)
+        assert_near_equal(b_i, expected)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -145,7 +145,7 @@ class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
-                assert_rel_error(self,
+                assert_near_equal(
                                  actual=cpd[comp][var, wrt]['J_fwd'],
                                  desired=cpd[comp][var, wrt]['J_fd'])
 
@@ -206,7 +206,7 @@ class TestFeature(unittest.TestCase):
     def test(self):
         import numpy as np
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         nn = 100
 
@@ -239,7 +239,7 @@ class TestFeature(unittest.TestCase):
             x_i = p['x'][i, :]
 
             expected_i = np.dot(A_i, x_i) * 3.2808399
-            assert_rel_error(self,
+            assert_near_equal(
                              p.get_val('mat_vec_product_comp.y', units='ft')[i, :],
                              expected_i,
                              tolerance=1.0E-8)

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -7,7 +7,7 @@ import numpy as np
 from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_partials
 
 scipy_gte_019 = True
 try:
@@ -424,8 +424,8 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         f, g = self.prob['comp.f'], self.prob['comp.g']
 
         tol = 1e-6
-        assert_rel_error(self, f, -0.05624571, tol)
-        assert_rel_error(self, g, 1.02068754, tol)
+        assert_near_equal(f, -0.05624571, tol)
+        assert_near_equal(g, 1.02068754, tol)
 
     def test_deriv1_swap(self):
         # Bugfix test that we can add outputs before inputs.
@@ -562,8 +562,8 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         val1 = np.array([-32.62094041, -31.67449135, -27.46959668])
 
         tol = 1e-5
-        assert_rel_error(self, prob['f'], val0, tol)
-        assert_rel_error(self, prob['g'], val1, tol)
+        assert_near_equal(prob['f'], val0, tol)
+        assert_near_equal(prob['g'], val1, tol)
         self.run_and_check_derivs(prob)
 
     def test_training_gradient_setup_called_twice(self):
@@ -604,8 +604,8 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         val1 = np.array([-32.62094041, -31.67449135, -27.46959668])
 
         tol = 1e-5
-        assert_rel_error(self, prob['f'], val0, tol)
-        assert_rel_error(self, prob['g'], val1, tol)
+        assert_near_equal(prob['f'], val0, tol)
+        assert_near_equal(prob['g'], val1, tol)
         self.run_and_check_derivs(prob)
 
         # Setup and run again
@@ -616,8 +616,8 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         val1 = np.array([-32.62094041, -31.67449135, -27.46959668])
 
         tol = 1e-5
-        assert_rel_error(self, prob['f'], val0, tol)
-        assert_rel_error(self, prob['g'], val1, tol)
+        assert_near_equal(prob['f'], val0, tol)
+        assert_near_equal(prob['g'], val1, tol)
         self.run_and_check_derivs(prob)
 
     def run_and_check_derivs(self, prob, tol=1e-5, verbose=False):
@@ -724,8 +724,8 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         f, g = self.prob['comp.f'], self.prob['comp.g']
 
         tol = 1e-6
-        assert_rel_error(self, f, -0.05624571, tol)
-        assert_rel_error(self, g, 1.02068754, tol)
+        assert_near_equal(f, -0.05624571, tol)
+        assert_near_equal(g, 1.02068754, tol)
 
     def test_deriv1_swap(self):
         # Bugfix test that we can add outputs before inputs.

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -9,7 +9,7 @@ from io import StringIO
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.logger_utils import TestLogger
 
 
@@ -62,7 +62,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
 
     def test_error_no_surrogate(self):
         # Seems like the error message from above should also be present and readable even if the
@@ -125,7 +125,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
 
     def test_sin_metamodel_rmse(self):
         # create MetaModelUnStructuredComp with Kriging, using the rmse option
@@ -148,7 +148,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], np.sin(2.1), 1e-4) # mean
+        assert_near_equal(prob['sin_mm.f_x'], np.sin(2.1), 1e-4) # mean
         self.assertTrue(self, sin_mm._metadata('f_x')['rmse'] < 1e-5) # std deviation
 
     def test_basics(self):
@@ -188,8 +188,8 @@ class MetaModelTestCase(unittest.TestCase):
         self.assertTrue(mm.train)   # training will occur before 1st run
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y1'], 2.0, .00001)
-        assert_rel_error(self, prob['mm.y2'], 4.0, .00001)
+        assert_near_equal(prob['mm.y1'], 2.0, .00001)
+        assert_near_equal(prob['mm.y2'], 4.0, .00001)
 
         # run problem for interpolated data point and check prediction
         prob['mm.x1'] = 2.5
@@ -198,7 +198,7 @@ class MetaModelTestCase(unittest.TestCase):
         self.assertFalse(mm.train)  # training will not occur before 2nd run
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y1'], 1.5934, .001)
+        assert_near_equal(prob['mm.y1'], 1.5934, .001)
 
         # change default surrogate, re-setup and check that metamodel re-trains
         mm.options['default_surrogate'] = om.KrigingSurrogate()
@@ -234,8 +234,8 @@ class MetaModelTestCase(unittest.TestCase):
         prob['mm.x'] = [1.0, 2.0, 1.0, 1.0]
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y1'], 1.0, .00001)
-        assert_rel_error(self, prob['mm.y2'], 7.0, .00001)
+        assert_near_equal(prob['mm.y1'], 1.0, .00001)
+        assert_near_equal(prob['mm.y2'], 7.0, .00001)
 
     def test_array_inputs(self):
         mm = om.MetaModelUnStructuredComp()
@@ -262,8 +262,8 @@ class MetaModelTestCase(unittest.TestCase):
         prob['mm.x'] = [[1.0, 2.0], [1.0, 1.0]]
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y1'], 1.0, .00001)
-        assert_rel_error(self, prob['mm.y2'], 7.0, .00001)
+        assert_near_equal(prob['mm.y1'], 1.0, .00001)
+        assert_near_equal(prob['mm.y2'], 7.0, .00001)
 
     def test_array_outputs(self):
         mm = om.MetaModelUnStructuredComp()
@@ -295,7 +295,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob['mm.x'] = [[1.0, 2.0], [1.0, 1.0]]
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y'], np.array([1.0, 7.0]), .00001)
+        assert_near_equal(prob['mm.y'], np.array([1.0, 7.0]), .00001)
 
     def test_2darray_outputs(self):
         mm = om.MetaModelUnStructuredComp()
@@ -327,7 +327,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob['mm.x'] = [[1.0, 2.0], [1.0, 1.0]]
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y'], np.array([[1.0, 7.0], [1.0, 7.0]]), .00001)
+        assert_near_equal(prob['mm.y'], np.array([[1.0, 7.0], [1.0, 7.0]]), .00001)
 
     def test_unequal_training_inputs(self):
         mm = om.MetaModelUnStructuredComp()
@@ -409,8 +409,8 @@ class MetaModelTestCase(unittest.TestCase):
         Jf = data['mm'][('f', 'x')]['J_fwd']
         Jr = data['mm'][('f', 'x')]['J_rev']
 
-        assert_rel_error(self, Jf[0][0], -1., 1.e-3)
-        assert_rel_error(self, Jr[0][0], -1., 1.e-3)
+        assert_near_equal(Jf[0][0], -1., 1.e-3)
+        assert_near_equal(Jr[0][0], -1., 1.e-3)
 
         abs_errors = data['mm'][('f', 'x')]['abs error']
         self.assertTrue(len(abs_errors) > 0)
@@ -457,8 +457,8 @@ class MetaModelTestCase(unittest.TestCase):
         prob['trig.x'] = 2.1
         prob.run_model()
 
-        assert_rel_error(self, prob['trig.sin_x'], .5*np.sin(prob['trig.x']), 1e-4)
-        assert_rel_error(self, prob['trig.cos_x'], .5*np.cos(prob['trig.x']), 1e-4)
+        assert_near_equal(prob['trig.sin_x'], .5*np.sin(prob['trig.x']), 1e-4)
+        assert_near_equal(prob['trig.cos_x'], .5*np.cos(prob['trig.x']), 1e-4)
 
     def test_metamodel_feature2d(self):
         # similar to previous example, but output is 2d
@@ -486,7 +486,7 @@ class MetaModelTestCase(unittest.TestCase):
         # train the surrogate and check predicted value
         prob['trig.x'] = 2.1
         prob.run_model()
-        assert_rel_error(self, prob['trig.y'],
+        assert_near_equal(prob['trig.y'],
                          np.append(
                              .5*np.sin(prob['trig.x']),
                              .5*np.cos(prob['trig.x'])
@@ -513,7 +513,7 @@ class MetaModelTestCase(unittest.TestCase):
         # train the surrogate and check predicted value
         prob['trig.x'] = np.array([2.1, 3.2, 4.3])
         prob.run_model()
-        assert_rel_error(self, prob['trig.y'],
+        assert_near_equal(prob['trig.y'],
                          np.array(.5*np.sin(prob['trig.x'])),
                          1e-4)
 
@@ -547,7 +547,7 @@ class MetaModelTestCase(unittest.TestCase):
         # train the surrogate and check predicted value
         prob['trig.x'] = np.array([2.1, 3.2, 4.3])
         prob.run_model()
-        assert_rel_error(self, prob['trig.y'],
+        assert_near_equal(prob['trig.y'],
                          np.array(.5*np.sin(prob['trig.x'])),
                          1e-4)
         self.assertEqual(len(prob.model.trig._metadata('y')['rmse']), 3)
@@ -656,7 +656,7 @@ class MetaModelTestCase(unittest.TestCase):
         # train the surrogate and check predicted value
         prob['trig.x'] = np.array([2.1, 3.2, 4.3])
         prob.run_model()
-        assert_rel_error(self, prob['trig.y'],
+        assert_near_equal(prob['trig.y'],
                          np.array(.5*np.sin(prob['trig.x'])),
                          1e-4)
 
@@ -688,7 +688,7 @@ class MetaModelTestCase(unittest.TestCase):
         # train the surrogate and check predicted value
         prob['trig.x'] = np.array([2.1, 3.2, 4.3])
         prob.run_model()
-        assert_rel_error(self, prob['trig.y'],
+        assert_near_equal(prob['trig.y'],
                          np.column_stack((
                              .5*np.sin(prob['trig.x']),
                              .5*np.cos(prob['trig.x'])
@@ -739,7 +739,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob.setup(check=True)
 
         self.assertEqual(prob['trig.x'], [5.])
-        assert_rel_error(self, prob['trig.sin_x'], [.0], 1e-6)
+        assert_near_equal(prob['trig.sin_x'], [.0], 1e-6)
 
     def test_metamodel_use_fd_if_no_surrogate_linearize(self):
         class SinSurrogate(om.SurrogateModel):
@@ -827,7 +827,7 @@ class MetaModelTestCase(unittest.TestCase):
 
         J = prob.compute_totals(of=['trig.sin_x'], wrt=['indep.x'])
         deriv_using_fd = J[('trig.sin_x', 'indep.x')]
-        assert_rel_error(self, deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
+        assert_near_equal(deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
 
         # Test with user explicitly setting fd inside of setup
         trig = TrigWithFdInSetup()
@@ -842,7 +842,7 @@ class MetaModelTestCase(unittest.TestCase):
             self.assertEqual(expected_fd_options[name], opts[name])
         J = prob.compute_totals(of=['trig.sin_x'], wrt=['indep.x'])
         deriv_using_fd = J[('trig.sin_x', 'indep.x')]
-        assert_rel_error(self, deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
+        assert_near_equal(deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
 
         # Test with user explicitly setting fd inside of configure for a group
         trig = TrigWithFdInConfigure()
@@ -857,7 +857,7 @@ class MetaModelTestCase(unittest.TestCase):
             self.assertEqual(expected_fd_options[name], opts[name])
         J = prob.compute_totals(of=['trig.sin_x'], wrt=['indep.x'])
         deriv_using_fd = J[('trig.sin_x', 'indep.x')]
-        assert_rel_error(self, deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
+        assert_near_equal(deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
 
         # Test with user explicitly setting cs inside of setup. Should throw an error
         prob = om.Problem()
@@ -941,7 +941,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob.run_model()
         J = prob.compute_totals(of=['trig.sin_x'], wrt=['indep.x'])
         deriv_using_fd = J[('trig.sin_x', 'indep.x')]
-        assert_rel_error(self, deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
+        assert_near_equal(deriv_using_fd[0], np.cos(prob['indep.x']), 1e-4)
 
     def test_metamodel_setup_called_twice_bug(self):
         class Trig(om.MetaModelUnStructuredComp):
@@ -982,7 +982,7 @@ class MetaModelTestCase(unittest.TestCase):
         # Second time.
         deriv_second_time = J[('trig.sin_x', 'indep.x')]
 
-        assert_rel_error(self, deriv_first_time, deriv_second_time, 1e-4)
+        assert_near_equal(deriv_first_time, deriv_second_time, 1e-4)
 
     def test_metamodel_setup_called_twice_bug_called_outside_setup(self):
         class Trig(om.MetaModelUnStructuredComp):
@@ -1027,7 +1027,7 @@ class MetaModelTestCase(unittest.TestCase):
         # Second time.
         deriv_second_time = J[('trig.sin_x', 'indep.x')]
 
-        assert_rel_error(self, deriv_first_time, deriv_second_time, 1e-4)
+        assert_near_equal(deriv_first_time, deriv_second_time, 1e-4)
 
     def test_warning_bug(self):
         # Make sure we don't warn that we are doing FD when the surrogate has analytic derivs.
@@ -1134,7 +1134,7 @@ class MetaModelUnstructuredSurrogatesFeatureTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
 
     def test_nearest_neighbor(self):
         import numpy as np
@@ -1163,7 +1163,7 @@ class MetaModelUnstructuredSurrogatesFeatureTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 2e-3)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 2e-3)
 
     def test_response_surface(self):
         import numpy as np
@@ -1192,7 +1192,7 @@ class MetaModelUnstructuredSurrogatesFeatureTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 2e-3)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 2e-3)
 
     def test_kriging_options_eval_rmse(self):
         import numpy as np
@@ -1222,9 +1222,9 @@ class MetaModelUnstructuredSurrogatesFeatureTestCase(unittest.TestCase):
         prob.run_model()
 
         print("mean")
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 1e-4)
         print("std")
-        assert_rel_error(self, sin_mm._metadata('f_x')['rmse'][0, 0], 0.0, 1e-4)
+        assert_near_equal(sin_mm._metadata('f_x')['rmse'][0, 0], 0.0, 1e-4)
 
     def test_nearest_neighbor_rbf_options(self):
         import numpy as np
@@ -1253,7 +1253,7 @@ class MetaModelUnstructuredSurrogatesFeatureTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 5e-3)
+        assert_near_equal(prob['sin_mm.f_x'], .5*np.sin(prob['sin_mm.x']), 5e-3)
 
 
 if __name__ == "__main__":

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 class MockSurrogate(om.MultiFiSurrogateModel):
@@ -315,12 +315,12 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
         prob['mm.x'] = np.array([[2./3., 1./3.]])
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y'], 26.26, tolerance=0.02)
+        assert_near_equal(prob['mm.y'], 26.26, tolerance=0.02)
 
         prob['mm.x'] = np.array([[1./3., 2./3.]])
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y'], 36.1031735, tolerance=0.02)
+        assert_near_equal(prob['mm.y'], 36.1031735, tolerance=0.02)
 
         # Now, vectorized model with both points predicted together.
 
@@ -342,7 +342,7 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
         prob['mm.x'] = np.array([[[2./3., 1./3.]], [[1./3., 2./3.]]])
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y'], [[26.26], [36.1031735]], tolerance=0.02)
+        assert_near_equal(prob['mm.y'], [[26.26], [36.1031735]], tolerance=0.02)
 
     def test_surrogate_message_format(self):
         mm = om.MultiFiMetaModelUnStructuredComp(nfi=2)
@@ -466,7 +466,7 @@ class MultiFiMetaModelFeatureTestCase(unittest.TestCase):
         prob['mm.x'] = np.array([[2./3., 1./3.]])
         prob.run_model()
 
-        assert_rel_error(self, prob['mm.y'], 26.26, tolerance=0.02)
+        assert_near_equal(prob['mm.y'], 26.26, tolerance=0.02)
 
 
 if __name__ == "__main__":

--- a/openmdao/components/tests/test_mux_comp.py
+++ b/openmdao/components/tests/test_mux_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 
 class TestMuxCompOptions(unittest.TestCase):
@@ -101,11 +101,11 @@ class TestMuxCompScalar(unittest.TestCase):
         for i in range(self.nn):
             out_i = self.p['mux_comp.a'][i]
             in_i = self.p['a_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
             out_i = self.p['mux_comp.b'][0, i]
             in_i = self.p['b_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -154,11 +154,11 @@ class TestMuxComp1D(unittest.TestCase):
         for i in range(self.nn):
             out_i = self.p['mux_comp.a'][i, ...]
             in_i = self.p['a_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
             out_i = self.p['mux_comp.b'][:, i]
             in_i = self.p['b_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -210,15 +210,15 @@ class TestMuxComp2D(unittest.TestCase):
         for i in range(self.nn):
             out_i = self.p['mux_comp.a'][i, ...]
             in_i = self.p['a_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
             out_i = self.p['mux_comp.b'][:, i, :]
             in_i = self.p['b_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
             out_i = self.p['mux_comp.c'][:, :, i]
             in_i = self.p['c_{0}'.format(i)]
-            assert_rel_error(self, in_i, out_i)
+            assert_near_equal(in_i, out_i)
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
@@ -235,7 +235,7 @@ class TestFeature(unittest.TestCase):
         import numpy as np
 
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         # The number of elements to be muxed
         n = 3
@@ -279,7 +279,7 @@ class TestFeature(unittest.TestCase):
         for i in range(n):
             r_i = [p['x'][i], p['y'][i], p['z'][i]]
             expected_i = np.sqrt(np.dot(r_i, r_i))
-            assert_rel_error(self, p.get_val('vec_mag_comp.r_mag')[i], expected_i)
+            assert_near_equal(p.get_val('vec_mag_comp.r_mag')[i], expected_i)
 
 
 if __name__ == '__main__':

--- a/openmdao/components/tests/test_spline_comp.py
+++ b/openmdao/components/tests/test_spline_comp.py
@@ -7,7 +7,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.components.spline_comp import SPLINE_METHODS
-from openmdao.utils.assert_utils import assert_check_partials, assert_rel_error
+from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.spline_distributions import cell_centered
 from openmdao.components.interp_util.interp import InterpND
@@ -106,7 +106,7 @@ class SplineCompTestCase(unittest.TestCase):
                             20.96983509, 21.37579297, 21.94811407, 22.66809748, 23.51629844,
                             24.47327219, 25.51957398, 26.63575905, 27.80238264, 29.        ]])
 
-        assert_rel_error(self, akima_y.flatten(), self.prob['akima1.y_val'].flatten(), tolerance=1e-8)
+        assert_near_equal(akima_y.flatten(), self.prob['akima1.y_val'].flatten(), tolerance=1e-8)
 
         derivs = self.prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(derivs, atol=1e-14, rtol=1e-14)
@@ -145,7 +145,7 @@ class SplineCompTestCase(unittest.TestCase):
                         6.        ,  6.73660714,  8.46428571, 10.45982143, 12.        ,
                         13.08035714, 14.        ]])
 
-        assert_rel_error(self, y.flatten(), self.prob['akima1.y_val'].flatten(), tolerance=1e-8)
+        assert_near_equal(y.flatten(), self.prob['akima1.y_val'].flatten(), tolerance=1e-8)
 
         derivs = self.prob.check_partials(out_stream=None, method='cs')
         assert_check_partials(derivs, atol=1e-14, rtol=1e-14)
@@ -257,18 +257,18 @@ class SplineCompTestCase(unittest.TestCase):
         xx = prob['interp.h']
 
         with printoptions(precision=3, floatmode='fixed'):
-            assert_rel_error(self, x[0, :], np.array([
+            assert_near_equal(x[0, :], np.array([
                 0., 0.38268343, 0.70710678, 0.92387953, 1.
             ]), 1e-5)
-            assert_rel_error(self, x[1, :], 2.0*np.array([
+            assert_near_equal(x[1, :], 2.0*np.array([
                 0., 0.38268343, 0.70710678, 0.92387953, 1.
             ]), 1e-5)
 
-            assert_rel_error(self, xx[0, :], np.array([
+            assert_near_equal(xx[0, :], np.array([
                 0., 0.06687281, 0.23486869, 0.43286622, 0.6062628,
                 0.74821484, 0.86228902, 0.94134389, 0.98587725, 1.
             ]), 1e-5)
-            assert_rel_error(self, xx[1, :], 2.0*np.array([
+            assert_near_equal(xx[1, :], 2.0*np.array([
                 0., 0.06687281, 0.23486869, 0.43286622, 0.6062628,
                 0.74821484, 0.86228902, 0.94134389, 0.98587725, 1.
             ]), 1e-5)
@@ -390,7 +390,7 @@ class SplineCompFeatureTestCase(unittest.TestCase):
                             20.96983509, 21.37579297, 21.94811407, 22.66809748, 23.51629844,
                             24.47327219, 25.51957398, 26.63575905, 27.80238264, 29.        ]])
 
-        assert_rel_error(self, akima_y.flatten(), prob['akima1.y_val'].flatten(), tolerance=1e-8)
+        assert_near_equal(akima_y.flatten(), prob['akima1.y_val'].flatten(), tolerance=1e-8)
 
     def test_multi_splines(self):
 
@@ -442,7 +442,7 @@ class SplineCompFeatureTestCase(unittest.TestCase):
                              17.96032258, 20.14140712, 22.31181718, 24.40891577, 26.27368825, 27.74068235,
                              28.67782484, 29.        ]])
 
-        assert_rel_error(self, akima_y.flatten(), prob['akima1.y_val'].flatten(), tolerance=1e-8)
+        assert_near_equal(akima_y.flatten(), prob['akima1.y_val'].flatten(), tolerance=1e-8)
 
     def test_akima_options(self):
         import numpy as np
@@ -525,7 +525,7 @@ class SplineCompFeatureTestCase(unittest.TestCase):
                         14.99875415, 16.        , 17.93874585, 21.        , 24.625    ,
                         29.        ]])
 
-        assert_rel_error(self, prob['comp1.chord'], y, 1e-6)
+        assert_near_equal(prob['comp1.chord'], y, 1e-6)
 
     def test_bsplines_2to3doc(self):
         from openmdao.utils.spline_distributions import sine_distribution
@@ -561,18 +561,18 @@ class SplineCompFeatureTestCase(unittest.TestCase):
         xx = prob['interp.h']
 
         with printoptions(precision=3, floatmode='fixed'):
-            assert_rel_error(self, x[0, :], np.array([
+            assert_near_equal(x[0, :], np.array([
                 0., 0.38268343, 0.70710678, 0.92387953, 1.
             ]), 1e-5)
-            assert_rel_error(self, x[1, :], 2.0*np.array([
+            assert_near_equal(x[1, :], 2.0*np.array([
                 0., 0.38268343, 0.70710678, 0.92387953, 1.
             ]), 1e-5)
 
-            assert_rel_error(self, xx[0, :], np.array([
+            assert_near_equal(xx[0, :], np.array([
                 0., 0.06687281, 0.23486869, 0.43286622, 0.6062628,
                 0.74821484, 0.86228902, 0.94134389, 0.98587725, 1.
             ]), 1e-5)
-            assert_rel_error(self, xx[1, :], 2.0*np.array([
+            assert_near_equal(xx[1, :], 2.0*np.array([
                 0., 0.06687281, 0.23486869, 0.43286622, 0.6062628,
                 0.74821484, 0.86228902, 0.94134389, 0.98587725, 1.
             ]), 1e-5)

--- a/openmdao/components/tests/test_vector_magnitude_comp.py
+++ b/openmdao/components/tests/test_vector_magnitude_comp.py
@@ -147,7 +147,7 @@ class TestFeature(unittest.TestCase):
         """
         import numpy as np
         import openmdao.api as om
-        from openmdao.utils.assert_utils import assert_rel_error
+        from openmdao.utils.assert_utils import assert_near_equal
 
         n = 100
 
@@ -177,7 +177,7 @@ class TestFeature(unittest.TestCase):
         for i in range(n):
             a_i = p['pos'][i, :]
             expected_i = np.sqrt(np.dot(a_i, a_i)) / 1000.0
-            assert_rel_error(self, p.get_val('vec_mag_comp.r_mag')[i], expected_i)
+            assert_near_equal(p.get_val('vec_mag_comp.r_mag')[i], expected_i)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_add_var.py
+++ b/openmdao/core/tests/test_add_var.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class CompAddWithDefault(om.ExplicitComponent):
@@ -101,16 +101,16 @@ class TestAddVar(unittest.TestCase):
         p = om.Problem(model=CompAddWithDefault())
         p.setup()
 
-        assert_rel_error(self, p['x_a'], 1.)
-        assert_rel_error(self, p['x_b'], 3.)
-        assert_rel_error(self, p['x_c'], 3. * np.ones(2))
-        assert_rel_error(self, p['x_d'], 3. * np.ones(2))
-        assert_rel_error(self, p['x_e'], 3. * np.ones((2, 2)))
-        assert_rel_error(self, p['y_a'], 1.)
-        assert_rel_error(self, p['y_b'], 6.)
-        assert_rel_error(self, p['y_c'], 6. * np.ones(3))
-        assert_rel_error(self, p['y_d'], 6. * np.ones(3))
-        assert_rel_error(self, p['y_e'], 6. * np.ones((3, 2)))
+        assert_near_equal(p['x_a'], 1.)
+        assert_near_equal(p['x_b'], 3.)
+        assert_near_equal(p['x_c'], 3. * np.ones(2))
+        assert_near_equal(p['x_d'], 3. * np.ones(2))
+        assert_near_equal(p['x_e'], 3. * np.ones((2, 2)))
+        assert_near_equal(p['y_a'], 1.)
+        assert_near_equal(p['y_b'], 6.)
+        assert_near_equal(p['y_c'], 6. * np.ones(3))
+        assert_near_equal(p['y_d'], 6. * np.ones(3))
+        assert_near_equal(p['y_e'], 6. * np.ones((3, 2)))
 
     def test_shape(self):
         """Test declaring only shape."""
@@ -120,12 +120,12 @@ class TestAddVar(unittest.TestCase):
         p = om.Problem(model=CompAddWithShape())
         p.setup()
 
-        assert_rel_error(self, p['x_a'], np.ones(2))
-        assert_rel_error(self, p['x_b'], np.ones((2, 2)))
-        assert_rel_error(self, p['x_c'], np.ones((2, 2)))
-        assert_rel_error(self, p['y_a'], np.ones(3))
-        assert_rel_error(self, p['y_b'], np.ones((3, 3)))
-        assert_rel_error(self, p['y_c'], np.ones((3, 3)))
+        assert_near_equal(p['x_a'], np.ones(2))
+        assert_near_equal(p['x_b'], np.ones((2, 2)))
+        assert_near_equal(p['x_c'], np.ones((2, 2)))
+        assert_near_equal(p['y_a'], np.ones(3))
+        assert_near_equal(p['y_b'], np.ones((3, 3)))
+        assert_near_equal(p['y_c'], np.ones((3, 3)))
 
     def test_indices(self):
         """Test declaring only indices."""
@@ -135,21 +135,21 @@ class TestAddVar(unittest.TestCase):
         p = om.Problem(model=CompAddWithIndices())
         p.setup()
 
-        assert_rel_error(self, p['x_a'], 1.)
-        assert_rel_error(self, p['x_b'], np.ones(2))
-        assert_rel_error(self, p['x_c'], np.ones(2))
-        assert_rel_error(self, p['x_d'], np.ones(6))
-        assert_rel_error(self, p['x_e'], np.ones((3,2)))
+        assert_near_equal(p['x_a'], 1.)
+        assert_near_equal(p['x_b'], np.ones(2))
+        assert_near_equal(p['x_c'], np.ones(2))
+        assert_near_equal(p['x_d'], np.ones(6))
+        assert_near_equal(p['x_e'], np.ones((3,2)))
 
     def test_shape_and_indices(self):
         """Test declaring shape and indices."""
         p = om.Problem(model=CompAddWithShapeAndIndices())
         p.setup()
 
-        assert_rel_error(self, p['x_a'], np.ones(2))
-        assert_rel_error(self, p['x_b'], np.ones(2))
-        assert_rel_error(self, p['x_c'], np.ones((2,2)))
-        assert_rel_error(self, p['x_d'], np.ones((2,2)))
+        assert_near_equal(p['x_a'], np.ones(2))
+        assert_near_equal(p['x_b'], np.ones(2))
+        assert_near_equal(p['x_c'], np.ones((2,2)))
+        assert_near_equal(p['x_d'], np.ones((2,2)))
 
     def test_scalar_array(self):
         """Test declaring a scalar val with an array variable."""
@@ -159,12 +159,12 @@ class TestAddVar(unittest.TestCase):
         p = om.Problem(model=CompAddArrayWithScalar())
         p.setup()
 
-        assert_rel_error(self, p['x_a'], 2. * np.ones(6))
-        assert_rel_error(self, p['x_b'], 2. * np.ones((3, 2)))
-        assert_rel_error(self, p['x_c'], 2. * np.ones(6))
-        assert_rel_error(self, p['x_d'], 2. * np.ones((3, 2)))
-        assert_rel_error(self, p['y_a'], 3. * np.ones(6))
-        assert_rel_error(self, p['y_b'], 3. * np.ones((3, 2)))
+        assert_near_equal(p['x_a'], 2. * np.ones(6))
+        assert_near_equal(p['x_b'], 2. * np.ones((3, 2)))
+        assert_near_equal(p['x_c'], 2. * np.ones(6))
+        assert_near_equal(p['x_d'], 2. * np.ones((3, 2)))
+        assert_near_equal(p['y_a'], 3. * np.ones(6))
+        assert_near_equal(p['y_b'], 3. * np.ones((3, 2)))
 
     def test_array_indices(self):
         """Test declaring with array val and array indices."""
@@ -174,8 +174,8 @@ class TestAddVar(unittest.TestCase):
         p = om.Problem(model=CompAddWithArrayIndices())
         p.setup()
 
-        assert_rel_error(self, p['x_a'], 2. * np.ones(6))
-        assert_rel_error(self, p['x_b'], 2. * np.ones((3, 2)))
+        assert_near_equal(p['x_a'], 2. * np.ones(6))
+        assert_near_equal(p['x_b'], 2. * np.ones((3, 2)))
 
     def test_bounds(self):
         """Test declaring bounds."""
@@ -185,11 +185,11 @@ class TestAddVar(unittest.TestCase):
         p = om.Problem(model=CompAddWithBounds())
         p.setup()
 
-        assert_rel_error(self, p['y_a'], 2.)
-        assert_rel_error(self, p['y_b'], 2.)
-        assert_rel_error(self, p['y_c'], 2. * np.ones(6))
-        assert_rel_error(self, p['y_d'], 2. * np.ones(6))
-        assert_rel_error(self, p['y_e'], 2. * np.ones((3, 2)))
+        assert_near_equal(p['y_a'], 2.)
+        assert_near_equal(p['y_b'], 2.)
+        assert_near_equal(p['y_c'], 2. * np.ones(6))
+        assert_near_equal(p['y_d'], 2. * np.ones(6))
+        assert_near_equal(p['y_e'], 2. * np.ones((3, 2)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -18,7 +18,7 @@ from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompC, TgtCompF, TgtCompK
 from openmdao.test_suite.groups.parallel_groups import FanInSubbedIDVC
 from openmdao.test_suite.parametric_suite import parametric_suite
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.mpi import MPI
 
@@ -57,8 +57,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
         self.assertEqual(len(model._approx_schemes['fd']._exec_dict), 2)
@@ -174,12 +174,12 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         Jfd = sub._jacobian
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.comp.x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.comp.y'], [[8.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.comp.x'], [[-6.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.comp.y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
         self.assertEqual(len(sub._approx_schemes['fd']._exec_dict), 2)
@@ -208,12 +208,12 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         Jfd = sub._jacobian
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.comp.x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.comp.y'], [[8.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.comp.x'], [[-6.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.comp.y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
         self.assertEqual(len(sub._approx_schemes['fd']._exec_dict), 2)
@@ -244,12 +244,12 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['p1.x', 'p2.y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['sub.comp.f_xy', 'p1.x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['sub.comp.f_xy', 'p2.y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['sub.comp.f_xy', 'p1.x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['sub.comp.f_xy', 'p2.y'], [[8.0]], 1e-6)
 
         Jfd = sub._jacobian
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.bx.xin'], [[-6.0]], 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.by.yin'], [[8.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.bx.xin'], [[-6.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.by.yin'], [[8.0]], 1e-6)
 
         # 3 outputs x 2 inputs
         n_entries = 0
@@ -284,10 +284,10 @@ class TestGroupFiniteDifference(unittest.TestCase):
         model.run_linearize()
 
         Jfd = model._jacobian
-        assert_rel_error(self, Jfd['comp.y1', 'p1.x1'], comp.JJ[0:2, 0:2], 1e-6)
-        assert_rel_error(self, Jfd['comp.y1', 'p2.x2'], comp.JJ[0:2, 2:4], 1e-6)
-        assert_rel_error(self, Jfd['comp.y2', 'p1.x1'], comp.JJ[2:4, 0:2], 1e-6)
-        assert_rel_error(self, Jfd['comp.y2', 'p2.x2'], comp.JJ[2:4, 2:4], 1e-6)
+        assert_near_equal(Jfd['comp.y1', 'p1.x1'], comp.JJ[0:2, 0:2], 1e-6)
+        assert_near_equal(Jfd['comp.y1', 'p2.x2'], comp.JJ[0:2, 2:4], 1e-6)
+        assert_near_equal(Jfd['comp.y2', 'p1.x1'], comp.JJ[2:4, 0:2], 1e-6)
+        assert_near_equal(Jfd['comp.y2', 'p2.x2'], comp.JJ[2:4, 2:4], 1e-6)
 
     def test_implicit_component_fd(self):
         # Somehow this wasn't tested in the original fd tests (which are mostly feature tests.)
@@ -313,8 +313,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         model.run_linearize()
 
         Jfd = comp._jacobian
-        assert_rel_error(self, Jfd['sub.comp.x', 'sub.comp.rhs'], -np.eye(2), 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.x', 'sub.comp.x'], comp.mtx, 1e-6)
+        assert_near_equal(Jfd['sub.comp.x', 'sub.comp.rhs'], -np.eye(2), 1e-6)
+        assert_near_equal(Jfd['sub.comp.x', 'sub.comp.x'], comp.mtx, 1e-6)
 
     def test_around_newton(self):
         # For a group that is set to FD that has a Newton solver, make sure it doesn't
@@ -339,7 +339,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.setup()
         prob.run_model()
         model.approx_totals()
-        assert_rel_error(self, prob['comp.x'], [1.97959184, 4.02040816], 1e-5)
+        assert_near_equal(prob['comp.x'], [1.97959184, 4.02040816], 1e-5)
 
         model.run_linearize()
 
@@ -347,7 +347,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['p_rhs.rhs']
         Jfd = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, Jfd['comp.x', 'p_rhs.rhs'],
+        assert_near_equal(Jfd['comp.x', 'p_rhs.rhs'],
                          [[1.01020408, -0.01020408], [-0.01020408, 1.01020408]], 1e-5)
 
     def test_step_size(self):
@@ -371,8 +371,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-5.99]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.01]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-5.99]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.01]], 1e-6)
 
     def test_unit_conv_group(self):
 
@@ -396,27 +396,27 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['sub1.src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['sub1.src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtK.x3'], 373.15, 1e-6)
 
         wrt = ['x1']
         of = ['sub2.tgtF.x3', 'sub2.tgtC.x3', 'sub2.tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
     def test_sellar(self):
         # Basic sellar test.
@@ -445,15 +445,15 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z']
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_desvar_with_indices(self):
         # Just desvars on this one to cover code missed by desvar+response test.
@@ -511,10 +511,10 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['x1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][2][0], Jbase[2, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][2][1], Jbase[2, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][2][0], Jbase[2, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][2][1], Jbase[2, 3], 1e-8)
 
     def test_desvar_and_response_with_indices(self):
 
@@ -570,10 +570,10 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['x1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][1][0], Jbase[2, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][1][0], Jbase[2, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
 
     def test_full_model_fd(self):
 
@@ -611,7 +611,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         wrt = ['p1.x']
         derivs = prob.driver._compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, derivs['comp.y']['p1.x'], [[4.0]], 1e-6)
+        assert_near_equal(derivs['comp.y']['p1.x'], [[4.0]], 1e-6)
 
     def test_newton_with_densejac_under_full_model_fd(self):
         # Basic sellar test.
@@ -643,15 +643,15 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z']
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_newton_with_cscjac_under_full_model_fd(self):
         # Basic sellar test.
@@ -682,15 +682,15 @@ class TestGroupFiniteDifference(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z']
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_approx_totals_multi_input_constrained_desvar(self):
         p = om.Problem()
@@ -730,11 +730,11 @@ class TestGroupFiniteDifference(unittest.TestCase):
         p.run_model()
         # Formerly a KeyError
         derivs = p.check_totals(compact_print=True, out_stream=None)
-        assert_rel_error(self, 0.0, derivs['indeps.y', 'indeps.x']['abs error'][0])
+        assert_near_equal(0.0, derivs['indeps.y', 'indeps.x']['abs error'][0])
 
         # Coverage
         derivs = p.driver._compute_totals(return_format='dict')
-        assert_rel_error(self, np.zeros((1, 10)), derivs['indeps.y']['indeps.x'])
+        assert_near_equal(np.zeros((1, 10)), derivs['indeps.y']['indeps.x'])
 
     def test_opt_with_linear_constraint(self):
         # Test for a bug where we weren't re-initializing things in-between computing totals on
@@ -808,7 +808,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
 
         p.run_driver()
 
-        assert_rel_error(self, p['circle.area'], np.pi, 1e-6)
+        assert_near_equal(p['circle.area'], np.pi, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -826,8 +826,8 @@ class TestGroupFiniteDifferenceMPI(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(wrt=['sub.sub1.p1.x', 'sub.sub2.p2.x'], of=['sum.y'])
-        assert_rel_error(self, J['sum.y', 'sub.sub1.p1.x'], [[2.0]], 1.0e-6)
-        assert_rel_error(self, J['sum.y', 'sub.sub2.p2.x'], [[4.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub1.p1.x'], [[2.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub2.p2.x'], [[4.0]], 1.0e-6)
 
 
 @unittest.skipUnless(MPI and  PETScVector, "MPI and PETSc are required.")
@@ -845,8 +845,8 @@ class TestGroupCSMPI(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(wrt=['sub.sub1.p1.x', 'sub.sub2.p2.x'], of=['sum.y'])
-        assert_rel_error(self, J['sum.y', 'sub.sub1.p1.x'], [[2.0]], 1.0e-6)
-        assert_rel_error(self, J['sum.y', 'sub.sub2.p2.x'], [[4.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub1.p1.x'], [[2.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub2.p2.x'], [[4.0]], 1.0e-6)
 
 
 @unittest.skipUnless(MPI and  PETScVector, "MPI and PETSc are required.")
@@ -864,8 +864,8 @@ class TestGroupFDMPI(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(wrt=['sub.sub1.p1.x', 'sub.sub2.p2.x'], of=['sum.y'])
-        assert_rel_error(self, J['sum.y', 'sub.sub1.p1.x'], [[2.0]], 1.0e-6)
-        assert_rel_error(self, J['sum.y', 'sub.sub2.p2.x'], [[4.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub1.p1.x'], [[2.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub2.p2.x'], [[4.0]], 1.0e-6)
 
 
 def title(txt):
@@ -911,8 +911,8 @@ class TestGroupComplexStep(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
         self.assertEqual(len(model._approx_schemes['cs']._exec_dict), 2)
@@ -943,12 +943,12 @@ class TestGroupComplexStep(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         Jfd = sub._jacobian
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.comp.x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.comp.y'], [[8.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.comp.x'], [[-6.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.comp.y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
         self.assertEqual(len(sub._approx_schemes['cs']._exec_dict), 2)
@@ -986,12 +986,12 @@ class TestGroupComplexStep(unittest.TestCase):
         wrt = ['p1.x', 'p2.y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['sub.comp.f_xy', 'p1.x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['sub.comp.f_xy', 'p2.y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['sub.comp.f_xy', 'p1.x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['sub.comp.f_xy', 'p2.y'], [[8.0]], 1e-6)
 
         Jfd = sub._jacobian
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.bx.xin'], [[-6.0]], 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.f_xy', 'sub.by.yin'], [[8.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.bx.xin'], [[-6.0]], 1e-6)
+        assert_near_equal(Jfd['sub.comp.f_xy', 'sub.by.yin'], [[8.0]], 1e-6)
 
         # 3 outputs x 2 inputs
         n_entries = 0
@@ -1032,10 +1032,10 @@ class TestGroupComplexStep(unittest.TestCase):
         model.run_linearize()
 
         Jfd = model._jacobian
-        assert_rel_error(self, Jfd['comp.y1', 'p1.x1'], comp.JJ[0:2, 0:2], 1e-6)
-        assert_rel_error(self, Jfd['comp.y1', 'p2.x2'], comp.JJ[0:2, 2:4], 1e-6)
-        assert_rel_error(self, Jfd['comp.y2', 'p1.x1'], comp.JJ[2:4, 0:2], 1e-6)
-        assert_rel_error(self, Jfd['comp.y2', 'p2.x2'], comp.JJ[2:4, 2:4], 1e-6)
+        assert_near_equal(Jfd['comp.y1', 'p1.x1'], comp.JJ[0:2, 0:2], 1e-6)
+        assert_near_equal(Jfd['comp.y1', 'p2.x2'], comp.JJ[0:2, 2:4], 1e-6)
+        assert_near_equal(Jfd['comp.y2', 'p1.x1'], comp.JJ[2:4, 0:2], 1e-6)
+        assert_near_equal(Jfd['comp.y2', 'p2.x2'], comp.JJ[2:4, 2:4], 1e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1065,27 +1065,27 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.setup(check=False, local_vector_class=vec_class)
         prob.run_model()
 
-        assert_rel_error(self, prob['sub1.src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['sub1.src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtK.x3'], 373.15, 1e-6)
 
         wrt = ['x1']
         of = ['sub2.tgtF.x3', 'sub2.tgtC.x3', 'sub2.tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev', local_vector_class=vec_class)
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1122,15 +1122,15 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z']
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
         self.assertFalse(model._vectors['output']['linear']._alloc_complex,
                          msg="Linear vector should not be allocated as complex.")
@@ -1189,10 +1189,10 @@ class TestGroupComplexStep(unittest.TestCase):
         wrt = ['x1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][1][0], Jbase[2, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][1][0], Jbase[2, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
 
     def test_desvar_with_indices(self):
         # Just desvars on this one to cover code missed by desvar+response test.
@@ -1249,10 +1249,10 @@ class TestGroupComplexStep(unittest.TestCase):
         wrt = ['x1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][2][0], Jbase[2, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][2][1], Jbase[2, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][2][0], Jbase[2, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][2][1], Jbase[2, 3], 1e-8)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1291,19 +1291,19 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z', 'x']
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1344,19 +1344,19 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z', 'x']
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1397,19 +1397,19 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z', 'x']
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1460,12 +1460,12 @@ class TestGroupComplexStep(unittest.TestCase):
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1516,12 +1516,12 @@ class TestGroupComplexStep(unittest.TestCase):
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1572,12 +1572,12 @@ class TestGroupComplexStep(unittest.TestCase):
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     @parameterized.expand(itertools.product([om.DefaultVector, PETScVector]),
                           name_func=lambda f, n, p:
@@ -1617,19 +1617,19 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z', 'x']
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     def test_newton_with_cscjac_under_cs(self):
         # Basic sellar test.
@@ -1662,19 +1662,19 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z', 'x']
         of = ['obj', 'con1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     def test_newton_with_fd_group(self):
         # Basic sellar test.
@@ -1713,19 +1713,19 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z', 'x']
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_rel_error(self, J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_rel_error(self, J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_rel_error(self, J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
     def test_nested_complex_step_unsupported(self):
         # Basic sellar test.
@@ -1754,16 +1754,16 @@ class TestGroupComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z']
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
         outs = prob.model.list_outputs(residuals=True, out_stream=None)
         for j in range(len(outs)):
@@ -1796,8 +1796,8 @@ class TestComponentComplexStep(unittest.TestCase):
         model.run_linearize()
 
         Jfd = comp._jacobian
-        assert_rel_error(self, Jfd['sub.comp.x', 'sub.comp.rhs'], -np.eye(2), 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.x', 'sub.comp.x'], comp.mtx, 1e-6)
+        assert_near_equal(Jfd['sub.comp.x', 'sub.comp.rhs'], -np.eye(2), 1e-6)
+        assert_near_equal(Jfd['sub.comp.x', 'sub.comp.x'], comp.mtx, 1e-6)
 
     def test_reconfigure(self):
         # In this test, we switch to 'cs' when we reconfigure.
@@ -1848,8 +1848,8 @@ class TestComponentComplexStep(unittest.TestCase):
 
         model.run_linearize()
         Jfd = comp._jacobian
-        assert_rel_error(self, Jfd['sub.comp.x', 'sub.comp.rhs'], -np.eye(2), 1e-6)
-        assert_rel_error(self, Jfd['sub.comp.x', 'sub.comp.x'], comp.mtx, 1e-6)
+        assert_near_equal(Jfd['sub.comp.x', 'sub.comp.rhs'], -np.eye(2), 1e-6)
+        assert_near_equal(Jfd['sub.comp.x', 'sub.comp.x'], comp.mtx, 1e-6)
 
     def test_vector_methods(self):
 
@@ -1889,10 +1889,10 @@ class TestComponentComplexStep(unittest.TestCase):
         wrt = ['px.x']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['comp.y1', 'px.x'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, derivs['comp.y1', 'px.x'][1][1], 3.0, 1e-6)
-        assert_rel_error(self, derivs['comp.y1', 'px.x'][2][2], 1.0, 1e-6)
-        assert_rel_error(self, derivs['comp.y1', 'px.x'][3][3], 1.0/2.34, 1e-6)
+        assert_near_equal(derivs['comp.y1', 'px.x'][0][0], 1.0, 1e-6)
+        assert_near_equal(derivs['comp.y1', 'px.x'][1][1], 3.0, 1e-6)
+        assert_near_equal(derivs['comp.y1', 'px.x'][2][2], 1.0, 1e-6)
+        assert_near_equal(derivs['comp.y1', 'px.x'][3][3], 1.0/2.34, 1e-6)
 
     def test_sellar_comp_cs(self):
         # Basic sellar test.
@@ -1920,15 +1920,15 @@ class TestComponentComplexStep(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['z']
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
         outs = prob.model.list_outputs(residuals=True, out_stream=None)
         for j in range(len(outs)):
@@ -2093,7 +2093,7 @@ class ApproxTotalsFeature(unittest.TestCase):
         wrt = ['x']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['z', 'x'], [[300.0]], 1e-6)
+        assert_near_equal(derivs['z', 'x'], [[300.0]], 1e-6)
         self.assertEqual(comp2._exec_count, 2)
 
     def test_basic_cs(self):
@@ -2141,7 +2141,7 @@ class ApproxTotalsFeature(unittest.TestCase):
         wrt = ['x']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['z', 'x'], [[300.0]], 1e-6)
+        assert_near_equal(derivs['z', 'x'], [[300.0]], 1e-6)
 
     def test_arguments(self):
         import numpy as np
@@ -2188,7 +2188,7 @@ class ApproxTotalsFeature(unittest.TestCase):
         wrt = ['x']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['z', 'x'], [[300.0]], 1e-6)
+        assert_near_equal(derivs['z', 'x'], [[300.0]], 1e-6)
 
     def test_sellarCS(self):
         # Just tests Newton on Sellar with FD derivs.
@@ -2201,8 +2201,8 @@ class ApproxTotalsFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -2231,17 +2231,17 @@ class ParallelFDParametricTestCase(unittest.TestCase):
         expected_values = model.expected_values
         if expected_values:
             actual = {key: problem[key] for key in expected_values}
-            assert_rel_error(self, actual, expected_values, 1e-4)
+            assert_near_equal(actual, expected_values, 1e-4)
 
         expected_totals = model.expected_totals
         if expected_totals:
             # Forward Derivatives Check
             totals = param_instance.compute_totals('fwd')
-            assert_rel_error(self, totals, expected_totals, 1e-4)
+            assert_near_equal(totals, expected_totals, 1e-4)
 
             # Reverse Derivatives Check
             totals = param_instance.compute_totals('rev')
-            assert_rel_error(self, totals, expected_totals, 1e-4)
+            assert_near_equal(totals, expected_totals, 1e-4)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -18,7 +18,7 @@ from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1w
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.components.array_comp import ArrayComp
 from openmdao.test_suite.groups.parallel_groups import FanInSubbedIDVC
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_partials
 from openmdao.utils.mpi import MPI
 
 try:
@@ -222,9 +222,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         # but we still get good derivative data for 'comp1'
         self.assertTrue('comp1' in data)
 
-        assert_rel_error(self, data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
-        assert_rel_error(self, data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
-        assert_rel_error(self, data['comp1'][('y', 'x')]['J_rev'][0][0], 2., 1e-15)
+        assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
+        assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
+        assert_near_equal(data['comp1'][('y', 'x')]['J_rev'][0][0], 2., 1e-15)
 
     def test_missing_entry(self):
         class MyComp(om.ExplicitComponent):
@@ -423,13 +423,13 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         data = p.check_partials(out_stream=None)
         identity = np.eye(4)
-        assert_rel_error(self, data['pt'][('bar', 'foo')]['J_fwd'], identity, 1e-15)
-        assert_rel_error(self, data['pt'][('bar', 'foo')]['J_rev'], identity, 1e-15)
-        assert_rel_error(self, data['pt'][('bar', 'foo')]['J_fd'], identity, 1e-9)
+        assert_near_equal(data['pt'][('bar', 'foo')]['J_fwd'], identity, 1e-15)
+        assert_near_equal(data['pt'][('bar', 'foo')]['J_rev'], identity, 1e-15)
+        assert_near_equal(data['pt'][('bar', 'foo')]['J_fd'], identity, 1e-9)
 
-        assert_rel_error(self, data['pt2'][('bar2', 'foo2')]['J_fwd'], identity, 1e-15)
-        assert_rel_error(self, data['pt2'][('bar2', 'foo2')]['J_rev'], identity, 1e-15)
-        assert_rel_error(self, data['pt2'][('bar2', 'foo2')]['J_fd'], identity, 1e-9)
+        assert_near_equal(data['pt2'][('bar2', 'foo2')]['J_fwd'], identity, 1e-15)
+        assert_near_equal(data['pt2'][('bar2', 'foo2')]['J_rev'], identity, 1e-15)
+        assert_near_equal(data['pt2'][('bar2', 'foo2')]['J_fd'], identity, 1e-9)
 
     def test_matrix_free_explicit(self):
         prob = om.Problem()
@@ -452,17 +452,17 @@ class TestProblemCheckPartials(unittest.TestCase):
             for partial_name, partial in comp.items():
                 abs_error = partial['abs error']
                 rel_error = partial['rel error']
-                assert_rel_error(self, abs_error.forward, 0., 1e-5)
-                assert_rel_error(self, abs_error.reverse, 0., 1e-5)
-                assert_rel_error(self, abs_error.forward_reverse, 0., 1e-5)
-                assert_rel_error(self, rel_error.forward, 0., 1e-5)
-                assert_rel_error(self, rel_error.reverse, 0., 1e-5)
-                assert_rel_error(self, rel_error.forward_reverse, 0., 1e-5)
+                assert_near_equal(abs_error.forward, 0., 1e-5)
+                assert_near_equal(abs_error.reverse, 0., 1e-5)
+                assert_near_equal(abs_error.forward_reverse, 0., 1e-5)
+                assert_near_equal(rel_error.forward, 0., 1e-5)
+                assert_near_equal(rel_error.reverse, 0., 1e-5)
+                assert_near_equal(rel_error.forward_reverse, 0., 1e-5)
 
-        assert_rel_error(self, data['comp'][('f_xy', 'x')]['J_fwd'][0][0], 5.0, 1e-6)
-        assert_rel_error(self, data['comp'][('f_xy', 'x')]['J_rev'][0][0], 5.0, 1e-6)
-        assert_rel_error(self, data['comp'][('f_xy', 'y')]['J_fwd'][0][0], 21.0, 1e-6)
-        assert_rel_error(self, data['comp'][('f_xy', 'y')]['J_rev'][0][0], 21.0, 1e-6)
+        assert_near_equal(data['comp'][('f_xy', 'x')]['J_fwd'][0][0], 5.0, 1e-6)
+        assert_near_equal(data['comp'][('f_xy', 'x')]['J_rev'][0][0], 5.0, 1e-6)
+        assert_near_equal(data['comp'][('f_xy', 'y')]['J_fwd'][0][0], 21.0, 1e-6)
+        assert_near_equal(data['comp'][('f_xy', 'y')]['J_rev'][0][0], 21.0, 1e-6)
 
     def test_matrix_free_implicit(self):
         prob = om.Problem()
@@ -483,12 +483,12 @@ class TestProblemCheckPartials(unittest.TestCase):
             for partial_name, partial in comp.items():
                 abs_error = partial['abs error']
                 rel_error = partial['rel error']
-                assert_rel_error(self, abs_error.forward, 0., 1e-5)
-                assert_rel_error(self, abs_error.reverse, 0., 1e-5)
-                assert_rel_error(self, abs_error.forward_reverse, 0., 1e-5)
-                assert_rel_error(self, rel_error.forward, 0., 1e-5)
-                assert_rel_error(self, rel_error.reverse, 0., 1e-5)
-                assert_rel_error(self, rel_error.forward_reverse, 0., 1e-5)
+                assert_near_equal(abs_error.forward, 0., 1e-5)
+                assert_near_equal(abs_error.reverse, 0., 1e-5)
+                assert_near_equal(abs_error.forward_reverse, 0., 1e-5)
+                assert_near_equal(rel_error.forward, 0., 1e-5)
+                assert_near_equal(rel_error.reverse, 0., 1e-5)
+                assert_near_equal(rel_error.forward_reverse, 0., 1e-5)
 
     def test_implicit_undeclared(self):
         # Test to see that check_partials works when state_wrt_input and state_wrt_state
@@ -531,10 +531,10 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         data = prob.check_partials(out_stream=None)
 
-        assert_rel_error(self, data['comp']['y', 'extra']['J_fwd'], np.zeros((2, 2)))
-        assert_rel_error(self, data['comp']['y', 'extra']['J_rev'], np.zeros((2, 2)))
-        assert_rel_error(self, data['comp']['y', 'dummy']['J_fwd'], np.zeros((2, 2)))
-        assert_rel_error(self, data['comp']['y', 'dummy']['J_rev'], np.zeros((2, 2)))
+        assert_near_equal(data['comp']['y', 'extra']['J_fwd'], np.zeros((2, 2)))
+        assert_near_equal(data['comp']['y', 'extra']['J_rev'], np.zeros((2, 2)))
+        assert_near_equal(data['comp']['y', 'dummy']['J_fwd'], np.zeros((2, 2)))
+        assert_near_equal(data['comp']['y', 'dummy']['J_rev'], np.zeros((2, 2)))
 
     def test_dependent_false_hide(self):
         # Test that we omit derivs declared with dependent=False
@@ -910,9 +910,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         data = prob.check_partials(out_stream=None)
 
         # Note 'aba' gets the better value from the second options call with the *a wildcard.
-        assert_rel_error(self, data['comp']['y', 'ab']['J_fd'][0][0], 507.3901, 1e-4)
-        assert_rel_error(self, data['comp']['y', 'aba']['J_fd'][0][0], 507.0039, 1e-4)
-        assert_rel_error(self, data['comp']['y', 'ba']['J_fd'][0][0], 507.0039, 1e-4)
+        assert_near_equal(data['comp']['y', 'ab']['J_fd'][0][0], 507.3901, 1e-4)
+        assert_near_equal(data['comp']['y', 'aba']['J_fd'][0][0], 507.0039, 1e-4)
+        assert_near_equal(data['comp']['y', 'ba']['J_fd'][0][0], 507.0039, 1e-4)
 
     def test_option_printing(self):
         # Make sure we print the approximation type for each variable.
@@ -1451,11 +1451,11 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # Comp1 and Comp3 are complex step, so have tighter tolerances.
         for key, val in data['comp1'].items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-15)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-15)
         for key, val in data['comp2'].items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-6)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
         for key, val in data['comp3'].items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-15)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-15)
 
     def test_rel_error_fd_zero(self):
         # When the fd turns out to be zero, test that we switch the definition of relative
@@ -1533,13 +1533,13 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
         x1_error = data['comp']['y', 'x1']['abs error']
 
-        assert_rel_error(self, x1_error.forward, 1., 1e-8)
-        assert_rel_error(self, x1_error.reverse, 1., 1e-8)
+        assert_near_equal(x1_error.forward, 1., 1e-8)
+        assert_near_equal(x1_error.reverse, 1., 1e-8)
 
         x2_error = data['comp']['y', 'x2']['rel error']
 
-        assert_rel_error(self, x2_error.forward, 9., 1e-8)
-        assert_rel_error(self, x2_error.reverse, 9., 1e-8)
+        assert_near_equal(x2_error.forward, 9., 1e-8)
+        assert_near_equal(x2_error.reverse, 9., 1e-8)
 
     def test_feature_check_partials_suppress(self):
         import numpy as np
@@ -1873,8 +1873,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertTrue('9.80614' in lines[5], "'9.80614' not found in '%s'" % lines[5])
         self.assertTrue('cs:None' in lines[5], "'cs:None not found in '%s'" % lines[5])
 
-        assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fwd'], [[0.09692762]], 1e-5)
-        assert_rel_error(self, totals['con_cmp2.con2', 'px.x']['J_fd'], [[0.09692762]], 1e-5)
+        assert_near_equal(totals['con_cmp2.con2', 'px.x']['J_fwd'], [[0.09692762]], 1e-5)
+        assert_near_equal(totals['con_cmp2.con2', 'px.x']['J_fd'], [[0.09692762]], 1e-5)
 
         # Test compact_print output
         compact_stream = StringIO()
@@ -1915,8 +1915,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertTrue('0.000' in lines[6])
         self.assertTrue('0.000' in lines[8])
 
-        assert_rel_error(self, totals['px.x', 'px.x']['J_fwd'], [[1.0]], 1e-5)
-        assert_rel_error(self, totals['px.x', 'px.x']['J_fd'], [[1.0]], 1e-5)
+        assert_near_equal(totals['px.x', 'px.x']['J_fwd'], [[1.0]], 1e-5)
+        assert_near_equal(totals['px.x', 'px.x']['J_fd'], [[1.0]], 1e-5)
 
     def test_desvar_and_response_with_indices(self):
 
@@ -1971,17 +1971,17 @@ class TestProblemCheckTotals(unittest.TestCase):
         wrt = ['x1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][1][0], Jbase[2, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][0], Jbase[0, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][1], Jbase[0, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][1][0], Jbase[2, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
 
         totals = prob.check_totals()
         jac = totals[('mycomp.y1', 'x_param1.x1')]['J_fd']
-        assert_rel_error(self, jac[0][0], Jbase[0, 1], 1e-8)
-        assert_rel_error(self, jac[0][1], Jbase[0, 3], 1e-8)
-        assert_rel_error(self, jac[1][0], Jbase[2, 1], 1e-8)
-        assert_rel_error(self, jac[1][1], Jbase[2, 3], 1e-8)
+        assert_near_equal(jac[0][0], Jbase[0, 1], 1e-8)
+        assert_near_equal(jac[0][1], Jbase[0, 3], 1e-8)
+        assert_near_equal(jac[1][0], Jbase[2, 1], 1e-8)
+        assert_near_equal(jac[1][1], Jbase[2, 3], 1e-8)
 
         # Objective instead
 
@@ -2004,13 +2004,13 @@ class TestProblemCheckTotals(unittest.TestCase):
         wrt = ['x1']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['y1', 'x1'][0][0], Jbase[1, 1], 1e-8)
-        assert_rel_error(self, J['y1', 'x1'][0][1], Jbase[1, 3], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][0], Jbase[1, 1], 1e-8)
+        assert_near_equal(J['y1', 'x1'][0][1], Jbase[1, 3], 1e-8)
 
         totals = prob.check_totals()
         jac = totals[('mycomp.y1', 'x_param1.x1')]['J_fd']
-        assert_rel_error(self, jac[0][0], Jbase[1, 1], 1e-8)
-        assert_rel_error(self, jac[0][1], Jbase[1, 3], 1e-8)
+        assert_near_equal(jac[0][0], Jbase[1, 1], 1e-8)
+        assert_near_equal(jac[0][1], Jbase[1, 3], 1e-8)
 
     def test_cs_suppress(self):
         prob = om.Problem()
@@ -2060,14 +2060,14 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
 
-        assert_rel_error(self, totals['px.x', 'px.x']['J_fwd'], [[1.0]], 1e-5)
-        assert_rel_error(self, totals['px.x', 'px.x']['J_fd'], [[1.0]], 1e-5)
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fwd'], np.eye(2), 1e-5)
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], np.eye(2), 1e-5)
-        assert_rel_error(self, totals['px.x', 'pz.z']['J_fwd'], [[0.0, 0.0]], 1e-5)
-        assert_rel_error(self, totals['px.x', 'pz.z']['J_fd'], [[0.0, 0.0]], 1e-5)
-        assert_rel_error(self, totals['pz.z', 'px.x']['J_fwd'], [[0.0], [0.0]], 1e-5)
-        assert_rel_error(self, totals['pz.z', 'px.x']['J_fd'], [[0.0], [0.0]], 1e-5)
+        assert_near_equal(totals['px.x', 'px.x']['J_fwd'], [[1.0]], 1e-5)
+        assert_near_equal(totals['px.x', 'px.x']['J_fd'], [[1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fwd'], np.eye(2), 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fd'], np.eye(2), 1e-5)
+        assert_near_equal(totals['px.x', 'pz.z']['J_fwd'], [[0.0, 0.0]], 1e-5)
+        assert_near_equal(totals['px.x', 'pz.z']['J_fd'], [[0.0, 0.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'px.x']['J_fwd'], [[0.0], [0.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'px.x']['J_fd'], [[0.0], [0.0]], 1e-5)
 
     def test_full_con_with_index_desvar(self):
         prob = om.Problem()
@@ -2087,8 +2087,8 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
 
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fwd'], [[0.0], [1.0]], 1e-5)
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], [[0.0], [1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fwd'], [[0.0], [1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fd'], [[0.0], [1.0]], 1e-5)
 
     def test_full_desvar_with_index_con(self):
         prob = om.Problem()
@@ -2108,8 +2108,8 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
 
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fwd'], [[0.0, 1.0]], 1e-5)
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], [[0.0, 1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fwd'], [[0.0, 1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fd'], [[0.0, 1.0]], 1e-5)
 
     def test_full_desvar_with_index_obj(self):
         prob = om.Problem()
@@ -2129,8 +2129,8 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
 
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fwd'], [[0.0, 1.0]], 1e-5)
-        assert_rel_error(self, totals['pz.z', 'pz.z']['J_fd'], [[0.0, 1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fwd'], [[0.0, 1.0]], 1e-5)
+        assert_near_equal(totals['pz.z', 'pz.z']['J_fd'], [[0.0, 1.0]], 1e-5)
 
     def test_bug_fd_with_sparse(self):
         # This bug was found via the x57 model in pointer.
@@ -2218,8 +2218,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         # Make sure we don't bomb out with an error.
         J = p.check_totals(out_stream=None)
 
-        assert_rel_error(self, J[('time.time', 'time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
-        assert_rel_error(self, J[('time.time', 'time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
+        assert_near_equal(J[('time.time', 'time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
+        assert_near_equal(J[('time.time', 'time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
 
         # Try again with a direct solver and sparse assembled hierarchy.
 
@@ -2237,14 +2237,14 @@ class TestProblemCheckTotals(unittest.TestCase):
         # Make sure we don't bomb out with an error.
         J = p.check_totals(out_stream=None)
 
-        assert_rel_error(self, J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
-        assert_rel_error(self, J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
+        assert_near_equal(J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
+        assert_near_equal(J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
 
         # Make sure check_totals cleans up after itself by running it a second time.
         J = p.check_totals(out_stream=None)
 
-        assert_rel_error(self, J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
-        assert_rel_error(self, J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
+        assert_near_equal(J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fwd'][0], 17.0, 1e-5)
+        assert_near_equal(J[('sub.time.time', 'sub.time_extents.t_duration')]['J_fd'][0], 17.0, 1e-5)
 
     def test_vector_scaled_derivs(self):
 
@@ -2279,10 +2279,10 @@ class TestProblemCheckTotals(unittest.TestCase):
         J[0, 1] *= oscale[0]*iscale[1]
         J[1, 0] *= oscale[1]*iscale[0]
         J[1, 1] *= oscale[1]*iscale[1]
-        assert_rel_error(self, J, derivs['comp.y1']['px.x'], 1.0e-3)
+        assert_near_equal(J, derivs['comp.y1']['px.x'], 1.0e-3)
 
         cderiv = prob.check_totals(driver_scaling=True, out_stream=None)
-        assert_rel_error(self, cderiv['comp.y1', 'px.x']['J_fwd'], J, 1.0e-3)
+        assert_near_equal(cderiv['comp.y1', 'px.x']['J_fwd'], J, 1.0e-3)
 
         # cleanup after FD
         prob.run_model()
@@ -2292,10 +2292,10 @@ class TestProblemCheckTotals(unittest.TestCase):
         derivs = prob.compute_totals(of=['comp.y1'], wrt=['px.x'], return_format='dict')
 
         J = comp.JJ[0:2, 0:2]
-        assert_rel_error(self, J, derivs['comp.y1']['px.x'], 1.0e-3)
+        assert_near_equal(J, derivs['comp.y1']['px.x'], 1.0e-3)
 
         cderiv = prob.check_totals(out_stream=None)
-        assert_rel_error(self, cderiv['comp.y1', 'px.x']['J_fwd'], J, 1.0e-3)
+        assert_near_equal(cderiv['comp.y1', 'px.x']['J_fwd'], J, 1.0e-3)
 
     def test_cs_around_newton(self):
         # Basic sellar test.
@@ -2337,7 +2337,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         totals = prob.check_totals(method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-10)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-10)
 
     def test_cs_around_broyden(self):
         # Basic sellar test.
@@ -2379,7 +2379,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         totals = prob.check_totals(method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-6)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
     def test_cs_error_allocate(self):
         prob = om.Problem()
@@ -2427,8 +2427,8 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # This test verifies fix of a TypeError (division by None)
         J = prob.check_totals(out_stream=None)
-        assert_rel_error(self, J['comp.y', 'p.x']['J_fwd'], [[14.0]], 1e-6)
-        assert_rel_error(self, J['comp.y', 'p.x']['J_fd'], [[0.0]], 1e-6)
+        assert_near_equal(J['comp.y', 'p.x']['J_fwd'], [[14.0]], 1e-6)
+        assert_near_equal(J['comp.y', 'p.x']['J_fd'], [[0.0]], 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -2446,10 +2446,10 @@ class TestProblemCheckTotalsMPI(unittest.TestCase):
         prob.run_model()
 
         J = prob.check_totals(out_stream=None)
-        assert_rel_error(self, J['sum.y', 'sub.sub1.p1.x']['J_fwd'], [[2.0]], 1.0e-6)
-        assert_rel_error(self, J['sum.y', 'sub.sub2.p2.x']['J_fwd'], [[4.0]], 1.0e-6)
-        assert_rel_error(self, J['sum.y', 'sub.sub1.p1.x']['J_fd'], [[2.0]], 1.0e-6)
-        assert_rel_error(self, J['sum.y', 'sub.sub2.p2.x']['J_fd'], [[4.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub1.p1.x']['J_fwd'], [[2.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub2.p2.x']['J_fwd'], [[4.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub1.p1.x']['J_fd'], [[2.0]], 1.0e-6)
+        assert_near_equal(J['sum.y', 'sub.sub2.p2.x']['J_fd'], [[4.0]], 1.0e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -20,7 +20,7 @@ except ImportError:
     load_npz = None
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.coloring import Coloring, _compute_coloring, array_viz, compute_total_coloring
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -8,7 +8,7 @@ from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimple
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArray
 from openmdao.test_suite.components.impl_comp_simple import TestImplCompSimple
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestExplicitComponent(unittest.TestCase):
@@ -32,7 +32,7 @@ class TestExplicitComponent(unittest.TestCase):
         prob['length'] = 3.
         prob['width'] = 2.
         prob.run_model()
-        assert_rel_error(self, prob['area'], 6.)
+        assert_near_equal(prob['area'], 6.)
 
     def test___init___array(self):
         """Test an explicit component with array inputs/outputs."""
@@ -42,7 +42,7 @@ class TestExplicitComponent(unittest.TestCase):
         prob['lengths'] = 3.
         prob['widths'] = 2.
         prob.run_model()
-        assert_rel_error(self, prob['total_volume'], 24.)
+        assert_near_equal(prob['total_volume'], 24.)
 
     def test_error_handling(self):
         """Test error handling when adding inputs/outputs."""
@@ -298,7 +298,7 @@ class TestImplicitComponent(unittest.TestCase):
 
         prob['a'] = a
         prob.run_model()
-        assert_rel_error(self, prob['x'], x)
+        assert_near_equal(prob['x'], x)
 
     def test___init___array(self):
         """Test an implicit component with array inputs/outputs."""
@@ -307,7 +307,7 @@ class TestImplicitComponent(unittest.TestCase):
 
         prob['rhs'] = np.ones(2)
         prob.run_model()
-        assert_rel_error(self, prob['x'], np.ones(2))
+        assert_near_equal(prob['x'], np.ones(2))
 
 
 class TestRangePartials(unittest.TestCase):
@@ -355,8 +355,8 @@ class TestRangePartials(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['vSum'], np.array([2., 3., 4., 5.]), 0.00001)
-        assert_rel_error(self, prob['vProd'], np.array([0., 2., 4., 6.]), 0.00001)
+        assert_near_equal(prob['vSum'], np.array([2., 3., 4., 5.]), 0.00001)
+        assert_near_equal(prob['vProd'], np.array([0., 2., 4., 6.]), 0.00001)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_compute_jacvec_prod.py
+++ b/openmdao/core/tests/test_compute_jacvec_prod.py
@@ -7,7 +7,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.core.system import get_relevant_vars
 from openmdao.core.driver import Driver
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
 

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -6,7 +6,7 @@ import numpy as np
 from io import StringIO
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestConnections(unittest.TestCase):
@@ -482,7 +482,7 @@ class TestShapes(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.y'], np.arange(10)[np.newaxis, :])
+        assert_near_equal(p['C1.y'], np.arange(10)[np.newaxis, :])
 
     def test_connect_flat_array_to_col_vector(self):
         p = Problem()
@@ -495,7 +495,7 @@ class TestShapes(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.y'], np.arange(10)[:, np.newaxis])
+        assert_near_equal(p['C1.y'], np.arange(10)[:, np.newaxis])
 
     def test_connect_row_vector_to_flat_array(self):
         p = Problem()
@@ -506,7 +506,7 @@ class TestShapes(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.y'], 5 * np.arange(10))
+        assert_near_equal(p['C1.y'], 5 * np.arange(10))
 
     def test_connect_col_vector_to_flat_array(self):
         p = Problem()
@@ -517,7 +517,7 @@ class TestShapes(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.y'], 5 * np.arange(10))
+        assert_near_equal(p['C1.y'], 5 * np.arange(10))
 
     def test_connect_flat_to_3d_array(self):
         p = Problem()
@@ -528,7 +528,7 @@ class TestShapes(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.y'], 5 * np.arange(10)[np.newaxis, :, np.newaxis])
+        assert_near_equal(p['C1.y'], 5 * np.arange(10)[np.newaxis, :, np.newaxis])
 
     def test_connect_flat_nd_to_flat_nd(self):
         p = Problem()
@@ -541,7 +541,7 @@ class TestShapes(unittest.TestCase):
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.y'],
+        assert_near_equal(p['C1.y'],
                          5 * np.arange(10)[np.newaxis, np.newaxis, np.newaxis, :])
 
     def test_connect_incompatible_shapes(self):

--- a/openmdao/core/tests/test_connections_in_configure.py
+++ b/openmdao/core/tests/test_connections_in_configure.py
@@ -4,7 +4,7 @@ A contrived example for issuing connections during configure rather than setup.
 import itertools
 import unittest
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class Squarer(om.ExplicitComponent):
@@ -189,14 +189,14 @@ class TestConnectionsInSetup(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['h.squarer.a_squared'], p['h.a'] ** 2)
-        assert_rel_error(self, p['h.squarer.b_squared'], p['h.b'] ** 2)
-        assert_rel_error(self, p['h.squarer.c_squared'], p['h.c'] ** 2)
+        assert_near_equal(p['h.squarer.a_squared'], p['h.a'] ** 2)
+        assert_near_equal(p['h.squarer.b_squared'], p['h.b'] ** 2)
+        assert_near_equal(p['h.squarer.c_squared'], p['h.c'] ** 2)
 
-        assert_rel_error(self, p['h.cuber.a_cubed'], p['h.a'] ** 3)
-        assert_rel_error(self, p['h.cuber.b_cubed'], p['h.b'] ** 3)
-        assert_rel_error(self, p['h.cuber.x_cubed'], p['h.x'] ** 3)
-        assert_rel_error(self, p['h.cuber.y_cubed'], p['h.y'] ** 3)
+        assert_near_equal(p['h.cuber.a_cubed'], p['h.a'] ** 3)
+        assert_near_equal(p['h.cuber.b_cubed'], p['h.b'] ** 3)
+        assert_near_equal(p['h.cuber.x_cubed'], p['h.x'] ** 3)
+        assert_near_equal(p['h.cuber.y_cubed'], p['h.y'] ** 3)
 
     def test_connect_in_configure(self):
 
@@ -219,14 +219,14 @@ class TestConnectionsInSetup(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['h.squarer.a_squared'], p['h.a'] ** 2)
-        assert_rel_error(self, p['h.squarer.b_squared'], p['h.b'] ** 2)
-        assert_rel_error(self, p['h.squarer.c_squared'], p['h.c'] ** 2)
+        assert_near_equal(p['h.squarer.a_squared'], p['h.a'] ** 2)
+        assert_near_equal(p['h.squarer.b_squared'], p['h.b'] ** 2)
+        assert_near_equal(p['h.squarer.c_squared'], p['h.c'] ** 2)
 
-        assert_rel_error(self, p['h.cuber.a_cubed'], p['h.a'] ** 3)
-        assert_rel_error(self, p['h.cuber.b_cubed'], p['h.b'] ** 3)
-        assert_rel_error(self, p['h.cuber.x_cubed'], p['h.x'] ** 3)
-        assert_rel_error(self, p['h.cuber.y_cubed'], p['h.y'] ** 3)
+        assert_near_equal(p['h.cuber.a_cubed'], p['h.a'] ** 3)
+        assert_near_equal(p['h.cuber.b_cubed'], p['h.b'] ** 3)
+        assert_near_equal(p['h.cuber.x_cubed'], p['h.x'] ** 3)
+        assert_near_equal(p['h.cuber.y_cubed'], p['h.y'] ** 3)
 
 
 class TestAddSubcomponentIOInConfigure(unittest.TestCase):
@@ -270,7 +270,7 @@ class TestAddSubcomponentIOInConfigure(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p.get_val('g.foo_cubed'), p.get_val('g.foo')**3)
+        assert_near_equal(p.get_val('g.foo_cubed'), p.get_val('g.foo')**3)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_core_simple.py
+++ b/openmdao/core/tests/test_core_simple.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 from openmdao.api import Problem, IndepVarComp, ExplicitComponent, Group, PETScVector
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 #      (A) -> x
@@ -60,23 +60,23 @@ class Test(unittest.TestCase):
                 idxs[name] for name in system._var_abs_names[type_]
             ])
 
-        assert_rel_error(self, get_inds(self.p, '', 'input'), np.array([0]))
-        assert_rel_error(self, get_inds(self.p, '', 'output'), np.array([0,1]))
+        assert_near_equal(get_inds(self.p, '', 'input'), np.array([0]))
+        assert_near_equal(get_inds(self.p, '', 'output'), np.array([0,1]))
 
-        assert_rel_error(self, get_inds(self.p, 'A', 'input'), np.array([]))
-        assert_rel_error(self, get_inds(self.p, 'A', 'output'), np.array([0]))
+        assert_near_equal(get_inds(self.p, 'A', 'input'), np.array([]))
+        assert_near_equal(get_inds(self.p, 'A', 'output'), np.array([0]))
 
-        assert_rel_error(self, get_inds(self.p, 'B', 'input'), np.array([0]))
-        assert_rel_error(self, get_inds(self.p, 'B', 'output'), np.array([1]))
+        assert_near_equal(get_inds(self.p, 'B', 'input'), np.array([0]))
+        assert_near_equal(get_inds(self.p, 'B', 'output'), np.array([1]))
 
     def test_var_allprocs_idx_range(self):
         rng = self.p.model._subsystems_var_range
 
-        assert_rel_error(self, rng['nonlinear']['input']['A'], np.array([0,0]))
-        assert_rel_error(self, rng['nonlinear']['input']['B'], np.array([0,1]))
+        assert_near_equal(rng['nonlinear']['input']['A'], np.array([0,0]))
+        assert_near_equal(rng['nonlinear']['input']['B'], np.array([0,1]))
 
-        assert_rel_error(self, rng['nonlinear']['output']['A'], np.array([0,1]))
-        assert_rel_error(self, rng['nonlinear']['output']['B'], np.array([1,2]))
+        assert_near_equal(rng['nonlinear']['output']['A'], np.array([0,1]))
+        assert_near_equal(rng['nonlinear']['output']['B'], np.array([1,2]))
 
     def test_GS(self):
         root = self.p.model
@@ -86,21 +86,21 @@ class Test(unittest.TestCase):
             compB = root.B
 
             if root.comm.rank == 0:
-                assert_rel_error(self, root._outputs['A.x'], 0)
-                assert_rel_error(self, compA._outputs['x'], 0)
+                assert_near_equal(root._outputs['A.x'], 0)
+                assert_near_equal(compA._outputs['x'], 0)
                 compA._outputs['x'] = 10
             if root.comm.rank == 2:
-                assert_rel_error(self, compB._inputs['x'], 0)
-                assert_rel_error(self, compB._outputs['f'], 0)
+                assert_near_equal(compB._inputs['x'], 0)
+                assert_near_equal(compB._outputs['f'], 0)
 
             root.run_solve_nonlinear()
 
             if root.comm.rank == 0:
-                assert_rel_error(self, root._outputs['A.x'], 10)
-                assert_rel_error(self, compA._outputs['x'], 10)
+                assert_near_equal(root._outputs['A.x'], 10)
+                assert_near_equal(compA._outputs['x'], 10)
             if root.comm.rank == 2:
-                assert_rel_error(self, compB._inputs['x'], 10)
-                assert_rel_error(self, compB._outputs['f'], 20)
+                assert_near_equal(compB._inputs['x'], 10)
+                assert_near_equal(compB._outputs['f'], 20)
 
 
 @unittest.skipUnless(PETScVector, "PETSc is required.")

--- a/openmdao/core/tests/test_deriv_transfers.py
+++ b/openmdao/core/tests/test_deriv_transfers.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     PETScVector = None
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.error_checking.check_config import _default_checks
 from openmdao.core.tests.test_distrib_derivs import DistribExecComp
@@ -72,8 +72,8 @@ class TestParallelGroups(unittest.TestCase):
         J = prob.compute_totals(of=of, wrt=wrt)
 
         print(model.comm.rank, "val:", J['C1.y', 'indep.x'][0][0])
-        assert_rel_error(self, J['C1.y', 'indep.x'][0][0], 2.5, 1e-6)
-        assert_rel_error(self, prob['C1.y'], 2.5, 1e-6)
+        assert_near_equal(J['C1.y', 'indep.x'][0][0], 2.5, 1e-6)
+        assert_near_equal(prob['C1.y'], 2.5, 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),
                           name_func=_test_func_name)
@@ -98,15 +98,15 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
-        assert_rel_error(self, prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
+        assert_near_equal(prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, J['par.C1.y', 'indep.x'][0][0], 2.5, 1e-6)
-        assert_rel_error(self, prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
-        assert_rel_error(self, J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
-        assert_rel_error(self, prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
+        assert_near_equal(J['par.C1.y', 'indep.x'][0][0], 2.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
+        assert_near_equal(J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
+        assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),
                           name_func=_test_func_name)
@@ -133,18 +133,18 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
-        assert_rel_error(self, prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
-        assert_rel_error(self, prob.get_val('dup.y', get_remote=True), 1.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
+        assert_near_equal(prob.get_val('dup.y', get_remote=True), 1.5, 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, J['par.C1.y', 'indep.x'][0][0], 2.5, 1e-6)
-        assert_rel_error(self, prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
-        assert_rel_error(self, J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
-        assert_rel_error(self, prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
-        assert_rel_error(self, J['dup.y', 'indep.x'][0][0], 1.5, 1e-6)
-        assert_rel_error(self, prob.get_val('dup.y', get_remote=True), 1.5, 1e-6)
+        assert_near_equal(J['par.C1.y', 'indep.x'][0][0], 2.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
+        assert_near_equal(J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
+        assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
+        assert_near_equal(J['dup.y', 'indep.x'][0][0], 1.5, 1e-6)
+        assert_near_equal(prob.get_val('dup.y', get_remote=True), 1.5, 1e-6)
 
     def test_dup_par_par_derivs(self):
         # duplicated output, parallel input
@@ -173,15 +173,15 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
-        assert_rel_error(self, prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
+        assert_near_equal(prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
 
         J = prob.driver._compute_totals()
 
-        assert_rel_error(self, J['par.C1.y', 'indep.x'][0][0], 2.5, 1e-6)
-        assert_rel_error(self, prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
-        assert_rel_error(self, J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
-        assert_rel_error(self, prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
+        assert_near_equal(J['par.C1.y', 'indep.x'][0][0], 2.5, 1e-6)
+        assert_near_equal(prob.get_val('par.C1.y', get_remote=True), 2.5, 1e-6)
+        assert_near_equal(J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
+        assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),
                           name_func=_test_func_name)
@@ -208,15 +208,15 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('C1.y', get_remote=True),
+        assert_near_equal(prob.get_val('C1.y', get_remote=True),
                          np.array([2.5,2.5,3.5], dtype=float), 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt)
 
         expected = np.array([[2.5, 0, 0], [0, 2.5, 0], [0,0,3.5]], dtype=float)
 
-        assert_rel_error(self, J['C1.y', 'indep.x'], expected, 1e-6)
-        assert_rel_error(self, prob.get_val('C1.y', get_remote=True),
+        assert_near_equal(J['C1.y', 'indep.x'], expected, 1e-6)
+        assert_near_equal(prob.get_val('C1.y', get_remote=True),
                          np.array([2.5,2.5,3.5], dtype=float), 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),
@@ -244,13 +244,13 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['C1.y'], 6., 1e-6)
+        assert_near_equal(prob['C1.y'], 6., 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, J['C1.y', 'par.indep1.x'][0][0], 2.5, 1e-6)
-        assert_rel_error(self, J['C1.y', 'par.indep2.x'][0][0], 3.5, 1e-6)
-        assert_rel_error(self, prob['C1.y'], 6., 1e-6)
+        assert_near_equal(J['C1.y', 'par.indep1.x'][0][0], 2.5, 1e-6)
+        assert_near_equal(J['C1.y', 'par.indep2.x'][0][0], 3.5, 1e-6)
+        assert_near_equal(prob['C1.y'], 6., 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),
                           name_func=_test_func_name)
@@ -279,15 +279,15 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('sink.y', get_remote=True),
+        assert_near_equal(prob.get_val('sink.y', get_remote=True),
                          np.array([-3.75,-3.75,-5.25], dtype=float), 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt)
 
         expected = np.array([[-3.75, 0, 0], [0, -3.75, 0], [0,0,-5.25]], dtype=float)
 
-        assert_rel_error(self, J['sink.y', 'indep.x'], expected, 1e-6)
-        assert_rel_error(self, prob.get_val('sink.y', get_remote=True),
+        assert_near_equal(J['sink.y', 'indep.x'], expected, 1e-6)
+        assert_near_equal(prob.get_val('sink.y', get_remote=True),
                          np.array([-3.75,-3.75,-5.25], dtype=float), 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),
@@ -320,15 +320,15 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('C3.y', get_remote=True),
+        assert_near_equal(prob.get_val('C3.y', get_remote=True),
                          np.array([17,17,5], dtype=float), 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt)
 
         expected = np.array([[17, 0, 0], [0, 17, 0], [0,0,5]], dtype=float)
 
-        assert_rel_error(self, J['C3.y', 'indep.x'], expected, 1e-6)
-        assert_rel_error(self, prob.get_val('C3.y', get_remote=True),
+        assert_near_equal(J['C3.y', 'indep.x'], expected, 1e-6)
+        assert_near_equal(prob.get_val('C3.y', get_remote=True),
                          np.array([17,17,5], dtype=float), 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']),

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from openmdao.api import Problem, NonlinearBlockGS, Group, IndepVarComp, ExecComp, ScipyKrylov,  \
     IndepVarComp, ScipyOptimizeDriver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1withDerivatives, \

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -13,7 +13,7 @@ from openmdao.visualization.n2_viewer.n2_viewer import _get_viewer_data
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import StateConnection, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.utils.logger_utils import TestLogger
 
@@ -194,7 +194,7 @@ class DiscreteTestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 2)
+        assert_near_equal(prob['comp.y'], 2)
 
     def test_simple_run_once_promoted(self):
         prob = om.Problem()
@@ -207,7 +207,7 @@ class DiscreteTestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y'], 2)
+        assert_near_equal(prob['y'], 2)
 
     def test_simple_run_once_implicit(self):
         prob = om.Problem()
@@ -222,7 +222,7 @@ class DiscreteTestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 2)
+        assert_near_equal(prob['comp.y'], 2)
 
     def test_list_inputs_outputs(self):
         prob = om.Problem()
@@ -872,7 +872,7 @@ class DiscreteFeatureTestCase(unittest.TestCase):
         prob.run_model()
 
         # minimum value
-        assert_rel_error(self, prob['SolidityComp.blade_solidity'], 0.02984155, 1e-4)
+        assert_near_equal(prob['SolidityComp.blade_solidity'], 0.02984155, 1e-4)
 
     def test_feature_discrete_implicit(self):
         import openmdao.api as om
@@ -922,7 +922,7 @@ class DiscreteFeatureTestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.x'], 3., 1e-4)
+        assert_near_equal(prob['comp.x'], 3., 1e-4)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_discrete_mpi.py
+++ b/openmdao/core/tests/test_discrete_mpi.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from openmdao.api import Problem, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, \
     ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent, ParallelGroup
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
 
@@ -44,12 +44,12 @@ class DiscreteMPITestCase(unittest.TestCase):
         prob.run_model()
 
         if prob.comm.rank == 0:
-            assert_rel_error(self, prob['par.comp1.y'], 1)
+            assert_near_equal(prob['par.comp1.y'], 1)
         else:
-            assert_rel_error(self, prob['par.comp2.y'], 2)
+            assert_near_equal(prob['par.comp2.y'], 2)
 
-        assert_rel_error(self, prob.get_val('par.comp1.y', get_remote=True), 1)
-        assert_rel_error(self, prob.get_val('par.comp2.y', get_remote=True), 2)
+        assert_near_equal(prob.get_val('par.comp1.y', get_remote=True), 1)
+        assert_near_equal(prob.get_val('par.comp2.y', get_remote=True), 2)
 
 
     def test_simple_run_once_discrete_implicit(self):
@@ -69,12 +69,12 @@ class DiscreteMPITestCase(unittest.TestCase):
         prob.run_model()
 
         if prob.comm.rank == 0:
-            assert_rel_error(self, prob['par.comp1.y'], 1)
+            assert_near_equal(prob['par.comp1.y'], 1)
         else:
-            assert_rel_error(self, prob['par.comp2.y'], 2)
+            assert_near_equal(prob['par.comp2.y'], 2)
 
-        assert_rel_error(self, prob.get_val('par.comp1.y', get_remote=True), 1)
-        assert_rel_error(self, prob.get_val('par.comp2.y', get_remote=True), 2)
+        assert_near_equal(prob.get_val('par.comp1.y', get_remote=True), 1)
+        assert_near_equal(prob.get_val('par.comp2.y', get_remote=True), 2)
 
 
 # This re-runs all of the DiscretePromTestCase tests under MPI

--- a/openmdao/core/tests/test_distrib_adder.py
+++ b/openmdao/core/tests/test_distrib_adder.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     PETScVector = None
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class DistributedAdder(ExplicitComponent):
@@ -104,7 +104,7 @@ class DistributedAdderTest(unittest.TestCase):
                 raise RuntimeError("Summer input y[%d] is %f but should be 11.0" %
                                    (i, inp[i]))
 
-        assert_rel_error(self, prob['sum'], 11.0 * size, 1.e-6)
+        assert_near_equal(prob['sum'], 11.0 * size, 1.e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -7,7 +7,7 @@ import itertools
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 try:
     from parameterized import parameterized
@@ -164,7 +164,7 @@ class MPITests2(unittest.TestCase):
         final[0:5] *= 2.0
         final[5:9] *= 3.0
 
-        assert_rel_error(self, prob['total.y'], final)
+        assert_near_equal(prob['total.y'], final)
 
     def test_two_simple(self):
         size = 3
@@ -189,13 +189,13 @@ class MPITests2(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(['C2.z'], ['P.x'])
-        assert_rel_error(self, J['C2.z', 'P.x'], numpy.diag([6.0, 6.0, 9.0]), 1e-6)
+        assert_near_equal(J['C2.z', 'P.x'], numpy.diag([6.0, 6.0, 9.0]), 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(['C2.z'], ['P.x'])
-        assert_rel_error(self, J['C2.z', 'P.x'], numpy.diag([6.0, 6.0, 9.0]), 1e-6)
+        assert_near_equal(J['C2.z', 'P.x'], numpy.diag([6.0, 6.0, 9.0]), 1e-6)
 
     @parameterized.expand(itertools.product([om.NonlinearRunOnce, om.NonlinearBlockGS]),
                           name_func=_test_func_name)
@@ -236,22 +236,22 @@ class MPITests2(unittest.TestCase):
         diag1 = [4.5, 4.5, 3.0]
         diag2 = [15.0, 15.0, 10.0]
 
-        assert_rel_error(self, prob['C2.y'], diag1)
-        assert_rel_error(self, prob['C3.y'], diag2)
+        assert_near_equal(prob['C2.y'], diag1)
+        assert_near_equal(prob['C3.y'], diag2)
 
         diag1 = numpy.diag(diag1)
         diag2 = numpy.diag(diag2)
 
         J = prob.compute_totals(of=['C2.y', "C3.y"], wrt=['P.x'])
-        assert_rel_error(self, J['C2.y', 'P.x'], diag1, 1e-6)
-        assert_rel_error(self, J['C3.y', 'P.x'], diag2, 1e-6)
+        assert_near_equal(J['C2.y', 'P.x'], diag1, 1e-6)
+        assert_near_equal(J['C3.y', 'P.x'], diag2, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(of=['C2.y', "C3.y"], wrt=['P.x'])
-        assert_rel_error(self, J['C2.y', 'P.x'], diag1, 1e-6)
-        assert_rel_error(self, J['C3.y', 'P.x'], diag2, 1e-6)
+        assert_near_equal(J['C2.y', 'P.x'], diag1, 1e-6)
+        assert_near_equal(J['C3.y', 'P.x'], diag2, 1e-6)
 
     @parameterized.expand(itertools.product([om.NonlinearRunOnce, om.NonlinearBlockGS]),
                           name_func=_test_func_name)
@@ -296,16 +296,16 @@ class MPITests2(unittest.TestCase):
         diag2 = numpy.diag([35.0, 35.0, 17.5])
 
         J = prob.compute_totals(of=['C4.y'], wrt=['P1.x', 'P2.x'])
-        assert_rel_error(self, J['C4.y', 'P1.x'], diag1, 1e-6)
-        assert_rel_error(self, J['C4.y', 'P2.x'], diag2, 1e-6)
+        assert_near_equal(J['C4.y', 'P1.x'], diag1, 1e-6)
+        assert_near_equal(J['C4.y', 'P2.x'], diag2, 1e-6)
 
         prob.setup(check=False, mode='rev')
 
         prob.run_driver()
 
         J = prob.compute_totals(of=['C4.y'], wrt=['P1.x', 'P2.x'])
-        assert_rel_error(self, J['C4.y', 'P1.x'], diag1, 1e-6)
-        assert_rel_error(self, J['C4.y', 'P2.x'], diag2, 1e-6)
+        assert_near_equal(J['C4.y', 'P1.x'], diag1, 1e-6)
+        assert_near_equal(J['C4.y', 'P2.x'], diag2, 1e-6)
 
     def test_distrib_voi(self):
         raise unittest.SkipTest("distrib vois no supported yet")
@@ -407,12 +407,12 @@ class MPITests3(unittest.TestCase):
         p.setup(mode='fwd')
         p.run_model()
         jac = p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
-        assert_rel_error(self, jac['out_var']['a'][0], expected, 1e-6)
+        assert_near_equal(jac['out_var']['a'][0], expected, 1e-6)
 
         p.setup(mode='rev')
         p.run_model()
         jac = p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
-        assert_rel_error(self, jac['out_var']['a'][0], expected, 1e-6)
+        assert_near_equal(jac['out_var']['a'][0], expected, 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -10,7 +10,7 @@ import openmdao.api as om
 
 from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions, remove_whitespace
 
 from openmdao.test_suite.groups.parallel_groups import FanOutGrouped
@@ -588,7 +588,7 @@ class DistributedListVarsTest(unittest.TestCase):
                 self.assertEqual(remove_whitespace(text[i]), remove_whitespace(line),
                                  '\nExpected: %s\nReceived: %s\n' % (line, text[i]))
 
-        assert_rel_error(self, prob['C3.out'], -5.)
+        assert_near_equal(prob['C3.out'], -5.)
 
 
 @unittest.skipUnless(PETScVector, "PETSc is required.")
@@ -632,7 +632,7 @@ class MPIFeatureTests(unittest.TestCase):
         # is different on each processor, use the all_procs argument to display on all processors
         model.C3.list_inputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True, all_procs=True)
 
-        assert_rel_error(self, prob['C3.out'], -5.)
+        assert_near_equal(prob['C3.out'], -5.)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -7,7 +7,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import evenly_distrib_idxs, take_nth
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -777,11 +777,11 @@ class MPIFeatureTests(unittest.TestCase):
         prob['indep.x'] = np.ones(size)
         prob.run_model()
 
-        assert_rel_error(self, prob['C2.invec'],
+        assert_near_equal(prob['C2.invec'],
                          np.ones((8,)) if model.comm.rank == 0 else np.ones((7,)))
-        assert_rel_error(self, prob['C2.outvec'],
+        assert_near_equal(prob['C2.outvec'],
                          2*np.ones((8,)) if model.comm.rank == 0 else -3*np.ones((7,)))
-        assert_rel_error(self, prob['C3.out'], -5.)
+        assert_near_equal(prob['C3.out'], -5.)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -821,12 +821,12 @@ class TestGroupMPI(unittest.TestCase):
         p.run_model()
 
         # each rank holds the assigned portion of the input array
-        assert_rel_error(self, p['C1.x'],
+        assert_near_equal(p['C1.x'],
                          np.arange(3, dtype=float) if p.model.C1.comm.rank == 0 else
                          np.arange(3, 5, dtype=float))
 
         # the output in each rank is based on the local inputs
-        assert_rel_error(self, p['C1.y'], 6. if p.model.C1.comm.rank == 0 else 14.)
+        assert_near_equal(p['C1.y'], 6. if p.model.C1.comm.rank == 0 else 14.)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import openmdao
 from openmdao.api import Problem, IndepVarComp, Group, ExecComp, ScipyOptimizeDriver
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import printoptions
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp, NonSquareArrayComp
@@ -125,8 +125,8 @@ class TestDriver(unittest.TestCase):
 
         derivs = prob.driver._compute_totals(of=['obj_cmp.obj', 'con_cmp1.con1'], wrt=['pz.z'],
                                              return_format='dict')
-        assert_rel_error(self, base[('con1', 'z')][0], derivs['con_cmp1.con1']['pz.z'][0], 1e-5)
-        assert_rel_error(self, base[('obj', 'z')][0]*2.0, derivs['obj_cmp.obj']['pz.z'][0], 1e-5)
+        assert_near_equal(base[('con1', 'z')][0], derivs['con_cmp1.con1']['pz.z'][0], 1e-5)
+        assert_near_equal(base[('obj', 'z')][0]*2.0, derivs['obj_cmp.obj']['pz.z'][0], 1e-5)
 
     def test_vector_scaled_derivs(self):
 
@@ -157,15 +157,15 @@ class TestDriver(unittest.TestCase):
         J[0, 1] *= oscale[0]*iscale[1]
         J[1, 0] *= oscale[1]*iscale[0]
         J[1, 1] *= oscale[1]*iscale[1]
-        assert_rel_error(self, J, derivs['comp.y1']['px.x'], 1.0e-3)
+        assert_near_equal(J, derivs['comp.y1']['px.x'], 1.0e-3)
 
         obj = prob.driver.get_objective_values()
         obj_base = np.array([ (prob['comp.y1'][0]-5.2)/(7.0-5.2), (prob['comp.y1'][1]-6.3)/(11.0-6.3) ])
-        assert_rel_error(self, obj['comp.y1'], obj_base, 1.0e-3)
+        assert_near_equal(obj['comp.y1'], obj_base, 1.0e-3)
 
         con = prob.driver.get_constraint_values()
         con_base = np.array([ (prob['comp.y2'][0]-1.2)/(2.0-1.2), (prob['comp.y2'][1]-2.3)/(4.0-2.3) ])
-        assert_rel_error(self, con['comp.y2'], con_base, 1.0e-3)
+        assert_near_equal(con['comp.y2'], con_base, 1.0e-3)
 
     def test_vector_bounds_inf(self):
 
@@ -222,15 +222,15 @@ class TestDriver(unittest.TestCase):
         J[1, 1] *= oscale[1]*iscale[1]
         J[2, 0] *= oscale[2]*iscale[0]
         J[2, 1] *= oscale[2]*iscale[1]
-        assert_rel_error(self, J, derivs['comp.y1']['px.x'], 1.0e-3)
+        assert_near_equal(J, derivs['comp.y1']['px.x'], 1.0e-3)
 
         obj = prob.driver.get_objective_values()
         obj_base = np.array([ (prob['comp.y1'][0]-5.2)/(7.0-5.2), (prob['comp.y1'][1]-6.3)/(11.0-6.3), (prob['comp.y1'][2]-1.2)/(2.0-1.2) ])
-        assert_rel_error(self, obj['comp.y1'], obj_base, 1.0e-3)
+        assert_near_equal(obj['comp.y1'], obj_base, 1.0e-3)
 
         con = prob.driver.get_constraint_values()
         con_base = np.array([ (prob['comp.y2'][0]-1.2)/(2.0-1.2)])
-        assert_rel_error(self, con['comp.y2'], con_base, 1.0e-3)
+        assert_near_equal(con['comp.y2'], con_base, 1.0e-3)
 
     def test_debug_print_option(self):
 

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -9,7 +9,7 @@ import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import SubSellar
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimple, \
     TestExplCompSimpleDense
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions, remove_whitespace
 
 
@@ -125,18 +125,18 @@ class ExplCompTestCase(unittest.TestCase):
         prob['comp1.length'] = 3.
         prob['comp1.width'] = 2.
         prob.run_model()
-        assert_rel_error(self, prob['comp2.area'], 6.)
-        assert_rel_error(self, prob['comp3.area'], 6.)
+        assert_near_equal(prob['comp2.area'], 6.)
+        assert_near_equal(prob['comp3.area'], 6.)
 
         # total derivs
         total_derivs = prob.compute_totals(
             wrt=['comp1.length', 'comp1.width'],
             of=['comp2.area', 'comp3.area']
         )
-        assert_rel_error(self, total_derivs['comp2.area', 'comp1.length'], [[2.]])
-        assert_rel_error(self, total_derivs['comp3.area', 'comp1.length'], [[2.]])
-        assert_rel_error(self, total_derivs['comp2.area', 'comp1.width'], [[3.]])
-        assert_rel_error(self, total_derivs['comp3.area', 'comp1.width'], [[3.]])
+        assert_near_equal(total_derivs['comp2.area', 'comp1.length'], [[2.]])
+        assert_near_equal(total_derivs['comp3.area', 'comp1.length'], [[2.]])
+        assert_near_equal(total_derivs['comp2.area', 'comp1.width'], [[3.]])
+        assert_near_equal(total_derivs['comp3.area', 'comp1.width'], [[3.]])
 
         # list inputs
         inputs = prob.model.list_inputs(out_stream=None)
@@ -280,7 +280,7 @@ class ExplCompTestCase(unittest.TestCase):
             self.assertEqual(expected[0], actual[0])
             self.assertEqual(expected[1]['units'], actual[1]['units'])
             self.assertEqual(expected[1]['shape'], actual[1]['shape'])
-            assert_rel_error(self, expected[1]['value'], actual[1]['value'], tol)
+            assert_near_equal(expected[1]['value'], actual[1]['value'], tol)
 
         text = stream.getvalue().split('\n')
         expected_text = [

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -14,7 +14,7 @@ from scipy.sparse import coo_matrix
 
 from openmdao.api import Problem, Group, IndepVarComp, ImplicitComponent, ExecComp, \
     ExplicitComponent, NonlinearBlockGS, ScipyOptimizeDriver
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.utils.mpi import MPI
 from openmdao.utils.coloring import compute_total_coloring, Coloring

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -10,7 +10,7 @@ import scipy
 from scipy.sparse.linalg import gmres
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class CacheLinearTestCase(unittest.TestCase):
@@ -109,7 +109,7 @@ class CacheLinearTestCase(unittest.TestCase):
 
         print(p['a'], p['b'], p['c'])
         print(p['states'])
-        assert_rel_error(self, p['obj.y'], 0.25029766, 1e-3)
+        assert_near_equal(p['obj.y'], 0.25029766, 1e-3)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -14,7 +14,7 @@ except ImportError:
 
 import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis2
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.error_checking.check_config import _check_hanging_inputs
 
@@ -810,9 +810,9 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p['indep.x'], np.ones(5))
-        assert_rel_error(self, p['comp1.x'], np.ones(5)*12.)
-        assert_rel_error(self, p['comp1.y'], 60.)
+        assert_near_equal(p['indep.x'], np.ones(5))
+        assert_near_equal(p['comp1.x'], np.ones(5)*12.)
+        assert_near_equal(p['comp1.y'], 60.)
 
     def test_unconnected_input_units_no_mismatch(self):
         p = om.Problem()
@@ -877,9 +877,9 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p['C1.y'], 10.)
-        assert_rel_error(self, p['C2.y'], 20.)
-        assert_rel_error(self, p['C3.y'], 30.)
+        assert_near_equal(p['C1.y'], 10.)
+        assert_near_equal(p['C2.y'], 20.)
+        assert_near_equal(p['C3.y'], 30.)
 
     def test_double_src_indices(self):
         class MyComp1(om.ExplicitComponent):
@@ -923,10 +923,10 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p['C1.x'], np.ones(3))
-        assert_rel_error(self, p['C1.y'], 6.)
-        assert_rel_error(self, p['C2.x'], np.ones(2))
-        assert_rel_error(self, p['C2.y'], 8.)
+        assert_near_equal(p['C1.x'], np.ones(3))
+        assert_near_equal(p['C1.y'], 6.)
+        assert_near_equal(p['C2.x'], np.ones(2))
+        assert_near_equal(p['C2.y'], 8.)
 
     def test_connect_src_indices_noflat(self):
         import numpy as np
@@ -946,9 +946,9 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p['C1.x'], np.array([[0., 10.],
+        assert_near_equal(p['C1.x'], np.array([[0., 10.],
                                                     [7., 4.]]))
-        assert_rel_error(self, p['C1.y'], 42.)
+        assert_near_equal(p['C1.y'], 42.)
 
     def test_promote_not_found1(self):
         p = om.Problem()
@@ -1064,10 +1064,10 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p['C1.x'], np.ones(3))
-        assert_rel_error(self, p['C1.y'], 6.)
-        assert_rel_error(self, p['C2.x'], np.ones(2))
-        assert_rel_error(self, p['C2.y'], 8.)
+        assert_near_equal(p['C1.x'], np.ones(3))
+        assert_near_equal(p['C1.y'], 6.)
+        assert_near_equal(p['C2.x'], np.ones(2))
+        assert_near_equal(p['C2.y'], 8.)
 
     def test_promote_src_indices_nonflat(self):
         import numpy as np
@@ -1105,10 +1105,10 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p['C1.x'],
+        assert_near_equal(p['C1.x'],
                          np.array([[0., 10.],
                                    [7., 4.]]))
-        assert_rel_error(self, p['C1.y'], 21.)
+        assert_near_equal(p['C1.y'], 21.)
 
     def test_promote_src_indices_nonflat_to_scalars(self):
         class MyComp(om.ExplicitComponent):
@@ -1129,8 +1129,8 @@ class TestGroup(unittest.TestCase):
         p.set_solver_print(level=0)
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.x'], 10.)
-        assert_rel_error(self, p['C1.y'], 20.)
+        assert_near_equal(p['C1.x'], 10.)
+        assert_near_equal(p['C1.y'], 20.)
 
     def test_promote_src_indices_nonflat_error(self):
         class MyComp(om.ExplicitComponent):
@@ -1198,9 +1198,9 @@ class TestGroup(unittest.TestCase):
         p.set_solver_print(level=0)
         p.setup()
         p.run_model()
-        assert_rel_error(self, p['C1.x'],
+        assert_near_equal(p['C1.x'],
                          np.array([0., 10., 7., 4.]).reshape(tgt_shape))
-        assert_rel_error(self, p['C1.y'], 21.)
+        assert_near_equal(p['C1.y'], 21.)
 
     def test_set_order_feature(self):
         import openmdao.api as om
@@ -1358,7 +1358,7 @@ class TestGroup(unittest.TestCase):
 
         self.assertEqual(p.model.nonlinear_solver._iter_count, 0)
 
-        assert_rel_error(self, p['discipline.x'], 1.41421356, 1e-6)
+        assert_near_equal(p['discipline.x'], 1.41421356, 1e-6)
 
     def test_guess_nonlinear_complex_step(self):
 
@@ -1406,12 +1406,12 @@ class TestGroup(unittest.TestCase):
 
         self.assertEqual(p.model.nonlinear_solver._iter_count, 0)
 
-        assert_rel_error(self, p['discipline.x'], 1.41421356, 1e-6)
+        assert_near_equal(p['discipline.x'], 1.41421356, 1e-6)
 
         totals = p.check_totals(of=['discipline.comp1.z'], wrt=['parameters.input_value'], method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-15)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-15)
 
 
 class MyComp(om.ExplicitComponent):
@@ -1604,7 +1604,7 @@ class TestConnect(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['tgt.y'], 600.)
+        assert_near_equal(prob['tgt.y'], 600.)
 
     def test_connect_units_with_nounits_prom(self):
         prob = om.Problem()
@@ -1622,7 +1622,7 @@ class TestConnect(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['tgt.z'], 600.)
+        assert_near_equal(prob['tgt.z'], 600.)
 
     def test_mix_promotes_types(self):
         prob = om.Problem()
@@ -1668,7 +1668,7 @@ class TestConnect(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['G1.par1.c4.y'], 8.0)
+        assert_near_equal(prob['G1.par1.c4.y'], 8.0)
 
     def test_bad_shapes(self):
         self.sub.connect('src.s', 'arr.x')

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -6,7 +6,7 @@ from io import StringIO
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 # Note: The following class definitions are used in feature docs
@@ -137,19 +137,19 @@ class ImplicitCompTestCase(unittest.TestCase):
         prob = self.prob
         prob.run_model()
 
-        assert_rel_error(self, prob['comp2.x'], 3.)
-        assert_rel_error(self, prob['comp2.x'], 3.)
+        assert_near_equal(prob['comp2.x'], 3.)
+        assert_near_equal(prob['comp2.x'], 3.)
 
         total_derivs = prob.compute_totals(
             wrt=['comp1.a', 'comp1.b', 'comp1.c'],
             of=['comp2.x', 'comp3.x']
         )
-        assert_rel_error(self, total_derivs['comp2.x', 'comp1.a'], [[-4.5]])
-        assert_rel_error(self, total_derivs['comp2.x', 'comp1.b'], [[-1.5]])
-        assert_rel_error(self, total_derivs['comp2.x', 'comp1.c'], [[-0.5]])
-        assert_rel_error(self, total_derivs['comp3.x', 'comp1.a'], [[-4.5]])
-        assert_rel_error(self, total_derivs['comp3.x', 'comp1.b'], [[-1.5]])
-        assert_rel_error(self, total_derivs['comp3.x', 'comp1.c'], [[-0.5]])
+        assert_near_equal(total_derivs['comp2.x', 'comp1.a'], [[-4.5]])
+        assert_near_equal(total_derivs['comp2.x', 'comp1.b'], [[-1.5]])
+        assert_near_equal(total_derivs['comp2.x', 'comp1.c'], [[-0.5]])
+        assert_near_equal(total_derivs['comp3.x', 'comp1.a'], [[-4.5]])
+        assert_near_equal(total_derivs['comp3.x', 'comp1.b'], [[-1.5]])
+        assert_near_equal(total_derivs['comp3.x', 'comp1.c'], [[-0.5]])
 
     def test_list_inputs_before_run(self):
         # cannot list_inputs on a Group before running
@@ -422,7 +422,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob['comp2.x'] = np.NaN
 
         prob.run_model()
-        assert_rel_error(self, prob['comp2.x'], 3.)
+        assert_near_equal(prob['comp2.x'], 3.)
 
     def test_guess_nonlinear_complex_step(self):
 
@@ -493,12 +493,12 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob.setup(force_alloc_complex=True)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.x'], 3.)
+        assert_near_equal(prob['comp.x'], 3.)
 
         totals = prob.check_totals(of=['fn.y'], wrt=['p.a'], method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-9)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-9)
 
     def test_guess_nonlinear_transfer(self):
         # Test that data is transfered to a component before calling guess_nonlinear.
@@ -537,7 +537,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
-        assert_rel_error(self, prob['comp2.y'], 77., 1e-5)
+        assert_near_equal(prob['comp2.y'], 77., 1e-5)
 
     def test_guess_nonlinear_transfer_subbed(self):
         # Test that data is transfered to a component before calling guess_nonlinear.
@@ -580,7 +580,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
-        assert_rel_error(self, prob['sub.comp2.y'], 77., 1e-5)
+        assert_near_equal(prob['sub.comp2.y'], 77., 1e-5)
 
     def test_guess_nonlinear_transfer_subbed2(self):
         # Test that data is transfered to a component before calling guess_nonlinear.
@@ -623,7 +623,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
-        assert_rel_error(self, prob['sub.comp2.y'], 77., 1e-5)
+        assert_near_equal(prob['sub.comp2.y'], 77., 1e-5)
 
     def test_guess_nonlinear_feature(self):
         import openmdao.api as om
@@ -676,7 +676,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.x'], 3.)
+        assert_near_equal(prob['comp.x'], 3.)
 
     def test_guess_nonlinear_inputs_read_only(self):
         class ImpWithInitial(om.ImplicitComponent):

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -2,7 +2,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestIndepVarComp(unittest.TestCase):
@@ -14,10 +14,10 @@ class TestIndepVarComp(unittest.TestCase):
         comp = om.IndepVarComp('indep_var')
         prob = om.Problem(comp).setup()
 
-        assert_rel_error(self, prob['indep_var'], 1.0)
+        assert_near_equal(prob['indep_var'], 1.0)
 
         prob['indep_var'] = 2.0
-        assert_rel_error(self, prob['indep_var'], 2.0)
+        assert_near_equal(prob['indep_var'], 2.0)
 
     def test_simple_default(self):
         """Define one independent variable with a default value."""
@@ -26,7 +26,7 @@ class TestIndepVarComp(unittest.TestCase):
         comp = om.IndepVarComp('indep_var', val=2.0)
         prob = om.Problem(comp).setup()
 
-        assert_rel_error(self, prob['indep_var'], 2.0)
+        assert_near_equal(prob['indep_var'], 2.0)
 
     def test_simple_kwargs(self):
         """Define one independent variable with a default value and additional options."""
@@ -35,7 +35,7 @@ class TestIndepVarComp(unittest.TestCase):
         comp = om.IndepVarComp('indep_var', val=2.0, units='m', lower=0, upper=10)
         prob = om.Problem(comp).setup()
 
-        assert_rel_error(self, prob['indep_var'], 2.0)
+        assert_near_equal(prob['indep_var'], 2.0)
 
     def test_simple_array(self):
         """Define one independent array variable."""
@@ -51,7 +51,7 @@ class TestIndepVarComp(unittest.TestCase):
         comp = om.IndepVarComp('indep_var', val=array)
         prob = om.Problem(comp).setup()
 
-        assert_rel_error(self, prob['indep_var'], array)
+        assert_near_equal(prob['indep_var'], array)
 
     def test_add_output(self):
         """Define two independent variables using the add_output method."""
@@ -63,8 +63,8 @@ class TestIndepVarComp(unittest.TestCase):
 
         prob = om.Problem(comp).setup()
 
-        assert_rel_error(self, prob['indep_var_1'], 1.0)
-        assert_rel_error(self, prob['indep_var_2'], 2.0)
+        assert_near_equal(prob['indep_var_1'], 1.0)
+        assert_near_equal(prob['indep_var_2'], 2.0)
 
     def test_invalid_tags(self):
         with self.assertRaises(TypeError) as cm:
@@ -182,7 +182,7 @@ class TestIndepVarComp(unittest.TestCase):
         prob['p.x1'][0] = 0.5
         prob.run_model()
 
-        assert_rel_error(self, prob['p.x1'][0], 0.5)
+        assert_near_equal(prob['p.x1'][0], 0.5)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class QuadraticCompVectorized(om.ImplicitComponent):
@@ -589,8 +589,8 @@ class MatMatTestCase(unittest.TestCase):
         p.driver = om.ScipyOptimizeDriver()
         p.run_driver()
 
-        assert_rel_error(self, p['x'], [0.10000691, 0.1, 0.1, 0.1, 0.1], 1e-5)
-        assert_rel_error(self, p['y'], [0, 1.41421, 2.0, 2.44948, 2.82842], 1e-5)
+        assert_near_equal(p['x'], [0.10000691, 0.1, 0.1, 0.1, 0.1], 1e-5)
+        assert_near_equal(p['y'], [0, 1.41421, 2.0, 2.44948, 2.82842], 1e-5)
 
     def test_simple_multi_fwd(self):
         p, expected = simple_model(order=20, vectorize=True)
@@ -606,7 +606,7 @@ class MatMatTestCase(unittest.TestCase):
         # plt.show()
 
         y_lgl = p['y_lgl']
-        assert_rel_error(self, expected, y_lgl, 1.e-5)
+        assert_near_equal(expected, y_lgl, 1.e-5)
 
     def test_simple_multi_rev(self):
         p, expected = simple_model(order=20, vectorize=True)
@@ -616,7 +616,7 @@ class MatMatTestCase(unittest.TestCase):
         p.run_driver()
 
         y_lgl = p['y_lgl']
-        assert_rel_error(self, expected, y_lgl, 1.e-5)
+        assert_near_equal(expected, y_lgl, 1.e-5)
 
     def test_phases_multi_fwd(self):
         N_PHASES = 4
@@ -636,7 +636,7 @@ class MatMatTestCase(unittest.TestCase):
         # plt.show()
 
         for i in range(N_PHASES):
-            assert_rel_error(self, expected, p['p%d.y_lgl' % i], 1.e-5)
+            assert_near_equal(expected, p['p%d.y_lgl' % i], 1.e-5)
 
     def test_phases_multi_rev(self):
         N_PHASES = 4
@@ -647,7 +647,7 @@ class MatMatTestCase(unittest.TestCase):
         p.run_driver()
 
         for i in range(N_PHASES):
-            assert_rel_error(self, expected, p['p%d.y_lgl' % i], 1.e-5)
+            assert_near_equal(expected, p['p%d.y_lgl' % i], 1.e-5)
 
     def test_feature_declaration(self):
         # Tests the code that shows the signature for compute_multi_jacvec
@@ -671,8 +671,8 @@ class MatMatTestCase(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(of=['comp.area'], wrt=['p.length', 'p.width'])
-        assert_rel_error(self, J['comp.area', 'p.length'], np.diag(np.array([1.0, 2.0, 3.0])))
-        assert_rel_error(self, J['comp.area', 'p.width'], np.diag(np.array([3.0, 4.0, 5.0])))
+        assert_near_equal(J['comp.area', 'p.length'], np.diag(np.array([1.0, 2.0, 3.0])))
+        assert_near_equal(J['comp.area', 'p.width'], np.diag(np.array([3.0, 4.0, 5.0])))
 
     def test_implicit(self):
         prob = QCVProblem()
@@ -682,9 +682,9 @@ class MatMatTestCase(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(of=['comp.x'], wrt=['p.a', 'p.b', 'p.c'])
-        assert_rel_error(self, J['comp.x', 'p.a'], np.diag(np.array([-0.06066017, -0.05, -0.03971954])), 1e-4)
-        assert_rel_error(self, J['comp.x', 'p.b'], np.diag(np.array([-0.14644661, -0.1, -0.07421663])), 1e-4)
-        assert_rel_error(self, J['comp.x', 'p.c'], np.diag(np.array([-0.35355339, -0.2, -0.13867505])), 1e-4)
+        assert_near_equal(J['comp.x', 'p.a'], np.diag(np.array([-0.06066017, -0.05, -0.03971954])), 1e-4)
+        assert_near_equal(J['comp.x', 'p.b'], np.diag(np.array([-0.14644661, -0.1, -0.07421663])), 1e-4)
+        assert_near_equal(J['comp.x', 'p.c'], np.diag(np.array([-0.35355339, -0.2, -0.13867505])), 1e-4)
 
     def test_apply_multi_linear_inputs_read_only(self):
         class BadComp(QuadraticCompVectorized):
@@ -841,64 +841,64 @@ class ComputeMultiJacVecTestCase(unittest.TestCase):
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev(self):
         p = self.setup_model(size=5, comp_class=JacVec, vectorize=False, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_fwd_vectorize(self):
         p = self.setup_model(size=5, comp_class=JacVec, vectorize=True, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev_vectorize(self):
         p = self.setup_model(size=5, comp_class=JacVec, vectorize=True, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_fwd_multi(self):
         p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=False, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev_multi(self):
         p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=False, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_fwd_vectorize_multi(self):
         p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=True, mode='fwd')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_multi_jacvec_prod_rev_vectorize_multi(self):
         p = self.setup_model(size=5, comp_class=MultiJacVec, vectorize=True, mode='rev')
 
         J = p.compute_totals(of=['comp.f_xy'], wrt=['px.x', 'py.y'])
 
-        assert_rel_error(self, J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
-        assert_rel_error(self, J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'px.x')], np.eye(5)*p['py.y'], 1e-5)
+        assert_near_equal(J[('comp.f_xy', 'py.y')], np.eye(5)*p['px.x'], 1e-5)
 
     def test_compute_jacvec_product_mode_read_only(self):
         class BadComp(JacVec):

--- a/openmdao/core/tests/test_mpi_coloring_bug.py
+++ b/openmdao/core/tests/test_mpi_coloring_bug.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 import openmdao.utils.coloring as coloring_mod
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 
 
@@ -508,4 +508,4 @@ class TestMPIColoringBug(unittest.TestCase):
         J = p.driver._compute_totals(of=of, wrt=wrt, return_format='dict')
         dd = J['phases.burn1.collocation_constraint.defects:deltav']['phases.burn1.indep_states.states:deltav']
 
-        assert_rel_error(self, np.array([[-0.75, 0.75]]), dd, 1e-6)
+        assert_near_equal(np.array([[-0.75, 0.75]]), dd, 1e-6)

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -14,7 +14,7 @@ import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDerivatives, \
     SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.groups.parallel_groups import FanOutGrouped, FanInGrouped
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 
@@ -48,8 +48,8 @@ class ParDerivTestCase(unittest.TestCase):
         unknown_list = ['c3.y']
 
         J = prob.compute_totals(unknown_list, indep_list, return_format='dict')
-        assert_rel_error(self, J['c3.y']['iv.x1'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y']['iv.x2'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y']['iv.x1'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y']['iv.x2'][0][0], 35.0, 1e-6)
 
     def test_fan_in_serial_sets_fwd(self):
 
@@ -69,8 +69,8 @@ class ParDerivTestCase(unittest.TestCase):
         unknown_list = ['c3.y']
 
         J = prob.compute_totals(unknown_list, indep_list, return_format='flat_dict')
-        assert_rel_error(self, J['c3.y', 'iv.x1'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x2'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x1'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x2'][0][0], 35.0, 1e-6)
 
     def test_fan_out_serial_sets_fwd(self):
 
@@ -90,8 +90,8 @@ class ParDerivTestCase(unittest.TestCase):
         indep_list = ['iv.x']
 
         J = prob.compute_totals(unknown_list, indep_list, return_format='flat_dict')
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
     def test_fan_out_serial_sets_rev(self):
 
@@ -111,8 +111,8 @@ class ParDerivTestCase(unittest.TestCase):
         indep_list = ['iv.x']
 
         J = prob.compute_totals(unknown_list, indep_list, return_format='flat_dict')
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
     def test_fan_in_parallel_sets_fwd(self):
 
@@ -133,8 +133,8 @@ class ParDerivTestCase(unittest.TestCase):
         unknown_list = ['c3.y']
 
         J = prob.compute_totals(unknown_list, indep_list, return_format='flat_dict')
-        assert_rel_error(self, J['c3.y', 'iv.x1'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x2'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x1'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x2'][0][0], 35.0, 1e-6)
 
     def test_debug_print_option_totals_color(self):
 
@@ -191,15 +191,15 @@ class ParDerivTestCase(unittest.TestCase):
         indep_list = ['iv.x']
 
         J = prob.compute_totals(unknown_list, indep_list, return_format='flat_dict')
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
         # Piggyback to make sure the distributed norm calculation is correct.
         vec = prob.model._vectors['residual']['c2.y']
         norm_val = vec.get_norm()
         # NOTE: BAN updated the norm value for the PR that added seed splitting, i.e.
         # the seed, c2.y in this case, is half what it was before (-.5 vs. -1).
-        assert_rel_error(self, norm_val, 6.422616289332565, 1e-6)
+        assert_near_equal(norm_val, 6.422616289332565, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -249,10 +249,10 @@ class DecoupledTestCase(unittest.TestCase):
         J = prob.compute_totals(['Con1.y', 'Con2.y'], ['Indep1.x', 'Indep2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.zeros((asize, asize+2))
         expected[:,:asize] = np.eye(asize)*8.0
-        assert_rel_error(self, J['Con2.y', 'Indep2.x'], expected, 1e-6)
+        assert_near_equal(J['Con2.y', 'Indep2.x'], expected, 1e-6)
 
     def test_parallel_fwd(self):
         asize = self.asize
@@ -269,10 +269,10 @@ class DecoupledTestCase(unittest.TestCase):
         J = prob.compute_totals(['Con1.y', 'Con2.y'], ['Indep1.x', 'Indep2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.zeros((asize, asize+2))
         expected[:,:asize] = np.eye(asize)*8.0
-        assert_rel_error(self, J['Con2.y', 'Indep2.x'], expected, 1e-6)
+        assert_near_equal(J['Con2.y', 'Indep2.x'], expected, 1e-6)
 
     def test_parallel_fwd_multi(self):
         asize = self.asize
@@ -289,10 +289,10 @@ class DecoupledTestCase(unittest.TestCase):
         J = prob.compute_totals(['Con1.y', 'Con2.y'], ['Indep1.x', 'Indep2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.zeros((asize, asize+2))
         expected[:,:asize] = np.eye(asize)*8.0
-        assert_rel_error(self, J['Con2.y', 'Indep2.x'], expected, 1e-6)
+        assert_near_equal(J['Con2.y', 'Indep2.x'], expected, 1e-6)
 
     def test_serial_rev(self):
         asize = self.asize
@@ -309,10 +309,10 @@ class DecoupledTestCase(unittest.TestCase):
         J = prob.compute_totals(['Con1.y', 'Con2.y'], ['Indep1.x', 'Indep2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.zeros((asize, asize+2))
         expected[:,:asize] = np.eye(asize)*8.0
-        assert_rel_error(self, J['Con2.y', 'Indep2.x'], expected, 1e-6)
+        assert_near_equal(J['Con2.y', 'Indep2.x'], expected, 1e-6)
 
     def test_parallel_rev(self):
         asize = self.asize
@@ -330,10 +330,10 @@ class DecoupledTestCase(unittest.TestCase):
         J = prob.compute_totals(['Con1.y', 'Con2.y'], ['Indep1.x', 'Indep2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['Con1.y', 'Indep1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.zeros((asize, asize+2))
         expected[:,:asize] = np.eye(asize)*8.0
-        assert_rel_error(self, J['Con2.y', 'Indep2.x'], expected, 1e-6)
+        assert_near_equal(J['Con2.y', 'Indep2.x'], expected, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -380,16 +380,16 @@ class IndicesTestCase(unittest.TestCase):
         J = prob.compute_totals(['c4.y', 'c5.y'], ['p.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['c5.y', 'p.x'][0], np.array([20., 25.]), 1e-6)
-        assert_rel_error(self, J['c4.y', 'p.x'][0], np.array([8., 0.]), 1e-6)
+        assert_near_equal(J['c5.y', 'p.x'][0], np.array([20., 25.]), 1e-6)
+        assert_near_equal(J['c4.y', 'p.x'][0], np.array([8., 0.]), 1e-6)
 
     def test_indices_rev(self):
         prob = self.setup_model('rev')
         J = prob.compute_totals(['c4.y', 'c5.y'], ['p.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['c5.y', 'p.x'][0], np.array([20., 25.]), 1e-6)
-        assert_rel_error(self, J['c4.y', 'p.x'][0], np.array([8., 0.]), 1e-6)
+        assert_near_equal(J['c5.y', 'p.x'][0], np.array([20., 25.]), 1e-6)
+        assert_near_equal(J['c4.y', 'p.x'][0], np.array([8., 0.]), 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -452,8 +452,8 @@ class IndicesTestCase2(unittest.TestCase):
                                 wrt=['G1.par1.p.x', 'G1.par2.p.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['G1.par2.c5.y', 'G1.par2.p.x'][0], np.array([20., 25.]), 1e-6)
-        assert_rel_error(self, J['G1.par1.c4.y', 'G1.par1.p.x'][0], np.array([8., 0.]), 1e-6)
+        assert_near_equal(J['G1.par2.c5.y', 'G1.par2.p.x'][0], np.array([20., 25.]), 1e-6)
+        assert_near_equal(J['G1.par1.c4.y', 'G1.par1.p.x'][0], np.array([8., 0.]), 1e-6)
 
     def test_indices_rev(self):
         prob = self.setup_model('rev')
@@ -461,8 +461,8 @@ class IndicesTestCase2(unittest.TestCase):
                                 ['G1.par1.p.x', 'G1.par2.p.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['G1.par2.c5.y', 'G1.par2.p.x'][0], np.array([20., 25.]), 1e-6)
-        assert_rel_error(self, J['G1.par1.c4.y', 'G1.par1.p.x'][0], np.array([8., 0.]), 1e-6)
+        assert_near_equal(J['G1.par2.c5.y', 'G1.par2.p.x'][0], np.array([20., 25.]), 1e-6)
+        assert_near_equal(J['G1.par1.c4.y', 'G1.par1.p.x'][0], np.array([8., 0.]), 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -512,9 +512,9 @@ class MatMatTestCase(unittest.TestCase):
         J = prob.compute_totals(['c3.y', 'c4.y'], ['p1.x', 'p2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.eye(asize)*8.0
-        assert_rel_error(self, J['c4.y', 'p2.x'], expected, 1e-6)
+        assert_near_equal(J['c4.y', 'p2.x'], expected, 1e-6)
 
     def test_parallel_multi_fwd(self):
         asize = self.asize
@@ -531,9 +531,9 @@ class MatMatTestCase(unittest.TestCase):
         J = prob.compute_totals(['c3.y', 'c4.y'], ['p1.x', 'p2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.eye(asize)*8.0
-        assert_rel_error(self, J['c4.y', 'p2.x'], expected, 1e-6)
+        assert_near_equal(J['c4.y', 'p2.x'], expected, 1e-6)
 
     def test_parallel_rev(self):
         asize = self.asize
@@ -550,9 +550,9 @@ class MatMatTestCase(unittest.TestCase):
         J = prob.compute_totals(['c3.y', 'c4.y'], ['p1.x', 'p2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.eye(asize)*8.0
-        assert_rel_error(self, J['c4.y', 'p2.x'], expected, 1e-6)
+        assert_near_equal(J['c4.y', 'p2.x'], expected, 1e-6)
 
     def test_parallel_multi_rev(self):
         asize = self.asize
@@ -569,9 +569,9 @@ class MatMatTestCase(unittest.TestCase):
         J = prob.compute_totals(['c3.y', 'c4.y'], ['p1.x', 'p2.x'],
                                 return_format='flat_dict')
 
-        assert_rel_error(self, J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'], np.array([[15., 20., 25.],[15., 20., 25.], [15., 20., 25.]]), 1e-6)
         expected = np.eye(asize)*8.0
-        assert_rel_error(self, J['c4.y', 'p2.x'], expected, 1e-6)
+        assert_near_equal(J['c4.y', 'p2.x'], expected, 1e-6)
 
 
 class SumComp(om.ExplicitComponent):
@@ -674,8 +674,8 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
 
         J = p.compute_totals(of, wrt, return_format='dict')
 
-        assert_rel_error(self, J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
-        assert_rel_error(self, J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
+        assert_near_equal(J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
+        assert_near_equal(J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
 
     def test_fwd_vs_rev(self):
         import time
@@ -699,8 +699,8 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         J = p.compute_totals(of, wrt, return_format='dict')
         elapsed_fwd = time.time() - elapsed_fwd
 
-        assert_rel_error(self, J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
-        assert_rel_error(self, J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
+        assert_near_equal(J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
+        assert_near_equal(J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
 
         # now run in rev mode and compare times for deriv calculation
         p = om.Problem(model=PartialDependGroup())
@@ -712,8 +712,8 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         J = p.compute_totals(of, wrt, return_format='dict')
         elapsed_rev = time.time() - elapsed_rev
 
-        assert_rel_error(self, J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
-        assert_rel_error(self, J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
+        assert_near_equal(J['ParallelGroup1.Con1.y']['Indep1.x'][0], np.ones(size)*2., 1e-6)
+        assert_near_equal(J['ParallelGroup1.Con2.y']['Indep1.x'][0], np.ones(size)*-3., 1e-6)
 
         # make sure that rev mode is faster than fwd mode
         self.assertGreater(elapsed_fwd / elapsed_rev, 1.0)

--- a/openmdao/core/tests/test_parallel_fd.py
+++ b/openmdao/core/tests/test_parallel_fd.py
@@ -8,7 +8,7 @@ TestCase = unittest.TestCase
 
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.test_suite.parametric_suite import parametric_suite
 from openmdao.test_suite.components.matmultcomp import MatMultComp
 
@@ -113,7 +113,7 @@ class SerialSimpleFDTestCase(TestCase):
         prob = setup_1comp_model(1, size, mult, add, 'fd')
 
         J = prob.compute_totals(['C1.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
+        assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
     def test_serial_cs(self):
         size = 15
@@ -122,7 +122,7 @@ class SerialSimpleFDTestCase(TestCase):
         prob = setup_1comp_model(1, size, mult, add, 'cs')
 
         J = prob.compute_totals(['C1.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
+        assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -138,7 +138,7 @@ class ParallelSimpleFDTestCase2(TestCase):
         prob = setup_1comp_model(2, size, mult, add, 'fd')
 
         J = prob.compute_totals(['C1.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
+        assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
     def test_parallel_cs2(self):
         size = 15
@@ -148,7 +148,7 @@ class ParallelSimpleFDTestCase2(TestCase):
         prob = setup_1comp_model(2, size, mult, add, 'cs')
 
         J = prob.compute_totals(['C1.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
+        assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -163,7 +163,7 @@ class ParallelFDTestCase5(TestCase):
         prob = setup_1comp_model(5, size, mult, add, 'fd')
 
         J = prob.compute_totals(['C1.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
+        assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
     def test_parallel_cs5(self):
         size = 15
@@ -172,7 +172,7 @@ class ParallelFDTestCase5(TestCase):
         prob = setup_1comp_model(5, size, mult, add, 'cs')
 
         J = prob.compute_totals(['C1.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
+        assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
 
 class SerialDiamondFDTestCase(TestCase):
@@ -180,18 +180,18 @@ class SerialDiamondFDTestCase(TestCase):
     def test_diamond_fd_totals(self):
         size = 15
         prob = setup_diamond_model(1, size, 'fd', 'model')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_diamond_cs_totals(self):
         size = 15
         prob = setup_diamond_model(1, size, 'cs', 'model')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_bad_num_par_fds(self):
         try:
@@ -208,50 +208,50 @@ class ParallelDiamondFDTestCase(TestCase):
     def test_diamond_fd_totals(self):
         size = 15
         prob = setup_diamond_model(2, size, 'fd', 'model')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_diamond_fd_nested_par_fd_totals(self):
         size = 15
         prob = setup_diamond_model(4, size, 'fd', 'par')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_diamond_fd_totals_num_fd_bigger_than_psize(self):
         size = 1
         prob = setup_diamond_model(2, size, 'fd', 'model')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_diamond_cs_totals(self):
         size = 15
         prob = setup_diamond_model(2, size, 'cs', 'model')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_diamond_cs_totals_nested_par_cs(self):
         size = 15
         prob = setup_diamond_model(4, size, 'cs', 'par')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
     def test_diamond_cs_totals_num_fd_bigger_than_psize(self):
         size = 1
         prob = setup_diamond_model(2, size, 'cs', 'model')
-        assert_rel_error(self, prob['C3.y'], np.ones(size)*24.0, 1e-6)
+        assert_near_equal(prob['C3.y'], np.ones(size)*24.0, 1e-6)
 
         J = prob.compute_totals(['C3.y'], ['P1.x'], return_format='dict')
-        assert_rel_error(self, J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
+        assert_near_equal(J['C3.y']['P1.x'], np.eye(size)*6.0, 1e-6)
 
 
 def _test_func_name(func, num, param):

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -27,7 +27,7 @@ except ImportError:
 from openmdao.test_suite.groups.parallel_groups import \
     FanOutGrouped, FanInGrouped2, Diamond, ConvergeDiverge
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.error_checking.check_config import _default_checks
 
@@ -81,22 +81,22 @@ class TestParallelGroups(unittest.TestCase):
 
         J = prob.compute_totals(of=['c2.y', "c3.y"], wrt=['iv.x'])
 
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
-        assert_rel_error(self, prob['c2.y'], -6.0, 1e-6)
-        assert_rel_error(self, prob['c3.y'], 15.0, 1e-6)
+        assert_near_equal(prob['c2.y'], -6.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 15.0, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(of=['c2.y', "c3.y"], wrt=['iv.x'])
 
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
-        assert_rel_error(self, prob['c2.y'], -6.0, 1e-6)
-        assert_rel_error(self, prob['c3.y'], 15.0, 1e-6)
+        assert_near_equal(prob['c2.y'], -6.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 15.0, 1e-6)
 
     @parameterized.expand(itertools.product([om.LinearRunOnce],
                                             [om.NonlinearBlockGS, om.NonlinearRunOnce]),
@@ -116,34 +116,34 @@ class TestParallelGroups(unittest.TestCase):
         indep_list = ['p1.x', 'p2.x']
         unknown_list = ['c3.y']
 
-        assert_rel_error(self, prob['c3.y'], 29.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 29.0, 1e-6)
 
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
 
         # do this a second time to test caching of dist rows/cols
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
 
-        assert_rel_error(self, prob['c3.y'], 29.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 29.0, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
-        assert_rel_error(self, prob['c3.y'], 29.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 29.0, 1e-6)
 
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
 
         # do this a second time to test caching of dist rows/cols
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p1.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'p2.x'][0][0], 35.0, 1e-6)
 
-        assert_rel_error(self, prob['c3.y'], 29.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 29.0, 1e-6)
 
     def test_fan_in_grouped_feature(self):
 
@@ -170,7 +170,7 @@ class TestParallelGroups(unittest.TestCase):
         prob.setup(check=False, mode='fwd')
         prob.run_model()
 
-        assert_rel_error(self, prob['c3.y'], 29.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 29.0, 1e-6)
 
     @parameterized.expand(itertools.product([om.LinearRunOnce],
                                             [om.NonlinearBlockGS, om.NonlinearRunOnce]),
@@ -187,25 +187,25 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['c4.y1'], 46.0, 1e-6)
-        assert_rel_error(self, prob['c4.y2'], -93.0, 1e-6)
+        assert_near_equal(prob['c4.y1'], 46.0, 1e-6)
+        assert_near_equal(prob['c4.y2'], -93.0, 1e-6)
 
         indep_list = ['iv.x']
         unknown_list = ['c4.y1', 'c4.y2']
 
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c4.y1', 'iv.x'][0][0], 25, 1e-6)
-        assert_rel_error(self, J['c4.y2', 'iv.x'][0][0], -40.5, 1e-6)
+        assert_near_equal(J['c4.y1', 'iv.x'][0][0], 25, 1e-6)
+        assert_near_equal(J['c4.y2', 'iv.x'][0][0], -40.5, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
-        assert_rel_error(self, prob['c4.y1'], 46.0, 1e-6)
-        assert_rel_error(self, prob['c4.y2'], -93.0, 1e-6)
+        assert_near_equal(prob['c4.y1'], 46.0, 1e-6)
+        assert_near_equal(prob['c4.y2'], -93.0, 1e-6)
 
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c4.y1', 'iv.x'][0][0], 25, 1e-6)
-        assert_rel_error(self, J['c4.y2', 'iv.x'][0][0], -40.5, 1e-6)
+        assert_near_equal(J['c4.y1', 'iv.x'][0][0], 25, 1e-6)
+        assert_near_equal(J['c4.y2', 'iv.x'][0][0], -40.5, 1e-6)
 
     @parameterized.expand(itertools.product([om.LinearRunOnce],
                                             [om.NonlinearBlockGS, om.NonlinearRunOnce]),
@@ -222,23 +222,23 @@ class TestParallelGroups(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+        assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
         indep_list = ['iv.x']
         unknown_list = ['c7.y1']
 
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
+        assert_near_equal(J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
-        assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+        assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
         J = prob.compute_totals(of=unknown_list, wrt=indep_list)
-        assert_rel_error(self, J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
+        assert_near_equal(J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
 
-        assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+        assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
     def test_zero_shape(self):
         raise unittest.SkipTest("zero shapes not fully supported yet")
@@ -291,22 +291,22 @@ class TestParallelGroups(unittest.TestCase):
 
         J = prob.compute_totals(of=['c2.y', "c3.y"], wrt=['iv.x'])
 
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
-        assert_rel_error(self, prob['c2.y'], -6.0, 1e-6)
-        assert_rel_error(self, prob['c3.y'], 15.0, 1e-6)
+        assert_near_equal(prob['c2.y'], -6.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 15.0, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(of=['c2.y', "c3.y"], wrt=['iv.x'])
 
-        assert_rel_error(self, J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
-        assert_rel_error(self, J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
+        assert_near_equal(J['c2.y', 'iv.x'][0][0], -6.0, 1e-6)
+        assert_near_equal(J['c3.y', 'iv.x'][0][0], 15.0, 1e-6)
 
-        assert_rel_error(self, prob['c2.y'], -6.0, 1e-6)
-        assert_rel_error(self, prob['c3.y'], 15.0, 1e-6)
+        assert_near_equal(prob['c2.y'], -6.0, 1e-6)
+        assert_near_equal(prob['c3.y'], 15.0, 1e-6)
 
     def test_setup_messages_bad_vec_type(self):
 

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -7,7 +7,7 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.proc_allocators.default_allocator import DefaultAllocator
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 if MPI:
@@ -171,4 +171,4 @@ class ProbRemote4TestCase(unittest.TestCase):
 
         objs = comm.allgather(prob['obj.o'])
         for i, obj in enumerate(objs):
-            assert_rel_error(self, obj, 2.0, 1e-6)
+            assert_near_equal(obj, 2.0, 1e-6)

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -10,7 +10,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.core.system import get_relevant_vars
 from openmdao.core.driver import Driver
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 import openmdao.utils.hooks as hooks
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
@@ -134,7 +134,7 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.f_xy'], -15.0)
+        assert_near_equal(prob['comp.f_xy'], -15.0)
 
     def test_feature_simple_run_once_input_input(self):
         import openmdao.api as om
@@ -155,8 +155,8 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp1.f_xy'], 13.0)
-        assert_rel_error(self, prob['comp2.f_xy'], 13.0)
+        assert_near_equal(prob['comp1.f_xy'], 13.0)
+        assert_near_equal(prob['comp2.f_xy'], 13.0)
 
     def test_feature_simple_run_once_compute_totals(self):
         import openmdao.api as om
@@ -176,12 +176,12 @@ class TestProblem(unittest.TestCase):
         prob.run_model()
 
         totals = prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'])
-        assert_rel_error(self, totals[('comp.f_xy', 'p1.x')][0][0], -4.0)
-        assert_rel_error(self, totals[('comp.f_xy', 'p2.y')][0][0], 3.0)
+        assert_near_equal(totals[('comp.f_xy', 'p1.x')][0][0], -4.0)
+        assert_near_equal(totals[('comp.f_xy', 'p2.y')][0][0], 3.0)
 
         totals = prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'], return_format='dict')
-        assert_rel_error(self, totals['comp.f_xy']['p1.x'][0][0], -4.0)
-        assert_rel_error(self, totals['comp.f_xy']['p2.y'][0][0], 3.0)
+        assert_near_equal(totals['comp.f_xy']['p1.x'][0][0], -4.0)
+        assert_near_equal(totals['comp.f_xy']['p2.y'][0][0], 3.0)
 
     def test_feature_simple_run_once_compute_totals_scaled(self):
         import openmdao.api as om
@@ -205,8 +205,8 @@ class TestProblem(unittest.TestCase):
         prob.run_model()
 
         totals = prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'], driver_scaling=True)
-        assert_rel_error(self, totals[('comp.f_xy', 'p1.x')][0][0], 196.0)
-        assert_rel_error(self, totals[('comp.f_xy', 'p2.y')][0][0], 3.0)
+        assert_near_equal(totals[('comp.f_xy', 'p1.x')][0][0], 196.0)
+        assert_near_equal(totals[('comp.f_xy', 'p2.y')][0][0], 3.0)
 
     def test_feature_simple_run_once_set_deriv_mode(self):
         import openmdao.api as om
@@ -226,7 +226,7 @@ class TestProblem(unittest.TestCase):
         # prob.setup(mode='fwd')
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.f_xy'], -15.0)
+        assert_near_equal(prob['comp.f_xy'], -15.0)
 
         prob.compute_totals(of=['comp.f_xy'], wrt=['p1.x', 'p2.y'])
 
@@ -246,7 +246,7 @@ class TestProblem(unittest.TestCase):
         prob.run_model()
 
         totals = prob.compute_totals(of='comp.f_xy', wrt='p1.x')
-        assert_rel_error(self, totals[('comp.f_xy', 'p1.x')][0][0], -4.0)
+        assert_near_equal(totals[('comp.f_xy', 'p1.x')][0][0], -4.0)
 
     def test_two_var_single_string_error(self):
 
@@ -289,12 +289,12 @@ class TestProblem(unittest.TestCase):
         p.run_model()
 
         J = p.compute_totals()
-        assert_rel_error(self, J[('MP1.y', 'indeps1.x')], np.eye(5)*7., 1e-10)
-        assert_rel_error(self, J[('MP2.y', 'indeps2.x')], np.eye(3)*-3., 1e-10)
+        assert_near_equal(J[('MP1.y', 'indeps1.x')], np.eye(5)*7., 1e-10)
+        assert_near_equal(J[('MP2.y', 'indeps2.x')], np.eye(3)*-3., 1e-10)
         # before the bug fix, the following two derivs contained nonzero values even
         # though the variables involved were not dependent on each other.
-        assert_rel_error(self, J[('MP2.y', 'indeps1.x')], np.zeros((3, 5)), 1e-10)
-        assert_rel_error(self, J[('MP1.y', 'indeps2.x')], np.zeros((5, 3)), 1e-10)
+        assert_near_equal(J[('MP2.y', 'indeps1.x')], np.zeros((3, 5)), 1e-10)
+        assert_near_equal(J[('MP1.y', 'indeps2.x')], np.zeros((5, 3)), 1e-10)
 
     def test_set_2d_array(self):
         import numpy as np
@@ -311,14 +311,14 @@ class TestProblem(unittest.TestCase):
         prob['indeps.X_c'] = new_val
         prob.final_setup()
 
-        assert_rel_error(self, prob['indeps.X_c'], new_val, 1e-10)
+        assert_near_equal(prob['indeps.X_c'], new_val, 1e-10)
 
         new_val = 2.5*np.ones(3)
         prob['indeps.X_c'][:, 0] = new_val
         prob.final_setup()
 
-        assert_rel_error(self, prob['indeps.X_c'], new_val.reshape((3, 1)), 1e-10)
-        assert_rel_error(self, prob['indeps.X_c'][:, 0], new_val, 1e-10)
+        assert_near_equal(prob['indeps.X_c'], new_val.reshape((3, 1)), 1e-10)
+        assert_near_equal(prob['indeps.X_c'][:, 0], new_val, 1e-10)
 
     def test_set_checks_shape(self):
 
@@ -336,7 +336,7 @@ class TestProblem(unittest.TestCase):
         # check valid scalar value
         new_val = -10.
         prob['indep.num'] = new_val
-        assert_rel_error(self, prob['indep.num'], new_val, 1e-10)
+        assert_near_equal(prob['indep.num'], new_val, 1e-10)
 
         # check bad scalar value
         bad_val = -10*np.ones((10))
@@ -349,12 +349,12 @@ class TestProblem(unittest.TestCase):
         arr_val = new_val*np.ones((10, 1))
         prob['indep.arr'] = new_val
         prob.final_setup()
-        assert_rel_error(self, prob['indep.arr'], arr_val, 1e-10)
+        assert_near_equal(prob['indep.arr'], arr_val, 1e-10)
 
         # check valid array value
         new_val = -10*np.ones((10, 1))
         prob['indep.arr'] = new_val
-        assert_rel_error(self, prob['indep.arr'], new_val, 1e-10)
+        assert_near_equal(prob['indep.arr'], new_val, 1e-10)
 
         # check bad array value
         bad_val = -10*np.ones((10))
@@ -364,7 +364,7 @@ class TestProblem(unittest.TestCase):
         # check valid list value
         new_val = new_val.tolist()
         prob['indep.arr'] = new_val
-        assert_rel_error(self, prob['indep.arr'], new_val, 1e-10)
+        assert_near_equal(prob['indep.arr'], new_val, 1e-10)
 
         # check bad list value
         bad_val = bad_val.tolist()
@@ -388,8 +388,8 @@ class TestProblem(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
@@ -398,8 +398,8 @@ class TestProblem(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt)
 
-        assert_rel_error(self, derivs['f_xy', 'x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy', 'y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
     def test_compute_totals_basic_return_dict(self):
         # Make sure 'dict' return_format works.
@@ -418,8 +418,8 @@ class TestProblem(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, derivs['f_xy']['x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy']['y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy']['x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy']['y'], [[8.0]], 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
@@ -428,8 +428,8 @@ class TestProblem(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, derivs['f_xy']['x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy']['y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy']['x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy']['y'], [[8.0]], 1e-6)
 
     def test_compute_totals_no_args_no_desvar(self):
         p = om.Problem()
@@ -491,7 +491,7 @@ class TestProblem(unittest.TestCase):
 
         derivs = p.compute_totals()
 
-        assert_rel_error(self, derivs['calc.y', 'des_vars.x'], [[2.0]], 1e-6)
+        assert_near_equal(derivs['calc.y', 'des_vars.x'], [[2.0]], 1e-6)
 
     def test_compute_totals_no_args_promoted(self):
         p = om.Problem()
@@ -509,7 +509,7 @@ class TestProblem(unittest.TestCase):
 
         derivs = p.compute_totals()
 
-        assert_rel_error(self, derivs['calc.y', 'des_vars.x'], [[2.0]], 1e-6)
+        assert_near_equal(derivs['calc.y', 'des_vars.x'], [[2.0]], 1e-6)
 
     @parameterized.expand(itertools.product(['fwd', 'rev']))
     def test_compute_jacvec_product(self, mode):
@@ -572,7 +572,7 @@ class TestProblem(unittest.TestCase):
         prob['x'] = 2.
         prob['y'] = 10.
         prob.run_model()
-        assert_rel_error(self, prob['f_xy'], 214.0, 1e-6)
+        assert_near_equal(prob['f_xy'], 214.0, 1e-6)
 
     def test_feature_basic_setup(self):
         import openmdao.api as om
@@ -589,19 +589,19 @@ class TestProblem(unittest.TestCase):
         prob['x'] = 2.
         prob['y'] = 10.
         prob.run_model()
-        assert_rel_error(self, prob['f_xy'], 214.0, 1e-6)
+        assert_near_equal(prob['f_xy'], 214.0, 1e-6)
 
         prob['x'] = 0.
         prob['y'] = 0.
         prob.run_model()
-        assert_rel_error(self, prob['f_xy'], 22.0, 1e-6)
+        assert_near_equal(prob['f_xy'], 22.0, 1e-6)
 
         prob.setup()
         prob['x'] = 4
         prob['y'] = 8.
 
         prob.run_model()
-        assert_rel_error(self, prob['f_xy'], 174.0, 1e-6)
+        assert_near_equal(prob['f_xy'], 174.0, 1e-6)
 
     def test_feature_petsc_setup(self):
         import openmdao.api as om
@@ -619,7 +619,7 @@ class TestProblem(unittest.TestCase):
         prob['y'] = 10.
 
         prob.run_model()
-        assert_rel_error(self, prob['f_xy'], 214.0, 1e-6)
+        assert_near_equal(prob['f_xy'], 214.0, 1e-6)
 
     def test_feature_check_totals_manual(self):
         import openmdao.api as om
@@ -850,11 +850,11 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], 0.0, 1e-5)
-        assert_rel_error(self, prob['y1'], 3.160000, 1e-2)
-        assert_rel_error(self, prob['y2'], 3.755278, 1e-2)
-        assert_rel_error(self, prob['z'], [1.977639, 0.000000], 1e-2)
-        assert_rel_error(self, prob['obj'], 3.18339395, 1e-2)
+        assert_near_equal(prob['x'], 0.0, 1e-5)
+        assert_near_equal(prob['y1'], 3.160000, 1e-2)
+        assert_near_equal(prob['y2'], 3.755278, 1e-2)
+        assert_near_equal(prob['z'], [1.977639, 0.000000], 1e-2)
+        assert_near_equal(prob['obj'], 3.18339395, 1e-2)
 
     def test_feature_promoted_sellar_set_get_outputs(self):
         import openmdao.api as om
@@ -869,9 +869,9 @@ class TestProblem(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['x'], 2.75, 1e-6)
+        assert_near_equal(prob['x'], 2.75, 1e-6)
 
-        assert_rel_error(self, prob['y1'], 27.3049178437, 1e-6)
+        assert_near_equal(prob['y1'], 27.3049178437, 1e-6)
 
     def test_feature_not_promoted_sellar_set_get_outputs(self):
         import openmdao.api as om
@@ -886,9 +886,9 @@ class TestProblem(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['px.x'], 2.75, 1e-6)
+        assert_near_equal(prob['px.x'], 2.75, 1e-6)
 
-        assert_rel_error(self, prob['d1.y1'], 27.3049178437, 1e-6)
+        assert_near_equal(prob['d1.y1'], 27.3049178437, 1e-6)
 
     def test_feature_promoted_sellar_set_get_inputs(self):
         import openmdao.api as om
@@ -903,12 +903,12 @@ class TestProblem(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['x'], 2.75, 1e-6)
+        assert_near_equal(prob['x'], 2.75, 1e-6)
 
         # the output variable, referenced by the promoted name
-        assert_rel_error(self, prob['y1'], 27.3049178437, 1e-6)
+        assert_near_equal(prob['y1'], 27.3049178437, 1e-6)
         # the connected input variable, referenced by the absolute path
-        assert_rel_error(self, prob['d2.y1'], 27.3049178437, 1e-6)
+        assert_near_equal(prob['d2.y1'], 27.3049178437, 1e-6)
 
     def test_get_set_with_units_exhaustive(self):
         import openmdao.api as om
@@ -935,47 +935,47 @@ class TestProblem(unittest.TestCase):
 
         # Gets
 
-        assert_rel_error(self, prob.get_val('comp.x'), 77.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'degC'), 25.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.y'), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.y', 'degF'), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), 77.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'degC'), 25.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.y'), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.y', 'degF'), 32.0, 1e-6)
 
-        assert_rel_error(self, prob.get_val('xx'), 77.0, 1e-6)
-        assert_rel_error(self, prob.get_val('xx', 'degC'), 25.0, 1e-6)
-        assert_rel_error(self, prob.get_val('yy'), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('yy', 'degF'), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('xx'), 77.0, 1e-6)
+        assert_near_equal(prob.get_val('xx', 'degC'), 25.0, 1e-6)
+        assert_near_equal(prob.get_val('yy'), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('yy', 'degF'), 32.0, 1e-6)
 
-        assert_rel_error(self, prob.get_val('acomp.x', indices=0), 77.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', indices=[1]), 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', 'degC', indices=[0]), 25.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', 'degC', indices=1), 35.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.y', indices=0), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.y', 'degF', indices=0), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', indices=0), 77.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', indices=[1]), 95.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', 'degC', indices=[0]), 25.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', 'degC', indices=1), 35.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.y', indices=0), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.y', 'degF', indices=0), 32.0, 1e-6)
 
-        assert_rel_error(self, prob.get_val('axx', indices=0), 77.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', indices=1), 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', 'degC', indices=0), 25.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', 'degC', indices=np.array([1])), 35.0, 1e-6)
-        assert_rel_error(self, prob.get_val('ayy', indices=0), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('ayy', 'degF', indices=0), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', indices=0), 77.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', indices=1), 95.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', 'degC', indices=0), 25.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', 'degC', indices=np.array([1])), 35.0, 1e-6)
+        assert_near_equal(prob.get_val('ayy', indices=0), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('ayy', 'degF', indices=0), 32.0, 1e-6)
 
         # Sets
 
         prob.set_val('comp.x', 30.0, 'degC')
-        assert_rel_error(self, prob['comp.x'], 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'degC'), 30.0, 1e-6)
+        assert_near_equal(prob['comp.x'], 86.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'degC'), 30.0, 1e-6)
 
         prob.set_val('xx', 30.0, 'degC')
-        assert_rel_error(self, prob['xx'], 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('xx', 'degC'), 30.0, 1e-6)
+        assert_near_equal(prob['xx'], 86.0, 1e-6)
+        assert_near_equal(prob.get_val('xx', 'degC'), 30.0, 1e-6)
 
         prob.set_val('acomp.x', 30.0, 'degC', indices=[0])
-        assert_rel_error(self, prob['acomp.x'][0], 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', 'degC', indices=0), 30.0, 1e-6)
+        assert_near_equal(prob['acomp.x'][0], 86.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', 'degC', indices=0), 30.0, 1e-6)
 
         prob.set_val('axx', 30.0, 'degC', indices=0)
-        assert_rel_error(self, prob['axx'][0], 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', 'degC', indices=np.array([0])), 30.0, 1e-6)
+        assert_near_equal(prob['axx'][0], 86.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', 'degC', indices=np.array([0])), 30.0, 1e-6)
 
         prob.final_setup()
 
@@ -983,47 +983,47 @@ class TestProblem(unittest.TestCase):
 
         # Gets
 
-        assert_rel_error(self, prob.get_val('comp.x'), 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'degC'), 30.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.y'), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.y', 'degF'), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), 86.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'degC'), 30.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.y'), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.y', 'degF'), 32.0, 1e-6)
 
-        assert_rel_error(self, prob.get_val('xx'), 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('xx', 'degC'), 30.0, 1e-6)
-        assert_rel_error(self, prob.get_val('yy'), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('yy', 'degF'), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('xx'), 86.0, 1e-6)
+        assert_near_equal(prob.get_val('xx', 'degC'), 30.0, 1e-6)
+        assert_near_equal(prob.get_val('yy'), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('yy', 'degF'), 32.0, 1e-6)
 
-        assert_rel_error(self, prob.get_val('acomp.x', indices=0), 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', indices=[1]), 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', 'degC', indices=[0]), 30.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', 'degC', indices=1), 35.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.y', indices=0), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.y', 'degF', indices=0), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', indices=0), 86.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', indices=[1]), 95.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', 'degC', indices=[0]), 30.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', 'degC', indices=1), 35.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.y', indices=0), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.y', 'degF', indices=0), 32.0, 1e-6)
 
-        assert_rel_error(self, prob.get_val('axx', indices=0), 86.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', indices=1), 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', 'degC', indices=0), 30.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', 'degC', indices=np.array([1])), 35.0, 1e-6)
-        assert_rel_error(self, prob.get_val('ayy', indices=0), 0.0, 1e-6)
-        assert_rel_error(self, prob.get_val('ayy', 'degF', indices=0), 32.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', indices=0), 86.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', indices=1), 95.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', 'degC', indices=0), 30.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', 'degC', indices=np.array([1])), 35.0, 1e-6)
+        assert_near_equal(prob.get_val('ayy', indices=0), 0.0, 1e-6)
+        assert_near_equal(prob.get_val('ayy', 'degF', indices=0), 32.0, 1e-6)
 
         # Sets
 
         prob.set_val('comp.x', 35.0, 'degC')
-        assert_rel_error(self, prob['comp.x'], 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'degC'), 35.0, 1e-6)
+        assert_near_equal(prob['comp.x'], 95.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'degC'), 35.0, 1e-6)
 
         prob.set_val('xx', 35.0, 'degC')
-        assert_rel_error(self, prob['xx'], 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('xx', 'degC'), 35.0, 1e-6)
+        assert_near_equal(prob['xx'], 95.0, 1e-6)
+        assert_near_equal(prob.get_val('xx', 'degC'), 35.0, 1e-6)
 
         prob.set_val('acomp.x', 35.0, 'degC', indices=[0])
-        assert_rel_error(self, prob['acomp.x'][0], 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('acomp.x', 'degC', indices=0), 35.0, 1e-6)
+        assert_near_equal(prob['acomp.x'][0], 95.0, 1e-6)
+        assert_near_equal(prob.get_val('acomp.x', 'degC', indices=0), 35.0, 1e-6)
 
         prob.set_val('axx', 35.0, 'degC', indices=0)
-        assert_rel_error(self, prob['axx'][0], 95.0, 1e-6)
-        assert_rel_error(self, prob.get_val('axx', 'degC', indices=np.array([0])), 35.0, 1e-6)
+        assert_near_equal(prob['axx'][0], 95.0, 1e-6)
+        assert_near_equal(prob.get_val('axx', 'degC', indices=np.array([0])), 35.0, 1e-6)
 
     def test_get_set_with_units_error_messages(self):
         import openmdao.api as om
@@ -1064,11 +1064,11 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('comp.x'), 100, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'm'), 1.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), 100, 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'm'), 1.0, 1e-6)
         prob.set_val('comp.x', 10.0, 'mm')
-        assert_rel_error(self, prob.get_val('comp.x'), 1.0, 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'm'), 1.0e-2, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), 1.0, 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'm'), 1.0e-2, 1e-6)
 
     def test_feature_get_set_array_with_units(self):
         import numpy as np
@@ -1082,17 +1082,17 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('comp.x'), np.array([100, 33.3]), 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'm'), np.array([1.0, 0.333]), 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'km', indices=[0]), 0.001, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), np.array([100, 33.3]), 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'm'), np.array([1.0, 0.333]), 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'km', indices=[0]), 0.001, 1e-6)
 
         prob.set_val('comp.x', 10.0, 'mm')
-        assert_rel_error(self, prob.get_val('comp.x'), np.array([1.0, 1.0]), 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'm', indices=0), 1.0e-2, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), np.array([1.0, 1.0]), 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'm', indices=0), 1.0e-2, 1e-6)
 
         prob.set_val('comp.x', 50.0, 'mm', indices=[1])
-        assert_rel_error(self, prob.get_val('comp.x'), np.array([1.0, 5.0]), 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', 'm', indices=1), 5.0e-2, 1e-6)
+        assert_near_equal(prob.get_val('comp.x'), np.array([1.0, 5.0]), 1e-6)
+        assert_near_equal(prob.get_val('comp.x', 'm', indices=1), 5.0e-2, 1e-6)
 
     def test_feature_get_set_array_with_slicer(self):
         import numpy as np
@@ -1106,14 +1106,14 @@ class TestProblem(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:, 0]), [1., 3.], 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[0, 1]), 2., 1e-6)
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[1, -1]), 4., 1e-6)
+        assert_near_equal(prob.get_val('comp.x', indices=om.slicer[:, 0]), [1., 3.], 1e-6)
+        assert_near_equal(prob.get_val('comp.x', indices=om.slicer[0, 1]), 2., 1e-6)
+        assert_near_equal(prob.get_val('comp.x', indices=om.slicer[1, -1]), 4., 1e-6)
 
         prob.set_val('comp.x', [5., 6.], indices=om.slicer[:,0])
-        assert_rel_error(self, prob.get_val('comp.x', indices=om.slicer[:, 0]), [5., 6.], 1e-6)
+        assert_near_equal(prob.get_val('comp.x', indices=om.slicer[:, 0]), [5., 6.], 1e-6)
         prob.run_model()
-        assert_rel_error(self, prob.get_val('comp.y', indices=om.slicer[:, 0]), [6., 7.], 1e-6)
+        assert_near_equal(prob.get_val('comp.y', indices=om.slicer[:, 0]), [6., 7.], 1e-6)
 
     def test_feature_set_get_array(self):
         import numpy as np
@@ -1127,27 +1127,27 @@ class TestProblem(unittest.TestCase):
         prob.setup()
 
         # default value from the class definition
-        assert_rel_error(self, prob['x'], 1.0, 1e-6)
+        assert_near_equal(prob['x'], 1.0, 1e-6)
 
         prob['x'] = 2.75
-        assert_rel_error(self, prob['x'], 2.75, 1e-6)
+        assert_near_equal(prob['x'], 2.75, 1e-6)
 
         # default value from the class definition
-        assert_rel_error(self, prob['z'], [5.0, 2.0], 1e-6)
+        assert_near_equal(prob['z'], [5.0, 2.0], 1e-6)
 
         prob['z'] = [1.5, 1.5]  # for convenience we convert the list to an array.
-        assert_rel_error(self, prob['z'], [1.5, 1.5], 1e-6)
+        assert_near_equal(prob['z'], [1.5, 1.5], 1e-6)
 
         prob.run_model()
-        assert_rel_error(self, prob['y1'], 5.43379016853, 1e-6)
-        assert_rel_error(self, prob['y2'], 5.33104915618, 1e-6)
+        assert_near_equal(prob['y1'], 5.43379016853, 1e-6)
+        assert_near_equal(prob['y2'], 5.33104915618, 1e-6)
 
         prob['z'] = np.array([2.5, 2.5])
-        assert_rel_error(self, prob['z'], [2.5, 2.5], 1e-6)
+        assert_near_equal(prob['z'], [2.5, 2.5], 1e-6)
 
         prob.run_model()
-        assert_rel_error(self, prob['y1'], 9.87161739688, 1e-6)
-        assert_rel_error(self, prob['y2'], 8.14191301549, 1e-6)
+        assert_near_equal(prob['y1'], 9.87161739688, 1e-6)
+        assert_near_equal(prob['y2'], 8.14191301549, 1e-6)
 
     def test_feature_residuals(self):
         import openmdao.api as om
@@ -1708,7 +1708,7 @@ class TestProblem(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_rel_error(self, p.get_val('totalforcecomp.total_force', units='kN'),
+        assert_near_equal(p.get_val('totalforcecomp.total_force', units='kN'),
                          np.array([[100, 200, 300], [0, -1, -2]]).T)
 
     def test_feature_system_configure(self):
@@ -1820,8 +1820,8 @@ class TestProblem(unittest.TestCase):
             prob.setup()
             prob.run_model()
 
-            assert_rel_error(self, prob['p2.y'], 5.0)
-            assert_rel_error(self, prob['comp.f_xy'], 21.0)
+            assert_near_equal(prob['p2.y'], 5.0)
+            assert_near_equal(prob['comp.f_xy'], 21.0)
         finally:
             hooks._unregister_hook('final_setup', class_name='Problem')
             hooks.use_hooks = False

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -5,7 +5,7 @@ from openmdao.api import Problem, Group, ExecComp
 from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, LinearBlockGS, \
     ExecComp, ExplicitComponent, PETScVector, ScipyKrylov, NonlinearBlockGS
 from openmdao.utils.mpi import MPI
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 try:
     from openmdao.api import PETScVector
@@ -63,10 +63,10 @@ class ProcTestCase2(unittest.TestCase):
         self.assertEqual(all_inds, [[0,1],[2,3]])
 
         p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
+        assert_near_equal(p['objective.y'], 8.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -81,10 +81,10 @@ class ProcTestCase3(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['objective.y'], 6.0)
+        assert_near_equal(p['objective.y'], 6.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 6.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 6.0, 1e-6)
 
     def test_4_subs(self):
         p = _build_model(nsubs=4)
@@ -92,10 +92,10 @@ class ProcTestCase3(unittest.TestCase):
         self.assertEqual(all_inds, [[0, 1], [2], [3]])
 
         p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
+        assert_near_equal(p['objective.y'], 8.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
 
     def test_4_subs_max2(self):
         p = _build_model(nsubs=4, max_procs=[2,2,2,2])
@@ -103,10 +103,10 @@ class ProcTestCase3(unittest.TestCase):
         self.assertEqual(all_inds, [[0, 1], [2], [3]])
 
         p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
+        assert_near_equal(p['objective.y'], 8.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
 
     def test_4_subs_with_mins(self):
         try:
@@ -151,10 +151,10 @@ class ProcTestCase3(unittest.TestCase):
         self.assertEqual(all_inds, [[0], [1], [1]])
 
         p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
+        assert_near_equal(p['objective.y'], 8.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -168,10 +168,10 @@ class ProcTestCase5(unittest.TestCase):
         self.assertEqual(all_inds, [[0], [0], [1], [2], [3]])
 
         p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
+        assert_near_equal(p['objective.y'], 8.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -199,10 +199,10 @@ class ProcTestCase8(unittest.TestCase):
         self.assertEqual(all_inds, [[0], [1], [1], [2], [3], [3], [3], [3]])
 
         p.run_model()
-        assert_rel_error(self, p['objective.y'], 8.0)
+        assert_near_equal(p['objective.y'], 8.0)
 
         J = p.compute_totals(['objective.y'], ['indep.x'], return_format='dict')
-        assert_rel_error(self, J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
+        assert_near_equal(J['objective.y']['indep.x'][0][0], 8.0, 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_reconf.py
+++ b/openmdao/core/tests/test_reconf.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 try:
     from openmdao.parallel_api import PETScVector
@@ -60,40 +60,40 @@ class Test(unittest.TestCase):
         p['x'] = 2
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 2.0)
-        assert_rel_error(self, p['y'], 4.0)
-        assert_rel_error(self, p['z'], 6.0)
-        assert_rel_error(self, totals['y', 'x'], [[2.0]])
+        assert_near_equal(p['x'], 2.0)
+        assert_near_equal(p['y'], 4.0)
+        assert_near_equal(p['z'], 6.0)
+        assert_near_equal(totals['y', 'x'], [[2.0]])
 
         # Now run the setup method on the root system; size of y = 2
         p.model.resetup()
         p['x'] = 3
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0 * np.ones(2))
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], 2.0 * np.ones((2, 1)))
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0 * np.ones(2))
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], 2.0 * np.ones((2, 1)))
 
         # Now reconfigure from c2 and update in root; size of y = 3; the value of x is preserved
         p.model.c2.resetup('reconf')
         p.model.resetup('update')
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0 * np.ones(3))
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], 2.0 * np.ones((3, 1)))
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0 * np.ones(3))
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], 2.0 * np.ones((3, 1)))
 
         # Now reconfigure from c3 and update in root; size of y = 3; the value of x is preserved
         p.model.c3.resetup('reconf')
         p.model.resetup('update')
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0 * np.ones(3))
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], 2.0 * np.ones((3, 1)))
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0 * np.ones(3))
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], 2.0 * np.ones((3, 1)))
 
         # Finally, setup reconf from root; size of y = 4
         # Since we are at the root, calling setup('full') and setup('reconf') have the same effect.
@@ -102,10 +102,10 @@ class Test(unittest.TestCase):
         p['x'] = 3
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0 * np.ones(4))
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], 2.0 * np.ones((4, 1)))
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0 * np.ones(4))
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], 2.0 * np.ones((4, 1)))
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_reconf_connections.py
+++ b/openmdao/core/tests/test_reconf_connections.py
@@ -13,7 +13,7 @@ from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent
 from openmdao.solvers.linear.direct import DirectSolver
 from openmdao.solvers.nonlinear.newton import NewtonSolver
 from openmdao.solvers.nonlinear.nonlinear_block_gs import NonlinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class ReconfComp1(ExplicitComponent):
@@ -81,9 +81,9 @@ class TestReconfConnections(unittest.TestCase):
         p.run_model()
 
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0)
-        assert_rel_error(self, totals['y', 'x'], [[2.0]])
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0)
+        assert_near_equal(totals['y', 'x'], [[2.0]])
 
         # Run the model again, which will trigger reconfiguration; counter = 2, size of y = 2
         p.run_model()  # Fails with ValueError
@@ -135,7 +135,7 @@ class TestReconfConnections(unittest.TestCase):
 
         self.assertEqual(len(p['c2.y']), 2)
         self.assertEqual(len(p['c3.y']), 2)
-        assert_rel_error(self, p['c3.y'], [6., 6.])
+        assert_near_equal(p['c3.y'], [6., 6.])
 
     @unittest.expectedFailure
     def test_reconf_comp_connections_nlbgs_solver(self):
@@ -161,7 +161,7 @@ class TestReconfConnections(unittest.TestCase):
 
         self.assertEqual(len(p['c2.y']), 2)
         self.assertEqual(len(p['c3.y']), 2)
-        assert_rel_error(self, p['c3.y'], [6., 6.])
+        assert_near_equal(p['c3.y'], [6., 6.])
 
     @unittest.expectedFailure
     def test_promoted_connections_newton_solver(self):
@@ -183,7 +183,7 @@ class TestReconfConnections(unittest.TestCase):
         # Run the model again, which will trigger reconfiguration; counter = 2, size of y = 2
         p.run_model()
         self.assertEqual(len(p['y']), 2)
-        assert_rel_error(self, p['y'], [6., 6.])
+        assert_near_equal(p['y'], [6., 6.])
 
     @unittest.expectedFailure
     def test_test_promoted_connections_nlbgs_solver(self):
@@ -206,7 +206,7 @@ class TestReconfConnections(unittest.TestCase):
         # Run the model again, which will trigger reconfiguration; counter = 2, size of y = 2
         p.run_model()
         self.assertEqual(len(p['y']), 2)
-        assert_rel_error(self, p['y'], [6., 6.])
+        assert_near_equal(p['y'], [6., 6.])
 
     def test_reconf_comp_not_connected(self):
         p = Problem()

--- a/openmdao/core/tests/test_reconf_dynamic.py
+++ b/openmdao/core/tests/test_reconf_dynamic.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, ExecComp
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class ReconfComp(ExplicitComponent):
@@ -67,19 +67,19 @@ class Test(unittest.TestCase):
         # First run the model once; counter = 1, size of y = 1
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0)
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], 2.0)
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0)
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], 2.0)
         print(p['x'], p['y'], p['z'], totals['y', 'x'].flatten())
 
         # Run the model again, which will trigger reconfiguration; counter = 2, size of y = 2
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0 * np.ones(2))
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], 2.0 * np.ones(2, 1))
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0 * np.ones(2))
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], 2.0 * np.ones(2, 1))
 
     def test_reconf_group(self):
         p = Problem()
@@ -94,16 +94,16 @@ class Test(unittest.TestCase):
 
         p.run_model()
         totals = p.compute_totals(wrt=['x'], of=['y'])
-        assert_rel_error(self, p['x'], 3.0)
-        assert_rel_error(self, p['y'], 6.0)
-        assert_rel_error(self, p['z'], 9.0)
-        assert_rel_error(self, totals['y', 'x'], [[2.0]])
+        assert_near_equal(p['x'], 3.0)
+        assert_near_equal(p['y'], 6.0)
+        assert_near_equal(p['z'], 9.0)
+        assert_near_equal(totals['y', 'x'], [[2.0]])
 
         # This tests for a bug in which inputs from sources outside the reconfiguring system
         # are zero-ed out during the execution following the reconfiguration (prior to updates)
         # because the scaling vectors for those external-source inputs are all zero.
         # The solution is to initialize the multiplier in the scaling vector to 1.
-        assert_rel_error(self, s2._inputs['x'], 3.0)
+        assert_near_equal(s2._inputs['x'], 3.0)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_reconf_group.py
+++ b/openmdao/core/tests/test_reconf_group.py
@@ -1,7 +1,7 @@
 import unittest
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 try:
     from openmdao.parallel_api import PETScVector
@@ -35,24 +35,24 @@ class Test(unittest.TestCase):
         # First run with the initial setup.
         prob['x'] = 2.0
         prob.run_model()
-        assert_rel_error(self, prob['y0'], 1.0)
+        assert_near_equal(prob['y0'], 1.0)
         print(prob['y0'])
 
         # Now reconfigure ReconfGroup and re-run, ensuring the value of x is preserved.
         prob.model.g.resetup('reconf')
         prob.model.resetup('update')
         prob.run_model()
-        assert_rel_error(self, prob['y0'], 1.0)
-        assert_rel_error(self, prob['y1'], 3.0)
+        assert_near_equal(prob['y0'], 1.0)
+        assert_near_equal(prob['y1'], 3.0)
         print(prob['y0'], prob['y1'])
 
         # Running reconf setup from root is equivalent to running full setup, but is faster
         prob.model.resetup('reconf')
         prob['x'] = 2.0
         prob.run_model()
-        assert_rel_error(self, prob['y0'], 1.0)
-        assert_rel_error(self, prob['y1'], 3.0)
-        assert_rel_error(self, prob['y2'], 5.0)
+        assert_near_equal(prob['y0'], 1.0)
+        assert_near_equal(prob['y1'], 3.0)
+        assert_near_equal(prob['y2'], 5.0)
         print(prob['y0'], prob['y1'], prob['y2'])
 
 

--- a/openmdao/core/tests/test_reconf_parallel_group.py
+++ b/openmdao/core/tests/test_reconf_parallel_group.py
@@ -3,7 +3,7 @@ import unittest
 
 from openmdao.api import Problem, Group, IndepVarComp, ExplicitComponent, ExecComp
 from openmdao.api import NewtonSolver, PETScKrylov, NonlinearBlockGS, LinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 try:
@@ -53,15 +53,15 @@ class Test(unittest.TestCase):
         prob['x0'] = 6.
         prob['x1'] = 4.
         prob.run_model()
-        assert_rel_error(self, prob.get_val('C1.z', get_remote=True), 8.0)
-        assert_rel_error(self, prob.get_val('C2.z', get_remote=True), 6.0)
+        assert_near_equal(prob.get_val('C1.z', get_remote=True), 8.0)
+        assert_near_equal(prob.get_val('C2.z', get_remote=True), 6.0)
 
         # Now, reconfigure so ReconfGroup is not parallel, and x0, x1 should be preserved
         prob.model.g.resetup('reconf')
         prob.model.resetup('update')
         prob.run_model()
-        assert_rel_error(self, prob.get_val('C1.z', get_remote=True), 8.0, 1e-8)
-        assert_rel_error(self, prob.get_val('C2.z', get_remote=True), 6.0, 1e-8)
+        assert_near_equal(prob.get_val('C1.z', get_remote=True), 8.0, 1e-8)
+        assert_near_equal(prob.get_val('C2.z', get_remote=True), 6.0, 1e-8)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_remote_vois.py
+++ b/openmdao/core/tests/test_remote_vois.py
@@ -7,7 +7,7 @@ import random
 from openmdao.api import Group, ParallelGroup, Problem, IndepVarComp, \
     ExecComp, PETScVector
 from openmdao.utils.mpi import MPI
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 if MPI:
     from openmdao.api import PETScVector
@@ -65,12 +65,12 @@ class RemoteVOITestCase(unittest.TestCase):
         J = prob.compute_totals(of=['Obj.obj', 'par.G1.c', 'par.G2.c'],
                                 wrt=['par.G1.x', 'par.G2.x'])
 
-        assert_rel_error(self, J['Obj.obj', 'par.G1.x'], np.array([[2.0]]), 1e-6)
-        assert_rel_error(self, J['Obj.obj', 'par.G2.x'], np.array([[2.0]]), 1e-6)
-        assert_rel_error(self, J['par.G1.c', 'par.G1.x'], np.array([[1.0]]), 1e-6)
-        assert_rel_error(self, J['par.G1.c', 'par.G2.x'], np.array([[0.0]]), 1e-6)
-        assert_rel_error(self, J['par.G2.c', 'par.G1.x'], np.array([[0.0]]), 1e-6)
-        assert_rel_error(self, J['par.G2.c', 'par.G2.x'], np.array([[1.0]]), 1e-6)
+        assert_near_equal(J['Obj.obj', 'par.G1.x'], np.array([[2.0]]), 1e-6)
+        assert_near_equal(J['Obj.obj', 'par.G2.x'], np.array([[2.0]]), 1e-6)
+        assert_near_equal(J['par.G1.c', 'par.G1.x'], np.array([[1.0]]), 1e-6)
+        assert_near_equal(J['par.G1.c', 'par.G2.x'], np.array([[0.0]]), 1e-6)
+        assert_near_equal(J['par.G2.c', 'par.G1.x'], np.array([[0.0]]), 1e-6)
+        assert_near_equal(J['par.G2.c', 'par.G2.x'], np.array([[1.0]]), 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -9,7 +9,7 @@ from openmdao.core.driver import Driver
 
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayDense
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class PassThroughLength(om.ExplicitComponent):
@@ -244,11 +244,11 @@ class TestScaling(unittest.TestCase):
         prob['sys1.old_length'] = 3.e5
         prob.final_setup()
 
-        assert_rel_error(self, prob['sys1.old_length'], 3.e5)
-        assert_rel_error(self, prob.model._outputs['sys1.old_length'], 3.e5)
+        assert_near_equal(prob['sys1.old_length'], 3.e5)
+        assert_near_equal(prob.model._outputs['sys1.old_length'], 3.e5)
         prob.run_model()
-        assert_rel_error(self, prob['sys2.new_length'], 3.e-1)
-        assert_rel_error(self, prob.model._outputs['sys2.new_length'], 3.e-1)
+        assert_near_equal(prob['sys2.new_length'], 3.e-1)
+        assert_near_equal(prob.model._outputs['sys2.new_length'], 3.e-1)
 
     def test_speed(self):
         comp = om.IndepVarComp()
@@ -266,11 +266,11 @@ class TestScaling(unittest.TestCase):
         prob.set_solver_print(level=0)
 
         prob.run_model()
-        assert_rel_error(self, prob['c1.distance'], 1.0)  # units: km
-        assert_rel_error(self, prob['c2.distance'], 1000.0)  # units: m
-        assert_rel_error(self, prob['c1.time'], 1.0)  # units: h
-        assert_rel_error(self, prob['c2.time'], 3600.0)  # units: s
-        assert_rel_error(self, prob['c2.speed'], 1.0)  # units: km/h (i.e., kph)
+        assert_near_equal(prob['c1.distance'], 1.0)  # units: km
+        assert_near_equal(prob['c2.distance'], 1000.0)  # units: m
+        assert_near_equal(prob['c1.time'], 1.0)  # units: h
+        assert_near_equal(prob['c2.time'], 3600.0)  # units: s
+        assert_near_equal(prob['c2.speed'], 1.0)  # units: km/h (i.e., kph)
 
     def test_scaling(self):
         """Test convergence in essentially one Newton iteration to atol=1e-5."""
@@ -392,7 +392,7 @@ class TestScaling(unittest.TestCase):
         # Jacobian is unscaled
         prob.model.run_linearize()
         deriv = model.p1._jacobian
-        assert_rel_error(self, deriv['p1.y', 'p1.x'], [[2.0]])
+        assert_near_equal(deriv['p1.y', 'p1.x'], [[2.0]])
 
         # Scale the outputs only.
         # Residual scaling uses output scaling by default.
@@ -429,7 +429,7 @@ class TestScaling(unittest.TestCase):
         # Jacobian is unscaled
         prob.model.run_linearize()
         deriv = model.p1._jacobian
-        assert_rel_error(self, deriv['p1.y', 'p1.x'], [[2.0]])
+        assert_near_equal(deriv['p1.y', 'p1.x'], [[2.0]])
 
         # Scale the residual
 
@@ -464,7 +464,7 @@ class TestScaling(unittest.TestCase):
         # Jacobian is unscaled
         prob.model.run_linearize()
         deriv = model.p1._jacobian
-        assert_rel_error(self, deriv['p1.y', 'p1.x'], [[2.0]])
+        assert_near_equal(deriv['p1.y', 'p1.x'], [[2.0]])
 
         # Simultaneously scale the residual and output with different values
 
@@ -501,7 +501,7 @@ class TestScaling(unittest.TestCase):
         # Jacobian is unscaled
         prob.model.run_linearize()
         deriv = model.p1._jacobian
-        assert_rel_error(self, deriv['p1.y', 'p1.x'], [[2.0]])
+        assert_near_equal(deriv['p1.y', 'p1.x'], [[2.0]])
 
     def test_scale_array_with_float(self):
 
@@ -530,20 +530,20 @@ class TestScaling(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.total_volume'], 4.)
+        assert_near_equal(prob['comp.total_volume'], 4.)
 
         with model._scaled_context_all():
             val = model.comp._outputs['areas']
-            assert_rel_error(self, val[0, 0], 0.5)
-            assert_rel_error(self, val[0, 1], 0.5)
-            assert_rel_error(self, val[1, 0], 0.5)
-            assert_rel_error(self, val[1, 1], 0.5)
+            assert_near_equal(val[0, 0], 0.5)
+            assert_near_equal(val[0, 1], 0.5)
+            assert_near_equal(val[1, 0], 0.5)
+            assert_near_equal(val[1, 1], 0.5)
 
             val = model.comp._outputs['stuff']
-            assert_rel_error(self, val[0, 0], 2.0/3)
-            assert_rel_error(self, val[0, 1], 2.0/3)
-            assert_rel_error(self, val[1, 0], 2.0/3)
-            assert_rel_error(self, val[1, 1], 2.0/3)
+            assert_near_equal(val[0, 0], 2.0/3)
+            assert_near_equal(val[0, 1], 2.0/3)
+            assert_near_equal(val[1, 0], 2.0/3)
+            assert_near_equal(val[1, 1], 2.0/3)
 
     def test_scale_array_with_array(self):
 
@@ -571,20 +571,20 @@ class TestScaling(unittest.TestCase):
         prob['comp.widths'] = np.ones((2, 2))
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.total_volume'], 4.)
+        assert_near_equal(prob['comp.total_volume'], 4.)
 
         with model._scaled_context_all():
             val = model.comp._outputs['areas']
-            assert_rel_error(self, val[0, 0], 1.0/2)
-            assert_rel_error(self, val[0, 1], 1.0/3)
-            assert_rel_error(self, val[1, 0], 1.0/5)
-            assert_rel_error(self, val[1, 1], 1.0/7)
+            assert_near_equal(val[0, 0], 1.0/2)
+            assert_near_equal(val[0, 1], 1.0/3)
+            assert_near_equal(val[1, 0], 1.0/5)
+            assert_near_equal(val[1, 1], 1.0/7)
 
             val = model.comp._outputs['stuff']
-            assert_rel_error(self, val[0, 0], 2.0/11)
-            assert_rel_error(self, val[0, 1], 2.0/13)
-            assert_rel_error(self, val[1, 0], 2.0/17)
-            assert_rel_error(self, val[1, 1], 2.0/19)
+            assert_near_equal(val[0, 0], 2.0/11)
+            assert_near_equal(val[0, 1], 2.0/13)
+            assert_near_equal(val[1, 0], 2.0/17)
+            assert_near_equal(val[1, 1], 2.0/19)
 
     def test_scale_and_add_array_with_array(self):
 
@@ -616,44 +616,44 @@ class TestScaling(unittest.TestCase):
         prob['comp.widths'] = np.ones((2, 2))
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.total_volume'], 4.)
+        assert_near_equal(prob['comp.total_volume'], 4.)
 
         with model._scaled_context_all():
             val = model.comp._outputs['areas']
-            assert_rel_error(self, val[0, 0], (1.0 - 0.1)/(2 - 0.1))
-            assert_rel_error(self, val[0, 1], (1.0 - 0.2)/(3 - 0.2))
-            assert_rel_error(self, val[1, 0], (1.0 - 0.3)/(5 - 0.3))
-            assert_rel_error(self, val[1, 1], (1.0 - 0.4)/(7 - 0.4))
+            assert_near_equal(val[0, 0], (1.0 - 0.1)/(2 - 0.1))
+            assert_near_equal(val[0, 1], (1.0 - 0.2)/(3 - 0.2))
+            assert_near_equal(val[1, 0], (1.0 - 0.3)/(5 - 0.3))
+            assert_near_equal(val[1, 1], (1.0 - 0.4)/(7 - 0.4))
 
             val = model.comp._outputs['stuff']
-            assert_rel_error(self, val[0, 0], (2.0 - 0.6)/(11 - 0.6))
-            assert_rel_error(self, val[0, 1], (2.0 - 0.7)/(13 - 0.7))
-            assert_rel_error(self, val[1, 0], (2.0 - 0.8)/(17 - 0.8))
-            assert_rel_error(self, val[1, 1], (2.0 - 0.9)/(19 - 0.9))
+            assert_near_equal(val[0, 0], (2.0 - 0.6)/(11 - 0.6))
+            assert_near_equal(val[0, 1], (2.0 - 0.7)/(13 - 0.7))
+            assert_near_equal(val[1, 0], (2.0 - 0.8)/(17 - 0.8))
+            assert_near_equal(val[1, 1], (2.0 - 0.9)/(19 - 0.9))
 
             lb = model.comp._lower_bounds['areas']
-            assert_rel_error(self, lb[0, 0], (-1000.0 - 0.1)/(2 - 0.1))
-            assert_rel_error(self, lb[0, 1], (-1000.0 - 0.2)/(3 - 0.2))
-            assert_rel_error(self, lb[1, 0], (-1000.0 - 0.3)/(5 - 0.3))
-            assert_rel_error(self, lb[1, 1], (-1000.0 - 0.4)/(7 - 0.4))
+            assert_near_equal(lb[0, 0], (-1000.0 - 0.1)/(2 - 0.1))
+            assert_near_equal(lb[0, 1], (-1000.0 - 0.2)/(3 - 0.2))
+            assert_near_equal(lb[1, 0], (-1000.0 - 0.3)/(5 - 0.3))
+            assert_near_equal(lb[1, 1], (-1000.0 - 0.4)/(7 - 0.4))
 
             ub = model.comp._upper_bounds['areas']
-            assert_rel_error(self, ub[0, 0], (1000.0 - 0.1)/(2 - 0.1))
-            assert_rel_error(self, ub[0, 1], (1000.0 - 0.2)/(3 - 0.2))
-            assert_rel_error(self, ub[1, 0], (1000.0 - 0.3)/(5 - 0.3))
-            assert_rel_error(self, ub[1, 1], (1000.0 - 0.4)/(7 - 0.4))
+            assert_near_equal(ub[0, 0], (1000.0 - 0.1)/(2 - 0.1))
+            assert_near_equal(ub[0, 1], (1000.0 - 0.2)/(3 - 0.2))
+            assert_near_equal(ub[1, 0], (1000.0 - 0.3)/(5 - 0.3))
+            assert_near_equal(ub[1, 1], (1000.0 - 0.4)/(7 - 0.4))
 
             lb = model.comp._lower_bounds['stuff']
-            assert_rel_error(self, lb[0, 0], (-5000.0 - 0.6)/(11 - 0.6))
-            assert_rel_error(self, lb[0, 1], (-4000.0 - 0.7)/(13 - 0.7))
-            assert_rel_error(self, lb[1, 0], (-3000.0 - 0.8)/(17 - 0.8))
-            assert_rel_error(self, lb[1, 1], (-2000.0 - 0.9)/(19 - 0.9))
+            assert_near_equal(lb[0, 0], (-5000.0 - 0.6)/(11 - 0.6))
+            assert_near_equal(lb[0, 1], (-4000.0 - 0.7)/(13 - 0.7))
+            assert_near_equal(lb[1, 0], (-3000.0 - 0.8)/(17 - 0.8))
+            assert_near_equal(lb[1, 1], (-2000.0 - 0.9)/(19 - 0.9))
 
             ub = model.comp._upper_bounds['stuff']
-            assert_rel_error(self, ub[0, 0], (5000.0 - 0.6)/(11 - 0.6))
-            assert_rel_error(self, ub[0, 1], (4000.0 - 0.7)/(13 - 0.7))
-            assert_rel_error(self, ub[1, 0], (3000.0 - 0.8)/(17 - 0.8))
-            assert_rel_error(self, ub[1, 1], (2000.0 - 0.9)/(19 - 0.9))
+            assert_near_equal(ub[0, 0], (5000.0 - 0.6)/(11 - 0.6))
+            assert_near_equal(ub[0, 1], (4000.0 - 0.7)/(13 - 0.7))
+            assert_near_equal(ub[1, 0], (3000.0 - 0.8)/(17 - 0.8))
+            assert_near_equal(ub[1, 1], (2000.0 - 0.9)/(19 - 0.9))
 
     def test_implicit_scale(self):
 
@@ -697,23 +697,23 @@ class TestScaling(unittest.TestCase):
 
         with model._scaled_context_all():
             val = model.comp._outputs['x']
-            assert_rel_error(self, val[0], (base_x[0] - 4.0)/(2.0 - 4.0))
-            assert_rel_error(self, val[1], (base_x[1] - 9.0)/(3.0 - 9.0))
+            assert_near_equal(val[0], (base_x[0] - 4.0)/(2.0 - 4.0))
+            assert_near_equal(val[1], (base_x[1] - 9.0)/(3.0 - 9.0))
             val = model.comp._outputs['extra']
-            assert_rel_error(self, val[0], (base_ex[0] - 14.0)/(12.0 - 14.0))
-            assert_rel_error(self, val[1], (base_ex[1] - 17.0)/(13.0 - 17.0))
+            assert_near_equal(val[0], (base_ex[0] - 14.0)/(12.0 - 14.0))
+            assert_near_equal(val[1], (base_ex[1] - 17.0)/(13.0 - 17.0))
             val = model.comp._residuals['x'].copy()
-            assert_rel_error(self, val[0], (base_res_x[0])/(7.0))
-            assert_rel_error(self, val[1], (base_res_x[1])/(11.0))
+            assert_near_equal(val[0], (base_res_x[0])/(7.0))
+            assert_near_equal(val[1], (base_res_x[1])/(11.0))
 
         model.run_linearize()
 
         with model._scaled_context_all():
             subjacs = comp._jacobian
 
-            assert_rel_error(self, subjacs['comp.x', 'comp.x'], np.ones((2, 2)))
-            assert_rel_error(self, subjacs['comp.x', 'comp.extra'], np.ones((2, 2)))
-            assert_rel_error(self, subjacs['comp.x', 'comp.rhs'], -np.eye(2))
+            assert_near_equal(subjacs['comp.x', 'comp.x'], np.ones((2, 2)))
+            assert_near_equal(subjacs['comp.x', 'comp.extra'], np.ones((2, 2)))
+            assert_near_equal(subjacs['comp.x', 'comp.rhs'], -np.eye(2))
 
     def test_implicit_scale_with_scalar_jac(self):
         raise unittest.SkipTest('Cannot specify an n by m subjac with a scalar yet.')
@@ -755,34 +755,34 @@ class TestScaling(unittest.TestCase):
         base_res_x = model.comp._residuals['x'].copy()
         with model._scaled_context_all():
             val = model.comp._outputs['x']
-            assert_rel_error(self, val[0], (base_x[0] - 4.0)/(2.0 - 4.0))
-            assert_rel_error(self, val[1], (base_x[1] - 9.0)/(3.0 - 9.0))
+            assert_near_equal(val[0], (base_x[0] - 4.0)/(2.0 - 4.0))
+            assert_near_equal(val[1], (base_x[1] - 9.0)/(3.0 - 9.0))
             val = model.comp._outputs['extra']
-            assert_rel_error(self, val[0], (base_ex[0] - 14.0)/(12.0 - 14.0))
-            assert_rel_error(self, val[1], (base_ex[1] - 17.0)/(13.0 - 17.0))
+            assert_near_equal(val[0], (base_ex[0] - 14.0)/(12.0 - 14.0))
+            assert_near_equal(val[1], (base_ex[1] - 17.0)/(13.0 - 17.0))
             val = model.comp._residuals['x'].copy()
-            assert_rel_error(self, val[0], (base_res_x[0])/(7.0))
-            assert_rel_error(self, val[1], (base_res_x[1])/(11.0))
+            assert_near_equal(val[0], (base_res_x[0])/(7.0))
+            assert_near_equal(val[1], (base_res_x[1])/(11.0))
 
         model.run_linearize()
 
         with model._scaled_context_all():
             subjacs = comp._jacobian
 
-            assert_rel_error(self, subjacs['comp.x', 'comp.x'][0][0], (2.0 - 4.0)/(7.0 - 13.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.x'][1][0], (2.0 - 4.0)/(11.0 - 18.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.x'][0][1], (3.0 - 9.0)/(7.0 - 13.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.x'][1][1], (3.0 - 9.0)/(11.0 - 18.0))
+            assert_near_equal(subjacs['comp.x', 'comp.x'][0][0], (2.0 - 4.0)/(7.0 - 13.0))
+            assert_near_equal(subjacs['comp.x', 'comp.x'][1][0], (2.0 - 4.0)/(11.0 - 18.0))
+            assert_near_equal(subjacs['comp.x', 'comp.x'][0][1], (3.0 - 9.0)/(7.0 - 13.0))
+            assert_near_equal(subjacs['comp.x', 'comp.x'][1][1], (3.0 - 9.0)/(11.0 - 18.0))
 
-            assert_rel_error(self, subjacs['comp.x', 'comp.extra'][0][0], (12.0 - 14.0)/(7.0 - 13.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.extra'][1][0], (12.0 - 14.0)/(11.0 - 18.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.extra'][0][1], (13.0 - 17.0)/(7.0 - 13.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.extra'][1][1], (13.0 - 17.0)/(11.0 - 18.0))
+            assert_near_equal(subjacs['comp.x', 'comp.extra'][0][0], (12.0 - 14.0)/(7.0 - 13.0))
+            assert_near_equal(subjacs['comp.x', 'comp.extra'][1][0], (12.0 - 14.0)/(11.0 - 18.0))
+            assert_near_equal(subjacs['comp.x', 'comp.extra'][0][1], (13.0 - 17.0)/(7.0 - 13.0))
+            assert_near_equal(subjacs['comp.x', 'comp.extra'][1][1], (13.0 - 17.0)/(11.0 - 18.0))
 
-            assert_rel_error(self, subjacs['comp.x', 'comp.rhs'][0][0], -1.0/(7.0 - 13.0))
-            assert_rel_error(self, subjacs['comp.x', 'comp.rhs'][1][0], 0.0)
-            assert_rel_error(self, subjacs['comp.x', 'comp.rhs'][0][1], 0.0)
-            assert_rel_error(self, subjacs['comp.x', 'comp.rhs'][1][1], -1.0/(11.0 - 18.0))
+            assert_near_equal(subjacs['comp.x', 'comp.rhs'][0][0], -1.0/(7.0 - 13.0))
+            assert_near_equal(subjacs['comp.x', 'comp.rhs'][1][0], 0.0)
+            assert_near_equal(subjacs['comp.x', 'comp.rhs'][0][1], 0.0)
+            assert_near_equal(subjacs['comp.x', 'comp.rhs'][1][1], -1.0/(11.0 - 18.0))
 
     def test_scale_array_bug1(self):
         # Tests a bug when you have two connections with different sizes (code was using a
@@ -822,8 +822,8 @@ class TestScaling(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp1.total_volume'], 14.)
-        assert_rel_error(self, prob['comp2.total_volume'], 28.)
+        assert_near_equal(prob['comp1.total_volume'], 14.)
+        assert_near_equal(prob['comp2.total_volume'], 28.)
 
     def test_newton_resid_scaling(self):
 
@@ -857,7 +857,7 @@ class TestScaling(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 2.0)
+        assert_near_equal(prob['comp.y'], 2.0)
 
         # Now, let's try with an AssembledJacobian.
 
@@ -875,7 +875,7 @@ class TestScaling(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 2.0)
+        assert_near_equal(prob['comp.y'], 2.0)
 
     def test_feature1(self):
         import openmdao.api as om
@@ -897,9 +897,9 @@ class TestScaling(unittest.TestCase):
 
         with model._scaled_context_all():
             val = model.comp._outputs['y1']
-            assert_rel_error(self, val, 2.0)
+            assert_near_equal(val, 2.0)
             val = model.comp._outputs['y2']
-            assert_rel_error(self, val, 6.0)
+            assert_near_equal(val, 6.0)
 
     def test_feature2(self):
         import openmdao.api as om
@@ -921,9 +921,9 @@ class TestScaling(unittest.TestCase):
 
         with model._scaled_context_all():
             val = model.comp._outputs['y1']
-            assert_rel_error(self, val, 0.5)
+            assert_near_equal(val, 0.5)
             val = model.comp._outputs['y2']
-            assert_rel_error(self, val, 0.5)
+            assert_near_equal(val, 0.5)
 
     def test_feature3(self):
         import openmdao.api as om
@@ -945,9 +945,9 @@ class TestScaling(unittest.TestCase):
 
         with model._scaled_context_all():
             val = model.comp._residuals['y1']
-            assert_rel_error(self, val, -.995)
+            assert_near_equal(val, -.995)
             val = model.comp._residuals['y2']
-            assert_rel_error(self, val, (1-6000.)/6000.)
+            assert_near_equal(val, (1-6000.)/6000.)
 
     def test_feature_vector(self):
         import openmdao.api as om
@@ -967,11 +967,11 @@ class TestScaling(unittest.TestCase):
 
         with model._scaled_context_all():
             val = model.comp._residuals['y']
-            assert_rel_error(self, val[0], (1-200.)/200.)
-            assert_rel_error(self, val[1], (1-6000.)/6000.)
+            assert_near_equal(val[0], (1-200.)/200.)
+            assert_near_equal(val[1], (1-6000.)/6000.)
             val = model.comp._outputs['y']
-            assert_rel_error(self, val[0], 2.0)
-            assert_rel_error(self, val[1], 6.0)
+            assert_near_equal(val[0], 2.0)
+            assert_near_equal(val[1], 6.0)
 
 
 class MyComp(om.ExplicitComponent):
@@ -1128,57 +1128,57 @@ class TestScalingOverhaul(unittest.TestCase):
         prob.run_driver()
 
         # Parameter values
-        assert_rel_error(self, driver.param_vals['p.x1_u_u'], 1.0)
-        assert_rel_error(self, driver.param_vals['p.x1_u_s'], 1.0/7.0)
-        assert_rel_error(self, driver.param_vals['p.x1_s_u'], 1.0)
-        assert_rel_error(self, driver.param_vals['p.x1_s_s'], 1.0/7.0)
+        assert_near_equal(driver.param_vals['p.x1_u_u'], 1.0)
+        assert_near_equal(driver.param_vals['p.x1_u_s'], 1.0/7.0)
+        assert_near_equal(driver.param_vals['p.x1_s_u'], 1.0)
+        assert_near_equal(driver.param_vals['p.x1_s_s'], 1.0/7.0)
 
-        assert_rel_error(self, driver.param_meta['p.x1_u_u']['upper'], 11.0)
-        assert_rel_error(self, driver.param_meta['p.x1_u_s']['upper'], 11.0/7.0)
-        assert_rel_error(self, driver.param_meta['p.x1_s_u']['upper'], 11.0)
-        assert_rel_error(self, driver.param_meta['p.x1_s_s']['upper'], 11.0/7.0)
+        assert_near_equal(driver.param_meta['p.x1_u_u']['upper'], 11.0)
+        assert_near_equal(driver.param_meta['p.x1_u_s']['upper'], 11.0/7.0)
+        assert_near_equal(driver.param_meta['p.x1_s_u']['upper'], 11.0)
+        assert_near_equal(driver.param_meta['p.x1_s_s']['upper'], 11.0/7.0)
 
-        assert_rel_error(self, driver.con_meta['p.x1_u_u']['upper'], 3.3)
-        assert_rel_error(self, driver.con_meta['p.x1_u_s']['upper'], 3.3/13.0)
-        assert_rel_error(self, driver.con_meta['p.x1_s_u']['upper'], 3.3)
-        assert_rel_error(self, driver.con_meta['p.x1_s_s']['upper'], 3.3/13.0)
+        assert_near_equal(driver.con_meta['p.x1_u_u']['upper'], 3.3)
+        assert_near_equal(driver.con_meta['p.x1_u_s']['upper'], 3.3/13.0)
+        assert_near_equal(driver.con_meta['p.x1_s_u']['upper'], 3.3)
+        assert_near_equal(driver.con_meta['p.x1_s_s']['upper'], 3.3/13.0)
 
-        assert_rel_error(self, driver.con_vals['p.x1_u_u'], 1.0)
-        assert_rel_error(self, driver.con_vals['p.x1_u_s'], 1.0/13.0)
-        assert_rel_error(self, driver.con_vals['p.x1_s_u'], 1.0)
-        assert_rel_error(self, driver.con_vals['p.x1_s_s'], 1.0/13.0)
+        assert_near_equal(driver.con_vals['p.x1_u_u'], 1.0)
+        assert_near_equal(driver.con_vals['p.x1_u_s'], 1.0/13.0)
+        assert_near_equal(driver.con_vals['p.x1_s_u'], 1.0)
+        assert_near_equal(driver.con_vals['p.x1_s_s'], 1.0/13.0)
 
-        assert_rel_error(self, driver.obj_vals['p.ox1_u_u'], 1.0)
-        assert_rel_error(self, driver.obj_vals['p.ox1_u_s'], 1.0/15.0)
-        assert_rel_error(self, driver.obj_vals['p.ox1_s_u'], 1.0)
-        assert_rel_error(self, driver.obj_vals['p.ox1_s_s'], 1.0/15.0)
+        assert_near_equal(driver.obj_vals['p.ox1_u_u'], 1.0)
+        assert_near_equal(driver.obj_vals['p.ox1_u_s'], 1.0/15.0)
+        assert_near_equal(driver.obj_vals['p.ox1_s_u'], 1.0)
+        assert_near_equal(driver.obj_vals['p.ox1_s_s'], 1.0/15.0)
 
         J = model.comp.J
 
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_u']['p.x1_u_u'][0][0], J[0, 0])
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_s']['p.x1_u_u'][0][0], J[1, 0] / 17.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_u']['p.x1_u_u'][0][0], J[2, 0])
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_s']['p.x1_u_u'][0][0], J[3, 0] / 17.0)
+        assert_near_equal(driver.sens_dict['comp.x3_u_u']['p.x1_u_u'][0][0], J[0, 0])
+        assert_near_equal(driver.sens_dict['comp.x3_u_s']['p.x1_u_u'][0][0], J[1, 0] / 17.0)
+        assert_near_equal(driver.sens_dict['comp.x3_s_u']['p.x1_u_u'][0][0], J[2, 0])
+        assert_near_equal(driver.sens_dict['comp.x3_s_s']['p.x1_u_u'][0][0], J[3, 0] / 17.0)
 
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_u']['p.x1_u_s'][0][0], J[0, 1] * 7.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_s']['p.x1_u_s'][0][0], J[1, 1] / 17.0 * 7.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_u']['p.x1_u_s'][0][0], J[2, 1] * 7.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_s']['p.x1_u_s'][0][0], J[3, 1] / 17.0 * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_u_u']['p.x1_u_s'][0][0], J[0, 1] * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_u_s']['p.x1_u_s'][0][0], J[1, 1] / 17.0 * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_s_u']['p.x1_u_s'][0][0], J[2, 1] * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_s_s']['p.x1_u_s'][0][0], J[3, 1] / 17.0 * 7.0)
 
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_u']['p.x1_s_u'][0][0], J[0, 2])
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_s']['p.x1_s_u'][0][0], J[1, 2] / 17.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_u']['p.x1_s_u'][0][0], J[2, 2])
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_s']['p.x1_s_u'][0][0], J[3, 2] / 17.0)
+        assert_near_equal(driver.sens_dict['comp.x3_u_u']['p.x1_s_u'][0][0], J[0, 2])
+        assert_near_equal(driver.sens_dict['comp.x3_u_s']['p.x1_s_u'][0][0], J[1, 2] / 17.0)
+        assert_near_equal(driver.sens_dict['comp.x3_s_u']['p.x1_s_u'][0][0], J[2, 2])
+        assert_near_equal(driver.sens_dict['comp.x3_s_s']['p.x1_s_u'][0][0], J[3, 2] / 17.0)
 
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_u']['p.x1_s_s'][0][0], J[0, 3] * 7.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_u_s']['p.x1_s_s'][0][0], J[1, 3] / 17.0* 7.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_u']['p.x1_s_s'][0][0], J[2, 3] * 7.0)
-        assert_rel_error(self, driver.sens_dict['comp.x3_s_s']['p.x1_s_s'][0][0], J[3, 3] / 17.0 * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_u_u']['p.x1_s_s'][0][0], J[0, 3] * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_u_s']['p.x1_s_s'][0][0], J[1, 3] / 17.0* 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_s_u']['p.x1_s_s'][0][0], J[2, 3] * 7.0)
+        assert_near_equal(driver.sens_dict['comp.x3_s_s']['p.x1_s_s'][0][0], J[3, 3] / 17.0 * 7.0)
 
         totals = prob.check_totals(compact_print=True, out_stream=None)
 
         for (of, wrt) in totals:
-            assert_rel_error(self, totals[of, wrt]['abs error'][0], 0.0, 1e-7)
+            assert_near_equal(totals[of, wrt]['abs error'][0], 0.0, 1e-7)
 
     def test_iimplicit(self):
         # Testing that our scale/unscale contexts leave the output vector in the correct state when
@@ -1210,7 +1210,7 @@ class TestScalingOverhaul(unittest.TestCase):
         totals = prob.check_totals(compact_print=True, out_stream=None)
 
         for (of, wrt) in totals:
-            assert_rel_error(self, totals[of, wrt]['abs error'][0], 0.0, 1e-7)
+            assert_near_equal(totals[of, wrt]['abs error'][0], 0.0, 1e-7)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_simple_impl_comp.py
+++ b/openmdao/core/tests/test_simple_impl_comp.py
@@ -4,7 +4,7 @@ import scipy.sparse.linalg
 
 from openmdao.api import Problem, ImplicitComponent, Group
 from openmdao.api import LinearBlockGS
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class CompA(ImplicitComponent):
@@ -100,12 +100,12 @@ class Test(unittest.TestCase):
         d_outputs.set_const(1.0)
         root.run_apply_linear(['linear'], 'fwd')
         output = d_residuals._data
-        assert_rel_error(self, output, [7, 3])
+        assert_near_equal(output, [7, 3])
 
         d_residuals.set_const(1.0)
         root.run_apply_linear(['linear'], 'rev')
         output = d_outputs._data
-        assert_rel_error(self, output, [7, 3])
+        assert_near_equal(output, [7, 3])
 
     def test_solve_linear(self):
         root = self.p.model
@@ -117,13 +117,13 @@ class Test(unittest.TestCase):
         d_outputs.set_const(0.0)
         root.run_solve_linear(['linear'], 'fwd')
         output = d_outputs._data
-        assert_rel_error(self, output, [1, 5], 1e-10)
+        assert_near_equal(output, [1, 5], 1e-10)
 
         d_outputs.set_const(11.0)
         d_residuals.set_const(0.0)
         root.run_solve_linear(['linear'], 'rev')
         output = d_residuals._data
-        assert_rel_error(self, output, [1, 5], 1e-10)
+        assert_near_equal(output, [1, 5], 1e-10)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp
 from openmdao.test_suite.components.options_feature_vector import VectorDoublingComp
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 class TestSystem(unittest.TestCase):
@@ -131,11 +131,11 @@ class TestSystem(unittest.TestCase):
 
         # assign scalar to array
         inputs['C2.x'] = num_val
-        assert_rel_error(self, inputs['C2.x'], arr_val, 1e-10)
+        assert_near_equal(inputs['C2.x'], arr_val, 1e-10)
 
         # assign array to array
         inputs['C2.x'] = arr_val
-        assert_rel_error(self, inputs['C2.x'], arr_val, 1e-10)
+        assert_near_equal(inputs['C2.x'], arr_val, 1e-10)
 
         # assign bad array shape to array
         with self.assertRaisesRegex(ValueError, msg):
@@ -143,7 +143,7 @@ class TestSystem(unittest.TestCase):
 
         # assign list to array
         inputs['C2.x'] = arr_val.tolist()
-        assert_rel_error(self, inputs['C2.x'], arr_val, 1e-10)
+        assert_near_equal(inputs['C2.x'], arr_val, 1e-10)
 
         # assign bad list shape to array
         with self.assertRaisesRegex(ValueError, msg):
@@ -159,11 +159,11 @@ class TestSystem(unittest.TestCase):
 
         # assign scalar to array
         outputs['C2.y'] = num_val
-        assert_rel_error(self, outputs['C2.y'], arr_val, 1e-10)
+        assert_near_equal(outputs['C2.y'], arr_val, 1e-10)
 
         # assign array to array
         outputs['C2.y'] = arr_val
-        assert_rel_error(self, outputs['C2.y'], arr_val, 1e-10)
+        assert_near_equal(outputs['C2.y'], arr_val, 1e-10)
 
         # assign bad array shape to array
         with self.assertRaisesRegex(ValueError, msg):
@@ -171,7 +171,7 @@ class TestSystem(unittest.TestCase):
 
         # assign list to array
         outputs['C2.y'] = arr_val.tolist()
-        assert_rel_error(self, outputs['C2.y'], arr_val, 1e-10)
+        assert_near_equal(outputs['C2.y'], arr_val, 1e-10)
 
         # assign bad list shape to array
         with self.assertRaisesRegex(ValueError, msg):
@@ -187,11 +187,11 @@ class TestSystem(unittest.TestCase):
 
         # assign scalar to array
         residuals['C2.y'] = num_val
-        assert_rel_error(self, residuals['C2.y'], arr_val, 1e-10)
+        assert_near_equal(residuals['C2.y'], arr_val, 1e-10)
 
         # assign array to array
         residuals['C2.y'] = arr_val
-        assert_rel_error(self, residuals['C2.y'], arr_val, 1e-10)
+        assert_near_equal(residuals['C2.y'], arr_val, 1e-10)
 
         # assign bad array shape to array
         with self.assertRaisesRegex(ValueError, msg):
@@ -199,7 +199,7 @@ class TestSystem(unittest.TestCase):
 
         # assign list to array
         residuals['C2.y'] = arr_val.tolist()
-        assert_rel_error(self, residuals['C2.y'], arr_val, 1e-10)
+        assert_near_equal(residuals['C2.y'], arr_val, 1e-10)
 
         # assign bad list shape to array
         with self.assertRaisesRegex(ValueError, msg):

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -3,7 +3,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.test_suite.components.unit_conv import UnitConvGroup, SrcComp, TgtCompC, TgtCompF, \
     TgtCompK, SrcCompFD, TgtCompCFD, TgtCompFFD, TgtCompKFD, TgtCompFMulti
 
@@ -33,28 +33,28 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup(check=False, mode='fwd')
         prob.run_model()
 
-        assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtK.x3'], 373.15, 1e-6)
 
         # Check the total derivatives in forward mode
         wrt = ['px1.x1']
         of = ['tgtF.x3', 'tgtC.x3', 'tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
 
     def test_dangling_input_w_units(self):
         prob = om.Problem()
@@ -82,14 +82,14 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['c1.distance'], 1.)  # units: m
-        assert_rel_error(self, prob['c2.distance'], 1.e-3)  # units: km
+        assert_near_equal(prob['c1.distance'], 1.)  # units: m
+        assert_near_equal(prob['c2.distance'], 1.e-3)  # units: km
 
-        assert_rel_error(self, prob['c1.time'], 1.)  # units: s
-        assert_rel_error(self, prob['c2.time'], 1./3600.)  # units: h
+        assert_near_equal(prob['c1.time'], 1.)  # units: s
+        assert_near_equal(prob['c2.time'], 1./3600.)  # units: h
 
-        assert_rel_error(self, prob['c2.speed'], 3.6)  # units: km/h
-        assert_rel_error(self, prob['c3.f'], 1.0)  # units: km/h
+        assert_near_equal(prob['c2.speed'], 3.6)  # units: km/h
+        assert_near_equal(prob['c3.f'], 1.0)  # units: km/h
 
     def test_basic(self):
         """Test that output values and total derivatives are correct."""
@@ -99,40 +99,40 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup(check=False, mode='fwd')
         prob.run_model()
 
-        assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtK.x3'], 373.15, 1e-6)
 
         # Check the total derivatives in forward mode
         wrt = ['px1.x1']
         of = ['tgtF.x3', 'tgtC.x3', 'tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3', 'px1.x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3', 'px1.x1'][0][0], 1.0, 1e-6)
 
         # Make sure check partials handles conversion
         data = prob.check_partials()
 
         for key1, val1 in data.items():
             for key2, val2 in val1.items():
-                assert_rel_error(self, val2['abs error'][0], 0.0, 1e-6)
-                assert_rel_error(self, val2['abs error'][1], 0.0, 1e-6)
-                assert_rel_error(self, val2['abs error'][2], 0.0, 1e-6)
-                assert_rel_error(self, val2['rel error'][0], 0.0, 1e-6)
-                assert_rel_error(self, val2['rel error'][1], 0.0, 1e-6)
-                assert_rel_error(self, val2['rel error'][2], 0.0, 1e-6)
+                assert_near_equal(val2['abs error'][0], 0.0, 1e-6)
+                assert_near_equal(val2['abs error'][1], 0.0, 1e-6)
+                assert_near_equal(val2['abs error'][2], 0.0, 1e-6)
+                assert_near_equal(val2['rel error'][0], 0.0, 1e-6)
+                assert_near_equal(val2['rel error'][1], 0.0, 1e-6)
+                assert_near_equal(val2['rel error'][2], 0.0, 1e-6)
 
     def test_basic_apply(self):
         """Test that output values and total derivatives are correct."""
@@ -189,22 +189,22 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup(check=False, mode='fwd')
         prob.run_model()
 
-        assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtF.x3'], 212.0, 1e-6)
 
         # Check the total derivatives in forward mode
         wrt = ['px1.x1']
         of = ['tgtF.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'px1.x1'][0][0], 1.8, 1e-6)
 
     def test_basic_fd_comps(self):
 
@@ -222,47 +222,47 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtK.x3'], 373.15, 1e-6)
 
         indep_list = ['x1']
         unknown_list = ['tgtF.x3', 'tgtC.x3', 'tgtK.x3']
         J = prob.compute_totals(of=unknown_list, wrt=indep_list, return_format='dict')
 
-        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=unknown_list, wrt=indep_list, return_format='dict')
 
-        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         prob.model.approx_totals(method='fd')
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=unknown_list, wrt=indep_list, return_format='dict')
 
-        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         # Make sure check partials handles conversion
         data = prob.check_partials()
 
         for key1, val1 in data.items():
             for key2, val2 in val1.items():
-                assert_rel_error(self, val2['abs error'][0], 0.0, 1e-6)
-                assert_rel_error(self, val2['abs error'][1], 0.0, 1e-6)
-                assert_rel_error(self, val2['abs error'][2], 0.0, 1e-6)
-                assert_rel_error(self, val2['rel error'][0], 0.0, 1e-6)
-                assert_rel_error(self, val2['rel error'][1], 0.0, 1e-6)
-                assert_rel_error(self, val2['rel error'][2], 0.0, 1e-6)
+                assert_near_equal(val2['abs error'][0], 0.0, 1e-6)
+                assert_near_equal(val2['abs error'][1], 0.0, 1e-6)
+                assert_near_equal(val2['abs error'][2], 0.0, 1e-6)
+                assert_near_equal(val2['rel error'][0], 0.0, 1e-6)
+                assert_near_equal(val2['rel error'][1], 0.0, 1e-6)
+                assert_near_equal(val2['rel error'][2], 0.0, 1e-6)
 
     def test_bad_units(self):
         """Test error handling when invalid units are declared."""
@@ -312,28 +312,28 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['x2'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtK.x3'], 373.15, 1e-6)
 
         # Check the total derivatives in forward mode
         wrt = ['x1']
         of = ['tgtF.x3', 'tgtC.x3', 'tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3', 'x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3', 'x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3', 'x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3', 'x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
-        assert_rel_error(self, J['tgtF.x3', 'x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3', 'x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3', 'x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3', 'x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3', 'x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3', 'x1'][0][0], 1.0, 1e-6)
 
     def test_basic_grouped(self):
 
@@ -355,27 +355,27 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['sub1.src.x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['sub2.tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['sub1.src.x2'], 100.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['sub2.tgtK.x3'], 373.15, 1e-6)
 
         wrt = ['x1']
         of = ['sub2.tgtF.x3', 'sub2.tgtC.x3', 'sub2.tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
     def test_basic_grouped_bug_from_pycycle(self):
 
@@ -397,27 +397,27 @@ class TestUnitConversion(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['x2'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtF.x3'], 212.0, 1e-6)
-        assert_rel_error(self, prob['tgtC.x3'], 100.0, 1e-6)
-        assert_rel_error(self, prob['tgtK.x3'], 373.15, 1e-6)
+        assert_near_equal(prob['x2'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtF.x3'], 212.0, 1e-6)
+        assert_near_equal(prob['tgtC.x3'], 100.0, 1e-6)
+        assert_near_equal(prob['tgtK.x3'], 373.15, 1e-6)
 
         wrt = ['x1']
         of = ['tgtF.x3', 'tgtC.x3', 'tgtK.x3']
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         # Check the total derivatives in reverse mode
         prob.setup(check=False, mode='rev')
         prob.run_model()
         J = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        assert_rel_error(self, J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        assert_rel_error(self, J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        assert_near_equal(J['tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        assert_near_equal(J['tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
     #def test_basic_grouped_grouped_implicit(self):
 
@@ -435,33 +435,33 @@ class TestUnitConversion(unittest.TestCase):
         #prob.setup()
         #prob.run_model()
 
-        #assert_rel_error(self, prob['x2'], 100.0, 1e-6)
-        #assert_rel_error(self, prob['sub2.tgtF.x3'], 212.0, 1e-6)
-        #assert_rel_error(self, prob['sub2.tgtC.x3'], 100.0, 1e-6)
-        #assert_rel_error(self, prob['sub2.tgtK.x3'], 373.15, 1e-6)
+        #assert_near_equal(prob['x2'], 100.0, 1e-6)
+        #assert_near_equal(prob['sub2.tgtF.x3'], 212.0, 1e-6)
+        #assert_near_equal(prob['sub2.tgtC.x3'], 100.0, 1e-6)
+        #assert_near_equal(prob['sub2.tgtK.x3'], 373.15, 1e-6)
 
         #indep_list = ['x1']
         #unknown_list = ['sub2.tgtF.x3', 'sub2.tgtC.x3', 'sub2.tgtK.x3']
         #J = prob.calc_gradient(indep_list, unknown_list, mode='fwd',
                                #return_format='dict')
 
-        #assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        #assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        #assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        #assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        #assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        #assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         #J = prob.calc_gradient(indep_list, unknown_list, mode='rev',
                                #return_format='dict')
 
-        #assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        #assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        #assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        #assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        #assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        #assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
         #J = prob.calc_gradient(indep_list, unknown_list, mode='fd',
                                #return_format='dict')
 
-        #assert_rel_error(self, J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
-        #assert_rel_error(self, J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
-        #assert_rel_error(self, J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
+        #assert_near_equal(J['sub2.tgtF.x3']['x1'][0][0], 1.8, 1e-6)
+        #assert_near_equal(J['sub2.tgtC.x3']['x1'][0][0], 1.0, 1e-6)
+        #assert_near_equal(J['sub2.tgtK.x3']['x1'][0][0], 1.0, 1e-6)
 
     #def test_apply_linear_adjoint(self):
         ## Make sure we can index into dinputs
@@ -571,7 +571,7 @@ class TestUnitConversion(unittest.TestCase):
         #for key, val in Jr.items():
             #for key2 in val:
                 #diff = abs(Jf[key][key2] - Jr[key][key2])
-                #assert_rel_error(self, diff, 0.0, 1e-10)
+                #assert_near_equal(diff, 0.0, 1e-10)
 
     def test_incompatible_connections(self):
 
@@ -646,8 +646,8 @@ class TestUnitConversion(unittest.TestCase):
         #sub.linear_solver.rel_inputs = ['sub.cc2.x', 'sub.cc1.x2']
         #rhs_buf = {None : np.array([3.5, 1.7])}
         #sol_buf = sub.linear_solver.solve(rhs_buf, sub, mode='fwd')[None]
-        #assert_rel_error(self, sol_buf[0], -3.52052052, 1e-3)
-        #assert_rel_error(self, sol_buf[1], -2.05205205, 1e-3)
+        #assert_near_equal(sol_buf[0], -3.52052052, 1e-3)
+        #assert_near_equal(sol_buf[1], -2.05205205, 1e-3)
 
     #def test_nested_relevancy(self):
 

--- a/openmdao/docs/_utils/docutil.py
+++ b/openmdao/docs/_utils/docutil.py
@@ -223,6 +223,17 @@ def replace_asserts_with_prints(src):
             #
             assert_node.value[0].replace("print")
 
+    if 'assert_near_equal' in src:
+        assert_nodes = rb.findAll("NameNode", value='assert_near_equal')
+        for assert_node in assert_nodes:
+            assert_node = assert_node.parent
+            # If relative error tolerance is specified, there are 3 arguments
+            if len(assert_node.value[1]) == 3:
+                # remove the relative error tolerance
+                remove_redbaron_node(assert_node.value[1], -1)
+            remove_redbaron_node(assert_node.value[1], -1)  # remove the expected value
+            assert_node.value[0].replace("print")
+
     if 'assert_almost_equal' in src:
         assert_nodes = rb.findAll("NameNode", value='assert_almost_equal')
         for assert_node in assert_nodes:

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -16,7 +16,7 @@ import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.groups.parallel_groups import FanInGrouped
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import run_driver, printoptions
 
 from openmdao.utils.mpi import MPI
@@ -469,7 +469,7 @@ class TestDOEDriver(unittest.TestCase):
         for case, expected_case in zip(cases, expected):
             outputs = cr.get_case(case).outputs
             for name in ('x', 'y'):
-                assert_rel_error(self, outputs[name], expected_case[name], 1e-4)
+                assert_near_equal(outputs[name], expected_case[name], 1e-4)
 
     def test_full_factorial(self):
         prob = om.Problem()
@@ -751,8 +751,8 @@ class TestDOEDriver(unittest.TestCase):
             bucket = int((y + y_offset) / (y_bucket_size / samples))
             y_buckets_filled.add(bucket)
 
-            assert_rel_error(self, x, expected_case['x'], 1e-4)
-            assert_rel_error(self, y, expected_case['y'], 1e-4)
+            assert_near_equal(x, expected_case['x'], 1e-4)
+            assert_near_equal(y, expected_case['y'], 1e-4)
 
         self.assertEqual(x_buckets_filled, all_buckets)
         self.assertEqual(y_buckets_filled, all_buckets)
@@ -819,8 +819,8 @@ class TestDOEDriver(unittest.TestCase):
             bucket = int((y + y_offset) / (y_bucket_size / samples))
             y_buckets_filled.add(bucket)
 
-            assert_rel_error(self, x, expected_case['xy'][0], 1e-4)
-            assert_rel_error(self, y, expected_case['xy'][1], 1e-4)
+            assert_near_equal(x, expected_case['xy'][0], 1e-4)
+            assert_near_equal(y, expected_case['xy'][1], 1e-4)
 
         self.assertEqual(x_buckets_filled, all_buckets)
         self.assertEqual(y_buckets_filled, all_buckets)
@@ -912,9 +912,9 @@ class TestDOEDriver(unittest.TestCase):
         final_case = cr.list_cases('driver')[-1]
         outputs = cr.get_case(final_case).outputs
 
-        assert_rel_error(self, outputs['x'], 10.0, 1e-7)
-        assert_rel_error(self, outputs['y'], 20.0, 1e-7)
-        assert_rel_error(self, outputs['z'], 30.0, 1e-7)
+        assert_near_equal(outputs['x'], 10.0, 1e-7)
+        assert_near_equal(outputs['y'], 20.0, 1e-7)
+        assert_near_equal(outputs['z'], 30.0, 1e-7)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -11,7 +11,7 @@ from openmdao.test_suite.components.branin import Branin, BraninDiscrete
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar_feature import SellarMDA
 from openmdao.test_suite.components.three_bar_truss import ThreeBarTruss
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 try:
@@ -78,9 +78,9 @@ class TestSimpleGA(unittest.TestCase):
 
         # TODO: Satadru listed this solution, but I get a way better one.
         # Solution: xopt = [0.2857, -0.8571], fopt = 23.2933
-        assert_rel_error(self, prob['obj.f'], 12.37306086, 1e-4)
-        assert_rel_error(self, prob['px.x'][0], 0.2, 1e-4)
-        assert_rel_error(self, prob['px.x'][1], -0.88653391, 1e-4)
+        assert_near_equal(prob['obj.f'], 12.37306086, 1e-4)
+        assert_near_equal(prob['px.x'][0], 0.2, 1e-4)
+        assert_near_equal(prob['px.x'][1], -0.88653391, 1e-4)
 
     def test_mixed_integer_branin(self):
         prob = om.Problem()
@@ -109,7 +109,7 @@ class TestSimpleGA(unittest.TestCase):
             print('comp.f', prob['comp.f'])
 
         # Optimal solution
-        assert_rel_error(self, prob['comp.f'], 0.49399549, 1e-4)
+        assert_near_equal(prob['comp.f'], 0.49399549, 1e-4)
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
     def test_mixed_integer_branin_discrete(self):
@@ -143,7 +143,7 @@ class TestSimpleGA(unittest.TestCase):
             print('p.xI', prob['p.xI'])
 
         # Optimal solution
-        assert_rel_error(self, prob['comp.f'], 0.49399549, 1e-4)
+        assert_near_equal(prob['comp.f'], 0.49399549, 1e-4)
         self.assertTrue(prob['p.xI'] in [3, -3])
         self.assertTrue(isinstance(prob['p.xI'], int))
 
@@ -208,8 +208,8 @@ class TestSimpleGA(unittest.TestCase):
         # as much as we can. Objective is still rather random, but it is close. GA does a great job
         # of picking the correct values for the integer desvars though.
         self.assertLess(prob['mass'], 6.0)
-        assert_rel_error(self, prob['mat1'], 3, 1e-5)
-        assert_rel_error(self, prob['mat2'], 3, 1e-5)
+        assert_near_equal(prob['mat1'], 3, 1e-5)
+        assert_near_equal(prob['mat2'], 3, 1e-5)
         # Material 3 can be anything
 
     def test_mixed_integer_3bar_default_bits(self):
@@ -276,8 +276,8 @@ class TestSimpleGA(unittest.TestCase):
         # as much as we can. Objective is still rather random, but it is close. GA does a great job
         # of picking the correct values for the integer desvars though.
         self.assertLess(prob['mass'], 6.0)
-        assert_rel_error(self, prob['mat1'], 3, 1e-5)
-        assert_rel_error(self, prob['mat2'], 3, 1e-5)
+        assert_near_equal(prob['mat1'], 3, 1e-5)
+        assert_near_equal(prob['mat2'], 3, 1e-5)
         # Material 3 can be anything
 
     def test_analysis_error(self):
@@ -789,7 +789,7 @@ class MPITestSimpleGA(unittest.TestCase):
             print('p2.xI', prob['p2.xI'])
 
         # Optimal solution
-        assert_rel_error(self, prob['comp.f'], 0.49399549, 1e-4)
+        assert_near_equal(prob['comp.f'], 0.49399549, 1e-4)
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
     def test_two_branin_parallel_model(self):
@@ -833,7 +833,7 @@ class MPITestSimpleGA(unittest.TestCase):
             print('p2.xI', prob['p2.xI'])
 
         # Optimal solution
-        assert_rel_error(self, prob['comp.f'], 0.98799098, 1e-4)
+        assert_near_equal(prob['comp.f'], 0.98799098, 1e-4)
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
     def test_mixed_integer_3bar_default_bits(self):
@@ -901,8 +901,8 @@ class MPITestSimpleGA(unittest.TestCase):
         # as much as we can. Objective is still rather random, but it is close. GA does a great job
         # of picking the correct values for the integer desvars though.
         self.assertLess(prob['mass'], 6.0)
-        assert_rel_error(self, prob['mat1'], 3, 1e-5)
-        assert_rel_error(self, prob['mat2'], 3, 1e-5)
+        assert_near_equal(prob['mat1'], 3, 1e-5)
+        assert_near_equal(prob['mat2'], 3, 1e-5)
         # Material 3 can be anything
 
     def test_mpi_bug_solver(self):
@@ -1068,7 +1068,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
             print('p2.xI', prob['p2.xI'])
 
         # Optimal solution
-        assert_rel_error(self, prob['comp.f'], 0.98799098, 1e-4)
+        assert_near_equal(prob['comp.f'], 0.98799098, 1e-4)
         self.assertTrue(int(prob['p2.xI']) in [3, -3])
 
     def test_indivisible_error(self):
@@ -1210,7 +1210,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
         prob.run_driver()
 
         # Optimal solution
-        assert_rel_error(self, prob['comp.f'], 0.49399549, 1e-4)
+        assert_near_equal(prob['comp.f'], 0.49399549, 1e-4)
 
     def test_option_max_gen(self):
         import openmdao.api as om

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -12,7 +12,7 @@ import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
@@ -210,8 +210,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_simple_paraboloid_upper_indices(self):
 
@@ -254,8 +254,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['p1.x'], np.array([50., 7.16667, 50.]), 1e-6)
-        assert_rel_error(self, prob['p2.y'], np.array([50., -7.833334, 50.]), 1e-6)
+        assert_near_equal(prob['p1.x'], np.array([50., 7.16667, 50.]), 1e-6)
+        assert_near_equal(prob['p2.y'], np.array([50., -7.833334, 50.]), 1e-6)
 
     def test_simple_paraboloid_lower(self):
 
@@ -289,8 +289,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_simple_paraboloid_lower_linear(self):
 
@@ -323,8 +323,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
         self.assertEqual(prob.driver._quantities, ['comp.f_xy'])
 
@@ -365,8 +365,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_simple_paraboloid_equality_linear(self):
 
@@ -399,8 +399,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_simple_paraboloid_double_sided_low(self):
 
@@ -431,7 +431,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['y'] - prob['x'], -11.0, 1e-6)
+        assert_near_equal(prob['y'] - prob['x'], -11.0, 1e-6)
 
     def test_simple_paraboloid_double_sided_high(self):
 
@@ -462,7 +462,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_array_comp2D(self):
 
@@ -494,7 +494,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         obj = prob['o']
-        assert_rel_error(self, obj, 20.0, 1e-6)
+        assert_near_equal(obj, 20.0, 1e-6)
 
     def test_simple_array_comp2D_array_lo_hi(self):
 
@@ -526,7 +526,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         obj = prob['o']
-        assert_rel_error(self, obj, 20.0, 1e-6)
+        assert_near_equal(obj, 20.0, 1e-6)
 
     def test_fan_out(self):
         # This tests sparse-response specification.
@@ -573,7 +573,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         obj = prob['obj.o']
-        assert_rel_error(self, obj, 30.0, 1e-6)
+        assert_near_equal(obj, 30.0, 1e-6)
 
         # Verify that pyOpt has the correct wrt names
         con1 = prob.driver.pyopt_solution.constraints['con1.c']
@@ -615,8 +615,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_pyopt_fd_solution(self):
 
@@ -650,8 +650,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-4)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-4)
+        assert_near_equal(prob['x'], 7.16667, 1e-4)
+        assert_near_equal(prob['y'], -7.833334, 1e-4)
 
     def test_pyopt_fd_is_called(self):
 
@@ -690,8 +690,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-4)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-4)
+        assert_near_equal(prob['x'], 7.16667, 1e-4)
+        assert_near_equal(prob['y'], -7.833334, 1e-4)
 
     def test_snopt_fd_option_error(self):
 
@@ -795,7 +795,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_fd(self):
         prob = om.Problem()
@@ -829,7 +829,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_cs(self):
         prob = om.Problem()
@@ -863,7 +863,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_rev(self):
 
@@ -896,7 +896,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_fwd(self):
 
@@ -929,7 +929,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_fd(self):
         prob = om.Problem()
@@ -963,7 +963,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_cs(self):
         prob = om.Problem()
@@ -997,7 +997,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_rev(self):
 
@@ -1030,7 +1030,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_objective_fwd(self):
 
@@ -1063,7 +1063,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_objective_rev(self):
 
@@ -1096,7 +1096,7 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_sellar_mdf(self):
 
@@ -1124,9 +1124,9 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
-        assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 4e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][1], 0.0, 1e-3)
+        assert_near_equal(prob['x'], 0.0, 4e-3)
 
     def test_sellar_mdf_linear_con_directsolver(self):
         # This test makes sure that we call solve_nonlinear first if we have any linear constraints
@@ -1230,9 +1230,9 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
-        assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 4e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][1], 0.0, 1e-3)
+        assert_near_equal(prob['x'], 0.0, 4e-3)
 
         # Piggyback test: make sure we can run the driver again as a subdriver without a keyerror.
         prob.driver.run()
@@ -1272,8 +1272,8 @@ class TestPyoptSparse(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
         # Normally it takes 9 iterations, but takes 13 here because of the
         # analysis failures. (note SLSQP takes 5 instead of 4)
@@ -1365,8 +1365,8 @@ class TestPyoptSparse(unittest.TestCase):
             tol = 1e-6
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, tol)
-        assert_rel_error(self, prob['y'], -7.833334, tol)
+        assert_near_equal(prob['x'], 7.16667, tol)
+        assert_near_equal(prob['y'], -7.833334, tol)
 
         # Normally it takes 9 iterations, but takes 13 here because of the
         # gradfunc failures. (note SLSQP just doesn't do well)
@@ -1841,7 +1841,7 @@ class TestPyoptSparse(unittest.TestCase):
         prob.setup(check=False, mode='rev')
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
 
 
 @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
@@ -1879,7 +1879,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob.setup(check=False, mode='rev')
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
 
     def test_settings_print(self):
         import numpy as np
@@ -1905,7 +1905,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob.setup(check=False, mode='rev')
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
 
     def test_slsqp_atol(self):
         import numpy as np
@@ -1932,7 +1932,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob.setup(check=False, mode='rev')
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
 
     def test_slsqp_maxit(self):
         import numpy as np
@@ -1959,7 +1959,7 @@ class TestPyoptSparseFeature(unittest.TestCase):
         prob.setup(check=False, mode='rev')
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.98337708, 1e-3)
+        assert_near_equal(prob['z'][0], 1.98337708, 1e-3)
 
 
 class TestPyoptSparseSnoptFeature(unittest.TestCase):
@@ -1995,7 +1995,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         prob.setup(check=False, mode='rev')
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
 
     def test_snopt_maxit(self):
         import numpy as np
@@ -2024,7 +2024,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9780247, 2e-3)
+        assert_near_equal(prob['z'][0], 1.9780247, 2e-3)
 
     def test_snopt_fd_solution(self):
 
@@ -2058,8 +2058,8 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_snopt_fd_is_called(self):
 
@@ -2098,8 +2098,8 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
                                  str(prob.driver.pyopt_solution.optInform))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_sellar_analysis_error(self):
         # One discipline of Sellar will something raise analysis error. This is to test that
@@ -2216,9 +2216,9 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
-        assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][1], 0.0, 1e-3)
+        assert_near_equal(prob['x'], 0.0, 1e-3)
 
         self.assertEqual(model.cycle.d1.failed, 2)
 

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -14,7 +14,7 @@ from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, SellarDerivatives
 from openmdao.test_suite.components.simple_comps import NonSquareArrayComp
 from openmdao.test_suite.groups.sin_fitter import SineFitter
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import run_driver
 from openmdao.utils.mpi import MPI
 
@@ -138,8 +138,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt, return_format='array')
 
-        assert_rel_error(self, derivs[0, 0], -6.0, 1e-6)
-        assert_rel_error(self, derivs[0, 1], 8.0, 1e-6)
+        assert_near_equal(derivs[0, 0], -6.0, 1e-6)
+        assert_near_equal(derivs[0, 1], 8.0, 1e-6)
 
         prob.setup(check=False, mode='rev')
 
@@ -149,8 +149,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt, return_format='array')
 
-        assert_rel_error(self, derivs[0, 0], -6.0, 1e-6)
-        assert_rel_error(self, derivs[0, 1], 8.0, 1e-6)
+        assert_near_equal(derivs[0, 0], -6.0, 1e-6)
+        assert_near_equal(derivs[0, 1], 8.0, 1e-6)
 
     def test_compute_totals_return_array_non_square(self):
 
@@ -175,7 +175,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         derivs = prob.compute_totals(of=['comp.y1'], wrt=['px.x'], return_format='array')
 
         J = comp.JJ[0:3, 0:2]
-        assert_rel_error(self, J, derivs, 1.0e-3)
+        assert_near_equal(J, derivs, 1.0e-3)
 
         # Support for a name to be in 'of' and 'wrt'
 
@@ -183,9 +183,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                      wrt=['px.x'],
                                      return_format='array')
 
-        assert_rel_error(self, J, derivs[3:, :], 1.0e-3)
-        assert_rel_error(self, comp.JJ[3:4, 0:2], derivs[0:1, :], 1.0e-3)
-        assert_rel_error(self, np.eye(2), derivs[1:3, :], 1.0e-3)
+        assert_near_equal(J, derivs[3:, :], 1.0e-3)
+        assert_near_equal(comp.JJ[3:4, 0:2], derivs[0:1, :], 1.0e-3)
+        assert_near_equal(np.eye(2), derivs[1:3, :], 1.0e-3)
 
     def test_deriv_wrt_self(self):
 
@@ -208,7 +208,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         J = prob.driver._compute_totals(of=['px.x'], wrt=['px.x'],
                                         return_format='array')
 
-        assert_rel_error(self, J, np.eye(2), 1.0e-3)
+        assert_near_equal(J, np.eye(2), 1.0e-3)
 
     def test_scipy_optimizer_simple_paraboloid_unconstrained(self):
 
@@ -234,8 +234,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_simple_paraboloid_unconstrained(self):
 
@@ -264,8 +264,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_simple_paraboloid_unconstrained_COBYLA(self):
         prob = om.Problem()
@@ -293,8 +293,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_simple_paraboloid_upper(self):
 
@@ -326,8 +326,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_simple_paraboloid_lower(self):
 
@@ -360,8 +360,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_simple_paraboloid_equality(self):
 
@@ -394,8 +394,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         # Minimum should be at (7.166667, -7.833334)
         # (Note, loose tol because of appveyor py3.4 machine.)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-4)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-4)
+        assert_near_equal(prob['x'], 7.16667, 1e-4)
+        assert_near_equal(prob['y'], -7.833334, 1e-4)
 
     def test_unsupported_equality(self):
 
@@ -484,7 +484,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['y'] - prob['x'], -11.0, 1e-6)
+        assert_near_equal(prob['y'] - prob['x'], -11.0, 1e-6)
 
     def test_simple_paraboloid_double_sided_high(self):
 
@@ -515,7 +515,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_array_comp2D(self):
 
@@ -549,7 +549,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         obj = prob['o']
-        assert_rel_error(self, obj, 20.0, 1e-6)
+        assert_near_equal(obj, 20.0, 1e-6)
 
     def test_simple_array_comp2D_eq_con(self):
 
@@ -580,7 +580,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         obj = prob['o']
-        assert_rel_error(self, obj, 41.5, 1e-6)
+        assert_near_equal(obj, 41.5, 1e-6)
 
     def test_simple_array_comp2D_dbl_sided_con(self):
 
@@ -611,7 +611,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         con = prob['areas']
-        assert_rel_error(self, con, np.array([[24.0, 21.0], [3.5, 17.5]]), 1e-6)
+        assert_near_equal(con, np.array([[24.0, 21.0], [3.5, 17.5]]), 1e-6)
 
     def test_simple_array_comp2D_dbl_sided_con_array(self):
 
@@ -642,7 +642,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         obj = prob['o']
-        assert_rel_error(self, obj, 20.0, 1e-6)
+        assert_near_equal(obj, 20.0, 1e-6)
 
     def test_simple_array_comp2D_array_lo_hi(self):
 
@@ -675,7 +675,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         obj = prob['o']
-        assert_rel_error(self, obj, 20.0, 1e-6)
+        assert_near_equal(obj, 20.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_fwd(self):
 
@@ -706,7 +706,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_desvars_rev(self):
 
@@ -737,7 +737,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_constraint_fwd(self):
 
@@ -768,7 +768,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_objective_fwd(self):
 
@@ -799,7 +799,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_simple_paraboloid_scaled_objective_rev(self):
 
@@ -830,7 +830,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['x'] - prob['y'], 11.0, 1e-6)
+        assert_near_equal(prob['x'] - prob['y'], 11.0, 1e-6)
 
     def test_sellar_mdf(self):
 
@@ -855,9 +855,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
-        assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][1], 0.0, 1e-3)
+        assert_near_equal(prob['x'], 0.0, 1e-3)
 
     def test_bug_in_eq_constraints(self):
         # We were getting extra constraints created because lower and upper are maxfloat instead of
@@ -869,7 +869,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         p.run_driver()
 
         max_defect = np.max(np.abs(p['defect.defect']))
-        assert_rel_error(self, max_defect, 0.0, 1e-10)
+        assert_near_equal(max_defect, 0.0, 1e-10)
 
     def test_reraise_exception_from_callbacks(self):
         class ReducedActuatorDisc(om.ExplicitComponent):
@@ -949,8 +949,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_sellar_mdf_COBYLA(self):
 
@@ -975,9 +975,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, result =\n" +
                                  str(prob.driver.result))
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
-        assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 1e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][1], 0.0, 1e-3)
+        assert_near_equal(prob['x'], 0.0, 1e-3)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
                          "scipy >= 1.1 is required.")
@@ -1016,8 +1016,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], np.ones(3), 2e-2)
-        assert_rel_error(self, prob['f'], 0., 1e-2)
+        assert_near_equal(prob['x'], np.ones(3), 2e-2)
+        assert_near_equal(prob['f'], 0., 1e-2)
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
@@ -1059,8 +1059,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], np.ones(3), 2e-2)
-        assert_rel_error(self, prob['f'], 0., 1e-2)
+        assert_near_equal(prob['x'], np.ones(3), 2e-2)
+        assert_near_equal(prob['f'], 0., 1e-2)
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
@@ -1103,7 +1103,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['con.c'], 1., 1e-3)
+        assert_near_equal(prob['con.c'], 1., 1e-3)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
@@ -1141,7 +1141,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['c'], 1.0, 1e-2)
+        assert_near_equal(prob['c'], 1.0, 1e-2)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
@@ -1176,8 +1176,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'][0], -1., 1e-2)
-        assert_rel_error(self, prob['x'][1], -1.2, 1e-2)
+        assert_near_equal(prob['x'][0], -1., 1e-2)
+        assert_near_equal(prob['x'][1], -1.2, 1e-2)
 
     def test_simple_paraboloid_lower_linear(self):
 
@@ -1209,8 +1209,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
         self.assertEqual(prob.driver._obj_and_nlcons, ['comp.f_xy'])
 
@@ -1244,8 +1244,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                                  str(prob.driver.result))
 
         # Minimum should be at (7.166667, -7.833334)
-        assert_rel_error(self, prob['x'], 7.16667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.833334, 1e-6)
+        assert_near_equal(prob['x'], 7.16667, 1e-6)
+        assert_near_equal(prob['y'], -7.833334, 1e-6)
 
     def test_debug_print_option_totals(self):
 
@@ -1385,9 +1385,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         failed = prob.run_driver()
 
-        assert_rel_error(self, prob['z'][0], 1.9776, 1e-3)
-        assert_rel_error(self, prob['z'][1], 0.0, 1e-3)
-        assert_rel_error(self, prob['x'], 0.0, 4e-3)
+        assert_near_equal(prob['z'][0], 1.9776, 1e-3)
+        assert_near_equal(prob['z'][1], 0.0, 1e-3)
+        assert_near_equal(prob['x'], 0.0, 4e-3)
 
         self.assertEqual(len(prob.driver._lincongrad_cache), 1)
         # Piggyback test: make sure we can run the driver again as a subdriver without a keyerror.
@@ -1453,7 +1453,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.run_driver()
 
         # minimum value
-        assert_rel_error(self, prob['parab.f_xy'], -27, 1e-6)
+        assert_near_equal(prob['parab.f_xy'], -27, 1e-6)
 
     def test_multiple_objectives_error(self):
 
@@ -1528,8 +1528,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], np.array([-0.1951, -0.1000]), 1e-3)
-        assert_rel_error(self, prob['f'], -1.0109, 1e-3)
+        assert_near_equal(prob['x'], np.array([-0.1951, -0.1000]), 1e-3)
+        assert_near_equal(prob['f'], -1.0109, 1e-3)
 
     def test_basinhopping_bounded(self):
         # It should find the local minimum, which is inside the bounds
@@ -1570,8 +1570,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], np.array([0.234171, -0.1000]), 1e-3)
-        assert_rel_error(self, prob['f'], -0.907267, 1e-3)
+        assert_near_equal(prob['x'], np.array([0.234171, -0.1000]), 1e-3)
+        assert_near_equal(prob['f'], -0.907267, 1e-3)
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
     def test_dual_annealing(self):
@@ -1596,8 +1596,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], np.ones(rosenbrock_size), 1e-2)
-        assert_rel_error(self, prob['f'], 0.0, 1e-2)
+        assert_near_equal(prob['x'], np.ones(rosenbrock_size), 1e-2)
+        assert_near_equal(prob['f'], 0.0, 1e-2)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
@@ -1635,8 +1635,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], np.zeros(size), 1e-2)
-        assert_rel_error(self, prob['f'], 0.0, 1e-2)
+        assert_near_equal(prob['x'], np.zeros(size), 1e-2)
+        assert_near_equal(prob['f'], 0.0, 1e-2)
 
     def test_differential_evolution(self):
         # Source of example:
@@ -1672,8 +1672,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], np.zeros(size), 1e-6)
-        assert_rel_error(self, prob['f'], 0.0, 1e-6)
+        assert_near_equal(prob['x'], np.zeros(size), 1e-6)
+        assert_near_equal(prob['f'], 0.0, 1e-6)
 
     def test_differential_evolution_bounded(self):
         # Source of example:
@@ -1709,8 +1709,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], -np.ones(size), 1e-2)
-        assert_rel_error(self, prob['f'], 3.0, 1e-2)
+        assert_near_equal(prob['x'], -np.ones(size), 1e-2)
+        assert_near_equal(prob['f'], 3.0, 1e-2)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")
@@ -1734,8 +1734,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_objective('f')
         prob.setup()
         prob.run_driver()
-        assert_rel_error(self, prob['x'], np.ones(rosenbrock_size), 1e-2)
-        assert_rel_error(self, prob['f'], 0.0, 1e-2)
+        assert_near_equal(prob['x'], np.ones(rosenbrock_size), 1e-2)
+        assert_near_equal(prob['f'], 0.0, 1e-2)
 
 class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
@@ -1763,8 +1763,8 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_feature_optimizer(self):
         import openmdao.api as om
@@ -1787,8 +1787,8 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_feature_maxiter(self):
         import openmdao.api as om
@@ -1812,8 +1812,8 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_feature_tol(self):
         import openmdao.api as om
@@ -1837,8 +1837,8 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], 6.66666667, 1e-6)
-        assert_rel_error(self, prob['y'], -7.3333333, 1e-6)
+        assert_near_equal(prob['x'], 6.66666667, 1e-6)
+        assert_near_equal(prob['y'], -7.3333333, 1e-6)
 
     def test_feature_debug_print_option(self):
 
@@ -1944,8 +1944,8 @@ class TestScipyOptimizeDriverFeatures(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        assert_rel_error(self, prob['x'], np.zeros(size), 1e-6)
-        assert_rel_error(self, prob['f'], 0.0, 1e-6)
+        assert_near_equal(prob['x'], np.zeros(size), 1e-6)
+        assert_near_equal(prob['f'], 0.0, 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -11,7 +11,7 @@ from openmdao.api import IndepVarComp, Group, Problem, \
                          ExplicitComponent, ImplicitComponent, ExecComp, \
                          NewtonSolver, ScipyKrylov, \
                          LinearBlockGS, DirectSolver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.api import ScipyOptimizeDriver
 
@@ -361,7 +361,7 @@ class TestJacobian(unittest.TestCase):
         self.assertEqual(len(jac_out.shape), 2)
         expected_dtype = np.promote_types(dtype, float)
         self.assertEqual(jac_out.dtype, expected_dtype)
-        assert_rel_error(self, jac_out, np.atleast_2d(expected).reshape(expected_shape), 1e-15)
+        assert_near_equal(jac_out, np.atleast_2d(expected).reshape(expected_shape), 1e-15)
 
     def test_group_assembled_jac_with_ext_mat(self):
 
@@ -484,7 +484,7 @@ class TestJacobian(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.setup()
         prob.run_model()
-        assert_rel_error(self, prob['C3.ee'], 8.0, 0000.1)
+        assert_near_equal(prob['C3.ee'], 8.0, 0000.1)
 
     def test_assembled_jacobian_submat_indexing_dense(self):
         prob = Problem(model=Group(assembled_jac_type='dense'))
@@ -511,8 +511,8 @@ class TestJacobian(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['G1.C1.y'], 50.0)
-        assert_rel_error(self, prob['G1.C2.y'], 243.0)
+        assert_near_equal(prob['G1.C1.y'], 50.0)
+        assert_near_equal(prob['G1.C2.y'], 243.0)
 
     def test_assembled_jacobian_submat_indexing_csc(self):
         prob = Problem(model=Group(assembled_jac_type='dense'))
@@ -542,8 +542,8 @@ class TestJacobian(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['G1.C1.y'], 50.0)
-        assert_rel_error(self, prob['G1.C2.y'], 243.0)
+        assert_near_equal(prob['G1.C1.y'], 50.0)
+        assert_near_equal(prob['G1.C2.y'], 243.0)
 
     def test_declare_partial_reference(self):
         # Test for a bug where declare_partials is given an array reference
@@ -569,7 +569,7 @@ class TestJacobian(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y'], 2 * np.ones(2))
+        assert_near_equal(prob['y'], 2 * np.ones(2))
 
     def test_declare_partials_row_col_size_mismatch(self):
         # Make sure we have clear error messages.
@@ -790,7 +790,7 @@ class TestJacobian(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(of=['G1.C1.z'], wrt=['indeps.x'])
-        assert_rel_error(self, J['G1.C1.z', 'indeps.x'], np.array([[ 3.,  0.,  2.,  0.],
+        assert_near_equal(J['G1.C1.z', 'indeps.x'], np.array([[ 3.,  0.,  2.,  0.],
                                                                    [-0.,  3.,  0.,  2.]]), .0001)
 
     def test_one_src_2_tgts_csc_error(self):
@@ -814,7 +814,7 @@ class TestJacobian(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(of=['G1.C1.z'], wrt=['indeps.x'])
-        assert_rel_error(self, J['G1.C1.z', 'indeps.x'], np.eye(10)*5.0, .0001)
+        assert_near_equal(J['G1.C1.z', 'indeps.x'], np.eye(10)*5.0, .0001)
 
     def test_dict_properties(self):
         # Make sure you can use the partials variable passed to compute_partials as a dict
@@ -849,7 +849,7 @@ class TestJacobian(unittest.TestCase):
                 [e[1] for e in sorted(comp.partials_values)],
                 [e[1] for e in sorted(expected)],
                 ):
-            assert_rel_error(self,act,exp, 1e-5)
+            assert_near_equal(act,exp, 1e-5)
 
 class MySparseComp(ExplicitComponent):
     def setup(self):

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -15,7 +15,7 @@ except ImportError:
 
 import openmdao.api as om
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class SimpleComp(om.ExplicitComponent):
@@ -292,7 +292,7 @@ class TestJacobianFeatures(unittest.TestCase):
         jacobian['g', 'x'] = [[1], [0], [0], [1]]
         jacobian['g', 'z'] = np.zeros((4, 4))
 
-        assert_rel_error(self, totals, jacobian)
+        assert_near_equal(totals, jacobian)
 
     @parameterized.expand(
         itertools.product([1e-6, 1e-8],  # Step size
@@ -324,7 +324,7 @@ class TestJacobianFeatures(unittest.TestCase):
         jacobian['g', 'x'] = [[1], [0], [0], [1]]
         jacobian['g', 'z'] = np.zeros((4, 4))
 
-        assert_rel_error(self, totals, jacobian, 1e-6)
+        assert_near_equal(totals, jacobian, 1e-6)
 
     def test_mixed_fd(self):
         comp = SimpleCompMixedFD()
@@ -350,7 +350,7 @@ class TestJacobianFeatures(unittest.TestCase):
         jacobian['g', 'x'] = [[1], [0], [0], [1]]
         jacobian['g', 'z'] = np.zeros((4, 4))
 
-        assert_rel_error(self, totals, jacobian, 1e-6)
+        assert_near_equal(totals, jacobian, 1e-6)
 
     def test_units_fd(self):
         class UnitCompBase(om.ExplicitComponent):
@@ -385,7 +385,7 @@ class TestJacobianFeatures(unittest.TestCase):
             ('flow:T', 'P'): [[0.]],
             ('flow:P', 'P'): [[14.50377]],
         }
-        assert_rel_error(self, totals, expected_totals, 1e-6)
+        assert_near_equal(totals, expected_totals, 1e-6)
 
         expected_subjacs = {
             ('units.flow:T', 'units.T'): [[1.]],
@@ -396,7 +396,7 @@ class TestJacobianFeatures(unittest.TestCase):
 
         jac = units._subjacs_info
         for deriv, val in expected_subjacs.items():
-            assert_rel_error(self, jac[deriv]['value'], val, 1e-6)
+            assert_near_equal(jac[deriv]['value'], val, 1e-6)
 
     def test_reference(self):
         class TmpComp(om.ExplicitComponent):
@@ -430,7 +430,7 @@ class TestJacobianFeatures(unittest.TestCase):
             ('y', 'x'): 9/5 * np.ones((3, 3)),
             ('z', 'x'): 9/5 * np.ones((3, 3)),
         }
-        assert_rel_error(self, totals, expected_totals, 1e-6)
+        assert_near_equal(totals, expected_totals, 1e-6)
 
 
 class TestJacobianForDocs(unittest.TestCase):
@@ -458,16 +458,16 @@ class TestJacobianForDocs(unittest.TestCase):
         totals = problem.compute_totals(['f', 'g'],
                                               ['x', 'y1', 'y2', 'y3', 'z'])
 
-        assert_rel_error(self, totals['f', 'x'], [[1.]])
-        assert_rel_error(self, totals['f', 'z'], np.ones((1, 4)))
-        assert_rel_error(self, totals['f', 'y1'], np.zeros((1, 2)))
-        assert_rel_error(self, totals['f', 'y2'], np.zeros((1, 2)))
-        assert_rel_error(self, totals['f', 'y3'], np.zeros((1, 2)))
-        assert_rel_error(self, totals['g', 'z'], np.zeros((4, 4)))
-        assert_rel_error(self, totals['g', 'y1'], [[1, 0], [1, 0], [0, 1], [0, 1]])
-        assert_rel_error(self, totals['g', 'y2'], [[1, 0], [0, 1], [1, 0], [0, 1]])
-        assert_rel_error(self, totals['g', 'y3'], [[1, 0], [1, 0], [0, 1], [0, 1]])
-        assert_rel_error(self, totals['g', 'x'], [[1], [0], [0], [1]])
+        assert_near_equal(totals['f', 'x'], [[1.]])
+        assert_near_equal(totals['f', 'z'], np.ones((1, 4)))
+        assert_near_equal(totals['f', 'y1'], np.zeros((1, 2)))
+        assert_near_equal(totals['f', 'y2'], np.zeros((1, 2)))
+        assert_near_equal(totals['f', 'y3'], np.zeros((1, 2)))
+        assert_near_equal(totals['g', 'z'], np.zeros((4, 4)))
+        assert_near_equal(totals['g', 'y1'], [[1, 0], [1, 0], [0, 1], [0, 1]])
+        assert_near_equal(totals['g', 'y2'], [[1, 0], [0, 1], [1, 0], [0, 1]])
+        assert_near_equal(totals['g', 'y3'], [[1, 0], [1, 0], [0, 1], [0, 1]])
+        assert_near_equal(totals['g', 'x'], [[1], [0], [0], [1]])
 
     def test_sparse_jacobian_in_place(self):
         import numpy as np
@@ -513,7 +513,7 @@ class TestJacobianForDocs(unittest.TestCase):
         problem.run_model()
         totals = problem.compute_totals(['example.f'], ['input.x'])
 
-        assert_rel_error(self, totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]])
+        assert_near_equal(totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]])
 
     def test_sparse_jacobian(self):
         import numpy as np
@@ -547,7 +547,7 @@ class TestJacobianForDocs(unittest.TestCase):
         problem.run_model()
         totals = problem.compute_totals(['example.f'], ['input.x'])
 
-        assert_rel_error(self, totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]])
+        assert_near_equal(totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]])
 
     def test_sparse_jacobian_const(self):
         import numpy as np
@@ -586,8 +586,8 @@ class TestJacobianForDocs(unittest.TestCase):
         problem.run_model()
         totals = problem.compute_totals(['example.f'], ['input.x', 'input.y'])
 
-        assert_rel_error(self, totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]])
-        assert_rel_error(self, totals['example.f', 'input.y'], [[1., 0.], [0., 1.]])
+        assert_near_equal(totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]])
+        assert_near_equal(totals['example.f', 'input.y'], [[1., 0.], [0., 1.]])
 
     def test_fd_glob(self):
         import numpy as np
@@ -629,9 +629,9 @@ class TestJacobianForDocs(unittest.TestCase):
         problem.run_model()
         totals = problem.compute_totals(['example.f'], ['input.x', 'input.y'])
 
-        assert_rel_error(self, totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]],
+        assert_near_equal(totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]],
                          tolerance=1e-8)
-        assert_rel_error(self, totals['example.f', 'input.y'], [[1., 0.], [0., 1.]], tolerance=1e-8)
+        assert_near_equal(totals['example.f', 'input.y'], [[1., 0.], [0., 1.]], tolerance=1e-8)
 
     def test_fd_options(self):
         import numpy as np
@@ -674,9 +674,9 @@ class TestJacobianForDocs(unittest.TestCase):
         problem.run_model()
         totals = problem.compute_totals(['example.f'], ['input.x', 'input.y'])
 
-        assert_rel_error(self, totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]],
+        assert_near_equal(totals['example.f', 'input.x'], [[1., 0., 0., 0.], [0., 2., 3., 4.]],
                          tolerance=1e-8)
-        assert_rel_error(self, totals['example.f', 'input.y'], [[1., 0.], [0., 1.]], tolerance=1e-8)
+        assert_near_equal(totals['example.f', 'input.y'], [[1., 0.], [0., 1.]], tolerance=1e-8)
 
 
 if __name__ == '__main__':

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -5,7 +5,7 @@ import json
 from contextlib import contextmanager
 
 from openmdao.utils.record_util import format_iteration_coordinate, deserialize
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.recorders.sqlite_recorder import blob_to_array, format_version
 
 import pickle
@@ -91,7 +91,7 @@ def assertProblemDataRecorded(test, expected, tolerance):
                                         '{} variable not found in actual data'
                                         ' from recorder'.format(key))
                         # Check to see if the values in actual and expected match
-                        assert_rel_error(test, actual[key], expected[key], tolerance)
+                        assert_near_equal(actual[key], expected[key], tolerance)
 
 
 def assertDriverIterDataRecorded(test, expected, tolerance, prefix=None):
@@ -150,7 +150,7 @@ def assertDriverIterDataRecorded(test, expected, tolerance, prefix=None):
                                         '{} variable not found in actual data'
                                         ' from recorder'.format(key))
                         # Check to see if the values in actual and expected match
-                        assert_rel_error(test, actual[key], expected[key], tolerance)
+                        assert_near_equal(actual[key], expected[key], tolerance)
 
 
 def assertDriverDerivDataRecorded(test, expected, tolerance, prefix=None):
@@ -202,7 +202,7 @@ def assertDriverDerivDataRecorded(test, expected, tolerance, prefix=None):
                                     '{} variable not found in actual data'
                                     ' from recorder'.format(key))
                     # Check to see if the values in actual and expected match
-                    assert_rel_error(test, actual[key], totals_expected[key], tolerance)
+                    assert_near_equal(actual[key], totals_expected[key], tolerance)
 
 
 def assertSystemIterDataRecorded(test, expected, tolerance, prefix=None):
@@ -262,7 +262,7 @@ def assertSystemIterDataRecorded(test, expected, tolerance, prefix=None):
                                         '{} variable not found in actual data '
                                         'from recorder'.format(key))
                         # Check to see if the values in actual and expected match
-                        assert_rel_error(test, actual[0][key], expected[key], tolerance)
+                        assert_near_equal(actual[0][key], expected[key], tolerance)
 
 
 def assertSolverIterDataRecorded(test, expected, tolerance, prefix=None):
@@ -304,10 +304,10 @@ def assertSolverIterDataRecorded(test, expected, tolerance, prefix=None):
             test.assertEqual(msg, '')
             if expected_abs_error:
                 test.assertTrue(abs_err, 'Expected absolute error but none recorded')
-                assert_rel_error(test, abs_err, expected_abs_error, tolerance)
+                assert_near_equal(abs_err, expected_abs_error, tolerance)
             if expected_rel_error:
                 test.assertTrue(rel_err, 'Expected relative error but none recorded')
-                assert_rel_error(test, rel_err, expected_rel_error, tolerance)
+                assert_near_equal(rel_err, expected_rel_error, tolerance)
 
             for vartype, actual, expected in (
                     ('outputs', output_actual, expected_output),
@@ -328,7 +328,7 @@ def assertSolverIterDataRecorded(test, expected, tolerance, prefix=None):
                                         '{} variable not found in actual data '
                                         'from recorder'.format(key))
                         # Check to see if the values in actual and expected match
-                        assert_rel_error(test, actual[0][key], expected[key], tolerance)
+                        assert_near_equal(actual[0][key], expected[key], tolerance)
 
 
 def assertMetadataRecorded(test, expected_prom2abs, expected_abs2prom):

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -22,7 +22,7 @@ from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTw
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
     SellarDis1withDerivatives, SellarDis2withDerivatives, SellarProblem
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt, determine_adder_scaler, printoptions
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.utils.testing_utils import use_tempdirs
@@ -1521,29 +1521,29 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         case = cr.get_case(0)
 
-        assert_rel_error(self, case.get_val('comp.x'), 77.0, 1e-6)
-        assert_rel_error(self, case.get_val('comp.x', 'degC'), 25.0, 1e-6)
-        assert_rel_error(self, case.get_val('comp.y'), 52., 1e-6)
-        assert_rel_error(self, case.get_val('comp.y', 'degF'), 125.6, 1e-6)
+        assert_near_equal(case.get_val('comp.x'), 77.0, 1e-6)
+        assert_near_equal(case.get_val('comp.x', 'degC'), 25.0, 1e-6)
+        assert_near_equal(case.get_val('comp.y'), 52., 1e-6)
+        assert_near_equal(case.get_val('comp.y', 'degF'), 125.6, 1e-6)
 
-        assert_rel_error(self, case.get_val('xx'), 77.0, 1e-6)
-        assert_rel_error(self, case.get_val('xx', 'degC'), 25.0, 1e-6)
-        assert_rel_error(self, case.get_val('yy'), 52., 1e-6)
-        assert_rel_error(self, case.get_val('yy', 'degF'), 125.6, 1e-6)
+        assert_near_equal(case.get_val('xx'), 77.0, 1e-6)
+        assert_near_equal(case.get_val('xx', 'degC'), 25.0, 1e-6)
+        assert_near_equal(case.get_val('yy'), 52., 1e-6)
+        assert_near_equal(case.get_val('yy', 'degF'), 125.6, 1e-6)
 
-        assert_rel_error(self, case.get_val('acomp.x', indices=0), 77.0, 1e-6)
-        assert_rel_error(self, case.get_val('acomp.x', indices=[1]), 95.0, 1e-6)
-        assert_rel_error(self, case.get_val('acomp.x', 'degC', indices=[0]), 25.0, 1e-6)
-        assert_rel_error(self, case.get_val('acomp.x', 'degC', indices=1), 35.0, 1e-6)
-        assert_rel_error(self, case.get_val('acomp.y', indices=0), 52., 1e-6)
-        assert_rel_error(self, case.get_val('acomp.y', 'degF', indices=0), 125.6, 1e-6)
+        assert_near_equal(case.get_val('acomp.x', indices=0), 77.0, 1e-6)
+        assert_near_equal(case.get_val('acomp.x', indices=[1]), 95.0, 1e-6)
+        assert_near_equal(case.get_val('acomp.x', 'degC', indices=[0]), 25.0, 1e-6)
+        assert_near_equal(case.get_val('acomp.x', 'degC', indices=1), 35.0, 1e-6)
+        assert_near_equal(case.get_val('acomp.y', indices=0), 52., 1e-6)
+        assert_near_equal(case.get_val('acomp.y', 'degF', indices=0), 125.6, 1e-6)
 
-        assert_rel_error(self, case.get_val('axx', indices=0), 77.0, 1e-6)
-        assert_rel_error(self, case.get_val('axx', indices=1), 95.0, 1e-6)
-        assert_rel_error(self, case.get_val('axx', 'degC', indices=0), 25.0, 1e-6)
-        assert_rel_error(self, case.get_val('axx', 'degC', indices=np.array([1])), 35.0, 1e-6)
-        assert_rel_error(self, case.get_val('ayy', indices=0), 52., 1e-6)
-        assert_rel_error(self, case.get_val('ayy', 'degF', indices=0), 125.6, 1e-6)
+        assert_near_equal(case.get_val('axx', indices=0), 77.0, 1e-6)
+        assert_near_equal(case.get_val('axx', indices=1), 95.0, 1e-6)
+        assert_near_equal(case.get_val('axx', 'degC', indices=0), 25.0, 1e-6)
+        assert_near_equal(case.get_val('axx', 'degC', indices=np.array([1])), 35.0, 1e-6)
+        assert_near_equal(case.get_val('ayy', indices=0), 52., 1e-6)
+        assert_near_equal(case.get_val('ayy', 'degF', indices=0), 125.6, 1e-6)
 
     def test_get_ambiguous_input(self):
         model = om.Group()
@@ -1566,14 +1566,14 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
         case = cr.get_case(0)
 
-        assert_rel_error(self, case.get_val('x'), 1., 1e-6)
-        assert_rel_error(self, case.get_val('x', units='ft'), 3.280839895, 1e-6)
+        assert_near_equal(case.get_val('x'), 1., 1e-6)
+        assert_near_equal(case.get_val('x', units='ft'), 3.280839895, 1e-6)
 
-        assert_rel_error(self, case.get_val('G1.C0.x'), 1., 1e-6)
-        assert_rel_error(self, case.get_val('G1.C0.x', units='ft'), 3.280839895, 1e-6)
+        assert_near_equal(case.get_val('G1.C0.x'), 1., 1e-6)
+        assert_near_equal(case.get_val('G1.C0.x', units='ft'), 3.280839895, 1e-6)
 
-        assert_rel_error(self, case.get_val('G2.C1.m'), 1., 1e-6)
-        assert_rel_error(self, case.get_val('G2.C2.f'), 3.280839895, 1e-6)
+        assert_near_equal(case.get_val('G2.C1.m'), 1., 1e-6)
+        assert_near_equal(case.get_val('G2.C2.f'), 3.280839895, 1e-6)
 
         # 'a' is ambiguous.. which input do you want when accessing 'a'?
         msg = "The promoted name 'a' is invalid because it refers to multiple inputs:" + \
@@ -2156,10 +2156,10 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # check 'use_indices' option, default is to use indices
         dvs = case.get_design_vars()
-        assert_rel_error(self, dvs['x'], x_vals[[0, 3]], 1e-12)
+        assert_near_equal(dvs['x'], x_vals[[0, 3]], 1e-12)
 
         dvs = case.get_design_vars(use_indices=False)
-        assert_rel_error(self, dvs['x'], x_vals, 1e-12)
+        assert_near_equal(dvs['x'], x_vals, 1e-12)
 
         cons = case.get_constraints()
         self.assertEqual(len(cons['theta_con.g']), len(EVEN_IND))
@@ -2997,7 +2997,7 @@ class TestFeatureSqliteReader(unittest.TestCase):
         ]))
 
         # Get specific derivative.
-        assert_rel_error(self, derivs['obj', 'z'], derivs['obj', 'z'])
+        assert_near_equal(derivs['obj', 'z'], derivs['obj', 'z'])
 
     def test_feature_recording_option_precedence(self):
         import openmdao.api as om
@@ -3167,13 +3167,13 @@ class TestFeatureSqliteReader(unittest.TestCase):
 
         case_inputs = sorted(case.list_inputs())
 
-        assert_rel_error(self, case_inputs[0][1]['value'], [1.], tolerance=1e-10) # d1.x
-        assert_rel_error(self, case_inputs[1][1]['value'], [12.27257053], tolerance=1e-10) # d1.y2
-        assert_rel_error(self, case_inputs[2][1]['value'], [5., 2.], tolerance=1e-10) # d1.z
+        assert_near_equal(case_inputs[0][1]['value'], [1.], tolerance=1e-10) # d1.x
+        assert_near_equal(case_inputs[1][1]['value'], [12.27257053], tolerance=1e-10) # d1.y2
+        assert_near_equal(case_inputs[2][1]['value'], [5., 2.], tolerance=1e-10) # d1.z
 
         case_outputs = case.list_outputs(prom_name=True)
 
-        assert_rel_error(self, case_outputs[0][1]['value'], [25.545485893882876], tolerance=1e-10) # d1.y1
+        assert_near_equal(case_outputs[0][1]['value'], [25.545485893882876], tolerance=1e-10) # d1.y1
 
     def test_feature_list_inputs_and_outputs_with_tags(self):
         import openmdao.api as om
@@ -3290,11 +3290,11 @@ class TestFeatureSqliteReader(unittest.TestCase):
         cr = om.CaseReader('cases.sql')
         case = cr.get_case(0)
 
-        assert_rel_error(self, case['x'], 100., 1e-6)
-        assert_rel_error(self, case.get_val('x', units='ft'), 328.0839895, 1e-6)
+        assert_near_equal(case['x'], 100., 1e-6)
+        assert_near_equal(case.get_val('x', units='ft'), 328.0839895, 1e-6)
 
-        assert_rel_error(self, case['v'], 100./60., 1e-6)
-        assert_rel_error(self, case.get_val('v', units='ft/s'), 5.46807, 1e-6)
+        assert_near_equal(case['v'], 100./60., 1e-6)
+        assert_near_equal(case.get_val('v', units='ft/s'), 5.46807, 1e-6)
 
 
 @use_tempdirs

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -24,7 +24,7 @@ from openmdao.recorders.tests.sqlite_recorder_test_utils import assertMetadataRe
     assertDriverDerivDataRecorded
 
 from openmdao.recorders.tests.recorder_test_utils import run_driver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import determine_adder_scaler
 from openmdao.utils.testing_utils import use_tempdirs
 
@@ -1877,8 +1877,8 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         cr = om.CaseReader(case_recorder_filename)
         case = cr.get_case('rank0:ScipyOptimize_SLSQP|4')
 
-        assert_rel_error(self, case.outputs['x'], 7.16666667, 1e-6)
-        assert_rel_error(self, case.outputs['y'], -7.83333333, 1e-6)
+        assert_near_equal(case.outputs['x'], 7.16666667, 1e-6)
+        assert_near_equal(case.outputs['y'], -7.83333333, 1e-6)
 
     def test_feature_problem_metadata(self):
         import openmdao.api as om
@@ -2105,10 +2105,10 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         design_vars = case.get_design_vars()
         constraints = case.get_constraints()
 
-        assert_rel_error(self, objectives['obj'], 28.58, 1e-1)
+        assert_near_equal(objectives['obj'], 28.58, 1e-1)
 
-        assert_rel_error(self, design_vars, case.get_design_vars(), 1e-1)
-        assert_rel_error(self, constraints, case.get_constraints(), 1e-1)
+        assert_near_equal(design_vars, case.get_design_vars(), 1e-1)
+        assert_near_equal(constraints, case.get_constraints(), 1e-1)
 
     def test_feature_solver_options(self):
         import openmdao.api as om
@@ -2360,10 +2360,10 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         design_vars = case.get_design_vars()
         constraints = case.get_constraints()
 
-        assert_rel_error(self, objectives['obj'], 3.18, 1e-1)
+        assert_near_equal(objectives['obj'], 3.18, 1e-1)
 
-        assert_rel_error(self, design_vars, case.get_design_vars(), 1e-1)
-        assert_rel_error(self, constraints, case.get_constraints(), 1e-1)
+        assert_near_equal(design_vars, case.get_design_vars(), 1e-1)
+        assert_near_equal(constraints, case.get_constraints(), 1e-1)
 
     def test_scaling_multiple_calls(self):
         import openmdao.api as om
@@ -2415,9 +2415,9 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         constraints = case.get_constraints()
 
         # Methods are called a second time
-        assert_rel_error(self, objectives['obj'], case.get_objectives()['obj'], 1e-1)
-        assert_rel_error(self, design_vars, case.get_design_vars(), 1e-1)
-        assert_rel_error(self, constraints, case.get_constraints(), 1e-1)
+        assert_near_equal(objectives['obj'], case.get_objectives()['obj'], 1e-1)
+        assert_near_equal(design_vars, case.get_design_vars(), 1e-1)
+        assert_near_equal(constraints, case.get_constraints(), 1e-1)
 
     def test_recorder_resetup(self):
         vec_size = 7
@@ -2482,7 +2482,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         y_recorded = case.get_val('test_sys.y')
 
-        assert_rel_error(self, y_recorded, y1)
+        assert_near_equal(y_recorded, y1)
 
 
 @use_tempdirs
@@ -2548,10 +2548,10 @@ class TestFeatureBasicRecording(unittest.TestCase):
         design_vars = case.get_design_vars()
         constraints = case.get_constraints()
 
-        assert_rel_error(self, objectives['obj'], 28.58, 1e-1)
+        assert_near_equal(objectives['obj'], 28.58, 1e-1)
 
-        assert_rel_error(self, design_vars, case.get_design_vars(), 1e-1)
-        assert_rel_error(self, constraints, case.get_constraints(), 1e-1)
+        assert_near_equal(design_vars, case.get_design_vars(), 1e-1)
+        assert_near_equal(constraints, case.get_constraints(), 1e-1)
 
         # get a list of cases that we manually recorded
         self.assertEqual(cr.list_cases('problem'), ['final'])
@@ -2563,10 +2563,10 @@ class TestFeatureBasicRecording(unittest.TestCase):
         design_vars = case.get_design_vars()
         constraints = case.get_constraints()
 
-        assert_rel_error(self, objectives['obj'], 3.18, 1e-1)
+        assert_near_equal(objectives['obj'], 3.18, 1e-1)
 
-        assert_rel_error(self, design_vars, case.get_design_vars(), 1e-1)
-        assert_rel_error(self, constraints, case.get_constraints(), 1e-1)
+        assert_near_equal(design_vars, case.get_design_vars(), 1e-1)
+        assert_near_equal(constraints, case.get_constraints(), 1e-1)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/linear/tests/linear_test_base.py
+++ b/openmdao/solvers/linear/tests/linear_test_base.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from openmdao.api import Group, IndepVarComp, Problem
 from openmdao.solvers.linear.direct import DirectSolver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
      SellarStateConnection, SellarDerivatives
@@ -76,14 +76,14 @@ class LinearSolverTests(object):
             wrt = ['length']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['area', 'length'], [[2.0]], 1e-6)
+            assert_near_equal(J['area', 'length'], [[2.0]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob['width'] = 2.0
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['area', 'length'], [[2.0]], 1e-6)
+            assert_near_equal(J['area', 'length'], [[2.0]], 1e-6)
 
         def test_simple_matvec_subbed(self):
             # Tests derivatives on a group that contains a simple comp that
@@ -113,14 +113,14 @@ class LinearSolverTests(object):
             wrt = ['length']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['area', 'length'], [[2.0]], 1e-6)
+            assert_near_equal(J['area', 'length'], [[2.0]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob['width'] = 2.0
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['area', 'length'], [[2.0]], 1e-6)
+            assert_near_equal(J['area', 'length'], [[2.0]], 1e-6)
 
         def test_simple_matvec_subbed_like_multipoint(self):
             # Tests derivatives on a group that contains a simple comp that
@@ -151,14 +151,14 @@ class LinearSolverTests(object):
             wrt = ['length']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['area', 'length'], [[2.0]], 1e-6)
+            assert_near_equal(J['area', 'length'], [[2.0]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob['width'] = 2.0
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['area', 'length'], [[2.0]], 1e-6)
+            assert_near_equal(J['area', 'length'], [[2.0]], 1e-6)
 
         def test_double_arraycomp(self):
             # Mainly testing an old bug in the array return for multiple arrays
@@ -184,13 +184,13 @@ class LinearSolverTests(object):
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
             diff = np.linalg.norm(J['y1', 'x1'] - Jbase[0:2, 0:2])
-            assert_rel_error(self, diff, 0.0, 1e-8)
+            assert_near_equal(diff, 0.0, 1e-8)
             diff = np.linalg.norm(J['y1', 'x2'] - Jbase[0:2, 2:4])
-            assert_rel_error(self, diff, 0.0, 1e-8)
+            assert_near_equal(diff, 0.0, 1e-8)
             diff = np.linalg.norm(J['y2', 'x1'] - Jbase[2:4, 0:2])
-            assert_rel_error(self, diff, 0.0, 1e-8)
+            assert_near_equal(diff, 0.0, 1e-8)
             diff = np.linalg.norm(J['y2', 'x2'] - Jbase[2:4, 2:4])
-            assert_rel_error(self, diff, 0.0, 1e-8)
+            assert_near_equal(diff, 0.0, 1e-8)
 
         def test_fan_out_fwd(self):
             # Test derivatives for fan-out topology.
@@ -206,12 +206,12 @@ class LinearSolverTests(object):
             of = ['comp2.y', "comp3.y"]
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['comp3.y', 'p.x'], [[15.0]], 1e-6)
+            assert_near_equal(J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p.x'], [[15.0]], 1e-6)
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['comp3.y', 'p.x'], [[15.0]], 1e-6)
+            assert_near_equal(J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p.x'], [[15.0]], 1e-6)
 
         def test_fan_out_rev(self):
             # Test derivatives for fan-out topology.
@@ -227,12 +227,12 @@ class LinearSolverTests(object):
             of = ['comp2.y', "comp3.y"]
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['comp3.y', 'p.x'], [[15.0]], 1e-6)
+            assert_near_equal(J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p.x'], [[15.0]], 1e-6)
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['comp3.y', 'p.x'], [[15.0]], 1e-6)
+            assert_near_equal(J['comp2.y', 'p.x'], [[-6.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p.x'], [[15.0]], 1e-6)
 
         def test_fan_out_grouped(self):
             # Test derivatives for fan-out-grouped topology.
@@ -248,12 +248,12 @@ class LinearSolverTests(object):
             of = ['sub.c2.y', "sub.c3.y"]
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['sub.c2.y', 'iv.x'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['sub.c3.y', 'iv.x'], [[15.0]], 1e-6)
+            assert_near_equal(J['sub.c2.y', 'iv.x'], [[-6.0]], 1e-6)
+            assert_near_equal(J['sub.c3.y', 'iv.x'], [[15.0]], 1e-6)
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['sub.c2.y', 'iv.x'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['sub.c3.y', 'iv.x'], [[15.0]], 1e-6)
+            assert_near_equal(J['sub.c2.y', 'iv.x'], [[-6.0]], 1e-6)
+            assert_near_equal(J['sub.c3.y', 'iv.x'], [[15.0]], 1e-6)
 
         def test_fan_in(self):
             # Test derivatives for fan-in topology.
@@ -269,15 +269,15 @@ class LinearSolverTests(object):
             of = ['comp3.y']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['comp3.y', 'p1.x1'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['comp3.y', 'p2.x2'], [[35.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p1.x1'], [[-6.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p2.x2'], [[35.0]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['comp3.y', 'p1.x1'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['comp3.y', 'p2.x2'], [[35.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p1.x1'], [[-6.0]], 1e-6)
+            assert_near_equal(J['comp3.y', 'p2.x2'], [[35.0]], 1e-6)
 
         def test_fan_in_grouped(self):
             # Test derivatives for fan-in-grouped topology.
@@ -293,15 +293,15 @@ class LinearSolverTests(object):
             of = ['c3.y']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c3.y', 'iv.x1'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['c3.y', 'iv.x2'], [[35.0]], 1e-6)
+            assert_near_equal(J['c3.y', 'iv.x1'], [[-6.0]], 1e-6)
+            assert_near_equal(J['c3.y', 'iv.x2'], [[35.0]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c3.y', 'iv.x1'], [[-6.0]], 1e-6)
-            assert_rel_error(self, J['c3.y', 'iv.x2'], [[35.0]], 1e-6)
+            assert_near_equal(J['c3.y', 'iv.x1'], [[-6.0]], 1e-6)
+            assert_near_equal(J['c3.y', 'iv.x2'], [[35.0]], 1e-6)
 
         def test_converge_diverge_flat(self):
             # Test derivatives for converge-diverge-flat topology.
@@ -317,16 +317,16 @@ class LinearSolverTests(object):
             of = ['c7.y1']
 
             # Make sure value is fine.
-            assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+            assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
+            assert_near_equal(J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
+            assert_near_equal(J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
 
         def test_converge_diverge_groups(self):
             # Test derivatives for converge-diverge-groups topology.
@@ -342,16 +342,16 @@ class LinearSolverTests(object):
             of = ['c7.y1']
 
             # Make sure value is fine.
-            assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+            assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
+            assert_near_equal(J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
+            assert_near_equal(J['c7.y1', 'iv.x'], [[-40.75]], 1e-6)
 
         def test_single_diamond(self):
             # Test derivatives for flat diamond topology.
@@ -367,15 +367,15 @@ class LinearSolverTests(object):
             of = ['c4.y1', 'c4.y2']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c4.y1', 'iv.x'], [[25]], 1e-6)
-            assert_rel_error(self, J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
+            assert_near_equal(J['c4.y1', 'iv.x'], [[25]], 1e-6)
+            assert_near_equal(J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c4.y1', 'iv.x'], [[25]], 1e-6)
-            assert_rel_error(self, J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
+            assert_near_equal(J['c4.y1', 'iv.x'], [[25]], 1e-6)
+            assert_near_equal(J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
 
         def test_single_diamond_grouped(self):
             # Test derivatives for grouped diamond topology.
@@ -392,15 +392,15 @@ class LinearSolverTests(object):
             of = ['c4.y1', 'c4.y2']
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c4.y1', 'iv.x'], [[25]], 1e-6)
-            assert_rel_error(self, J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
+            assert_near_equal(J['c4.y1', 'iv.x'], [[25]], 1e-6)
+            assert_near_equal(J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-            assert_rel_error(self, J['c4.y1', 'iv.x'], [[25]], 1e-6)
-            assert_rel_error(self, J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
+            assert_near_equal(J['c4.y1', 'iv.x'], [[25]], 1e-6)
+            assert_near_equal(J['c4.y2', 'iv.x'], [[-40.5]], 1e-6)
 
         def test_sellar_derivs_grouped(self):
             # Test derivatives across a converged Sellar model.
@@ -414,8 +414,8 @@ class LinearSolverTests(object):
             prob.run_model()
 
             # Just make sure we are at the right answer
-            assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-            assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+            assert_near_equal(prob['y1'], 25.58830273, .00001)
+            assert_near_equal(prob['y2'], 12.05848819, .00001)
 
             wrt = ['x', 'z']
             of = ['obj', 'con1', 'con2']
@@ -430,14 +430,14 @@ class LinearSolverTests(object):
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
             for key, val in Jbase.items():
-                assert_rel_error(self, J[key], val, .00001)
+                assert_near_equal(J[key], val, .00001)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
             for key, val in Jbase.items():
-                assert_rel_error(self, J[key], val, .00001)
+                assert_near_equal(J[key], val, .00001)
 
         def test_sellar_state_connection(self):
             # Test derivatives across a converged Sellar model.
@@ -450,8 +450,8 @@ class LinearSolverTests(object):
             prob.run_model()
 
             # Just make sure we are at the right answer
-            assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-            assert_rel_error(self, prob['d2.y2'], 12.05848819, .00001)
+            assert_near_equal(prob['y1'], 25.58830273, .00001)
+            assert_near_equal(prob['d2.y2'], 12.05848819, .00001)
 
             wrt = ['x', 'z']
             of = ['obj', 'con1', 'con2']
@@ -466,11 +466,11 @@ class LinearSolverTests(object):
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
             for key, val in Jbase.items():
-                assert_rel_error(self, J[key], val, .00001)
+                assert_near_equal(J[key], val, .00001)
 
             prob.setup(check=False, mode='rev')
             prob.run_model()
 
             J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
             for key, val in Jbase.items():
-                assert_rel_error(self, J[key], val, .00001)
+                assert_near_equal(J[key], val, .00001)

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -9,7 +9,7 @@ from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 from openmdao.core.tests.test_distrib_derivs import DistribExecComp
 try:
@@ -129,7 +129,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         g1.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, g1.expected_solution, 1e-15)
+        assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
         d_inputs, d_outputs, d_residuals = g1.get_linear_vectors()
@@ -140,7 +140,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         g1.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, g1.expected_solution, 3e-15)
+        assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_rev_mode_bug(self):
 
@@ -152,8 +152,8 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         wrt = ['x', 'z']
         of = ['obj', 'con1', 'con2']
@@ -168,14 +168,14 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
         for key, val in Jbase.items():
-            assert_rel_error(self, J[key], val, .00001)
+            assert_near_equal(J[key], val, .00001)
 
         # In the bug, the solver mode got switched from fwd to rev when it shouldn't
         # have been, causing a singular matrix and NaNs in the output.
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_multi_dim_src_indices(self):
         prob = om.Problem()
@@ -902,8 +902,8 @@ class TestDirectSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -10,7 +10,7 @@ from openmdao.test_suite.components.sellar import SellarImplicitDis1, SellarImpl
     SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
 from openmdao.test_suite.components.sellar import SellarDerivatives
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class SimpleImp(om.ImplicitComponent):
@@ -137,7 +137,7 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
 
         derivs = prob.compute_totals(of=['sub.z'], wrt=['sub.z'])
 
-        assert_rel_error(self, derivs[('sub.z', 'sub.z')], [[0., 1.]])
+        assert_near_equal(derivs[('sub.z', 'sub.z')], [[0., 1.]])
 
 
 class TestBGSSolverFeature(unittest.TestCase):
@@ -174,8 +174,8 @@ class TestBGSSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -211,8 +211,8 @@ class TestBGSSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.60230118004, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78022500547, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.60230118004, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78022500547, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -248,8 +248,8 @@ class TestBGSSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61016296175, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78456955704, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61016296175, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78456955704, .00001)
 
     def test_feature_rtol(self):
         import numpy as np
@@ -285,8 +285,8 @@ class TestBGSSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61016296175, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78456955704, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61016296175, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78456955704, .00001)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/linear/tests/test_linear_block_jac.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_jac.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDense
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
@@ -66,8 +66,8 @@ class TestBJacSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -103,8 +103,8 @@ class TestBJacSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.60230118004, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78022500547, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.60230118004, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78022500547, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -140,8 +140,8 @@ class TestBJacSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61016296175, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78456955704, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61016296175, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78456955704, .00001)
 
     def test_feature_rtol(self):
         import numpy as np
@@ -177,8 +177,8 @@ class TestBJacSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61016296175, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78456955704, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61016296175, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78456955704, .00001)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/linear/tests/test_linear_runonce.py
+++ b/openmdao/solvers/linear/tests/test_linear_runonce.py
@@ -5,7 +5,7 @@ import unittest
 import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.groups.parallel_groups import ConvergeDivergeGroups
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestLinearRunOnceSolver(unittest.TestCase):
@@ -28,16 +28,16 @@ class TestLinearRunOnceSolver(unittest.TestCase):
         of = ['c7.y1']
 
         # Make sure value is fine.
-        assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+        assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
+        assert_near_equal(J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
 
         prob.setup(check=False, mode='rev')
         prob.run_model()
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
+        assert_near_equal(J['c7.y1', 'iv.x'][0][0], -40.75, 1e-6)
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class cause an error
@@ -72,8 +72,8 @@ class TestLinearRunOnceSolver(unittest.TestCase):
         wrt = ['x', 'y']
         derivs = prob.compute_totals(of=of, wrt=wrt, return_format='dict')
 
-        assert_rel_error(self, derivs['f_xy']['x'], [[-6.0]], 1e-6)
-        assert_rel_error(self, derivs['f_xy']['y'], [[8.0]], 1e-6)
+        assert_near_equal(derivs['f_xy']['x'], [[-6.0]], 1e-6)
+        assert_near_equal(derivs['f_xy']['y'], [[8.0]], 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -16,7 +16,7 @@ except ImportError:
 
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
 
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 @unittest.skipUnless(PETScVector is not None, "PETSc is required.")
@@ -50,7 +50,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_const(1.0)
@@ -58,7 +58,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_ksp_gmres(self):
         """Solve implicit system with PETScKrylov using 'gmres' method."""
@@ -81,7 +81,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_const(1.0)
@@ -89,7 +89,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_ksp_maxiter(self):
         """Verify that PETScKrylov abides by the 'maxiter' option."""
@@ -141,7 +141,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         self.assertTrue(precon._iter_count > 0)
 
@@ -151,7 +151,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 3e-15)
+        assert_near_equal(output, group.expected_solution, 3e-15)
 
         self.assertTrue(precon._iter_count > 0)
 
@@ -171,7 +171,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_const(1.0)
@@ -180,7 +180,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 3e-15)
+        assert_near_equal(output, group.expected_solution, 3e-15)
 
     def test_solve_linear_ksp_precon_left(self):
         """Solve implicit system with PETScKrylov using a preconditioner."""
@@ -206,7 +206,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_const(1.0)
@@ -215,7 +215,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 3e-15)
+        assert_near_equal(output, group.expected_solution, 3e-15)
 
         # test the direct solver and make sure KSP correctly recurses for _linearize
         precon = group.linear_solver.precon = om.DirectSolver(assemble_jac=False)
@@ -236,7 +236,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_const(1.0)
@@ -245,7 +245,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 3e-15)
+        assert_near_equal(output, group.expected_solution, 3e-15)
 
     def test_solve_on_subsystem(self):
         """solve an implicit system with KSP attached anywhere but the root"""
@@ -273,7 +273,7 @@ class TestPETScKrylov(unittest.TestCase):
         g1.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, g1.expected_solution, 1e-15)
+        assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
         d_inputs, d_outputs, d_residuals = g1.get_linear_vectors()
@@ -284,7 +284,7 @@ class TestPETScKrylov(unittest.TestCase):
         g1.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, g1.expected_solution, 3e-15)
+        assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_linear_solution_cache(self):
         # Test derivatives across a converged Sellar model. When caching
@@ -417,8 +417,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_specify_ksp_type(self):
         import numpy as np
@@ -455,8 +455,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -492,8 +492,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 4.93218027, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.73406455, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 4.93218027, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.73406455, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -529,8 +529,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001055699, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448533563, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001055699, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448533563, .00001)
 
     def test_feature_rtol(self):
         import numpy as np
@@ -566,8 +566,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001055699, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448533563, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001055699, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448533563, .00001)
 
     def test_specify_precon(self):
         import numpy as np
@@ -601,8 +601,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_specify_precon_left(self):
         import numpy as np
@@ -637,8 +637,8 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -10,7 +10,7 @@ from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleDe
 from openmdao.test_suite.components.misc_components import Comp4LinearCacheTest
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 # use this to fake out the TestImplicitGroup so it'll use the solver we want.
@@ -51,14 +51,14 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         d_outputs.set_const(0.0)
         group.run_solve_linear(['linear'], 'fwd')
         output = d_outputs._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_const(1.0)
         d_residuals.set_const(0.0)
         group.run_solve_linear(['linear'], 'rev')
         output = d_residuals._data
-        assert_rel_error(self, output, group.expected_solution, 1e-15)
+        assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_scipy_maxiter(self):
         """Verify that ScipyKrylov abides by the 'maxiter' option."""
@@ -116,7 +116,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         g1.run_solve_linear(['linear'], 'fwd')
 
         output = d_outputs._data
-        assert_rel_error(self, output, g1.expected_solution, 1e-15)
+        assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
         d_inputs, d_outputs, d_residuals = g1.get_linear_vectors()
@@ -127,7 +127,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         g1.run_solve_linear(['linear'], 'rev')
 
         output = d_residuals._data
-        assert_rel_error(self, output, g1.expected_solution, 3e-15)
+        assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_linear_solution_cache(self):
         # Test derivatives across a converged Sellar model. When caching
@@ -214,7 +214,7 @@ class TestScipyKrylovFeature(unittest.TestCase):
         wrt = ['length']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['area', 'length'][0][0], 2.0, 1e-6)
+        assert_near_equal(J['area', 'length'][0][0], 2.0, 1e-6)
 
     def test_specify_solver(self):
         import numpy as np
@@ -250,8 +250,8 @@ class TestScipyKrylovFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001056, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448534, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -287,8 +287,8 @@ class TestScipyKrylovFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 0.0, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 0.0, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 0.0, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 0.0, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -324,8 +324,8 @@ class TestScipyKrylovFeature(unittest.TestCase):
         of = ['obj']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_rel_error(self, J['obj', 'z'][0][0], 9.61001055699, .00001)
-        assert_rel_error(self, J['obj', 'z'][0][1], 1.78448533563, .00001)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001055699, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448533563, .00001)
 
     def test_specify_precon(self):
         import numpy as np
@@ -361,8 +361,8 @@ class TestScipyKrylovFeature(unittest.TestCase):
         prob.set_solver_print(level=2)
         prob.run_model()
 
-        assert_rel_error(self, prob['sub1.q1.x'], 1.996, .0001)
-        assert_rel_error(self, prob['sub2.q2.x'], 1.996, .0001)
+        assert_near_equal(prob['sub1.q1.x'], 1.996, .0001)
+        assert_near_equal(prob['sub2.q2.x'], 1.996, .0001)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/linear/tests/test_user_defined.py
+++ b/openmdao/solvers/linear/tests/test_user_defined.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.array_utils import evenly_distrib_idxs
 
 try:
@@ -132,7 +132,7 @@ class TestUserDefinedSolver(unittest.TestCase):
         p.run_model()
         jac = p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
 
-        assert_rel_error(self, 15.0, jac['out_var']['a'][0][0])
+        assert_near_equal(15.0, jac['out_var']['a'][0][0])
 
     def test_scaling(self):
         # Make sure values are unscaled/dimensional.
@@ -184,7 +184,7 @@ class TestUserDefinedSolver(unittest.TestCase):
         p.run_model()
         jac = p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
 
-        assert_rel_error(self, 15.0, jac['out_var']['a'][0][0])
+        assert_near_equal(15.0, jac['out_var']['a'][0][0])
 
     def test_feature(self):
         import numpy as np
@@ -300,7 +300,7 @@ class TestUserDefinedSolver(unittest.TestCase):
         prob.run_model()
         jac = prob.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
 
-        assert_rel_error(self, 15.0, jac['out_var']['a'][0][0])
+        assert_near_equal(15.0, jac['out_var']['a'][0][0])
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -13,7 +13,7 @@ from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.implicit_newton_linesearch \
     import ImplCompTwoStates, ImplCompTwoStatesArrays
 from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestArmejoGoldsteinBounds(unittest.TestCase):
@@ -39,14 +39,14 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         # Run without a line search at x=2.0
         top['px.x'] = 2.0
         top.run_model()
-        assert_rel_error(self, top['comp.y'], 4.666666, 1e-4)
-        assert_rel_error(self, top['comp.z'], 1.333333, 1e-4)
+        assert_near_equal(top['comp.y'], 4.666666, 1e-4)
+        assert_near_equal(top['comp.z'], 1.333333, 1e-4)
 
         # Run without a line search at x=0.5
         top['px.x'] = 0.5
         top.run_model()
-        assert_rel_error(self, top['comp.y'], 5.833333, 1e-4)
-        assert_rel_error(self, top['comp.z'], 2.666666, 1e-4)
+        assert_near_equal(top['comp.y'], 5.833333, 1e-4)
+        assert_near_equal(top['comp.z'], 2.666666, 1e-4)
 
     def test_linesearch_bounds_vector(self):
         top = self.top
@@ -63,14 +63,14 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         top['comp.y'] = 0.0
         top['comp.z'] = 1.6
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 1.5, 1e-8)
+        assert_near_equal(top['comp.z'], 1.5, 1e-8)
 
         # Test upper bound: should go to the upper bound and stall
         top['px.x'] = 0.5
         top['comp.y'] = 0.0
         top['comp.z'] = 2.4
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 2.5, 1e-8)
+        assert_near_equal(top['comp.z'], 2.5, 1e-8)
 
     def test_linesearch_bounds_wall(self):
         top = self.top
@@ -87,14 +87,14 @@ class TestArmejoGoldsteinBounds(unittest.TestCase):
         top['comp.y'] = 0.0
         top['comp.z'] = 1.6
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 1.5, 1e-8)
+        assert_near_equal(top['comp.z'], 1.5, 1e-8)
 
         # Test upper bound: should go to the upper bound and stall
         top['px.x'] = 0.5
         top['comp.y'] = 0.0
         top['comp.z'] = 2.4
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 2.5, 1e-8)
+        assert_near_equal(top['comp.z'], 2.5, 1e-8)
 
     def test_linesearch_bounds_scalar(self):
         top = self.top
@@ -191,7 +191,7 @@ class TestAnalysisErrorExplicit(unittest.TestCase):
         top['comp.y'] = 0.0
         top['comp.z'] = 2.1
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 1.8, 1e-8)
+        assert_near_equal(top['comp.z'], 1.8, 1e-8)
 
     def test_no_retry(self):
         # Test the behavior with the switch turned off.
@@ -397,7 +397,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
         # Test upper bounds: should go to the minimum upper bound and stall
         top['px.x'] = 0.5
@@ -418,7 +418,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         self.assertTrue("'comp.z' exceeds upper bound" in txt)
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [2.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [2.5], 1e-8)
 
     def test_linesearch_wall_bound_enforcement_wall(self):
         top = self.top
@@ -434,7 +434,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
         # Test upper bounds: should go to the upper bound and stall
         top['px.x'] = 0.5
@@ -442,7 +442,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 2.4
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [self.ub[ind]], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [self.ub[ind]], 1e-8)
 
     def test_linesearch_wall_bound_enforcement_scalar(self):
         top = self.top
@@ -621,7 +621,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
         # Test upper bounds: should go to the minimum upper bound and stall
         top['px.x'] = 0.5
@@ -629,7 +629,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 2.4
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [2.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [2.5], 1e-8)
 
     def test_linesearch_wall_bound_enforcement_wall(self):
         top = self.top
@@ -645,7 +645,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 1.6
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
         # Test upper bounds: should go to the upper bound and stall
         top['px.x'] = 0.5
@@ -653,7 +653,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 2.4
         top.run_model()
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [self.ub[ind]], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [self.ub[ind]], 1e-8)
 
     def test_linesearch_wall_bound_enforcement_scalar(self):
         top = self.top
@@ -706,10 +706,10 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
 
 class CompAtan(om.ImplicitComponent):
@@ -779,7 +779,7 @@ class TestFeatureLineSearch(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], 19.68734033, 1e-6)
+        assert_near_equal(prob['comp.y'], 19.68734033, 1e-6)
 
     def test_feature_boundsenforcels_basic(self):
         import numpy as np
@@ -807,7 +807,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_armijogoldsteinls_basic(self):
         import numpy as np
@@ -835,7 +835,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_boundscheck_basic(self):
         import numpy as np
@@ -863,7 +863,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_boundscheck_vector(self):
         import numpy as np
@@ -891,7 +891,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_boundscheck_wall(self):
         import numpy as np
@@ -918,9 +918,9 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 2.4
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [2.6], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [2.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [2.65], 1e-8)
+        assert_near_equal(top['comp.z'][0], [2.6], 1e-8)
+        assert_near_equal(top['comp.z'][1], [2.5], 1e-8)
+        assert_near_equal(top['comp.z'][2], [2.65], 1e-8)
 
     def test_feature_boundscheck_scalar(self):
         import numpy as np
@@ -976,7 +976,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_armijo_boundscheck_vector(self):
         import numpy as np
@@ -1004,7 +1004,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_armijo_boundscheck_wall(self):
         import numpy as np
@@ -1031,9 +1031,9 @@ class TestFeatureLineSearch(unittest.TestCase):
         top['comp.z'] = 2.4
         top.run_model()
 
-        assert_rel_error(self, top['comp.z'][0], [2.6], 1e-8)
-        assert_rel_error(self, top['comp.z'][1], [2.5], 1e-8)
-        assert_rel_error(self, top['comp.z'][2], [2.65], 1e-8)
+        assert_near_equal(top['comp.z'][0], [2.6], 1e-8)
+        assert_near_equal(top['comp.z'][1], [2.5], 1e-8)
+        assert_near_equal(top['comp.z'][2], [2.65], 1e-8)
 
     def test_feature_armijo_boundscheck_scalar(self):
         import numpy as np
@@ -1089,7 +1089,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
     def test_feature_goldstein(self):
         import numpy as np
@@ -1118,7 +1118,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.run_model()
 
         for ind in range(3):
-            assert_rel_error(self, top['comp.z'][ind], [1.5], 1e-8)
+            assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -11,7 +11,7 @@ from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStates
 from openmdao.test_suite.components.sellar import SellarStateConnection, SellarDerivatives, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -207,8 +207,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
     def test_simple_sellar_cycle(self):
         # Test top level Sellar (i.e., not grouped).
@@ -226,8 +226,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_sellar_state_connection_fd_system(self):
         # Sellar model closes loop with state connection instead of a cycle.
@@ -244,8 +244,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 6)
@@ -270,7 +270,7 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['vec.x'], np.zeros((5, )), 1e-6)
+        assert_near_equal(prob['vec.x'], np.zeros((5, )), 1e-6)
 
     def test_mixed(self):
         # Testing Broyden on a 5 state case split among 3 vars.
@@ -292,9 +292,9 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['mixed.x12'], np.zeros((2, )), 1e-6)
-        assert_rel_error(self, prob['mixed.x3'], 0.0, 1e-6)
-        assert_rel_error(self, prob['mixed.x45'], np.zeros((2, )), 1e-6)
+        assert_near_equal(prob['mixed.x12'], np.zeros((2, )), 1e-6)
+        assert_near_equal(prob['mixed.x3'], 0.0, 1e-6)
+        assert_near_equal(prob['mixed.x45'], np.zeros((2, )), 1e-6)
 
     def test_missing_state_warning(self):
         # Testing Broyden on a 5 state case split among 3 vars.
@@ -362,9 +362,9 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['x12'], np.zeros((2, )), 1e-6)
-        assert_rel_error(self, prob['x3'], 0.0, 1e-6)
-        assert_rel_error(self, prob['x45'], np.zeros((2, )), 1e-6)
+        assert_near_equal(prob['x12'], np.zeros((2, )), 1e-6)
+        assert_near_equal(prob['x3'], 0.0, 1e-6)
+        assert_near_equal(prob['x45'], np.zeros((2, )), 1e-6)
 
     def test_mixed_jacobian(self):
         # Testing Broyden on a 5 state case split among 3 vars.
@@ -386,9 +386,9 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['mixed.x12'], np.zeros((2, )), 1e-6)
-        assert_rel_error(self, prob['mixed.x3'], 0.0, 1e-6)
-        assert_rel_error(self, prob['mixed.x45'], np.zeros((2, )), 1e-6)
+        assert_near_equal(prob['mixed.x12'], np.zeros((2, )), 1e-6)
+        assert_near_equal(prob['mixed.x3'], 0.0, 1e-6)
+        assert_near_equal(prob['mixed.x45'], np.zeros((2, )), 1e-6)
 
         # Normally takes about 13 iters, but takes around 4 if you calculate an initial
         # Jacobian.
@@ -408,8 +408,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Normally takes about 4 iters, but takes around 3 if you calculate an initial
         # Jacobian.
@@ -428,8 +428,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Normally takes about 4 iters, but takes around 3 if you calculate an initial
         # Jacobian.
@@ -449,8 +449,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Normally takes about 4 iters, but takes around 3 if you calculate an initial
         # Jacobian.
@@ -470,8 +470,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Normally takes about 5 iters, but takes around 4 if you calculate an initial
         # Jacobian.
@@ -490,8 +490,8 @@ class TestBryoden(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Normally takes about 5 iters, but takes around 4 if you calculate an initial
         # Jacobian.
@@ -520,7 +520,7 @@ class TestBryoden(unittest.TestCase):
         prob.set_solver_print(level=2)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], np.array([-36.26230985,  10.20857237, -54.17658612]), 1e-6)
+        assert_near_equal(prob['comp.y'], np.array([-36.26230985,  10.20857237, -54.17658612]), 1e-6)
 
     def test_jacobian_update_diverge_limit(self):
         # This model needs jacobian updates to converge.
@@ -544,7 +544,7 @@ class TestBryoden(unittest.TestCase):
         prob.set_solver_print(level=2)
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.y'], np.array([-36.26230985,  10.20857237, -54.17658612]), 1e-6)
+        assert_near_equal(prob['comp.y'], np.array([-36.26230985,  10.20857237, -54.17658612]), 1e-6)
 
     def test_backtracking(self):
         top = om.Problem()
@@ -570,14 +570,14 @@ class TestBryoden(unittest.TestCase):
         top['comp.y'] = 0.0
         top['comp.z'] = 1.6
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 1.5, 1e-8)
+        assert_near_equal(top['comp.z'], 1.5, 1e-8)
 
         # Test upper bound: should go to the upper bound and stall
         top['px.x'] = 0.5
         top['comp.y'] = 0.0
         top['comp.z'] = 2.4
         top.run_model()
-        assert_rel_error(self, top['comp.z'], 2.5, 1e-8)
+        assert_near_equal(top['comp.z'], 2.5, 1e-8)
 
     def test_cs_around_broyden(self):
         # Basic sellar test.
@@ -619,7 +619,7 @@ class TestBryoden(unittest.TestCase):
         totals = prob.check_totals(method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-6)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
     def test_cs_around_broyden_compute_jac(self):
         # Basic sellar test.
@@ -661,7 +661,7 @@ class TestBryoden(unittest.TestCase):
         totals = prob.check_totals(method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-6)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
     def test_cs_around_broyden_compute_jac_dense(self):
         # Basic sellar test.
@@ -703,7 +703,7 @@ class TestBryoden(unittest.TestCase):
         totals = prob.check_totals(method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-6)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
     def test_complex_step(self):
         prob = om.Problem()
@@ -743,7 +743,7 @@ class TestBryoden(unittest.TestCase):
         totals = prob.check_totals(method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_rel_error(self, val['rel error'][0], 0.0, 1e-7)
+            assert_near_equal(val['rel error'][0], 0.0, 1e-7)
 
 
 @unittest.skipUnless(MPI and PETScVector, "only run with MPI and PETSc.")
@@ -792,8 +792,8 @@ class TestBryodenFeature(unittest.TestCase):
         prob.set_solver_print(level=2)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
     def test_circuit(self):
         import openmdao.api as om
@@ -827,11 +827,11 @@ class TestBryodenFeature(unittest.TestCase):
         p.set_solver_print(level=2)
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278226, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278226, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_options(self):
         import openmdao.api as om
@@ -865,11 +865,11 @@ class TestBryodenFeature(unittest.TestCase):
         p.set_solver_print(level=2)
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278226, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278226, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_full(self):
         import openmdao.api as om
@@ -899,11 +899,11 @@ class TestBryodenFeature(unittest.TestCase):
         p.set_solver_print(level=2)
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278226, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278226, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -14,7 +14,7 @@ from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTw
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
      SellarNoDerivatives, SellarDerivatives, SellarStateConnection, StateConnection, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning, assert_no_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning
 from openmdao.utils.mpi import MPI
 
 try:
@@ -38,8 +38,8 @@ class TestNewton(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_newton_basic(self):
         """ Feature test for slotting a Newton solver and using it to solve
@@ -53,8 +53,8 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_sellar_grouped(self):
         # Tests basic Newton solution on Sellar in a subgroup
@@ -65,8 +65,8 @@ class TestNewton(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -79,8 +79,8 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -98,8 +98,8 @@ class TestNewton(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -120,8 +120,8 @@ class TestNewton(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -135,8 +135,8 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -152,8 +152,8 @@ class TestNewton(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 6)
@@ -204,8 +204,8 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(model.nonlinear_solver._iter_count, 8)
@@ -258,8 +258,8 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['state_eq.y2_command'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['state_eq.y2_command'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(model.nonlinear_solver._iter_count, 8)
@@ -290,10 +290,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_csc(self):
         prob = om.Problem(model=DoubleSellar())
@@ -315,10 +315,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_dense_jac(self):
         prob = om.Problem(model=DoubleSellar())
@@ -339,10 +339,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_dense_jac_scaling(self):
         prob = om.Problem(model=DoubleSellar(units=None, scaling=True))
@@ -363,10 +363,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_basic_dense_jac_units_scaling(self):
         prob = om.Problem(model=DoubleSellar(units=True, scaling=True))
@@ -390,10 +390,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.0533333333, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.0533333333, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.0533333333, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.0533333333, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top(self):
         prob = om.Problem(model=DoubleSellar())
@@ -414,10 +414,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_csc(self):
         prob = om.Problem(model=DoubleSellar())
@@ -437,10 +437,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_implicit(self):
         prob = om.Problem(model=DoubleSellarImplicit())
@@ -461,10 +461,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_implicit_scaling(self):
         prob = om.Problem(model=DoubleSellarImplicit(scaling=True))
@@ -485,10 +485,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_top_implicit_scaling_units(self):
         prob = om.Problem(model=DoubleSellarImplicit(units=True, scaling=True))
@@ -512,10 +512,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.053333333, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.053333333, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.053333333, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.053333333, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_assembled_jac_subgroup(self):
         prob = om.Problem(model=DoubleSellar())
@@ -536,10 +536,10 @@ class TestNewton(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_solve_subsystems_internals(self):
         # Here we test that this feature is doing what it should do by counting the
@@ -825,7 +825,7 @@ class TestNewton(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals()
-        assert_rel_error(self, J['ecomp.y', 'p1.x'][0][0], -0.703467422498, 1e-6)
+        assert_near_equal(J['ecomp.y', 'p1.x'][0][0], -0.703467422498, 1e-6)
 
     def test_error_specify_solve_subsystems(self):
         # Raise AnalysisError when it fails to converge
@@ -877,8 +877,8 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -911,8 +911,8 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5878516779, .00001)
-        assert_rel_error(self, prob['y2'], 12.0607416105, .00001)
+        assert_near_equal(prob['y1'], 25.5878516779, .00001)
+        assert_near_equal(prob['y2'], 12.0607416105, .00001)
 
     def test_feature_rtol(self):
         import numpy as np
@@ -945,8 +945,8 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5878516779, .00001)
-        assert_rel_error(self, prob['y2'], 12.0607416105, .00001)
+        assert_near_equal(prob['y1'], 25.5878516779, .00001)
+        assert_near_equal(prob['y2'], 12.0607416105, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -979,8 +979,8 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5882856302, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.5882856302, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_linear_solver(self):
         import numpy as np
@@ -1015,8 +1015,8 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_max_sub_solves(self):
         import numpy as np
@@ -1116,10 +1116,10 @@ class TestNewtonFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
@@ -10,7 +10,7 @@ from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.sellar import SellarDerivatives, \
     SellarDis1withDerivatives, SellarDis2withDerivatives, \
     SellarDis1, SellarDis2
-from openmdao.utils.assert_utils import assert_rel_error, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 from openmdao.utils.mpi import MPI
 try:
@@ -83,8 +83,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_basic(self):
         import numpy as np
@@ -114,8 +114,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -146,8 +146,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
         prob.set_solver_print()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58914915, .00001)
-        assert_rel_error(self, prob['y2'], 12.05857185, .00001)
+        assert_near_equal(prob['y1'], 25.58914915, .00001)
+        assert_near_equal(prob['y2'], 12.05857185, .00001)
 
     def test_feature_rtol(self):
         import numpy as np
@@ -178,8 +178,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5883027, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.5883027, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -210,8 +210,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5882856302, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.5882856302, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_sellar(self):
         # Basic sellar test.
@@ -238,8 +238,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertEqual(model.nonlinear_solver._iter_count, 7)
@@ -272,8 +272,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertEqual(model.nonlinear_solver._iter_count, 7)
@@ -347,10 +347,10 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
     def test_NLBGS_Aitken(self):
 
@@ -362,8 +362,8 @@ class TestNLBGaussSeidel(unittest.TestCase):
         model.nonlinear_solver.options['use_aitken'] = True
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
         self.assertTrue(model.nonlinear_solver._iter_count == 5)
 
     def test_NLBGS_Aitken_cs(self):
@@ -381,11 +381,11 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         J = prob.compute_totals(of=['y1'], wrt=['x'])
-        assert_rel_error(self, J['y1', 'x'][0][0], 0.98061448, 1e-6)
+        assert_near_equal(J['y1', 'x'][0][0], 0.98061448, 1e-6)
 
     def test_NLBGS_cs(self):
 
@@ -401,11 +401,11 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         J = prob.compute_totals(of=['y1'], wrt=['x'])
-        assert_rel_error(self, J['y1', 'x'][0][0], 0.98061448, 1e-6)
+        assert_near_equal(J['y1', 'x'][0][0], 0.98061448, 1e-6)
 
     def test_res_ref(self):
 
@@ -481,10 +481,10 @@ class ProcTestCase1(unittest.TestCase):
         print(prob.get_val('d1b.y2', get_remote=True))
         print(prob.get_val('d2b.y2', get_remote=True))
 
-        assert_rel_error(self, prob.get_val('d1a.y1', get_remote=True), 25.58830273, .00001)
-        assert_rel_error(self, prob.get_val('d1b.y1', get_remote=True), 25.58830273, .00001)
-        assert_rel_error(self, prob.get_val('d2a.y2', get_remote=True), 12.05848819, .00001)
-        assert_rel_error(self, prob.get_val('d2b.y2', get_remote=True), 12.05848819, .00001)
+        assert_near_equal(prob.get_val('d1a.y1', get_remote=True), 25.58830273, .00001)
+        assert_near_equal(prob.get_val('d1b.y1', get_remote=True), 25.58830273, .00001)
+        assert_near_equal(prob.get_val('d2a.y2', get_remote=True), 12.05848819, .00001)
+        assert_near_equal(prob.get_val('d2b.y2', get_remote=True), 12.05848819, .00001)
 
         # Test that Aitken accelerated the convergence, normally takes 7.
         self.assertTrue(model.nonlinear_solver._iter_count == 5)

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_jac.py
@@ -7,7 +7,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.components.ae_tests import AEComp, AEDriver
 from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 try:
@@ -47,8 +47,8 @@ class TestNLBlockJacobi(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_feature_maxiter(self):
         import numpy as np
@@ -81,8 +81,8 @@ class TestNLBlockJacobi(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5723813937, .00001)
-        assert_rel_error(self, prob['y2'], 12.0542542372, .00001)
+        assert_near_equal(prob['y1'], 25.5723813937, .00001)
+        assert_near_equal(prob['y2'], 12.0542542372, .00001)
 
     def test_feature_rtol(self):
         import numpy as np
@@ -115,8 +115,8 @@ class TestNLBlockJacobi(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5891491526, .00001)
-        assert_rel_error(self, prob['y2'], 12.0569142166, .00001)
+        assert_near_equal(prob['y1'], 25.5891491526, .00001)
+        assert_near_equal(prob['y2'], 12.0569142166, .00001)
 
     def test_feature_atol(self):
         import numpy as np
@@ -149,8 +149,8 @@ class TestNLBlockJacobi(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.5886171567, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.5886171567, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_runonce.py
@@ -6,7 +6,7 @@ import openmdao.api as om
 from openmdao.test_suite.components.ae_tests import AEComp, AEDriver
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.groups.parallel_groups import ConvergeDivergeGroups
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 try:
@@ -34,7 +34,7 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
         prob.run_model()
 
         # Make sure value is fine.
-        assert_rel_error(self, prob['c7.y1'], -102.7, 1e-6)
+        assert_near_equal(prob['c7.y1'], -102.7, 1e-6)
 
     def test_undeclared_options(self):
         # Test that using options that should not exist in class cause an error
@@ -68,7 +68,7 @@ class TestNonlinearRunOnceSolver(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['f_xy'], 122.0)
+        assert_near_equal(prob['f_xy'], 122.0)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -15,7 +15,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import run_model
 from openmdao.utils.general_utils import printoptions
 

--- a/openmdao/solvers/tests/test_solver_features.py
+++ b/openmdao/solvers/tests/test_solver_features.py
@@ -4,7 +4,7 @@ import unittest
 
 import openmdao.api as om
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.components.double_sellar import DoubleSellar
 
@@ -29,8 +29,8 @@ class TestSolverFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
     def test_specify_subgroup_solvers(self):
         import openmdao.api as om
@@ -56,10 +56,10 @@ class TestSolverFeatures(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['g1.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g1.y2'], 0.80, .00001)
-        assert_rel_error(self, prob['g2.y1'], 0.64, .00001)
-        assert_rel_error(self, prob['g2.y2'], 0.80, .00001)
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/tests/test_solver_parametric_suite.py
+++ b/openmdao/solvers/tests/test_solver_parametric_suite.py
@@ -6,7 +6,7 @@ import unittest
 from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.solvers.nonlinear.newton import NewtonSolver
 from openmdao.solvers.linear.direct import DirectSolver
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
@@ -55,7 +55,7 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
             prob.setup()
 
             prob.run_model()
-            assert_rel_error(self, prob['y'], [-1., 1.])
+            assert_near_equal(prob['y'], [-1., 1.])
 
             d_inputs, d_outputs, d_residuals = prob.model.get_linear_vectors()
 
@@ -63,13 +63,13 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
             d_outputs.set_const(0.0)
             prob.model.run_solve_linear(['linear'], 'fwd')
             result = d_outputs._data
-            assert_rel_error(self, result, [-2., 2.])
+            assert_near_equal(result, [-2., 2.])
 
             d_outputs.set_const(2.0)
             d_residuals.set_const(0.0)
             prob.model.run_solve_linear(['linear'], 'rev')
             result = d_residuals._data
-            assert_rel_error(self, result, [2., -2.])
+            assert_near_equal(result, [2., -2.])
 
     def test_direct_solver_group(self):
         """
@@ -93,13 +93,13 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
         d_outputs.set_const(0.0)
         prob.model.run_solve_linear(['linear'], 'fwd')
         result = d_outputs._data
-        assert_rel_error(self, result, prob.model.expected_solution, 1e-15)
+        assert_near_equal(result, prob.model.expected_solution, 1e-15)
 
         d_outputs.set_const(1.0)
         d_residuals.set_const(0.0)
         prob.model.run_solve_linear(['linear'], 'rev')
         result = d_residuals._data
-        assert_rel_error(self, result, prob.model.expected_solution, 1e-15)
+        assert_near_equal(result, prob.model.expected_solution, 1e-15)
 
     @parametric_suite(
         assembled_jac=[False, True],
@@ -121,17 +121,17 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
         expected_values = model.expected_values
         if expected_values:
             actual = {key: problem[key] for key in expected_values}
-            assert_rel_error(self, actual, expected_values, 1e-8)
+            assert_near_equal(actual, expected_values, 1e-8)
 
         expected_totals = model.expected_totals
         if expected_totals:
             # Forward Derivatives Check
             totals = param_instance.compute_totals('fwd')
-            assert_rel_error(self, totals, expected_totals, 1e-8)
+            assert_near_equal(totals, expected_totals, 1e-8)
 
             # Reverse Derivatives Check
             totals = param_instance.compute_totals('rev')
-            assert_rel_error(self, totals, expected_totals, 1e-8)
+            assert_near_equal(totals, expected_totals, 1e-8)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/surrogate_models/tests/test_kriging.py
+++ b/openmdao/surrogate_models/tests/test_kriging.py
@@ -6,7 +6,7 @@ import itertools
 import numpy as np
 
 from openmdao.api import KrigingSurrogate
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 def branin(x):
@@ -30,8 +30,8 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu, sigma = surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
-            assert_rel_error(self, sigma, [[0]], 1e-5)
+            assert_near_equal(mu, [y0], 1e-9)
+            assert_near_equal(sigma, [[0]], 1e-5)
 
     def test_1d_predictor(self):
         x = np.array([[0.0], [2.0], [3.0], [4.0], [6.0]])
@@ -43,8 +43,8 @@ class TestKrigingSurrogate(unittest.TestCase):
         new_x = np.array([3.5])
         mu, sigma = surrogate.predict(new_x)
 
-        assert_rel_error(self, mu, [[branin_1d(new_x)]], 1e-1)
-        assert_rel_error(self, sigma, [[0.07101449]], 1e-2)
+        assert_near_equal(mu, [[branin_1d(new_x)]], 1e-1)
+        assert_near_equal(sigma, [[0.07101449]], 1e-2)
 
     def test_1d_ill_conditioned(self):
         # Test for least squares solver utilization when ill-conditioned
@@ -55,7 +55,7 @@ class TestKrigingSurrogate(unittest.TestCase):
         new_x = np.array([0.5])
         mu, sigma = surrogate.predict(new_x)
         self.assertTrue(sigma < 1.e-5)
-        assert_rel_error(self, mu, [[np.sin(0.5)]], 1e-5)
+        assert_near_equal(mu, [[np.sin(0.5)]], 1e-5)
 
     def test_2d(self):
 
@@ -69,13 +69,13 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu, sigma = surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
-            assert_rel_error(self, sigma, [[0]], 1e-4)
+            assert_near_equal(mu, [y0], 1e-9)
+            assert_near_equal(sigma, [[0]], 1e-4)
 
         mu, sigma = surrogate.predict([5., 5.])
 
-        assert_rel_error(self, mu, [[16.72]], 1e-1)
-        assert_rel_error(self, sigma, [[15.27]], 1e-2)
+        assert_near_equal(mu, [[16.72]], 1e-1)
+        assert_near_equal(sigma, [[15.27]], 1e-2)
 
     def test_no_training_data(self):
         surrogate = KrigingSurrogate()
@@ -110,8 +110,8 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu, sigma = surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
-            assert_rel_error(self, sigma, [[0]], 1e-6)
+            assert_near_equal(mu, [y0], 1e-9)
+            assert_near_equal(sigma, [[0]], 1e-6)
 
     def test_vector_output(self):
         surrogate = KrigingSurrogate(nugget=0., eval_rmse=True)
@@ -123,8 +123,8 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu, sigma = surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
-            assert_rel_error(self, sigma, [[0, 0]], 1e-6)
+            assert_near_equal(mu, [y0], 1e-9)
+            assert_near_equal(sigma, [[0, 0]], 1e-6)
 
     def test_scalar_derivs(self):
         surrogate = KrigingSurrogate(nugget=0.)
@@ -135,7 +135,7 @@ class TestKrigingSurrogate(unittest.TestCase):
         surrogate.train(x, y)
         jac = surrogate.linearize(np.array([[0.]]))
 
-        assert_rel_error(self, jac[0][0], 1., 5e-3)
+        assert_near_equal(jac[0][0], 1., 5e-3)
 
     def test_vector_derivs(self):
         surrogate = KrigingSurrogate()
@@ -146,7 +146,7 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         surrogate.train(x, y)
         jac = surrogate.linearize(np.array([[0.5, 0.5]]))
-        assert_rel_error(self, jac, np.array([[1, 1], [1, -1], [1, 2]]), 5e-4)
+        assert_near_equal(jac, np.array([[1, 1], [1, -1], [1, 2]]), 5e-4)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/surrogate_models/tests/test_map.py
+++ b/openmdao/surrogate_models/tests/test_map.py
@@ -1,5 +1,5 @@
 from openmdao.api import Group, Problem, MetaModelUnStructuredComp, NearestNeighbor
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 import numpy as np
 import unittest
@@ -52,18 +52,18 @@ class TestMap(unittest.TestCase):
         p.run_model()
 
         tol = 1e-1
-        assert_rel_error(self, p['compmap.PR'], p['compmap.Nc']*p['compmap.Rline']+p['compmap.alpha'], tol)
-        assert_rel_error(self, p['compmap.eff'], p['compmap.Nc']*p['compmap.Rline']**2+p['compmap.alpha'], tol)
-        assert_rel_error(self, p['compmap.Wc'], p['compmap.Nc']**2*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+        assert_near_equal(p['compmap.PR'], p['compmap.Nc']*p['compmap.Rline']+p['compmap.alpha'], tol)
+        assert_near_equal(p['compmap.eff'], p['compmap.Nc']*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+        assert_near_equal(p['compmap.Wc'], p['compmap.Nc']**2*p['compmap.Rline']**2+p['compmap.alpha'], tol)
 
         p['compmap.Nc'] = 0.95
         p['compmap.Rline'] = 2.1
         p['compmap.alpha'] = 0.0
         p.run_model()
 
-        assert_rel_error(self, p['compmap.PR'], p['compmap.Nc']*p['compmap.Rline']+p['compmap.alpha'], tol)
-        assert_rel_error(self, p['compmap.eff'], p['compmap.Nc']*p['compmap.Rline']**2+p['compmap.alpha'], tol)
-        assert_rel_error(self, p['compmap.Wc'], p['compmap.Nc']**2*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+        assert_near_equal(p['compmap.PR'], p['compmap.Nc']*p['compmap.Rline']+p['compmap.alpha'], tol)
+        assert_near_equal(p['compmap.eff'], p['compmap.Nc']*p['compmap.Rline']**2+p['compmap.alpha'], tol)
+        assert_near_equal(p['compmap.Wc'], p['compmap.Nc']**2*p['compmap.Rline']**2+p['compmap.alpha'], tol)
 
 
 if __name__ == "__main__":

--- a/openmdao/surrogate_models/tests/test_multifi_cokriging.py
+++ b/openmdao/surrogate_models/tests/test_multifi_cokriging.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from openmdao.api import MultiFiCoKrigingSurrogate
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class CoKrigingSurrogateTest(unittest.TestCase):
@@ -19,24 +19,24 @@ class CoKrigingSurrogateTest(unittest.TestCase):
         new_x = np.array([0.5])
 
         mu, sigma = krig1.predict(x[0])
-        assert_rel_error(self, mu, [[y[0]]], 1e-4)
-        assert_rel_error(self, sigma, [[0.]], 1e-4)
+        assert_near_equal(mu, [[y[0]]], 1e-4)
+        assert_near_equal(sigma, [[0.]], 1e-4)
 
         mu, sigma = krig1.predict(new_x)
-        assert_rel_error(self, mu, [[-2.0279]], 1e-3)
-        assert_rel_error(self, sigma, [[1.3408]], 1e-3)
+        assert_near_equal(mu, [[-2.0279]], 1e-3)
+        assert_near_equal(sigma, [[1.3408]], 1e-3)
 
         # Test with theta setting instead of estimation
         krig2 = MultiFiCoKrigingSurrogate(theta=0.1, normalize=False)
         krig2.train(x, y)
 
         mu, sigma = krig2.predict(x[0])
-        assert_rel_error(self , mu, [[y[0]]], 1e-4)
-        assert_rel_error(self, sigma, [[.0]], 1e-4)
+        assert_near_equal(mu, [[y[0]]], 1e-4)
+        assert_near_equal(sigma, [[.0]], 1e-4)
 
         mu, sigma = krig2.predict(new_x)
-        assert_rel_error(self, mu, [[-1.2719]], 1e-3)
-        assert_rel_error(self, sigma, [[0.0439]], 1e-3)
+        assert_near_equal(mu, [[-1.2719]], 1e-3)
+        assert_near_equal(sigma, [[0.0439]], 1e-3)
 
     def test_1d_2fi_cokriging(self):
         # Example from Forrester: Engineering design via surrogate modelling
@@ -57,8 +57,8 @@ class CoKrigingSurrogateTest(unittest.TestCase):
 
         new_x = np.array([0.75])
         mu, sigma = cokrig.predict(new_x)
-        assert_rel_error(self, mu,  [[f_expensive(new_x[0])]], 0.05)
-        assert_rel_error(self, sigma, [[0.]], 0.02)
+        assert_near_equal(mu,  [[f_expensive(new_x[0])]], 0.05)
+        assert_near_equal(sigma, [[0.]], 0.02)
 
     def test_2d_1fi_cokriging(self):
         # CoKrigingSurrogate with one fidelity could be used as a KrigingSurrogate
@@ -76,24 +76,24 @@ class CoKrigingSurrogateTest(unittest.TestCase):
         krig1.train(x, y)
 
         mu, sigma = krig1.predict([-2., 0.])
-        assert_rel_error(self, mu, [[branin(x[0])]], 1e-5)
-        assert_rel_error(self, sigma, [[0.]], 1e-5)
+        assert_near_equal(mu, [[branin(x[0])]], 1e-5)
+        assert_near_equal(sigma, [[0.]], 1e-5)
 
         mu, sigma = krig1.predict([5., 5.])
-        assert_rel_error(self, mu, [[22]], 1)
-        assert_rel_error(self, sigma, [[13]], 1)
+        assert_near_equal(mu, [[22]], 1)
+        assert_near_equal(sigma, [[13]], 1)
 
         # Test with theta setting instead of estimation
         krig2 = MultiFiCoKrigingSurrogate(theta=[0.1])
         krig1.train(x, y)
 
         mu, sigma = krig1.predict([-2., 0.])
-        assert_rel_error(self, mu, [[branin(x[0])]], 1e-5)
-        assert_rel_error(self, sigma, [[0.]], 1e-5)
+        assert_near_equal(mu, [[branin(x[0])]], 1e-5)
+        assert_near_equal(sigma, [[0.]], 1e-5)
 
         mu, sigma = krig1.predict([5., 5.])
-        assert_rel_error(self, mu, [[22]], 1)
-        assert_rel_error(self, sigma, [[13]], 1)
+        assert_near_equal(mu, [[22]], 1)
+        assert_near_equal(sigma, [[13]], 1)
 
     def test_2d_2fi_cokriging(self):
 
@@ -144,24 +144,24 @@ class CoKrigingSurrogateTest(unittest.TestCase):
         cokrig.train_multifi(x, y)
 
         mu, sigma = cokrig.predict([2./3., 1/3.])
-        assert_rel_error(self, mu, [[26]], 0.2)
-        assert_rel_error(self, sigma, [[0.3]], 0.2)
+        assert_near_equal(mu, [[26]], 0.2)
+        assert_near_equal(sigma, [[0.3]], 0.2)
 
         # Test with theta setting instead of theta estimation
         cokrig2 = MultiFiCoKrigingSurrogate(theta=0.1, normalize=False)
         cokrig2.train_multifi(x, y)
 
         mu, sigma = cokrig2.predict([2./3., 1/3.])
-        assert_rel_error(self, mu, [[21.7]], 0.1)
-        assert_rel_error(self, sigma, [[2.29]], 0.1)
+        assert_near_equal(mu, [[21.7]], 0.1)
+        assert_near_equal(sigma, [[2.29]], 0.1)
 
         # Test with theta setting instead of theta estimation
         cokrig2 = MultiFiCoKrigingSurrogate(theta=[0.1, 10], normalize=False)
         cokrig2.train_multifi(x, y)
 
         mu, sigma = cokrig2.predict([2./3., 1/3.])
-        assert_rel_error(self, mu, [[21.01]], 0.2)
-        assert_rel_error(self, sigma, [[2.29]], 0.2)
+        assert_near_equal(mu, [[21.01]], 0.2)
+        assert_near_equal(sigma, [[2.29]], 0.2)
 
         # Test bad theta setting
         cokrig3 = MultiFiCoKrigingSurrogate(theta=[0.1])

--- a/openmdao/surrogate_models/tests/test_nearest_neighbor.py
+++ b/openmdao/surrogate_models/tests/test_nearest_neighbor.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 from openmdao.api import NearestNeighbor
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestNearestNeighbor(unittest.TestCase):
@@ -26,7 +26,7 @@ class TestLinearInterpolator1D(unittest.TestCase):
     def test_training(self):
         for x0, y0 in zip(self.x, self.y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_prediction(self):
         test_x = np.array([[0.5], [1.5], [2.5]])
@@ -34,13 +34,13 @@ class TestLinearInterpolator1D(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_bulk_prediction(self):
         test_x = np.array([[0.5], [1.5], [2.5]])
         expected_y = np.array([[0.5], [1.], [0.5]])
         mu = self.surrogate.predict(test_x)
-        assert_rel_error(self, mu, expected_y, 1e-9)
+        assert_near_equal(mu, expected_y, 1e-9)
 
     def test_jacobian(self):
         test_x = np.array([[0.5], [1.5], [2.5]])
@@ -48,7 +48,7 @@ class TestLinearInterpolator1D(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_deriv):
             jac = self.surrogate.linearize(x0)
-            assert_rel_error(self, jac, [y0], 1e-9)
+            assert_near_equal(jac, [y0], 1e-9)
 
     def test_pt_cache(self):
         test_x = np.array([[0.5]])
@@ -60,7 +60,7 @@ class TestLinearInterpolator1D(unittest.TestCase):
 
         mu = self.surrogate.linearize(test_x)
 
-        assert_rel_error(self, mu, np.array([[1.]]), 1e-6)
+        assert_near_equal(mu, np.array([[1.]]), 1e-6)
 
 
 class TestLinearInterpolatorND(unittest.TestCase):
@@ -77,7 +77,7 @@ class TestLinearInterpolatorND(unittest.TestCase):
     def test_training(self):
         for x0, y0 in zip(self.x, self.y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_prediction(self):
         test_x = np.array([[1., 0.5],
@@ -97,7 +97,7 @@ class TestLinearInterpolatorND(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_bulk_prediction(self):
         test_x = np.array([[1., 0.5],
@@ -116,7 +116,7 @@ class TestLinearInterpolatorND(unittest.TestCase):
                                ])
 
         mu = self.surrogate.predict(test_x)
-        assert_rel_error(self, mu, expected_y, 1e-9)
+        assert_near_equal(mu, expected_y, 1e-9)
 
     def test_jacobian(self):
         test_x = np.array([[1., 0.5],
@@ -133,7 +133,7 @@ class TestLinearInterpolatorND(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_deriv):
             mu = self.surrogate.linearize(x0)
-            assert_rel_error(self, mu, y0, 1e-9)
+            assert_near_equal(mu, y0, 1e-9)
 
 
 class TestWeightedInterpolator1D(unittest.TestCase):
@@ -155,7 +155,7 @@ class TestWeightedInterpolator1D(unittest.TestCase):
     def test_training(self):
         for x0, y0 in zip(self.x, self.y):
             mu = self.surrogate.predict(x0, num_neighbors=3)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_prediction(self):
         test_x = np.array([[0.5], [1.5], [2.5]])
@@ -163,7 +163,7 @@ class TestWeightedInterpolator1D(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_y):
             mu = self.surrogate.predict(x0, num_neighbors=3)
-            assert_rel_error(self, mu, [y0], 1e-8)
+            assert_near_equal(mu, [y0], 1e-8)
 
     def test_bulk_prediction(self):
 
@@ -171,7 +171,7 @@ class TestWeightedInterpolator1D(unittest.TestCase):
         expected_y = np.array([[0.52631579], [0.94736842], [0.52631579]])
 
         mu = self.surrogate.predict(test_x, num_neighbors=3)
-        assert_rel_error(self, mu, expected_y, 1e-8)
+        assert_near_equal(mu, expected_y, 1e-8)
 
     def test_jacobian(self):
         test_x = np.array([[0.5], [1.5], [2.5]])
@@ -179,7 +179,7 @@ class TestWeightedInterpolator1D(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_deriv):
             jac = self.surrogate.linearize(x0, num_neighbors=3)
-            assert_rel_error(self, jac, [y0], 1e-6)
+            assert_near_equal(jac, [y0], 1e-6)
 
     def test_pt_cache(self):
         test_x = np.array([[0.5]])
@@ -191,7 +191,7 @@ class TestWeightedInterpolator1D(unittest.TestCase):
 
         mu = self.surrogate.linearize(test_x, num_neighbors=3)
 
-        assert_rel_error(self, mu, np.array([[1.92797784]]), 1e-6)
+        assert_near_equal(mu, np.array([[1.92797784]]), 1e-6)
 
 
 class TestWeightedInterpolatorND(unittest.TestCase):
@@ -208,7 +208,7 @@ class TestWeightedInterpolatorND(unittest.TestCase):
     def test_training(self):
         for x0, y0 in zip(self.x, self.y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_prediction(self):
         test_x = np.array([[1., 0.5],
@@ -235,7 +235,7 @@ class TestWeightedInterpolatorND(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_y):
             mu = self.surrogate.predict(x0, num_neighbors=5, dist_eff=3)
-            assert_rel_error(self, mu, [y0], 1e-6)
+            assert_near_equal(mu, [y0], 1e-6)
 
     def test_bulk_prediction(self):
         test_x = np.array([[1., 0.5],
@@ -261,7 +261,7 @@ class TestWeightedInterpolatorND(unittest.TestCase):
                                ])
 
         mu = self.surrogate.predict(test_x, num_neighbors=5, dist_eff=3)
-        assert_rel_error(self, mu, expected_y, 1e-6)
+        assert_near_equal(mu, expected_y, 1e-6)
 
     def test_jacobian(self):
         test_x = np.array([[1., 0.5],
@@ -279,7 +279,7 @@ class TestWeightedInterpolatorND(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_deriv):
             mu = self.surrogate.linearize(x0)
-            assert_rel_error(self, mu, y0, 1e-6)
+            assert_near_equal(mu, y0, 1e-6)
 
 
 class TestRBFInterpolator1D(unittest.TestCase):
@@ -292,7 +292,7 @@ class TestRBFInterpolator1D(unittest.TestCase):
     def test_training(self):
         for x0, y0 in zip(self.x, self.y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_prediction(self):
         test_x = np.array([[0.5], [1.5], [2.5]])
@@ -300,7 +300,7 @@ class TestRBFInterpolator1D(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-8)
+            assert_near_equal(mu, [y0], 1e-8)
 
     def test_bulk_prediction(self):
 
@@ -308,7 +308,7 @@ class TestRBFInterpolator1D(unittest.TestCase):
         expected_y = np.array([[0.82893803], [1.72485853], [0.82893803]])
 
         mu = self.surrogate.predict(test_x)
-        assert_rel_error(self, mu, expected_y, 1e-8)
+        assert_near_equal(mu, expected_y, 1e-8)
 
     def test_jacobian(self):
         from distutils.version import LooseVersion
@@ -320,7 +320,7 @@ class TestRBFInterpolator1D(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_deriv):
             jac = self.surrogate.linearize(x0)
-            assert_rel_error(self, jac, [y0], 1e-6)
+            assert_near_equal(jac, [y0], 1e-6)
 
     def test_pt_cache(self):
         test_x = np.array([[0.5]])
@@ -332,7 +332,7 @@ class TestRBFInterpolator1D(unittest.TestCase):
 
         mu = self.surrogate.linearize(test_x)
 
-        assert_rel_error(self, mu, np.array([[2.34609214]]), 1e-6)
+        assert_near_equal(mu, np.array([[2.34609214]]), 1e-6)
 
 
 class TestRBFInterpolatorND(unittest.TestCase):
@@ -349,7 +349,7 @@ class TestRBFInterpolatorND(unittest.TestCase):
     def test_training(self):
         for x0, y0 in zip(self.x, self.y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-9)
+            assert_near_equal(mu, [y0], 1e-9)
 
     def test_prediction(self):
         test_x = np.array([[1., 0.5],
@@ -374,7 +374,7 @@ class TestRBFInterpolatorND(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_y):
             mu = self.surrogate.predict(x0)
-            assert_rel_error(self, mu, [y0], 1e-6)
+            assert_near_equal(mu, [y0], 1e-6)
 
     def test_bulk_prediction(self):
         test_x = np.array([[1., 0.5],
@@ -399,7 +399,7 @@ class TestRBFInterpolatorND(unittest.TestCase):
                                ])
 
         mu = self.surrogate.predict(test_x)
-        assert_rel_error(self, mu, expected_y, 1e-6)
+        assert_near_equal(mu, expected_y, 1e-6)
 
     def test_jacobian(self):
         from distutils.version import LooseVersion
@@ -425,4 +425,4 @@ class TestRBFInterpolatorND(unittest.TestCase):
 
         for x0, y0 in zip(test_x, expected_deriv):
             mu = self.surrogate.linearize(x0)
-            assert_rel_error(self, mu, y0, 1e-6)
+            assert_near_equal(mu, y0, 1e-6)

--- a/openmdao/surrogate_models/tests/test_response_surface.py
+++ b/openmdao/surrogate_models/tests/test_response_surface.py
@@ -6,7 +6,7 @@ import unittest, itertools
 from numpy import array, linspace, sin, cos, pi
 
 from openmdao.api import ResponseSurface
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 def branin(x):
@@ -30,7 +30,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu = surrogate.predict(x0)
-            assert_rel_error(self, mu, y0, 1e-9)
+            assert_near_equal(mu, y0, 1e-9)
 
     def test_1d_predictor(self):
         x = array([[0.0], [2.0], [3.0], [4.0], [6.0]])
@@ -42,7 +42,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
         new_x = array([pi])
         mu = surrogate.predict(new_x)
 
-        assert_rel_error(self, mu, 1.73114, 1e-4)
+        assert_near_equal(mu, 1.73114, 1e-4)
 
     def test_1d_ill_conditioned(self):
         # Test for least squares solver utilization when ill-conditioned
@@ -53,7 +53,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
         new_x = array([0.5])
         mu = surrogate.predict(new_x)
 
-        assert_rel_error(self, mu, sin(0.5), 1e-3)
+        assert_near_equal(mu, sin(0.5), 1e-3)
 
     def test_2d(self):
 
@@ -65,11 +65,11 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu = surrogate.predict(x0)
-            assert_rel_error(self, mu, y0, 1e-9)
+            assert_near_equal(mu, y0, 1e-9)
 
         mu = surrogate.predict(array([.5, .5]))
 
-        assert_rel_error(self, mu, branin([.5, .5]), 1e-1)
+        assert_near_equal(mu, branin([.5, .5]), 1e-1)
 
     def test_no_training_data(self):
         surrogate = ResponseSurface()
@@ -88,7 +88,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
         y = array([[1.]])
 
         surrogate.train(x, y)
-        assert_rel_error(self, surrogate.betas, array([[1.], [0.], [0.]]), 1e-9)
+        assert_near_equal(surrogate.betas, array([[1.], [0.], [0.]]), 1e-9)
 
     def test_vector_input(self):
         surrogate = ResponseSurface()
@@ -100,7 +100,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu = surrogate.predict(x0)
-            assert_rel_error(self, mu, y0, 1e-9)
+            assert_near_equal(mu, y0, 1e-9)
 
     def test_vector_output(self):
         surrogate = ResponseSurface()
@@ -112,7 +112,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
 
         for x0, y0 in zip(x, y):
             mu = surrogate.predict(x0)
-            assert_rel_error(self, mu, y0, 1e-9)
+            assert_near_equal(mu, y0, 1e-9)
 
     def test_scalar_derivs(self):
         surrogate = ResponseSurface()
@@ -123,7 +123,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
         surrogate.train(x, y)
         jac = surrogate.linearize(array([[0.]]))
 
-        assert_rel_error(self, jac[0][0], 1., 1e-3)
+        assert_near_equal(jac[0][0], 1., 1e-3)
 
     def test_vector_derivs(self):
         surrogate = ResponseSurface()
@@ -134,7 +134,7 @@ class TestResponseSurfaceSurrogate(unittest.TestCase):
 
         surrogate.train(x, y)
         jac = surrogate.linearize(array([[0.5, 0.5]]))
-        assert_rel_error(self, jac, array([[1, 1], [1, -1]]), 1e-5)
+        assert_near_equal(jac, array([[1, 1], [1, -1]]), 1e-5)
 
 
 if __name__ == "__main__":

--- a/openmdao/test_suite/scripts/circuit_analysis.py
+++ b/openmdao/test_suite/scripts/circuit_analysis.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class Resistor(om.ExplicitComponent):

--- a/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
+++ b/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.paraboloid import Paraboloid
 
 
@@ -35,11 +35,11 @@ class BasicOptParaboloid(unittest.TestCase):
         prob.run_driver()
 
         # minimum value
-        assert_rel_error(self, prob['paraboloid.f_xy'], -27.33333, 1e-6)
+        assert_near_equal(prob['paraboloid.f_xy'], -27.33333, 1e-6)
 
         # location of the minimum
-        assert_rel_error(self, prob['indeps.x'], 6.6667, 1e-4)
-        assert_rel_error(self, prob['indeps.y'], -7.33333, 1e-4)
+        assert_near_equal(prob['indeps.x'], 6.6667, 1e-4)
+        assert_near_equal(prob['indeps.y'], -7.33333, 1e-4)
 
 
     def test_constrained(self):
@@ -78,11 +78,11 @@ class BasicOptParaboloid(unittest.TestCase):
         prob.run_driver()
 
         # minimum value
-        assert_rel_error(self, prob['parab.f_xy'], -27., 1e-6)
+        assert_near_equal(prob['parab.f_xy'], -27., 1e-6)
 
         # location of the minimum
-        assert_rel_error(self, prob['indeps.x'], 7, 1e-4)
-        assert_rel_error(self, prob['indeps.y'], -7, 1e-4)
+        assert_near_equal(prob['indeps.x'], 7, 1e-4)
+        assert_near_equal(prob['indeps.y'], -7, 1e-4)
 
 
 if __name__ == "__main__":

--- a/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
@@ -3,7 +3,7 @@ import unittest
 import openmdao.api as om
 from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
-from openmdao.utils.assert_utils import assert_rel_error, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.mpi import MPI
 
 try:
@@ -38,7 +38,7 @@ class TestCase(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['inputs_comp.h'],
+        assert_near_equal(prob['inputs_comp.h'],
                          [0.14915754,  0.14764328,  0.14611321,  0.14456715,  0.14300421,  0.14142417,
                           0.13982611,  0.13820976,  0.13657406,  0.13491866,  0.13324268,  0.13154528,
                           0.12982575,  0.12808305,  0.12631658,  0.12452477,  0.12270701,  0.12086183,
@@ -79,7 +79,7 @@ class TestCase(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['interp.h'][0],
+        assert_near_equal(prob['interp.h'][0],
                          [ 0.14122705,  0.14130706,  0.14154096,  0.1419107,   0.14238706,  0.14293095,
                            0.14349514,  0.14402636,  0.1444677,   0.14476123,  0.14485062,  0.14468388,
                            0.14421589,  0.1434107,   0.14224356,  0.14070252,  0.13878952,  0.13652104,
@@ -121,7 +121,7 @@ class TestCase(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['interp.h'][0],
+        assert_near_equal(prob['interp.h'][0],
                          [ 0.45632323,  0.45612552,  0.45543324,  0.45397058,  0.45134629,  0.44714397,
                            0.4410258,   0.43283139,  0.42265378,  0.41087801,  0.3981731,   0.3854358,
                            0.37369202,  0.36342186,  0.35289066,  0.34008777,  0.32362887,  0.30300358,
@@ -148,9 +148,9 @@ class TestCase(unittest.TestCase):
         prob.run_model()
 
         derivs = prob.check_totals(method='cs', out_stream=None)
-        assert_rel_error(self, derivs[('compliance_comp.compliance', 'inputs_comp.h')]['rel error'][0],
+        assert_near_equal(derivs[('compliance_comp.compliance', 'inputs_comp.h')]['rel error'][0],
                          0.0, 1e-8)
-        assert_rel_error(self, derivs[('volume_comp.volume', 'inputs_comp.h')]['rel error'][0],
+        assert_near_equal(derivs[('volume_comp.volume', 'inputs_comp.h')]['rel error'][0],
                          0.0, 1e-8)
 
         derivs = prob.check_partials(method='cs', out_stream=None)
@@ -182,9 +182,9 @@ class TestCase(unittest.TestCase):
         prob.run_model()
 
         derivs = prob.check_totals(method='cs', out_stream=None)
-        assert_rel_error(self, derivs[('obj_sum.obj', 'inputs_comp.h_cp')]['rel error'][0],
+        assert_near_equal(derivs[('obj_sum.obj', 'inputs_comp.h_cp')]['rel error'][0],
                          0.0, 1e-8)
-        assert_rel_error(self, derivs[('volume_comp.volume', 'inputs_comp.h_cp')]['rel error'][0],
+        assert_near_equal(derivs[('volume_comp.volume', 'inputs_comp.h_cp')]['rel error'][0],
                          0.0, 1e-8)
 
         derivs = prob.check_partials(method='cs', out_stream=None)
@@ -226,7 +226,7 @@ class TestParallelGroups(unittest.TestCase):
 
         prob.run_driver()
 
-        assert_rel_error(self, prob['interp.h'][0],
+        assert_near_equal(prob['interp.h'][0],
                          [ 0.14122705,  0.14130706,  0.14154096,  0.1419107,   0.14238706,  0.14293095,
                            0.14349514,  0.14402636,  0.1444677,   0.14476123,  0.14485062,  0.14468388,
                            0.14421589,  0.1434107,   0.14224356,  0.14070252,  0.13878952,  0.13652104,

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -4,7 +4,7 @@ import unittest
 import scipy
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 # duplicate definition here so it can be included in docs by itself
@@ -206,12 +206,12 @@ class TestBetzLimit(unittest.TestCase):
         prob.model.list_outputs(values = False, hierarchical=False)
 
         # minimum value
-        assert_rel_error(self, prob['a_disk.Cp'], 16./27., 1e-4)
-        assert_rel_error(self, prob['a'], 0.33333, 1e-4)
+        assert_near_equal(prob['a_disk.Cp'], 16./27., 1e-4)
+        assert_near_equal(prob['a'], 0.33333, 1e-4)
 
         # There is a bug in scipy version < 1.0 that causes this value to be wrong.
         if LooseVersion(scipy.__version__) >= LooseVersion("1.0"):
-            assert_rel_error(self, prob['Area'], 1.0, 1e-4)
+            assert_near_equal(prob['Area'], 1.0, 1e-4)
 
     def test_betz_with_var_tags(self):
         import openmdao.api as om

--- a/openmdao/test_suite/test_examples/test_circuit_analysis.py
+++ b/openmdao/test_suite/test_examples/test_circuit_analysis.py
@@ -3,7 +3,7 @@ import numpy as np
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestCircuit(unittest.TestCase):
@@ -58,14 +58,14 @@ class TestCircuit(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278185, 1e-5)
-        assert_rel_error(self, p['circuit.R1.I'], 0.09908047, 1e-5)
-        assert_rel_error(self, p['circuit.R2.I'], 0.00091953, 1e-5)
-        assert_rel_error(self, p['circuit.D1.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278185, 1e-5)
+        assert_near_equal(p['circuit.R1.I'], 0.09908047, 1e-5)
+        assert_near_equal(p['circuit.R2.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.D1.I'], 0.00091953, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_plain_newton(self):
 
@@ -113,14 +113,14 @@ class TestCircuit(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278185, 1e-5)
-        assert_rel_error(self, p['circuit.R1.I'], 0.09908047, 1e-5)
-        assert_rel_error(self, p['circuit.R2.I'], 0.00091953, 1e-5)
-        assert_rel_error(self, p['circuit.D1.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278185, 1e-5)
+        assert_near_equal(p['circuit.R1.I'], 0.09908047, 1e-5)
+        assert_near_equal(p['circuit.R2.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.D1.I'], 0.00091953, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_plain_newton_many_iter(self):
 
@@ -149,11 +149,11 @@ class TestCircuit(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.98744708, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 8.73215484, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.98744708, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 8.73215484, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self,  p['circuit.R1.I'] + p['circuit.D1.I'], 0.09987447, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], 0.09987447, 1e-6)
 
     def test_circuit_advanced_newton(self):
         import openmdao.api as om
@@ -186,14 +186,14 @@ class TestCircuit(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278185, 1e-5)
-        assert_rel_error(self, p['circuit.R1.I'], 0.09908047, 1e-5)
-        assert_rel_error(self, p['circuit.R2.I'], 0.00091953, 1e-5)
-        assert_rel_error(self, p['circuit.D1.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278185, 1e-5)
+        assert_near_equal(p['circuit.R1.I'], 0.09908047, 1e-5)
+        assert_near_equal(p['circuit.R2.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.D1.I'], 0.00091953, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self, p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
     def test_circuit_voltage_source(self):
         import openmdao.api as om
@@ -250,11 +250,11 @@ class TestCircuit(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 1.5, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.65113362, 1e-5)
-        assert_rel_error(self, p['circuit.R1.I'], 0.015, 1e-5)
-        assert_rel_error(self, p['circuit.R2.I'], 8.48866375e-05, 1e-5)
-        assert_rel_error(self, p['circuit.D1.I'], 8.48866375e-05, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 1.5, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.65113362, 1e-5)
+        assert_near_equal(p['circuit.R1.I'], 0.015, 1e-5)
+        assert_near_equal(p['circuit.R2.I'], 8.48866375e-05, 1e-5)
+        assert_near_equal(p['circuit.D1.I'], 8.48866375e-05, 1e-5)
 
 
 if __name__ == "__main__":

--- a/openmdao/test_suite/test_examples/test_circuit_analysis_derivs.py
+++ b/openmdao/test_suite/test_examples/test_circuit_analysis_derivs.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestNonlinearCircuit(unittest.TestCase):
@@ -141,14 +141,14 @@ class TestNonlinearCircuit(unittest.TestCase):
 
         p.run_model()
 
-        assert_rel_error(self, p['circuit.n1.V'], 9.90804735, 1e-5)
-        assert_rel_error(self, p['circuit.n2.V'], 0.71278185, 1e-5)
-        assert_rel_error(self, p['circuit.R1.I'], 0.09908047, 1e-5)
-        assert_rel_error(self, p['circuit.R2.I'], 0.00091953, 1e-5)
-        assert_rel_error(self, p['circuit.D1.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.n1.V'], 9.90804735, 1e-5)
+        assert_near_equal(p['circuit.n2.V'], 0.71278185, 1e-5)
+        assert_near_equal(p['circuit.R1.I'], 0.09908047, 1e-5)
+        assert_near_equal(p['circuit.R2.I'], 0.00091953, 1e-5)
+        assert_near_equal(p['circuit.D1.I'], 0.00091953, 1e-5)
 
         # sanity check: should sum to .1 Amps
-        assert_rel_error(self, p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
+        assert_near_equal(p['circuit.R1.I'] + p['circuit.D1.I'], .1, 1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/test_suite/test_examples/test_sellar_mda_promote_connect.py
+++ b/openmdao/test_suite/test_examples/test_sellar_mda_promote_connect.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestSellarMDAPromoteConnect(unittest.TestCase):
@@ -54,7 +54,7 @@ class TestSellarMDAPromoteConnect(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, (prob['y1'][0], prob['y2'][0], prob['obj'][0], prob['con1'][0], prob['con2'][0]),
+        assert_near_equal((prob['y1'][0], prob['y2'][0], prob['obj'][0], prob['con1'][0], prob['con2'][0]),
                          (2.10951651, -0.54758253,  6.8385845,  1.05048349, -24.54758253), 1e-5)
 
 
@@ -104,7 +104,7 @@ class TestSellarMDAPromoteConnect(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, (prob['cycle.d1.y1'][0], prob['cycle.d2.y2'][0], prob['obj_cmp.obj'][0], prob['con_cmp1.con1'][0], prob['con_cmp2.con2'][0]),
+        assert_near_equal((prob['cycle.d1.y1'][0], prob['cycle.d2.y2'][0], prob['obj_cmp.obj'][0], prob['con_cmp1.con1'][0], prob['con_cmp2.con2'][0]),
                          (2.10951651, -0.54758253, 6.8385845, 1.05048349, -24.54758253), 1e-5)
 
 
@@ -155,7 +155,7 @@ class TestSellarMDAPromoteConnect(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, (prob['d1.y1'][0], prob['d2.y2'][0], prob['obj_cmp.obj'][0], prob['con_cmp1.con1'][0], prob['con_cmp2.con2'][0]),
+        assert_near_equal((prob['d1.y1'][0], prob['d2.y2'][0], prob['obj_cmp.obj'][0], prob['con_cmp1.con1'][0], prob['con_cmp2.con2'][0]),
                          (2.10951651, -0.54758253, 6.8385845, 1.05048349, -24.54758253), 1e-5)
 
 

--- a/openmdao/test_suite/test_examples/test_sellar_opt.py
+++ b/openmdao/test_suite/test_examples/test_sellar_opt.py
@@ -1,7 +1,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestSellarOpt(unittest.TestCase):
@@ -33,11 +33,11 @@ class TestSellarOpt(unittest.TestCase):
         prob.run_driver()
 
         print('minimum found at')
-        assert_rel_error(self, prob['x'][0], 0., 1e-5)
-        assert_rel_error(self, prob['z'], [1.977639, 0.], 1e-5)
+        assert_near_equal(prob['x'][0], 0., 1e-5)
+        assert_near_equal(prob['z'], [1.977639, 0.], 1e-5)
 
         print('minumum objective')
-        assert_rel_error(self, prob['obj'][0], 3.18339395045, 1e-5)
+        assert_near_equal(prob['obj'][0], 3.18339395045, 1e-5)
 
 
 if __name__ == "__main__":

--- a/openmdao/test_suite/test_examples/test_tldr_paraboloid_b.py
+++ b/openmdao/test_suite/test_examples/test_tldr_paraboloid_b.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestParaboloidTLDR(unittest.TestCase):
@@ -33,11 +33,11 @@ class TestParaboloidTLDR(unittest.TestCase):
         #
         try:
             # minimum value
-            assert_rel_error(self, prob['paraboloid.f'], -27.33333, 1e-6)
+            assert_near_equal(prob['paraboloid.f'], -27.33333, 1e-6)
 
             # location of the minimum
-            assert_rel_error(self, prob['indeps.x'], 6.6667, 1e-4)
-            assert_rel_error(self, prob['indeps.y'], -7.33333, 1e-4)
+            assert_near_equal(prob['indeps.x'], 6.6667, 1e-4)
+            assert_near_equal(prob['indeps.y'], -7.33333, 1e-4)
         except AssertionError as err:
             msg = str(err) + "\n If the code in this test must be changed, please go change sister example, " \
                              "tldr_paraboloid.py, and also the front page of the OpenMDAO website!"

--- a/openmdao/test_suite/test_examples/tldr_paraboloid.py
+++ b/openmdao/test_suite/test_examples/tldr_paraboloid.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestParaboloidTLDR(unittest.TestCase):
@@ -31,11 +31,11 @@ class TestParaboloidTLDR(unittest.TestCase):
         prob.run_driver()
 
         # minimum value
-        assert_rel_error(self, prob['paraboloid.f'], -27.33333, 1e-6)
+        assert_near_equal(prob['paraboloid.f'], -27.33333, 1e-6)
 
         # location of the minimum
-        assert_rel_error(self, prob['indeps.x'], 6.6667, 1e-4)
-        assert_rel_error(self, prob['indeps.y'], -7.33333, 1e-4)
+        assert_near_equal(prob['indeps.x'], 6.6667, 1e-4)
+        assert_near_equal(prob['indeps.y'], -7.33333, 1e-4)
 
 if __name__ == "__main__":
 

--- a/openmdao/test_suite/tests/test_feature_sellar.py
+++ b/openmdao/test_suite/tests/test_feature_sellar.py
@@ -4,7 +4,7 @@ import unittest
 
 import openmdao.api as om
 from openmdao.test_suite.components.sellar_feature import SellarMDA, SellarMDALinearSolver
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestSellarFeature(unittest.TestCase):
@@ -16,8 +16,8 @@ class TestSellarFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
@@ -32,20 +32,20 @@ class TestSellarFeature(unittest.TestCase):
         prob.model.cycle.nonlinear_solver.options['use_apply_nonlinear'] = True
         prob.run_model()
 
-        assert_rel_error(self, prob['y1'], 25.58830273, .00001)
-        assert_rel_error(self, prob['y2'], 12.05848819, .00001)
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
 
         # Make sure we aren't iterating like crazy
         self.assertLess(prob.model.nonlinear_solver._iter_count, 8)
 
         jac = prob.compute_totals(of=['obj', 'con1', 'con2'], wrt=['x', 'z'])
 
-        assert_rel_error(self, jac['obj', 'x'][0], 2.98061391, 1e-4)
-        assert_rel_error(self, jac['obj', 'z'][0], [9.61001154, 1.78448533], 1e-4)
-        assert_rel_error(self, jac['con1', 'x'][0], -0.98061447, 1e-4)
-        assert_rel_error(self, jac['con1', 'z'][0], [-9.61002284, -0.78449158], 1e-4)
-        assert_rel_error(self, jac['con2', 'x'][0], 0.09692762, 1e-4)
-        assert_rel_error(self, jac['con2', 'z'][0], [1.94989079, 1.0775421], 1e-4)
+        assert_near_equal(jac['obj', 'x'][0], 2.98061391, 1e-4)
+        assert_near_equal(jac['obj', 'z'][0], [9.61001154, 1.78448533], 1e-4)
+        assert_near_equal(jac['con1', 'x'][0], -0.98061447, 1e-4)
+        assert_near_equal(jac['con1', 'z'][0], [-9.61002284, -0.78449158], 1e-4)
+        assert_near_equal(jac['con2', 'x'][0], 0.09692762, 1e-4)
+        assert_near_equal(jac['con2', 'z'][0], [1.94989079, 1.0775421], 1e-4)
 
 
 if __name__ == "__main__":

--- a/openmdao/test_suite/tests/test_general.py
+++ b/openmdao/test_suite/tests/test_general.py
@@ -32,7 +32,7 @@ CycleGroup ('group_type': 'cycle')
 import unittest
 
 from openmdao.test_suite.parametric_suite import parametric_suite
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class ParameterizedTestCases(unittest.TestCase):
@@ -48,7 +48,7 @@ class ParameterizedTestCases(unittest.TestCase):
         expected_values = root.expected_values
         if expected_values:
             actual = {key: problem[key] for key in expected_values}
-            assert_rel_error(self, actual, expected_values, 1e-8)
+            assert_near_equal(actual, expected_values, 1e-8)
 
         error_bound = 1e-4 if root.options['partial_method'] != 'exact' else 1e-8
 
@@ -56,11 +56,11 @@ class ParameterizedTestCases(unittest.TestCase):
         if expected_totals:
             # Forward Derivatives Check
             totals = test.compute_totals('fwd')
-            assert_rel_error(self, totals, expected_totals, error_bound)
+            assert_near_equal(totals, expected_totals, error_bound)
 
             # Reverse Derivatives Check
             totals = test.compute_totals('rev')
-            assert_rel_error(self, totals, expected_totals, error_bound)
+            assert_near_equal(totals, expected_totals, error_bound)
 
 
 class ParameterizedTestCasesSubset(unittest.TestCase):
@@ -78,21 +78,21 @@ class ParameterizedTestCasesSubset(unittest.TestCase):
         expected_values = model.expected_values
         if expected_values:
             actual = {key: problem[key] for key in expected_values}
-            assert_rel_error(self, actual, expected_values, 1e-8)
+            assert_near_equal(actual, expected_values, 1e-8)
 
         expected_totals = model.expected_totals
         if expected_totals:
             # Reverse Derivatives Check
             totals = param_instance.compute_totals('rev')
-            assert_rel_error(self, totals, expected_totals, 1e-8)
+            assert_near_equal(totals, expected_totals, 1e-8)
 
             # Forward Derivatives Check
             totals = param_instance.compute_totals('fwd')
-            assert_rel_error(self, totals, expected_totals, 1e-8)
+            assert_near_equal(totals, expected_totals, 1e-8)
 
             # Reverse Derivatives Check
             totals = param_instance.compute_totals('rev')
-            assert_rel_error(self, totals, expected_totals, 1e-8)
+            assert_near_equal(totals, expected_totals, 1e-8)
 
 
 if __name__ == '__main__':

--- a/openmdao/test_suite/tests/test_paraboloid_feature.py
+++ b/openmdao/test_suite/tests/test_paraboloid_feature.py
@@ -3,7 +3,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.paraboloid_feature import Paraboloid
 
 
@@ -24,7 +24,7 @@ class TestSellarFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        assert_rel_error(self, prob['comp.f_xy'], -15.0)
+        assert_near_equal(prob['comp.f_xy'], -15.0)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -14,6 +14,7 @@ from openmdao.core.component import Component
 from openmdao.core.group import Group
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.general_utils import pad_name, reset_warning_registry
+from openmdao.utils.general_utils import warn_deprecation
 
 
 @contextmanager
@@ -42,7 +43,8 @@ def assert_warning(category, msg):
         if (issubclass(warn.category, category) and str(warn.message) == msg):
             break
     else:
-        raise AssertionError("Did not see expected %s: %s" % (category.__name__, msg))
+        raise AssertionError("Did not see expected %s: %s" %
+                             (category.__name__, msg))
 
 
 @contextmanager
@@ -118,7 +120,8 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
                             wrt_string = '{0} wrt {1}'.format(var, wrt)
                             norm_string = '{}'.format(norm)
                             len_wrt_width = max(len_wrt_width, len(wrt_string))
-                            len_norm_width = max(len_norm_width, len(norm_string))
+                            len_norm_width = max(
+                                len_norm_width, len(norm_string))
 
                     elif error_type == 'abs error' and norm_type == 'fwd-fd':
                         # Capturing case where computed partials or output are NaN.
@@ -140,7 +143,8 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
                                 norm_string = '{}'.format(norm)
                                 err_msg = '{0} | {1} | {2} | {3}'.format(
                                     pad_name(wrt_string, len_wrt_width),
-                                    pad_name(error_type.split()[0], len_absrel_width),
+                                    pad_name(error_type.split()[
+                                             0], len_absrel_width),
                                     pad_name(norm_type, len_norm_type_width),
                                     pad_name(norm_string, len_norm_width)) + '\n'
                                 comp_error_string += err_msg
@@ -151,7 +155,8 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
                             norm_string = '{}'.format(norm)
                             err_msg = '{0} | {1} | {2} | {3}'.format(
                                 pad_name(wrt_string, len_wrt_width),
-                                pad_name(error_type.split()[0], len_absrel_width),
+                                pad_name(error_type.split()[
+                                         0], len_absrel_width),
                                 pad_name(norm_type, len_norm_type_width),
                                 pad_name(norm_string, len_norm_width)) + '\n'
                             comp_error_string += err_msg
@@ -179,7 +184,8 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
     # if error string then raise error with that string
     if error_string:
         header_line1 = 'Assert Check Partials failed for the following Components'
-        header_line2 = 'with absolute tolerance = {} and relative tolerance = {}'.format(atol, rtol)
+        header_line2 = 'with absolute tolerance = {} and relative tolerance = {}'.format(
+            atol, rtol)
         header_width = max(len(header_line1), len(header_line2))
         header = '\n' + header_width * '=' + '\n'
         header += header_line1 + '\n'
@@ -273,6 +279,9 @@ def assert_rel_error(test_case, actual, desired, tolerance=1e-15):
     float
         The error.
     """
+    warn_deprecation("'assert_rel_error' has been deprecated. Use "
+                     "'assert_near_equal' instead.")
+
     if isinstance(actual, dict) and isinstance(desired, dict):
 
         actual_keys = set(actual.keys())
@@ -288,7 +297,8 @@ def assert_rel_error(test_case, actual, desired, tolerance=1e-15):
 
         for key in actual_keys:
             try:
-                new_error = assert_rel_error(test_case, actual[key], desired[key], tolerance)
+                new_error = assert_rel_error(
+                    test_case, actual[key], desired[key], tolerance)
                 error = max(error, new_error)
             except test_case.failureException as exception:
                 msg = '{}: '.format(key) + str(exception)
@@ -332,6 +342,94 @@ def assert_rel_error(test_case, actual, desired, tolerance=1e-15):
             else:
                 test_case.fail('arrays do not match, rel error %.3e > tol (%.3e)' %
                                (error, tolerance))
+
+    return error
+
+
+def assert_near_equal(actual, desired, tolerance=1e-15):
+    """
+    Check relative error.
+
+    Determine that the relative error between `actual` and `desired`
+    is within `tolerance`. If `desired` is zero, then use absolute error.
+
+    Parameters
+    ----------
+    actual : float, array-like, dict
+        The value from the test.
+    desired : float, array-like, dict
+        The value expected.
+    tolerance : float
+        Maximum relative error ``(actual - desired) / desired``.
+
+    Returns
+    -------
+    float
+        The error.
+    """
+    if isinstance(actual, dict) and isinstance(desired, dict):
+
+        actual_keys = set(actual.keys())
+        desired_keys = set(desired.keys())
+
+        if actual_keys.symmetric_difference(desired_keys):
+            msg = 'Actual and desired keys differ. Actual extra keys: {}, Desired extra keys: {}'
+            actual_extra = actual_keys.difference(desired_keys)
+            desired_extra = desired_keys.difference(actual_keys)
+            raise KeyError(msg.format(actual_extra, desired_extra))
+
+        error = 0.
+
+        for key in actual_keys:
+            try:
+                new_error = assert_near_equal(
+                    actual[key], desired[key], tolerance)
+                error = max(error, new_error)
+            except ValueError as exception:
+                msg = '{}: '.format(key) + str(exception)
+                raise ValueError(msg) from None
+            except KeyError as exception:
+                msg = '{}: '.format(key) + str(exception)
+                raise KeyError(msg) from None
+
+    elif isinstance(actual, float) and isinstance(desired, float):
+        if isnan(actual) and not isnan(desired):
+            raise ValueError('actual nan, desired %s' % desired)
+        if desired != 0:
+            error = (actual - desired) / desired
+        else:
+            error = actual
+        if abs(error) > tolerance:
+            raise ValueError('actual %s, desired %s, rel error %s, tolerance %s'
+                             % (actual, desired, error, tolerance))
+
+    # array values
+    else:
+        actual = np.atleast_1d(actual)
+        desired = np.atleast_1d(desired)
+        if actual.shape != desired.shape:
+            raise ValueError(
+                'actual and desired have differing shapes.'
+                ' actual {}, desired {}'.format(actual.shape, desired.shape))
+        if not np.all(np.isnan(actual) == np.isnan(desired)):
+            if actual.size == 1 and desired.size == 1:
+                raise ValueError('actual %s, desired %s' % (actual, desired))
+            else:
+                raise ValueError('actual and desired values have non-matching nan'
+                                 ' values')
+
+        if np.linalg.norm(desired) == 0:
+            error = np.linalg.norm(actual)
+        else:
+            error = np.linalg.norm(actual - desired) / np.linalg.norm(desired)
+
+        if abs(error) > tolerance:
+            if actual.size < 10 and desired.size < 10:
+                raise ValueError('actual %s, desired %s, rel error %s, tolerance %s'
+                                 % (actual, desired, error, tolerance))
+            else:
+                raise ValueError('arrays do not match, rel error %.3e > tol (%.3e)' %
+                                 (error, tolerance))
 
     return error
 

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -43,8 +43,7 @@ def assert_warning(category, msg):
         if (issubclass(warn.category, category) and str(warn.message) == msg):
             break
     else:
-        raise AssertionError("Did not see expected %s: %s" %
-                             (category.__name__, msg))
+        raise AssertionError("Did not see expected %s: %s" % (category.__name__, msg))
 
 
 @contextmanager
@@ -120,8 +119,7 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
                             wrt_string = '{0} wrt {1}'.format(var, wrt)
                             norm_string = '{}'.format(norm)
                             len_wrt_width = max(len_wrt_width, len(wrt_string))
-                            len_norm_width = max(
-                                len_norm_width, len(norm_string))
+                            len_norm_width = max(len_norm_width, len(norm_string))
 
                     elif error_type == 'abs error' and norm_type == 'fwd-fd':
                         # Capturing case where computed partials or output are NaN.
@@ -143,8 +141,7 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
                                 norm_string = '{}'.format(norm)
                                 err_msg = '{0} | {1} | {2} | {3}'.format(
                                     pad_name(wrt_string, len_wrt_width),
-                                    pad_name(error_type.split()[
-                                             0], len_absrel_width),
+                                    pad_name(error_type.split()[0], len_absrel_width),
                                     pad_name(norm_type, len_norm_type_width),
                                     pad_name(norm_string, len_norm_width)) + '\n'
                                 comp_error_string += err_msg
@@ -155,8 +152,7 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
                             norm_string = '{}'.format(norm)
                             err_msg = '{0} | {1} | {2} | {3}'.format(
                                 pad_name(wrt_string, len_wrt_width),
-                                pad_name(error_type.split()[
-                                         0], len_absrel_width),
+                                pad_name(error_type.split()[0], len_absrel_width),
                                 pad_name(norm_type, len_norm_type_width),
                                 pad_name(norm_string, len_norm_width)) + '\n'
                             comp_error_string += err_msg
@@ -184,8 +180,7 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6):
     # if error string then raise error with that string
     if error_string:
         header_line1 = 'Assert Check Partials failed for the following Components'
-        header_line2 = 'with absolute tolerance = {} and relative tolerance = {}'.format(
-            atol, rtol)
+        header_line2 = 'with absolute tolerance = {} and relative tolerance = {}'.format(atol, rtol)
         header_width = max(len(header_line1), len(header_line2))
         header = '\n' + header_width * '=' + '\n'
         header += header_line1 + '\n'
@@ -297,8 +292,7 @@ def assert_rel_error(test_case, actual, desired, tolerance=1e-15):
 
         for key in actual_keys:
             try:
-                new_error = assert_rel_error(
-                    test_case, actual[key], desired[key], tolerance)
+                new_error = assert_rel_error(test_case, actual[key], desired[key], tolerance)
                 error = max(error, new_error)
             except test_case.failureException as exception:
                 msg = '{}: '.format(key) + str(exception)

--- a/openmdao/utils/tests/test_array_utils.py
+++ b/openmdao/utils/tests/test_array_utils.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from openmdao.utils.array_utils import array_connection_compatible, abs_complex, dv_abs_complex
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestArrayConnectionCompatible(unittest.TestCase):
@@ -63,7 +63,7 @@ class TestArrayUtils(unittest.TestCase):
 
         row = np.array([1.0 + 2j, 1.0 + 2j, 1.0 + 2j])
         dy_check = np.vstack((row, -row, -row, -row))
-        assert_rel_error(self, dy, dy_check, 1e-10)
+        assert_near_equal(dy, dy_check, 1e-10)
 
 
 if __name__ == "__main__":

--- a/openmdao/utils/tests/test_file_wrap.py
+++ b/openmdao/utils/tests/test_file_wrap.py
@@ -8,7 +8,7 @@ import shutil
 
 import unittest
 
-from openmdao.utils.assert_utils import assert_rel_error, assert_equal_arrays
+from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays
 
 import numpy
 from numpy import array, isnan, isinf
@@ -794,7 +794,7 @@ class FileParserFeature(unittest.TestCase):
         parser.mark_anchor("LOAD CASE")
         var = parser.transfer_array(2, 2, 2, 5)
 
-        assert_rel_error(self, var, numpy.array([2.1, 4.6, 3.1, 2.22234]))
+        assert_near_equal(var, numpy.array([2.1, 4.6, 3.1, 2.22234]))
 
     def test_parse_array_multiline(self):
         parser.reset_anchor()
@@ -920,7 +920,7 @@ class FileParserArrayColumnsFeature(unittest.TestCase):
 
         parser.set_delimiters(" \t")
 
-        assert_rel_error(self, var,
+        assert_near_equal(var,
                          numpy.array([11., 22., 33., 44., 55., 66.]))
 
 

--- a/openmdao/utils/tests/test_options_dictionary_feature.py
+++ b/openmdao/utils/tests/test_options_dictionary_feature.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestOptionsDictionaryFeature(unittest.TestCase):
@@ -22,7 +22,7 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
         prob['inputs.x'] = [1., 2., 3.]
 
         prob.run_model()
-        assert_rel_error(self, prob['double.y'], [2., 4., 6.])
+        assert_near_equal(prob['double.y'], [2., 4., 6.])
 
     def test_simple_fail(self):
         import openmdao.api as om
@@ -71,7 +71,7 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['a_comp.y'], [5., 10., 15.])
+        assert_near_equal(prob['a_comp.y'], [5., 10., 15.])
 
     def test_simple_function(self):
         import openmdao.api as om
@@ -91,7 +91,7 @@ class TestOptionsDictionaryFeature(unittest.TestCase):
 
         prob.run_model()
 
-        assert_rel_error(self, prob['f_comp.y'], 10.)
+        assert_near_equal(prob['f_comp.y'], 10.)
 
 
 if __name__ == "__main__":

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -3,7 +3,7 @@
 import os
 import unittest
 
-# from openmdao.utils.assert_utils import assert_rel_error
+# from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, \
     add_unit, add_offset_unit, get_conversion
 

--- a/openmdao/utils/tests/test_visualization.py
+++ b/openmdao/utils/tests/test_visualization.py
@@ -8,7 +8,7 @@ except ImportError:
     matplotlib = None
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 @unittest.skipUnless(matplotlib, "Matplotlib is required.")
 class TestVisualization(unittest.TestCase):
@@ -65,19 +65,19 @@ class TestVisualization(unittest.TestCase):
                                    [1., 0., 1., 0.],
                                    [0., 1., 0., 1.]])
         actual_array = ax[0].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
         expected_array = np.array([[ 1.,  0.,  0.,  1.],
                                    [ 0.,  1.,  1.,  0.],
                                    [ 1.,  0.,  1.,  0.],
                                    [ 0.,  1.,  0.,  1.]])
         actual_array = ax[1].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
         expected_array = np.array([[  9.31322575e-10,   0.0,   0.0, 1.0e-07],
                                    [  0.0,   0.0,  -2.0e-07, 0.0],
                                    [  0.0,   0.0,   9.31322575e-10, 0.0],
                                    [  0.0,   0.0,   0.0, 1.86264515e-09]])
         actual_array = ax[2].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
 
         # plot with specified jac_method
         fig, ax = om.partial_deriv_plot('y1', 'x1', check_partials_data, jac_method = "J_rev",
@@ -87,19 +87,19 @@ class TestVisualization(unittest.TestCase):
                                    [1., 0., 1., 0.],
                                    [0., 1., 0., 1.]])
         actual_array = ax[0].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
         expected_array = np.array([[ 1.,  0.,  0.,  1.],
                                    [ 0.,  1.,  1.,  0.],
                                    [ 1.,  0.,  1.,  0.],
                                    [ 0.,  1.,  0.,  1.]])
         actual_array = ax[1].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
         expected_array = np.array([[  9.31322575e-10,   0.0,   0.0, 1.0e-07],
                                    [  0.0,   0.0,  -2.0e-07, 0.0],
                                    [  0.0,   0.0,   9.31322575e-10, 0.0],
                                    [  0.0,   0.0,   0.0, 1.86264515e-09]])
         actual_array = ax[2].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
 
         # plot in non-binary mode
         fig, ax = om.partial_deriv_plot('y1', 'x1', check_partials_data, binary = False,
@@ -109,19 +109,19 @@ class TestVisualization(unittest.TestCase):
                                    [-1. ,  0. ,  8. ,  0. ],
                                    [ 0. ,  4. ,  0. ,  6. ]])
         actual_array = ax[0].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
         expected_array = np.array([[  1.0e+00,   0.0,   0.0, 7.00000010e+00],
                                    [  0.0,   2.5e+00,  -2.0e-07, 0.0],
                                    [ -1.0e+00,   0.0,   8.0e+00, 0.0],
                                    [  0.0,   4.0e+00,   0.0, 6.0e+00]])
         actual_array = ax[1].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
         expected_array = np.array([[  9.31322575e-10,   0.0,   0.0, 1.0e-07],
                                    [  0.0,   0.0,  -2.0e-07, 0.0],
                                    [  0.0,   0.0,   9.31322575e-10, 0.0],
                                    [  0.0,   0.0,   0.0, 1.86264515e-09]])
         actual_array = ax[2].images[0]._A.data
-        assert_rel_error(self, expected_array, actual_array, 1e-8)
+        assert_near_equal(expected_array, actual_array, 1e-8)
 
         # plot with different tol values
         # Not obvious how to test this other than image matching

--- a/openmdao/vectors/tests/test_vector.py
+++ b/openmdao/vectors/tests/test_vector.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
 try:
@@ -152,13 +152,13 @@ class TestPETScVector2Proc(unittest.TestCase):
         vec = prob.model._vectors['output']['nonlinear']
         norm_val = vec.get_norm()
 
-        assert_rel_error(self, norm_val, 0.22595230821097395, 1e-10)
+        assert_near_equal(norm_val, 0.22595230821097395, 1e-10)
 
         # test petsc dot while we're at it
         vec.set_const(3.)
         vec2 = prob.model._vectors['residual']['linear']
         vec2.set_const(4.)
-        assert_rel_error(self, vec.dot(vec2), 12.*6, 1e-10)
+        assert_near_equal(vec.dot(vec2), 12.*6, 1e-10)
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestPETScVector3Proc(unittest.TestCase):
@@ -184,13 +184,13 @@ class TestPETScVector3Proc(unittest.TestCase):
         vec = prob.model._vectors['output']['nonlinear']
         norm_val = vec.get_norm()
 
-        assert_rel_error(self, norm_val, 0.22595230821097395, 1e-10)
+        assert_near_equal(norm_val, 0.22595230821097395, 1e-10)
 
         # test petsc dot while we're at it
         vec.set_const(3.)
         vec2 = prob.model._vectors['residual']['linear']
         vec2.set_const(4.)
-        assert_rel_error(self, vec.dot(vec2), 12.*6, 1e-10)
+        assert_near_equal(vec.dot(vec2), 12.*6, 1e-10)
 
     def test_distributed_norm_parallel_group(self):
         prob = om.Problem()
@@ -218,19 +218,19 @@ class TestPETScVector3Proc(unittest.TestCase):
 
         vec = prob.model._vectors['output']['nonlinear']
         norm_val = vec.get_norm()
-        assert_rel_error(self, norm_val, 89.61584681293817, 1e-10)
+        assert_near_equal(norm_val, 89.61584681293817, 1e-10)
 
         J = prob.compute_totals(of=['pp.calc1.y', 'pp.calc2.y', 'pp.calc3.y'], wrt=['des_vars.v1'])
 
         vec = prob.model._vectors['output']['linear']
         norm_val = vec.get_norm()
-        assert_rel_error(self, norm_val, 8.888194417315589, 1e-10)
+        assert_near_equal(norm_val, 8.888194417315589, 1e-10)
 
         # test petsc dot while we're at it
         vec.set_const(3.)
         vec2 = prob.model._vectors['residual']['linear']
         vec2.set_const(4.)
-        assert_rel_error(self, vec.dot(vec2), 12.*13, 1e-10)
+        assert_near_equal(vec.dot(vec2), 12.*13, 1e-10)
 
 
 if __name__ == '__main__':

--- a/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
@@ -12,7 +12,7 @@ except ImportError:
     bokeh = None
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_rel_error
+from openmdao.utils.assert_utils import assert_near_equal
 
 @unittest.skipUnless(bokeh, "Bokeh is required")
 class UnstructuredMetaModelCompTests(unittest.TestCase):
@@ -325,8 +325,8 @@ class UnstructuredMetaModelCompTests(unittest.TestCase):
         bottom_plot = adjusted_points._bottom_plot()
         bottom_transparency = adjusted_points.bottom_alphas
 
-        assert_rel_error(self, right_transparency, known_points_right, 1.1e-02)
-        assert_rel_error(self, bottom_transparency, known_points_bottom, 1.6e-02)
+        assert_near_equal(right_transparency, known_points_right, 1.1e-02)
+        assert_near_equal(bottom_transparency, known_points_bottom, 1.6e-02)
 
 
 


### PR DESCRIPTION
### Summary

- New function called `assert_near_equal()` because `assert_almost_equal()` conflicts with numpy function of the same name
- `assert_near_equal()` has the same behavior as `assert_rel_error()`, but drops testcase as the first argument, raises `ValueError` if the value is not within tolerance, or `KeyError` if there's a mismatch in the number of dictionary keys
- Added deprecation warning to `assert_rel_error()`
- Replaced all instances of `assert_rel_error()` with `assert_near_equal()`

### Related Issues

- Resolves #1260

### Backwards incompatibilities

None

### New Dependencies

None
