### PR TITLE
I1271 deprecate system metadata

### DIFF
--- a/openmdao/docs/features/recording/reading_metadata.rst
+++ b/openmdao/docs/features/recording/reading_metadata.rst
@@ -18,22 +18,22 @@ a `CaseReader`.
     openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_problem_metadata
     :layout: interleave
 
-System Metadata
-----------------
+System Options
+--------------
 
 Systems record both scaling factors and options within 'scaling_factors' and 'component_options',
-respectively, in :code:`system_metadata`.
+respectively, in :code:`system_options`.
 
 The component options include user-defined options that were defined
 through the :code:`system.options.declare` method. By default, everything in options is
 pickled and recorded. If there are options that cannot be pickled or you simply do not wish
 to record, they can be excluded using the 'options_excludes' recording option on the system.
 
-By setting the :code:`record_model_metadata` option on `Driver`, you can record the metadata
+By setting the :code:`record_model_metadata` option on `Driver`, you can record the options
 for every system in the model.
 
 .. embed-code::
-    openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_system_metadata
+    openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_recording_system_options
     :layout: interleave
 
 .. note::

--- a/openmdao/docs/features/recording/reading_metadata.rst
+++ b/openmdao/docs/features/recording/reading_metadata.rst
@@ -29,9 +29,6 @@ through the :code:`system.options.declare` method. By default, everything in opt
 pickled and recorded. If there are options that cannot be pickled or you simply do not wish
 to record, they can be excluded using the 'options_excludes' recording option on the system.
 
-By setting the :code:`record_model_metadata` option on `Driver`, you can record the options
-for every system in the model.
-
 .. embed-code::
     openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_recording_system_options
     :layout: interleave

--- a/openmdao/docs/features/recording/saving_data.rst
+++ b/openmdao/docs/features/recording/saving_data.rst
@@ -75,7 +75,7 @@ System Recording Options
 System Recording Example
 ^^^^^^^^^^^^^^^^^^^^^^^^
 .. embed-code::
-    openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_system_options
+    openmdao.recorders.tests.test_sqlite_recorder.TestFeatureSqliteRecorder.test_feature_system_recording_options
     :layout: interleave
 
 Solver Recording Options

--- a/openmdao/recorders/base_case_reader.py
+++ b/openmdao/recorders/base_case_reader.py
@@ -2,6 +2,8 @@
 Base class for all CaseReaders.
 """
 
+from openmdao.utils.assert_utils import warn_deprecation
+
 
 class BaseCaseReader(object):
     """
@@ -15,7 +17,7 @@ class BaseCaseReader(object):
         Metadata about the problem, including the system hierachy and connections.
     solver_metadata : dict
         The solver options for each solver in the recorded model.
-    system_metadata : dict
+    system_options : dict
         Metadata about each system in the recorded model, including options and scaling factors.
     """
 
@@ -33,7 +35,21 @@ class BaseCaseReader(object):
         self._format_version = None
         self.problem_metadata = {}
         self.solver_metadata = {}
-        self.system_metadata = {}
+        self.system_options = {}
+
+    @property
+    def system_metadata(self):
+        """
+        Provide 'system_metadata' property for backwards compatibility.
+
+        Returns
+        -------
+        dict
+            reference to the 'system_options' attribute.
+        """
+        warn_deprecation("The BaseCaseReader.system_metadata attribute is deprecated. "
+                         "Use the BaseCaseReader.system_option attribute instead.")
+        return self.system_options
 
     def get_cases(self, source, recurse=True, flat=False):
         """

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -28,7 +28,7 @@ class SqliteCaseReader(BaseCaseReader):
         Metadata about the problem, including the system hierachy and connections.
     solver_metadata : dict
         The solver options for each solver in the recorded model.
-    system_metadata : dict
+    system_options : dict
         Metadata about each system in the recorded model, including options and scaling factors.
     _format_version : int
         The version of the format assumed when loading the file.
@@ -101,7 +101,7 @@ class SqliteCaseReader(BaseCaseReader):
 
             # collect data from the system_metadata table. this includes:
             #   component metadata and scaling factors for each system,
-            #   which is added to system_metadata
+            #   which is added to system_options
             self._collect_system_metadata(cur)
 
             # collect data from the solver_metadata table. this includes:
@@ -223,7 +223,7 @@ class SqliteCaseReader(BaseCaseReader):
         """
         Load data from the system table.
 
-        Populates the `system_metadata` attribute of this CaseReader.
+        Populates the `system_options` attribute of this CaseReader.
 
         Parameters
         ----------
@@ -233,10 +233,10 @@ class SqliteCaseReader(BaseCaseReader):
         cur.execute("SELECT id, scaling_factors, component_metadata FROM system_metadata")
         for row in cur:
             id = row[0]
-            self.system_metadata[id] = {}
+            self.system_options[id] = {}
 
-            self.system_metadata[id]['scaling_factors'] = pickle.loads(row[1])
-            self.system_metadata[id]['component_options'] = pickle.loads(row[2])
+            self.system_options[id]['scaling_factors'] = pickle.loads(row[1])
+            self.system_options[id]['component_options'] = pickle.loads(row[2])
 
     def _collect_solver_metadata(self, cur):
         """

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1944,7 +1944,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         prob.cleanup()
         cr = om.CaseReader(self.filename)
-        subs_options = cr.system_metadata['subs']['component_options']
+        subs_options = cr.system_options['subs']['component_options']
 
         # no options should have been recorded for d1
         self.assertEqual(len(subs_options._dict), 0)
@@ -1980,7 +1980,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         self.assertEqual(cr._format_version, format_version)
 
-        self.assertEqual(set(cr.system_metadata.keys()),
+        self.assertEqual(set(cr.system_options.keys()),
                          set(['root'] + [sys.name for sys in prob.model._subsystems_allprocs]))
 
         self.assertEqual(set(cr.problem_metadata.keys()), {
@@ -2008,7 +2008,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         self.assertEqual(cr._format_version, format_version)
 
-        self.assertEqual(set(cr.system_metadata.keys()),
+        self.assertEqual(set(cr.system_options.keys()),
                          set(['root'] + [sys.name for sys in prob.model._subsystems_allprocs]))
 
         self.assertEqual(set(cr.problem_metadata.keys()), {
@@ -2788,6 +2788,19 @@ class TestSqliteCaseReader(unittest.TestCase):
             num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
             self.assertEqual(num_non_empty_lines, 49)
 
+    def test_system_metadata_attribute_deprecated(self):
+        model = om.Group()
+        model.add_recorder(self.recorder)
+        prob = om.Problem(model)
+        prob.setup()
+        prob.run_model()
+        prob.cleanup()
+
+        cr = om.CaseReader(self.filename)
+        msg = "The BaseCaseReader.system_metadata attribute is deprecated. " \
+        "Use the BaseCaseReader.system_option attribute instead."
+        with assert_warning(DeprecationWarning, msg):
+            options = cr.system_metadata
 
 @use_tempdirs
 class TestFeatureSqliteReader(unittest.TestCase):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -474,7 +474,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
-        self.assertEqual(len(cr.system_metadata.keys()), 0)
+        self.assertEqual(len(cr.system_options.keys()), 0)
 
     def test_system_record_model_metadata(self):
         # first check to see if recorded recursively, which is the default
@@ -491,9 +491,9 @@ class TestSqliteRecorder(unittest.TestCase):
         cr = om.CaseReader("cases.sql")
         # Quick check to see that keys and values were recorded
         for key in ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']:
-            self.assertTrue(key in cr.system_metadata.keys())
+            self.assertTrue(key in cr.system_options.keys())
 
-        value = cr.system_metadata['root']['component_options']['assembled_jac_type']
+        value = cr.system_options['root']['component_options']['assembled_jac_type']
         self.assertEqual(value, 'csc')  # quick check only. Too much to check exhaustively
 
         # second check to see if not recorded recursively, when option set to False
@@ -509,8 +509,8 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
-        self.assertEqual(list(cr.system_metadata.keys()), ['root'])
-        self.assertEqual(cr.system_metadata['root']['component_options']['assembled_jac_type'],
+        self.assertEqual(list(cr.system_options.keys()), ['root'])
+        self.assertEqual(cr.system_options['root']['component_options']['assembled_jac_type'],
                          'csc')
 
     def test_driver_record_model_metadata(self):
@@ -527,9 +527,9 @@ class TestSqliteRecorder(unittest.TestCase):
         cr = om.CaseReader("cases.sql")
         # Quick check to see that keys and values were recorded
         for key in ['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']:
-            self.assertTrue(key in cr.system_metadata.keys())
+            self.assertTrue(key in cr.system_options.keys())
 
-        value = cr.system_metadata['root']['component_options']['assembled_jac_type']
+        value = cr.system_options['root']['component_options']['assembled_jac_type']
         self.assertEqual(value, 'csc')  # quick check only. Too much to check exhaustively
 
         prob = om.Problem(model=SellarDerivatives())
@@ -544,7 +544,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
-        self.assertEqual(len(cr.system_metadata.keys()), 0)
+        self.assertEqual(len(cr.system_options.keys()), 0)
 
     def test_without_n2_data(self):
         prob = SellarProblem()
@@ -2001,7 +2001,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(metadata['d1.NonlinearBlockGS']['solver_options']['maxiter'], 5)
         self.assertEqual(metadata['root.NonlinearBlockGS']['solver_options']['maxiter'], 10)
 
-    def test_feature_system_metadata(self):
+    def test_feature_recording_system_options(self):
         import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
@@ -2027,7 +2027,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         cr = om.CaseReader("cases.sql")
 
         # metadata for all the systems in the model
-        metadata = cr.system_metadata
+        metadata = cr.system_options
 
         self.assertEqual(sorted(metadata.keys()),
                          sorted(['root', 'px', 'pz', 'd1', 'd2', 'obj_cmp', 'con_cmp1', 'con_cmp2']))
@@ -2036,7 +2036,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(metadata['d1']['component_options']['distributed'], False)
         self.assertEqual(metadata['d1']['component_options']['options value 1'], 1)
 
-    def test_feature_system_options(self):
+    def test_feature_system_recording_options(self):
         import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 


### PR DESCRIPTION
### Summary

SqliteCaseReader.system_metadata and BaseCaseReader.system_metadata are deprecated and replaced with system_options

### Related Issues

- Resolves #1271

### Backwards incompatibilities

None

### New Dependencies

None
