### PR TITLE
Fix a bug where a driver's response indices were being changed during total derivative computation.

### DIFF
--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -471,7 +471,7 @@ class _TotalJacInfo(object):
                     # if the var is not distributed, global_size == local size
                     irange = np.arange(in_var_meta['global_size'], dtype=INT_DTYPE)
                 else:
-                    irange = in_idxs
+                    irange = in_idxs.copy()
                     # correct for any negative indices
                     irange[in_idxs < 0] += in_var_meta['global_size']
 


### PR DESCRIPTION
### Summary

The indices just needed to be copied before mucking with them.

### Related Issues

- Resolves #1287

### Backwards incompatibilities

None

### New Dependencies

None
