### PR TITLE
Raise error if DirectSolver or BroydenSolver are above a parallel group or distributed component.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -78,7 +78,8 @@ class Group(System):
     _setup_procs_finished : bool
         Flag to check if setup_procs is complete
     _has_distrib_vars : bool
-        If True, this Group contains distributed variables.
+        If True, this Group contains distributed variables. Only used to determine if a parallel
+        group or distributed component is below a DirectSolver so that we can raise an exception.
     _raise_connection_errors : bool
         Flag indicating whether connection errors are raised as an Exception.
     """
@@ -741,7 +742,10 @@ class Group(System):
                                                        INT_DTYPE)
 
                 for ind, subsys in enumerate(self._subsystems_myproc):
-                    if isinstance(subsys, Component) and subsys.options['distributed']:
+                    if isinstance(subsys, Component):
+                        if subsys.options['distributed']:
+                            n_distrib_vars += 1
+                    elif subsys._has_distrib_vars or subsys._mpi_proc_allocator.parallel:
                         n_distrib_vars += 1
 
                     if vec_name not in subsys._rel_vec_names:

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -858,8 +858,65 @@ class TestDirectSolverRemoteErrors(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        self.assertEqual(str(cm.exception),
-                         "Group (<model>) has a DirectSolver solver and contains a distributed system.")
+        msg = "DirectSolver linear solver in Group (<model>) cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_distrib_direct_subbed(self):
+        size = 3
+        prob = om.Problem()
+        group = prob.model = om.Group()
+
+        group.add_subsystem('P', om.IndepVarComp('x', np.arange(size)))
+        sub = group.add_subsystem('sub', om.Group())
+
+        sub.add_subsystem('C1', DistribExecComp(['y=2.0*x', 'y=3.0*x'], arr_size=size,
+                                                x=np.zeros(size),
+                                                y=np.zeros(size)))
+        sub.add_subsystem('C2', om.ExecComp(['z=3.0*y'],
+                                            y=np.zeros(size),
+                                            z=np.zeros(size)))
+
+        prob.model.linear_solver = om.DirectSolver()
+        group.connect('P.x', 'sub.C1.x')
+        group.connect('sub.C1.y', 'sub.C2.y')
+
+        prob.setup(check=False, mode='fwd')
+        with self.assertRaises(Exception) as cm:
+            prob.run_model()
+
+        msg = "DirectSolver linear solver in Group (<model>) cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_par_direct_subbed(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+        model.add_subsystem('p2', om.IndepVarComp('x', 1.0))
+
+        parallel = model.add_subsystem('parallel', om.ParallelGroup())
+        parallel.add_subsystem('c1', om.ExecComp(['y=-2.0*x']))
+        parallel.add_subsystem('c2', om.ExecComp(['y=5.0*x']))
+
+        model.add_subsystem('c3', om.ExecComp(['y=3.0*x1+7.0*x2']))
+
+        model.connect("parallel.c1.y", "c3.x1")
+        model.connect("parallel.c2.y", "c3.x2")
+
+        model.connect("p1.x", "parallel.c1.x")
+        model.connect("p2.x", "parallel.c2.x")
+
+        model.linear_solver = om.DirectSolver()
+
+        prob.setup(check=False, mode='fwd')
+        with self.assertRaises(Exception) as cm:
+            prob.run_model()
+
+        msg = "DirectSolver linear solver in Group (<model>) cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
 
     def test_par_direct(self):
         prob = om.Problem()
@@ -878,8 +935,9 @@ class TestDirectSolverRemoteErrors(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        self.assertEqual(str(cm.exception),
-                         "Group (<model>) has a DirectSolver solver and contains remote variables.")
+        msg = "DirectSolver linear solver in Group (<model>) cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
 
 
 

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -770,8 +770,9 @@ class TestBryodenMPI(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        self.assertEqual(str(cm.exception),
-                         "Group (sub) has a BroydenSolver solver and contains a distributed system.")
+        msg = "BroydenSolver linear solver in Group (sub) cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
 
 
 class TestBryodenFeature(unittest.TestCase):

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -549,13 +549,9 @@ class Solver(object):
         from openmdao.core.group import Group
         if (isinstance(s, Group) and s._has_distrib_vars) or (isinstance(s, Component) and
                                                               s.options['distributed']):
-            raise RuntimeError("%s has a %s solver and contains a distributed system." %
-                               (s.msginfo, type(self).__name__))
-
-        if not (np.all(s._var_sizes['nonlinear']['output']) and
-                np.all(s._var_sizes['nonlinear']['input'])):
-            raise RuntimeError("%s has a %s solver and contains remote variables." %
-                               (s.msginfo, type(self).__name__))
+            msg = "{} linear solver in {} cannot be used in or above a ParallelGroup or a " + \
+                "distributed component."
+            raise RuntimeError(msg.format(type(self).__name__, s.msginfo))
 
 
 class NonlinearSolver(Solver):


### PR DESCRIPTION
### Summary

Raise error if DirectSolver or BroydenSolver are above a parallel group or distributed component. There was a bug that prevented the error from being raised if there were intermediate subsystems.

### Related Issues

- Resolves #1278

### Backwards incompatibilities

None

### New Dependencies

None
