### PR TITLE
set_solver_print is now a public method on System

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1403,7 +1403,7 @@ class Problem(object):
         if (level, depth, type_) not in self._solver_print_cache:
             self._solver_print_cache.append((level, depth, type_))
 
-        self.model._set_solver_print(level=level, depth=depth, type_=type_)
+        self.model.set_solver_print(level=level, depth=depth, type_=type_)
 
     def list_problem_vars(self,
                           show_promoted_name=True,

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -93,8 +93,6 @@ class Problem(object):
         Derivatives calculation mode assigned by the user.  If set to 'auto', _mode will be
         automatically assigned to 'fwd' or 'rev' based on relative sizes of design variables vs.
         responses.
-    _solver_print_cache : list
-        Allows solver iprints to be set to requested values after setup calls.
     _initial_condition_cache : dict
         Any initial conditions that are set at the problem level via setitem are cached here
         until they can be processed.
@@ -173,8 +171,6 @@ class Problem(object):
                             ": The value provided for 'driver' is not a valid Driver.")
 
         self.comm = comm
-
-        self._solver_print_cache = []
 
         self._mode = None  # mode is assigned in setup()
 
@@ -825,11 +821,6 @@ class Problem(object):
             self._setup_recording()
             record_viewer_data(self)
 
-        # Now that setup has been called, we can set the iprints.
-        for items in self._solver_print_cache:
-            self.set_solver_print(level=items[0], depth=items[1], type_=items[2])
-        self._solver_print_cache = []
-
         if self._setup_status < 2:
             self._setup_status = 2
             self._set_initial_conditions()
@@ -1400,9 +1391,6 @@ class Problem(object):
         type_ : str
             Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
         """
-        if (level, depth, type_) not in self._solver_print_cache:
-            self._solver_print_cache.append((level, depth, type_))
-
         self.model.set_solver_print(level=level, depth=depth, type_=type_)
 
     def list_problem_vars(self,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2460,6 +2460,11 @@ class System(object):
     def _setup_solver_print(self, recurse=True):
         """
         Apply the cached solver print settings during setup.
+
+        Parameters
+        ----------
+        recurse : bool
+            Whether to call this method in subsystems.
         """
         for level, depth, type_ in self._solver_print_cache:
             self._set_solver_print(level, depth, type_)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -34,9 +34,9 @@ from openmdao.utils.name_maps import name2abs_name
 from openmdao.utils.coloring import _compute_coloring, Coloring, \
     _STD_COLORING_FNAME, _DEF_COMP_SPARSITY_ARGS
 import openmdao.utils.coloring as coloring_mod
-from openmdao.utils.general_utils import determine_adder_scaler, find_matches, \
+from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, ContainsAll, all_ancestors, \
-    simple_warning, make_set, match_includes_excludes
+    simple_warning, make_set, match_includes_excludes, warn_deprecation
 from openmdao.approximation_schemes.complex_step import ComplexStep
 from openmdao.approximation_schemes.finite_difference import FiniteDifference
 from openmdao.utils.units import unit_conversion
@@ -2451,6 +2451,29 @@ class System(object):
                 subsys._linear_solver._set_solver_print(level=level, type_=type_)
             if subsys.nonlinear_solver is not None and type_ != 'LN':
                 subsys.nonlinear_solver._set_solver_print(level=level, type_=type_)
+
+    def _set_solver_print(self, level=2, depth=1e99, type_='all'):
+        """
+        Control printing for solvers and subsolvers in the model.
+
+        This method has been deprecated and users should instead use
+        set_solver_print (no leading underscore).
+
+        Parameters
+        ----------
+        level : int
+            iprint level. Set to 2 to print residuals each iteration; set to 1
+            to print just the iteration totals; set to 0 to disable all printing
+            except for failures, and set to -1 to disable all printing including failures.
+        depth : int
+            How deep to recurse. For example, you can set this to 0 if you only want
+            to print the top level linear and nonlinear solver messages. Default
+            prints everything.
+        type_ : str
+            Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
+        """
+        warn_deprecation('System._set_solver_print has been renamed System.set_solver_print')
+        self.set_solver_print(level, depth, type_)
 
     def _set_approx_partials_meta(self):
         # this will load a static coloring (if any) and will populate wrt_matches if

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -36,7 +36,7 @@ from openmdao.utils.coloring import _compute_coloring, Coloring, \
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, ContainsAll, all_ancestors, \
-    simple_warning, make_set, match_includes_excludes, warn_deprecation
+    simple_warning, make_set, match_includes_excludes
 from openmdao.approximation_schemes.complex_step import ComplexStep
 from openmdao.approximation_schemes.finite_difference import FiniteDifference
 from openmdao.utils.units import unit_conversion
@@ -2451,29 +2451,6 @@ class System(object):
                 subsys._linear_solver._set_solver_print(level=level, type_=type_)
             if subsys.nonlinear_solver is not None and type_ != 'LN':
                 subsys.nonlinear_solver._set_solver_print(level=level, type_=type_)
-
-    def _set_solver_print(self, level=2, depth=1e99, type_='all'):
-        """
-        Control printing for solvers and subsolvers in the model.
-
-        This method has been deprecated and users should instead use
-        set_solver_print (no leading underscore).
-
-        Parameters
-        ----------
-        level : int
-            iprint level. Set to 2 to print residuals each iteration; set to 1
-            to print just the iteration totals; set to 0 to disable all printing
-            except for failures, and set to -1 to disable all printing including failures.
-        depth : int
-            How deep to recurse. For example, you can set this to 0 if you only want
-            to print the top level linear and nonlinear solver messages. Default
-            prints everything.
-        type_ : str
-            Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
-        """
-        warn_deprecation('System._set_solver_print has been renamed System.set_solver_print')
-        self.set_solver_print(level, depth, type_)
 
     def _set_approx_partials_meta(self):
         # this will load a static coloring (if any) and will populate wrt_matches if

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2417,7 +2417,7 @@ class System(object):
         """
         self._linear_solver = solver
 
-    def _set_solver_print(self, level=2, depth=1e99, type_='all'):
+    def set_solver_print(self, level=2, depth=1e99, type_='all'):
         """
         Control printing for solvers and subsolvers in the model.
 
@@ -2445,7 +2445,7 @@ class System(object):
             if current_depth >= depth:
                 continue
 
-            subsys._set_solver_print(level=level, depth=depth - current_depth, type_=type_)
+            subsys.set_solver_print(level=level, depth=depth - current_depth, type_=type_)
 
             if subsys._linear_solver is not None and type_ != 'NL':
                 subsys._linear_solver._set_solver_print(level=level, type_=type_)

--- a/openmdao/docs/features/core_features/controlling_solvers/solver_options.rst
+++ b/openmdao/docs/features/core_features/controlling_solvers/solver_options.rst
@@ -97,5 +97,15 @@ top solver and the solver in 'g2', but not the solver in 'sub1.sub2.g1'.
     openmdao.solvers.tests.test_solver_iprint.TestSolverPrint.test_feature_set_solver_print3
     :layout: interleave
 
+The `set_solver_print` method can also be called on Systems.
+For instance, if we want to print detailed output from group 'g2' down, we can first call
+`set_solver_print` on the problem or the top level model with a level of "-1", and then call it
+on group 'g2' with a level of "2".
+
+.. embed-code::
+    openmdao.solvers.tests.test_solver_iprint.TestSolverPrint.test_feature_set_solver_print4
+    :layout: interleave
+
+
 
 .. tags:: Solver

--- a/openmdao/docs/features/debugging/profiling/inst_call_tracing.rst
+++ b/openmdao/docs/features/debugging/profiling/inst_call_tracing.rst
@@ -50,7 +50,7 @@ indented based on its location in the call stack. :
             LinearRunOnce#2.Solver.__init__
                 LinearRunOnce#2.Solver._declare_options
     Problem#1.Problem.set_solver_print
-        Group#1().System._set_solver_print
+        Group#1().System.set_solver_print
             LinearRunOnce#2.Solver._set_solver_print
             NonlinearRunOnce#2.Solver._set_solver_print
     Problem#1.Problem.setup

--- a/openmdao/solvers/tests/test_solver_iprint.py
+++ b/openmdao/solvers/tests/test_solver_iprint.py
@@ -1,6 +1,8 @@
 """ Unit test for the solver printing behavior. """
 
 import os
+from io import StringIO
+import re
 import sys
 import unittest
 
@@ -8,7 +10,6 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import SubSellar
-from openmdao.test_suite.components.sellar import SellarDerivatives
 
 from openmdao.utils.general_utils import run_model
 from openmdao.utils.mpi import MPI
@@ -44,6 +45,18 @@ class TestSolverPrint(unittest.TestCase):
         scipy.options['iprint'] = -1
         prob.run_model()
 
+    def test_iprint_neg1(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_iprint_neg1()
+        finally:
+            sys.stdout = old_stdout
+
+        # Verify output
+        self.assertEqual(str_out.getvalue().strip(), "")
+
     def test_feature_iprint_0(self):
         import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
@@ -66,7 +79,21 @@ class TestSolverPrint(unittest.TestCase):
 
         prob.run_model()
 
-    def test_feature_iprint_1(self):
+    def test_iprint_0(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_iprint_0()
+        finally:
+            sys.stdout = old_stdout
+
+        # Verify output
+        self.assertEqual(str_out.getvalue().strip(),
+                         "NL: NewtonSolver 'NL: Newton' on system '' failed to converge in "
+                         "1 iterations.")
+
+    def test_feature_iprint_1(self, stdout=None):
         import openmdao.api as om
         from openmdao.test_suite.components.sellar import SellarDerivatives
 
@@ -86,6 +113,19 @@ class TestSolverPrint(unittest.TestCase):
         newton.options['iprint'] = 1
         scipy.options['iprint'] = 0
         prob.run_model()
+
+    def test_iprint_1(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_iprint_1()
+        finally:
+            sys.stdout = old_stdout
+
+        # Verify output
+        self.assertEqual(str_out.getvalue().strip(),
+                         "NL: Newton Converged in 2 iterations")
 
     def test_feature_iprint_2(self):
         import openmdao.api as om
@@ -107,6 +147,20 @@ class TestSolverPrint(unittest.TestCase):
         newton.options['iprint'] = 2
         scipy.options['iprint'] = 1
         prob.run_model()
+
+    def test_iprint_2(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_iprint_2()
+        finally:
+            sys.stdout = old_stdout
+
+        # Verify output
+        lines = str_out.getvalue().strip().split('\n')
+        for line in lines:
+            self.assertEqual(line[:3], 'NL:')
 
     def test_hierarchy_iprint(self):
 
@@ -142,7 +196,13 @@ class TestSolverPrint(unittest.TestCase):
         prob.setup()
 
         output = run_model(prob)
-        # TODO: check output
+
+        # Check that certain things show up in our outputs
+        self.assertGreaterEqual(output.count('sub1.sub2.g1'), 1)
+        self.assertGreaterEqual(output.count('g2'), 1)
+        self.assertGreaterEqual(output.count('NL: Newton'), 2)
+        self.assertGreaterEqual(output.count('LN: SCIPY'), 2)
+        self.assertGreaterEqual(output.count('precon: LNBGS'), 2)
 
     def test_hierarchy_iprint2(self):
 
@@ -169,7 +229,11 @@ class TestSolverPrint(unittest.TestCase):
         prob.setup()
 
         output = run_model(prob)
-        # TODO: check output
+
+        # Check that certain things show up in our outputs
+        self.assertGreaterEqual(output.count('sub1.sub2.g1'), 2)
+        self.assertGreaterEqual(output.count('g2'), 2)
+        self.assertGreaterEqual(output.count('NL: NLBGS'), 2)
 
     def test_hierarchy_iprint3(self):
 
@@ -198,7 +262,13 @@ class TestSolverPrint(unittest.TestCase):
         prob.setup()
 
         output = run_model(prob)
-        # TODO: check output
+
+        # Check that certain things show up in our outputs
+        self.assertGreaterEqual(output.count('sub1'), 2)
+        self.assertGreaterEqual(output.count('sub1.sub2'), 2)
+        self.assertGreaterEqual(output.count('sub1.sub2.g1'), 2)
+        self.assertGreaterEqual(output.count('g2'), 2)
+        self.assertGreaterEqual(output.count('NL: NLBJ'), 2)
 
     def test_feature_set_solver_print1(self):
         import numpy as np
@@ -237,6 +307,26 @@ class TestSolverPrint(unittest.TestCase):
 
         prob.setup()
         prob.run_model()
+
+    def test_set_solver_print1(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_set_solver_print1()
+        finally:
+            sys.stdout = old_stdout
+
+        # Check that certain things show up in our outputs
+        output = str_out.getvalue()
+        self.assertGreaterEqual(output.count('sub1.sub2.g1'), 2)
+        self.assertGreaterEqual(output.count('g2'), 2)
+        self.assertGreaterEqual(output.count('NL: Newton'), 2)
+        self.assertGreaterEqual(output.count('LN: LNBGS'), 2)
+        self.assertGreaterEqual(output.count('LN: SCIPY'), 2)
+        self.assertGreaterEqual(output.count('LS: BCHK'), 2)
+        self.assertGreaterEqual(output.count('precon: LNBGS'), 2)
+
 
     def test_feature_set_solver_print2(self):
         import numpy as np
@@ -277,6 +367,22 @@ class TestSolverPrint(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
+    def test_set_solver_print2(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_set_solver_print2()
+        finally:
+            sys.stdout = old_stdout
+
+        # Check that certain things show up in our outputs
+        output = str_out.getvalue()
+        self.assertGreaterEqual(output.count('sub1.sub2.g1'), 1)
+        self.assertGreaterEqual(output.count('g2'), 1)
+        self.assertGreaterEqual(output.count('NL: Newton'), 2)
+        self.assertGreaterEqual(output.count('LS: BCHK'), 2)
+
     def test_feature_set_solver_print3(self):
         import numpy as np
 
@@ -316,6 +422,24 @@ class TestSolverPrint(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
+    def test_set_solver_print3(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_set_solver_print3()
+        finally:
+            sys.stdout = old_stdout
+
+        # Check that certain things show up in our outputs
+        output = str_out.getvalue()
+        self.assertGreaterEqual(output.count('sub1.sub2.g1'), 1)
+        self.assertGreaterEqual(output.count('g2'), 1)
+        self.assertGreaterEqual(output.count('NL: Newton'), 2)
+        self.assertGreaterEqual(output.count('precon: LNBGS'), 2)
+        self.assertGreaterEqual(output.count('LS: BCHK'), 2)
+        self.assertGreaterEqual(output.count('LN: SCIPY'), 2)
+
     def test_feature_set_solver_print4(self):
         import numpy as np
 
@@ -349,11 +473,29 @@ class TestSolverPrint(unittest.TestCase):
         g2.linear_solver.precon = om.LinearBlockGS()
         g2.linear_solver.precon.options['maxiter'] = 2
 
-        prob.set_solver_print(level=-1)
+        prob.set_solver_print(level=-1, type_='all')
         g2.set_solver_print(level=2, type_='NL')
 
         prob.setup()
         prob.run_model()
+
+    def test_set_solver_print4(self):
+        old_stdout = sys.stdout
+        sys.stdout = str_out = StringIO()
+
+        try:
+            self.test_feature_set_solver_print4()
+        finally:
+            sys.stdout = old_stdout
+
+        # Check that certain things show up in our outputs
+        output = str_out.getvalue()
+        self.assertEqual(output.count('sub1.sub2.g1'), 0)
+        self.assertGreaterEqual(output.count('g2'), 1)
+        self.assertGreaterEqual(output.count('NL: Newton'), 2)
+        self.assertEqual(output.count('precon: LNBGS'), 0)
+        self.assertGreaterEqual(output.count('LS: BCHK'), 1)
+        self.assertEqual(output.count('LN: SCIPY'), 0)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")


### PR DESCRIPTION
### Summary

This PR makes set_solver_print available on Systems (in addition to still being available on Problem).

### Related Issues

- Resolves #1301 

### Backwards incompatibilities

Previous `_set_solver_print` method on System has been renamed to `set_solver_print`.

### New Dependencies

None
