### PR TITLE
Fix for MPI hang when using DirectSolver on a serial model run on multiple procs.

### DIFF
--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -11,8 +11,6 @@ from openmdao.matrices.csr_matrix import CSRMatrix
 from openmdao.matrices.csc_matrix import CSCMatrix
 from openmdao.utils.units import unit_conversion
 from openmdao.utils.array_utils import _flatten_src_indices
-from openmdao.utils.mpi import MPI
-from openmdao.vectors.vector import INT_DTYPE
 
 _empty_dict = {}
 
@@ -114,13 +112,11 @@ class AssembledJacobian(Jacobian):
         ext_mtx = self._matrix_class(system.comm, False)
 
         iproc = system.comm.rank
-        abs2idx = system._var_allprocs_abs2idx['nonlinear']
         in_sizes = system._var_sizes['nonlinear']['input']
         out_ranges = self._out_ranges
         in_ranges = self._in_ranges
 
         abs2prom_out = system._var_abs2prom['output']
-        owns = system._owning_rank
         conns = {} if isinstance(system, Component) else system._conn_global_abs_in2out
         abs_key2shape = self._abs_key2shape
 
@@ -280,23 +276,16 @@ class AssembledJacobian(Jacobian):
             int_mtx = self._int_mtx
             ext_mtx = self._ext_mtx[system.pathname]
             subjacs = system._subjacs_info
-            owned = system._owning_rank
-            irank = system.comm.rank
-            meta = system._var_allprocs_abs2meta
             sys_inputs = system._var_allprocs_abs2prom['input']
             sys_outputs = system._var_allprocs_abs2prom['output']
 
             if isinstance(system, Component):
                 global_conns = _empty_dict
-                iscomp = True
             else:
                 global_conns = system._conn_global_abs_in2out
-                iscomp = False
 
-            output_names = set(n for n in system._var_abs_names['output']
-                               if iscomp or owned[n] == irank or meta[n]['distributed'])
-            input_names = set(n for n in system._var_abs_names['input']
-                              if iscomp or owned[n] == irank or meta[n]['distributed'])
+            output_names = set(n for n in system._var_abs_names['output'])
+            input_names = set(n for n in system._var_abs_names['input'])
 
             rev_conns = defaultdict(list)
             for tgt, src in global_conns.items():
@@ -310,7 +299,7 @@ class AssembledJacobian(Jacobian):
             iters_in_ext = []
 
             for abs_key in subjacs:
-                ofname, wrtname = abs_key
+                _, wrtname = abs_key
                 if wrtname in sys_outputs:
                     if wrtname in output_names:
                         if abs_key in int_mtx._submats:
@@ -378,6 +367,7 @@ class AssembledJacobian(Jacobian):
                 ext_mtx._update_submat(key, subjacs[key]['value'])
 
         int_mtx._post_update()
+
         if ext_mtx is not None:
             ext_mtx._post_update()
 

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -284,8 +284,8 @@ class AssembledJacobian(Jacobian):
             else:
                 global_conns = system._conn_global_abs_in2out
 
-            output_names = set(n for n in system._var_abs_names['output'])
-            input_names = set(n for n in system._var_abs_names['input'])
+            output_names = set(system._var_abs_names['output'])
+            input_names = set(system._var_abs_names['input'])
 
             rev_conns = defaultdict(list)
             for tgt, src in global_conns.items():

--- a/openmdao/matrices/dense_matrix.py
+++ b/openmdao/matrices/dense_matrix.py
@@ -1,8 +1,5 @@
 """Define the DenseMatrix class."""
 import numpy as np
-from numpy import ndarray
-
-from scipy.sparse import coo_matrix
 
 from openmdao.matrices.coo_matrix import COOMatrix
 

--- a/openmdao/matrices/dense_matrix.py
+++ b/openmdao/matrices/dense_matrix.py
@@ -116,10 +116,3 @@ class DenseMatrix(COOMatrix):
         """
         # this will add any repeated entries together
         self._matrix = self._coo.toarray()
-
-    def _get_assembled_matrix(self, system):
-        mat = super(DenseMatrix, self)._get_assembled_matrix(system)
-        if mat is None:
-            return mat
-
-        return mat.toarray()

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -5,13 +5,14 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
+from openmdao.core.tests.test_distrib_derivs import DistribExecComp
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
+from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
-from openmdao.core.tests.test_distrib_derivs import DistribExecComp
 try:
     from openmdao.vectors.petsc_vector import PETScVector
 except ImportError:
@@ -962,6 +963,46 @@ class TestDirectSolverFeature(unittest.TestCase):
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
         assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
         assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
+
+
+class TestDirectSolverMPI(unittest.TestCase):
+
+    N_PROCS = 2
+
+    def test_serial_in_mpi(self):
+        # Tests that we can take an MPI model with a DirectSolver and run it in mpi with more
+        # procs. This verifies fix of a bug.
+
+        prob = om.Problem(model=DoubleSellar())
+        model = prob.model
+
+        g1 = model.g1
+        g1.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        g1.nonlinear_solver.options['rtol'] = 1.0e-5
+        g1.linear_solver = om.DirectSolver(assemble_jac=True)
+        g1.options['assembled_jac_type'] = 'dense'
+
+        g2 = model.g2
+        g2.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        g2.nonlinear_solver.options['rtol'] = 1.0e-5
+        g2.linear_solver = om.DirectSolver(assemble_jac=True)
+        g2.options['assembled_jac_type'] = 'dense'
+
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
+        model.options['assembled_jac_type'] = 'dense'
+
+        model.nonlinear_solver.options['solve_subsystems'] = True
+
+        prob.set_solver_print(level=0)
+
+        prob.setup()
+        prob.run_model()
+
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

Fix for MPI hang when using DirectSolver on a serial model run on multiple procs.

### Related Issues

- Resolves #1322 

### Backwards incompatibilities

None

### New Dependencies

None
