### PR TITLE
Prevent users from adding obj or con from distributed components

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3104,6 +3104,15 @@ class System(object):
             msg = "{}: Output not found for response {}."
             raise RuntimeError(msg.format(self.msginfo, str(err)))
 
+        # check to make sure none of the vars are distributed
+        abs2meta = self._var_allprocs_abs2meta
+        for abs_name in out:
+            meta = abs2meta[abs_name]
+            if meta['distributed']:
+                msg = "{}: Output {} is from a distributed component and cannot \
+                yet be used as an objective or constraint"
+                raise NotImplementedError(msg.format(self.msginfo, abs_name))
+
         if get_sizes:
             # Size them all
             sizes = self._var_sizes['nonlinear']['output']

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3107,11 +3107,16 @@ class System(object):
         # check to make sure none of the vars are distributed
         abs2meta = self._var_allprocs_abs2meta
         for abs_name in out:
-            meta = abs2meta[abs_name]
-            if meta['distributed']:
-                msg = "{}: Output {} is from a distributed component and cannot \
-                yet be used as an objective or constraint"
-                raise NotImplementedError(msg.format(self.msginfo, abs_name))
+            try:
+                meta = abs2meta[abs_name]
+                if meta['distributed']:
+                    msg = "{}: Output {} is from a distributed component and cannot \
+                    yet be used as an objective or constraint"
+                    raise NotImplementedError(msg.format(self.msginfo, abs_name))
+            except KeyError:
+                # Discrete outputs have separate metadata but not 'distributed' yet
+                # meta = self._var_allprocs_discrete['output'][abs_name]
+                pass
 
         if get_sizes:
             # Size them all

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -11,6 +11,8 @@ from openmdao.utils.mpi import MPI
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1withDerivatives, \
      SellarDis2withDerivatives
 
+from openmdao.core.tests.test_distribcomp import DistribInputDistribOutputComp
+
 try:
     from openmdao.vectors.petsc_vector import PETScVector
 except ImportError:
@@ -350,6 +352,23 @@ class TestConstraintOnModel(unittest.TestCase):
             prob.setup()
 
         self.assertEqual(str(context.exception), "SellarDerivatives (<model>): Output not found for response 'junk'.")
+
+    def test_constraint_on_distrib_output(self):
+        # this test should be removed once distributed outputs are able to be used as constraints
+        # this tests a temporary fix for issue #1331
+        prob = Problem()
+        model = Group()
+        model.add_subsystem('dvs', IndepVarComp('x', val=1.0*np.ones((2,))))
+        model.add_subsystem('distcomp', DistribInputDistribOutputComp(arr_size=2))
+        model.add_subsystem('sum', ExecComp('y = sum(x)', x=np.ones((2,))))
+        model.connect('dvs.x', 'distcomp.invec')
+        model.connect('distcomp.outvec', 'sum.x')
+        prob.model = model
+        prob.model.add_design_var('dvs.x', lower=-100, upper=100)
+        prob.model.add_objective('sum.y')
+        prob.model.add_constraint('distcomp.outvec', lower=-10.5)
+        with self.assertRaises(NotImplementedError) as context:
+            prob.setup()
 
     def test_constraint_affine_and_scaleradder(self):
 


### PR DESCRIPTION
### Summary

This is a tempfix to add a NotImplementedError in the situation where a user tries to use a distributed output as an objective or constraint

### Related Issues

- Tempfix for  #1331 

### Backwards incompatibilities

- It is theoretically possible that someone has a runscript that only runs the model (no driver) but also adds a distributed output as a response variable. This change will cause that runscript to fail with an insightful error message

### New Dependencies
None
