### PR TITLE
Fix FD derivatives on distributed components closes #1279

### DIFF
--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -381,7 +381,7 @@ class MPITests(unittest.TestCase):
         p.final_setup()
 
         # run the model and check partials
-        p.run_model
+        p.run_model()
 
         # this used to fail (bug #1279)
         cpd = p.check_partials(out_stream=None)

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -386,9 +386,6 @@ class MPITests(unittest.TestCase):
         # this used to fail (bug #1279)
         cpd = p.check_partials(out_stream=None)
         for (of, wrt) in cpd['C2']:
-            print(of)
-            print(wrt)
-            print(cpd['C2'][of, wrt]['rel error'])
             np.testing.assert_almost_equal(cpd['C2'][of, wrt]['rel error'], 0.0, decimal=5)
 
     def test_list_inputs_outputs(self):


### PR DESCRIPTION
### Summary

Finite difference approximations were broken for distributed components.
The reason was that the FD routine had separate paths for parallel groups but not distributed components and the way proc ownership was handled wasn't quite right, causing an array mismatch error.

### Related Issues

- Resolves #1279

### Backwards incompatibilities

If test coverage on parallel groups is poor then I might have messed something up?

### New Dependencies

None
