### PR TITLE
N2 node information update

### DIFF
--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -108,32 +108,6 @@
                     </div>
 
                     <div class="node-data-container" id="node-data">
-                        <div class="node-data-name node-data">
-                            <p>Name</p>
-                            <p id="node-name"></p>
-                        </div>
-                        <div class="node-data-path node-data">
-                            <p>Path</p>
-                            <p id="node-path"></p>
-                        </div>
-                        <div class="node-data-type node-data">
-                            <p>Type</p>
-                            <p id="node-type"></p>
-                        </div>
-                        <!-- <div class="node-data-value node-data">
-                            <p>Value</p>
-                            <p id="node-value">10</p>
-                        </div>
-                        <div class="node-data-unit node-data">
-                            <p>Unit</p>
-                            <p id="node-unit">m/s^2</p>
-                        </div>
-                        <div class="node-data-shape node-data">
-                            <p>Shape</p>
-                            <p id="node-shape">
-                                Semper Fi
-                            </p>
-                        </div> -->
                     </div>
                 </div>
 

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -101,16 +101,6 @@
                     </svg>
                 </div>
 
-                <!-- Information on selected Node -->
-                <div class="node-info-container hide-node-data" id="node-data-container">
-                    <div class="info-header">
-                        <p>Node Data</p>
-                    </div>
-
-                    <div class="node-data-container" id="node-data">
-                    </div>
-                </div>
-
                 <!-- Legend to show all symbols -->
                 <div class="legend" id="legend-div">
                     <div class="sys-var-container">
@@ -162,6 +152,20 @@
         <div id="connectionId"></div>
     </div>
 </div>
+
+<table id="node-info-container" class='info-hidden' cellpadding='0' cellspacing='0'>
+    <thead>
+        <tr>
+            <th scope='col' colspan='2'>Name</th>
+        </tr>
+    </thead>
+    <tbody></tbody>
+    <tfoot>
+        <tr>
+            <th scope='col' colspan='2'>&nbsp;</th>
+        </tr>
+    </tfoot>
+</table>
 
 <div class="tool-tip" style="position: absolute; visibility: hidden;"></div>
 <div id="top" class="offgrid" style="visibility: hidden;"></div>

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -205,11 +205,11 @@ class N2Diagram {
 
         this.dom.n2Groups = {};
         for (let gName of ['elements', 'gridlines', 'componentBoxes',
-                'dots', 'highlights', 'arrows'
-            ]) {
+            'dots', 'highlights', 'arrows'
+        ]) {
             this.dom.n2Groups[gName] =
                 this.dom.n2InnerGroup.append('g')
-                .attr('id', 'n2' + gName);
+                    .attr('id', 'n2' + gName);
         };
 
         for (let clippedGrp of ['elements', 'gridlines', 'componentBoxes', 'dots']) {
@@ -256,7 +256,7 @@ class N2Diagram {
         this.scales.model.x
             .domain([this.zoomedElement.dims.x, 1])
             .range([this.zoomedElement.dims.x ? this.layout.size.parentNodeWidth : 0,
-                this.layout.size.partitionTree.width
+            this.layout.size.partitionTree.width
             ]);
         this.scales.model.y
             .domain([this.zoomedElement.dims.y, this.zoomedElement.dims.y +
@@ -277,7 +277,7 @@ class N2Diagram {
             ]);
         this.scales.solver.y
             .domain([this.zoomedElement.solverDims.y,
-                this.zoomedElement.solverDims.y + this.zoomedElement.solverDims.height
+            this.zoomedElement.solverDims.y + this.zoomedElement.solverDims.height
             ])
             .range([0, this.layout.size.solverTree.height]);
 
@@ -322,9 +322,9 @@ class N2Diagram {
             this.dom.pSolverTreeGroup
                 .attr("height", innerDims.height)
                 .attr("transform", "translate(" + (this.dims.size.partitionTree.width +
-                        innerDims.margin +
-                        innerDims.height +
-                        innerDims.margin) + " " +
+                    innerDims.margin +
+                    innerDims.height +
+                    innerDims.margin) + " " +
                     innerDims.margin + ")");
 
             let offgridHeight = this.dims.size.font + 2;
@@ -344,49 +344,49 @@ class N2Diagram {
         let self = this; // For callbacks that change "this". Alternative to using .bind().
 
         let selection = this.dom.pTreeGroup.selectAll(".partition_group")
-            .data(this.layout.zoomedNodes, function(node) {
+            .data(this.layout.zoomedNodes, function (node) {
                 return node.id;
             });
 
         // Create a new SVG group for each node in zoomedNodes
         let nodeEnter = selection.enter().append("svg:g")
-            .attr("class", function(d) {
+            .attr("class", function (d) {
                 return "partition_group " + self.style.getNodeClass(d);
             })
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 return "translate(" +
                     self.prevScales.model.x(d.prevDims.x) + " " +
                     self.prevScales.model.y(d.prevDims.y) + ")";
             })
-            .on("click", function(d) {
+            .on("click", function (d) {
                 self.ui.leftClick(d);
             })
-            .on("contextmenu", function(d) {
+            .on("contextmenu", function (d) {
                 self.ui.rightClick(d, this);
             })
-            .on("mouseover", function(d) {
-                self.setActiveNode(d);
+            .on("mouseover", function (d) {
+                self.ui.nodeInfoBox.update(d3.event, d, d3.select(this).select('rect').style('fill'));
 
                 if (self.model.abs2prom != undefined) {
                     if (d.isParam()) {
                         return self.dom.toolTip.text(
-                                self.model.abs2prom.input[d.absPathName])
+                            self.model.abs2prom.input[d.absPathName])
                             .style("visibility", "visible");
                     }
                     if (d.isUnknown()) {
                         return self.dom.toolTip.text(
-                                self.model.abs2prom.output[d.absPathName])
+                            self.model.abs2prom.output[d.absPathName])
                             .style("visibility", "visible");
                     }
                 }
             })
-            .on("mouseleave", function(d) {
-                self.clearActiveNode();
+            .on("mouseleave", function (d) {
+                self.ui.nodeInfoBox.clear();
                 if (self.model.abs2prom != undefined) {
                     return self.dom.toolTip.style("visibility", "hidden");
                 }
             })
-            .on("mousemove", function() {
+            .on("mousemove", function () {
                 if (self.model.abs2prom != undefined) {
                     return self.dom.toolTip.style("top", (d3.event.pageY - 30) + "px")
                         .style("left", (d3.event.pageX + 5) + "px");
@@ -394,25 +394,25 @@ class N2Diagram {
             });
 
         nodeEnter.append("svg:rect")
-            .attr("width", function(d) {
+            .attr("width", function (d) {
                 return d.prevDims.width * self.prevTransitCoords.model.x;
             })
-            .attr("height", function(d) {
+            .attr("height", function (d) {
                 return d.prevDims.height * self.prevTransitCoords.model.y;
             })
-            .attr("id", function(d) {
+            .attr("id", function (d) {
                 return d.absPathName.replace(/\./g, '_');
             });
 
         nodeEnter.append("svg:text")
             .attr("dy", ".35em")
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let anchorX = d.prevDims.width * self.prevTransitCoords.model.x -
                     self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + " " + d.prevDims.height *
                     self.prevTransitCoords.model.y / 2 + ")";
             })
-            .style("opacity", function(d) {
+            .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
                 return d.textOpacity;
             })
@@ -433,32 +433,32 @@ class N2Diagram {
 
         let nodeUpdate = d3Refs.nodeEnter.merge(d3Refs.selection)
             .transition(sharedTransition)
-            .attr("class", function(d) {
+            .attr("class", function (d) {
                 return "partition_group " + self.style.getNodeClass(d);
             })
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 return "translate(" + self.scales.model.x(d.dims.x) + " " +
                     self.scales.model.y(d.dims.y) + ")";
             });
 
         nodeUpdate.select("rect")
-            .attr("width", function(d) {
+            .attr("width", function (d) {
                 return d.dims.width * self.transitCoords.model.x;
             })
-            .attr("height", function(d) {
+            .attr("height", function (d) {
                 return d.dims.height * self.transitCoords.model.y;
             })
             .attr('rx', 12)
             .attr('ry', 12);
 
         nodeUpdate.select("text")
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
                     self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + " " + d.dims.height *
                     self.transitCoords.model.y / 2 + ")";
             })
-            .style("opacity", function(d) {
+            .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
                 return d.textOpacity;
             })
@@ -480,22 +480,22 @@ class N2Diagram {
 
         // Transition exiting nodes to the parent's new position.
         let nodeExit = selection.exit().transition(sharedTransition)
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 return "translate(" + self.scales.model.x(d.dims.x) + "," +
                     self.scales.model.y(d.dims.y) + ")";
             })
             .remove();
 
         nodeExit.select("rect")
-            .attr("width", function(d) {
+            .attr("width", function (d) {
                 return d.dims.width * self.transitCoords.model.x;
             })
-            .attr("height", function(d) {
+            .attr("height", function (d) {
                 return d.dims.height * self.transitCoords.model.y;
             });
 
         nodeExit.select("text")
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
                     self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + "," + d.dims.height *
@@ -508,33 +508,33 @@ class N2Diagram {
         let self = this; // For callbacks that change "this". Alternative to using .bind().
 
         let selection = self.dom.pSolverTreeGroup.selectAll(".solver_group")
-            .data(self.layout.zoomedSolverNodes, function(d) {
+            .data(self.layout.zoomedSolverNodes, function (d) {
                 return d.id;
             });
 
         let nodeEnter = selection.enter().append("svg:g")
-            .attr("class", function(d) {
+            .attr("class", function (d) {
                 let solver_class = self.style.getSolverClass(self.showLinearSolverNames, {
                     'linear': d.linear_solver,
                     'nonLinear': d.nonlinear_solver
                 });
                 return solver_class + " solver_group " + self.style.getNodeClass(d);
             })
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let x = 1.0 - d.prevSolverDims.x - d.prevSolverDims.width;
                 // The magic for reversing the blocks on the right side
                 // The solver tree goes from the root on the right and expands to the left
                 return "translate(" + self.prevScales.solver.x(x) + "," +
                     self.prevScales.solver.y(d.prevSolverDims.y) + ")";
             })
-            .on("click", function(d) {
+            .on("click", function (d) {
                 self.ui.leftClick(d);
             })
-            .on("contextmenu", function(d) {
+            .on("contextmenu", function (d) {
                 self.ui.rightClick(d, this);
             })
-            .on("mouseover", function(d) {
-                self.setActiveNode(d)
+            .on("mouseover", function (d) {
+                self.ui.nodeInfoBox.update(d3.event, d, d3.select(this).select('rect').style('fill'))
 
                 if (self.model.abs2prom != undefined) {
                     if (d.isParam()) {
@@ -547,40 +547,40 @@ class N2Diagram {
                     }
                 }
             })
-            .on("mouseleave", function(d) {
-                self.clearActiveNode();
+            .on("mouseleave", function (d) {
+                self.ui.nodeInfoBox.clear();
 
                 if (self.model.abs2prom != undefined) {
-                    return self.dom.toolTip.style("visibility", "hidden");
+                    self.dom.toolTip.style("visibility", "hidden");
                 }
             })
-            .on("mousemove", function() {
+            .on("mousemove", function () {
                 if (self.model.abs2prom != undefined) {
-                    return self.dom.toolTip.style("top", (d3.event.pageY - 30) + "px")
+                    self.dom.toolTip.style("top", (d3.event.pageY - 30) + "px")
                         .style("left", (d3.event.pageX + 5) + "px");
                 }
             });
 
         nodeEnter.append("svg:rect")
-            .attr("width", function(d) {
+            .attr("width", function (d) {
                 return d.prevSolverDims.width * self.prevTransitCoords.solver.x;
             })
-            .attr("height", function(d) {
+            .attr("height", function (d) {
                 return d.prevSolverDims.height * self.prevTransitCoords.solver.y;
             })
-            .attr("id", function(d) {
+            .attr("id", function (d) {
                 return d.absPathName.replace(/\./g, '_');
             });
 
         nodeEnter.append("svg:text")
             .attr("dy", ".35em")
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let anchorX = d.prevSolverDims.width * self.prevTransitCoords.solver.x -
                     self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + "," + d.prevSolverDims.height *
                     self.prevTransitCoords.solver.y / 2 + ")";
             })
-            .style("opacity", function(d) {
+            .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
                 return d.textOpacity;
             })
@@ -601,14 +601,14 @@ class N2Diagram {
 
         let nodeUpdate = d3Refs.nodeEnter.merge(d3Refs.selection)
             .transition(sharedTransition)
-            .attr("class", function(d) {
+            .attr("class", function (d) {
                 let solver_class = self.style.getSolverClass(self.showLinearSolverNames, {
                     'linear': d.linear_solver,
                     'nonLinear': d.nonlinear_solver
                 });
                 return solver_class + " solver_group " + self.style.getNodeClass(d);
             })
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let x = 1.0 - d.solverDims.x - d.solverDims.width;
                 // The magic for reversing the blocks on the right side
 
@@ -619,23 +619,23 @@ class N2Diagram {
 
 
         nodeUpdate.select("rect")
-            .attr("width", function(d) {
+            .attr("width", function (d) {
                 return d.solverDims.width * self.transitCoords.solver.x;
             })
-            .attr("height", function(d) {
+            .attr("height", function (d) {
                 return d.solverDims.height * self.transitCoords.solver.y;
             })
             .attr('rx', 12)
             .attr('ry', 12);
 
         nodeUpdate.select("text")
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let anchorX = d.solverDims.width * self.transitCoords.solver.x -
                     self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + "," + d.solverDims.height *
                     self.transitCoords.solver.y / 2 + ")";
             })
-            .style("opacity", function(d) {
+            .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
                 return d.textOpacity;
             })
@@ -648,22 +648,22 @@ class N2Diagram {
         // Transition exiting nodes to the parent's new position.
         let nodeExit = selection.exit()
             .transition(sharedTransition)
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 return "translate(" + self.scales.solver.x(d.solverDims.x) + "," +
                     self.scales.solver.y(d.solverDims.y) + ")";
             })
             .remove();
 
         nodeExit.select("rect")
-            .attr("width", function(d) {
+            .attr("width", function (d) {
                 return d.solverDims.width * self.transitCoords.solver.x;
             })
-            .attr("height", function(d) {
+            .attr("height", function (d) {
                 return d.solverDims.height * self.transitCoords.solver.y;
             });
 
         nodeExit.select("text")
-            .attr("transform", function(d) {
+            .attr("transform", function (d) {
                 let anchorX = d.solverDims.width * self.transitCoords.solver.x -
                     self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + "," + d.solverDims.height *
@@ -782,7 +782,7 @@ class N2Diagram {
     mouseOverOnDiagonal(cell) {
         if (this.matrix.cellExists(cell)) {
             this.matrix.mouseOverOnDiagonal(cell);
-            this.setActiveNode(cell.obj);
+            this.ui.nodeInfoBox.update(d3.event, cell.obj, cell.color());
         }
     }
 
@@ -803,7 +803,7 @@ class N2Diagram {
             .style("visibility", "hidden")
             .html('');
 
-        this.clearActiveNode();
+        this.ui.nodeInfoBox.clear();
     }
 
     /**
@@ -831,35 +831,6 @@ class N2Diagram {
             this.dom.n2OuterGroup
                 .selectAll("path.n2_hover_elements, circle.n2_hover_elements")
                 .attr("class", newClassName);
-        }
-    }
-
-    setActiveNode(obj) {
-        function mirror(val) { return val; }
-        function yesNo(val) { return val? 'Yes' : 'No'; }
-
-        const propList = [
-            { 'key': 'name', 'desc': 'Name', 'fn': mirror },
-            { 'key': 'absPathName', 'desc': 'Path', 'fn': mirror  },
-            { 'key': 'class', 'desc': 'Class', 'fn': mirror  },
-            { 'key': 'type', 'desc': 'Type', 'fn': mirror  },
-            { 'key': 'dtype', 'desc': 'DType', 'fn': mirror  },
-            { 'key': 'subsystem_type', 'desc': 'Subsystem Type', 'fn': mirror  },
-            { 'key': 'component_type', 'desc': 'Component Type', 'fn': mirror  },
-            { 'key': 'implicit', 'desc': 'Implicit', 'fn': yesNo  },
-            { 'key': 'is_parallel', 'desc': 'Parallel', 'fn': yesNo },
-            { 'key': 'linear_solver', 'desc': 'Linear Solver', 'fn': mirror  },
-            { 'key': 'nonlinear_solver', 'desc': 'Non-Linear Solver', 'fn': mirror  }
-        ]
-
-        for (const prop of propList) {
-            if (obj.propExists(prop.key)) {
-                const newDiv = this.dom.nodeInfo.append('div')
-                    .attr('class', 'node-data');
-                
-                newDiv.append('p').text(prop.desc);
-                newDiv.append('p').text(prop.fn(obj[prop.key]));
-            }
         }
     }
 

--- a/openmdao/visualization/n2_viewer/src/N2Toolbar.js
+++ b/openmdao/visualization/n2_viewer/src/N2Toolbar.js
@@ -1,4 +1,133 @@
 /**
+ * Base class for toolbar button events. Show, hide, or
+ * move the tool tip box.
+ * @typedef N2ToolbarButtonNoClick
+ * @property {Object} tooltipBox A reference to the tool-tip element.
+ * @property {Array} tooltips One or two tooltips to display.
+ * @property {Object} toolbarButton A reference to the toolbar button.
+ */
+class N2ToolbarButtonNoClick {
+    /**
+     * Set up the event handlers.
+     * @param {String} id A selector for the button element.
+     * @param {Object} tooltipBox A reference to the tool-tip element.
+     * @param {String} tooptipText Content to fill the tool-tip box with.
+     */
+    constructor(id, tooltipBox, tooltipText) {
+        this.tooltips = [tooltipText];
+
+        this.toolbarButton = d3.select(id);
+        this.tooltipBox = tooltipBox;
+
+        this.toolbarButton
+            .on("mouseover", this.mouseOver.bind(this))
+            .on("mouseleave", this.mouseLeave.bind(this))
+            .on("mousemove", this.mouseMove.bind(this));
+    }
+
+    /** When the mouse enters the element, show the tool tip */
+    mouseOver() {
+        this.tooltipBox
+            .text(this.tooltips[0])
+            .style("visibility", "visible");
+    }
+
+    /** When the mouse leaves the element, hide the tool tip */
+    mouseLeave() {
+        this.tooltipBox.style("visibility", "hidden");
+    }
+
+    /** Keep the tool-tip near the mouse */
+    mouseMove() {
+        this.tooltipBox.style("top", (d3.event.pageY - 30) + "px")
+            .style("left", (d3.event.pageX + 5) + "px");
+    }
+}
+
+/**
+ * Manage clickable toolbar buttons
+ * @typedef N2ToolbarButtonClick
+ * @property {Object} tooltipBox A reference to the tool-tip element.
+ * @property {Array} tooltips One or two tooltips to display.
+ * @property {Object} toolbarButton A reference to the toolbar button.
+ * @property {Function} clickFn The function to call when clicked.
+ */
+class N2ToolbarButtonClick extends N2ToolbarButtonNoClick {
+    /**
+     * Set up the event handlers.
+     * @param {String} id A selector for the button element.
+     * @param {Object} tooltipBox A reference to the tool-tip element.
+     * @param {String} tooptipText Content to fill the tool-tip box with.
+     * @param {Function} clickFn The function to call when clicked.
+     */ 
+    constructor(id, tooltipBox, tooltipText, clickFn) {
+        super(id, tooltipBox, tooltipText);
+        this.clickFn = clickFn;
+
+        let self = this;
+
+        this.toolbarButton.on('click', function() { self.click(this); });
+    }
+
+    /**
+     * Defined separately so the derived class can override
+     * @param {Object} target Reference to the HTML element that was clicked
+     */
+    click(target) {
+        this.clickFn(target);
+    }
+}
+
+/**
+ * Manage toolbar buttons that alternate states when clicked.
+ * @typedef N2ToolbarButtonToggle
+ * @property {Object} tooltipBox A reference to the tool-tip element.
+ * @property {Array} tooltips One or two tooltips to display.
+ * @property {Object} toolbarButton A reference to the toolbar button.
+ * @property {Function} clickFn The function to call when clicked.
+ * @property {Function} predicateFn Function returning a boolean representing the state.
+ */
+class N2ToolbarButtonToggle extends N2ToolbarButtonClick {
+    /**
+     * Set up the event handlers.
+     * @param {String} id A selector for the button element.
+     * @param {Object} tooltipBox A reference to the tool-tip element.
+     * @param {String} tooptipTextArr A pair of tooltips for alternate states.
+     * @param {Function} predicateFn Function returning a boolean representing the state.
+     * @param {Function} clickFn The function to call when clicked.
+     */ 
+    constructor(id, tooltipBox, tooltipTextArr, predicateFn, clickFn) {
+        super(id, tooltipBox, tooltipTextArr[0], clickFn);
+        this.tooltips.push(tooltipTextArr[1]);
+        this.predicateFn = predicateFn;
+    }
+
+    /**
+     * When the mouse enters the element, show a tool tip based
+     * on the result of the predicate function.
+     */
+    mouseOver() {
+        this.tooltipBox
+            .text(this.predicateFn() ? this.tooltips[0] : this.tooltips[1])
+            .style("visibility", "visible");
+    }
+
+    /**
+     * When clicked, perform the associated function, then change the tool tip
+     * based on the result of the predicate function.
+     * @param {Object} target Reference to the HTML element that was clicked
+     */
+    click(target) {
+        this.clickFn(target);
+
+        this.tooltipBox
+            .text(this.predicateFn() ? this.tooltips[0] : this.tooltips[1])
+            .style("visibility", "visible");
+
+    }
+}
+
+/**
  * Manage the set of buttons and tools at the left of the diagram.
  * @typedef N2Toolbar
  * @property {Boolean} hidden Whether the toolbar is visible or not.
@@ -19,9 +148,12 @@ class N2Toolbar {
         this.searchBar = d3.select('#awesompleteId');
 
         this.hidden = true;
-        if (! EMBEDDED) this.show();
+        if (!EMBEDDED) this.show();
 
-        d3.select('#model-slider').node().value = sliderHeight;
+        d3.select('#model-slider')
+            .attr('min', window.innerHeight * .5)
+            .attr('max', window.innerHeight * 2)
+            .attr('value', window.innerHeight * .95)
 
         this._setupExpandableButtons();
         this._setupButtonFunctions(n2ui);
@@ -88,91 +220,122 @@ class N2Toolbar {
             .node().onclick = button.node().onclick;
     }
 
-    /** Associate all of the buttons on the toolbar with a method in N2UserInterface. */
+    /**
+     * Associate all of the buttons on the toolbar with a method in N2UserInterface.
+     * @param {N2UserInterface} n2ui A reference to the UI object 
+     */
     _setupButtonFunctions(n2ui) {
         const self = this; // For callbacks that change "this". Alternative to using .bind().
+        const tooltipBox = d3.select(".tool-tip");
 
-        // There are a lot of simple click and mouse over/leave/move events, so iterate over this array of arrays.
-        // There are two kinds of sub-arrays in this array.
-        // For buttons that always have the same tooltip no matter the state of the application, the array is of length 3
-        //    and has these elements:
-        //        [ selector, click function, tooltip text ]
-        // For buttons that have two different tooltips depending on the state of the application, the array is of length 5
-        //    and has these elements:
-        //        [ selector, click function, predicate function, tooltip text when predicate is true, tooltip text when predicate is false ]
-        const clickEventArray = [
-            ['#reset-graph', e => { n2ui.homeButtonClick() }, "View entire model starting from root"],
-            ['#undo-graph', e => { n2ui.backButtonPressed() }, "Move back in view history"],
-            ['#redo-graph', e => { n2ui.forwardButtonPressed()}, "Move forward in view history"],
+        new N2ToolbarButtonClick('#reset-graph', tooltipBox,
+            "View entire model starting from root", e => { n2ui.homeButtonClick(); });
 
-            ['#collapse-element', e => { n2ui.collapseOutputsButtonClick(n2ui.n2Diag.zoomedElement)}, "Control variable collapsing" ],
-            ['#collapse-element-2',function() { n2ui.collapseOutputsButtonClick(n2ui.n2Diag.zoomedElement); self._setRootButton(this) },
-            	"Collapse only variables in current view"],
-            ['#collapse-all', function() { n2ui.collapseOutputsButtonClick(n2ui.n2Diag.model.root); self._setRootButton(this) },
-            	"Collapse all variables in entire model"],
-            ['#expand-element', function() { n2ui.uncollapseButtonClick(n2ui.n2Diag.zoomedElement); self._setRootButton(this) },
-            	"Expand only variables in current view"],
-            ['#expand-all', function() { n2ui.uncollapseButtonClick(n2ui.n2Diag.model.root); self._setRootButton(this) },
-            	"Expand all variables in entire model"],
+        new N2ToolbarButtonClick('#undo-graph', tooltipBox,
+            "Move back in view history", e => { n2ui.backButtonPressed() });
 
-            ['#show-connections', e => { n2ui.n2Diag.showArrows(); self._setRootButton(this) }, "Set connections visibility"],
-            ['#hide-connections', function() { n2ui.n2Diag.clearArrows(); self._setRootButton(this) }, "Hide all connection arrows"],
-            ['#show-connections-2', function() { n2ui.n2Diag.showArrows(); self._setRootButton(this) }, "Show pinned connection arrows"],
-            ['#show-all-connections', function() { n2ui.n2Diag.showAllArrows(); self._setRootButton(this) }, "Show all connections in model"],
+        new N2ToolbarButtonClick('#redo-graph', tooltipBox,
+            "Move forward in view history", e => { n2ui.forwardButtonPressed() });
 
-            ['#linear-solver-button', e => { n2ui.toggleSolverNamesCheckboxChange() }, pred => { return  n2ui.n2Diag.showLinearSolverNames },
-            	"Show non-linear solvers", "Show linear solvers"],
+        new N2ToolbarButtonClick('#collapse-element', tooltipBox,
+            "Control variable collapsing",
+            e => { n2ui.collapseOutputsButtonClick(n2ui.n2Diag.zoomedElement) });
 
-            ['#legend-button', e => { n2ui.toggleLegend() }, pred => { return n2ui.legend.hidden }, "Show legend", "Hide legend"],
+        new N2ToolbarButtonClick('#collapse-element-2', tooltipBox,
+            "Collapse only variables in current view",
+            function (target) {
+                n2ui.collapseOutputsButtonClick(n2ui.n2Diag.zoomedElement);
+                self._setRootButton(target);
+            });
 
-            ['#text-slider-button', null, "Set text height"],
-            ['#depth-slider-button', null, "Set collapse depth"],
-            ['#model-slider-button', null, "Set model height"],
+        new N2ToolbarButtonClick('#collapse-all', tooltipBox,
+            "Collapse all variables in entire model",
+            function (target) {
+                n2ui.collapseOutputsButtonClick(n2ui.n2Diag.model.root);
+                self._setRootButton(target);
+            });
 
-            ['#save-button', e => { n2ui.n2Diag.saveSvg() }, "Save to SVG"],
+        new N2ToolbarButtonClick('#expand-element', tooltipBox,
+            "Expand only variables in current view",
+            function (target) {
+                n2ui.uncollapseButtonClick(n2ui.n2Diag.zoomedElement);
+                self._setRootButton(target);
+            });
 
-            ['#info-button', e => { n2ui.toggleNodeData() }, pred => { return !d3.select('#info-button').attr('class').includes('active-tab-icon') },
-            	"Show connection matrix information", "Hide connection matrix information"],
+        new N2ToolbarButtonClick('#expand-all', tooltipBox,
+            "Expand all variables in entire model",
+            function (target) {
+                n2ui.uncollapseButtonClick(n2ui.n2Diag.model.root);
+                self._setRootButton(target);
+            });
 
-            ['#question-button', DisplayModal, pred => { return  parentDiv.querySelector("#myModal").style.display === "block"},
-            	"Hide N2 diagram help", "Show N2 diagram help" ],
+        new N2ToolbarButtonClick('#show-connections', tooltipBox,
+            "Set connections visibility",
+            function (target) {
+                n2ui.n2Diag.showArrows();
+                self._setRootButton(target);
+            });
 
-            ['#hide-toolbar', e => { self.toggle() }, pred => { return  this.hidden }, "Show toolbar", "Hide toolbar"],
-        ];
+        new N2ToolbarButtonClick('#hide-connections', tooltipBox,
+            "Hide all connection arrows",
+            function (target) {
+                n2ui.n2Diag.clearArrows();
+                self._setRootButton(target);
+            });
 
-        for (let evt of clickEventArray) {
-            let toolbarButton = d3.select(evt[0]);
-            let displayText = "";
+        new N2ToolbarButtonClick('#show-connections-2', tooltipBox,
+            "Show pinned connection arrows",
+            function (target) {
+                n2ui.n2Diag.showArrows();
+                self._setRootButton(target);
+            });
 
-            toolbarButton
-                .on('click', function(d) {
-                    evt[1]();
-                    if (evt.length == 3) {
-                        displayText = evt[2];
-                    } else {
-                        displayText = evt[2]() ? evt[3] : evt[4];
-                    }
-                    n2ui.n2Diag.dom.toolTip.text(displayText);
-                })
-                .on("mouseover", function(d) {
-                    if (evt.length == 3) {
-                        displayText = evt[2];
-                    } else {
-                        displayText = evt[2]() ? evt[3] : evt[4];
-                    }
-                    return n2ui.n2Diag.dom.toolTip.text(displayText).style("visibility", "visible");
-                })
-                .on("mouseleave", function(d) {
-                    return n2ui.n2Diag.dom.toolTip.style("visibility", "hidden");
-                })
-                .on("mousemove", function() {
-                    return n2ui.n2Diag.dom.toolTip.style("top", (d3.event.pageY - 30) + "px")
-                            .style("left", (d3.event.pageX + 5) + "px");
-                });
-        }
+        new N2ToolbarButtonClick('#show-all-connections', tooltipBox,
+            "Show all connections in model",
+            function (target) {
+                n2ui.n2Diag.showAllArrows();
+                self._setRootButton(target);
+            });
+
+        new N2ToolbarButtonToggle('#linear-solver-button', tooltipBox,
+            ["Show non-linear solvers", "Show linear solvers"],
+            pred => { return !n2ui.n2Diag.showLinearSolverNames; },
+            e => { n2ui.toggleSolverNamesCheckboxChange(); }
+        );
+
+        new N2ToolbarButtonToggle('#legend-button', tooltipBox,
+            ["Show legend", "Hide legend"],
+            pred => { return n2ui.legend.hidden; },
+            e => { n2ui.toggleLegend(); }
+        );
+
+        new N2ToolbarButtonNoClick('#text-slider-button', tooltipBox, "Set text height");
+        new N2ToolbarButtonNoClick('#depth-slider-button', tooltipBox, "Set collapse depth");
+        new N2ToolbarButtonNoClick('#model-slider-button', tooltipBox, "Set model height");
+
+        new N2ToolbarButtonClick('#save-button', tooltipBox,
+            "Save to SVG", e => { n2ui.n2Diag.saveSvg() });
+
+        new N2ToolbarButtonToggle('#info-button', tooltipBox,
+            ["Show detailed node information", "Hide detailed node information"],
+            pred => { return n2ui.nodeInfoBox.hidden; },
+            e => { n2ui.nodeInfoBox.toggle(); }
+        );
+
+        new N2ToolbarButtonToggle('#question-button', tooltipBox,
+            ["Hide N2 diagram help", "Show N2 diagram help"],
+            pred => { return d3.select("#myModal").style('display') == "block"; },
+            DisplayModal
+        );
+
+        new N2ToolbarButtonToggle('#hide-toolbar', tooltipBox,
+            ["Show toolbar", "Hide toolbar"],
+            pred => { return self.hidden },
+            e => { self.toggle() }
+        );
 
         // The font size slider is a range input
-        this.toolbar.select('#text-slider').on('input', function() {
+        this.toolbar.select('#text-slider').on('input', function () {
             const fontSize = this.value;
             n2ui.n2Diag.fontSizeSelectChange(fontSize);
 
@@ -181,7 +344,7 @@ class N2Toolbar {
         });
 
         // The model height slider is a range input
-        this.toolbar.select('#model-slider').on('mouseup', function() {
+        this.toolbar.select('#model-slider').on('mouseup', function () {
             const modelHeight = parseInt(this.value);
             n2ui.n2Diag.verticalResize(modelHeight);
         });

--- a/openmdao/visualization/n2_viewer/style/legend.css
+++ b/openmdao/visualization/n2_viewer/style/legend.css
@@ -10,7 +10,7 @@
     flex-direction: row;
     border-radius: 15px;
     cursor: grab;
-    opacity: 0.8;
+    opacity: 0.95;
     box-shadow: 3px 3px 3px 1px rgba(0, 0, 0, 0.2);
 }
 

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -10,7 +10,7 @@
     box-shadow: 3px 3px 3px 1px rgba(0, 0, 0, 0.2);
     min-width: 200px;
     border-collapse: separate;
-    opacity: .8;
+    opacity: .95;
 }
 
 .info-hidden {

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -4,12 +4,12 @@
 	right: 0;
 	overflow: hidden;
 	background-color: white;
-	border-top-left-radius: 20px;
-	border-bottom-left-radius: 20px;
+	border-top-left-radius: 5px;
+	border-bottom-left-radius: 5px;
 	border-top: 1px solid #42926b;
 	border-left: 1px solid #42926b;
 	border-bottom: 1px solid #42926b;
-	width: 200px;
+	/* width: 250px; */
 	z-index: 10;
 	transition: opacity 0.25s;
 }
@@ -20,7 +20,6 @@
 
 .info-header {
 	background-color: #42926b;
-	padding: 6px 12px;
 }
 
 .info-header p {
@@ -39,7 +38,6 @@
 	display: flex;
 	justify-content: space-between;
 	font-size: 13px;
-	width: 90%;
 	align-self: center;
 }
 
@@ -47,8 +45,3 @@
 	font-weight: 600;
 }
 
-.node-data p:nth-child(2) {
-}
-
-.node-data-name {
-}

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -1,21 +1,58 @@
 /******************* Node Data styling *******************/
-.node-info-container {
+#node-info-container {
 	position: absolute;
-	right: 0;
 	overflow: hidden;
 	background-color: white;
-	border-top-left-radius: 5px;
-	border-bottom-left-radius: 5px;
-	border-top: 1px solid #42926b;
-	border-left: 1px solid #42926b;
-	border-bottom: 1px solid #42926b;
-	/* width: 250px; */
+	border-radius: 10px;
+	border: 1px solid #a0a0a0;
 	z-index: 10;
-	transition: opacity 0.25s;
+    transition: opacity 0.25s;
+    box-shadow: 3px 3px 3px 1px rgba(0, 0, 0, 0.2);
+    min-width: 200px;
+    border-collapse: separate;
+    opacity: .8;
 }
 
-.hide-node-data {
-	opacity: 0;
+.info-hidden {
+    visibility: hidden;
+}
+
+.info-visible {
+    visibility: visible;
+}
+
+#node-info-container thead th {
+    background-color: #42926b;
+    color: black;
+    padding: 5px;
+    font-size: 11pt;
+}
+
+#node-info-container tbody th {
+    text-align: right;
+    font-size: 9pt;
+    margin-top: 0;
+    border-top: 0;
+    border-bottom: 1px solid #a0a0a0;
+    border-right: 1px solid #a0a0a0;
+    padding: 3px;
+}
+
+#node-info-container tbody td {
+    text-align: left;
+    font-size: 9pt;
+    margin-top: 0;
+    margin-left: 0;
+    border-top: 0;
+    border-left: 0;
+    border-bottom: 1px solid #a0a0a0;
+    padding: 3px;
+}
+
+#node-info-container tfoot th {
+    background-color: #42926b;
+    padding: 2px;
+    font-size: 11pt;
 }
 
 .info-header {


### PR DESCRIPTION
### Summary

Previously, the node info box would only show a few pieces of info on variables/parameters that were clicked. The new behavior:
- Is triggered by mouseover instead of left clicking
- Shows all metadata that N2 has for the node
- Also works for groups, components, and solvers
- Now consists of a box colored the same as the hovered node, located near the mouse pointer

![nodeinfo2](https://user-images.githubusercontent.com/12797795/79758126-fb66d500-82ea-11ea-9939-ef996fe76ed4.png)
![nodeinfo1](https://user-images.githubusercontent.com/12797795/79758128-fd309880-82ea-11ea-98c5-48494ef7f702.png)

This commit also has a quick fix for the N2 height slider, which had a range (600-1200) that could easily be exceeded on higher resolution monitors. It's now adjusted dynamically for 50% to 200% initial window height.

There are also cleanups for some of the new toolbar button code - the button event setup was an array that had gotten unwieldy, so it was converted into classes.

### Related Issues

- Resolves #1308

### Backwards incompatibilities

None

### New Dependencies

None
