### PR TITLE
Idx

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1206,7 +1206,7 @@ class Group(System):
                         else:
                             simple_warning(msg)
 
-                if src_indices is not None:
+                elif src_indices is not None:
                     src_indices = np.atleast_1d(src_indices)
 
                     # initial dimensions of indices shape must be same shape as target
@@ -1263,25 +1263,29 @@ class Group(System):
                                 simple_warning(msg)
                         if src_indices.ndim > 1:
                             abs2meta[abs_in]['src_indices'] = \
-                                abs2meta[abs_in]['src_indices'].flatten()
+                                abs2meta[abs_in]['src_indices'].ravel()
                     else:
+                        # For 1D source, we allow user to specify a flat list without setting
+                        # flat_src_indices to True.
+                        if src_indices.ndim == 1:
+                            src_indices = src_indices[:, np.newaxis]
+
                         for d in range(source_dimensions):
                             # when running under MPI, there is a value for each proc
                             d_size = out_shape[d] * self.comm.size
-                            if src_indices.size > 0:
-                                arr = src_indices[..., d]
-                                if np.any(arr >= d_size) or np.any(arr <= -d_size):
-                                    for i in arr.flat:
-                                        if abs(i) >= d_size:
-                                            msg = f"{self.msginfo}: The source indices " + \
-                                                  f"do not specify a valid index for the " + \
-                                                  f"connection '{abs_out}' to '{abs_in}'. " + \
-                                                  f"Index '{i}' is out of range for source " + \
-                                                  f"dimension of size {d_size}."
-                                            if self._raise_connection_errors:
-                                                raise ValueError(msg)
-                                            else:
-                                                simple_warning(msg)
+                            arr = src_indices[..., d]
+                            if np.any(arr >= d_size) or np.any(arr <= -d_size):
+                                for i in arr.flat:
+                                    if abs(i) >= d_size:
+                                        msg = f"{self.msginfo}: The source indices " + \
+                                              f"do not specify a valid index for the " + \
+                                              f"connection '{abs_out}' to '{abs_in}'. " + \
+                                              f"Index '{i}' is out of range for source " + \
+                                              f"dimension of size {d_size}."
+                                        if self._raise_connection_errors:
+                                            raise ValueError(msg)
+                                        else:
+                                            simple_warning(msg)
 
     def _set_subsys_connection_errors(self, val=True):
         """

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -445,7 +445,7 @@ class TestConnectionsIndices(unittest.TestCase):
             self.fail('Exception expected.')
 
         self.prob.model._raise_connection_errors = False
-        
+
         with assert_warning(UserWarning, expected):
             self.prob.setup()
 
@@ -466,7 +466,7 @@ class TestConnectionsIndices(unittest.TestCase):
             self.fail('Exception expected.')
 
         self.prob.model._raise_connection_errors = False
-        
+
         with assert_warning(UserWarning, expected):
             self.prob.setup()
 
@@ -487,7 +487,28 @@ class TestConnectionsIndices(unittest.TestCase):
             self.fail('Exception expected.')
 
         self.prob.model._raise_connection_errors = False
-        
+
+        with assert_warning(UserWarning, expected):
+            self.prob.setup()
+
+    def test_bad_value_bug(self):
+        # Should not be allowed because the index value within src_indices is outside
+        # the valid range for the source
+        self.prob.model.connect('idvp.arrout', 'arraycomp.inp', src_indices=[0, 100000])
+
+        expected = "Group (<model>): The source indices do not specify a valid index " + \
+                   "for the connection 'idvp.arrout' to 'arraycomp.inp'. " + \
+                   "Index '100000' is out of range for source dimension of size 5."
+
+        try:
+            self.prob.setup()
+        except ValueError as err:
+            self.assertEqual(str(err), expected)
+        else:
+            self.fail('Exception expected.')
+
+        self.prob.model._raise_connection_errors = False
+
         with assert_warning(UserWarning, expected):
             self.prob.setup()
 

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -492,8 +492,8 @@ class TestConnectionsIndices(unittest.TestCase):
             self.prob.setup()
 
     def test_bad_value_bug(self):
-        # Should not be allowed because the index value within src_indices is outside
-        # the valid range for the source
+        # Should not be allowed because the 2nd index value within src_indices is outside
+        # the valid range for the source.  A bug prevented this from being checked.
         self.prob.model.connect('idvp.arrout', 'arraycomp.inp', src_indices=[0, 100000])
 
         expected = "Group (<model>): The source indices do not specify a valid index " + \


### PR DESCRIPTION
### Summary

Fixes a bug for case where src_indices are declared for a 1D source, and are given as a flat list with flat_src_indices set to False.  If any entry beyond the first were out-of-bounds, no exception was being raised.

### Related Issues

- Resolves #1341

### Backwards incompatibilities

None

### New Dependencies

None
