### PR TITLE
Both promoted and absolute names now in node info panel

### DIFF
--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -349,7 +349,7 @@ class N2Diagram {
             });
 
         // Create a new SVG group for each node in zoomedNodes
-        let nodeEnter = selection.enter().append("svg:g")
+        let nodeEnter = selection.enter().append("g")
             .attr("class", function (d) {
                 return "partition_group " + self.style.getNodeClass(d);
             })
@@ -366,34 +366,15 @@ class N2Diagram {
             })
             .on("mouseover", function (d) {
                 self.ui.nodeInfoBox.update(d3.event, d, d3.select(this).select('rect').style('fill'));
-
-                if (self.model.abs2prom != undefined) {
-                    if (d.isParam()) {
-                        return self.dom.toolTip.text(
-                            self.model.abs2prom.input[d.absPathName])
-                            .style("visibility", "visible");
-                    }
-                    if (d.isUnknown()) {
-                        return self.dom.toolTip.text(
-                            self.model.abs2prom.output[d.absPathName])
-                            .style("visibility", "visible");
-                    }
-                }
             })
             .on("mouseleave", function (d) {
                 self.ui.nodeInfoBox.clear();
-                if (self.model.abs2prom != undefined) {
-                    return self.dom.toolTip.style("visibility", "hidden");
-                }
             })
             .on("mousemove", function () {
-                if (self.model.abs2prom != undefined) {
-                    return self.dom.toolTip.style("top", (d3.event.pageY - 30) + "px")
-                        .style("left", (d3.event.pageX + 5) + "px");
-                }
+                self.ui.nodeInfoBox.move(d3.event);
             });
 
-        nodeEnter.append("svg:rect")
+        nodeEnter.append("rect")
             .attr("width", function (d) {
                 return d.prevDims.width * self.prevTransitCoords.model.x;
             })
@@ -404,7 +385,7 @@ class N2Diagram {
                 return d.absPathName.replace(/\./g, '_');
             });
 
-        nodeEnter.append("svg:text")
+        nodeEnter.append("text")
             .attr("dy", ".35em")
             .attr("transform", function (d) {
                 let anchorX = d.prevDims.width * self.prevTransitCoords.model.x -

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -758,6 +758,16 @@ class N2Diagram {
     }
 
     /**
+     * Move the node info panel around if it's visible
+     * @param {N2MatrixCell} cell The cell the event occured on.
+     */
+    mouseMoveOnDiagonal(cell) {
+        if (this.matrix.cellExists(cell)) {
+            this.ui.nodeInfoBox.move(d3.event);
+        }
+    }
+
+    /**
      * Since the matrix can be destroyed and recreated, use this to invoke the callback
      * rather than setting one up that points directly to a specific matrix.
      */
@@ -832,6 +842,7 @@ class N2Diagram {
         let mf = {
             'overOffDiag': self.mouseOverOffDiagonal.bind(self),
             'overOnDiag': self.mouseOverOnDiagonal.bind(self),
+            'moveOnDiag': self.mouseMoveOnDiagonal.bind(self),
             'out': self.mouseOut.bind(self),
             'click': self.mouseClick.bind(self)
         }

--- a/openmdao/visualization/n2_viewer/src/N2Matrix.js
+++ b/openmdao/visualization/n2_viewer/src/N2Matrix.js
@@ -370,6 +370,7 @@ class N2Matrix {
                 // "this" refers to the element here, so leave it alone:
                 d.renderer.renderPrevious(this)
                     .on('mouseover', d.mouseover())
+                    .on('mousemove', d.mousemove())
                     .on('mouseleave', n2MouseFuncs.out)
                     .on('click', n2MouseFuncs.click);
             });

--- a/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
+++ b/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
@@ -421,6 +421,14 @@ class N2MatrixCell {
             n2MouseFuncs.overOffDiag);
     }
 
+     /**
+     * Select the mousemove callback depending on whether we"re on the diagonal.
+     * TODO: Remove these globals
+     */
+    mousemove() {
+        return (this.onDiagonal() ? n2MouseFuncs.moveOnDiag : null);
+    }
+
     /**
      * Choose a color based on our location and state of the associated N2TreeNode.
      */

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -85,12 +85,14 @@ class NodeInfo {
     show() {
         this.toolbarButton.attr('class', 'fas icon-info-circle active-tab-icon');
         this.hidden = false;
+        d3.select('#all_pt_n2_content_div').classed('node-data-cursor', true);
     }
 
     /** Make the info box hidden if it's visible */
     hide() {
         this.toolbarButton.attr('class', 'fas icon-info-circle');
         this.hidden = true;
+        d3.select('#all_pt_n2_content_div').classed('node-data-cursor', false);
     }
 
     /** Toggle the visibility setting */

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -3,11 +3,13 @@
  * @typedef InfoPropDefault
  * @property {String} key The identifier of the property.
  * @property {String} desc The description (label) to display.
+ * @property {Boolean} capitalize Whether to capitialize every word in the desc.
  */
 class InfoPropDefault {
-    constructor(key, desc) {
+    constructor(key, desc, capitalize = false) {
         this.key = key;
         this.desc = desc;
+        this.capitalize = capitalize;
     }
 
     /** Return the same message since this is the base class */
@@ -19,12 +21,30 @@ class InfoPropDefault {
  * @typedef InfoPropYesNo
  */
 class InfoPropYesNo extends InfoPropDefault {
-    constructor(key, desc) {
-        super(key, desc);
+    constructor(key, desc, capitalize = false) {
+        super(key, desc, capitalize);
     }
 
     /** Return Yes or No when given True or False */
-    output(boolVal) { return boolVal? 'Yes' : 'No'; }
+    output(boolVal) { return boolVal ? 'Yes' : 'No'; }
+}
+
+/**
+ * Rename params to inputs and unknowns to outputs. 
+ * @typedef InfoPropYesNo
+ */
+class InfoUpdateType extends InfoPropDefault {
+    constructor(key, desc, capitalize = false) {
+        super(key, desc, capitalize);
+    }
+
+    /** Replace the old terms with new ones */
+    output(msg) {
+        return msg
+            .replace(/param/, 'input')
+            .replace(/unknown/, 'output')
+            .replace('_', ' ');
+    }
 }
 
 /**
@@ -37,21 +57,23 @@ class NodeInfo {
     /**
      * Build a list of the properties we care about and set up
      * references to the HTML elements.
+     * @param {Object} abs2prom Object containing promoted variable names.
      */
-    constructor() {
+    constructor(abs2prom) {
         this.propList = [
-            new InfoPropDefault('absPathName', 'Path'),
+            new InfoPropDefault('absPathName', 'Absolute Name'),
             new InfoPropDefault('class', 'Class'),
-            new InfoPropDefault('type', 'Type'),
+            new InfoUpdateType('type', 'Type', true),
             new InfoPropDefault('dtype', 'DType'),
-            new InfoPropDefault('subsystem_type', 'Subsystem Type'),
-            new InfoPropDefault('component_type', 'Component Type'),
+            new InfoPropDefault('subsystem_type', 'Subsystem Type', true),
+            new InfoPropDefault('component_type', 'Component Type', true),
             new InfoPropYesNo('implicit', 'Implicit'),
             new InfoPropYesNo('is_parallel', 'Parallel'),
             new InfoPropDefault('linear_solver', 'Linear Solver'),
             new InfoPropDefault('nonlinear_solver', 'Non-Linear Solver')
         ];
 
+        this.abs2prom = abs2prom;
         this.table = d3.select('#node-info-container');
         this.thead = this.table.select('thead');
         this.tbody = this.table.select('tbody');
@@ -77,6 +99,19 @@ class NodeInfo {
         else this.hide();
     }
 
+    _addPropertyRow(label, val, capitalize = false) {
+        const newRow = this.tbody.append('tr');
+
+        newRow.append('th')
+            .attr('scope', 'row')
+            .text(label);
+
+        const td = newRow.append('td')
+            .text(val);
+
+        if (capitalize) td.attr('class', 'caps');
+    }
+
     /**
      * Iterate over the list of known properties and display them
      * if the specified object contains them.
@@ -94,15 +129,18 @@ class NodeInfo {
         this.table.select('tfoot th')
             .style('background-color', color);
 
+        if (this.abs2prom) {
+            if (obj.isParam()) {
+                this._addPropertyRow('Promoted Name', this.abs2prom.input[obj.absPathName]);
+            }
+            else if (obj.isUnknown()) {
+                this._addPropertyRow('Promoted Name', this.abs2prom.output[obj.absPathName]);
+            }
+        }
+
         for (const prop of this.propList) {
             if (obj.propExists(prop.key) && obj[prop.key] != '') {
-                const newRow = this.tbody.append('tr');
-                
-                newRow.append('th')
-                    .attr('scope', 'row')
-                    .text(prop.desc);
-                newRow.append('td')
-                    .text(prop.output(obj[prop.key]));
+                this._addPropertyRow(prop.desc, prop.output(obj[prop.key]), prop.capitalize)
             }
         }
 
@@ -199,7 +237,7 @@ class N2UserInterface {
         this._setupSearch();
 
         this.legend = new N2Legend(this.n2Diag.modelData);
-        this.nodeInfoBox = new NodeInfo();
+        this.nodeInfoBox = new NodeInfo(this.n2Diag.model.abs2prom);
     }
 
     /** Set up the menu for selecting an arbitrary depth to collapse to. */
@@ -213,7 +251,7 @@ class N2UserInterface {
         collapseDepthElement.max = this.n2Diag.model.maxDepth - 1;
         collapseDepthElement.value = collapseDepthElement.max;
 
-        collapseDepthElement.onmouseup = function(e) {
+        collapseDepthElement.onmouseup = function (e) {
             const modelDepth = parseInt(e.target.value);
             self.collapseToDepthSelectChange(modelDepth);
         };
@@ -562,10 +600,10 @@ class N2UserInterface {
 
         this.n2Diag.toggleSolverNameType();
         this.n2Diag.dom.parentDiv.querySelector(
-                '#linear-solver-button'
-            ).className = !this.n2Diag.showLinearSolverNames ?
-            'fas icon-nonlinear-solver solver-button' :
-            'fas icon-linear-solver solver-button';
+            '#linear-solver-button'
+        ).className = !this.n2Diag.showLinearSolverNames ?
+                'fas icon-nonlinear-solver solver-button' :
+                'fas icon-linear-solver solver-button';
 
         this.legend.toggleSolvers(this.n2Diag.showLinearSolverNames);
 
@@ -583,7 +621,7 @@ class N2UserInterface {
         this.legend.toggle();
 
         d3.select('#legend-button').attr('class',
-            this.legend.hidden? 'fas icon-key' : 'fas icon-key active-tab-icon');
+            this.legend.hidden ? 'fas icon-key' : 'fas icon-key active-tab-icon');
     }
 
     toggleNodeData() {

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -36,6 +36,7 @@
     border-bottom: 1px solid #a0a0a0;
     border-right: 1px solid #a0a0a0;
     padding: 3px;
+    white-space: nowrap;
 }
 
 #node-info-container tbody td {
@@ -47,12 +48,17 @@
     border-left: 0;
     border-bottom: 1px solid #a0a0a0;
     padding: 3px;
+    white-space: nowrap;
 }
 
 #node-info-container tfoot th {
     background-color: #42926b;
     padding: 2px;
     font-size: 11pt;
+}
+
+.caps {
+    text-transform: capitalize;
 }
 
 .info-header {

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -89,6 +89,6 @@
 }
 
 .node-data-cursor {
-    cursor: crosshair;
+    cursor: context-menu;
 }
 

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -88,3 +88,7 @@
 	font-weight: 600;
 }
 
+.node-data-cursor {
+    cursor: crosshair;
+}
+

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -309,7 +309,19 @@ n2_gui_test_scripts = {
             "test": "click",
             "selector": "g#solver_tree rect#g1_d1",
             "button": "right"
-        }
+        },
+        {
+            "desc": "Right-click on partition tree element to collapse",
+            "test": "click",
+            "selector": "g#tree rect#g1",
+            "button": "right"
+        },
+        {
+            "desc": "Hover over N2 cell and check arrow count with collapsed group",
+            "test": "hoverArrow",
+            "selector": "g#n2elements rect#cellShape_15_15.vMid",
+            "arrowCount": 2
+        },
     ],
     "udpi_circuit": [
         {


### PR DESCRIPTION
### Summary

The node info panel used to show just the absolute name, and now it shows both the absolute and promoted names with proper labels. The additional tooltip was removed since it was redundant. The cursor changes to a crosshair when the info panel mode is enabled.  Also, "param" is now renamed to "Input" and "unknown" renamed to "Output" in this view.

A test was added for the previous problem of offscreen arrows being drawn for collapsed nodes.

### Related Issues

- Resolves #1309

### Backwards incompatibilities

None

### New Dependencies

None
