### PR TITLE
Correctly raise connection error in mpi when src_indices are out-of-bounds.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1209,6 +1209,9 @@ class Group(System):
                 elif src_indices is not None:
                     src_indices = np.atleast_1d(src_indices)
 
+                    if np.prod(src_indices.shape) == 0:
+                        continue
+
                     # initial dimensions of indices shape must be same shape as target
                     for idx_d, inp_d in zip(src_indices.shape, in_shape):
                         if idx_d != inp_d:
@@ -1271,8 +1274,11 @@ class Group(System):
                             src_indices = src_indices[:, np.newaxis]
 
                         for d in range(source_dimensions):
-                            # when running under MPI, there is a value for each proc
-                            d_size = out_shape[d] * self.comm.size
+                            if allprocs_abs2meta[abs_out]['distributed'] is True or \
+                               allprocs_abs2meta[abs_in]['distributed'] is True:
+                                d_size = out_shape[d] * self.comm.size
+                            else:
+                                d_size = out_shape[d]
                             arr = src_indices[..., d]
                             if np.any(arr >= d_size) or np.any(arr <= -d_size):
                                 for i in arr.flat:

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -5,8 +5,14 @@ import numpy as np
 
 from io import StringIO
 
-from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
+import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.mpi import MPI
+
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
 
 
 class TestConnections(unittest.TestCase):
@@ -15,7 +21,7 @@ class TestConnections(unittest.TestCase):
         self.setup_model(None, None)
 
     def setup_model(self, c1meta=None, c3meta=None):
-        self.p = Problem()
+        self.p = om.Problem()
         root = self.p.model
 
         if c1meta is None:
@@ -24,15 +30,15 @@ class TestConnections(unittest.TestCase):
         if c3meta is None:
             c3meta = {}
 
-        self.G1 = root.add_subsystem("G1", Group())
-        self.G2 = self.G1.add_subsystem("G2", Group())
-        self.C1 = self.G2.add_subsystem("C1", ExecComp('y=x*2.0', **c1meta))
-        self.C2 = self.G2.add_subsystem("C2", IndepVarComp('x', 1.0))
+        self.G1 = root.add_subsystem("G1", om.Group())
+        self.G2 = self.G1.add_subsystem("G2", om.Group())
+        self.C1 = self.G2.add_subsystem("C1", om.ExecComp('y=x*2.0', **c1meta))
+        self.C2 = self.G2.add_subsystem("C2", om.IndepVarComp('x', 1.0))
 
-        self.G3 = root.add_subsystem("G3", Group())
-        self.G4 = self.G3.add_subsystem("G4", Group())
-        self.C3 = self.G4.add_subsystem("C3", ExecComp('y=x*2.0', **c3meta))
-        self.C4 = self.G4.add_subsystem("C4", ExecComp('y=x*2.0'))
+        self.G3 = root.add_subsystem("G3", om.Group())
+        self.G4 = self.G3.add_subsystem("G4", om.Group())
+        self.C3 = self.G4.add_subsystem("C3", om.ExecComp('y=x*2.0', **c3meta))
+        self.C4 = self.G4.add_subsystem("C4", om.ExecComp('y=x*2.0'))
 
     def test_no_conns(self):
         self.p.setup()
@@ -46,20 +52,6 @@ class TestConnections(unittest.TestCase):
         self.assertEqual(self.C1._inputs['x'], 111.)
         self.assertEqual(self.C3._inputs['x'], 222.)
         self.assertEqual(self.C4._inputs['x'], 333.)
-
-    def test_inp_inp_explicit_conn_w_src(self):
-        raise unittest.SkipTest("explicit input-input connections not supported yet")
-        self.p.model.connect('G3.G4.C3.x', 'G3.G4.C4.x')  # connect inputs
-        self.p.model.connect('G1.G2.C2.x', 'G3.G4.C3.x')  # connect src to one of connected inputs
-        self.p.setup()
-
-        self.p['G1.G2.C2.x'] = 999.
-        self.assertEqual(self.C3._inputs['x'], 0.)
-        self.assertEqual(self.C4._inputs['x'], 0.)
-
-        self.p.run_model()
-        self.assertEqual(self.C3._inputs['x'], 999.)
-        self.assertEqual(self.C4._inputs['x'], 999.)
 
     def test_pull_size_from_source(self):
         raise unittest.SkipTest("setting input size based on src size not supported yet")
@@ -94,7 +86,7 @@ class TestConnections(unittest.TestCase):
                 outputs['y1'] = np.sum(x1)
                 outputs['y2'] = np.sum(x2)
 
-        p = Problem()
+        p = om.Problem()
         p.model.add_subsystem('src', Src())
         p.model.add_subsystem('tgt', Tgt())
 
@@ -150,7 +142,7 @@ class TestConnections(unittest.TestCase):
                 outputs['y2'] = np.sum(x2)
                 outputs['y3'] = np.sum(x3)
 
-        top = Problem()
+        top = om.Problem()
         top.model.add_subsystem('src', Src())
         top.model.add_subsystem('tgt', Tgt())
 
@@ -183,120 +175,23 @@ class TestConnections(unittest.TestCase):
                         "G1.G2.C1\nG1.G2.C2\nG3.G4.C3\nG3.G4.C4\n" in content)
         self.assertTrue("No recorders have been specified, so no data will be saved." in content)
 
-    def test_diff_conn_input_vals(self):
-        raise unittest.SkipTest("no checking yet of connected inputs without a src")
-
-        # set different initial values
-        self.C1._inputs['x'] = 7.
-        self.C3._inputs['x'] = 5.
-
-        # connect two inputs
-        self.p.model.connect('G1.G2.C1.x', 'G3.G4.C3.x')
-
-        try:
-            self.p.setup()
-        except Exception as err:
-            self.assertTrue(
-                "The following sourceless connected inputs have different initial values: "
-                "[('G1.G2.C1.x', 7.0), ('G3.G4.C3.x', 5.0)].  Connect one of them to the output of "
-                "an IndepVarComp to ensure that they have the same initial value." in str(err))
-        else:
-            self.fail("Exception expected")
-
-    def test_diff_conn_input_units(self):
-        raise unittest.SkipTest("no compatability checking of connected inputs yet")
-
-        # set different but compatible units
-        self.setup_model(c1meta={'x': {'units': 'ft'}}, c3meta={'x': {'units': 'inch'}})
-
-        # connect two inputs
-        self.p.model.connect('G1.G2.C1.x', 'G3.G4.C3.x')
-
-        try:
-            self.p.setup()
-        except Exception as err:
-            msg = "The following connected inputs have no source and different units: " \
-                  "[('G1.G2.C1.x', 'ft'), ('G3.G4.C3.x', 'inch')]. " \
-                  "Connect 'G1.G2.C1.x' to a source (such as an IndepVarComp) with defined units."
-            self.assertTrue(msg in str(err))
-        else:
-            self.fail("Exception expected")
-
-    def test_diff_conn_input_units_swap(self):
-        raise unittest.SkipTest("no compatability checking of connected inputs yet")
-
-        # set different but compatible units
-        self.setup_model(c1meta={'x': {'units': 'ft'}}, c3meta={'x': {'units': 'inch'}})
-
-        # connect two inputs
-        self.p.model.connect('G3.G4.C3.x', 'G1.G2.C1.x')
-
-        try:
-            self.p.setup()
-        except Exception as err:
-            msg = "The following connected inputs have no source and different units: " \
-                  "[('G1.G2.C1.x', 'ft'), ('G3.G4.C3.x', 'inch')]. " \
-                  "Connect 'G3.G4.C3.x' to a source (such as an IndepVarComp) with defined units."
-            self.assertTrue(msg in str(err))
-        else:
-            self.fail("Exception expected")
-
-    def test_diff_conn_input_units_w_src(self):
-        raise unittest.SkipTest("no compatability checking of connected inputs yet")
-
-        p = Problem()
-        root = p.model
-
-        num_comps = 50
-
-        root.add_subsystem("desvars", IndepVarComp('dvar1', 1.0))
-
-        # add a bunch of comps
-        for i in range(num_comps):
-            if i % 2 == 0:
-                units = "ft"
-            else:
-                units = "m"
-
-            root.add_subsystem("C%d" % i, ExecComp('y=x*2.0', units={'x': units}))
-
-        # connect all of their inputs (which have different units)
-        for i in range(1, num_comps):
-            root.connect("C%d.x" % (i-1), "C%d.x" % i)
-
-        try:
-            p.setup()
-        except Exception as err:
-            self.assertTrue("The following connected inputs have no source and different units" in
-                            str(err))
-        else:
-            self.fail("Exception expected")
-
-        # now, connect a source and the error should go away
-
-        p.cleanup()
-
-        root.connect('desvars.dvar1', 'C10.x')
-
-        p.setup()
-
 
 class TestConnectionsPromoted(unittest.TestCase):
 
     def test_inp_inp_promoted_no_src(self):
 
-        p = Problem()
+        p = om.Problem()
         root = p.model
 
-        G1 = root.add_subsystem("G1", Group())
-        G2 = G1.add_subsystem("G2", Group())
-        G2.add_subsystem("C1", ExecComp('y=x*2.0'))
-        G2.add_subsystem("C2", ExecComp('y=x*2.0'))
+        G1 = root.add_subsystem("G1", om.Group())
+        G2 = G1.add_subsystem("G2", om.Group())
+        G2.add_subsystem("C1", om.ExecComp('y=x*2.0'))
+        G2.add_subsystem("C2", om.ExecComp('y=x*2.0'))
 
-        G3 = root.add_subsystem("G3", Group())
-        G4 = G3.add_subsystem("G4", Group(), promotes=['x'])
-        G4.add_subsystem("C3", ExecComp('y=x*2.0'), promotes=['x'])
-        G4.add_subsystem("C4", ExecComp('y=x*2.0'), promotes=['x'])
+        G3 = root.add_subsystem("G3", om.Group())
+        G4 = G3.add_subsystem("G4", om.Group(), promotes=['x'])
+        G4.add_subsystem("C3", om.ExecComp('y=x*2.0'), promotes=['x'])
+        G4.add_subsystem("C4", om.ExecComp('y=x*2.0'), promotes=['x'])
 
         p.setup()
         p.final_setup()
@@ -309,18 +204,18 @@ class TestConnectionsPromoted(unittest.TestCase):
                          "[G3.G4.C3.x, G3.G4.C4.x] that are not connected to an output variable.")
 
     def test_inp_inp_promoted_w_prom_src(self):
-        p = Problem()
+        p = om.Problem()
         root = p.model
 
-        G1 = root.add_subsystem("G1", Group(), promotes=['x'])
-        G2 = G1.add_subsystem("G2", Group(), promotes=['x'])
-        G2.add_subsystem("C1", ExecComp('y=x*2.0'))
-        G2.add_subsystem("C2", IndepVarComp('x', 1.0), promotes=['x'])
+        G1 = root.add_subsystem("G1", om.Group(), promotes=['x'])
+        G2 = G1.add_subsystem("G2", om.Group(), promotes=['x'])
+        G2.add_subsystem("C1", om.ExecComp('y=x*2.0'))
+        G2.add_subsystem("C2", om.IndepVarComp('x', 1.0), promotes=['x'])
 
-        G3 = root.add_subsystem("G3", Group(), promotes=['x'])
-        G4 = G3.add_subsystem("G4", Group(), promotes=['x'])
-        C3 = G4.add_subsystem("C3", ExecComp('y=x*2.0'), promotes=['x'])
-        C4 = G4.add_subsystem("C4", ExecComp('y=x*2.0'), promotes=['x'])
+        G3 = root.add_subsystem("G3", om.Group(), promotes=['x'])
+        G4 = G3.add_subsystem("G4", om.Group(), promotes=['x'])
+        C3 = G4.add_subsystem("C3", om.ExecComp('y=x*2.0'), promotes=['x'])
+        C4 = G4.add_subsystem("C4", om.ExecComp('y=x*2.0'), promotes=['x'])
 
         p.setup()
         p.set_solver_print(level=0)
@@ -334,18 +229,18 @@ class TestConnectionsPromoted(unittest.TestCase):
         self.assertEqual(C4._inputs['x'], 999.)
 
     def test_inp_inp_promoted_w_explicit_src(self):
-        p = Problem()
+        p = om.Problem()
         root = p.model
 
-        G1 = root.add_subsystem("G1", Group())
-        G2 = G1.add_subsystem("G2", Group(), promotes=['x'])
-        G2.add_subsystem("C1", ExecComp('y=x*2.0'))
-        G2.add_subsystem("C2", IndepVarComp('x', 1.0), promotes=['x'])
+        G1 = root.add_subsystem("G1", om.Group())
+        G2 = G1.add_subsystem("G2", om.Group(), promotes=['x'])
+        G2.add_subsystem("C1", om.ExecComp('y=x*2.0'))
+        G2.add_subsystem("C2", om.IndepVarComp('x', 1.0), promotes=['x'])
 
-        G3 = root.add_subsystem("G3", Group())
-        G4 = G3.add_subsystem("G4", Group(), promotes=['x'])
-        C3 = G4.add_subsystem("C3", ExecComp('y=x*2.0'), promotes=['x'])
-        C4 = G4.add_subsystem("C4", ExecComp('y=x*2.0'), promotes=['x'])
+        G3 = root.add_subsystem("G3", om.Group())
+        G4 = G3.add_subsystem("G4", om.Group(), promotes=['x'])
+        C3 = G4.add_subsystem("C3", om.ExecComp('y=x*2.0'), promotes=['x'])
+        C4 = G4.add_subsystem("C4", om.ExecComp('y=x*2.0'), promotes=['x'])
 
         p.model.connect('G1.x', 'G3.x')
         p.setup()
@@ -359,47 +254,16 @@ class TestConnectionsPromoted(unittest.TestCase):
         self.assertEqual(C3._inputs['x'], 999.)
         self.assertEqual(C4._inputs['x'], 999.)
 
-    def test_unit_conv_message(self):
-        raise unittest.SkipTest("no units yet")
-        prob = Problem()
-        root = prob.model
-
-        root.add_subsystem("C1", ExecComp('y=x*2.0', units={'x': 'ft'}), promotes=['x'])
-        root.add_subsystem("C2", ExecComp('y=x*2.0', units={'x': 'inch'}), promotes=['x'])
-        root.add_subsystem("C3", ExecComp('y=x*2.0', units={'x': 'm'}), promotes=['x'])
-
-        try:
-            prob.setup()
-        except Exception as err:
-            msg = "The following connected inputs are promoted to 'x', but have different units: " \
-                  "[('C1.x', 'ft'), ('C2.x', 'inch'), ('C3.x', 'm')]. " \
-                  "Connect 'x' to a source (such as an IndepVarComp) with defined units."
-            self.assertTrue(msg in str(err))
-        else:
-            self.fail("Exception expected")
-
-        # Remedy the problem with an Indepvarcomp
-
-        prob = Problem()
-        root = prob.model
-
-        root.add_subsystem("C1", ExecComp('y=x*2.0', units={'x': 'ft'}), promotes=['x'])
-        root.add_subsystem("C2", ExecComp('y=x*2.0', units={'x': 'inch'}), promotes=['x'])
-        root.add_subsystem("C3", ExecComp('y=x*2.0', units={'x': 'm'}), promotes=['x'])
-        root.add_subsystem('p', IndepVarComp('x', 1.0, units='cm'), promotes=['x'])
-
-        prob.setup()
-
     def test_overlapping_system_names(self):
         # This ensures that _setup_connections does not think g1 and g1a are the same system
-        prob = Problem()
+        prob = om.Problem()
         model = prob.model
 
-        g1 = model.add_subsystem('g1', Group())
-        g1a = model.add_subsystem('g1a', Group())
+        g1 = model.add_subsystem('g1', om.Group())
+        g1a = model.add_subsystem('g1a', om.Group())
 
-        g1.add_subsystem('c', ExecComp('y=x'))
-        g1a.add_subsystem('c', ExecComp('y=x'))
+        g1.add_subsystem('c', om.ExecComp('y=x'))
+        g1a.add_subsystem('c', om.ExecComp('y=x'))
 
         model.connect('g1.c.y', 'g1a.c.x')
         model.connect('g1a.c.y', 'g1.c.x')
@@ -410,7 +274,7 @@ class TestConnectionsPromoted(unittest.TestCase):
 class TestConnectionsIndices(unittest.TestCase):
 
     def setUp(self):
-        class ArrayComp(ExplicitComponent):
+        class ArrayComp(om.ExplicitComponent):
             def setup(self):
                 self.add_input('inp', val=np.ones((2)))
                 self.add_input('inp1', val=0)
@@ -419,11 +283,11 @@ class TestConnectionsIndices(unittest.TestCase):
             def compute(self, inputs, outputs):
                 outputs['out'] = inputs['inp'] * 2.
 
-        indep_var_comp = IndepVarComp()
+        indep_var_comp = om.IndepVarComp()
         indep_var_comp.add_output('blammo', val=3.)
         indep_var_comp.add_output('arrout', val=np.ones(5))
 
-        prob = Problem()
+        prob = om.Problem()
         prob.model.add_subsystem('idvp', indep_var_comp)
         prob.model.add_subsystem('arraycomp', ArrayComp())
 
@@ -515,72 +379,72 @@ class TestConnectionsIndices(unittest.TestCase):
 
 class TestShapes(unittest.TestCase):
     def test_connect_flat_array_to_row_vector(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', val=np.arange(10)))
         p.model.add_subsystem('C1',
-                              ExecComp('y=dot(x, A)',
-                                       x={'value': np.zeros((1, 10))},
-                                       A={'value': np.eye(10)},
-                                       y={'value': np.zeros((1, 10))}))
+                              om.ExecComp('y=dot(x, A)',
+                                          x={'value': np.zeros((1, 10))},
+                                          A={'value': np.eye(10)},
+                                          y={'value': np.zeros((1, 10))}))
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
         assert_near_equal(p['C1.y'], np.arange(10)[np.newaxis, :])
 
     def test_connect_flat_array_to_col_vector(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', val=np.arange(10)))
         p.model.add_subsystem('C1',
-                              ExecComp('y=dot(A, x)',
-                                       x={'value': np.zeros((10, 1))},
-                                       A={'value': np.eye(10)},
-                                       y={'value': np.zeros((10, 1))}))
+                              om.ExecComp('y=dot(A, x)',
+                                          x={'value': np.zeros((10, 1))},
+                                          A={'value': np.eye(10)},
+                                          y={'value': np.zeros((10, 1))}))
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
         assert_near_equal(p['C1.y'], np.arange(10)[:, np.newaxis])
 
     def test_connect_row_vector_to_flat_array(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)[np.newaxis, :]))
-        p.model.add_subsystem('C1', ExecComp('y=5*x',
-                                             x={'value': np.zeros(10)},
-                                             y={'value': np.zeros(10)}))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', val=np.arange(10)[np.newaxis, :]))
+        p.model.add_subsystem('C1', om.ExecComp('y=5*x',
+                                                x={'value': np.zeros(10)},
+                                                y={'value': np.zeros(10)}))
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
         assert_near_equal(p['C1.y'], 5 * np.arange(10))
 
     def test_connect_col_vector_to_flat_array(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)[:, np.newaxis]))
-        p.model.add_subsystem('C1', ExecComp('y=5*x',
-                                             x={'value': np.zeros(10)},
-                                             y={'value': np.zeros(10)}))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', val=np.arange(10)[:, np.newaxis]))
+        p.model.add_subsystem('C1', om.ExecComp('y=5*x',
+                                                x={'value': np.zeros(10)},
+                                                y={'value': np.zeros(10)}))
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
         assert_near_equal(p['C1.y'], 5 * np.arange(10))
 
     def test_connect_flat_to_3d_array(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)))
-        p.model.add_subsystem('C1', ExecComp('y=5*x',
-                                             x={'value': np.zeros((1, 10, 1))},
-                                             y={'value': np.zeros((1, 10, 1))}))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', val=np.arange(10)))
+        p.model.add_subsystem('C1', om.ExecComp('y=5*x',
+                                                x={'value': np.zeros((1, 10, 1))},
+                                                y={'value': np.zeros((1, 10, 1))}))
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
         assert_near_equal(p['C1.y'], 5 * np.arange(10)[np.newaxis, :, np.newaxis])
 
     def test_connect_flat_nd_to_flat_nd(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x',
-                                                    val=np.arange(10)[np.newaxis, :, np.newaxis,
-                                                                      np.newaxis]))
-        p.model.add_subsystem('C1', ExecComp('y=5*x',
-                                             x={'value': np.zeros((1, 1, 1, 10))},
-                                             y={'value': np.zeros((1, 1, 1, 10))}))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x',
+                                                       val=np.arange(10)[np.newaxis, :, np.newaxis,
+                                                                         np.newaxis]))
+        p.model.add_subsystem('C1', om.ExecComp('y=5*x',
+                                                x={'value': np.zeros((1, 1, 1, 10))},
+                                                y={'value': np.zeros((1, 1, 1, 10))}))
         p.model.connect('indep.x', 'C1.x')
         p.setup()
         p.run_model()
@@ -588,12 +452,12 @@ class TestShapes(unittest.TestCase):
                          5 * np.arange(10)[np.newaxis, np.newaxis, np.newaxis, :])
 
     def test_connect_incompatible_shapes(self):
-        p = Problem()
-        p.model.add_subsystem('indep', IndepVarComp('x', val=np.arange(10)[np.newaxis, :,
-                                                                           np.newaxis, np.newaxis]))
-        p.model.add_subsystem('C1', ExecComp('y=5*x',
-                                             x={'value': np.zeros((5, 2))},
-                                             y={'value': np.zeros((5, 2))}))
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', val=np.arange(10)[np.newaxis, :,
+                                                                              np.newaxis, np.newaxis]))
+        p.model.add_subsystem('C1', om.ExecComp('y=5*x',
+                                                x={'value': np.zeros((5, 2))},
+                                                y={'value': np.zeros((5, 2))}))
         p.model.connect('indep.x', 'C1.x')
 
         expected = "Group (<model>): The source and target shapes do not match or are " + \
@@ -614,15 +478,15 @@ class TestShapes(unittest.TestCase):
 class TestMultiConns(unittest.TestCase):
     def test_mult_conns(self):
 
-        class SubGroup(Group):
+        class SubGroup(om.Group):
             def setup(self):
-                self.add_subsystem('c1', ExecComp('y = 2*x', x=np.ones(4), y=2*np.ones(4)),
+                self.add_subsystem('c1', om.ExecComp('y = 2*x', x=np.ones(4), y=2*np.ones(4)),
                                    promotes=['y', 'x'])
-                self.add_subsystem('c2', ExecComp('z = 2*y', y=np.ones(4), z=2*np.ones(4)),
+                self.add_subsystem('c2', om.ExecComp('z = 2*y', y=np.ones(4), z=2*np.ones(4)),
                                    promotes=['z', 'y'])
 
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp(), promotes=['*'])
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
         indeps.add_output('x', 10*np.ones(4))
         indeps.add_output('y', np.ones(4))
 
@@ -646,14 +510,14 @@ class TestMultiConns(unittest.TestCase):
 
     def test_mixed_conns_same_level(self):
 
-        prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp())
+        prob = om.Problem()
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())
         indeps.add_output('x', 10*np.ones(4))
 
         # c2.y is implicitly connected to c1.y
-        prob.model.add_subsystem('c1', ExecComp('y = 2*x', x=np.ones(4), y=2*np.ones(4)),
+        prob.model.add_subsystem('c1', om.ExecComp('y = 2*x', x=np.ones(4), y=2*np.ones(4)),
                                  promotes=['y'])
-        prob.model.add_subsystem('c2', ExecComp('z = 2*y', y=np.ones(4), z=2*np.ones(4)),
+        prob.model.add_subsystem('c2', om.ExecComp('z = 2*y', y=np.ones(4), z=2*np.ones(4)),
                                  promotes=['y'])
 
         # make a second, explicit, connection to y (which is c2.y promoted)
@@ -673,6 +537,81 @@ class TestMultiConns(unittest.TestCase):
         with assert_warning(UserWarning, expected):
             prob.setup()
 
+
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class TestConnectionsDistrib(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_serial_mpi_error(self):
+        # Should still catch the bad index when we are running under mpi with no distributed comps.
+        # A bug formerly prevented this.
+        class TestComp(om.ExplicitComponent):
+
+            def initialize(self):
+                self.options['distributed'] = False
+
+            def setup(self):
+                self.add_input('x', shape=2, src_indices=[1, 2], val=-2038.0)
+                self.add_output('y', shape=1)
+                self.declare_partials('y', 'x')
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = np.sum(inputs['x'])
+
+            def compute_partials(self, inputs, J):
+                J['y', 'x'] = np.ones((2,))
+
+        prob = om.Problem()
+        model = prob.model
+        model.add_subsystem('p1', om.IndepVarComp('x', np.array([1.0, 3.0])))
+        model.add_subsystem('c3', TestComp())
+        model.connect("p1.x", "c3.x")
+
+        expected = "Group (<model>): The source indices do not specify a valid index " + \
+                   "for the connection 'p1.x' to 'c3.x'. " + \
+                   "Index '2' is out of range for source dimension of size 2."
+
+        try:
+            prob.setup()
+        except ValueError as err:
+            self.assertEqual(str(err), expected)
+        else:
+            self.fail('Exception expected.')
+
+    def test_serial_mpi_error_flat(self):
+        # Make sure the flat branch works too.
+        class TestComp(om.ExplicitComponent):
+
+            def initialize(self):
+                self.options['distributed'] = False
+
+            def setup(self):
+                self.add_input('x', shape=2, src_indices=[1, 2], val=-2038.0, flat_src_indices=True)
+                self.add_output('y', shape=1)
+                self.declare_partials('y', 'x')
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = np.sum(inputs['x'])
+
+            def compute_partials(self, inputs, J):
+                J['y', 'x'] = np.ones((2,))
+
+        prob = om.Problem()
+        model = prob.model
+        model.add_subsystem('p1', om.IndepVarComp('x', np.array([1.0, 3.0])))
+        model.add_subsystem('c3', TestComp())
+        model.connect("p1.x", "c3.x")
+
+        expected = "Group (<model>): The source indices do not specify a valid index " + \
+                   "for the connection 'p1.x' to 'c3.x'. " + \
+                   "Index '2' is out of range for a flat source of size 2."
+
+        try:
+            prob.setup()
+        except ValueError as err:
+            self.assertEqual(str(err), expected)
+        else:
+            self.fail('Exception expected.')
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/tests/test_parallel_src_indices.py
+++ b/openmdao/core/tests/test_parallel_src_indices.py
@@ -16,6 +16,7 @@ except ImportError:
 class Comp(ExplicitComponent):
     def initialize(self):
         self.options['distributed'] = True
+        self.options.declare('flat', False)
 
     def setup(self):
         irank = self.comm.Get_rank()
@@ -28,7 +29,8 @@ class Comp(ExplicitComponent):
         n1 = np.sum(n_list[:irank])
         n2 = np.sum(n_list[:irank+1])
 
-        self.add_input( 'x',shape=node_size,src_indices=np.arange(n1,n2,dtype=int))
+        self.add_input( 'x',shape=node_size, src_indices=np.arange(n1, n2, dtype=int),
+                        flat_src_indices=self.options['flat'])
         self.add_output('y',shape=node_size)
 
     def compute(self,inputs,outputs):
@@ -47,6 +49,27 @@ class TestSrcIndices(unittest.TestCase):
 
         model.add_subsystem('comp1',Comp())
         model.add_subsystem('comp2',Comp())
+        model.connect('comp1.y','comp2.x')
+        model.connect('comp2.y','comp1.x')
+
+        prob.setup()
+        prob.run_model()
+
+        if model.comm.rank == 1:
+            np.testing.assert_almost_equal(model.comp1._outputs['y'], np.array([]))
+            np.testing.assert_almost_equal(model.comp2._outputs['y'], np.array([]))
+        else:
+            np.testing.assert_almost_equal(model.comp1._outputs['y'], np.ones(3) * 2.)
+            np.testing.assert_almost_equal(model.comp2._outputs['y'], np.ones(3) * 3.)
+
+    def test_zero_src_indices_flat(self):
+        prob = Problem()
+        model = prob.model
+        model.nonlinear_solver = NonlinearRunOnce()
+        model.linear_solver = LinearRunOnce()
+
+        model.add_subsystem('comp1',Comp(flat=True))
+        model.add_subsystem('comp2',Comp(flat=True))
         model.connect('comp1.y','comp2.x')
         model.connect('comp2.y','comp1.x')
 


### PR DESCRIPTION
### Summary

1. Correctly raise connection error in mpi when src_indices are out-of-bounds.
2. Fix for a hang when setting up a distributed comp with  flat_src_indices.
3. Added a few distribcomp tests with flat_src_indices.
4. Cleaned up some old skipped tests for input-input connections, which will not be supported with connect.

### Related Issues

- Resolves 

### Backwards incompatibilities

None

### New Dependencies

None
