### PR TITLE
Rename Problem.record_state to Problem.record

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -645,7 +645,7 @@ class Problem(object):
         for system in self.model.system_iter(include_self=True, recurse=True):
             system.cleanup()
 
-    def record_state(self, case_name):
+    def record(self, case_name):
         """
         Record the variables at the Problem level.
 
@@ -666,7 +666,7 @@ class Problem(object):
             Name used to identify this Problem case.
         """
         warn_deprecation("'Problem.record_iteration' has been deprecated. "
-                         "Use 'Problem.record_state' instead.")
+                         "Use 'Problem.record' instead.")
 
         record_iteration(self, self, case_name)
 

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -207,7 +207,7 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.setup(mode='fwd')
 
         t0, t1 = run_driver(prob)
-        prob.record_state('final')
+        prob.record('final')
         t2 = time()
 
         prob.cleanup()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1490,7 +1490,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         # expected input and output values after run_once
@@ -2030,8 +2030,8 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.model.nonlinear_solver.add_recorder(recorder)
 
         prob.run_driver()
-        prob.record_state('c_1')
-        prob.record_state('c_2')
+        prob.record('c_1')
+        prob.record('c_2')
         prob.cleanup()
 
         # without pre_load, we should get format_version and metadata but no cases
@@ -2106,8 +2106,8 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.model.nonlinear_solver.add_recorder(self.recorder)
 
         prob.run_driver()
-        prob.record_state('c_1')
-        prob.record_state('c_2')
+        prob.record('c_1')
+        prob.record('c_2')
         prob.cleanup()
 
         cr = om.CaseReader(self.filename, pre_load=False)
@@ -2384,7 +2384,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         fail = prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         self.assertFalse(fail, 'Problem optimization failed.')
@@ -2883,7 +2883,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.run_driver()
 
         case_name = "c1"
-        prob.record_state(case_name)
+        prob.record(case_name)
 
         prob.cleanup()
 
@@ -3433,14 +3433,14 @@ class TestFeatureSqliteReader(unittest.TestCase):
         prob.run_driver()
         print(prob['x'], prob['y'], prob['f_xy'])
         case_name_1 = "c1"
-        prob.record_state(case_name_1)
+        prob.record(case_name_1)
 
         prob['x'] = 0.1
         prob['y'] = -0.1
         prob.run_driver()
         print(prob['x'], prob['y'], prob['f_xy'])
         case_name_2 = "c2"
-        prob.record_state(case_name_2)
+        prob.record(case_name_2)
         prob.cleanup()
 
         cr = om.CaseReader('cases.sql')
@@ -3619,7 +3619,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         #
         # fail = prob.run_driver()
         #
-        # prob.record_state('final')
+        # prob.record('final')
         # prob.cleanup()
 
         filename = os.path.join(self.legacy_dir, 'case_problem_driver_v7.sql')
@@ -3663,7 +3663,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         # prob.setup()
         # prob.run_driver()
         #
-        # prob.record_state('final')
+        # prob.record('final')
         # prob.cleanup()
 
         filename = os.path.join(self.legacy_dir, 'case_problem_v6.sql')

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1626,7 +1626,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
@@ -1657,7 +1657,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        msg = "'Problem.record_iteration' has been deprecated. Use 'Problem.record_state' instead."
+        msg = "'Problem.record_iteration' has been deprecated. Use 'Problem.record' instead."
 
         with assert_warning(DeprecationWarning, msg):
             prob.record_iteration('final')
@@ -1697,7 +1697,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
@@ -1738,7 +1738,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
@@ -1774,7 +1774,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.set_solver_print(0)
         prob.run_driver()
-        prob.record_state('case1')
+        prob.record('case1')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('case1')
         self.assertEqual(final_case.residuals, None)
@@ -1783,7 +1783,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['record_inputs'] = True
         prob.setup()
         prob.run_driver()
-        prob.record_state('case2')
+        prob.record('case2')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('case2')
         self.assertEqual(set(final_case.inputs.keys()), {'y', 'x'})
@@ -1795,7 +1795,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['excludes'] = ['*y']
         prob.setup()
         prob.run_driver()
-        prob.record_state('case3')
+        prob.record('case3')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('case3')
         self.assertEqual(set(final_case.inputs.keys()), {'x'})
@@ -1805,7 +1805,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['includes'] = ['*y']
         prob.setup()
         prob.run_driver()
-        prob.record_state('case4')
+        prob.record('case4')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('case4')
         self.assertEqual(set(final_case.inputs.keys()), {'y'})
@@ -1816,7 +1816,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['record_residuals'] = False
         prob.setup()
         prob.run_driver()
-        prob.record_state('case5')
+        prob.record('case5')
         prob.cleanup()
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('case5')
@@ -1835,7 +1835,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.set_solver_print(0)
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('final')
         self.assertEqual(set(final_case.residuals.keys()), {'f_xy', 'y', 'x', 'c'})
@@ -1846,7 +1846,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['includes'] = ['x*']
         prob.setup()
         prob.run_driver()
-        prob.record_state('final2')
+        prob.record('final2')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('final2')
         self.assertEqual(set(final_case.residuals.keys()), {'x'})
@@ -1857,7 +1857,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['record_residuals'] = False
         prob.setup()
         prob.run_driver()
-        prob.record_state('final3')
+        prob.record('final3')
         prob.cleanup()
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('final3')
@@ -1876,7 +1876,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.set_solver_print(0)
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('final')
         self.assertEqual(set(final_case.residuals.keys()), {'f_xy', 'y', 'x', 'c'})
@@ -1887,7 +1887,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['includes'] = ['x*']
         prob.setup()
         prob.run_driver()
-        prob.record_state('final2')
+        prob.record('final2')
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('final2')
         self.assertEqual(set(final_case.residuals.keys()), {'x'})
@@ -1898,7 +1898,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.recording_options['record_residuals'] = False
         prob.setup()
         prob.run_driver()
-        prob.record_state('final3')
+        prob.record('final3')
         prob.cleanup()
         cr = om.CaseReader(self.filename)
         final_case = cr.get_case('final3')
@@ -2037,7 +2037,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.setup()
         prob.run_driver()
 
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
@@ -2070,7 +2070,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
         case_name = "state1"
-        prob.record_state(case_name)
+        prob.record(case_name)
         prob.cleanup()
 
         expected_derivs = {
@@ -2095,7 +2095,7 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.set_solver_print(0)
         t0, t1 = run_driver(prob)
         case_name = "state1"
-        prob.record_state(case_name)
+        prob.record(case_name)
         prob.cleanup()
 
         expected_derivs = None
@@ -2114,7 +2114,7 @@ class TestSqliteRecorder(unittest.TestCase):
         t0, t1 = run_driver(prob)
 
         case_name = "state1"
-        prob.record_state(case_name)
+        prob.record(case_name)
 
         prob.cleanup()
 
@@ -2683,7 +2683,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         prob.setup()
         prob.run_driver()
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
@@ -2737,7 +2737,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         prob.setup()
         prob.run_driver()
-        prob.record_state('final')
+        prob.record('final')
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
@@ -2868,7 +2868,7 @@ class TestFeatureBasicRecording(unittest.TestCase):
         prob.run_driver()
 
         # record the final state of the problem
-        prob.record_state('final')
+        prob.record('final')
 
         # clean up and shut down
         prob.cleanup()


### PR DESCRIPTION
### Summary

Rename Problem.record_state to Problem.record since users do not think only "state variables" are being recorded. Actually, all variables are being recorded.

### Related Issues

- Resolves #1354

### Backwards incompatibilities

None

### New Dependencies

None
