### PR TITLE
Prevent users from setting driver.supports options

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -159,7 +159,7 @@ class Driver(object):
                                             'driver level.')
 
         # What the driver supports.
-        self.supports = OptionsDictionary(parent_name=type(self).__name__, read_only=False)
+        self.supports = OptionsDictionary(parent_name=type(self).__name__)
         self.supports.declare('inequality_constraints', types=bool, default=False)
         self.supports.declare('equality_constraints', types=bool, default=False)
         self.supports.declare('linear_constraints', types=bool, default=False)

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -159,7 +159,7 @@ class Driver(object):
                                             'driver level.')
 
         # What the driver supports.
-        self.supports = OptionsDictionary(parent_name=type(self).__name__)
+        self.supports = OptionsDictionary(parent_name=type(self).__name__, read_only=False)
         self.supports.declare('inequality_constraints', types=bool, default=False)
         self.supports.declare('equality_constraints', types=bool, default=False)
         self.supports.declare('linear_constraints', types=bool, default=False)

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -74,6 +74,7 @@ class SimpleGADriver(Driver):
         self.supports['linear_constraints'] = False
         self.supports['simultaneous_derivatives'] = False
         self.supports['active_set'] = False
+        self.supports._read_only = True
 
         self._desvar_idx = {}
         self._ga = None

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -145,7 +145,7 @@ class pyOptSparseDriver(Driver):
         # What we don't support yet
         self.supports['active_set'] = False
         self.supports['integer_design_vars'] = False
-        self.supports._read_only = False
+        self.supports._read_only = True
 
         # The user places optimizer-specific settings in here.
         self.opt_settings = {}

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -201,6 +201,7 @@ class pyOptSparseDriver(Driver):
 
         self.supports._read_only = False
         self.supports['gradients'] = self.options['optimizer'] in grad_drivers
+        self.supports._read_only = True
 
         if len(self._objs) > 1 and self.options['optimizer'] not in multi_obj_drivers:
             raise RuntimeError('Multiple objectives have been added to pyOptSparseDriver'

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -201,7 +201,6 @@ class pyOptSparseDriver(Driver):
 
         self.supports._read_only = False
         self.supports['gradients'] = self.options['optimizer'] in grad_drivers
-        self.supports._read_only = True
 
         if len(self._objs) > 1 and self.options['optimizer'] not in multi_obj_drivers:
             raise RuntimeError('Multiple objectives have been added to pyOptSparseDriver'

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -145,6 +145,7 @@ class pyOptSparseDriver(Driver):
         # What we don't support yet
         self.supports['active_set'] = False
         self.supports['integer_design_vars'] = False
+        self.supports._read_only = False
 
         # The user places optimizer-specific settings in here.
         self.opt_settings = {}
@@ -198,7 +199,9 @@ class pyOptSparseDriver(Driver):
         """
         super(pyOptSparseDriver, self)._setup_driver(problem)
 
+        self.supports._read_only = False
         self.supports['gradients'] = self.options['optimizer'] in grad_drivers
+        self.supports._read_only = True
 
         if len(self._objs) > 1 and self.options['optimizer'] not in multi_obj_drivers:
             raise RuntimeError('Multiple objectives have been added to pyOptSparseDriver'

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -132,6 +132,7 @@ class ScipyOptimizeDriver(Driver):
         self.supports['multiple_objectives'] = False
         self.supports['active_set'] = False
         self.supports['integer_design_vars'] = False
+        self.supports._read_only = True
 
         # The user places optimizer-specific settings in here.
         self.opt_settings = OrderedDict()
@@ -188,10 +189,12 @@ class ScipyOptimizeDriver(Driver):
         super(ScipyOptimizeDriver, self)._setup_driver(problem)
         opt = self.options['optimizer']
 
+        self.supports._read_only = False
         self.supports['gradients'] = opt in _gradient_optimizers
         self.supports['inequality_constraints'] = opt in _constraint_optimizers
         self.supports['two_sided_constraints'] = opt in _constraint_optimizers
         self.supports['equality_constraints'] = opt in _eq_constraint_optimizers
+        self.supports._read_only = True
 
         # Raises error if multiple objectives are not supported, but more objectives were defined.
         if not self.supports['multiple_objectives'] and len(self._objs) > 1:

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -194,6 +194,7 @@ class ScipyOptimizeDriver(Driver):
         self.supports['inequality_constraints'] = opt in _constraint_optimizers
         self.supports['two_sided_constraints'] = opt in _constraint_optimizers
         self.supports['equality_constraints'] = opt in _eq_constraint_optimizers
+        self.supports._read_only = True
 
         # Raises error if multiple objectives are not supported, but more objectives were defined.
         if not self.supports['multiple_objectives'] and len(self._objs) > 1:

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -194,7 +194,6 @@ class ScipyOptimizeDriver(Driver):
         self.supports['inequality_constraints'] = opt in _constraint_optimizers
         self.supports['two_sided_constraints'] = opt in _constraint_optimizers
         self.supports['equality_constraints'] = opt in _eq_constraint_optimizers
-        self.supports._read_only = True
 
         # Raises error if multiple objectives are not supported, but more objectives were defined.
         if not self.supports['multiple_objectives'] and len(self._objs) > 1:

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -671,17 +671,14 @@ class TestConstrainedSimpleGA(unittest.TestCase):
         # setup the optimization
         driver = prob.driver = om.SimpleGADriver()
 
-        prob.driver.supports['equality_constraints'] = False
+        with self.assertRaises(KeyError) as raises_msg:
+            prob.driver.supports['equality_constraints'] = False
 
-        prob.model.add_design_var('radius', lower=0.5, upper=5.)
-        prob.model.add_design_var('height', lower=0.5, upper=5.)
-        prob.model.add_objective('Area')
-        prob.model.add_constraint('Volume', lower=10.)
+        exception = raises_msg.exception
 
-        prob.setup()
-        prob.run_driver()
+        msg = "SimpleGADriver: Tried to set read-only option 'equality_constraints'."
 
-        #self.assertRaises()
+        self.assertEqual(exception.args[0], msg)
 
     def test_constrained_without_penalty(self):
 

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -642,31 +642,9 @@ class TestConstrainedSimpleGA(unittest.TestCase):
 
     def test_driver_supports(self):
 
-        class Cylinder(om.ExplicitComponent):
-            """Main class"""
-
-            def setup(self):
-                self.add_input('radius', val=1.0)
-                self.add_input('height', val=1.0)
-
-                self.add_output('Area', val=1.0)
-                self.add_output('Volume', val=1.0)
-
-            def compute(self, inputs, outputs):
-                radius = inputs['radius']
-                height = inputs['height']
-
-                area = height * radius * 2 * 3.14 + 3.14 * radius ** 2 * 2
-                volume = 3.14 * radius ** 2 * height
-                outputs['Area'] = area
-                outputs['Volume'] = volume
-
         prob = om.Problem()
-        prob.model.add_subsystem('cylinder', Cylinder(), promotes=['*'])
 
         indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
-        indeps.add_output('radius', 2.)  # height
-        indeps.add_output('height', 3.)  # radius
 
         # setup the optimization
         driver = prob.driver = om.SimpleGADriver()

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -534,13 +534,18 @@ class TestPyoptSparse(unittest.TestCase):
         model = prob.model
 
         model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
-        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
-        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
-
-        prob.set_solver_print(level=0)
 
         prob.driver = pyOptSparseDriver(optimizer=OPTIMIZER, print_results=False)
+
+        with self.assertRaises(KeyError) as raises_msg:
+            prob.driver.supports['equality_constraints'] = False
+
+        exception = raises_msg.exception
+
+        msg = "pyOptSparseDriver: Tried to set read-only option 'equality_constraints'."
+
+        self.assertEqual(exception.args[0], msg)
+
 
     def test_fan_out(self):
         # This tests sparse-response specification.

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -528,7 +528,7 @@ class TestPyoptSparse(unittest.TestCase):
         obj = prob['o']
         assert_near_equal(obj, 20.0, 1e-6)
 
-    def test_simple_driver_supports(self):
+    def test_driver_supports(self):
 
         prob = om.Problem()
         model = prob.model

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -528,6 +528,20 @@ class TestPyoptSparse(unittest.TestCase):
         obj = prob['o']
         assert_near_equal(obj, 20.0, 1e-6)
 
+    def test_simple_driver_supports(self):
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = pyOptSparseDriver(optimizer=OPTIMIZER, print_results=False)
+
     def test_fan_out(self):
         # This tests sparse-response specification.
         # This is a slightly modified FanOut

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -114,6 +114,25 @@ class TestMPIScatter(unittest.TestCase):
 
 class TestScipyOptimizeDriver(unittest.TestCase):
 
+    def test_driver_supports(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=False)
+
+        with self.assertRaises(KeyError) as raises_msg:
+            prob.driver.supports['equality_constraints'] = False
+
+        exception = raises_msg.exception
+
+        msg = "ScipyOptimizeDriver: Tried to set read-only option 'equality_constraints'."
+
+        self.assertEqual(exception.args[0], msg)
+
     def test_compute_totals_basic_return_array(self):
         # Make sure 'array' return_format works.
 


### PR DESCRIPTION
### Summary

User is no longer able to change the options in `driver.supports` dictionary

### Related Issues

- Resolves #1294 

### Backwards incompatibilities

Will now throw error if user tries to set an option on `driver.supports` OptionsDictionary.

### New Dependencies

None
