### PR TITLE
pyoptsparse driver now handles IPOPT return codes

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -430,7 +430,10 @@ class pyOptSparseDriver(Driver):
             self.fail = False
 
             # These are various failed statuses.
-            if exit_status > 2:
+            if optimizer == 'IPOPT':
+                if exit_status not in {0, 1}:
+                    self.fail = True
+            elif exit_status > 2:
                 self.fail = True
 
         except KeyError:


### PR DESCRIPTION
### Summary

Fixes pyoptsparseDriver so that it correctly handles IPOPT return codes.

### Related Issues

- Resolves #1371

### Backwards incompatibilities

None

### New Dependencies

None
