### PR TITLE
Removed upOneLevelButtonClick function since it is not being used anymore

### DIFF
--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -478,22 +478,6 @@ class N2UserInterface {
     }
 
     /**
-     * When the up button is pushed, add the current zoomed element to the
-     * back button history, and zoom to its parent.
-     */
-    upOneLevelButtonClick() {
-        testThis(this, 'N2UserInterface', 'upOneLevelButtonClick');
-
-        if (this.n2Diag.zoomedElement === this.n2Diag.model.root) return;
-        this.backButtonHistory.push({
-            node: this.n2Diag.zoomedElement,
-        });
-        this.forwardButtonHistory = [];
-        this._setupLeftClick(this.n2Diag.zoomedElement.parent);
-        this.n2Diag.update();
-    }
-
-    /**
      * Minimize the specified node and recursively minimize its children.
      * @param {N2TreeNode} node The current node to operate on.
      */


### PR DESCRIPTION
### Summary

The N2 toolbar used to have a button for going up in the model hierarchy. That is gone so the JavaScript code for that is not needed.

### Related Issues

No issue made for this. 

### Backwards incompatibilities

None

### New Dependencies

None
