### PR TITLE
Update feature doc for distributed components

### DIFF
--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -577,16 +577,16 @@ class MPIFeatureTests(unittest.TestCase):
         prob.run_model()
 
         assert_near_equal(prob['C2.invec'],
-                          np.ones((8,)) if model.comm.rank == 0 else np.ones((7,)))
+                          np.ones(8) if model.comm.rank == 0 else np.ones(7))
         assert_near_equal(prob['C2.outvec'],
-                          2*np.ones((8,)) if model.comm.rank == 0 else -3*np.ones((7,)))
-        assert_near_equal(prob['C3.out'], -5.)
+                          2*np.ones(8) if model.comm.rank == 0 else -3*np.ones(7))
+        assert_near_equal(prob['C3.sum'], -5.)
 
         assert_check_partials(prob.check_partials())
 
         J = prob.compute_totals(of=['C2.outvec'], wrt=['indep.x'])
         assert_near_equal(J[('C2.outvec', 'indep.x')], 
-                          np.eye(15)*np.append(np.ones(8)*2., np.ones(7)*-3))
+                          np.eye(15)*np.append(2*np.ones(8), -3*np.ones(7)))
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -549,6 +549,46 @@ class MPITests3(unittest.TestCase):
             assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
 
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class MPIFeatureTests(unittest.TestCase):
+
+    N_PROCS = 2
+
+    def test_distribcomp_derivs_feature(self):
+        import numpy as np
+        import openmdao.api as om
+        from openmdao.test_suite.components.distributed_components import DistribCompDerivs, SummerDerivs
+        from openmdao.utils.assert_utils import assert_check_partials
+
+        size = 15
+
+        model = om.Group()
+        model.add_subsystem("indep", om.IndepVarComp('x', np.zeros(size)))
+        model.add_subsystem("C2", DistribCompDerivs(size=size))
+        model.add_subsystem("C3", SummerDerivs(size=size))
+
+        model.connect('indep.x', 'C2.invec')
+        model.connect('C2.outvec', 'C3.invec')
+
+        prob = om.Problem(model)
+        prob.setup()
+
+        prob['indep.x'] = np.ones(size)
+        prob.run_model()
+
+        assert_near_equal(prob['C2.invec'],
+                          np.ones((8,)) if model.comm.rank == 0 else np.ones((7,)))
+        assert_near_equal(prob['C2.outvec'],
+                          2*np.ones((8,)) if model.comm.rank == 0 else -3*np.ones((7,)))
+        assert_near_equal(prob['C3.out'], -5.)
+
+        assert_check_partials(prob.check_partials())
+
+        J = prob.compute_totals(of=['C2.outvec'], wrt=['indep.x'])
+        assert_near_equal(J[('C2.outvec', 'indep.x')], 
+                          np.eye(15)*np.append(np.ones(8)*2., np.ones(7)*-3))
+
+
 if __name__ == "__main__":
     from openmdao.utils.mpi import mpirun_tests
     mpirun_tests()

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -180,6 +180,7 @@ class DistribInputDistribOutputComp(om.ExplicitComponent):
         self.add_input('invec', np.ones(sizes[rank], float))
         self.add_output('outvec', np.ones(sizes[rank], float))
 
+
 class DistribCompWithDerivs(om.ExplicitComponent):
     """Uses 2 procs and takes input var slices, but also computes partials"""
 
@@ -218,6 +219,7 @@ class DistribCompWithDerivs(om.ExplicitComponent):
         self.add_output('outvec', np.ones(sizes[rank], float))
         self.declare_partials('outvec', 'invec', rows=np.arange(0, sizes[rank]),
                                                  cols=np.arange(0, sizes[rank]))
+
 
 class DistribInputDistribOutputDiscreteComp(DistribInputDistribOutputComp):
 

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -844,7 +844,7 @@ class MPIFeatureTests(unittest.TestCase):
                           np.ones((8,)) if model.comm.rank == 0 else np.ones((7,)))
         assert_near_equal(prob['C2.outvec'],
                           2*np.ones((8,)) if model.comm.rank == 0 else -3*np.ones((7,)))
-        assert_near_equal(prob['C3.out'], -5.)
+        assert_near_equal(prob['C3.sum'], -5.)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -841,9 +841,9 @@ class MPIFeatureTests(unittest.TestCase):
         prob.run_model()
 
         assert_near_equal(prob['C2.invec'],
-                         np.ones((8,)) if model.comm.rank == 0 else np.ones((7,)))
+                          np.ones((8,)) if model.comm.rank == 0 else np.ones((7,)))
         assert_near_equal(prob['C2.outvec'],
-                         2*np.ones((8,)) if model.comm.rank == 0 else -3*np.ones((7,)))
+                          2*np.ones((8,)) if model.comm.rank == 0 else -3*np.ones((7,)))
         assert_near_equal(prob['C3.out'], -5.)
 
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -953,8 +953,14 @@ class TestGroup(unittest.TestCase):
         p.setup()
         p.run_model()
 
+        assert_near_equal(p['indep.x'], np.array([[0., 1., 2.],
+                                                  [3., 4., 5.],
+                                                  [6., 7., 8.],
+                                                  [9., 10., 11.]]))
+
         assert_near_equal(p['C1.x'], np.array([[0., 10.],
-                                                    [7., 4.]]))
+                                               [7., 4.]]))
+
         assert_near_equal(p['C1.y'], 42.)
 
     def test_promote_not_found1(self):

--- a/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
+++ b/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
@@ -32,14 +32,7 @@ Component Options
 
 .. note::
 
-	If a Component is distributed then *all* of its outputs are distributed.
-
-.. note::
-
-	You should always specify *src_indices* when adding an input to a distributed 
-	component unless your input is equal to the size of the entire distributed output.
-	Otherwise, the assumed *src_indices* will be from 0 to 1 less than the 
-	size of your input, which is probably not what you want.
+    If a Component is distributed then *all* of its outputs are distributed.
 
 
 Distributed Component Example
@@ -48,20 +41,56 @@ Distributed Component Example
 The following example shows how to create a distributed component, `DistribComp`, 
 that distributes its computation evenly across the available processes. A second 
 component, `Summer`, sums the values from the distributed component into a scalar 
-output value.  Note that a component that takes a distributed output as input does
-not need to do anything special as OpenMDAO performs the required MPI operations 
-to make the full value available.
+output value.  
 
 These components can found in the OpenMDAO test suite:
 
 .. embed-code::
-  openmdao.test_suite.components.distributed_components.DistribComp
+    openmdao.test_suite.components.distributed_components.DistribComp
+
+.. note::
+
+    In this example component, we have explicitly specified *src_indices* when adding
+    the input. This is not really necessary in this case, because it replicates the
+    default behavior. If no *src_indices* are specified, OpenMDAO will assume an offset
+    that is the sum of the sizes in all ranks up to the current rank and a range equal
+    to the specified size (the size is given per the usual arguments to :code:`add_input`).
 
 .. embed-code::
-  openmdao.test_suite.components.distributed_components.Summer
+    openmdao.test_suite.components.distributed_components.Summer
 
-This example is run with 2 processes and a size of 15:
+.. note::
+
+    A component that takes a distributed output as input does not need to do anything
+    special as OpenMDAO performs the required MPI operations to make the full value 
+    available.
+
+This example is run with two processes and a :code:`size` of 15:
 
 .. embed-code::
-  openmdao.core.tests.test_distribcomp.MPIFeatureTests.test_distribcomp_feature
-  :layout: interleave
+    openmdao.core.tests.test_distribcomp.MPIFeatureTests.test_distribcomp_feature
+    :layout: interleave
+
+
+Distributed Component with Derivatives
+--------------------------------------
+
+Derivatives can be computed for distributed components as shown in the following
+variation on the example.  Also, in this version, we have taken advantage of the automatic
+determination of *src_indices*.
+
+
+.. embed-code::
+    openmdao.test_suite.components.distributed_components.DistribCompDerivs
+
+.. embed-code::
+    openmdao.test_suite.components.distributed_components.SummerDerivs
+
+
+This example is again run with two processes and a :code:`size` of 15.  We can use
+:ref:`assert_check_partials<feature_unit_testing_partials>` to verify that
+the partial derivatives are calculated correctly.
+
+.. embed-code::
+    openmdao.core.tests.test_distrib_derivs.MPIFeatureTests.test_distribcomp_derivs_feature
+    :layout: interleave

--- a/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
+++ b/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
@@ -13,15 +13,11 @@ OpenMDAO using a distributed component.  A distributed component is a component
 that operates on distributed variables. A variable is distributed if each process
 contains only a part of the whole variable.
 
-We've already seen that by using *src_indices* we can connect an input to only a
-subset of an output variable.  By giving different values for *src_indices*
-in each MPI process, we can distribute computations on a distributed output
-across the processes.  You should always specify *src_indices* when connecting
-to a distributed output unless your input is equal to the size of the entire
-distributed output.  Otherwise, the assumed *src_indices* will be from 0 to
-1 less than the size of your input, which is probably not what you want.
+We've already seen that by using :ref:`src_indices <connect_src_indices>`
+we can connect an input to only a subset of an output variable.  
+By giving different values for *src_indices* in each MPI process, we can
+distribute computations on a distributed output across the processes.  
 
-If a Component has *any* distributed outputs then *all* of its outputs are distributed.
 You tell the framework that a Component is a distributed component by setting its
 :code:`distributed` option to True:
 
@@ -34,12 +30,27 @@ Component Options
     Component
     options
 
+.. note::
+
+	If a Component is distributed then *all* of its outputs are distributed.
+
+.. note::
+
+	You should always specify *src_indices* when adding an input to a distributed 
+	component unless your input is equal to the size of the entire distributed output.
+	Otherwise, the assumed *src_indices* will be from 0 to 1 less than the 
+	size of your input, which is probably not what you want.
+
+
 Distributed Component Example
 -----------------------------
 
-The following simple example shows how to create a distributed component, `DistribComp`, 
-that distributes its computation evenly across the available processes. A second `Summer`
-component sums the values from the distributed component into a scalar output value.
+The following example shows how to create a distributed component, `DistribComp`, 
+that distributes its computation evenly across the available processes. A second 
+component, `Summer`, sums the values from the distributed component into a scalar 
+output value.  Note that a component that takes a distributed output as input does
+not need to do anything special as OpenMDAO performs the required MPI operations 
+to make the full value available.
 
 These components can found in the OpenMDAO test suite:
 
@@ -49,8 +60,7 @@ These components can found in the OpenMDAO test suite:
 .. embed-code::
   openmdao.test_suite.components.distributed_components.Summer
 
-
-This example is run with 2 processes:
+This example is run with 2 processes and a size of 15:
 
 .. embed-code::
   openmdao.core.tests.test_distribcomp.MPIFeatureTests.test_distribcomp_feature

--- a/openmdao/docs/features/core_features/grouping_components/connect.rst
+++ b/openmdao/docs/features/core_features/grouping_components/connect.rst
@@ -32,6 +32,7 @@ Usage
     openmdao.core.tests.test_group.TestGroup.test_connect_1_to_many
     :layout: interleave
 
+.. _connect_src_indices:
 
 3. Connect only part of an array output to an input of a smaller size.
 

--- a/openmdao/test_suite/components/distributed_components.py
+++ b/openmdao/test_suite/components/distributed_components.py
@@ -24,15 +24,17 @@ class DistribComp(om.ExplicitComponent):
 
         size = self.options['size']
 
-        # results in 8 entries for proc 0 and 7 entries for proc 1 when using 2 processes.
+        # if comm.size is 2 and size is 15, this results in
+        # 8 entries for proc 0 and 7 entries for proc 1
         sizes, offsets = evenly_distrib_idxs(comm.size, size)
+        mysize = sizes[rank]
         start = offsets[rank]
-        end = start + sizes[rank]
+        end = start + mysize
 
-        self.add_input('invec', np.ones(sizes[rank], float),
+        self.add_input('invec', np.ones(mysize, float),
                        src_indices=np.arange(start, end, dtype=int))
 
-        self.add_output('outvec', np.ones(sizes[rank], float))
+        self.add_output('outvec', np.ones(mysize, float))
 
     def compute(self, inputs, outputs):
         if self.comm.rank == 0:
@@ -42,37 +44,18 @@ class DistribComp(om.ExplicitComponent):
 
 
 class Summer(om.ExplicitComponent):
-    """Sums a distributed input."""
+    """Sums an input array."""
 
     def initialize(self):
         self.options.declare('size', types=int, default=1,
                              desc="Size of input and output vectors.")
 
     def setup(self):
-        comm = self.comm
-        rank = comm.rank
-
         size = self.options['size']
 
-        # this results in 8 entries for proc 0 and 7 entries for proc 1
-        # when using 2 processes.
-        sizes, offsets = evenly_distrib_idxs(comm.size, size)
-        start = offsets[rank]
-        end = start + sizes[rank]
-
-        # NOTE: you must specify src_indices here for the input. Otherwise,
-        #       you'll connect the input to [0:local_input_size] of the
-        #       full distributed output!
-        self.add_input('invec', np.ones(sizes[rank], float),
-                       src_indices=np.arange(start, end, dtype=int))
+        self.add_input('invec', np.ones(size, float))
 
         self.add_output('out', 0.0)
 
     def compute(self, inputs, outputs):
-        data = np.zeros(1)
-        data[0] = np.sum(inputs['invec'])
-
-        total = np.zeros(1)
-        self.comm.Allreduce(data, total, op=MPI.SUM)
-
-        outputs['out'] = total[0]
+        outputs['out'] = np.sum(inputs['invec'])

--- a/openmdao/test_suite/components/distributed_components.py
+++ b/openmdao/test_suite/components/distributed_components.py
@@ -11,6 +11,7 @@ from openmdao.utils.array_utils import evenly_distrib_idxs
 
 
 class DistribComp(om.ExplicitComponent):
+    """Simple Distributed Component."""
 
     def initialize(self):
         self.options['distributed'] = True
@@ -56,6 +57,72 @@ class Summer(om.ExplicitComponent):
         self.add_input('invec', np.ones(size, float))
 
         self.add_output('out', 0.0)
+
+    def compute(self, inputs, outputs):
+        outputs['out'] = np.sum(inputs['invec'])
+
+
+class DistribCompDerivs(om.ExplicitComponent):
+    """Simple Distributed Component with Derivatives."""
+
+    def initialize(self):
+        self.options['distributed'] = True
+
+        self.options.declare('size', types=int, default=1,
+                             desc="Size of input and output vectors.")
+
+    def setup(self):
+        comm = self.comm
+        rank = comm.rank
+
+        size = self.options['size']
+
+        # if comm.size is 2 and size is 15, this results in
+        # 8 entries for proc 0 and 7 entries for proc 1
+        sizes, _ = evenly_distrib_idxs(comm.size, size)
+        self.mysize = mysize = sizes[rank]
+
+        # don't set src_indices on the input, just use default behavior
+        self.add_input('invec', np.ones(mysize, float))
+        self.add_output('outvec', np.ones(mysize, float))
+
+        # declare partial derivatives (diagonal of mysize)
+        self.declare_partials('outvec', 'invec', 
+                              rows=np.arange(0, mysize),
+                              cols=np.arange(0, mysize))
+
+    def compute(self, inputs, outputs):
+        if self.comm.rank == 0:
+            outputs['outvec'] = inputs['invec'] * 2.0
+        else:
+            outputs['outvec'] = inputs['invec'] * -3.0
+
+    def compute_partials(self, inputs, J):
+        # get mysize from the input vector for this process
+        mysize = inputs['invec'].size
+
+        if self.comm.rank == 0:
+            J['outvec', 'invec'] = 2.0 * np.ones((mysize,))
+        else:
+            J['outvec', 'invec'] = -3.0 * np.ones((mysize,))
+
+
+class SummerDerivs(om.ExplicitComponent):
+    """Sums an input array."""
+
+    def initialize(self):
+        self.options.declare('size', types=int, default=1,
+                             desc="Size of input and output vectors.")
+
+    def setup(self):
+        size = self.options['size']
+
+        self.add_input('invec', np.ones(size, float))
+
+        self.add_output('out', 0.0)
+
+        # the derivative is constant
+        self.declare_partials('out', 'invec', val=1.)
 
     def compute(self, inputs, outputs):
         outputs['out'] = np.sum(inputs['invec'])

--- a/openmdao/test_suite/components/distributed_components.py
+++ b/openmdao/test_suite/components/distributed_components.py
@@ -52,14 +52,12 @@ class Summer(om.ExplicitComponent):
                              desc="Size of input and output vectors.")
 
     def setup(self):
-        size = self.options['size']
+        self.add_input('invec', np.ones(self.options['size'], float))
 
-        self.add_input('invec', np.ones(size, float))
-
-        self.add_output('out', 0.0)
+        self.add_output('sum', 0.0, shape=1)
 
     def compute(self, inputs, outputs):
-        outputs['out'] = np.sum(inputs['invec'])
+        outputs['sum'] = np.sum(inputs['invec'])
 
 
 class DistribCompDerivs(om.ExplicitComponent):
@@ -102,9 +100,9 @@ class DistribCompDerivs(om.ExplicitComponent):
         mysize = inputs['invec'].size
 
         if self.comm.rank == 0:
-            J['outvec', 'invec'] = 2.0 * np.ones((mysize,))
+            J['outvec', 'invec'] = np.ones((mysize,)) * 2.0
         else:
-            J['outvec', 'invec'] = -3.0 * np.ones((mysize,))
+            J['outvec', 'invec'] = np.ones((mysize,)) * -3.0
 
 
 class SummerDerivs(om.ExplicitComponent):
@@ -115,14 +113,12 @@ class SummerDerivs(om.ExplicitComponent):
                              desc="Size of input and output vectors.")
 
     def setup(self):
-        size = self.options['size']
+        self.add_input('invec', np.ones(self.options['size'], float))
 
-        self.add_input('invec', np.ones(size, float))
-
-        self.add_output('out', 0.0)
+        self.add_output('sum', 0.0, shape=1)
 
         # the derivative is constant
-        self.declare_partials('out', 'invec', val=1.)
+        self.declare_partials('sum', 'invec', val=1.)
 
     def compute(self, inputs, outputs):
-        outputs['out'] = np.sum(inputs['invec'])
+        outputs['sum'] = np.sum(inputs['invec'])


### PR DESCRIPTION
### Summary

Update feature doc for distributed components

- highlight how a component that takes a distributed output as input doesn't need to do anything special; openmdao performs any mpi operations to make the vector available.
- show components with derivatives defined, show that `check_partials` yields correct results.

### Related Issues

- Resolves #1290 

Note that I could not document use of `check_totals` in this PR, pending
https://github.com/OpenMDAO/OpenMDAO/projects/2#card-36750563

### Backwards incompatibilities

None

### New Dependencies

None
