### PR TITLE
BoundsEnforceLS linesearch UserWarning Remove

### DIFF
--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -11,6 +11,7 @@ from tempfile import mkdtemp
 
 import openmdao.api as om
 from openmdao.utils.general_utils import set_pyoptsparse_opt
+from openmdao.utils.assert_utils import assert_no_warning
 
 from openmdao.test_suite.components.ae_tests import AEComp
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDerivativesGrouped, \
@@ -2588,7 +2589,12 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         prob['circuit.n1.V'] = 10.
         prob['circuit.n2.V'] = 1.
 
-        prob.run_driver()
+        msg = ("BoundsEnforceLS in Circuit (circuit): linesearch is active but no bounds have been "
+               "set.")
+
+        with assert_no_warning(UserWarning, msg):
+            prob.run_driver()
+
         prob.cleanup()
 
         # create the case reader

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2589,11 +2589,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         prob['circuit.n1.V'] = 10.
         prob['circuit.n2.V'] = 1.
 
-        msg = ("BoundsEnforceLS in Circuit (circuit): linesearch is active but no bounds have been "
-               "set.")
-
-        with assert_no_warning(UserWarning, msg):
-            prob.run_driver()
+        prob.run_driver()
 
         prob.cleanup()
 

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -141,7 +141,6 @@ class LinesearchSolver(NonlinearSolver):
 
                 start = end
         else:
-            simple_warning(f"{self.msginfo}: linesearch is active but no bounds have been set.")
             self._lower_bounds = self._upper_bounds = None
 
     def _enforce_bounds(self, step, alpha):


### PR DESCRIPTION
### Summary

Removed UserWarning because it's no longer needed. There isn't a performance hit because of this anymore so the warning can be removed.

### Related Issues

- Resolves #1370

### Backwards incompatibilities

None

### New Dependencies

None
