### PR TITLE
Allow partials on distributed comps with zero-length inputs/outputs on some procs

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1262,9 +1262,19 @@ class Component(System):
                 if shape[0] == 0 or shape[1] == 0:
                     msg = "{}: '{}' is an array of size 0"
                     if shape[0] == 0:
-                        raise ValueError(msg.format(self.msginfo, abs_key[0]))
-                    elif shape[1] == 0:
-                        raise ValueError(msg.format(self.msginfo, abs_key[1]))
+                        if not abs2meta[abs_key[0]]['distributed']:
+                            # non-distributed components are not allowed to have zero size inputs
+                            raise ValueError(msg.format(self.msginfo, abs_key[0]))
+                        else:
+                            # distributed components are allowed to have zero size inputs on some procs
+                            rows_max = -1
+                    if shape[1] == 0:
+                        if not abs2meta[abs_key[1]]['distributed']:
+                            # non-distributed components are not allowed to have zero size outputs
+                            raise ValueError(msg.format(self.msginfo, abs_key[1]))
+                        else:
+                            # distributed components are allowed to have zero size outputs on some procs
+                            cols_max = -1
 
                 if val is None:
                     # we can only get here if rows is None  (we're not sparse list format)

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1266,14 +1266,14 @@ class Component(System):
                             # non-distributed components are not allowed to have zero size inputs
                             raise ValueError(msg.format(self.msginfo, abs_key[0]))
                         else:
-                            # distributed components are allowed to have zero size inputs on some procs
+                            # distributed comp are allowed to have zero size inputs on some procs
                             rows_max = -1
                     if shape[1] == 0:
                         if not abs2meta[abs_key[1]]['distributed']:
                             # non-distributed components are not allowed to have zero size outputs
                             raise ValueError(msg.format(self.msginfo, abs_key[1]))
                         else:
-                            # distributed components are allowed to have zero size outputs on some procs
+                            # distributed comp are allowed to have zero size outputs on some procs
                             cols_max = -1
 
                 if val is None:

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -597,8 +597,6 @@ class ZeroLengthInputsOutputs(unittest.TestCase):
     # issue 1350
 
     def test_distribcomp_zerolengthinputsoutputs(self):
-        import numpy as np
-        import openmdao.api as om
         from openmdao.test_suite.components.distributed_components import DistribCompDerivs, SummerDerivs
         from openmdao.utils.assert_utils import assert_check_partials
 

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -90,13 +90,6 @@ class Jacobian(object):
         system = self._system()
         abs2meta = system._var_allprocs_abs2meta
         of, wrt = abs_key
-        if system.comm.size > 1:
-            if wrt in system._outputs._views:
-                sz = abs2meta[wrt]['global_size']
-            else:
-                sz = abs2meta[wrt]['size']
-            return (abs2meta[of]['global_size'], sz)
-
         return (abs2meta[of]['size'], abs2meta[wrt]['size'])
 
     def __contains__(self, key):


### PR DESCRIPTION
### Summary

This is a fix for issue #1350 and enables partial derivative computation on distributed components with zero-length outputs or inputs on some processors

### Related Issues

- Resolves #1350

### Backwards incompatibilities

- I removed some code that Bret had added in jacobians.py which didn't break any tests, but I'm not sure what the purpose of that logic was in the first place?

### New Dependencies

None
