### PR TITLE
Fix redundant calls to matrix-free in parallel coloring algorithm clo…

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1363,6 +1363,7 @@ class Problem(object):
         # Assemble and Return all metrics.
         data = {}
         data[''] = {}
+        # TODO key should not be fwd when exact computed in rev mode or auto
         for key, val in Jcalc.items():
             data[''][key] = {}
             data[''][key]['J_fwd'] = val
@@ -1817,6 +1818,7 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
             do_rev_dp = not totals and matrix_free and directional
 
             derivative_info = derivatives[of, wrt]
+            # TODO total derivs may have been computed in rev mode, not fwd
             forward = derivative_info['J_fwd']
             fd = derivative_info['J_fd']
             if do_rev:

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -460,7 +460,7 @@ class _TotalJacInfo(object):
                 if matmat or parallel_deriv_color:
                     rhsname = name
 
-                    if parallel_deriv_color and self.debug_print:
+                    if parallel_deriv_color:
                         if parallel_deriv_color not in self.par_deriv:
                             self.par_deriv[parallel_deriv_color] = []
                         self.par_deriv[parallel_deriv_color].append(name)
@@ -1336,7 +1336,13 @@ class _TotalJacInfo(object):
                             model._solve_linear(model._lin_vec_names, self.mode, rel_systems)
                             self._save_linear_solution(vec_names, cache_key, self.mode)
                         else:
-                            model._solve_linear(model._lin_vec_names, mode, rel_systems)
+                            if par_deriv and key in par_deriv:
+                                # parallel colored derivatives only need to solve
+                                # the vectors relevant to this color, not all of them
+                                vecnames_par_deriv = par_deriv[key].copy()
+                                model._solve_linear(vecnames_par_deriv, mode, rel_systems)
+                            else:
+                                model._solve_linear(model._lin_vec_names, mode, rel_systems)
 
                     if debug_print:
                         print('Elapsed Time:', time.time() - t0, '\n', flush=True)


### PR DESCRIPTION
### Summary

Redundant calls to the matrix-free API were being done when running under parallel deriv coloring (for fan-out parallel problems). This adds a fix and tests.

### Related Issues

- Resolves #1405 

### Backwards incompatibilities

None

### New Dependencies

None
