### PR TITLE
Raise a RuntimeError rather than excluding pyOptSparseDriver from the API when pyoptsparse is not installed or not installed properly.

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -72,10 +72,7 @@ from openmdao.visualization.n2_viewer.n2_viewer import n2
 from openmdao.visualization.connection_viewer.viewconns import view_connections
 
 # Drivers
-try:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
-except ImportError:
-    pass
+from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 from openmdao.drivers.scipy_optimizer import ScipyOptimizeDriver
 from openmdao.drivers.genetic_algorithm_driver import SimpleGADriver
 from openmdao.drivers.doe_driver import DOEDriver

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -16,9 +16,9 @@ import numpy as np
 from scipy.sparse import coo_matrix
 
 try:
-    from pyoptsparse import OPT
+    from pyoptsparse import Optimization
 except ImportError:
-    OPT = None
+    Optimization = None
 
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.core.driver import Driver, RecordingDebugging
@@ -134,7 +134,7 @@ class pyOptSparseDriver(Driver):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
         """
-        if OPT is None:
+        if Optimization is None:
             raise RuntimeError('pyOptSparseDriver is not available, pyOptsparse is not installed.')
 
         super(pyOptSparseDriver, self).__init__(**kwargs)

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -15,7 +15,10 @@ import traceback
 import numpy as np
 from scipy.sparse import coo_matrix
 
-from pyoptsparse import Optimization
+try:
+    from pyoptsparse import OPT
+except ImportError:
+    OPT = None
 
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.core.driver import Driver, RecordingDebugging
@@ -131,6 +134,9 @@ class pyOptSparseDriver(Driver):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
         """
+        if OPT is None:
+            raise RuntimeError('pyOptSparseDriver is not available, pyOptsparse is not installed.')
+
         super(pyOptSparseDriver, self).__init__(**kwargs)
 
         # What we support

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -147,7 +147,6 @@ class DataSave(om.ExplicitComponent):
 
 @unittest.skipUnless(OPT is None, "only run if pyoptsparse is NOT installed.")
 class TestNotInstalled(unittest.TestCase):
-    N_PROCS = 2
 
     def test_pyoptsparse_not_installed(self):
         # the import should not fail
@@ -601,7 +600,6 @@ class TestPyoptSparse(unittest.TestCase):
         msg = "pyOptSparseDriver: Tried to set read-only option 'equality_constraints'."
 
         self.assertEqual(exception.args[0], msg)
-
 
     def test_fan_out(self):
         # This tests sparse-response specification.

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -160,7 +160,6 @@ class TestNotInstalled(unittest.TestCase):
                          'pyOptSparseDriver is not available, pyOptsparse is not installed.')
 
 
-
 @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestMPIScatter(unittest.TestCase):

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -145,6 +145,23 @@ class DataSave(om.ExplicitComponent):
         partials['y', 'x'] = 2.0*x - 6.0
 
 
+@unittest.skipUnless(OPT is None, "only run if pyoptsparse is NOT installed.")
+class TestNotInstalled(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_pyoptsparse_not_installed(self):
+        # the import should not fail
+        from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+
+        # but we get a RuntimeError if we try to instantiate
+        with self.assertRaises(RuntimeError) as ctx:
+            pyOptSparseDriver()
+
+        self.assertEqual(str(ctx.exception),
+                         'pyOptSparseDriver is not available, pyOptsparse is not installed.')
+
+
+
 @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestMPIScatter(unittest.TestCase):


### PR DESCRIPTION
### Summary

Raise a `RuntimeError` rather than excluding `pyOptSparseDriver` from the API when `pyoptsparse` is not installed or not installed properly.  This should be less confusing to the user when it occurs.

### Related Issues

- Resolves #1422

### Backwards incompatibilities

None

### New Dependencies

None
