### PR TITLE
Fixed collapsing the zoomed element's parent, as well as other collapse/search bugs

### DIFF
--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -333,7 +333,7 @@ class N2Diagram {
                 self.ui.leftClick(d);
             })
             .on("contextmenu", function (d) {
-                self.ui.rightClick(d);
+                self.ui.rightClick(d, this);
             })
             .on("mouseover", function (d) {
                 self.ui.nodeInfoBox.update(d3.event, d, d3.select(this).select('rect').style('fill'));

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -333,7 +333,7 @@ class N2Diagram {
                 self.ui.leftClick(d);
             })
             .on("contextmenu", function (d) {
-                self.ui.rightClick(d, this);
+                self.ui.rightClick(d);
             })
             .on("mouseover", function (d) {
                 self.ui.nodeInfoBox.update(d3.event, d, d3.select(this).select('rect').style('fill'));

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -413,7 +413,6 @@ class N2UserInterface {
      * @param {N2TreeNode} node The node that was right-clicked.
      */
     rightClick(node) {
-        console.log("rightClick() called")
         testThis(this, 'N2UserInterface', 'rightClick');
 
         d3.event.preventDefault();

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -413,12 +413,19 @@ class N2UserInterface {
      * @param {N2TreeNode} node The node that was right-clicked.
      */
     rightClick(node) {
+        console.log("rightClick() called")
         testThis(this, 'N2UserInterface', 'rightClick');
 
         d3.event.preventDefault();
         d3.event.stopPropagation();
 
-        if (this.isCollapsible(node)) {
+        if (node.isMinimized) {
+            this.rightClickedNode = node;
+            this.addBackButtonHistory();
+            this._uncollapse(node);
+            this.n2Diag.update();
+        }
+        else if (this.isCollapsible(node)) {
             this.rightClickedNode = node;
             node.collapsable = true;
 
@@ -451,13 +458,14 @@ class N2UserInterface {
      */
     leftClick(node) {
         testThis(this, 'N2UserInterface', 'leftClick');
+        d3.event.preventDefault();
+        d3.event.stopPropagation();
 
         if (!node.hasChildren() || node.isParam()) return;
         if (d3.event.button != 0) return;
         this.addBackButtonHistory();
         this._setupLeftClick(node);
-        d3.event.preventDefault();
-        d3.event.stopPropagation();
+
         this.n2Diag.update();
     }
 
@@ -664,13 +672,12 @@ class N2UserInterface {
     }
 
     /**
-     * Mark this node and all of its children as unminimized
+     * Mark this node and all of its children as unminimized/unhidden
      * @param {N2TreeNode} node The node to operate on.
      */
     _uncollapse(node) {
-        if (!node.isParam()) {
-            node.isMinimized = false;
-        }
+        node.isMinimized = false;
+        node.varIsHidden = false;
 
         if (node.hasChildren()) {
             for (let child of node.children) {

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -389,10 +389,9 @@ class N2UserInterface {
     collapse() {
         testThis(this, 'N2UserInterface', 'collapse');
 
-        let node = this.leftClickedNode;
+        let node = this.rightClickedNode;
 
         if (this.isCollapsible(node)) {
-            this.rightClickedNode = node;
 
             if (this.collapsedRightClickNode !== undefined) {
                 this.rightClickedNode = this.collapsedRightClickNode;
@@ -412,17 +411,15 @@ class N2UserInterface {
     /**
      * When a node is right-clicked, collapse it if it's allowed.
      * @param {N2TreeNode} node The node that was right-clicked.
-     * @param {Object} element The HTML element associated with the node that triggered the event.
      */
-    rightClick(node, element) {
+    rightClick(node) {
         testThis(this, 'N2UserInterface', 'rightClick');
 
         d3.event.preventDefault();
         d3.event.stopPropagation();
 
         if (this.isCollapsible(node)) {
-            this.leftClickedNode = node;
-            this.rightClickedNode = element;
+            this.rightClickedNode = node;
             node.collapsable = true;
 
             this.addBackButtonHistory();

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -161,7 +161,31 @@ n2_gui_test_scripts = {
             "test": "click",
             "selector": "g#solver_tree rect#circuit_n1",
             "button": "right"
-        }
+        },
+        {
+            "test": "root"
+        },
+        {
+            "desc": "Check the number of cells in the N2 Matrix",
+            "test": "count",
+            "selector": "g#n2elements > g.n2cell",
+            "count": 40
+        },
+        {
+            "desc": "Perform a search on V_out",
+            "test": "search",
+            "searchString": "V_out",
+            "n2ElementCount": 11
+        },
+        {
+            "test": "root"
+        },
+        {
+            "desc": "Check that home button works after search",
+            "test": "count",
+            "selector": "g#n2elements > g.n2cell",
+            "count": 40
+        },
     ],
     "bug_arrow": [
         {
@@ -325,10 +349,10 @@ n2_gui_test_scripts = {
     ],
     "udpi_circuit": [
         {
-        "desc": "Check the number of cells in the N2 Matrix",
-        "test": "count",
-        "selector": "g#n2elements > g.n2cell",
-        "count": 29
+            "desc": "Check the number of cells in the N2 Matrix",
+            "test": "count",
+            "selector": "g#n2elements > g.n2cell",
+            "count": 29
         }
     ],
     "parabaloid": [
@@ -372,6 +396,7 @@ n2_gui_test_scripts = {
 }
 
 n2_gui_test_models = n2_gui_test_scripts.keys()
+
 
 class n2_gui_test_case(unittest.TestCase):
 
@@ -535,7 +560,7 @@ class n2_gui_test_case(unittest.TestCase):
         self.log_test("Return to root")
         hndl = await self.get_handle("#reset-graph")
         await hndl.click()
-        await self.page.waitFor(self.transition_wait)
+        await self.page.waitFor(self.transition_wait * 2)
 
     async def search_and_check_result(self, options):
         """
@@ -548,17 +573,17 @@ class n2_gui_test_case(unittest.TestCase):
                       "' and checking for " +
                       str(options['n2ElementCount']) + " N2 elements after.")
 
-        await self.page.hover(".searchbar-container")
-        await self.page.click(".searchbar")
+        # await self.page.hover(".searchbar-container")
+        await self.page.click("#searchbar-container")
         await self.page.waitFor(500)
 
         searchbar = await self.page.querySelector('#awesompleteId')
-        await self.page.evaluate('(element, searchString, page) => element.value = searchString + " "', searchbar, searchString, page)
+        await searchbar.type(searchString + "\n")
 
-        await self.page.waitFor(500)
+        # await self.page.waitFor(500)
 
-        await self.page.keyboard.press('Backspace')
-        await self.page.keyboard.press("Enter")
+        # await self.page.keyboard.press('Backspace')
+        # await self.page.keyboard.press("Enter")
         await self.page.waitFor(self.transition_wait + 500)
         await self.assert_element_count("g#n2elements > g.n2cell",
                                         options['n2ElementCount'])


### PR DESCRIPTION
### Summary

If a group/component was zoomed and the user right-clicked on its parent, the parent would be collapsed, preventing navigation it. This fixes that behavior.

Also, uncollapse wasn't working, and there were still some issues with hitting the home button after a search that have been fixed.

Fixed the test code for performing a search and added tests that use it and check element after the search and then again after pressing home.

### Related Issues

- Resolves #1429

### Backwards incompatibilities

None

### New Dependencies

None
