### PR TITLE
CI Support for SNOPT 7.7 and PyoptSparse 2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,7 +118,7 @@ install:
       echo "  > Secure copying SNOPT 7.2 over SSH";
       mkdir SNOPT;
       scp -r "$SNOPT_LOCATION_72" SNOPT;
-      ./build_pyoptsparse.sh -s SNOPT -b "$PYOPTSPARSE_VERSION";
+      ./build_pyoptsparse.sh -s SNOPT/source -b "$PYOPTSPARSE_VERSION";
 
     else
       ./build_pyoptsparse.sh -b "$PYOPTSPARSE_VERSION";

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,10 @@ language: generic
 env:
   matrix:
     # test with the latest version of Python 3.x
-    - PY=3   NUMPY=1.18 SCIPY=1.4 PETSc=3.12 UPLOAD_DOCS=1
-    - PY=3.7 NUMPY=1.17 SCIPY=1.3
-    - PY=3.6 NUMPY=1.16 SCIPY=1.2 PETSc=3.10.2
+    - PY=3   NUMPY=1.18 SCIPY=1.4 PETSc=3.12 UPLOAD_DOCS=1 SNOPT_VERSION=7.7 PYOPTSPARSE_VERSION=v2.1.0
+    - PY=3 NUMPY=1.17 SCIPY=1.3 SNOPT_VERSION=7.2 PYOPTSPARSE_VERSION=v1.2
+    - PY=3.7 NUMPY=1.17 SCIPY=1.3 SNOPT_VERSION=7.7 PYOPTSPARSE_VERSION=v2.1.0
+    - PY=3.6 NUMPY=1.16 SCIPY=1.2 PETSc=3.10.2 SNOPT_VERSION=7.7 PYOPTSPARSE_VERSION=v2.1.0
 
 git:
   depth: 99999
@@ -100,16 +101,30 @@ install:
   pip install git+https://github.com/swryan/coveralls-python@work;
 
   echo " >> Installing pyOptSparse";
-  git clone http://github.com/OpenMDAO/build_pyoptsparse;
+  git clone https://github.com/OpenMDAO/build_pyoptsparse;
   cd build_pyoptsparse;
   chmod 755 ./build_pyoptsparse.sh;
-  if [ "$SNOPT_LOCATION" ]; then
-    echo "  > Secure copying SNOPT over SSH";
-    mkdir SNOPT;
-    scp -r "$SNOPT_LOCATION" SNOPT;
-    ./build_pyoptsparse.sh -s SNOPT/source;
+
+  echo " >> Checking SNOPT and PyoptSparse version"
+  if [[ "$SNOPT_VERSION" == "7.7" && "$PYOPTSPARSE_VERSION" == "v2.1.0" ]] || [[ "$SNOPT_VERSION" == "7.2" && "$PYOPTSPARSE_VERSION" == "v1.2" ]]; then
+    echo " >> Found SNOPT and PyoptSparse"
+    if [ "$SNOPT_VERSION" == "7.7" ] && [ "$SNOPT_LOCATION_77" ]; then
+      echo "  > Secure copying SNOPT 7.7 over SSH";
+      mkdir SNOPT;
+      scp -r "$SNOPT_LOCATION_77" SNOPT;
+      ./build_pyoptsparse.sh -s SNOPT -b "$PYOPTSPARSE_VERSION";
+
+    elif [ "$SNOPT_VERSION" == "7.2" ]  && [ "$SNOPT_LOCATION_72" ]; then
+      echo "  > Secure copying SNOPT 7.2 over SSH";
+      mkdir SNOPT;
+      scp -r "$SNOPT_LOCATION_72" SNOPT;
+      ./build_pyoptsparse.sh -s SNOPT -b "$PYOPTSPARSE_VERSION";
+
+    else
+      ./build_pyoptsparse.sh -b "$PYOPTSPARSE_VERSION";
+    fi
   else
-    ./build_pyoptsparse.sh;
+    echo "Incompatible versions of SNOPT and PyoptSparse"
   fi
   cd ..;
 


### PR DESCRIPTION
### Summary

Added in CI support for SNOPT 7.7 and PyoptSparse 2.1.0

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
