### PR TITLE
Precursor to the PR that adds AutoIndepVarComps to eliminate unconnected inputs.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2501,3 +2501,56 @@ class Group(System):
                 graph.add_edge(src_sys, tgt_sys, conns=edge_data[key])
 
         return graph
+
+    def _resolve_connected_input_defaults(self):
+        # these are meta dict entries that cannot differ between inputs unless a default
+        # is specified from a corresponding group.add_input call
+        group_nodiff = ['value', 'units']
+
+        srcconns = defaultdict(list)
+        for tgt, src in self._conn_global_abs_in2out.items():
+            srcconns[src].append(tgt)
+
+        abs2prom = self._var_allprocs_abs2prom['input']
+        all_abs2meta = self._var_allprocs_abs2meta
+        abs2meta = self._var_abs2meta
+        discrete_outs = self._var_allprocs_discrete['output']
+
+        for src, tgts in srcconns.items():
+            if len(tgts) > 1 and src not in discrete_outs:
+                if src in abs2meta:
+                    smeta = abs2meta[src]
+                    sloc = True
+                else:
+                    smeta = all_abs2meta[tgt]
+                    sloc = False
+
+                sunits = smeta['units'] if 'units' in smeta else None
+                sval = self._get_val(src, kind='output', get_remote=True, from_src=False)
+
+                for tgt in tgts:
+                    prom = abs2prom[tgt]
+                    if prom in self._group_inputs:
+                        gmeta = self._group_inputs[prom]
+                    else:
+                        gmeta = ()
+
+                    if tgt in abs2meta:  # var is local
+                        tmeta = abs2meta[tgt]
+                    else:
+                        tmeta = all_abs2meta[tgt]
+
+                    tunits = tmeta['units'] if 'units' in tmeta else None
+                    tval = self._get_val(tgt, kind='input', get_remote=True, from_src=False)
+
+                    errs = []
+                    if 'units' not in gmeta and sunits != tunits:
+                        errs.append('units')
+                    if 'value' not in gmeta and not np.all(sval == tval):
+                        errs.append('value')
+
+                    if errs:
+                        inputs = list(sorted(tgts))
+                        raise RuntimeError(f"{self.msginfo}: The following inputs, {inputs} are "
+                                           f"connected but the metadata entries {errs} differ and "
+                                           "have not been specified by Group.add_input.")

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -165,16 +165,16 @@ class Group(System):
 
     def add_input(self, name, val=_undefined, units=None):
         """
-        Specify metadata for a connected promoted inputs without a source.
+        Specify metadata for connected promoted inputs without a source.
 
         Parameters
         ----------
         name : str
             The name of the promoted inputs.
         val : object
-            Value to use as default.
+            Value for the auto_ivc source.
         units : str or None
-            Specifies units to be assumed for the source.
+            Units for the auto_ivc source.
         """
         if name in self._group_inputs:
             simple_warning(f"{self.msginfo}: Adding group input '{name}' which "
@@ -735,7 +735,7 @@ class Group(System):
         ginputs = self._group_inputs
         for prom, meta in group_inputs:
             if prom in ginputs:
-                # check for any conflicting src_indices, units, ...
+                # check for any conflicting units or values
                 old = ginputs[prom]
 
                 for n, val in meta.items():

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -32,7 +32,7 @@ from openmdao.utils.general_utils import ContainsAll, pad_name, simple_warning, 
 from openmdao.utils.mpi import FakeComm
 from openmdao.utils.mpi import MPI
 from openmdao.utils.name_maps import prom_name2abs_name
-from openmdao.utils.options_dictionary import OptionsDictionary
+from openmdao.utils.options_dictionary import OptionsDictionary, _undefined
 from openmdao.utils.units import unit_conversion
 from openmdao.utils import coloring as coloring_mod
 from openmdao.utils.name_maps import abs_key2rel_key
@@ -57,7 +57,6 @@ ErrorTuple = namedtuple('ErrorTuple', ['forward', 'reverse', 'forward_reverse'])
 MagnitudeTuple = namedtuple('MagnitudeTuple', ['forward', 'reverse', 'fd'])
 
 _contains_all = ContainsAll()
-_undefined = object()
 
 
 CITATION = """@article{openmdao_2019,
@@ -397,7 +396,7 @@ class Problem(object):
 
         val = self.model._get_val(name, units=units, indices=indices, get_remote=get_remote)
 
-        if val is System._undefined:
+        if val is _undefined:
             if get_remote:
                 raise KeyError('{}: Variable name "{}" not found.'.format(self.msginfo, name))
             else:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4151,9 +4151,14 @@ class System(object):
             kind = typ
 
         if not discrete:
-            vec = self._vectors[kind][vec_name]
-            if abs_name in vec._views:
-                val = vec._views_flat[abs_name] if flat else vec._views[abs_name]
+            try:
+                vec = self._vectors[kind][vec_name]
+            except KeyError:
+                if abs_name in self._var_abs2meta:
+                    val = self._var_abs2meta[abs_name]['value']
+            else:
+                if abs_name in vec._views:
+                    val = vec._views_flat[abs_name] if flat else vec._views[abs_name]
 
         if get_remote and self.comm.size > 1:
             owner = self._owning_rank[abs_name]

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -19,7 +19,7 @@ from openmdao.jacobians.assembled_jacobian import DenseJacobian, CSCJacobian
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.vectors.vector import INT_DTYPE
 from openmdao.utils.mpi import MPI
-from openmdao.utils.options_dictionary import OptionsDictionary
+from openmdao.utils.options_dictionary import OptionsDictionary, _undefined
 from openmdao.utils.record_util import create_local_meta, check_path
 from openmdao.utils.units import is_compatible, unit_conversion
 from openmdao.utils.variable_table import write_var_table
@@ -302,8 +302,6 @@ class System(object):
     _first_call_to_linearize : bool
         If True, this is the first call to _linearize.
     """
-
-    _undefined = object()
 
     def __init__(self, num_par_fd=1, **kwargs):
         """
@@ -4122,7 +4120,7 @@ class System(object):
             The value of the requested output/input/resid variable.  None if variable is not found.
         """
         discrete = distrib = False
-        val = System._undefined
+        val = _undefined
         typ = 'output' if abs_name in self._var_allprocs_abs2prom['output'] else 'input'
 
         try:
@@ -4143,7 +4141,7 @@ class System(object):
             elif abs_name in self._var_allprocs_discrete['input']:
                 pass  # non-local discrete input
             else:
-                return System._undefined
+                return _undefined
 
         if kind is None:
             kind = typ
@@ -4155,7 +4153,7 @@ class System(object):
 
         if get_remote and self.comm.size > 1:
             owner = self._owning_rank[abs_name]
-            loc_val = val if val is not System._undefined else np.zeros(0)
+            loc_val = val if val is not _undefined else np.zeros(0)
             if rank is None:   # bcast
                 if distrib:
                     idx = self._var_allprocs_abs2idx['nonlinear'][abs_name]
@@ -4193,7 +4191,7 @@ class System(object):
                         elif self.comm.rank == rank:
                             val = self.comm.recv(source=owner, tag=tag)
 
-        if not flat and val is not System._undefined and not discrete:
+        if not flat and val is not _undefined and not discrete:
             val.shape = meta['global_shape'] if get_remote and distrib else meta['shape']
 
         return val

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -803,6 +803,10 @@ class System(object):
         self._setup_relevance(mode, self._relevant)
         self._setup_var_index_ranges(recurse=recurse)
         self._setup_var_sizes(recurse=recurse)
+
+        if self.pathname == '':
+            self._resolve_connected_input_defaults()
+
         self._setup_connections(recurse=recurse)
 
     def _configure_check(self):
@@ -4370,6 +4374,9 @@ class System(object):
             return meta[abs_name]
 
         raise KeyError('{}: Metadata for variable "{}" not found.'.format(self.msginfo, name))
+
+    def _resolve_connected_input_defaults(self):
+        pass
 
 
 def get_relevant_vars(connections, desvars, responses, mode):

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1827,7 +1827,7 @@ class TestGroupAddInput(unittest.TestCase):
                                             y={'value': 1.0, 'units': 'inch'}),
                                             promotes_inputs=['x'])
 
-        msg = "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['units', 'value'] differ and have not been specified by Group.add_input."
+        msg = "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['units', 'value'] differ and have not been specified by Group.add_input.  This warning will become an error in a future version.  To remove the abiguity, call par.add_input() and specify the ['units', 'value'] arg(s)."
         with assert_warning(UserWarning, msg):
            p.setup()
 
@@ -1839,7 +1839,7 @@ class TestGroupAddInput(unittest.TestCase):
         par.add_subsystem('C1', om.ExecComp('y = 3. * x', x=1.0), promotes_inputs=['x'])
         par.add_subsystem('C2', om.ExecComp('y = 5. * x', x=1.1), promotes_inputs=['x'])
 
-        msg = "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['value'] differ and have not been specified by Group.add_input."
+        msg = "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['value'] differ and have not been specified by Group.add_input.  This warning will become an error in a future version.  To remove the abiguity, call par.add_input() and specify the ['value'] arg(s)."
 
         with assert_warning(UserWarning, msg):
            p.setup()

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -14,9 +14,15 @@ except ImportError:
 
 import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis2
+from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.error_checking.check_config import _check_hanging_inputs
+
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
 
 
 class SimpleGroup(om.Group):
@@ -1743,6 +1749,220 @@ class TestSrcIndices(unittest.TestCase):
                                 src_indices=[[-10, 5], [7, 8]],
                                 flat_src_indices=True,
                                 raise_connection_errors=False)
+
+class TestGroupAddInput(unittest.TestCase):
+
+    def _make_tree_model(self, diff_units=False, diff_vals=False):
+        p = om.Problem()
+        model = p.model
+
+        if diff_units:
+            units1 = 'ft'
+            units2 = 'inch'
+        else:
+            units1 = units2 = 'ft'
+
+        val = 1.0
+
+        g1 = model.add_subsystem("G1", om.Group(), promotes_inputs=['x'])
+
+        g2 = g1.add_subsystem("G2", om.Group(), promotes_inputs=['x'])
+        g2.add_subsystem("C1", om.ExecComp("y = 2. * x",
+                                            x={'value': val, 'units': units2},
+                                            y={'value': 1.0, 'units': units2}),
+                                            promotes_inputs=['x'])
+        g2.add_subsystem("C2", om.ExecComp("y = 3. * x",
+                                            x={'value': val, 'units': units1},
+                                            y={'value': 1.0, 'units': units1}),
+                                            promotes_inputs=['x'])
+
+        g3 = g1.add_subsystem("G3", om.Group(), promotes_inputs=['x'])
+        if diff_vals: val = 2.0
+        g3.add_subsystem("C3", om.ExecComp("y = 4. * x",
+                                            x={'value': val, 'units': units1},
+                                            y={'value': 1.0, 'units': units1}),
+                                            promotes_inputs=['x'])
+        g3.add_subsystem("C4", om.ExecComp("y = 5. * x",
+                                            x={'value': val, 'units': units2},
+                                            y={'value': 1.0, 'units': units2}),
+                                            promotes_inputs=['x'])
+
+        par = model.add_subsystem("par", om.ParallelGroup(), promotes_inputs=['x'])
+
+        g4 = par.add_subsystem("G4", om.Group(), promotes_inputs=['x'])
+        if diff_vals: val = 3.0
+        g4.add_subsystem("C5", om.ExecComp("y = 6. * x",
+                                            x={'value': val, 'units': units2},
+                                            y={'value': 1.0, 'units': units2}),
+                                            promotes_inputs=['x'])
+        g4.add_subsystem("C6", om.ExecComp("y = 7. * x",
+                                            x={'value': val, 'units': units1},
+                                            y={'value': 1.0, 'units': units1}),
+                                            promotes_inputs=['x'])
+
+        g5 = par.add_subsystem("G5", om.Group(), promotes_inputs=['x'])
+        if diff_vals: val = 4.0
+        g5.add_subsystem("C7", om.ExecComp("y = 8. * x",
+                                            x={'value': val, 'units': units1},
+                                            y={'value': 1.0, 'units': units1}),
+                                            promotes_inputs=['x'])
+        g5.add_subsystem("C8", om.ExecComp("y = 9. * x",
+                                            x={'value': val, 'units': units2},
+                                            y={'value': 1.0, 'units': units2}),
+                                            promotes_inputs=['x'])
+
+        return p
+
+    def test_missing_diff_units(self):
+        p = om.Problem()
+        model = p.model
+
+        par = model.add_subsystem('par', om.ParallelGroup(), promotes_inputs=['x'])
+        par.add_subsystem('C1', om.ExecComp('y = 3. * x',
+                                            x={'value': 1.0, 'units': 'ft'},
+                                            y={'value': 1.0, 'units': 'ft'}),
+                                            promotes_inputs=['x'])
+        par.add_subsystem('C2', om.ExecComp('y = 5. * x',
+                                            x={'value': 1.0, 'units': 'inch'},
+                                            y={'value': 1.0, 'units': 'inch'}),
+                                            promotes_inputs=['x'])
+
+        with self.assertRaises(Exception) as cm:
+           p.setup()
+
+        self.assertEqual(cm.exception.args[0],
+                         "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['units'] differ and have not been specified by Group.add_input.")
+
+    def test_missing_diff_vals(self):
+        p = om.Problem()
+        model = p.model
+
+        par = model.add_subsystem('par', om.ParallelGroup(), promotes_inputs=['x'])
+        par.add_subsystem('C1', om.ExecComp('y = 3. * x', x=1.0), promotes_inputs=['x'])
+        par.add_subsystem('C2', om.ExecComp('y = 5. * x', x=1.1), promotes_inputs=['x'])
+
+        with self.assertRaises(Exception) as cm:
+           p.setup()
+
+        self.assertEqual(cm.exception.args[0],
+                         "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['value'] differ and have not been specified by Group.add_input.")
+
+    def test_conflicting_units(self):
+        # multiple Group.add_input calls at same tree level with conflicting units args
+        p = self._make_tree_model(diff_units=True)
+        model = p.model
+        g2 = model._get_subsystem('G1.G2')
+        g2.add_input('x', units='ft')
+
+        g3 = model._get_subsystem('G1.G3')
+        g3.add_input('x', units='ft')
+
+        g4 = model._get_subsystem('par.G4')
+        g4.add_input('x', units='inch')
+
+        g5 = model._get_subsystem('par.G5')
+        g5.add_input('x', units='ft')
+
+        with self.assertRaises(Exception) as cm:
+            p.setup()
+
+        self.assertEqual(cm.exception.args[0], "Groups 'par.G4' and 'par.G5' added the input 'x' with conflicting 'units'.")
+
+    def test_conflicting_units_multi_level(self):
+        # multiple Group.add_input calls at different tree levels with conflicting units args
+        p = self._make_tree_model(diff_units=True)
+        model = p.model
+        g2 = model._get_subsystem('G1.G2')
+        g2.add_input('x', units='ft')
+
+        g3 = model._get_subsystem('G1.G3')
+        g3.add_input('x', units='ft')
+
+        g4 = model._get_subsystem('par.G4')
+        g4.add_input('x', units='ft')
+
+        g5 = model._get_subsystem('par.G5')
+        g5.add_input('x', units='ft')
+
+        g1 = model._get_subsystem('G1')
+        g1.add_input('x', units='inch')
+
+        with self.assertRaises(Exception) as cm:
+            p.setup()
+
+        self.assertEqual(cm.exception.args[0], "Groups 'G1' and 'G1.G2' added the input 'x' with conflicting 'units'.")
+
+    def test_conflicting_units_multi_level_par(self):
+        # multiple Group.add_input calls at different tree levels with conflicting units args
+        p = self._make_tree_model(diff_units=True)
+        model = p.model
+        g2 = model._get_subsystem('G1.G2')
+        g2.add_input('x', units='ft')
+
+        g3 = model._get_subsystem('G1.G3')
+        g3.add_input('x', units='ft')
+
+        g4 = model._get_subsystem('par.G4')
+        g4.add_input('x', units='ft')
+
+        g5 = model._get_subsystem('par.G5')
+        g5.add_input('x', units='ft')
+
+        par = model._get_subsystem('par')
+        par.add_input('x', units='inch')
+
+        with self.assertRaises(Exception) as cm:
+            p.setup()
+
+        self.assertEqual(cm.exception.args[0], "Groups 'par' and 'par.G4' added the input 'x' with conflicting 'units'.")
+
+    def test_group_input_not_found(self):
+        p = self._make_tree_model(diff_units=True)
+        model = p.model
+        g2 = model._get_subsystem('G1.G2')
+        g2.add_input('xx', units='ft')
+
+        g3 = model._get_subsystem('G1.G3')
+        g3.add_input('x', units='ft')
+
+        g4 = model._get_subsystem('par.G4')
+        g4.add_input('x', units='ft')
+
+        g5 = model._get_subsystem('par.G5')
+        g5.add_input('x', units='ft')
+
+        with self.assertRaises(Exception) as cm:
+            p.setup()
+
+        self.assertEqual(cm.exception.args[0], "Group (G1.G2): The following group inputs could not be found: ['xx'].")
+
+    def test_conflicting_val(self):
+        p = self._make_tree_model(diff_vals=True)
+        model = p.model
+        g2 = model._get_subsystem('G1.G2')
+        g2.add_input('x', val=3.0)
+
+        g3 = model._get_subsystem('G1.G3')
+        g3.add_input('x', val=3.0)
+
+        g4 = model._get_subsystem('par.G4')
+        g4.add_input('x', val=3.0)
+
+        g5 = model._get_subsystem('par.G5')
+        g5.add_input('x', val=3.0)
+
+        g1 = model._get_subsystem('G1')
+        g1.add_input('x', val=4.0)
+
+        with self.assertRaises(Exception) as cm:
+            p.setup()
+
+        self.assertEqual(cm.exception.args[0], "Groups 'G1' and 'G1.G2' added the input 'x' with conflicting 'value'.")
+
+
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class TestGroupAddInputMPI(TestGroupAddInput):
+    N_PROCS = 2
 
 
 #

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1827,11 +1827,9 @@ class TestGroupAddInput(unittest.TestCase):
                                             y={'value': 1.0, 'units': 'inch'}),
                                             promotes_inputs=['x'])
 
-        with self.assertRaises(Exception) as cm:
+        msg = "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['units', 'value'] differ and have not been specified by Group.add_input."
+        with assert_warning(UserWarning, msg):
            p.setup()
-
-        self.assertEqual(cm.exception.args[0],
-                         "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['units'] differ and have not been specified by Group.add_input.")
 
     def test_missing_diff_vals(self):
         p = om.Problem()
@@ -1841,11 +1839,10 @@ class TestGroupAddInput(unittest.TestCase):
         par.add_subsystem('C1', om.ExecComp('y = 3. * x', x=1.0), promotes_inputs=['x'])
         par.add_subsystem('C2', om.ExecComp('y = 5. * x', x=1.1), promotes_inputs=['x'])
 
-        with self.assertRaises(Exception) as cm:
-           p.setup()
+        msg = "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['value'] differ and have not been specified by Group.add_input."
 
-        self.assertEqual(cm.exception.args[0],
-                         "Group (<model>): The following inputs, ['par.C1.x', 'par.C2.x'] are connected but the metadata entries ['value'] differ and have not been specified by Group.add_input.")
+        with assert_warning(UserWarning, msg):
+           p.setup()
 
     def test_conflicting_units(self):
         # multiple Group.add_input calls at same tree level with conflicting units args

--- a/openmdao/docs/_exts/embed_options.py
+++ b/openmdao/docs/_exts/embed_options.py
@@ -7,7 +7,7 @@ from docutils.statemachine import ViewList
 import sphinx
 from docutils.parsers.rst import Directive
 from sphinx.util.nodes import nested_parse_with_titles
-from openmdao.utils.options_dictionary import OptionsDictionary, _undefined
+from openmdao.utils.options_dictionary import OptionsDictionary
 
 
 class EmbedOptionsDirective(Directive):

--- a/openmdao/docs/_exts/embed_options.py
+++ b/openmdao/docs/_exts/embed_options.py
@@ -7,7 +7,7 @@ from docutils.statemachine import ViewList
 import sphinx
 from docutils.parsers.rst import Directive
 from sphinx.util.nodes import nested_parse_with_titles
-from openmdao.utils.options_dictionary import OptionsDictionary
+from openmdao.utils.options_dictionary import OptionsDictionary, _undefined
 
 
 class EmbedOptionsDirective(Directive):

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -15,7 +15,7 @@ from openmdao.utils.class_util import overrides_method
 from openmdao.utils.mpi import MPI
 from openmdao.utils.hooks import _register_hook
 from openmdao.utils.general_utils import printoptions, simple_warning
-from openmdao.utils.units import convert_units
+from openmdao.utils.units import convert_units, _has_val_mismatch
 from openmdao.utils.file_utils import _load_and_exec
 
 
@@ -257,7 +257,7 @@ def _trim_str(obj, size):
     return s
 
 
-def _has_val_mismatch(discretes, names, units, vals):
+def _list_has_val_mismatch(discretes, names, units, vals):
     """
     Return True if any of the given values don't match, subject to unit conversion.
 
@@ -292,13 +292,8 @@ def _has_val_mismatch(discretes, names, units, vals):
         if u0 is _UNSET:
             u0 = u
             v0 = v
-        else:
-            if u != u0:
-                # convert units
-                v = convert_units(v, u, new_units=u0)
-
-            if np.linalg.norm(v - v0) > 1e-10:
-                return True
+        elif _has_val_mismatch(u0, v0, u, v):
+            return True
 
     return False
 
@@ -352,8 +347,8 @@ def _check_hanging_inputs(problem, logger):
                 msg.append(template_abs.format(a, units[0], valstr, nwid=nwid + 3, uwid=uwid))
             else:  # promoted
                 vals = [problem.get_val(a, get_remote=True) for a in absnames]
-                mismatch = _has_val_mismatch(problem.model._var_allprocs_discrete['input'],
-                                             absnames, units, vals)
+                mismatch = _list_has_val_mismatch(problem.model._var_allprocs_discrete['input'],
+                                                  absnames, units, vals)
                 if mismatch:
                     msg.append("\n   ----- WARNING: connected input values don't match when "
                                "converted to consistent units. -----\n")

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -875,3 +875,40 @@ def env_truthy(env_var):
         True if the specified environment variable is 'truthy'.
     """
     return os.environ.get(env_var, '0').lower() not in ('0', 'false', 'no', '')
+
+
+def common_subpath(pathnames):
+    """
+    Return the common dotted subpath found in all of the given dotted pathnames.
+
+    Parameters
+    ----------
+    pathnames : iter of str
+        Dotted pathnames of systems.
+
+    Returns
+    -------
+    str
+        Common dotted subpath.  Returns '' if no common subpath is found.
+    """
+    if len(pathnames) == 1:
+        return pathnames[0]
+
+    if pathnames:
+        npaths = len(pathnames)
+        splits = [p.split('.') for p in pathnames]
+        minlen = np.min([len(s) for s in splits])
+        for common_loc in range(minlen):
+            p0 = splits[0][common_loc]
+            for i in range(1, npaths):
+                if p0 != splits[i][common_loc]:
+                    break
+            else:
+                continue
+            break
+        else:
+            common_loc += 1
+
+        return '.'.join(splits[0][:common_loc])
+
+    return ''

--- a/openmdao/utils/tests/test_general_utils.py
+++ b/openmdao/utils/tests/test_general_utils.py
@@ -1,6 +1,6 @@
 import unittest
 
-from openmdao.utils.general_utils import remove_whitespace
+from openmdao.utils.general_utils import remove_whitespace, common_subpath
 
 import re
 import sys
@@ -23,6 +23,19 @@ class TestGeneralUtils(unittest.TestCase):
 
         self.assertEqual(remove_whitespace(self.test_str, right=True, left=True), 'abc'+ws+'def')
 
+    def test_common_subpath(self):
+        plists = [
+            ([], ''),
+            (['foo.bar.baz'], 'foo.bar.baz'),
+            (['a.b.c', 'a.b'], 'a.b'),
+            (['a.b', 'a.b.c'], 'a.b'),
+            (['foo.foo', 'foo.bar'], 'foo'),
+            (['foo.foo', 'bar'], ''),
+            (['xx.yy.zz.foo.bar', 'xx.yy.zz.blah', 'xx.yy.zz.blah.ho'], 'xx.yy.zz'),
+        ]
+
+        for plist, ans in plists:
+            self.assertEqual(common_subpath(plist), ans)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -1055,6 +1055,20 @@ def convert_units(val, old_units, new_units=None):
 
 
 def _has_val_mismatch(units1, val1, units2, val2):
+    """
+    Return True if values differ after unit conversion or if values differ when units are None.
+
+    Parameters
+    ----------
+    units1 : str or None
+        Units for first value.
+    val1 : float or ndarray
+        First value.
+    units2 : str or None
+        Units for second value.
+    val2 : float or ndarray
+        Second value.
+    """
     if units1 != units2:
         if units1 is None or units2 is None:
             return True

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -21,6 +21,8 @@ from openmdao.utils.general_utils import warn_deprecation
 # pylint: disable=E0611, F0401
 from math import floor, pi
 
+import numpy as np
+
 
 ####################################
 # Class Definitions
@@ -1050,6 +1052,17 @@ def convert_units(val, old_units, new_units=None):
 
     (factor, offset) = old_unit.conversion_tuple_to(new_unit)
     return (val + offset) * factor
+
+
+def _has_val_mismatch(units1, val1, units2, val2):
+    if units1 != units2:
+        if units1 is None or units2 is None:
+            return True
+
+        # convert units
+        val1 = convert_units(val1, units1, new_units=units2)
+
+    return np.linalg.norm(val1 - val2) > 1e-10
 
 
 # Load in the default unit library

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -1076,7 +1076,12 @@ def _has_val_mismatch(units1, val1, units2, val2):
         # convert units
         val1 = convert_units(val1, units1, new_units=units2)
 
-    return np.linalg.norm(val1 - val2) > 1e-10
+    rtol = 1e-10
+    norm1 = np.linalg.norm(val1)
+    if norm1 == 0.:
+        return np.linalg.norm(val2) > rtol
+    else:
+        return np.linalg.norm(val2 - val1) / norm1 > rtol
 
 
 # Load in the default unit library


### PR DESCRIPTION

Adds warnings for connected inputs without a source that have different units and/or values, and adds the Group.add_input method, which is mostly non-functional until AutoIndepVarComps are added.
