### PR TITLE
Several N2 appearance changes

### DIFF
--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -122,8 +122,9 @@
                     <g id='n2outer'>
                         <g id='n2inner'>
                             <rect id='backgroundRect' class='background'></rect>
-                            <g id='n2elements' clip-path='url(#n2MatrixClip)'></g>
+                            <g id='n2background' clip-path='url(#n2MatrixClip)'></g>
                             <g id='n2gridlines' clip-path='url(#n2MatrixClip)'></g>
+                            <g id='n2elements' clip-path='url(#n2MatrixClip)'></g>
                             <g id='n2componentBoxes' clip-path='url(#n2MatrixClip)'></g>
                             <g id='n2dots' clip-path='url(#n2MatrixClip)'></g>
                             <g id='n2arrows'></g>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -214,7 +214,7 @@
         </tr>
     </tfoot>
 </table>
-<p id='node-info-pin'></p>
+<p id='node-info-pin' class='info-hidden'>&#x1F4CC;</p>
 </div>
 
 <div class="tool-tip" style="position: absolute; visibility: hidden;"></div>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -115,8 +115,11 @@
                         <clipPath id="solverTreeClip">
                             <rect id="solver-clip-rect" x="0" y="0" width="1200" height="600" />
                         </clipPath>
-                        <g id='matrix-connector' width='10' height='10'>
+                        <g id='matrix-connector-arrow' width='10' height='10'>
                             <path d='M0,3 h2 q5,0 5,5 h1 l-3,2 l-3,-2 h1 q0,-1 -1,-1 h-2 z'></path>
+                        </g>
+                        <g id='matrix-connector-square' width='10' height='10'>
+                            <rect x='2' y='2' width='6' height='6'></rect>
                         </g>
                     </defs>
                     <g id='tree' clip-path='url(#partitionTreeClip)'></g>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -116,6 +116,9 @@
                             <rect id="solver-clip-rect" x="0" y="0" width="1200" height="600" />
                         </clipPath>
                     </defs>
+                    <g id='tree' clip-path='url(#partitionTreeClip)'></g>
+                    <g id='highlight-bar'></g>
+                    <g id='solver_tree' clip-path='url(#solverTreeClip)'></g>
                     <g id='n2outer'>
                         <g id='n2inner'>
                             <rect id='backgroundRect' class='background'></rect>
@@ -123,7 +126,6 @@
                             <g id='n2gridlines' clip-path='url(#n2MatrixClip)'></g>
                             <g id='n2componentBoxes' clip-path='url(#n2MatrixClip)'></g>
                             <g id='n2dots' clip-path='url(#n2MatrixClip)'></g>
-                            <g id='n2highlights'></g>
                             <g id='n2arrows'></g>
                         </g>
                         <g id='n2top' class='offgridLabel'></g>
@@ -131,8 +133,9 @@
                         <g id='n2right' class='offgridLabel'></g>
                         <g id='n2bottom' class='offgridLabel'></g>
                     </g>
-                    <g id='tree' clip-path='url(#partitionTreeClip)'></g>
-                    <g id='solver_tree' clip-path='url(#solverTreeClip)'></g>
+                    <g id='text-width-renderer' class='partition_group'>
+                        <text x='-200'></text>
+                    </g>
                 </svg>
                 <div id='n2-resizer-box' class='inactive-resizer-box'>
                     <p id='n2-resizer-handle' class='inactive-resizer-handle'></p>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -115,6 +115,9 @@
                         <clipPath id="solverTreeClip">
                             <rect id="solver-clip-rect" x="0" y="0" width="1200" height="600" />
                         </clipPath>
+                        <g id='matrix-connector' width='10' height='10'>
+                            <path d='M0,3 h2 q5,0 5,5 h1 l-3,2 l-3,-2 h1 q0,-1 -1,-1 h-2 z'></path>
+                        </g>
                     </defs>
                     <g id='tree' clip-path='url(#partitionTreeClip)'></g>
                     <g id='highlight-bar'></g>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -200,7 +200,8 @@
     </div>
 </div>
 
-<table id="node-info-container" class='info-hidden' cellpadding='0' cellspacing='0'>
+<div id="node-info-container" class='info-hidden'>
+<table id="node-info-table" cellpadding='0' cellspacing='0'>
     <thead>
         <tr>
             <th scope='col' colspan='2'>Name</th>
@@ -213,6 +214,8 @@
         </tr>
     </tfoot>
 </table>
+<p id='node-info-pin'></p>
+</div>
 
 <div class="tool-tip" style="position: absolute; visibility: hidden;"></div>
 <div id="top" class="offgrid" style="visibility: hidden;"></div>

--- a/openmdao/visualization/n2_viewer/src/N2Arrow.js
+++ b/openmdao/visualization/n2_viewer/src/N2Arrow.js
@@ -82,16 +82,14 @@ class N2BentArrow extends N2Arrow {
         this.pts.end.y = this.nodeSize.height * this.end.row + this.nodeSize.height * .5 + offsetY;
     }
 
-    /**
-     * Use SVG to draw the line segments, add a circle at the "middle",
-     * and an arrow at the end-point.
-     */
+    /** Use SVG to draw the line segments and an arrow at the end-point. */
     draw() {
         const dir = (this.offsetX > 0)? 1 : -1;
         const s = this.nodeSize.width * .5 * dir;
 
         this.path = this.arrowsGrp.insert("path")
             .attr("class", "n2_hover_elements")
+            .attr("marker-end", "url(#arrow)")
             .attr("d", "M" + this.pts.start.x + " " + this.pts.start.y +
                 " L" + this.pts.mid.x + " " + this.pts.mid.y +
                 ` q${s} 0 ${s} ${s}` +
@@ -99,26 +97,6 @@ class N2BentArrow extends N2Arrow {
             .attr("fill", "none")
             .style("stroke-width", this.width)
             .style("stroke", this.color);
-/*
-        this.dotsGrp.append("circle")
-            .attr("class", "n2_hover_elements")
-            .attr("cx", this.pts.mid.x + (this.nodeSize.width * .394 * dir))
-            .attr("cy", this.pts.mid.y + (this.nodeSize.height * .144 * dir))
-            .attr("r", this.width * 1.0)
-            .style("stroke-width", 0)
-            .style("fill-opacity", 1)
-            .style("fill", "black");
-
-        this.dotsGrp.append("circle")
-            .attr("class", "n2_hover_elements")
-            .attr("cx", this.pts.mid.x + (this.nodeSize.width * .394 * dir))
-            .attr("cy", this.pts.mid.y + (this.nodeSize.height * .144 * dir))
-            .attr("r", this.width * 1.0)
-            .style("stroke-width", 0)
-            .style("fill-opacity", .75)
-            .style("fill", this.color);
-*/
-        this.path.attr("marker-end", "url(#arrow)");
     }
 }
 
@@ -185,14 +163,13 @@ class N2OffGridArrow extends N2Arrow {
         return true;
     }
 
-    /**
-     * Put the SVG arrow on the screen and position the tooltip.
-     */
+    /** Put the SVG arrow on the screen and position the tooltip. */
     draw() {
         debugInfo('Adding offscreen ' + this.attribs.direction +
             ' arrow connected to ' + this.label.text);
 
         this.path = this.arrowsGrp.insert('path')
+            .attr('marker-end', 'url(#arrow)')
             .attr('class', 'n2_hover_elements')
             .attr('stroke-dasharray', '5,5')
             .attr('d', 'M' + this.pts.start.x + ' ' + this.pts.start.y +
@@ -200,8 +177,6 @@ class N2OffGridArrow extends N2Arrow {
             .attr('fill', 'none')
             .style('stroke-width', this.width)
             .style('stroke', this.color);
-
-        this.path.attr('marker-end', 'url(#arrow)');
 
         for (let pos in this.label.pts) {
             this.label.ref.style(pos, this.label.pts[pos] + 'px');

--- a/openmdao/visualization/n2_viewer/src/N2Arrow.js
+++ b/openmdao/visualization/n2_viewer/src/N2Arrow.js
@@ -70,9 +70,10 @@ class N2BentArrow extends N2Arrow {
         let offsetAbsX = this.offsetAbsX;
         let offsetAbsY = this.offsetAbsY;
 
-        let offsetX = (this.start.col < this.end.col) ? offsetAbsX : -offsetAbsX; // Left-to-Right : Right-to-Left
-        this.pts.start.x = this.nodeSize.width * this.start.col + this.nodeSize.width * .5 + offsetX;
-        this.pts.mid.x = this.nodeSize.width * this.middle.col + this.nodeSize.width * .5;
+        this.offsetX = (this.start.col < this.end.col) ? offsetAbsX : -offsetAbsX; // Left-to-Right : Right-to-Left
+        this.pts.start.x = this.nodeSize.width * this.start.col + this.nodeSize.width * .5 + this.offsetX;
+        // this.pts.mid.x = this.nodeSize.width * this.middle.col + this.nodeSize.width * .5;
+        this.pts.mid.x = (this.offsetX > 0)? this.nodeSize.width * this.middle.col : this.nodeSize.width * (this.middle.col + 1);
         this.pts.end.x = this.nodeSize.width * this.end.col + this.nodeSize.width * .5;
 
         let offsetY = (this.start.row < this.end.row) ? -offsetAbsY : offsetAbsY; // Down : Up
@@ -86,19 +87,23 @@ class N2BentArrow extends N2Arrow {
      * and an arrow at the end-point.
      */
     draw() {
+        const dir = (this.offsetX > 0)? 1 : -1;
+        const s = this.nodeSize.width * .5 * dir;
+
         this.path = this.arrowsGrp.insert("path")
             .attr("class", "n2_hover_elements")
             .attr("d", "M" + this.pts.start.x + " " + this.pts.start.y +
                 " L" + this.pts.mid.x + " " + this.pts.mid.y +
+                ` q${s} 0 ${s} ${s}` +
                 " L" + this.pts.end.x + " " + this.pts.end.y)
             .attr("fill", "none")
             .style("stroke-width", this.width)
             .style("stroke", this.color);
-
+/*
         this.dotsGrp.append("circle")
             .attr("class", "n2_hover_elements")
-            .attr("cx", this.pts.mid.x)
-            .attr("cy", this.pts.mid.y)
+            .attr("cx", this.pts.mid.x + (this.nodeSize.width * .394 * dir))
+            .attr("cy", this.pts.mid.y + (this.nodeSize.height * .144 * dir))
             .attr("r", this.width * 1.0)
             .style("stroke-width", 0)
             .style("fill-opacity", 1)
@@ -106,13 +111,13 @@ class N2BentArrow extends N2Arrow {
 
         this.dotsGrp.append("circle")
             .attr("class", "n2_hover_elements")
-            .attr("cx", this.pts.mid.x)
-            .attr("cy", this.pts.mid.y)
+            .attr("cx", this.pts.mid.x + (this.nodeSize.width * .394 * dir))
+            .attr("cy", this.pts.mid.y + (this.nodeSize.height * .144 * dir))
             .attr("r", this.width * 1.0)
             .style("stroke-width", 0)
             .style("fill-opacity", .75)
             .style("fill", this.color);
-
+*/
         this.path.attr("marker-end", "url(#arrow)");
     }
 }

--- a/openmdao/visualization/n2_viewer/src/N2Arrow.js
+++ b/openmdao/visualization/n2_viewer/src/N2Arrow.js
@@ -24,6 +24,7 @@ class N2Arrow {
         this.elementsGrp = n2Groups.elements;
         this.nodeSize = nodeSize;
         this.attribs = attribs;
+        this._genPath = this._angledPath;
     }
 
     get offsetAbsX() {
@@ -72,8 +73,8 @@ class N2BentArrow extends N2Arrow {
 
         this.offsetX = (this.start.col < this.end.col) ? offsetAbsX : -offsetAbsX; // Left-to-Right : Right-to-Left
         this.pts.start.x = this.nodeSize.width * this.start.col + this.nodeSize.width * .5 + this.offsetX;
-        // this.pts.mid.x = this.nodeSize.width * this.middle.col + this.nodeSize.width * .5;
-        this.pts.mid.x = (this.offsetX > 0)? this.nodeSize.width * this.middle.col : this.nodeSize.width * (this.middle.col + 1);
+        this.pts.mid.x = this.nodeSize.width * this.middle.col + this.nodeSize.width * .5;
+        // this.pts.mid.x = (this.offsetX > 0)? this.nodeSize.width * this.middle.col : this.nodeSize.width * (this.middle.col + 1);
         this.pts.end.x = this.nodeSize.width * this.end.col + this.nodeSize.width * .5;
 
         let offsetY = (this.start.row < this.end.row) ? -offsetAbsY : offsetAbsY; // Down : Up
@@ -82,21 +83,51 @@ class N2BentArrow extends N2Arrow {
         this.pts.end.y = this.nodeSize.height * this.end.row + this.nodeSize.height * .5 + offsetY;
     }
 
-    /** Use SVG to draw the line segments and an arrow at the end-point. */
-    draw() {
+    /** Create a path string with a quadratic curve at the bend. */
+    _curvedPath() {
         const dir = (this.offsetX > 0)? 1 : -1;
         const s = this.nodeSize.width * .5 * dir;
 
+        return "M" + this.pts.start.x + " " + this.pts.start.y +
+            " L" + this.pts.mid.x + " " + this.pts.mid.y +
+            ` q${s} 0 ${s} ${s}` +
+            " L" + this.pts.end.x + " " + this.pts.end.y;
+    }
+
+    /** Generate a path with a 90-degree angle at the bend. */
+    _angledPath() {
+        return "M" + this.pts.start.x + " " + this.pts.start.y +
+            " L" + this.pts.mid.x + " " + this.pts.mid.y +
+            " L" + this.pts.end.x + " " + this.pts.end.y;
+    }
+
+    /** Use SVG to draw the line segments and an arrow at the end-point. */
+    draw() {
         this.path = this.arrowsGrp.insert("path")
             .attr("class", "n2_hover_elements")
             .attr("marker-end", "url(#arrow)")
-            .attr("d", "M" + this.pts.start.x + " " + this.pts.start.y +
-                " L" + this.pts.mid.x + " " + this.pts.mid.y +
-                ` q${s} 0 ${s} ${s}` +
-                " L" + this.pts.end.x + " " + this.pts.end.y)
+            .attr("d", this._genPath())
             .attr("fill", "none")
             .style("stroke-width", this.width)
             .style("stroke", this.color);
+
+        this.dotsGrp.append("circle")
+            .attr("class", "n2_hover_elements")
+            .attr("cx", this.pts.mid.x)
+            .attr("cy", this.pts.mid.y)
+            .attr("r", this.width * 1.0)
+            .style("stroke-width", 0)
+            .style("fill-opacity", 1)
+            .style("fill", N2Style.color.connection);
+
+        this.dotsGrp.append("circle")
+            .attr("class", "n2_hover_elements")
+            .attr("cx", this.pts.mid.x)
+            .attr("cy", this.pts.mid.y)
+            .attr("r", this.width * 1.0)
+            .style("stroke-width", 0)
+            .style("fill-opacity", .75)
+            .style("fill", this.color);
     }
 }
 

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -164,7 +164,6 @@ class N2Diagram {
             'svgStyle': d3.select("#svgId style"),
             'toolTip': d3.select(".tool-tip"),
             'arrowMarker': d3.select("#arrow"),
-            'nodeInfo': d3.select('#node-data'),
             'n2OuterGroup': d3.select('g#n2outer'),
             'n2InnerGroup': d3.select('g#n2inner'),
             'pTreeGroup': d3.select('g#tree'),
@@ -813,10 +812,6 @@ class N2Diagram {
             this.ui.nodeInfoBox.togglePin();
             this.ui.nodeInfoBox.update(d3.event, cell.obj, cell.color());
         }
-    }
-
-    clearActiveNode() {
-        this.dom.nodeInfo.html('');
     }
 
     mouseClickAll(cell) {

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -347,14 +347,16 @@ class N2Diagram {
 
         nodeEnter.append("rect")
             .attr("width", function (d) {
-                return d.prevDims.width * self.prevTransitCoords.model.x;
+                return d.prevDims.width * self.prevTransitCoords.model.x - 2;
             })
             .attr("height", function (d) {
-                return d.prevDims.height * self.prevTransitCoords.model.y;
+                return d.prevDims.height * self.prevTransitCoords.model.y - 2;
             })
             .attr("id", function (d) {
-                return d.absPathName.replace(/\./g, '_');
-            });
+                return d.absPathName.replace(/[\.:]/g, '_');
+            })
+            .attr('rx', 12)
+            .attr('ry', 12);
 
         nodeEnter.append("text")
             .attr("dy", ".35em")
@@ -395,10 +397,10 @@ class N2Diagram {
 
         nodeUpdate.select("rect")
             .attr("width", function (d) {
-                return d.dims.width * self.transitCoords.model.x;
+                return d.dims.width * self.transitCoords.model.x - 2;
             })
             .attr("height", function (d) {
-                return d.dims.height * self.transitCoords.model.y;
+                return d.dims.height * self.transitCoords.model.y - 2;
             })
             .attr('rx', 12)
             .attr('ry', 12);
@@ -430,10 +432,10 @@ class N2Diagram {
 
         nodeExit.select("rect")
             .attr("width", function (d) {
-                return d.dims.width * self.transitCoords.model.x;
+                return d.dims.width * self.transitCoords.model.x - 2;
             })
             .attr("height", function (d) {
-                return d.dims.height * self.transitCoords.model.y;
+                return d.dims.height * self.transitCoords.model.y - 2;
             });
 
         nodeExit.select("text")
@@ -614,8 +616,16 @@ class N2Diagram {
             .style("opacity", 0);
     }
 
+    clearHighlights() {
+        for (const varType of ['diag', 'input', 'output']) {
+            this.dom.pTreeGroup.selectAll('.' + varType + 'Highlight')
+                .classed(varType + 'Highlight', false)
+        }
+    }
+
     clearArrows() {
         this.dom.n2OuterGroup.selectAll("[class^=n2_hover_elements]").remove();
+        this.clearHighlights();
     }
 
     /** Reveal arrows that had been hidden */
@@ -752,9 +762,8 @@ class N2Diagram {
     /** When the mouse leaves a cell, remove all temporary arrows. */
     mouseOut() {
         this.dom.n2OuterGroup.selectAll(".n2_hover_elements").remove();
-        d3.selectAll("div.offgrid")
-            .style("visibility", "hidden")
-            .html('');
+        this.clearHighlights();
+        d3.selectAll("div.offgrid").style("visibility", "hidden").html('');
 
         this.ui.nodeInfoBox.clear();
     }

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -347,12 +347,16 @@ class N2Diagram {
 
         nodeEnter.append("rect")
             .attr("width", function (d) {
-                return d.prevDims.width * self.prevTransitCoords.model.x -
-                    self.dims.size.partitionTree.strokeWidth * 2;
+                const w = d.prevDims.width * self.prevTransitCoords.model.x;
+                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
+
+                return (w > sw2)? w - sw2 : w;
             })
             .attr("height", function (d) {
-                return d.prevDims.height * self.prevTransitCoords.model.y - 
-                    self.dims.size.partitionTree.strokeWidth * 2;
+                const h = d.prevDims.height * self.prevTransitCoords.model.y;
+                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
+
+                return (h > sw2)? h - sw2 : h;
             })
             .attr("id", function (d) {
                 return d.absPathName.replace(/[\.:]/g, '_');
@@ -400,12 +404,14 @@ class N2Diagram {
 
         nodeUpdate.select("rect")
             .attr("width", function (d) {
-                return d.dims.width * self.transitCoords.model.x - 
-                    self.dims.size.partitionTree.strokeWidth * 2;
+                const w = d.dims.width * self.transitCoords.model.x;
+                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
+                return (w > sw2)? w - sw2 : w;
             })
             .attr("height", function (d) {
-                return d.dims.height * self.transitCoords.model.y -
-                    self.dims.size.partitionTree.strokeWidth * 2;
+                const h = d.dims.height * self.transitCoords.model.y;
+                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
+                return (h > sw2)? h - sw2 : h;
             })
             .attr('rx', 12)
             .attr('ry', 12);
@@ -437,20 +443,24 @@ class N2Diagram {
 
         nodeExit.select("rect")
             .attr("width", function (d) {
-                return d.dims.width * self.transitCoords.model.x - 
-                    self.dims.size.partitionTree.strokeWidth * 2;
+                const w = d.dims.width * self.transitCoords.model.x;
+                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
+
+                return (w > sw2)? w - sw2 : w;
             })
             .attr("height", function (d) {
-                return d.dims.height * self.transitCoords.model.y -
-                    self.dims.size.partitionTree.strokeWidth * 2;
+                const h = d.dims.height * self.transitCoords.model.y;
+                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
+
+                return (h > sw2)? h - sw2 : h;
             });
 
         nodeExit.select("text")
             .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
                     self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
-                return "translate(" + anchorX + "," + d.dims.height *
-                    self.transitCoords.model.y / 2 - self.dims.size.partitionTree.strokeWidth + ")";
+                return "translate(" + anchorX + "," + (d.dims.height *
+                    self.transitCoords.model.y / 2 - self.dims.size.partitionTree.strokeWidth) + ")";
             })
             .style("opacity", 0);
     }

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -168,6 +168,7 @@ class N2Diagram {
             'n2OuterGroup': d3.select('g#n2outer'),
             'n2InnerGroup': d3.select('g#n2inner'),
             'pTreeGroup': d3.select('g#tree'),
+            'highlightBar': d3.select('g#highlight-bar'),
             'pSolverTreeGroup': d3.select('g#solver_tree'),
             'n2BackgroundRect': d3.select('g#n2inner rect'),
             'clips': {
@@ -274,6 +275,11 @@ class N2Diagram {
                 .attr("width", this.dims.size.partitionTree.width)
                 .attr("transform", "translate(0 " + innerDims.margin + ")");
 
+            this.dom.highlightBar
+                .attr("height", innerDims.height)
+                .attr("width", "8")
+                .attr("transform", "translate(" + this.dims.size.partitionTree.width + 1 + " " + innerDims.margin + ")");
+
             this.dom.n2OuterGroup
                 .attr("height", outerDims.height)
                 .attr("width", outerDims.height)
@@ -311,7 +317,7 @@ class N2Diagram {
         }
     }
 
-    _createPartitionCells() {
+     _createPartitionCells() {
         let self = this; // For callbacks that change "this". Alternative to using .bind().
 
         let selection = this.dom.pTreeGroup.selectAll(".partition_group")
@@ -347,16 +353,10 @@ class N2Diagram {
 
         nodeEnter.append("rect")
             .attr("width", function (d) {
-                const w = d.prevDims.width * self.prevTransitCoords.model.x;
-                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
-
-                return (w > sw2)? w - sw2 : w;
+                return d.prevDims.width * self.prevTransitCoords.model.x;
             })
             .attr("height", function (d) {
-                const h = d.prevDims.height * self.prevTransitCoords.model.y;
-                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
-
-                return (h > sw2)? h - sw2 : h;
+                return d.prevDims.height * self.prevTransitCoords.model.y;
             })
             .attr("id", function (d) {
                 return d.absPathName.replace(/[\.:]/g, '_');
@@ -368,10 +368,9 @@ class N2Diagram {
             .attr("dy", ".35em")
             .attr("transform", function (d) {
                 let anchorX = d.prevDims.width * self.prevTransitCoords.model.x -
-                    self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
+                    self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + " " +
-                    (d.prevDims.height * self.prevTransitCoords.model.y / 2 -
-                    self.dims.size.partitionTree.strokeWidth) + ")";
+                    (d.prevDims.height * self.prevTransitCoords.model.y / 2) + ")";
             })
             .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
@@ -404,14 +403,10 @@ class N2Diagram {
 
         nodeUpdate.select("rect")
             .attr("width", function (d) {
-                const w = d.dims.width * self.transitCoords.model.x;
-                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
-                return (w > sw2)? w - sw2 : w;
+                return d.dims.width * self.transitCoords.model.x;
             })
             .attr("height", function (d) {
-                const h = d.dims.height * self.transitCoords.model.y;
-                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
-                return (h > sw2)? h - sw2 : h;
+                return d.dims.height * self.transitCoords.model.y;
             })
             .attr('rx', 12)
             .attr('ry', 12);
@@ -419,9 +414,9 @@ class N2Diagram {
         nodeUpdate.select("text")
             .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
-                    self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
+                    self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + " " + (d.dims.height *
-                    self.transitCoords.model.y / 2 - self.dims.size.partitionTree.strokeWidth) + ")";
+                    self.transitCoords.model.y / 2) + ")";
             })
             .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
@@ -443,24 +438,18 @@ class N2Diagram {
 
         nodeExit.select("rect")
             .attr("width", function (d) {
-                const w = d.dims.width * self.transitCoords.model.x;
-                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
-
-                return (w > sw2)? w - sw2 : w;
+                return d.dims.width * self.transitCoords.model.x;
             })
             .attr("height", function (d) {
-                const h = d.dims.height * self.transitCoords.model.y;
-                const sw2 = self.dims.size.partitionTree.strokeWidth * 2;
-
-                return (h > sw2)? h - sw2 : h;
+                return d.dims.height * self.transitCoords.model.y;
             });
 
         nodeExit.select("text")
             .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
-                    self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
+                    self.layout.size.rightTextMargin;
                 return "translate(" + anchorX + "," + (d.dims.height *
-                    self.transitCoords.model.y / 2 - self.dims.size.partitionTree.strokeWidth) + ")";
+                    self.transitCoords.model.y / 2 ) + ")";
             })
             .style("opacity", 0);
     }
@@ -634,10 +623,7 @@ class N2Diagram {
     }
 
     clearHighlights() {
-        for (const varType of ['diag', 'input', 'output']) {
-            this.dom.pTreeGroup.selectAll('.' + varType + 'Highlight')
-                .classed(varType + 'Highlight', false)
-        }
+       this.dom.highlightBar.selectAll('rect').remove();
     }
 
     clearArrows() {

--- a/openmdao/visualization/n2_viewer/src/N2Diagram.js
+++ b/openmdao/visualization/n2_viewer/src/N2Diagram.js
@@ -347,10 +347,12 @@ class N2Diagram {
 
         nodeEnter.append("rect")
             .attr("width", function (d) {
-                return d.prevDims.width * self.prevTransitCoords.model.x - 2;
+                return d.prevDims.width * self.prevTransitCoords.model.x -
+                    self.dims.size.partitionTree.strokeWidth * 2;
             })
             .attr("height", function (d) {
-                return d.prevDims.height * self.prevTransitCoords.model.y - 2;
+                return d.prevDims.height * self.prevTransitCoords.model.y - 
+                    self.dims.size.partitionTree.strokeWidth * 2;
             })
             .attr("id", function (d) {
                 return d.absPathName.replace(/[\.:]/g, '_');
@@ -362,9 +364,10 @@ class N2Diagram {
             .attr("dy", ".35em")
             .attr("transform", function (d) {
                 let anchorX = d.prevDims.width * self.prevTransitCoords.model.x -
-                    self.layout.size.rightTextMargin;
-                return "translate(" + anchorX + " " + d.prevDims.height *
-                    self.prevTransitCoords.model.y / 2 + ")";
+                    self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
+                return "translate(" + anchorX + " " +
+                    (d.prevDims.height * self.prevTransitCoords.model.y / 2 -
+                    self.dims.size.partitionTree.strokeWidth) + ")";
             })
             .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
@@ -397,10 +400,12 @@ class N2Diagram {
 
         nodeUpdate.select("rect")
             .attr("width", function (d) {
-                return d.dims.width * self.transitCoords.model.x - 2;
+                return d.dims.width * self.transitCoords.model.x - 
+                    self.dims.size.partitionTree.strokeWidth * 2;
             })
             .attr("height", function (d) {
-                return d.dims.height * self.transitCoords.model.y - 2;
+                return d.dims.height * self.transitCoords.model.y -
+                    self.dims.size.partitionTree.strokeWidth * 2;
             })
             .attr('rx', 12)
             .attr('ry', 12);
@@ -408,9 +413,9 @@ class N2Diagram {
         nodeUpdate.select("text")
             .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
-                    self.layout.size.rightTextMargin;
-                return "translate(" + anchorX + " " + d.dims.height *
-                    self.transitCoords.model.y / 2 + ")";
+                    self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
+                return "translate(" + anchorX + " " + (d.dims.height *
+                    self.transitCoords.model.y / 2 - self.dims.size.partitionTree.strokeWidth) + ")";
             })
             .style("opacity", function (d) {
                 if (d.depth < self.zoomedElement.depth) return 0;
@@ -432,18 +437,20 @@ class N2Diagram {
 
         nodeExit.select("rect")
             .attr("width", function (d) {
-                return d.dims.width * self.transitCoords.model.x - 2;
+                return d.dims.width * self.transitCoords.model.x - 
+                    self.dims.size.partitionTree.strokeWidth * 2;
             })
             .attr("height", function (d) {
-                return d.dims.height * self.transitCoords.model.y - 2;
+                return d.dims.height * self.transitCoords.model.y -
+                    self.dims.size.partitionTree.strokeWidth * 2;
             });
 
         nodeExit.select("text")
             .attr("transform", function (d) {
                 let anchorX = d.dims.width * self.transitCoords.model.x -
-                    self.layout.size.rightTextMargin;
+                    self.layout.size.rightTextMargin - self.dims.size.partitionTree.strokeWidth;
                 return "translate(" + anchorX + "," + d.dims.height *
-                    self.transitCoords.model.y / 2 + ")";
+                    self.transitCoords.model.y / 2 - self.dims.size.partitionTree.strokeWidth + ")";
             })
             .style("opacity", 0);
     }

--- a/openmdao/visualization/n2_viewer/src/N2Layout.js
+++ b/openmdao/visualization/n2_viewer/src/N2Layout.js
@@ -116,10 +116,8 @@ class N2Layout {
 
     /** Create an off-screen area to render text for _getTextWidth() */
     _setupTextRenderer() {
-        let textGroup = this.svg.append("g").attr("class", "partition_group");
-        let textSVG = textGroup.append("text")
-            .text("")
-            .attr("x", -100); // Put text off screen to the left.
+        const textGroup = this.svg.select('#text-width-renderer');
+        const textSVG = textGroup.select('text');
 
         this.textRenderer = {
             'group': textGroup,
@@ -522,8 +520,8 @@ class N2Layout {
 
         this.ratio = (window.innerWidth - 200) / outerDims.width;
         if (this.ratio > 1 || manuallyResized) this.ratio = 1;
-        else if ( this.ratio < 1 )
-            debugInfo("Scaling diagram to " + Math.round(this.ratio * 100) + "%" );
+        else if (this.ratio < 1)
+            debugInfo("Scaling diagram to " + Math.round(this.ratio * 100) + "%");
 
         dom.svgDiv
             .style("width", (outerDims.width * this.ratio) + this.size.unit)
@@ -546,6 +544,12 @@ class N2Layout {
             .attr("height", innerDims.height)
             .attr("width", this.size.partitionTree.width)
             .attr("transform", "translate(0 " + innerDims.margin + ")");
+
+        dom.highlightBar
+            .transition(sharedTransition)
+            .attr("height", innerDims.height)
+            .attr("width", "8")
+            .attr("transform", "translate(" + this.size.partitionTree.width + 1 + " " + innerDims.margin + ")");
 
         // Move n2 outer group to right of partition tree, spaced by the margin.
         dom.n2OuterGroup

--- a/openmdao/visualization/n2_viewer/src/N2Matrix.js
+++ b/openmdao/visualization/n2_viewer/src/N2Matrix.js
@@ -649,9 +649,7 @@ class N2Matrix {
 
         let leftTextWidthHovered = this.diagNodes[cell.row].nameWidthPx;
 
-        this.highlight(-leftTextWidthHovered - this.layout.size.partitionTreeGap,
-            this.nodeSize.height * cell.row, leftTextWidthHovered,
-            this.nodeSize.height, N2Style.color.highlightHovered); //highlight hovered
+        cell.highlight();
 
         this._drawOffscreenArrows(cell, lineWidth);
 
@@ -674,10 +672,7 @@ class N2Matrix {
                         'width': lineWidth
                     }, this.n2Groups, this.nodeSize);
 
-                    //highlight var name
-                    this.highlight(-leftTextWidthDependency - this.layout.size.partitionTreeGap,
-                        this.nodeSize.height * col, leftTextWidthDependency,
-                        this.nodeSize.height, N2Style.color.greenArrow);
+                    this.cell(cell.row, col).highlight('target', 'output');
                 }
 
             }
@@ -699,10 +694,7 @@ class N2Matrix {
                         'width': lineWidth
                     }, this.n2Groups, this.nodeSize);
 
-                    //highlight var name
-                    this.highlight(-leftTextWidthDependency - this.layout.size.partitionTreeGap,
-                        this.nodeSize.height * col, leftTextWidthDependency,
-                        this.nodeSize.height, N2Style.color.redArrow);
+                    this.cell(col, cell.row).highlight('source', 'input');
                 }
 
             }
@@ -822,14 +814,7 @@ class N2Matrix {
         let leftTextWidthR = this.layout.visibleNodes[cell.row].nameWidthPx,
             leftTextWidthC = this.layout.visibleNodes[cell.col].nameWidthPx;
 
-        // highlight var name
-        this.highlight(-leftTextWidthR - this.layout.size.partitionTreeGap,
-            this.nodeSize.height * cell.row, leftTextWidthR, this.nodeSize.height,
-            N2Style.color.redArrow);
-
-        // highlight var name
-        this.highlight(-leftTextWidthC - this.layout.size.partitionTreeGap,
-            this.nodeSize.height * cell.col, leftTextWidthC, this.nodeSize.height,
-            N2Style.color.greenArrow);
+        cell.highlight('source', 'input');
+        cell.highlight('target', 'output');
     }
 }

--- a/openmdao/visualization/n2_viewer/src/N2Matrix.js
+++ b/openmdao/visualization/n2_viewer/src/N2Matrix.js
@@ -308,26 +308,6 @@ class N2Matrix {
     }
 
     /**
-     * Draw a rectangle at the specified locate to bring attention to
-     * a variable name.
-     * @param {Number} x Upper-left corner X-coordinate in px.
-     * @param {Number} y Upper-left corner Y-coordinate in px.
-     * @param {Number} width Rectangle width in px.
-     * @param {Number} height Rectangle height in px.
-     * @param {string} fill Fill color.
-     */
-    highlight(x, y, width, height, fill) {
-        this.n2Groups.highlights.insert("rect")
-            .attr("class", "n2_hover_elements")
-            .attr("y", y)
-            .attr("x", x)
-            .attr("width", width)
-            .attr("height", height)
-            .attr("fill", fill)
-            .attr("fill-opacity", "1");
-    }
-
-    /**
      * Create an SVG group for each visible element, and have the element
      * render its shape in it. Move the groups around to their correct
      * positions, providing an animated transition from the previous
@@ -809,9 +789,6 @@ class N2Matrix {
                 }
             }
         }
-
-        let leftTextWidthR = this.layout.visibleNodes[cell.row].nameWidthPx,
-            leftTextWidthC = this.layout.visibleNodes[cell.col].nameWidthPx;
 
         cell.highlight('source', 'input');
         cell.highlight('target', 'output');

--- a/openmdao/visualization/n2_viewer/src/N2Matrix.js
+++ b/openmdao/visualization/n2_viewer/src/N2Matrix.js
@@ -696,7 +696,6 @@ class N2Matrix {
 
                     this.cell(col, cell.row).highlight('source', 'input');
                 }
-
             }
         }
     }

--- a/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
+++ b/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
@@ -421,10 +421,10 @@ class N2MatrixCell {
             n2MouseFuncs.overOffDiag);
     }
 
-     /**
-     * Select the mousemove callback depending on whether we"re on the diagonal.
-     * TODO: Remove these globals
-     */
+    /**
+    * Select the mousemove callback depending on whether we"re on the diagonal.
+    * TODO: Remove these globals
+    */
     mousemove() {
         return (this.onDiagonal() ? n2MouseFuncs.moveOnDiag : null);
     }
@@ -531,15 +531,27 @@ class N2MatrixCell {
      *   to indicate the style of the highlighting.
      */
     highlight(varType = 'self', direction = 'self') {
-        let abspath = this.obj.absPathName;
-        let className = 'diagHighlight';
 
-        if (varType == 'target') abspath = this.tgtObj.absPathName;
+        const obj = (varType == 'target') ? this.tgtObj : this.srcObj;
+        const treeId = obj.absPathName.replace(/[\.:]/g, '_');
+        const treeNode = d3.select('rect#' + treeId);
 
-        if (direction == 'input') className = 'inputHighlight';
-        else if (direction == 'output') className = 'outputHighlight';
+        /*        let className = 'diagHighlight';
+                if (direction == 'input') className = 'inputHighlight';
+                else if (direction == 'output') className = 'outputHighlight';
+                */
+        let fill = treeNode.style('fill');
+        if (direction == 'input') fill = N2Style.color.input;
+        else if (direction == 'output') fill = N2Style.color.output;
 
-        const treeId = abspath.replace(/[\.:]/g, '_');
-        d3.select('rect#' + treeId).classed(className, true);
+        d3.select('#highlight-bar').append('rect')
+            .attr('x', 0)
+            .attr('y', treeNode.node().parentNode.transform.baseVal[0].matrix.f)
+            .attr('rx', 4)
+            .attr('ry', 4)
+            .attr('width', 8)
+            .attr('height', treeNode.attr('height'))
+            .attr('stroke', N2Style.color.treeStroke)
+            .attr('fill', fill);
     }
 }

--- a/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
+++ b/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
@@ -195,7 +195,7 @@ class N2Connector extends N2CellRenderer {
         super(color, "vMid", id);
     }
 
-    genPath() { throw ("ERROR: N2Connector.genPath() called.") }
+    _transform(scale) { throw ("ERROR: N2Connector._transform() called.") }
 
     /**
      * Select the element with D3 if not already done, attach a transition
@@ -208,21 +208,24 @@ class N2Connector extends N2CellRenderer {
         if (!d3Elem) d3Elem = d3.select(svgGroup).select("." + this.className)
             .transition(sharedTransition);
 
-        let ret = d3Elem.attr('d', this.genPath());
+        let ret = d3Elem.attr("transform", this._transform(dims.size.width/10.0));
 
         return ret;
     }
 
     /** 
-     * Get the D3 selection for the appropriate group and append a filled rectangle.
+     * Get the D3 selection for the appropriate group and append a filled arrow.
      * @param {Object} svgGroup Reference to SVG <g> element associated with data.
      * @param {Object} dims The cell spec to use while rendering.
      */
     render(svgGroup, dims) {
-        let d3Elem = d3.select(svgGroup).append('path')
+        let d3Elem = d3.select(svgGroup).append('use')
             .attr("class", this.className)
             .attr("id", this.id)
-            .style("fill", this.color);
+            .style("fill", this.color)
+            .attr("x", -5)
+            .attr("y", -5)
+            .attr("xlink:href", "#matrix-connector")
 
         return this.update(svgGroup, dims, d3Elem);
     }
@@ -378,16 +381,8 @@ class N2ConnectorUpper extends N2Connector {
         super(color, id);
     }
 
-    genPath() {
-        /*
-        const s = this.dims.size.width / 5;        
-        const p = `M${-s/2} ${-s*1.5} h${s} v${s} h${s} v${s} h-${s} v${s} h-${s} v-${s} h-${s} v-${s} h${s} z`;
-        */
-        const s = this.dims.size.width / 10;
-        // const p = `M${-5*s} ${-3*s} q${8*s} 0 ${8*s} ${8*s} h${-6*s} q0 ${-2*s} ${-2*s} ${-2*s} z`;
-        const p = `M${-5*s} ${-2*s} q${7*s} 0 ${7*s} ${7*s} h${-4*s} q0 ${-3*s} ${-3*s} ${-3*s} z`;
-        return p;
-    }
+    /** Generate a string to use for the transform attribute */
+    _transform(scale) { return('scale(' + scale + ')'); }
 }
 
 class N2ConnectorLower extends N2Connector {
@@ -395,15 +390,8 @@ class N2ConnectorLower extends N2Connector {
         super(color, id);
     }
 
-    genPath() {
-        /*
-        const s = this.dims.size.width / 5;        
-        const p = `M${-s/2} ${-s*1.5} h${s} v${s} h${s} v${s} h-${s} v${s} h-${s} v-${s} h-${s} v-${s} h${s} z`;
-        */
-        const s = this.dims.size.width / 10;
-        const p = `M${-2*s} ${-5*s} q0 ${7*s} ${7*s} ${7*s} v${-4*s} q${-3*s} 0 ${-3*s} ${-3*s} z`;
-        return p;    
-    }
+    /** Generate a string to use for the transform attribute */
+    _transform(scale) { return('scale(' + scale + ') rotate(180)'); }
 }
 
 class N2ScalarGroupCell extends N2GroupBase {
@@ -585,7 +573,7 @@ class N2MatrixCell {
     _newRenderer() {
         if (this.color() == N2Style.color.connection) {
             if (this.inUpperTriangle()) return new N2ConnectorUpper(this.color(), this.id);
-            
+
             return new N2ConnectorLower(this.color(), this.id)
         }
 

--- a/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
+++ b/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
@@ -520,4 +520,26 @@ class N2MatrixCell {
                 return new N2GroupGroupCell(this.color(), this.id);
         }
     }
+
+    /**
+     * Highlight the variable nodes *associated* with the cell, not the cell
+     * itself. The default is for cells on the diagonal to highlight the
+     * variable directly across from them.
+     * @param {String} [varType = 'self'] Either 'self', 'source', or 'target'
+     *   to indicate the variable name to highlight.
+     * @param {String} [direction = 'self'] Either 'self', 'input', or 'output'
+     *   to indicate the style of the highlighting.
+     */
+    highlight(varType = 'self', direction = 'self') {
+        let abspath = this.obj.absPathName;
+        let className = 'diagHighlight';
+
+        if (varType == 'target') abspath = this.tgtObj.absPathName;
+
+        if (direction == 'input') className = 'inputHighlight';
+        else if (direction == 'output') className = 'outputHighlight';
+
+        const treeId = abspath.replace(/[\.:]/g, '_');
+        d3.select('rect#' + treeId).classed(className, true);
+    }
 }

--- a/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
+++ b/openmdao/visualization/n2_viewer/src/N2MatrixCell.js
@@ -225,7 +225,7 @@ class N2Connector extends N2CellRenderer {
             .style("fill", this.color)
             .attr("x", -5)
             .attr("y", -5)
-            .attr("xlink:href", "#matrix-connector")
+            .attr("xlink:href", "#matrix-connector-square")
 
         return this.update(svgGroup, dims, d3Elem);
     }

--- a/openmdao/visualization/n2_viewer/src/N2Style.js
+++ b/openmdao/visualization/n2_viewer/src/N2Style.js
@@ -210,7 +210,7 @@ class N2Style {
 
 // From Isaias Reyes
 N2Style.color = {
-    'connection': '#000000',
+    'connection': 'gray',
     'unknownImplicit': '#C7D06D',
     'unknownExplicit': '#9FC4C6',
     'componentBox': '#555',

--- a/openmdao/visualization/n2_viewer/src/N2Style.js
+++ b/openmdao/visualization/n2_viewer/src/N2Style.js
@@ -49,60 +49,48 @@ class N2Style {
         // Define as JSON first
         let newCssJson = {
             'rect': {
-                'stroke': N2Style.color.treeStroke
-            },
-            '#tree > g > rect': {
-                'stroke-width': 1,
+                'stroke': N2Style.color.treeStroke,
             },
             '#tree > g.unknown > rect': {
                 'fill': N2Style.color.unknownExplicit,
-                'stroke': N2Style.color.unknownExplicit,
                 'fill-opacity': '.8',
             },
             '#tree > g.unknown_implicit > rect': {
                 'fill': N2Style.color.unknownImplicit,
-                'stroke': N2Style.color.unknownImplicit,                
                 'fill-opacity': '.8',
             },
             '#tree > g.param > rect': {
                 'fill': N2Style.color.param,
-                'stroke': N2Style.color.param,
                 'fill-opacity': '.8',
             },
             '#tree > g.unconnected_param > rect': {
                 'fill': N2Style.color.unconnectedParam,
-                'stroke': N2Style.color.unconnectedParam,
                 'fill-opacity': '.8',
             },
             '#tree > g.subsystem > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.group,
-                'stroke': N2Style.color.group
             },
             '#tree > g.component > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.component,
-                'stroke': N2Style.color.component,
             },
             '#tree > g.param_group > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.paramGroup,
-                'stroke': N2Style.color.paramGroup,
             },
             '#tree > g.unknown_group > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.unknownGroup,
-                'stroke': N2Style.color.unknownGroup,
             },
             '#tree > g.minimized > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.collapsed,
-                'stroke': N2Style.color.collapsed,
             },
             'text': {
                 //'dominant-baseline: middle',
@@ -238,7 +226,9 @@ N2Style.color = {
     'unconnectedParam': '#F42F0D',
     'highlightHovered': 'blue',
     'redArrow': 'salmon',
+    'input': 'salmon',
     'greenArrow': 'seagreen',
+    'output': 'seagreen'
 };
 
 Object.freeze(N2Style.color); // Make it the equivalent of a constant

--- a/openmdao/visualization/n2_viewer/src/N2Style.js
+++ b/openmdao/visualization/n2_viewer/src/N2Style.js
@@ -49,48 +49,60 @@ class N2Style {
         // Define as JSON first
         let newCssJson = {
             'rect': {
-                'stroke': N2Style.color.treeStroke,
+                'stroke': N2Style.color.treeStroke
             },
-            'g.unknown > rect': {
+            '#tree > g > rect': {
+                'stroke-width': 1,
+            },
+            '#tree > g.unknown > rect': {
                 'fill': N2Style.color.unknownExplicit,
+                'stroke': N2Style.color.unknownExplicit,
                 'fill-opacity': '.8',
             },
-            'g.unknown_implicit > rect': {
+            '#tree > g.unknown_implicit > rect': {
                 'fill': N2Style.color.unknownImplicit,
+                'stroke': N2Style.color.unknownImplicit,                
                 'fill-opacity': '.8',
             },
-            'g.param > rect': {
+            '#tree > g.param > rect': {
                 'fill': N2Style.color.param,
+                'stroke': N2Style.color.param,
                 'fill-opacity': '.8',
             },
-            'g.unconnected_param > rect': {
+            '#tree > g.unconnected_param > rect': {
                 'fill': N2Style.color.unconnectedParam,
+                'stroke': N2Style.color.unconnectedParam,
                 'fill-opacity': '.8',
             },
-            'g.subsystem > rect': {
+            '#tree > g.subsystem > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.group,
+                'stroke': N2Style.color.group
             },
-            'g.component > rect': {
+            '#tree > g.component > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.component,
+                'stroke': N2Style.color.component,
             },
-            'g.param_group > rect': {
+            '#tree > g.param_group > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.paramGroup,
+                'stroke': N2Style.color.paramGroup,
             },
-            'g.unknown_group > rect': {
+            '#tree > g.unknown_group > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.unknownGroup,
+                'stroke': N2Style.color.unknownGroup,
             },
-            'g.minimized > rect': {
+            '#tree > g.minimized > rect': {
                 'cursor': 'pointer',
                 'fill-opacity': '.8',
                 'fill': N2Style.color.collapsed,
+                'stroke': N2Style.color.collapsed,
             },
             'text': {
                 //'dominant-baseline: middle',

--- a/openmdao/visualization/n2_viewer/src/N2Toolbar.js
+++ b/openmdao/visualization/n2_viewer/src/N2Toolbar.js
@@ -311,7 +311,11 @@ class N2Toolbar {
         new N2ToolbarButtonToggle('#info-button', tooltipBox,
             ["Show detailed node information", "Hide detailed node information"],
             pred => { return n2ui.nodeInfoBox.hidden; },
-            e => { n2ui.nodeInfoBox.toggle(); }
+            e => {
+                n2ui.nodeInfoBox.unpin();
+                n2ui.nodeInfoBox.clear();
+                n2ui.nodeInfoBox.toggle();
+            }
         );
 
         new N2ToolbarButtonToggle('#question-button', tooltipBox,

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -115,6 +115,7 @@ class NodeInfo {
     unpin() {
         this.pinned = false;
         this.pinButton.attr('class', 'info-hidden');
+        this.clear();
     }
 
     togglePin() {

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -81,6 +81,10 @@ class NodeInfo {
         this.toolbarButton = d3.select('#info-button');
         this.hidden = true;
         this.pinned = false;
+
+        const self = this;
+        this.pinButton = d3.select('#node-info-pin')
+            .on('click', e => { self.unpin(); })
     }
 
     /** Make the info box visible if it's hidden */
@@ -103,9 +107,20 @@ class NodeInfo {
         else this.hide();
     }
 
-    pin() { this.pinned = true; }
-    unpin() { this.pinned = false; }
-    togglePin() { this.pinned = !this.pinned; }
+    pin() { 
+        this.pinned = true;
+        this.pinButton.attr('class', 'info-visible');
+    }
+    
+    unpin() {
+        this.pinned = false;
+        this.pinButton.attr('class', 'info-hidden');
+    }
+
+    togglePin() {
+        if (this.pinned) this.unpin();
+        else this.pin();
+    }
 
     _addPropertyRow(label, val, capitalize = false) {
         const newRow = this.tbody.append('tr');

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -74,7 +74,8 @@ class NodeInfo {
         ];
 
         this.abs2prom = abs2prom;
-        this.table = d3.select('#node-info-container');
+        this.table = d3.select('#node-info-table');
+        this.container = d3.select('#node-info-container');
         this.thead = this.table.select('thead');
         this.tbody = this.table.select('tbody');
         this.toolbarButton = d3.select('#info-button');
@@ -160,16 +161,20 @@ class NodeInfo {
             .style('height', this.table.node().scrollHeight + 'px')
 
         this.move(event);
-        this.table.attr('class', 'info-visible');
+        this.container.attr('class', 'info-visible');
     }
 
     /** Wipe the contents of the table body */
     clear() {
         if (this.hidden || this.pinned) return;
-        this.table
+        this.container
             .attr('class', 'info-hidden')
             .style('width', 'auto')
-            .style('height', 'auto')
+            .style('height', 'auto');
+
+        this.table
+            .style('width', 'auto')
+            .style('height', 'auto');
 
         this.tbody.html('');
     }
@@ -184,24 +189,24 @@ class NodeInfo {
 
         // Mouse is in left half of window, put box to right of mouse
         if (event.clientX < window.innerWidth / 2) {
-            this.table.style('right', 'auto');
-            this.table.style('left', (event.clientX + offset) + 'px')
+            this.container.style('right', 'auto');
+            this.container.style('left', (event.clientX + offset) + 'px')
         }
         // Mouse is in right half of window, put box to left of mouse
         else {
-            this.table.style('left', 'auto');
-            this.table.style('right', (window.innerWidth - event.clientX + offset) + 'px')
+            this.container.style('left', 'auto');
+            this.container.style('right', (window.innerWidth - event.clientX + offset) + 'px')
         }
 
         // Mouse is in top half of window, put box below mouse
         if (event.clientY < window.innerHeight / 2) {
-            this.table.style('bottom', 'auto');
-            this.table.style('top', (event.clientY - offset) + 'px')
+            this.container.style('bottom', 'auto');
+            this.container.style('top', (event.clientY - offset) + 'px')
         }
         // Mouse is in bottom half of window, put box above mouse
         else {
-            this.table.style('top', 'auto');
-            this.table.style('bottom', (window.innerHeight - event.clientY - offset) + 'px')
+            this.container.style('top', 'auto');
+            this.container.style('bottom', (window.innerHeight - event.clientY - offset) + 'px')
         }
     }
 }
@@ -786,7 +791,7 @@ class N2UserInterface {
         testThis(this, 'N2UserInterface', 'toggleNodeData');
 
         const infoButton = d3.select('#info-button');
-        const nodeData = d3.select('#node-info-container');
+        const nodeData = d3.select('#node-info-table');
 
         if (nodeData.classed('info-hidden')) {
             nodeData.attr('class', 'info-visible');

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -79,6 +79,7 @@ class NodeInfo {
         this.tbody = this.table.select('tbody');
         this.toolbarButton = d3.select('#info-button');
         this.hidden = true;
+        this.pinned = false;
     }
 
     /** Make the info box visible if it's hidden */
@@ -101,6 +102,10 @@ class NodeInfo {
         else this.hide();
     }
 
+    pin() { this.pinned = true; }
+    unpin() { this.pinned = false; }
+    togglePin() { this.pinned = !this.pinned; }
+
     _addPropertyRow(label, val, capitalize = false) {
         const newRow = this.tbody.append('tr');
 
@@ -122,7 +127,9 @@ class NodeInfo {
      * @param {N2TreeNode} color The color to make the title bar.
      */
     update(event, obj, color = '#42926b') {
-        if (this.hidden) return;
+        if (this.hidden || this.pinned) return;
+
+        this.clear();
         // Put the name in the title
         this.table.select('thead th')
             .style('background-color', color)
@@ -158,7 +165,7 @@ class NodeInfo {
 
     /** Wipe the contents of the table body */
     clear() {
-        if (this.hidden) return;
+        if (this.hidden || this.pinned) return;
         this.table
             .attr('class', 'info-hidden')
             .style('width', 'auto')
@@ -172,7 +179,7 @@ class NodeInfo {
      * @param {Object} event The triggering event containing the position.
      */
     move(event) {
-        if (this.hidden) return;
+        if (this.hidden || this.pinned) return;
         const offset = 30;
 
         // Mouse is in left half of window, put box to right of mouse

--- a/openmdao/visualization/n2_viewer/src/defaults.js
+++ b/openmdao/visualization/n2_viewer/src/defaults.js
@@ -16,6 +16,7 @@ defaultDims = {
         'partitionTree': { // Dimensions of the tree on the left side of the diagram
             'width': 0,
             'height': _DEFAULT_N2_DIAGRAM_HEIGHT,
+            'strokeWidth': 1 // The stroke width around each of the nodes
         },
         'solverTree': { // Dimensions of the tree on the right side of the diagram
             'width': 0,

--- a/openmdao/visualization/n2_viewer/src/defaults.js
+++ b/openmdao/visualization/n2_viewer/src/defaults.js
@@ -16,7 +16,6 @@ defaultDims = {
         'partitionTree': { // Dimensions of the tree on the left side of the diagram
             'width': 0,
             'height': _DEFAULT_N2_DIAGRAM_HEIGHT,
-            'strokeWidth': 1 // The stroke width around each of the nodes
         },
         'solverTree': { // Dimensions of the tree on the right side of the diagram
             'width': 0,

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -1,11 +1,15 @@
 /******************* Node Data styling *******************/
 #node-info-container {
-	position: absolute;
+    position: absolute;
+    z-index: 10;
+    height: auto;
+}
+
+#node-info-table {
 	overflow: hidden;
 	background-color: white;
 	border-radius: 10px;
 	border: 1px solid #a0a0a0;
-	z-index: 10;
     transition: opacity 0.25s;
     box-shadow: 3px 3px 3px 1px rgba(0, 0, 0, 0.2);
     min-width: 200px;
@@ -21,14 +25,14 @@
     visibility: visible;
 }
 
-#node-info-container thead th {
+#node-info-table thead th {
     background-color: #42926b;
     color: black;
     padding: 5px;
     font-size: 11pt;
 }
 
-#node-info-container tbody th {
+#node-info-table tbody th {
     text-align: right;
     font-size: 9pt;
     margin-top: 0;
@@ -39,7 +43,7 @@
     white-space: nowrap;
 }
 
-#node-info-container tbody td {
+#node-info-table tbody td {
     text-align: left;
     font-size: 9pt;
     margin-top: 0;
@@ -51,7 +55,7 @@
     white-space: nowrap;
 }
 
-#node-info-container tfoot th {
+#node-info-table tfoot th {
     background-color: #42926b;
     padding: 2px;
     font-size: 11pt;
@@ -68,24 +72,6 @@
 .info-header p {
 	color: white;
 	text-align: center;
-}
-
-.node-data-container {
-	width: 100%;
-	display: flex;
-	flex-direction: column;
-	align-items: center;
-}
-
-.node-data {
-	display: flex;
-	justify-content: space-between;
-	font-size: 13px;
-	align-self: center;
-}
-
-.node-data p:first-child {
-	font-weight: 600;
 }
 
 .node-data-cursor {

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -94,3 +94,9 @@
     /* box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.2); */
     border-radius: 3px;
 }
+
+#node-info-pin:hover {
+    top: 4px;
+    right: 9px;
+    box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.2);
+}

--- a/openmdao/visualization/n2_viewer/style/nodedata.css
+++ b/openmdao/visualization/n2_viewer/style/nodedata.css
@@ -78,3 +78,19 @@
     cursor: context-menu;
 }
 
+#node-info-pin {
+    position: absolute;
+    top: 5px;
+    right: 8px;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    border: 0;
+    font-size: 12px;
+    background: #ccc;
+    width: 18px;
+    height: 18px;
+    padding: 0 2px 0 2px;
+    /* box-shadow: 1px 1px 1px 1px rgba(0, 0, 0, 0.2); */
+    border-radius: 3px;
+}

--- a/openmdao/visualization/n2_viewer/style/partition_tree.css
+++ b/openmdao/visualization/n2_viewer/style/partition_tree.css
@@ -312,16 +312,13 @@ div.offgrid {
 }
 
 rect.diagHighlight {
-    fill: yellow !important;
-    stroke: brown !important;
+    fill: black !important;
 }
 
 rect.inputHighlight {
     fill: salmon !important;
-    stroke: red !important;
 }
 
 rect.outputHighlight {
     fill: seagreen !important;
-    stroke: lightgreen !important;
 }

--- a/openmdao/visualization/n2_viewer/style/partition_tree.css
+++ b/openmdao/visualization/n2_viewer/style/partition_tree.css
@@ -310,3 +310,18 @@ div.offgrid {
     margin-top: -15px;
     pointer-events: none;
 }
+
+rect.diagHighlight {
+    fill: yellow !important;
+    stroke: brown !important;
+}
+
+rect.inputHighlight {
+    fill: salmon !important;
+    stroke: red !important;
+}
+
+rect.outputHighlight {
+    fill: seagreen !important;
+    stroke: lightgreen !important;
+}


### PR DESCRIPTION
### Summary

There are several N2 updates:
- The issue with the weird variable name highlighting is addressed by drawing a vertical line next to the variable name with the same color as the node, similar to the method used in Excel.
- The info panel is now pinnable. When using info-panel mode and a node is left-clicked, the panel is pinned and won't change when the mouse moves off the node. To unpin the panel, either left-click on another node, click the pushpin on the panel, or exit info-panel mode.
- Connection nodes in the matrix are now represented by a gray, curved arrow instead of a black square. The arrow makes it obvious that the connections and variables are different entities, and the gray color doesn't contrast as harshly with the rest of the diagram colors.
- Connection arrows now curve through the connection nodes instead of forming a right angle with a dot at the vertex.

- Resolves #1362 
- Resolves #1410

![n2_new_matrix](https://user-images.githubusercontent.com/12797795/83180201-14845200-a0f1-11ea-8e11-5197e50c3b73.png)

![n2_info_panel](https://user-images.githubusercontent.com/12797795/83180210-16e6ac00-a0f1-11ea-87c5-d0632caeb810.png)

### Backwards incompatibilities

None

### New Dependencies

None
