### PR TITLE
Also control importing of petsc4py with the use of OPENMDAO_REQUIRE_MPI

### DIFF
--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -10,18 +10,21 @@ import time
 
 import numpy as np
 
+from openmdao.vectors.vector import INT_DTYPE
+from openmdao.utils.general_utils import ContainsAll, simple_warning
+from openmdao.utils.mpi import MPI
+from openmdao.utils.coloring import _initialize_model_approx, Coloring
+
 # Attempt to import petsc4py.
 # If OPENMDAO_REQUIRE_MPI is set to a recognized positive value, attempt import
 # and raise exception on failure. If set to anything else, no import is attempted.
 if 'OPENMDAO_REQUIRE_MPI' in os.environ:
     if os.environ['OPENMDAO_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
         try:
-            print("from petsc4py import PETSc")
             from petsc4py import PETSc
         except ImportError:
             PETSc = None
     else:
-        print("PETSc = None total jac")
         PETSc = None
 # If OPENMDAO_REQUIRE_MPI is unset, attempt to import petsc4py, but continue on failure
 # with a notification.
@@ -32,19 +35,6 @@ else:
         PETSc = None
         sys.stdout.write("Unable to import petsc4py. Parallel processing unavailable.\n")
         sys.stdout.flush()
-#
-#
-# try:
-#     from petsc4py import PETSc
-#     from openmdao.vectors.petsc_vector import PETScVector
-# except ImportError:
-#     PETSc = None
-
-from openmdao.vectors.vector import INT_DTYPE
-from openmdao.utils.general_utils import ContainsAll, simple_warning
-from openmdao.utils.mpi import MPI
-from openmdao.utils.coloring import _initialize_model_approx, Coloring
-
 
 _contains_all = ContainsAll()
 

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -20,10 +20,7 @@ from openmdao.utils.coloring import _initialize_model_approx, Coloring
 # and raise exception on failure. If set to anything else, no import is attempted.
 if 'OPENMDAO_REQUIRE_MPI' in os.environ:
     if os.environ['OPENMDAO_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
-        try:
-            from petsc4py import PETSc
-        except ImportError:
-            PETSc = None
+        from petsc4py import PETSc
     else:
         PETSc = None
 # If OPENMDAO_REQUIRE_MPI is unset, attempt to import petsc4py, but continue on failure

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -3,17 +3,42 @@ Helper class for total jacobian computation.
 """
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
+import os
 import pprint
 import sys
 import time
 
 import numpy as np
 
-try:
-    from petsc4py import PETSc
-    from openmdao.vectors.petsc_vector import PETScVector
-except ImportError:
-    PETSc = None
+# Attempt to import petsc4py.
+# If OPENMDAO_REQUIRE_MPI is set to a recognized positive value, attempt import
+# and raise exception on failure. If set to anything else, no import is attempted.
+if 'OPENMDAO_REQUIRE_MPI' in os.environ:
+    if os.environ['OPENMDAO_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
+        try:
+            print("from petsc4py import PETSc")
+            from petsc4py import PETSc
+        except ImportError:
+            PETSc = None
+    else:
+        print("PETSc = None total jac")
+        PETSc = None
+# If OPENMDAO_REQUIRE_MPI is unset, attempt to import petsc4py, but continue on failure
+# with a notification.
+else:
+    try:
+        from petsc4py import PETSc
+    except ImportError:
+        PETSc = None
+        sys.stdout.write("Unable to import petsc4py. Parallel processing unavailable.\n")
+        sys.stdout.flush()
+#
+#
+# try:
+#     from petsc4py import PETSc
+#     from openmdao.vectors.petsc_vector import PETScVector
+# except ImportError:
+#     PETSc = None
 
 from openmdao.vectors.vector import INT_DTYPE
 from openmdao.utils.general_utils import ContainsAll, simple_warning

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -14,7 +14,7 @@ import traceback
 
 import numpy as np
 from scipy.sparse import coo_matrix
-
+#
 try:
     from pyoptsparse import Optimization
 except ImportError:

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -14,7 +14,7 @@ import traceback
 
 import numpy as np
 from scipy.sparse import coo_matrix
-#
+
 try:
     from pyoptsparse import Optimization
 except ImportError:

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -1,12 +1,27 @@
 """LinearSolver that uses PetSC KSP to solve for a system's derivatives."""
 
 import numpy as np
+import os
 
-try:
-    import petsc4py
-    from petsc4py import PETSc
-except ImportError:
-    PETSc = None
+if 'OPENMDAO_REQUIRE_MPI' in os.environ:
+    if os.environ['OPENMDAO_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
+        try:
+            import petsc4py
+            from petsc4py import PETSc
+        except ImportError:
+            PETSc = None
+    else:
+        PETSc = None
+# If OPENMDAO_REQUIRE_MPI is unset, attempt to import petsc4py, but continue on failure
+# with a notification.
+else:
+    try:
+        import petsc4py
+        from petsc4py import PETSc
+    except ImportError:
+        PETSc = None
+        sys.stdout.write("Unable to import petsc4py. Parallel processing unavailable.\n")
+        sys.stdout.flush()
 
 from openmdao.solvers.solver import LinearSolver
 

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import os
+import sys
 
 from openmdao.solvers.solver import LinearSolver
 

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -3,6 +3,8 @@
 import numpy as np
 import os
 
+from openmdao.solvers.solver import LinearSolver
+
 if 'OPENMDAO_REQUIRE_MPI' in os.environ:
     if os.environ['OPENMDAO_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
         try:
@@ -23,7 +25,6 @@ else:
         sys.stdout.write("Unable to import petsc4py. Parallel processing unavailable.\n")
         sys.stdout.flush()
 
-from openmdao.solvers.solver import LinearSolver
 
 KSP_TYPES = [
     "richardson",

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -6,13 +6,12 @@ import sys
 
 from openmdao.solvers.solver import LinearSolver
 
+# If OPENMDAO_REQUIRE_MPI is set to a recognized positive value, attempt import
+# and raise exception on failure. If set to anything else, no import is attempted.
 if 'OPENMDAO_REQUIRE_MPI' in os.environ:
     if os.environ['OPENMDAO_REQUIRE_MPI'].lower() in ['always', '1', 'true', 'yes']:
-        try:
-            import petsc4py
-            from petsc4py import PETSc
-        except ImportError:
-            PETSc = None
+        import petsc4py
+        from petsc4py import PETSc
     else:
         PETSc = None
 # If OPENMDAO_REQUIRE_MPI is unset, attempt to import petsc4py, but continue on failure


### PR DESCRIPTION
### Summary

The environment variable OPENMDAO_REQUIRE_MPI affected the importing of mpi4y but not petsc4py. This PR fixes that. 

This issue came up because if the user's MPI install was corrupt, it was impossible to even run serial code. This gives the user to force serial mode and not import even petsc4py. 

This fix actually does not completely solve the problem. Since OpenMDAO uses pyoptsparse, and since pyoptsparse also uses mpi4py, the user still will have issues. So a PR was submitted to the pyoptsparse repo, with the blessing of that team, to have a similar environment variable `PYOPTSPARSE_REQUIRE_MPI` to give explicit control over running in parallel or serial. 

### Related Issues

- Resolves #1421 

### Backwards incompatibilities

None

### New Dependencies

None
