### PR TITLE
Adding out_stream to list_* methods

### DIFF
--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -479,7 +479,7 @@ class SimulColoringRecordingTestCase(unittest.TestCase):
 
         cr = om.CaseReader('cases.sql')
 
-        self.assertEqual(cr.list_cases(), ['rank0:pyOptSparse_SNOPT|%d' % i for i in range(p.driver.iter_count)])
+        self.assertEqual(cr.list_cases(out_stream=None), ['rank0:pyOptSparse_SNOPT|%d' % i for i in range(p.driver.iter_count)])
 
 
 @use_tempdirs

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -331,7 +331,7 @@ class SqliteCaseReader(BaseCaseReader):
                 for source in sources:
                     out_stream.write('{}\n'.format(source))
 
-    def list_source_vars(self, source):
+    def list_source_vars(self, source, out_stream=_DEFAULT_OUT_STREAM):
         """
         List of all inputs and outputs recorded by the specified source.
 
@@ -339,6 +339,9 @@ class SqliteCaseReader(BaseCaseReader):
         ----------
         source : {'problem', 'driver', <system hierarchy location>, <solver hierarchy location>}
             Identifies the source for which to return information.
+        out_stream : file-like object
+            Where to send human readable output. Default is sys.stdout.
+            Set to None to suppress.
 
         Returns
         -------
@@ -378,7 +381,14 @@ class SqliteCaseReader(BaseCaseReader):
         if case.residuals:
             dct['residuals'] = list(case.residuals)
 
-        return dct
+        if not out_stream:
+            return dct
+        else:
+            if out_stream is _DEFAULT_OUT_STREAM:
+                out_stream = sys.stdout
+
+            if out_stream:
+                return write_source_table(dct, out_stream)
 
     def list_cases(self, source=None, recurse=True, flat=True, out_stream=_DEFAULT_OUT_STREAM):
         """

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -151,7 +151,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
 
         # check that driver is our only source
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check source vars
         source_vars = cr.list_source_vars('driver')
@@ -195,10 +195,10 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
 
         # check that we only have driver cases
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check source vars
-        source_vars = cr.list_source_vars('driver')
+        source_vars = cr.list_source_vars('driver',)
         self.assertEqual(sorted(source_vars['inputs']), ['x', 'y1', 'y2', 'z'])
         self.assertEqual(sorted(source_vars['outputs']), ['con1', 'con2', 'obj', 'x', 'y1', 'y2', 'z'])
 
@@ -257,7 +257,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
 
         # check that we only have driver cases
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check source vars
         source_vars = cr.list_source_vars('driver')
@@ -290,7 +290,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
 
         # check that we only have driver cases
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check source vars
         source_vars = cr.list_source_vars('driver')
@@ -326,7 +326,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
 
         # check that we only have the three system sources
-        self.assertEqual(sorted(cr.list_sources()), ['root', 'root.d1', 'root.obj_cmp'])
+        self.assertEqual(sorted(cr.list_sources(out_stream=None)), ['root', 'root.d1', 'root.obj_cmp'])
 
         # check source vars
         source_vars = cr.list_source_vars('root')
@@ -380,7 +380,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         cr = om.CaseReader(self.filename)
 
         # check that we only have the one solver source
-        self.assertEqual(sorted(cr.list_sources()), ['root.nonlinear_solver'])
+        self.assertEqual(sorted(cr.list_sources(out_stream=None)), ['root.nonlinear_solver'])
 
         # check source vars
         source_vars = cr.list_source_vars('root.nonlinear_solver')
@@ -741,7 +741,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         #
         # get a list of cases for each source
         #
-        sources = cr.list_sources()
+        sources = cr.list_sources(out_stream=None)
         self.assertEqual(sorted(sources), [
             'driver', 'root', 'root.mda', 'root.mda.nonlinear_solver', 'root.nonlinear_solver'
         ])
@@ -952,7 +952,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         #
         # get a list of cases for each source
         #
-        sources = cr.list_sources()
+        sources = cr.list_sources(out_stream=None)
         self.assertEqual(sorted(sources), [
             'driver', 'root', 'root.mda', 'root.mda.nonlinear_solver', 'root.nonlinear_solver'
         ])
@@ -2395,7 +2395,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         # check sources
         #
 
-        self.assertEqual(sorted(cr.list_sources()), [
+        self.assertEqual(sorted(cr.list_sources(out_stream=None)), [
             'driver', 'problem', 'root.mda.nonlinear_solver', 'root.nonlinear_solver', 'root.pz'
         ])
 
@@ -3039,10 +3039,32 @@ class TestSqliteCaseReader(unittest.TestCase):
         for i, line in enumerate(expected_cases):
             self.assertEqual(text[i], line)
 
+    def test_list_sources_format(self):
+        prob = SellarProblem()
+        prob.setup()
 
+        prob.add_recorder(self.recorder)
+        prob.driver.add_recorder(self.recorder)
+        prob.model.d1.add_recorder(self.recorder)
 
-        # for i, coord in enumerate(cases):
-        #     self.assertEqual(coord, expected_cases[i])
+        prob.run_driver()
+
+        prob.record('final')
+        prob.cleanup()
+
+        cr = om.CaseReader(self.filename)
+
+        expected_cases = [
+            'driver',
+            'root.d1',
+            'problem'
+        ]
+
+        stream = StringIO()
+        cases = cr.list_sources(out_stream=stream)
+        text = stream.getvalue().split('\n')
+        for i, line in enumerate(expected_cases):
+            self.assertEqual(text[i], line)
 
 @use_tempdirs
 class TestFeatureSqliteReader(unittest.TestCase):
@@ -3200,7 +3222,7 @@ class TestFeatureSqliteReader(unittest.TestCase):
         # examine cases to see what was recorded
         cr = om.CaseReader('cases.sql')
 
-        self.assertEqual(sorted(cr.list_sources()), ['driver', 'root', 'root.nonlinear_solver'])
+        self.assertEqual(sorted(cr.list_sources(out_stream=None)), ['driver', 'root', 'root.nonlinear_solver'])
 
         driver_vars = cr.list_source_vars('driver')
         self.assertEqual(('inputs:', sorted(driver_vars['inputs']), 'outputs:', sorted(driver_vars['outputs'])),
@@ -3881,7 +3903,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         # check sources
         #
 
-        self.assertEqual(sorted(cr.list_sources()), [
+        self.assertEqual(sorted(cr.list_sources(out_stream=None)), [
             'problem',
         ])
 
@@ -3933,7 +3955,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         cr = om.CaseReader(filename)
 
         # recorded data from driver only
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check that we got the correct number of cases
         driver_cases = cr.list_cases('driver')
@@ -3963,7 +3985,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         # check sources
         #
 
-        self.assertEqual(sorted(cr.list_sources()), [
+        self.assertEqual(sorted(cr.list_sources(out_stream=None)), [
             'driver', 'problem', 'root.mda.nonlinear_solver', 'root.nonlinear_solver', 'root.pz'
         ])
 
@@ -4303,7 +4325,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         cr = om.CaseReader(filename)
 
         # recorded data from driver only
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check that we got the correct number of cases
         driver_cases = cr.list_cases('driver')
@@ -4350,7 +4372,7 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         cr = om.CaseReader(filename)
 
         # recorded data from driver only
-        self.assertEqual(cr.list_sources(), ['driver'])
+        self.assertEqual(cr.list_sources(out_stream=None), ['driver'])
 
         # check that we got the correct number of cases
         driver_cases = cr.list_cases('driver')

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3094,8 +3094,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         cases = cr.list_source_vars('driver', out_stream=stream)
         text = sorted(stream.getvalue().split('\n'), reverse=True)
         for i, line in enumerate(expected_cases):
-            if line:
-                self.assertEqual(text[i], line)
+            self.assertEqual(text[i], line)
 
 @use_tempdirs
 class TestFeatureSqliteReader(unittest.TestCase):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2798,7 +2798,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(problem_cases, ['final'])
 
         # get list of output variables recorded on problem
-        problem_vars = cr.list_source_vars('problem')
+        problem_vars = cr.list_source_vars('problem', out_stream=None)
         self.assertEqual(sorted(problem_vars['outputs']), ['con1', 'con2', 'obj', 'x', 'z'])
 
         # get the recorded case and check values
@@ -2852,7 +2852,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(problem_cases, ['final'])
 
         # get list of output variables recorded on problem
-        problem_vars = cr.list_source_vars('problem')
+        problem_vars = cr.list_source_vars('problem', out_stream=None)
         self.assertEqual(sorted(problem_vars['outputs']), ['con1', 'con2', 'obj', 'x', 'z'])
 
         # get the recorded case and check values
@@ -3044,7 +3044,7 @@ class TestFeatureAdvancedExample(unittest.TestCase):
         self.assertEqual(problem_cases, ['final_state'])
 
         # get list of output variables recorded on problem
-        problem_vars = cr.list_source_vars('problem')
+        problem_vars = cr.list_source_vars('problem', out_stream=None)
         self.assertEqual(sorted(problem_vars['outputs']),
                          ['con1', 'con2', 'obj', 'x', 'y1', 'y2', 'z'])
 

--- a/openmdao/utils/variable_table.py
+++ b/openmdao/utils/variable_table.py
@@ -162,6 +162,14 @@ def write_var_table(pathname, var_list, var_type, var_dict,
                             print_arrays)
     out_stream.write(2 * '\n')
 
+def write_source_table(source_dict, out_stream):
+
+    for key, value in source_dict.items():
+        if value:
+            out_stream.write('{}\n'.format(key))
+            for i in value:
+                out_stream.write('    {}\n'.format(i))
+
 
 def _write_variable(out_stream, row, column_names, var_dict, print_arrays):
     """

--- a/openmdao/utils/variable_table.py
+++ b/openmdao/utils/variable_table.py
@@ -162,8 +162,20 @@ def write_var_table(pathname, var_list, var_type, var_dict,
                             print_arrays)
     out_stream.write(2 * '\n')
 
-def write_source_table(source_dict, out_stream):
 
+def write_source_table(source_dict, out_stream):
+    """
+    Write table of cases and their respective sources.
+
+    Parameters
+    ----------
+    source_dict : dict
+        Dict of source and cases
+    out_stream : file-like object
+        Where to send human readable output.
+        Set to None to suppress.
+
+    """
     for key, value in source_dict.items():
         if value:
             out_stream.write('{}\n'.format(key))


### PR DESCRIPTION
### Summary

Added out_stream arg to CaseReader list_sources, list_cases, and list_source_vars, default `sys.stdout`. Option `None` to supress output and only return list.

### Related Issues

- Resolves #1420 

### Backwards incompatibilities

None

### New Dependencies

None
