### PR TITLE
Fix for issue #1447

### DIFF
--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -70,7 +70,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         self._static_surrogate_output_names = []
         self._static_input_size = 0
 
-    def _setup_procs(self, pathname, comm, mode, prob_options):
+    def _setup_procs(self, pathname, comm, mode, setup_mode, prob_options):
         self._surrogate_input_names = []
         self._surrogate_output_names = []
 
@@ -78,7 +78,8 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         self._surrogate_output_names.extend(self._static_surrogate_output_names)
         self._input_size = self._static_input_size
 
-        super(MetaModelUnStructuredComp, self)._setup_procs(pathname, comm, mode, prob_options)
+        super(MetaModelUnStructuredComp, self)._setup_procs(pathname, comm, mode, setup_mode,
+                                                            prob_options)
 
     def initialize(self):
         """

--- a/openmdao/components/multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/multifi_meta_model_unstructured_comp.py
@@ -110,11 +110,11 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         self.options.declare('nfi', types=int, default=1, lower=1,
                              desc='Number of levels of fidelity.')
 
-    def _setup_procs(self, pathname, comm, mode, prob_options):
+    def _setup_procs(self, pathname, comm, mode, setup_mode, prob_options):
         self._input_sizes = list(self._static_input_sizes)
 
         super(MultiFiMetaModelUnStructuredComp, self)._setup_procs(pathname, comm, mode,
-                                                                   prob_options)
+                                                                   setup_mode, prob_options)
 
     def add_input(self, name, val=1.0, shape=None, src_indices=None, flat_src_indices=None,
                   units=None, desc=''):

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -127,7 +127,7 @@ class Component(System):
         """
         pass
 
-    def _setup_procs(self, pathname, comm, mode, prob_options):
+    def _setup_procs(self, pathname, comm, mode, setup_mode, prob_options):
         """
         Execute first phase of the setup process.
 
@@ -142,6 +142,8 @@ class Component(System):
         mode : string
             Derivatives calculation mode, 'fwd' for forward, and 'rev' for
             reverse (adjoint). Default is 'rev'.
+        setup_mode : string
+            What type of setup this is, one of ['full', 'reconf', 'update'].
         prob_options : OptionsDictionary
             Problem level options.
         """
@@ -150,6 +152,10 @@ class Component(System):
 
         self.options._parent_name = self.msginfo
         self.recording_options._parent_name = self.msginfo
+
+        # TODO: get rid of this after we remove reconfig.
+        if setup_mode == 'full':
+            self._vectors = {}
 
         orig_comm = comm
         if self._num_par_fd > 1:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -324,7 +324,7 @@ class Group(System):
 
         self.configure()
 
-    def _setup_procs(self, pathname, comm, mode, prob_options):
+    def _setup_procs(self, pathname, comm, mode, setup_mode, prob_options):
         """
         Execute first phase of the setup process.
 
@@ -340,6 +340,8 @@ class Group(System):
         mode : string
             Derivatives calculation mode, 'fwd' for forward, and 'rev' for
             reverse (adjoint). Default is 'rev'.
+        setup_mode : string
+            What type of setup this is, one of ['full', 'reconf', 'update'].
         prob_options : OptionsDictionary
             Problem level options.
         """
@@ -350,6 +352,10 @@ class Group(System):
         self.recording_options._parent_name = self.msginfo
 
         self._setup_procs_finished = False
+
+        # TODO: get rid of this after we remove reconfig.
+        if setup_mode == 'full':
+            self._vectors = {}
 
         if self._num_par_fd > 1:
             info = self._coloring_info
@@ -442,7 +448,7 @@ class Group(System):
             subsys._use_derivatives = self._use_derivatives
             subsys._solver_info = self._solver_info
             subsys._recording_iter = self._recording_iter
-            subsys._setup_procs(subsys.pathname, sub_comm, mode, prob_options)
+            subsys._setup_procs(subsys.pathname, sub_comm, mode, setup_mode, prob_options)
 
         # build a list of local subgroups to speed up later loops
         self._subgroups_myproc = [s for s in self._subsystems_myproc if isinstance(s, Group)]

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -784,7 +784,7 @@ class System(object):
         # If we're only updating and not recursing, processors don't need to be redistributed.
         if recurse:
             # Besides setting up the processors, this method also builds the model hierarchy.
-            self._setup_procs(self.pathname, comm, mode, self._problem_options)
+            self._setup_procs(self.pathname, comm, mode, setup_mode, self._problem_options)
 
         # Recurse model from the bottom to the top for configuring.
         # Set static_mode to False in all subsystems because inputs & outputs may be created.
@@ -1457,8 +1457,10 @@ class System(object):
         self._var_abs_names = {'input': [], 'output': []}
         self._var_allprocs_prom2abs_list = {'input': OrderedDict(), 'output': OrderedDict()}
         self._var_abs2prom = {'input': {}, 'output': {}}
+        self._var_allprocs_abs2prom = {'input': {}, 'output': {}}
         self._var_allprocs_abs2meta = {}
         self._var_abs2meta = {}
+        self._var_allprocs_abs2idx = {}
 
     def _setup_var_index_maps(self, recurse=True):
         """
@@ -4144,6 +4146,8 @@ class System(object):
                 pass  # non-local discrete output
             elif abs_name in self._var_allprocs_discrete['input']:
                 pass  # non-local discrete input
+            elif get_remote:
+                raise ValueError(f"{self.msginfo}: Can't find variable named '{abs_name}'.")
             else:
                 return _undefined
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1894,5 +1894,27 @@ class NestedProblemTestCase(unittest.TestCase):
         p.run_model()
 
 
+class SystemInTwoProblemsTestCase(unittest.TestCase):
+    def test_2problems(self):
+        prob = om.Problem()
+        G1 = prob.model.add_subsystem("G1", om.Group())
+        G2 = G1.add_subsystem('G2', om.Group(), promotes_inputs=['x'])
+        G2.add_subsystem('C1', om.ExecComp('y = 2 * x'), promotes_inputs=['x'])
+        G2.add_subsystem('C2', om.ExecComp('y = 3 * x'), promotes_inputs=['x'])
+
+        prob.setup()
+        prob.run_model()
+
+        # 2nd problem
+        prob = om.Problem()
+        prob.model = G2
+
+        prob.setup()
+        prob.run_model()
+
+        np.testing.assert_allclose(prob['C1.y'], 2.0)
+        np.testing.assert_allclose(prob['C2.y'], 3.0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION

### Summary

User got the error message `TypeError: unsupported operand type(s) for *: 'Undefined' and 'Undefined'` after calling setup on a problem where the top level system was a group that was already setup earlier in a different problem.  The problem was due to the fact that the internal vector dictionaries were not being reinitialized early enough.

### Related Issues

- Resolves #1447

### Backwards incompatibilities

None

### New Dependencies

None
