### PR TITLE
User can specify units for KScomp input and output

### DIFF
--- a/openmdao/docs/features/building_blocks/components/ks_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/ks_comp.rst
@@ -87,4 +87,13 @@ conservative.
     openmdao.components.tests.test_ks_comp.TestKSFunctionFeatures.test_add_constraint
     :layout: code, plot
 
+**units**
+
+Finally, note that you can pass a units option to the KSComp that will define units on its input and output variables.
+There is only one unit, shared between both inputs and outputs.
+
+.. embed-code::
+    openmdao.components.tests.test_ks_comp.TestKSFunctionFeatures.test_units
+    :layout: interleave
+
 .. tags:: KSComp, Component, Constraints, Optimization

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -321,16 +321,14 @@ class SqliteCaseReader(BaseCaseReader):
         if self._format_version >= 2 and self._problem_cases.count() > 0:
             sources.extend(self._problem_cases.list_sources())
 
-        if not out_stream:
-            return sources
-        else:
+        if out_stream:
             if out_stream is _DEFAULT_OUT_STREAM:
                 out_stream = sys.stdout
 
-            if out_stream:
-                for source in sources:
-                    out_stream.write('{}\n'.format(source))
-            return sources
+            for source in sources:
+                out_stream.write('{}\n'.format(source))
+
+        return sources
 
     def list_source_vars(self, source, out_stream=_DEFAULT_OUT_STREAM):
         """
@@ -382,15 +380,13 @@ class SqliteCaseReader(BaseCaseReader):
         if case.residuals:
             dct['residuals'] = list(case.residuals)
 
-        if not out_stream:
-            return dct
-        else:
+        if out_stream:
             if out_stream is _DEFAULT_OUT_STREAM:
                 out_stream = sys.stdout
 
-            if out_stream:
-                write_source_table(dct, out_stream)
-            return dct
+            write_source_table(dct, out_stream)
+
+        return dct
 
     def list_cases(self, source=None, recurse=True, flat=True, out_stream=_DEFAULT_OUT_STREAM):
         """
@@ -548,15 +544,13 @@ class SqliteCaseReader(BaseCaseReader):
                 self.source_cases_table[table].append(case_coord)
                 cases.append(case_coord)
 
-        if not out_stream:
-            return cases
-        else:
+        if out_stream:
             if out_stream is _DEFAULT_OUT_STREAM:
                 out_stream = sys.stdout
 
-            if out_stream:
-                write_source_table(self.source_cases_table, out_stream)
-            return cases
+            write_source_table(self.source_cases_table, out_stream)
+
+        return cases
 
     def _list_cases_recurse_nested(self, coord=None):
         """

--- a/openmdao/test_suite/test_examples/beam_optimization/components/multi_stress_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/multi_stress_comp.py
@@ -1,7 +1,7 @@
 """
 Stress calculation component.
 
-Simple calculation of beam bending stress assuming small angular displacments.
+Simple calculation of beam bending stress assuming small angular displacements.
 Vectorized for multiple load cases.
 """
 

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
@@ -124,9 +124,8 @@ class MultipointBeamGroup(om.Group):
             comp = MultiStressComp(num_elements=num_elements, E=E, num_rhs=num_rhs)
             sub.add_subsystem('stress_comp', comp)
 
-            self.connect(
-                'local_stiffness_matrix_comp.K_local',
-                'parallel.%s.states_comp.K_local' % name)
+            self.connect('local_stiffness_matrix_comp.K_local',
+                         'parallel.%s.states_comp.K_local' % name)
 
             for k in range(num_rhs):
                 sub.connect('states_comp.d_%d' % k,
@@ -144,9 +143,8 @@ class MultipointBeamGroup(om.Group):
 
                 sub.add_subsystem('KS_%d' % k, comp)
 
-                sub.connect(
-                    'stress_comp.stress_%d' % k,
-                    'KS_%d.g' % k)
+                sub.connect('stress_comp.stress_%d' % k,
+                            'KS_%d.g' % k)
 
                 if not self.options['ks_add_constraint']:
                     sub.add_constraint('KS_%d.KS' % k, upper=0.0,


### PR DESCRIPTION
### Summary

User can pass a units option to the KS comp that will define units on its input and output variables. There is only one unit, shared between both inputs and outputs.

### Related Issues

- Resolves #1388

### Backwards incompatibilities

None

### New Dependencies

None
