### PR TITLE
Adding init Constructors to OpenMDAO Docs

### DIFF
--- a/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
@@ -12,10 +12,10 @@ AddSubtractComp
     result = a * \textrm{scaling factor}_a + b * \textrm{scaling factor}_b + c * \textrm{scaling factor}_c + ...
 
 
-DotProductComp Constructor
+AddSubtractComp Constructor
 --------------------------
 
-The call signature for the `DotProductComp` constructor is:
+The call signature for the `AddSubtractComp` constructor is:
 
 .. automethod:: openmdao.components.add_subtract_comp.AddSubtractComp.__init__
     :noindex:

--- a/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
@@ -13,7 +13,7 @@ AddSubtractComp
 
 
 AddSubtractComp Constructor
---------------------------
+---------------------------
 
 The call signature for the `AddSubtractComp` constructor is:
 

--- a/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
@@ -13,7 +13,7 @@ AddSubtractComp
 
 
 DotProductComp Constructor
---------------------
+--------------------------
 
 The call signature for the `DotProductComp` constructor is:
 

--- a/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/add_subtract_comp.rst
@@ -11,6 +11,16 @@ AddSubtractComp
 
     result = a * \textrm{scaling factor}_a + b * \textrm{scaling factor}_b + c * \textrm{scaling factor}_c + ...
 
+
+DotProductComp Constructor
+--------------------
+
+The call signature for the `DotProductComp` constructor is:
+
+.. automethod:: openmdao.components.add_subtract_comp.AddSubtractComp.__init__
+    :noindex:
+
+
 Using the AddSubtractComp
 ---------------------------------------------------
 

--- a/openmdao/docs/features/building_blocks/components/balance_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/balance_comp.rst
@@ -19,11 +19,11 @@ BalanceComp Options
     options
 
 BalanceComp Constructor
---------------------
+-----------------------
 
 The call signature for the `BalanceComp` constructor is:
 
-.. automethod:: openmdao.components.balance_comp.BalanceComp.__init__
+.. automethod:: openmdao.components.balance_comp.BalanceComp.__init__()
     :noindex:
 
 

--- a/openmdao/docs/features/building_blocks/components/balance_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/balance_comp.rst
@@ -18,6 +18,14 @@ BalanceComp Options
     BalanceComp
     options
 
+BalanceComp Constructor
+--------------------
+
+The call signature for the `BalanceComp` constructor is:
+
+.. automethod:: openmdao.components.balance_comp.BalanceComp.__init__
+    :noindex:
+
 
 `BalanceComp` allows you to add one or more state variables and its associated
 implicit equations.  For each ``balance`` added to the component it

--- a/openmdao/docs/features/building_blocks/components/balance_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/balance_comp.rst
@@ -26,6 +26,7 @@ The call signature for the `BalanceComp` constructor is:
 .. automethod:: openmdao.components.balance_comp.BalanceComp.__init__()
     :noindex:
 
+----
 
 `BalanceComp` allows you to add one or more state variables and its associated
 implicit equations.  For each ``balance`` added to the component it

--- a/openmdao/docs/features/building_blocks/components/eq_constraint_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/eq_constraint_comp.rst
@@ -61,6 +61,14 @@ Note that the `kwargs` arguments can include any of the keyword arguments normal
 when creating an output variable with the
 :meth:`add_output <openmdao.core.component.Component.add_output>` method of a `Component`.
 
+EQConstraintComp Constructor
+-----------------------------
+
+The call signature for the `EQConstraintComp` constructor is:
+
+.. automethod:: openmdao.components.eq_constraint_comp.EQConstraintComp.__init__
+    :noindex:
+
 
 Example: Sellar IDF
 -------------------

--- a/openmdao/docs/features/building_blocks/components/eq_constraint_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/eq_constraint_comp.rst
@@ -61,14 +61,6 @@ Note that the `kwargs` arguments can include any of the keyword arguments normal
 when creating an output variable with the
 :meth:`add_output <openmdao.core.component.Component.add_output>` method of a `Component`.
 
-EQConstraintComp Constructor
------------------------------
-
-The call signature for the `EQConstraintComp` constructor is:
-
-.. automethod:: openmdao.components.eq_constraint_comp.EQConstraintComp.__init__
-    :noindex:
-
 
 Example: Sellar IDF
 -------------------

--- a/openmdao/docs/features/building_blocks/components/external_code_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_comp.rst
@@ -28,6 +28,14 @@ ExternalCodeComp Options
     ExternalCodeComp
     options
 
+ExternalCodeComp Constructor
+----------------------------
+
+The call signature for the `ExternalCodeComp` constructor is:
+
+.. automethod:: openmdao.components.external_code_comp.ExternalCodeComp.__init__
+    :noindex:
+
 
 ExternalCodeComp Example
 ------------------------

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -25,6 +25,7 @@ The call signature for the `ExternalCodeImplicitComp` constructor is:
 .. automethod:: openmdao.components.external_code_comp.ExternalCodeImplicitComp.__init__
     :noindex:
 
+----
 
 When using an `ExternalCodeImplicitComp`, you have the option to define two external programs rather than one. The
 first of these is "command_apply", which is the command that you want to run to evaluate the residuals. You should

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -17,6 +17,13 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
     ExternalCodeImplicitComp
     options
 
+When using an `ExternalCodeImplicitComp`, you have the option to define two external programs rather than one. The
+first of these is "command_apply", which is the command that you want to run to evaluate the residuals. You should
+always specify a value for this option. The second is "command_solve", which is the command that you want to run
+to let the external program solve its own states. This is optional, but you should specify it if your code can
+solve itself, and if you want it to do so (for example, while using a Newton solver with "solve_subsystems" turned
+on in a higher-level `Group`.)
+
 ExternalCodeImplicitComp Constructor
 ------------------------------------
 
@@ -24,15 +31,6 @@ The call signature for the `ExternalCodeImplicitComp` constructor is:
 
 .. automethod:: openmdao.components.external_code_comp.ExternalCodeImplicitComp.__init__
     :noindex:
-
-----
-
-When using an `ExternalCodeImplicitComp`, you have the option to define two external programs rather than one. The
-first of these is "command_apply", which is the command that you want to run to evaluate the residuals. You should
-always specify a value for this option. The second is "command_solve", which is the command that you want to run
-to let the external program solve its own states. This is optional, but you should specify it if your code can
-solve itself, and if you want it to do so (for example, while using a Newton solver with "solve_subsystems" turned
-on in a higher-level `Group`.)
 
 ExternalCodeImplicitComp Example
 --------------------------------

--- a/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/external_code_implicit_comp.rst
@@ -17,6 +17,15 @@ operating system. But it treats the `Component` as an `ImplicitComponent` rather
     ExternalCodeImplicitComp
     options
 
+ExternalCodeImplicitComp Constructor
+------------------------------------
+
+The call signature for the `ExternalCodeImplicitComp` constructor is:
+
+.. automethod:: openmdao.components.external_code_comp.ExternalCodeImplicitComp.__init__
+    :noindex:
+
+
 When using an `ExternalCodeImplicitComp`, you have the option to define two external programs rather than one. The
 first of these is "command_apply", which is the command that you want to run to evaluate the residuals. You should
 always specify a value for this option. The second is "command_solve", which is the command that you want to run

--- a/openmdao/docs/features/building_blocks/components/ks_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/ks_comp.rst
@@ -25,6 +25,14 @@ KSComp Options
     KSComp
     options
 
+KSComp Constructor
+------------------
+
+The call signature for the `KSComp` constructor is:
+
+.. automethod:: openmdao.components.ks_comp.KSComp.__init__
+    :noindex:
+
 
 KSComp Example
 --------------

--- a/openmdao/docs/features/building_blocks/components/linearsystem_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/linearsystem_comp.rst
@@ -14,6 +14,15 @@ LinearSystemComp Options
     LinearSystemComp
     options
 
+LinearSystemComp Constructor
+----------------------------
+
+The call signature for the `LinearSystemComp` constructor is:
+
+.. automethod:: openmdao.components.linear_system_comp.LinearSystemComp.__init__
+    :noindex:
+
+
 LinearSystemComp Example
 ------------------------
 

--- a/openmdao/docs/features/building_blocks/components/metamodelstructured_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/metamodelstructured_comp.rst
@@ -76,6 +76,15 @@ MetaModelStructuredComp Options
     MetaModelStructuredComp
     options
 
+MetaModelStructuredComp Constructor
+-----------------------------------
+
+The call signature for the `MetaModelStructuredComp` constructor is:
+
+.. automethod:: openmdao.components.meta_model_structured_comp.MetaModelStructuredComp.__init__
+    :noindex:
+
+
 MetaModelStructuredComp Examples
 --------------------------------
 

--- a/openmdao/docs/features/building_blocks/components/metamodelunstructured_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/metamodelunstructured_comp.rst
@@ -27,6 +27,15 @@ MetaModelUnStructuredComp Options
     MetaModelUnStructuredComp
     options
 
+MetaModelUnStructuredComp Constructor
+-------------------------------------
+
+The call signature for the `MetaModelUnStructuredComp` constructor is:
+
+.. automethod:: openmdao.components.meta_model_unstructured_comp.MetaModelUnStructuredComp.__init__
+    :noindex:
+
+
 Simple Example
 --------------
 

--- a/openmdao/docs/features/building_blocks/components/multifi_metamodelunstructured_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/multifi_metamodelunstructured_comp.rst
@@ -24,6 +24,15 @@ MultiFiMetaModelUnStructuredComp Options
     MultiFiMetaModelUnStructuredComp
     options
 
+MultiFiMetaModelUnStructuredComp Constructor
+--------------------------------------------
+
+The call signature for the `MultiFiMetaModelUnStructuredComp` constructor is:
+
+.. automethod:: openmdao.components.multifi_meta_model_unstructured_comp.MultiFiMetaModelUnStructuredComp.__init__
+    :noindex:
+
+
 Simple Example
 --------------
 

--- a/openmdao/docs/features/building_blocks/components/spline_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/spline_comp.rst
@@ -63,6 +63,14 @@ SplineComp Options
     SplineComp
     options
 
+SplineComp Constructor
+----------------------
+
+The call signature for the `SplineComp` constructor is:
+
+.. automethod:: openmdao.components.spline_comp.SplineComp.__init__
+    :noindex:
+
 
 SplineComp Basic Example
 -------------------------

--- a/openmdao/docs/features/building_blocks/components/vector_magnitude_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/vector_magnitude_comp.rst
@@ -27,6 +27,15 @@ and the output :math:`a_mag`, as well as specifying their units.
     VectorMagnitudeComp
     options
 
+VectorMagnitudeComp Constructor
+-------------------------------
+
+The call signature for the `VectorMagnitudeComp` constructor is:
+
+.. automethod:: openmdao.components.vector_magnitude_comp.VectorMagnitudeComp.__init__
+    :noindex:
+
+
 VectorMagnitudeComp Example
 ---------------------------
 

--- a/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
@@ -34,6 +34,15 @@ DOEDriver Options
     DOEDriver
     options
 
+DOEDriver Constructor
+----------------------
+
+The call signature for the `DOEDriver` constructor is:
+
+.. automethod:: openmdao.drivers.doe_driver.DOEDriver.__init__
+    :noindex:
+
+
 Simple Example
 --------------
 `UniformGenerator` implements the simplest method and will generate a requested number of

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -42,6 +42,7 @@ The call signature for the `SimpleGADriver` constructor is:
 .. automethod:: openmdao.drivers.genetic_algorithm_driver.SimpleGADriver.__init__
     :noindex:
 
+----
 
 You can change the number of generations to run the genetic algorithm by setting the "max_gen" option.
 

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -34,6 +34,15 @@ SimpleGADriver Options
     SimpleGADriver
     options
 
+SimpleGADriver Constructor
+--------------------------
+
+The call signature for the `SimpleGADriver` constructor is:
+
+.. automethod:: openmdao.drivers.genetic_algorithm_driver.SimpleGADriver.__init__
+    :noindex:
+
+
 You can change the number of generations to run the genetic algorithm by setting the "max_gen" option.
 
 .. embed-code::

--- a/openmdao/docs/features/building_blocks/drivers/pyoptsparse_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/pyoptsparse_driver.rst
@@ -35,6 +35,7 @@ The call signature for the `pyOptSparseDriver` constructor is:
 .. automethod:: openmdao.drivers.pyoptsparse_driver.pyOptSparseDriver.__init__
     :noindex:
 
+----
 
 pyOptSparseDriver has a small number of unified options that can be specified as keyword arguments when
 it is instantiated or by using the "options" dictionary. We have already shown how to set the

--- a/openmdao/docs/features/building_blocks/drivers/pyoptsparse_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/pyoptsparse_driver.rst
@@ -27,6 +27,15 @@ pyOptSparseDriver Options
     pyOptSparseDriver
     options
 
+pyOptSparseDriver Constructor
+-----------------------------
+
+The call signature for the `pyOptSparseDriver` constructor is:
+
+.. automethod:: openmdao.drivers.pyoptsparse_driver.pyOptSparseDriver.__init__
+    :noindex:
+
+
 pyOptSparseDriver has a small number of unified options that can be specified as keyword arguments when
 it is instantiated or by using the "options" dictionary. We have already shown how to set the
 `optimizer` option. Next we see how the `print_results` option can be used to turn on or off the echoing

--- a/openmdao/docs/features/building_blocks/drivers/scipy_optimize_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/scipy_optimize_driver.rst
@@ -25,7 +25,7 @@ ScipyOptimizeDriver Constructor
 
 The call signature for the `ScipyOptimizeDriver` constructor is:
 
-.. automethod:: openmdao.drivers.scipy_optimizer.ScipyOptimizerDriver.__init__
+.. automethod:: openmdao.drivers.scipy_optimizer.ScipyOptimizeDriver.__init__
     :noindex:
 
 

--- a/openmdao/docs/features/building_blocks/drivers/scipy_optimize_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/scipy_optimize_driver.rst
@@ -20,6 +20,15 @@ ScipyOptimizeDriver Options
     ScipyOptimizeDriver
     options
 
+ScipyOptimizeDriver Constructor
+-------------------------------
+
+The call signature for the `ScipyOptimizeDriver` constructor is:
+
+.. automethod:: openmdao.drivers.scipy_optimizer.ScipyOptimizerDriver.__init__
+    :noindex:
+
+
 ScipyOptimizeDriver Option Examples
 -----------------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/backtracking/armijo_goldstein.rst
+++ b/openmdao/docs/features/building_blocks/solvers/backtracking/armijo_goldstein.rst
@@ -25,6 +25,14 @@ ArmijoGoldsteinLS Options
     ArmijoGoldsteinLS
     options
 
+ArmijoGoldsteinLS Constructor
+-------------------------------
+
+The call signature for the `ArmijoGoldsteinLS` constructor is:
+
+.. automethod:: openmdao.solvers.armijo_goldstein.ArmijoGoldsteinLS.__init__
+    :noindex:
+
 
 ArmijoGoldsteinLS Option Examples
 ---------------------------------

--- a/openmdao/docs/features/building_blocks/solvers/backtracking/armijo_goldstein.rst
+++ b/openmdao/docs/features/building_blocks/solvers/backtracking/armijo_goldstein.rst
@@ -30,7 +30,7 @@ ArmijoGoldsteinLS Constructor
 
 The call signature for the `ArmijoGoldsteinLS` constructor is:
 
-.. automethod:: openmdao.solvers.armijo_goldstein.ArmijoGoldsteinLS.__init__
+.. automethod:: openmdao.solvers.linesearch.backtracking.ArmijoGoldsteinLS.__init__
     :noindex:
 
 

--- a/openmdao/docs/features/building_blocks/solvers/backtracking/bounds_enforce.rst
+++ b/openmdao/docs/features/building_blocks/solvers/backtracking/bounds_enforce.rst
@@ -21,6 +21,14 @@ BoundsEnforceLS Options
     BoundsEnforceLS
     options
 
+BoundsEnforceLS Constructor
+-------------------------------
+
+The call signature for the `BoundsEnforceLS` constructor is:
+
+.. automethod:: openmdao.solvers.linesearch.backtracking.BoundsEnforceLS.__init__
+    :noindex:
+
 
 BoundsEnforceLS Option Examples
 -------------------------------

--- a/openmdao/docs/features/building_blocks/solvers/linear/direct_solver.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/direct_solver.rst
@@ -26,4 +26,13 @@ DirectSolver Options
     DirectSolver
     options
 
+DirectSolver Constructor
+------------------------
+
+The call signature for the `DirectSolver` constructor is:
+
+.. automethod:: openmdao.solvers.linear.direct.DirectSolver.__init__
+    :noindex:
+
+
 .. tags:: Solver, LinearSolver

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_block_gs.rst
@@ -31,6 +31,15 @@ LinearBlockGS Options
     LinearBlockGS
     options
 
+LinearBlockGS Constructor
+------------------------
+
+The call signature for the `LinearBlockGS` constructor is:
+
+.. automethod:: openmdao.solvers.linear.linear_block_gs.LinearBlockGS.__init__
+    :noindex:
+
+
 LinearBlockGS Option Examples
 -----------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_block_gs.rst
@@ -32,7 +32,7 @@ LinearBlockGS Options
     options
 
 LinearBlockGS Constructor
-------------------------
+-------------------------
 
 The call signature for the `LinearBlockGS` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_block_jac.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_block_jac.rst
@@ -26,7 +26,7 @@ LinearBlockJac Options
     options
 
 LinearBlockJac Constructor
-------------------------
+--------------------------
 
 The call signature for the `LinearBlockJac` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_block_jac.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_block_jac.rst
@@ -25,6 +25,15 @@ LinearBlockJac Options
     LinearBlockJac
     options
 
+LinearBlockJac Constructor
+------------------------
+
+The call signature for the `LinearBlockJac` constructor is:
+
+.. automethod:: openmdao.solvers.linear.linear_block_jac.LinearBlockJac.__init__
+    :noindex:
+
+
 LinearBlockJac Option Examples
 ------------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_runonce.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_runonce.rst
@@ -32,7 +32,7 @@ LinearRunOnce Options
     options
 
 LinearRunOnce Constructor
-------------------------
+-------------------------
 
 The call signature for the `LinearRunOnce` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_runonce.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_runonce.rst
@@ -31,4 +31,13 @@ LinearRunOnce Options
     LinearRunOnce
     options
 
+LinearRunOnce Constructor
+------------------------
+
+The call signature for the `LinearRunOnce` constructor is:
+
+.. automethod:: openmdao.solvers.linear.linear_runonce.LinearRunOnce.__init__
+    :noindex:
+
+
 .. tags:: Solver, LinearSolver

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_user_defined.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_user_defined.rst
@@ -49,7 +49,7 @@ LinearUserDefined Options
     options
 
 LinearUserDefined Constructor
-------------------------
+-----------------------------
 
 The call signature for the `LinearUserDefined` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/linear_user_defined.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/linear_user_defined.rst
@@ -48,4 +48,13 @@ LinearUserDefined Options
     LinearUserDefined
     options
 
+LinearUserDefined Constructor
+------------------------
+
+The call signature for the `LinearUserDefined` constructor is:
+
+.. automethod:: openmdao.solvers.linear.user_defined.LinearUserDefined.__init__
+    :noindex:
+
+
 .. tags:: Solver, LinearSolver

--- a/openmdao/docs/features/building_blocks/solvers/linear/petsc_krylov.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/petsc_krylov.rst
@@ -28,6 +28,15 @@ PETScKrylov Options
     PETScKrylov
     options
 
+PETScKrylov Constructor
+------------------------
+
+The call signature for the `PETScKrylov` constructor is:
+
+.. automethod:: openmdao.solvers.linear.petsc_ksp.PETScKrylov.__init__
+    :noindex:
+
+
 PETScKrylov Option Examples
 ---------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/linear/scipy_iter_solver.rst
+++ b/openmdao/docs/features/building_blocks/solvers/linear/scipy_iter_solver.rst
@@ -27,6 +27,15 @@ ScipyKrylov Options
     ScipyKrylov
     options
 
+ScipyKrylov Constructor
+------------------------
+
+The call signature for the `ScipyKrylov` constructor is:
+
+.. automethod:: openmdao.solvers.linear.scipy_iter_solver.ScipyKrylov.__init__
+    :noindex:
+
+
 ScipyKrylov Option Examples
 ---------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/broyden.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/broyden.rst
@@ -31,7 +31,7 @@ The BroydenSolver also contains a slot for a linear solver and a slot for a line
 :ref:`feature doc about linesearches <feature_line_search>` for more about these.
 
 BroydenSolver Constructor
-------------------------
+-------------------------
 
 The call signature for the `BroydenSolver` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/broyden.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/broyden.rst
@@ -30,6 +30,14 @@ BroydenSolver Options
 The BroydenSolver also contains a slot for a linear solver and a slot for a linesearch. See the
 :ref:`feature doc about linesearches <feature_line_search>` for more about these.
 
+BroydenSolver Constructor
+------------------------
+
+The call signature for the `BroydenSolver` constructor is:
+
+.. automethod:: openmdao.solvers.nonlinear.broyden.BroydenSolver.__init__
+    :noindex:
+
 
 BroydenSolver on a Full Model
 -----------------------------

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/newton.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/newton.rst
@@ -29,6 +29,15 @@ NewtonSolver Options
     NewtonSolver
     options
 
+NewtonSolver Constructor
+------------------------
+
+The call signature for the `NewtonSolver` constructor is:
+
+.. automethod:: openmdao.solvers.nonlinear.newton.NewtonSolver.__init__
+    :noindex:
+
+
 NewtonSolver Option Examples
 ----------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -38,6 +38,14 @@ NonlinearBlockGS Options
     NonlinearBlockGS
     options
 
+NonlinearBlockGS Constructor
+------------------------
+
+The call signature for the `NonlinearBlockGS` constructor is:
+
+.. automethod:: openmdao.solvers.nonlinear.nonlinear_block_gs.NonlinearBlockGS.__init__
+    :noindex:
+
 
 Aitken relaxation
 -------------------

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_gs.rst
@@ -39,7 +39,7 @@ NonlinearBlockGS Options
     options
 
 NonlinearBlockGS Constructor
-------------------------
+----------------------------
 
 The call signature for the `NonlinearBlockGS` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_jac.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_jac.rst
@@ -39,7 +39,7 @@ NonlinearBlockJac Options
     options
 
 NonlinearBlockJac Constructor
-------------------------
+-----------------------------
 
 The call signature for the `NonlinearBlockJac` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_jac.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_block_jac.rst
@@ -38,6 +38,15 @@ NonlinearBlockJac Options
     NonlinearBlockJac
     options
 
+NonlinearBlockJac Constructor
+------------------------
+
+The call signature for the `NonlinearBlockJac` constructor is:
+
+.. automethod:: openmdao.solvers.nonlinear.nonlinear_block_jac.NonlinearBlockJac.__init__
+    :noindex:
+
+
 NonlinearBlockJac Option Examples
 ---------------------------------
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_runonce.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_runonce.rst
@@ -30,7 +30,7 @@ NonlinearRunOnce Options
     options
 
 NonlinearRunOnce Constructor
-------------------------
+----------------------------
 
 The call signature for the `NonlinearRunOnce` constructor is:
 

--- a/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_runonce.rst
+++ b/openmdao/docs/features/building_blocks/solvers/nonlinear/nonlinear_runonce.rst
@@ -29,4 +29,13 @@ NonlinearRunOnce Options
     NonlinearRunOnce
     options
 
+NonlinearRunOnce Constructor
+------------------------
+
+The call signature for the `NonlinearRunOnce` constructor is:
+
+.. automethod:: openmdao.solvers.nonlinear.nonlinear_runonce.NonlinearRunOnce.__init__
+    :noindex:
+
+
 .. tags:: Solver, NonlinearSolver

--- a/openmdao/docs/features/building_blocks/surrogates/kriging.rst
+++ b/openmdao/docs/features/building_blocks/surrogates/kriging.rst
@@ -27,6 +27,14 @@ All options can be passed in as arguments or set later by accessing the `options
     KrigingSurrogate
     options
 
+KrigingSurrogate Constructor
+------------------------
+
+The call signature for the `KrigingSurrogate` constructor is:
+
+.. automethod:: openmdao.surrogate_models.kriging.KrigingSurrogate.__init__
+    :noindex:
+
 
 KrigingSurrogate Option Examples
 --------------------------------

--- a/openmdao/docs/features/building_blocks/surrogates/kriging.rst
+++ b/openmdao/docs/features/building_blocks/surrogates/kriging.rst
@@ -28,7 +28,7 @@ All options can be passed in as arguments or set later by accessing the `options
     options
 
 KrigingSurrogate Constructor
-------------------------
+----------------------------
 
 The call signature for the `KrigingSurrogate` constructor is:
 

--- a/openmdao/docs/features/building_blocks/surrogates/nearestneighbor.rst
+++ b/openmdao/docs/features/building_blocks/surrogates/nearestneighbor.rst
@@ -28,7 +28,7 @@ All options can be passed in as arguments or set later by accessing the `options
 Additional interpolant-specific options can be passed in as call arguments.
 
 NearestNeighbor Constructor
-------------------------
+---------------------------
 
 The call signature for the `NearestNeighbor` constructor is:
 

--- a/openmdao/docs/features/building_blocks/surrogates/nearestneighbor.rst
+++ b/openmdao/docs/features/building_blocks/surrogates/nearestneighbor.rst
@@ -27,6 +27,14 @@ All options can be passed in as arguments or set later by accessing the `options
 
 Additional interpolant-specific options can be passed in as call arguments.
 
+NearestNeighbor Constructor
+------------------------
+
+The call signature for the `NearestNeighbor` constructor is:
+
+.. automethod:: openmdao.surrogate_models.nearest_neighbor.NearestNeighbor.__init__
+    :noindex:
+
 
 NearestNeighbor Option Examples
 -------------------------------

--- a/openmdao/docs/features/recording/case_reader.rst
+++ b/openmdao/docs/features/recording/case_reader.rst
@@ -10,6 +10,14 @@ Currently, OpenMDAO only supports the :code:`SqliteCaseRecorder` case
 recorder. Therefore, all the examples will
 make use of this recorder. OpenMDAO will support other case recorders in the future.
 
+CaseReader Constructor
+--------------------
+
+The call signature for the `CaseReader` constructor is:
+
+.. automethod:: openmdao.recorders.sqlite_reader.SqliteCaseReader.__init__
+    :noindex:
+
 Determining What Sources and Variables Were Recorded
 ----------------------------------------------------
 

--- a/openmdao/docs/features/recording/case_reader.rst
+++ b/openmdao/docs/features/recording/case_reader.rst
@@ -11,7 +11,7 @@ recorder. Therefore, all the examples will
 make use of this recorder. OpenMDAO will support other case recorders in the future.
 
 CaseReader Constructor
---------------------
+----------------------
 
 The call signature for the `CaseReader` constructor is:
 


### PR DESCRIPTION
### Summary

Added `__init__` constructor to `CaseReader` docs as well as all components, solvers, and drivers.

### Related Issues

- Resolves #1382

### Backwards incompatibilities

None

### New Dependencies

None
