### PR TITLE
POEM-25: Add "compute_pareto" option to SimpleGADriver

### DIFF
--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -48,6 +48,15 @@ bits for all variables encoded.
     openmdao.drivers.tests.test_genetic_algorithm_driver.TestFeatureSimpleGA.test_option_pop_size
     :layout: interleave
 
+If you have more than one objective, you can use the `SimpleGADriver` to compute a set of non-dominated
+candidate optimums by setting the "compute_pareto" option to True.  In this case, the final state of the
+model will only be one of the pareto-optimal designs. The full set can be accessed via the 'desvar_nd' and
+'obj_nd' attributes on the driver for the design variable values and their corresponding objectives.
+
+.. embed-code::
+    openmdao.drivers.tests.test_genetic_algorithm_driver.TestFeatureSimpleGA.test_pareto
+    :layout: interleave
+
 Constrained Optimization
 ------------------------
 

--- a/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
+++ b/openmdao/docs/features/building_blocks/drivers/genetic_algorithm.rst
@@ -49,7 +49,7 @@ bits for all variables encoded.
     :layout: interleave
 
 If you have more than one objective, you can use the `SimpleGADriver` to compute a set of non-dominated
-candidate optimums by setting the "compute_pareto" option to True.  In this case, the final state of the
+candidate optima by setting the "compute_pareto" option to True.  In this case, the final state of the
 model will only be one of the pareto-optimal designs. The full set can be accessed via the 'desvar_nd' and
 'obj_nd' attributes on the driver for the design variable values and their corresponding objectives.
 

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -131,6 +131,11 @@ class SimpleGADriver(Driver):
                              'if not given.')
         self.options.declare('multi_obj_exponent', default=1., lower=0.,
                              desc='Multi-objective weighting exponent.')
+        self.options.declare('compute_pareto', default=False, types=(bool, ),
+                             desc='When True, compute a set of non-dominated points based on all '
+                             'given objectives and update it each generation. The multi-objective '
+                             'weight and exponents are ignored because the algorithm uses all '
+                             'objective values instead of a composite.')
 
     def _setup_driver(self, problem):
         """
@@ -223,10 +228,15 @@ class SimpleGADriver(Driver):
         pop_size = self.options['pop_size']
         max_gen = self.options['max_gen']
         user_bits = self.options['bits']
+        compute_pareto = self.options['compute_pareto']
+
         Pm = self.options['Pm']  # if None, it will be calculated in execute_ga()
         Pc = self.options['Pc']
 
         self._check_for_missing_objective()
+
+        if compute_pareto:
+            self._ga.nobj = len(self._objs)
 
         # Size design variables.
         desvars = self._designvars
@@ -297,18 +307,24 @@ class SimpleGADriver(Driver):
                                               bits, pop_size, max_gen,
                                               self._randomstate, Pm, Pc)
 
-        # Pull optimal parameters back into framework and re-run, so that
-        # framework is left in the right final state
-        for name in desvars:
-            i, j = self._desvar_idx[name]
-            val = desvar_new[i:j]
-            self.set_design_var(name, val)
+        if compute_pareto:
+            # Just save the non-dominated points.
+            self.desvar_nd = desvar_new
+            self.obj_nd = obj
 
-        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
-            model.run_solve_nonlinear()
-            rec.abs = 0.0
-            rec.rel = 0.0
-        self.iter_count += 1
+        else:
+            # Pull optimal parameters back into framework and re-run, so that
+            # framework is left in the right final state
+            for name in desvars:
+                i, j = self._desvar_idx[name]
+                val = desvar_new[i:j]
+                self.set_design_var(name, val)
+
+            with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
+                model.run_solve_nonlinear()
+                rec.abs = 0.0
+                rec.rel = 0.0
+            self.iter_count += 1
 
         return False
 
@@ -421,6 +437,10 @@ class SimpleGADriver(Driver):
             if is_single_objective:  # Single objective optimization
                 for i in obj_values.values():
                     obj = i  # First and only key in the dict
+
+            elif self.options['compute_pareto']:
+                obj = np.array([val for val in obj_values.values()]).flatten()
+
             else:  # Multi-objective optimization with weighted sums
                 weighted_objectives = np.array([])
                 for name, val in obj_values.items():
@@ -520,6 +540,7 @@ class GeneticAlgorithm(object):
 
         self.lchrom = 0
         self.npop = 0
+        self.nobj = 1
         self.elite = True
         self.gray_code = False
         self.cross_bits = False
@@ -563,14 +584,28 @@ class GeneticAlgorithm(object):
             Number of successful function evaluations.
         """
         comm = self.comm
-        xopt = copy.deepcopy(vlb)
-        fopt = np.inf
+        nobj = self.nobj
         self.lchrom = int(np.sum(bits))
 
-        if np.mod(pop_size, 2) == 1:
-            pop_size += 1
+        if nobj > 1:
+            xopt = []
+            fopt = []
+
+            # Needs to be divisible by number of objectives because of tournament selection
+            # strategy.
+            if np.mod(pop_size, nobj) > 0:
+                pop_size += nobj - np.mod(pop_size, nobj)
+        else:
+            xopt = copy.deepcopy(vlb)
+            fopt = np.inf
+
+            # Needs to be divisible by two because tournament selection pits one half of the
+            # population against the other half.
+            if np.mod(pop_size, 2) == 1:
+                pop_size += 1
+
         self.npop = int(pop_size)
-        fitness = np.zeros((self.npop, ))
+        fitness = np.zeros((self.npop, nobj))
 
         # If mutation rate is not provided as input
         if Pm is None:
@@ -615,7 +650,7 @@ class GeneticAlgorithm(object):
                     if returns:
                         val, success, ii = returns
                         if success:
-                            fitness[ii] = val
+                            fitness[ii, :] = val
                             nfit += 1
 
                     else:
@@ -632,36 +667,92 @@ class GeneticAlgorithm(object):
                         # Exceeded bounds for integer variables that are over-allocated.
                         success = False
                     else:
-                        fitness[ii], success, _ = self.objfun(x, 0)
+                        fitness[ii, :], success, _ = self.objfun(x, 0)
 
                     if success:
                         nfit += 1
                     else:
-                        fitness[ii] = np.inf
+                        fitness[ii, :] = np.inf
 
-            # Elitism means replace worst performing point with best from previous generation.
-            if elite and generation > 0:
-                max_index = np.argmax(fitness)
-                old_gen[max_index] = min_gen
-                x_pop[max_index] = min_x
-                fitness[max_index] = min_fit
+            # Find Pareto front.
+            if nobj > 1:
+                xopt, fopt = self.eval_pareto(x_pop, fitness, xopt, fopt)
 
-            # Find best performing point in this generation.
-            min_fit = np.min(fitness)
-            min_index = np.argmin(fitness)
-            min_gen = old_gen[min_index]
-            min_x = x_pop[min_index]
+            # Find best objective.
+            else:
+                # Elitism means replace worst performing point with best from
+                # previous generation.
+                if elite and generation > 0:
+                    max_index = np.argmax(fitness[:, 0])
+                    old_gen[max_index] = min_gen
+                    x_pop[max_index] = min_x
+                    fitness[max_index, 0] = min_fit
 
-            if min_fit < fopt:
-                fopt = min_fit
-                xopt = min_x
+                # Find best performing point in this generation.
+                min_fit = np.min(fitness)
+                min_index = np.argmin(fitness)
+                min_gen = old_gen[min_index]
+                min_x = x_pop[min_index]
+
+                if min_fit < fopt:
+                    fopt = min_fit
+                    xopt = min_x
 
             # Evolve new generation.
-            new_gen = self.tournament(old_gen, fitness)
+
+            if nobj > 1:
+                new_gen, new_obj = self.tournament_multi_obj(old_gen, fitness)
+            else:
+                new_gen = self.tournament(old_gen, fitness[:, 0])
+
             new_gen = self.crossover(new_gen, Pc)
             new_gen = self.mutate(new_gen, Pm)
 
         return xopt, fopt, nfit
+
+    def eval_pareto(self, x, obj, x_nd, obj_nd):
+        """
+        Produce a set of non dominated designs.
+
+        Parameters
+        ----------
+        x : ndarray
+            Design points from new generation.
+        obj : ndarray
+            Objective values from new generation.
+        x_nd : ndarray
+            Non dominated design points from previous pareto evaluation.
+        obj_nd : ndarray
+            Non dominated objective values from previous pareto evaluation.
+
+        Returns
+        -------
+        ndarray
+            Nondominated design points.
+        ndarray
+            Objective at nondominated design points.
+        """
+
+        if len(x_nd) > 1:
+            ypop = np.concatenate((np.array(obj_nd), obj), axis=0)
+            xpop = np.concatenate((x_nd, x), axis=0)
+        else:
+            ypop = obj
+            xpop = x
+
+        n_pts = ypop.shape[0]
+        i = 0
+        pot_idx = np.arange(n_pts)
+        while i < len(ypop):
+            nd_point_mask = np.any(ypop < ypop[i, :], axis=1)
+            nd_point_mask[i] = True
+
+            # Remove dominated points
+            pot_idx = pot_idx[nd_point_mask]
+            ypop = ypop[nd_point_mask]
+            i = np.sum(nd_point_mask[:i]) + 1
+
+        return xpop[pot_idx, :], ypop
 
     def tournament(self, old_gen, fitness):
         """
@@ -671,7 +762,6 @@ class GeneticAlgorithm(object):
         ----------
         old_gen : ndarray
             Points in current generation
-
         fitness : ndarray
             Objective value of each point.
 
@@ -692,6 +782,47 @@ class GeneticAlgorithm(object):
             new_gen.append(old_gen[selected])
 
         return np.concatenate(np.array(new_gen), axis=1).reshape(old_gen.shape)
+
+    def tournament_multi_obj(self, old_gen, obj_val):
+        """
+        Apply tournament selection and keep the best points.
+
+        This method is used if there are multiple objectives and the non-dominated set is being
+        kept.
+
+        Parameters
+        ----------
+        old_gen : ndarray
+            Points in current generation
+        obj_val : ndarray
+            Objective value of each point.
+
+        Returns
+        -------
+        ndarray
+            New generation with best points.
+        ndarray
+            Corresponding objective values.
+        """
+        nobj = self.nobj
+        npop = self.npop
+        nrow = npop // nobj
+        new_gen = []
+        new_obj = []
+
+        idx = np.array(range(0, npop - 1, nobj))
+        for j in np.arange(nobj):
+            old_gen, i_shuffled = self.shuffle(old_gen)
+            obj_val = obj_val[i_shuffled]
+
+            # Each point competes with its neighbor; save the best.
+            i_min = np.argmin(obj_val[:, j].reshape((nrow, nobj)), axis=1)
+            selected = i_min + idx
+            new_gen.append(old_gen[selected])
+            new_obj.append(obj_val[selected])
+
+        return np.concatenate(np.array(new_gen), axis=1).reshape(old_gen.shape), \
+               np.concatenate(np.array(new_obj), axis=1).reshape(obj_val.shape)
 
     def crossover(self, old_gen, Pc):
         """

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -519,6 +519,8 @@ class GeneticAlgorithm(object):
         If the model in objfun is also parallel, then this will contain a tuple with the the
         total number of population points to evaluate concurrently, and the color of the point
         to evaluate on this rank.
+    nobj : int
+        Number of objectives.
     npop : int
         Population size.
     objfun : function
@@ -737,7 +739,6 @@ class GeneticAlgorithm(object):
         ndarray
             Objective at nondominated design points.
         """
-
         if len(x_nd) > 1:
             ypop = np.concatenate((np.array(obj_nd), obj), axis=0)
             xpop = np.concatenate((x_nd, x), axis=0)
@@ -827,7 +828,7 @@ class GeneticAlgorithm(object):
             new_obj.append(obj_val[selected])
 
         return np.concatenate(np.array(new_gen), axis=1).reshape(old_gen.shape), \
-               np.concatenate(np.array(new_obj), axis=1).reshape(obj_val.shape)
+            np.concatenate(np.array(new_obj), axis=1).reshape(obj_val.shape)
 
     def crossover(self, old_gen, Pc):
         """

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -1406,6 +1406,108 @@ class TestFeatureSimpleGA(unittest.TestCase):
         self.assertGreater(prob['radius'], 1.)
         self.assertGreater(prob['height'], 1.)
 
+    def test_pareto(self):
+        import openmdao.api as om
+
+        class Box(om.ExplicitComponent):
+
+            def setup(self):
+                self.add_input('length', val=1.)
+                self.add_input('width', val=1.)
+                self.add_input('height', val=1.)
+
+                self.add_output('front_area', val=1.0)
+                self.add_output('top_area', val=1.0)
+                self.add_output('area', val=1.0)
+                self.add_output('volume', val=1.)
+
+            def compute(self, inputs, outputs):
+                length = inputs['length']
+                width = inputs['width']
+                height = inputs['height']
+
+                outputs['top_area'] = length * width
+                outputs['front_area'] = length * height
+                outputs['area'] = 2*length*height + 2*length*width + 2*height*width
+                outputs['volume'] = length*height*width
+
+        prob = om.Problem()
+
+        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
+        indeps.add_output('length', 1.5)
+        indeps.add_output('width', 1.5)
+        indeps.add_output('height', 1.5)
+
+        prob.model.add_subsystem('box', Box(), promotes=['*'])
+
+        # setup the optimization
+        prob.driver = om.SimpleGADriver()
+        prob.driver.options['max_gen'] = 20
+        prob.driver.options['bits'] = {'length': 8, 'width': 8, 'height': 8}
+        prob.driver.options['penalty_parameter'] = 10.
+        prob.driver.options['compute_pareto'] = True
+
+        prob.model.add_design_var('length', lower=0.1, upper=2.)
+        prob.model.add_design_var('width', lower=0.1, upper=2.)
+        prob.model.add_design_var('height', lower=0.1, upper=2.)
+        prob.model.add_objective('front_area', scaler=-1)  # maximize
+        prob.model.add_objective('top_area', scaler=-1)  # maximize
+        prob.model.add_constraint('volume', upper=1.)
+
+        prob.setup()
+        prob.run_driver()
+
+        desvar_nd = prob.driver.desvar_nd
+        nd_obj = prob.driver.obj_nd
+
+        assert_near_equal(desvar_nd,
+                          np.array([[1.83607843, 0.54705882, 0.95686275],
+                                    [1.50823529, 0.28627451, 1.95529412],
+                                    [1.45607843, 1.90313725, 0.34588235],
+                                    [1.76156863, 0.54705882, 1.01647059],
+                                    [1.85098039, 1.03137255, 0.49490196],
+                                    [1.87333333, 0.57686275, 0.90470588],
+                                    [1.38156863, 1.87333333, 0.38313725],
+                                    [1.68705882, 0.39803922, 1.47098039],
+                                    [1.86588235, 0.50980392, 1.01647059],
+                                    [2.        , 0.42784314, 1.13568627],
+                                    [1.99254902, 0.69607843, 0.70352941],
+                                    [1.74666667, 0.39803922, 1.40392157],
+                                    [1.99254902, 0.30117647, 1.38901961],
+                                    [1.97764706, 0.20431373, 1.95529412],
+                                    [1.99254902, 0.57686275, 0.84509804],
+                                    [1.9254902 , 0.30117647, 1.50823529],
+                                    [1.75411765, 0.57686275, 0.97176471],
+                                    [1.94039216, 0.92705882, 0.5545098 ],
+                                    [1.74666667, 0.81529412, 0.70352941],
+                                    [1.75411765, 0.42039216, 1.35176471]]),
+                          1e-6)
+
+        sorted_obj = nd_obj[nd_obj[:, 0].argsort()]
+
+        assert_near_equal(sorted_obj,
+                          np.array([[-3.86688166, -0.40406044],
+                                    [-2.9490436 , -0.43176932],
+                                    [-2.90409227, -0.57991234],
+                                    [-2.76768966, -0.60010888],
+                                    [-2.48163045, -0.67151557],
+                                    [-2.45218301, -0.69524183],
+                                    [-2.37115433, -0.7374173 ],
+                                    [-2.27137255, -0.85568627],
+                                    [-1.89661453, -0.95123414],
+                                    [-1.7905827 , -0.96368166],
+                                    [-1.75687505, -1.00444291],
+                                    [-1.70458962, -1.01188512],
+                                    [-1.69481569, -1.08065621],
+                                    [-1.68389927, -1.1494273 ],
+                                    [-1.40181684, -1.3869704 ],
+                                    [-1.21024148, -1.40545716],
+                                    [-1.07596647, -1.79885767],
+                                    [-0.91605383, -1.90905037],
+                                    [-0.52933041, -2.58813856],
+                                    [-0.50363183, -2.77111711]]),
+                          1e-6)
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class MPIFeatureTests(unittest.TestCase):


### PR DESCRIPTION
### Summary

Add option to SimpleGADriver to compute a set of non-dominated points in the multi-objective case.

This needed to be added here to support conversion of AMIEGO to a plugin.

### Related Issues

- Resolves #1454

### Backwards incompatibilities

None

### New Dependencies

None
