### PR TITLE
Edited error message for incompatible src_indices

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1364,8 +1364,8 @@ class Group(System):
                                         msg = f"{self.msginfo}: The source indices " + \
                                               f"do not specify a valid index for the " + \
                                               f"connection '{abs_out}' to '{abs_in}'. " + \
-                                              f"Index '{i}' is out of range for source " + \
-                                              f"dimension of size {d_size}."
+                                              f"src_indices index: {i} must out of range for " + \
+                                              f"the input vector: {d_size}."
                                         if self._raise_connection_errors:
                                             raise ValueError(msg)
                                         else:

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -339,9 +339,9 @@ class TestConnectionsIndices(unittest.TestCase):
         # the valid range for the source
         self.prob.model.connect('idvp.arrout', 'arraycomp.inp1', src_indices=[100000])
 
-        expected = "Group (<model>): The source indices do not specify a valid index " + \
-                   "for the connection 'idvp.arrout' to 'arraycomp.inp1'. " + \
-                   "Index '100000' is out of range for source dimension of size 5."
+        expected = "Group (<model>): The source indices do not specify a valid index for the connection "+\
+                   "'idvp.arrout' to 'arraycomp.inp1'. src_indices index: 100000 must out of range for the " +\
+                   "input vector: 5."
 
         try:
             self.prob.setup()
@@ -360,9 +360,9 @@ class TestConnectionsIndices(unittest.TestCase):
         # the valid range for the source.  A bug prevented this from being checked.
         self.prob.model.connect('idvp.arrout', 'arraycomp.inp', src_indices=[0, 100000])
 
-        expected = "Group (<model>): The source indices do not specify a valid index " + \
-                   "for the connection 'idvp.arrout' to 'arraycomp.inp'. " + \
-                   "Index '100000' is out of range for source dimension of size 5."
+        expected = "Group (<model>): The source indices do not specify a valid index for the connection "+\
+                   "'idvp.arrout' to 'arraycomp.inp'. src_indices index: 100000 must out of range for the " +\
+                   "input vector: 5."
 
         try:
             self.prob.setup()
@@ -567,9 +567,9 @@ class TestConnectionsDistrib(unittest.TestCase):
         model.add_subsystem('c3', TestComp())
         model.connect("p1.x", "c3.x")
 
-        expected = "Group (<model>): The source indices do not specify a valid index " + \
-                   "for the connection 'p1.x' to 'c3.x'. " + \
-                   "Index '2' is out of range for source dimension of size 2."
+        expected = "Group (<model>): The source indices do not specify a valid index for " + \
+                   "the connection 'p1.x' to 'c3.x'. src_indices index: 2 must out of range for " + \
+                   "the input vector: 2."
 
         try:
             prob.setup()

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1650,9 +1650,9 @@ class TestConnect(unittest.TestCase):
         self.sub.connect('src.x', 'arr.x', src_indices=[(2, -1), (4, 4)],
                          flat_src_indices=False)
 
-        msg = ("Group (sub): The source indices do not specify a valid index for the "
-               "connection 'sub.src.x' to 'sub.arr.x'. Index '4' "
-               "is out of range for source dimension of size 3.")
+        msg = ("Group (sub): The source indices do not specify a valid index for the " + \
+               "connection 'sub.src.x' to 'sub.arr.x'. src_indices index: 4 must out of range " + \
+               "for the input vector: 3.")
 
         try:
             self.prob.setup()


### PR DESCRIPTION
### Summary

Error is already raised when src_indices does not match input vector when running in parallel on a non distributed component.

### Related Issues

- Resolves #1340

### Backwards incompatibilities

None

### New Dependencies

None
