### PR TITLE
Fix a typo in user_terminate_signal option, deprecate the old.

### DIFF
--- a/openmdao/docs/features/building_blocks/drivers/pyoptsparse_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/pyoptsparse_driver.rst
@@ -101,7 +101,7 @@ you are on a supercomputing cluster. Here is a simple example for unix and mpi.
     ktmoore1$ kill -SIGUSR1 17955
 
 If SIGUSR1 is already used for something else, or its behavior is not supported on your operating system, mpi implementation,
-or queuing system, then you can choose a different signal by setting the "user_teriminate_signal" option and giving it a
+or queuing system, then you can choose a different signal by setting the "user_terminate_signal" option and giving it a
 different signal, or None to disable the feature.  Here, we change the signal to SIGUSR2:
 
 .. embed-code::

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -120,7 +120,7 @@ class pyOptSparseDriver(Driver):
         Contains the objectives plus nonlinear constraints.
     _signal_cache : <Function>
         Cached function pointer that was assigned as handler for signal defined in option
-        user_teriminate_signal.
+        user_terminate_signal.
     _user_termination_flag : bool
         This is set to True when the user sends a signal to terminate the job.
     """
@@ -188,9 +188,16 @@ class pyOptSparseDriver(Driver):
         self.options.declare('gradient method', default='openmdao',
                              values={'openmdao', 'pyopt_fd', 'snopt_fd'},
                              desc='Finite difference implementation to use')
-        self.options.declare('user_teriminate_signal', default=signal.SIGUSR1, allow_none=True,
-                             desc='OS signal that triggers a clean user-terimnation. Only SNOPT'
+        self.options.declare('user_terminate_signal', default=signal.SIGUSR1, allow_none=True,
+                             desc='OS signal that triggers a clean user-termination. Only SNOPT'
                              'supports this option.')
+
+        # Deprecated option
+        self.options.declare('user_teriminate_signal', default=None, allow_none=True,
+                             desc='OS signal that triggers a clean user-termination. Only SNOPT'
+                             'supports this option.',
+                             deprecation="The option 'user_teriminate_signal' was misspelled and "
+                             "will be deprecated. Please use 'user_terminate_signal' instead.")
 
     def _setup_driver(self, problem):
         """
@@ -215,6 +222,10 @@ class pyOptSparseDriver(Driver):
                                ' multiple objectives.'.format(self.options['optimizer']))
 
         self._setup_tot_jac_sparsity()
+
+        # Handle deprecated option.
+        if self.options['user_teriminate_signal'] is not None:
+            self.options['user_terminate_signal'] = self.options['user_teriminate_signal']
 
     def run(self):
         """
@@ -450,7 +461,7 @@ class pyOptSparseDriver(Driver):
             pass
 
         # revert signal handler to cached version
-        sigusr = self.options['user_teriminate_signal']
+        sigusr = self.options['user_terminate_signal']
         if sigusr is not None:
             signal.signal(sigusr, self._signal_cache)
             self._signal_cache = None   # to prevent memory leak test from failing
@@ -483,7 +494,7 @@ class pyOptSparseDriver(Driver):
 
         # Note: we place our handler as late as possible so that codes that run in the
         # workflow can place their own handlers.
-        sigusr = self.options['user_teriminate_signal']
+        sigusr = self.options['user_terminate_signal']
         if sigusr is not None and self._signal_cache is None:
             self._signal_cache = signal.getsignal(sigusr)
             signal.signal(sigusr, self._signal_handler)

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -13,7 +13,7 @@ from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDens
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
@@ -2307,7 +2307,19 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
         prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SNOPT"
-        prob.driver.options['user_teriminate_signal'] = signal.SIGUSR2
+        prob.driver.options['user_terminate_signal'] = signal.SIGUSR2
+
+    def test_options_deprecated(self):
+        # Not a feature test.
+        prob = om.Problem()
+        model = prob.model
+
+        prob.driver = om.pyOptSparseDriver()
+        prob.driver.options['optimizer'] = "SNOPT"
+
+        msg = "The option 'user_teriminate_signal' was misspelled and will be deprecated. Please use 'user_terminate_signal' instead."
+        with assert_warning(DeprecationWarning, msg):
+            prob.driver.options['user_teriminate_signal'] = None
 
 
 class MatMultCompExact(om.ExplicitComponent):


### PR DESCRIPTION
### Summary

Fix a typo in user_terminate_signal option, deprecate the old.

### Related Issues

- Resolves #1468 

### Backwards incompatibilities

None

### New Dependencies

None
