### PR TITLE
Added flag for `under_approx` and a new counter `iter_count_without_approx`

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -281,10 +281,10 @@ class ApproximationScheme(object):
 
     def _compute_approximations(self, system, jac, total, under_cs):
         from openmdao.core.component import Component
-        
+
         # Set system flag that we're under approximation to true
         system._set_approx_mode(True)
-        
+
         # Clean vector for results
         results_array = system._outputs._data.copy() if total else system._residuals._data.copy()
 
@@ -448,8 +448,8 @@ class ApproximationScheme(object):
                     jac._override_checks = False
                 else:
                     jac[key] = _from_dense(jacobian, key, oview, rows_reduced, cols_reduced)
-                
-        # Set system flag that we're under approximation to false    
+
+        # Set system flag that we're under approximation to false
         system._set_approx_mode(False)
 
 

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -281,6 +281,9 @@ class ApproximationScheme(object):
 
     def _compute_approximations(self, system, jac, total, under_cs):
         from openmdao.core.component import Component
+        
+        system._set_approx_mode(True)
+        
         # Clean vector for results
         results_array = system._outputs._data.copy() if total else system._residuals._data.copy()
 
@@ -444,6 +447,8 @@ class ApproximationScheme(object):
                     jac._override_checks = False
                 else:
                     jac[key] = _from_dense(jacobian, key, oview, rows_reduced, cols_reduced)
+                    
+        system._set_approx_mode(False)
 
 
 def _from_dense(jac, key, subjac, reduced_rows=_full_slice, reduced_cols=_full_slice):

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -282,6 +282,7 @@ class ApproximationScheme(object):
     def _compute_approximations(self, system, jac, total, under_cs):
         from openmdao.core.component import Component
         
+        # Set system flag that we're under approximation to true
         system._set_approx_mode(True)
         
         # Clean vector for results
@@ -447,7 +448,8 @@ class ApproximationScheme(object):
                     jac._override_checks = False
                 else:
                     jac[key] = _from_dense(jacobian, key, oview, rows_reduced, cols_reduced)
-                    
+                
+        # Set system flag that we're under approximation to false    
         system._set_approx_mode(False)
 
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -358,7 +358,7 @@ class System(object):
 
         # Case recording related
         self.iter_count = 0
-        self.iter_count_without_approx = 0        
+        self.iter_count_without_approx = 0
 
         self.cite = ""
 
@@ -3790,13 +3790,13 @@ class System(object):
 
                 if sub._assembled_jac:
                     sub._assembled_jac.set_complex_step_mode(active)
-                    
+
     def _set_approx_mode(self, active):
         """
         Turn on or off approx mode flag.
-    
+
         Recurses to turn on or off approx mode flag in all subsystems.
-    
+
         Parameters
         ----------
         active : bool

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -103,6 +103,8 @@ class System(object):
         Problem level options.
     under_complex_step : bool
         When True, this system is undergoing complex step.
+    under_approx : bool
+        When True, this system is undergoing approximation.
     force_alloc_complex : bool
         When True, the vectors have been allocated for checking with complex step.
     iter_count : int

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -402,6 +402,7 @@ class System(object):
         self._subjacs_info = {}
         self.matrix_free = False
 
+        self.under_approx = False
         self._owns_approx_jac = False
         self._owns_approx_jac_meta = {}
         self._owns_approx_wrt = None
@@ -3781,6 +3782,20 @@ class System(object):
 
                 if sub._assembled_jac:
                     sub._assembled_jac.set_complex_step_mode(active)
+                    
+    def _set_approx_mode(self, active):
+        """
+        Turn on or off approx mode flag.
+    
+        Recurses to turn on or off approx mode flag in all subsystems.
+    
+        Parameters
+        ----------
+        active : bool
+            Approx mode flag; set to True prior to commencing approximation.
+        """
+        for sub in self.system_iter(include_self=True, recurse=True):
+            sub.under_approx = active
 
     def cleanup(self):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -108,6 +108,9 @@ class System(object):
     iter_count : int
         Int that holds the number of times this system has iterated
         in a recording run.
+    iter_count_without_approx : int
+        Int that holds the number of times this system has iterated
+        in a recording run excluding any calls due to approximation schemes.
     cite : str
         Listing of relevant citations that should be referenced when
         publishing work that uses this class.
@@ -353,6 +356,7 @@ class System(object):
 
         # Case recording related
         self.iter_count = 0
+        self.iter_count_without_approx = 0        
 
         self.cite = ""
 
@@ -3715,6 +3719,8 @@ class System(object):
             self._rec_mgr.record_iteration(self, data, metadata)
 
         self.iter_count += 1
+        if not self.under_approx:
+            self.iter_count_without_approx += 1
 
     def is_active(self):
         """

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -110,6 +110,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
 
         # 1. run_model; 2. step x; 3. step y
         self.assertEqual(model.parab.count, 3)
+        self.assertEqual(model.parab.iter_count_without_approx, 1)
+        self.assertEqual(model.parab.iter_count, 3)
 
     def test_fd_count_driver(self):
         # Make sure we aren't doing FD wrt any var that isn't in the driver desvar set.

--- a/openmdao/docs/features/core_features/working_with_derivatives/approximating_partials.rst
+++ b/openmdao/docs/features/core_features/working_with_derivatives/approximating_partials.rst
@@ -27,7 +27,7 @@ Usage
         - :code:`form='central'`: Approximates the derivative as :math:`\displaystyle\frac{\partial f}{\partial x} \approx \frac{f(x+\delta, y) - f(x-\delta,y)}{2||\delta||}`. Error scales like :math:`||\delta||^2`, but requires an extra function evaluation.
 
 The step size can be any nonzero number, but should be positive (one can change the form to perform backwards finite difference formulas), small enough to reduce truncation error, but large enough to avoid round-off error. Choosing a step size can be highly problem dependent, but for double precision floating point numbers and reasonably bounded derivatives, :math:`10^{-6}` can be a good place to start.
-The step_calc can be either 'abs' for absolute or 'rel' for relative. It determines whether the stepsize ie absolute or a percentage of the input value.
+The step_calc can be either 'abs' for absolute or 'rel' for relative. It determines whether the stepsize is absolute or a percentage of the input value.
 
 .. embed-code::
     openmdao.jacobians.tests.test_jacobian_features.TestJacobianForDocs.test_fd_options


### PR DESCRIPTION
### Summary

Just as a user may want to know when a system is [under complex step](http://openmdao.org/twodocs/versions/latest/features/core_features/working_with_derivatives/approximating_partials.html?highlight=under_complex#complex-step), it's helpful to know when the system is under approximation of any kind. This PR adds a flag for all systems that is True when the system is under approximation, and False when it is not.

Additionally, this PR adds `iter_count_without_approx` to systems, which counts the number of times `compute()` has been called while not counting any `compute()` calls that have been called as part of an approximation. This allows the user to add logic to a system based on the number of analysis calls to it regardless of the approximation scheme used.

I've added a test for the counting and the relevant docstrings. Feel free to suggest any syntax or docs as needed.

### Related Issues

No known issues

### Backwards incompatibilities

None, only adds attributes to systems

### New Dependencies

None
