### PR TITLE
Raise exceptions for disallowed auto-ivc configurations..

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2606,8 +2606,7 @@ class Group(System):
             elif dist:  # distributed and local everywhere
                 # OpenMDAO currently can't create an automatic IndepVarComp for inputs on
                 # distributed components.
-                msg = 'Distributed component input "{}" cannot be connected to an automatic '
-                msg += 'IndepVarComp.  Please add one manually and connect it.'
+                msg = 'Distributed component input "{}" requires an IndepVarComp.'
                 raise RuntimeError(msg.format(tgt))
 
             elif has_src_inds:  # local with non-distrib src_indices
@@ -2618,9 +2617,8 @@ class Group(System):
 
         if src_idx_found:  # auto_ivc connected to local vars with src_indices
             tgts = ', '.join(src_idx_found)
-            msg = 'The following inputs [{}] are defined using src_indices. These cannot be '
-            msg += 'connected to an automatic IndepVarComp because the source size is '
-            msg += 'undetermined.  Please add one manually and connect it.'
+            msg = 'The following inputs [{}] are defined using src_indices but the total source '
+            msg += 'size is undetermined.  Please add an IndepVarComp as the source.'
             raise RuntimeError(msg.format(tgts))
 
         # return max sized tgt, size, value

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -541,9 +541,8 @@ class TestMultiConns(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             prob.setup()
 
-        msg = 'The following inputs [c1.x, c2.x] are defined using src_indices. These cannot be '
-        msg += 'connected to an automatic IndepVarComp because the source size is '
-        msg += 'undetermined.  Please add one manually and connect it.'
+        msg = 'The following inputs [c1.x, c2.x] are defined using src_indices but the total source '
+        msg += 'size is undetermined.  Please add an IndepVarComp as the source.'
 
         err_msg = str(context.exception).split(':')[-1]
         self.assertEqual(err_msg, msg)

--- a/openmdao/core/tests/test_deriv_transfers.py
+++ b/openmdao/core/tests/test_deriv_transfers.py
@@ -186,9 +186,10 @@ class TestParallelGroups(unittest.TestCase):
         assert_near_equal(J['par.C2.y', 'indep.x'][0][0], 7., 1e-6)
         assert_near_equal(prob.get_val('par.C2.y', get_remote=True), 7., 1e-6)
 
-    @parameterized.expand(itertools.product(['fwd', 'rev'], [True, False]),
+    @parameterized.expand(itertools.product(['fwd', 'rev'], [False]),
                           name_func=_test_func_name)
     def test_dup_dist(self, mode, auto):
+        # Note: Auto-ivc not supported for distributed inputs.
 
         # duplicated output, parallel input
         prob = om.Problem()
@@ -254,10 +255,11 @@ class TestParallelGroups(unittest.TestCase):
         assert_near_equal(J['C1.y', 'par.indep2.x'][0][0], 3.5, 1e-6)
         assert_near_equal(prob['C1.y'], 6., 1e-6)
 
-    @parameterized.expand(itertools.product(['fwd', 'rev'], [True, False]),
+    @parameterized.expand(itertools.product(['fwd', 'rev'], [False]),
                           name_func=_test_func_name)
     def test_dist_dup(self, mode, auto):
         # duplicated output, parallel input
+        # Note: Auto-ivc not supported for distributed inputs.
         prob = om.Problem()
         model = prob.model
         size = 3
@@ -274,7 +276,7 @@ class TestParallelGroups(unittest.TestCase):
         wrt=['x']
 
         prob.model.linear_solver = om.LinearRunOnce()
-        
+
         prob.setup(check=False, mode=mode)
         prob.set_solver_print(level=0)
         prob.run_model()

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -177,7 +177,8 @@ class MPITests2(unittest.TestCase):
         size = 3
         group = om.Group()
 
-        group.add_subsystem('P', om.IndepVarComp('x', np.arange(size)))
+        group.add_subsystem('P', om.IndepVarComp('x', np.arange(size)),
+                            promotes_outputs=['x'])
         group.add_subsystem('C1', DistribExecComp(['y=2.0*x', 'y=3.0*x'], arr_size=size,
                                                   x=np.zeros(size),
                                                   y=np.zeros(size)),

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -670,6 +670,21 @@ class MPITests(unittest.TestCase):
         if MPI and self.comm.rank == 0:
             self.assertTrue(all(C3._outputs['outvec'] == np.array(range(size, 0, -1), float)*4))
 
+    def test_auto_ivc_error(self):
+        size = 2
+
+        prob = om.Problem()
+        C2 = prob.model.add_subsystem("C", DistribCompSimple(arr_size=size))
+
+        with self.assertRaises(RuntimeError) as context:
+            prob.setup()
+
+        msg = ' Distributed component input "C.invec" cannot be connected to an automatic '
+        msg += 'IndepVarComp.  Please add one manually and connect it.'
+
+        err_msg = str(context.exception).split(':')[-1]
+        self.assertEqual(err_msg, msg)
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class ProbRemoteTests(unittest.TestCase):
@@ -685,21 +700,21 @@ class ProbRemoteTests(unittest.TestCase):
         p = om.Problem()
         top = p.model
         par = top.add_subsystem('par', om.ParallelGroup())
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('invec1', np.ones(size))
+        ivc.add_output('invec2', np.ones(size))
+        top.add_subsystem('P', ivc)
+        top.connect('P.invec1', 'par.C1.invec')
+        top.connect('P.invec2', 'par.C2.invec')
+
         C1 = par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
         C2 = par.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
-        
-        #import wingdbstub
-        
+
         p.setup()
 
-        # Conclude setup but don't run model.
-        p.final_setup()
-
-        if C1 in p.model.par._subsystems_myproc:
-            p['par.C1.invec'] = np.array(range(C1._inputs.asarray().size, 0, -1), float)
-
-        if C2 in p.model.par._subsystems_myproc:
-            p['par.C2.invec'] = np.array(range(C2._inputs.asarray().size, 0, -1), float) * 3
+        p['P.invec1'] = np.array([2, 1, 1], float)
+        p['P.invec2'] = np.array([6, 3, 3], float)
 
         p.run_model()
 
@@ -718,20 +733,25 @@ class ProbRemoteTests(unittest.TestCase):
         p = om.Problem()
         top = p.model
         par = top.add_subsystem('par', om.ParallelGroup())
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('invec1', np.ones(size))
+        ivc.add_output('invec2', np.ones(size))
+        ivc.add_discrete_output('disc_in1', 'C1foo')
+        ivc.add_discrete_output('disc_in2', 'C2foo')
+        top.add_subsystem('P', ivc)
+        top.connect('P.invec1', 'par.C1.invec')
+        top.connect('P.invec2', 'par.C2.invec')
+        top.connect('P.disc_in1', 'par.C1.disc_in')
+        top.connect('P.disc_in2', 'par.C2.disc_in')
+
         C1 = par.add_subsystem("C1", DistribInputDistribOutputDiscreteComp(arr_size=size))
         C2 = par.add_subsystem("C2", DistribInputDistribOutputDiscreteComp(arr_size=size))
+
         p.setup()
 
-        # Conclude setup but don't run model.
-        p.final_setup()
-
-        if C1 in p.model.par._subsystems_myproc:
-            p['par.C1.invec'] = np.array(range(C1._inputs.asarray().size, 0, -1), float)
-        p['par.C1.disc_in'] = 'C1foo'
-
-        if C2 in p.model.par._subsystems_myproc:
-            p['par.C2.invec'] = np.array(range(C2._inputs.asarray().size, 0, -1), float) * 3
-        p['par.C2.disc_in'] = 'C2foo'
+        p['P.invec1'] = np.array([2, 1, 1], float)
+        p['P.invec2'] = np.array([6, 3, 3], float)
 
         p.run_model()
 
@@ -771,6 +791,14 @@ class ProbRemoteTests(unittest.TestCase):
         p = om.Problem()
 
         top = p.model
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('invec', np.ones(size))
+        ivc.add_discrete_output('disc_in', 'C1foo')
+        top.add_subsystem('P', ivc)
+        top.connect('P.invec', 'C1.invec')
+        top.connect('P.disc_in', 'C1.disc_in')
+
         C1 = top.add_subsystem("C1", DistribInputDistribOutputDiscreteComp(arr_size=size))
         p.setup()
 
@@ -779,8 +807,8 @@ class ProbRemoteTests(unittest.TestCase):
 
         rank = p.comm.rank
 
-        p['C1.invec'] = np.array(range(C1._inputs._data.size, 0, -1), float) * (rank + 1)
-        p['C1.disc_in'] = 'boo'
+        p['P.invec'] = np.array([[4, 3, 2, 1, 8, 6, 4, 2, 9, 6, 3, 12, 8, 4.0]])
+        p['P.disc_in'] = 'boo'
 
         p.run_model()
 

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -679,8 +679,7 @@ class MPITests(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             prob.setup()
 
-        msg = ' Distributed component input "C.invec" cannot be connected to an automatic '
-        msg += 'IndepVarComp.  Please add one manually and connect it.'
+        msg = ' Distributed component input "C.invec" requires an IndepVarComp.'
 
         err_msg = str(context.exception).split(':')[-1]
         self.assertEqual(err_msg, msg)

--- a/openmdao/core/tests/test_getset_vars.py
+++ b/openmdao/core/tests/test_getset_vars.py
@@ -349,14 +349,18 @@ class TestGetSetVariables(unittest.TestCase):
         p.model.add_subsystem('C2', ExecComp('y=x*3.',
                                              x={'value': np.zeros(3),
                                                 'units': 'inch',
-                                                'src_indices': list(range(7,10))},
+                                                'src_indices': list(range(7, 10))},
                                              y={'value': np.zeros(3), 'units': 'inch'}),
                               promotes=['x'])
+        p.model.add_subsystem('C3', ExecComp('y=x*4.',
+                                             x={'value': np.zeros(10), 'units': 'mm'},
+                                             y={'value': np.zeros(10), 'units': 'mm'}),
+                         promotes=['x'])
 
         with self.assertRaises(RuntimeError) as cm:
             p.setup()
 
-        self.assertEqual(str(cm.exception), "Group (<model>): The following inputs, ['C1.x', 'C2.x'], promoted to 'x', are connected but the metadata entries ['units'] differ. Call <group>.set_input_defaults('x', units=?), where <group> is the Group named '' to remove the ambiguity.")
+        self.assertEqual(str(cm.exception), "Group (<model>): The following inputs, ['C1.x', 'C2.x', 'C3.x'], promoted to 'x', are connected but the metadata entries ['units'] differ. Call <group>.set_input_defaults('x', units=?), where <group> is the Group named '' to remove the ambiguity.")
 
     def test_serial_multi_src_inds_units_setval_promoted(self):
         p = Problem()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1106,6 +1106,10 @@ class TestProblem(unittest.TestCase):
                                             x={'value': 1.0, 'units': 'mm', 'src_indices': [1,2]},
                                             y={'value': np.zeros(2), 'units': 'mm'}),
                          promotes=['x'])
+        G1.add_subsystem('C3', om.ExecComp('y=x*4.',
+                                            x={'value': np.ones(3), 'units': 'mm'},
+                                            y={'value': np.zeros(3), 'units': 'mm'}),
+                         promotes=['x'])
 
         # units and value to use for the _auto_ivc output are ambiguous.  This fixes that.
         G1.set_input_defaults('x', units='m', val=np.ones(3))

--- a/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
+++ b/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
@@ -74,11 +74,11 @@ This example is run with two processes and a :code:`size` of 15:
 In this example, we introduce a new component called an ``IndepVarComp``. If you used OpenMDAO prior to
 version 3.2, then you have are familiar with this component. An IndepVarComp is used to define an
 independent variable. You no longer have to define these because OpenMDAO defines and uses them
-automatically for all inputs in your model. However, when we define a distributed input, we often
+automatically for all unconnected inputs in your model. However, when we define a distributed input, we often
 use the "src_indices" attribute to determine the allocation of that input to the processors that the
-component sees. For some sets of these indices, it isn't possible to easilly determine the full size
+component sees. For some sets of these indices, it isn't possible to easily determine the full size
 of the corresponding independent variable, the IndepVarComp cannot be created automatically.  So, for
-unconnected inputs on a distributed component, you must manuallly create one, as we did in this example.
+unconnected inputs on a distributed component, you must manually create one, as we did in this example.
 
 The call signature for the `IndepVarComp` constructor is:
 

--- a/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
+++ b/openmdao/docs/features/core_features/defining_components/distributed_comps.rst
@@ -14,9 +14,9 @@ that operates on distributed variables. A variable is distributed if each proces
 contains only a part of the whole variable.
 
 We've already seen that by using :ref:`src_indices <connect_src_indices>`
-we can connect an input to only a subset of an output variable.  
+we can connect an input to only a subset of an output variable.
 By giving different values for *src_indices* in each MPI process, we can
-distribute computations on a distributed output across the processes.  
+distribute computations on a distributed output across the processes.
 
 You tell the framework that a Component is a distributed component by setting its
 :code:`distributed` option to True:
@@ -38,10 +38,10 @@ Component Options
 Distributed Component Example
 -----------------------------
 
-The following example shows how to create a distributed component, `DistribComp`, 
-that distributes its computation evenly across the available processes. A second 
-component, `Summer`, sums the values from the distributed component into a scalar 
-output value.  
+The following example shows how to create a distributed component, `DistribComp`,
+that distributes its computation evenly across the available processes. A second
+component, `Summer`, sums the values from the distributed component into a scalar
+output value.
 
 These components can found in the OpenMDAO test suite:
 
@@ -62,7 +62,7 @@ These components can found in the OpenMDAO test suite:
 .. note::
 
     A component that takes a distributed output as input does not need to do anything
-    special as OpenMDAO performs the required MPI operations to make the full value 
+    special as OpenMDAO performs the required MPI operations to make the full value
     available.
 
 This example is run with two processes and a :code:`size` of 15:
@@ -70,6 +70,20 @@ This example is run with two processes and a :code:`size` of 15:
 .. embed-code::
     openmdao.core.tests.test_distribcomp.MPIFeatureTests.test_distribcomp_feature
     :layout: interleave
+
+In this example, we introduce a new component called an ``IndepVarComp``. If you used OpenMDAO prior to
+version 3.2, then you have are familiar with this component. An IndepVarComp is used to define an
+independent variable. You no longer have to define these because OpenMDAO defines and uses them
+automatically for all inputs in your model. However, when we define a distributed input, we often
+use the "src_indices" attribute to determine the allocation of that input to the processors that the
+component sees. For some sets of these indices, it isn't possible to easilly determine the full size
+of the corresponding independent variable, the IndepVarComp cannot be created automatically.  So, for
+unconnected inputs on a distributed component, you must manuallly create one, as we did in this example.
+
+The call signature for the `IndepVarComp` constructor is:
+
+.. automethod:: openmdao.core.indepvarcomp.IndepVarComp.__init__()
+    :noindex:
 
 
 Distributed Component with Derivatives

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -249,7 +249,6 @@ class ScipyOptimizeDriver(Driver):
             self.iter_count += 1
 
         self._con_cache = self.get_constraint_values()
-        print('initial cons', self._con_cache)
         desvar_vals = self.get_design_var_values()
         self._dvlist = list(self._designvars)
 
@@ -593,9 +592,9 @@ class ScipyOptimizeDriver(Driver):
             self._exc_info = msg
             return 0
 
-        print("Functions calculated")
-        print('   xnew', x_new)
-        print('   fnew', f_new)
+        # print("Functions calculated")
+        # print('   xnew', x_new)
+        # print('   fnew', f_new)
 
         return f_new
 

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -249,6 +249,7 @@ class ScipyOptimizeDriver(Driver):
             self.iter_count += 1
 
         self._con_cache = self.get_constraint_values()
+        print('initial cons', self._con_cache)
         desvar_vals = self.get_design_var_values()
         self._dvlist = list(self._designvars)
 
@@ -260,7 +261,8 @@ class ScipyOptimizeDriver(Driver):
         # Size Problem
         nparam = 0
         for param in self._designvars.values():
-            nparam += param['size']
+            size = param['global_size'] if param['distributed'] else param['size']
+            nparam += size
         x_init = np.empty(nparam)
 
         # Initial Design Vars
@@ -272,7 +274,7 @@ class ScipyOptimizeDriver(Driver):
             bounds = None
 
         for name, meta in self._designvars.items():
-            size = meta['size']
+            size = meta['global_size'] if meta['distributed'] else meta['size']
             x_init[i:i + size] = desvar_vals[name]
             i += size
 
@@ -591,9 +593,9 @@ class ScipyOptimizeDriver(Driver):
             self._exc_info = msg
             return 0
 
-        # print("Functions calculated")
-        # print('   xnew', x_new)
-        # print('   fnew', f_new)
+        print("Functions calculated")
+        print('   xnew', x_new)
+        print('   fnew', f_new)
 
         return f_new
 

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -196,8 +196,12 @@ class TestMPIScatter(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.set_input_defaults('a', -3.0 + 0.6 * np.arange(size))
+        ivc = om.IndepVarComp()
+        ivc.add_output('x', np.ones((size, )))
+        ivc.add_output('y', np.ones((size, )))
+        ivc.add_output('a', -3.0 + 0.6 * np.arange(size))
 
+        model.add_subsystem('p', ivc, promotes=['*'])
         model.add_subsystem("parab", DistParab(arr_size=size, deriv_type='dense'), promotes=['*'])
         model.add_subsystem('sum', om.ExecComp('f_sum = sum(f_xy)',
                                                f_sum=np.ones((size, )),

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -80,6 +80,7 @@ class DummyComp(om.ExecComp):
         partials['c', 'x'] = 2.0*x - 6.0 + y
         partials['c', 'y'] = 2.0*y + 8.0 + x
 
+
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestMPIScatter(unittest.TestCase):
     N_PROCS = 2
@@ -89,8 +90,8 @@ class TestMPIScatter(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
-        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model.set_input_defaults('x', 50.0)
+        model.set_input_defaults('y', 50.0)
         model.add_subsystem('comp', Paraboloid(), promotes=['*'])
         model.add_subsystem('con', DummyComp(), promotes=['*'])
 

--- a/openmdao/test_suite/components/paraboloid_distributed.py
+++ b/openmdao/test_suite/components/paraboloid_distributed.py
@@ -56,7 +56,6 @@ class DistParab(om.ExplicitComponent):
         x = inputs['x']
         y = inputs['y']
         a = inputs['a']
-        print('parab', x, y, a)
 
         outputs['f_xy'] = (x + a)**2 + x * y + (y + 4.0)**2 - 3.0
 

--- a/openmdao/test_suite/components/paraboloid_distributed.py
+++ b/openmdao/test_suite/components/paraboloid_distributed.py
@@ -56,6 +56,7 @@ class DistParab(om.ExplicitComponent):
         x = inputs['x']
         y = inputs['y']
         a = inputs['a']
+        print('parab', x, y, a)
 
         outputs['f_xy'] = (x + a)**2 + x * y + (y + 4.0)**2 - 3.0
 


### PR DESCRIPTION
### Summary

Raise an exception if when OpenMDAO tries to create an automatic IndepVarComp ouput for these cases:

1. Any input on a distributed component.
2. Any inputs promoted together with src_indices if there isn't at least one that is full width.

Also corrected a couple of sizes in scipyoptimizer.

### Related Issues

- Resolves #1516

### Backwards incompatibilities

None

### New Dependencies

None
