### PR TITLE
Fix so that discrete variables work as driver des_vars.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -266,8 +266,8 @@ class Driver(object):
         )
 
         # Determine if any design variables are discrete.
-        self._designvars_discrete = [dv for dv in self._designvars
-                                     if dv in model._discrete_outputs]
+        self._designvars_discrete = [name for name, meta in self._designvars.items()
+                                     if meta['ivc_source'] in model._discrete_outputs]
         if not self.supports['integer_design_vars'] and len(self._designvars_discrete) > 0:
             msg = "Discrete design variables are not supported by this driver: "
             msg += '.'.join(self._designvars_discrete)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4260,8 +4260,14 @@ class System(object):
                     for n in variables:
                         if n in views:
                             vdict[n] = views[n]
-                        else:  # discrete
+                        elif n[offset:] in discrete_vec:
                             vdict[n] = discrete_vec[n[offset:]]['value']
+                        else:
+                            ivc_path = conns[prom2abs_in[n][0]]
+                            if ivc_path in views:
+                                vdict[ivc_path] = views[ivc_path]
+                            elif n[offset:] in discrete_vec:
+                                vdict[ivc_path] = discrete_vec[ivc_path[offset:]]['value']
                 else:
                     for name in variables:
                         if name in views:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4266,7 +4266,7 @@ class System(object):
                             ivc_path = conns[prom2abs_in[n][0]]
                             if ivc_path in views:
                                 vdict[ivc_path] = views[ivc_path]
-                            elif n[offset:] in discrete_vec:
+                            elif ivc_path[offset:] in discrete_vec:
                                 vdict[ivc_path] = discrete_vec[ivc_path[offset:]]['value']
                 else:
                     for name in variables:

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1081,11 +1081,6 @@ class TestDOEDriver(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        # Add independent variables
-        indeps = model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
-        indeps.add_discrete_output('x', np.ones((2, ), dtype=np.int))
-        indeps.add_discrete_output('y', np.ones((2, ), dtype=np.int))
-
         # Add components
         model.add_subsystem('parab', ParaboloidDiscreteArray(), promotes=['*'])
 
@@ -1104,6 +1099,10 @@ class TestDOEDriver(unittest.TestCase):
         prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
 
         prob.setup()
+
+        prob.set_val('x', np.ones((2, ), dtype=np.int))
+        prob.set_val('y', np.ones((2, ), dtype=np.int))
+
         prob.run_driver()
         prob.cleanup()
 


### PR DESCRIPTION
### Summary

Discrete variables now work as driver des_vars.

### Related Issues

- Resolves #1527

### Backwards incompatibilities

None

### New Dependencies

None
