### PR TITLE
support options on IndepVarComp

### DIFF
--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -1,5 +1,7 @@
 """Define the IndepVarComp class."""
 
+import numpy as np
+
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.utils.general_utils import make_set
 
@@ -47,6 +49,49 @@ class IndepVarComp(ExplicitComponent):
             if illegal in kwargs:
                 raise ValueError("IndepVarComp init: '%s' is not supported "
                                  "in IndepVarComp." % illegal)
+
+    def initialize(self):
+        """
+        Declare options.
+        """
+        opt = self.options
+        opt.declare('name', types=str,
+                    desc="Name of the variable in this component's namespace.")
+        opt.declare('val', types=(float, list, tuple, np.ndarray), default=1.0,
+                    desc="The initial value of the variable being added in user-defined units.")
+        opt.declare('shape', types=(int, tuple, list), default=None,
+                    desc="Shape of this variable, only required if val is not an array.")
+        opt.declare('units', types=str, default=None,
+                    desc="Units in which the output variables will be provided to the "
+                         "component during execution.")
+        opt.declare('res_units', types=str, default=None,
+                    desc="Units in which the residuals of this output will be given to "
+                         "the user when requested.")
+        opt.declare('desc', types=str,
+                    desc="Description of the variable")
+        opt.declare('lower', types=(int, float, list, tuple, np.ndarray), default=None,
+                    desc="Lower bound(s) in user-defined units. It can be (1) a float, "
+                         "(2) an array_like consistent with the shape arg (if given), or "
+                         "(3) an array_like matching the shape of val, if val is array_like. "
+                         "A value of None means this output has no lower bound.")
+        opt.declare('upper', types=(int, float, list, tuple, np.ndarray), default=None,
+                    desc="Upper bound(s) in user-defined units. It can be (1) a float, "
+                         "(2) an array_like consistent with the shape arg (if given), or "
+                         "(3) an array_like matching the shape of val, if val is array_like. "
+                         "A value of None means this output has no upper bound.")
+        opt.declare('ref', types=float, default=1.,
+                    desc="Scaling parameter. The value in the user-defined units of this output "
+                         "variable when the scaled value is 1")
+        opt.declare('ref0', types=float, default=0.,
+                    desc="Scaling parameter. The value in the user-defined units of this output "
+                         "variable when the scaled value is 0.")
+        opt.declare('res_ref', types=float, default=None,
+                    desc="Scaling parameter. The value in the user-defined res_units of this "
+                         "output's residual when the scaled value is 1. Default is None, which "
+                         "means residual scaling matches output scaling.")
+        opt.declare('tags', types=(str, list), default=None,
+                    desc="User defined tags that can be used to filter what gets listed when "
+                         "calling list_outputs.")
 
     def _configure_check(self):
         """

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -23,7 +23,7 @@ class IndepVarComp(ExplicitComponent):
         **kwargs : dict
             keyword arguments.
         """
-        super(IndepVarComp, self).__init__()
+        super(IndepVarComp, self).__init__(**kwargs)
 
         if 'tags' not in kwargs:
             kwargs['tags'] = {'indep_var'}

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -1,5 +1,6 @@
 """IndepVarComp tests used in the IndepVarComp feature doc."""
 import unittest
+import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
@@ -183,6 +184,23 @@ class TestIndepVarComp(unittest.TestCase):
         prob.run_model()
 
         assert_near_equal(prob.get_val('p.x1')[0], 0.5)
+
+    def test_options(self):
+        class Parameters(om.IndepVarComp):
+            def initialize(self):
+                self.options.declare('num_x', default=0)
+                self.options.declare('val_y', default=0.)
+
+            def setup(self):
+                self.add_discrete_output('num_x', val = np.zeros(self.options['num_x']))
+                self.add_output('val_y',val = self.options['val_y'])
+
+        prob = om.Problem(model=Parameters(num_x=4, val_y=2.5))
+        prob.setup()
+        prob.run_model()
+
+        self.assertEqual(len(prob.get_val('num_x')), 4)
+        self.assertEqual(prob.get_val('val_y'), 2.5)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -72,7 +72,8 @@ class TestIndepVarComp(unittest.TestCase):
             comp = om.IndepVarComp('indep_var', tags=99)
 
         self.assertEqual(str(cm.exception),
-            "The tags argument should be str, set, or list: 99")
+            "IndepVarComp: Value (99) of option 'tags' has type 'int', "
+            "but one of types ('str', 'list') was expected.")
 
     def test_simple_with_tags(self):
         """Define one independent variable and set its value. Try filtering with tag"""

--- a/openmdao/docs/features/building_blocks/components/vector_magnitude_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/vector_magnitude_comp.rst
@@ -66,7 +66,7 @@ the input.
 VectorMagnitudeComp Example with Multiple Magnitudes
 ----------------------------------------------------
 
-Note that, when defining multiple products, an input name in one call to `add_magnitude` may not be an 
+Note that, when defining multiple magnitudes, an input name in one call to `add_magnitude` may not be an
 output name in another call, and vice-versa.
 
 

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -383,6 +383,10 @@ class OptionsDictionary(object):
 
         default_provided = default is not _undefined
 
+        if default_provided and default is None:
+            # specifying default=None implies allow_none
+            allow_none = True
+
         self._dict[name] = {
             'value': default,
             'values': values,


### PR DESCRIPTION
### Summary

IndepVarComp did not use the `options` mechanism like other Components, which was an issue for a user that wanted to subclass it with additional options. 

### Related Issues

- Resolves #1481

### Backwards incompatibilities

None

### New Dependencies

None
