### PR TITLE
Document prerequisite calls to Problem.record()

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -741,6 +741,10 @@ class Problem(object):
         """
         Record the variables at the Problem level.
 
+        Must be called after `final_setup` has been called. This can either
+        happen automatically through `run_driver` or `run_model`, or it can be
+        called manually.
+
         Parameters
         ----------
         case_name : str


### PR DESCRIPTION
### Summary

Document in the `Problem.record` doc-string that it must be called
after `Problem.final_setup`. Otherwise the following error gets thrown:

    AttributeError: 'Problem' object has no attribute 
    '_filtered_vars_to_record'

### Related Issues

### Backwards incompatibilities

None

### New Dependencies

None
