### PR TITLE
Removed unused args from IndepVarComp.add_output

### DIFF
--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -105,8 +105,7 @@ class IndepVarComp(ExplicitComponent):
 
         super(IndepVarComp, self)._configure_check()
 
-    def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
-                   lower=None, upper=None, ref=1.0, ref0=0.0, res_ref=None, tags=None):
+    def add_output(self, name, val=1.0, shape=None, units=None, desc='', tags=None):
         """
         Add an independent variable to this component.
 
@@ -122,47 +121,18 @@ class IndepVarComp(ExplicitComponent):
         units : str or None
             Units in which the output variables will be provided to the component during execution.
             Default is None, which means it has no units.
-        res_units : str or None
-            Units in which the residuals of this output will be given to the user when requested.
-            Default is None, which means it has no units.
         desc : str
             description of the variable
-        lower : float or list or tuple or ndarray or None
-            lower bound(s) in user-defined units. It can be (1) a float, (2) an array_like
-            consistent with the shape arg (if given), or (3) an array_like matching the shape of
-            val, if val is array_like. A value of None means this output has no lower bound.
-            Default is None.
-        upper : float or list or tuple or ndarray or None
-            upper bound(s) in user-defined units. It can be (1) a float, (2) an array_like
-            consistent with the shape arg (if given), or (3) an array_like matching the shape of
-            val, if val is array_like. A value of None means this output has no upper bound.
-            Default is None.
-        ref : float
-            Scaling parameter. The value in the user-defined units of this output variable when
-            the scaled value is 1. Default is 1.
-        ref0 : float
-            Scaling parameter. The value in the user-defined units of this output variable when
-            the scaled value is 0. Default is 0.
-        res_ref : float
-            Scaling parameter. The value in the user-defined res_units of this output's residual
-            when the scaled value is 1. Default is None, which means residual scaling matches
-            output scaling.
         tags : str or list of strs
             User defined tags that can be used to filter what gets listed when calling
             list_outputs.
         """
-        if res_ref is None:
-            res_ref = ref
-
         if tags is None:
             tags = {'indep_var'}
         else:
             tags = make_set(tags) | {'indep_var'}
 
-        kwargs = {'shape': shape, 'units': units, 'res_units': res_units, 'desc': desc,
-                  'lower': lower, 'upper': upper, 'ref': ref, 'ref0': ref0,
-                  'res_ref': res_ref, 'tags': tags
-                  }
+        kwargs = {'shape': shape, 'units': units, 'desc': desc, 'tags': tags}
         super(IndepVarComp, self).add_output(name, val, **kwargs)
 
     def add_discrete_output(self, name, val, desc='', tags=None):

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -152,8 +152,8 @@ class IndepVarComp(ExplicitComponent):
             list_outputs.
         """
         if res_units is not None:
-            warn_deprecation("'res_units' has been deprecated and will be removed in a future" +
-                             "version")
+            warn_deprecation(
+                "'res_units' has been deprecated and will be removed in a future version")
         elif lower is not None:
             warn_deprecation("'lower' has been deprecated and will be removed in a future version")
         elif upper is not None:
@@ -161,8 +161,8 @@ class IndepVarComp(ExplicitComponent):
         elif ref0:
             warn_deprecation("'ref0' has been deprecated and will be removed in a future version")
         elif res_ref is not None:
-            warn_deprecation("'res_ref' has been deprecated and will be removed in a future " +
-                             "version")
+            warn_deprecation(
+                "'res_ref' has been deprecated and will be removed in a future version")
         elif ref:
             warn_deprecation("'ref' has been deprecated and will be removed in a future version")
 

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
-from openmdao.utils.general_utils import make_set
+from openmdao.utils.general_utils import make_set, warn_deprecation
 
 
 class IndepVarComp(ExplicitComponent):
@@ -105,7 +105,8 @@ class IndepVarComp(ExplicitComponent):
 
         super(IndepVarComp, self)._configure_check()
 
-    def add_output(self, name, val=1.0, shape=None, units=None, desc='', tags=None):
+    def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
+                   lower=None, upper=None, ref=1.0, ref0=0.0, res_ref=None, tags=None):
         """
         Add an independent variable to this component.
 
@@ -121,18 +122,61 @@ class IndepVarComp(ExplicitComponent):
         units : str or None
             Units in which the output variables will be provided to the component during execution.
             Default is None, which means it has no units.
+        res_units : str or None
+            Units in which the residuals of this output will be given to the user when requested.
+            Default is None, which means it has no units.
         desc : str
             description of the variable
+        lower : float or list or tuple or ndarray or None
+            lower bound(s) in user-defined units. It can be (1) a float, (2) an array_like
+            consistent with the shape arg (if given), or (3) an array_like matching the shape of
+            val, if val is array_like. A value of None means this output has no lower bound.
+            Default is None.
+        upper : float or list or tuple or ndarray or None
+            upper bound(s) in user-defined units. It can be (1) a float, (2) an array_like
+            consistent with the shape arg (if given), or (3) an array_like matching the shape of
+            val, if val is array_like. A value of None means this output has no upper bound.
+            Default is None.
+        ref : float
+            Scaling parameter. The value in the user-defined units of this output variable when
+            the scaled value is 1. Default is 1.
+        ref0 : float
+            Scaling parameter. The value in the user-defined units of this output variable when
+            the scaled value is 0. Default is 0.
+        res_ref : float
+            Scaling parameter. The value in the user-defined res_units of this output's residual
+            when the scaled value is 1. Default is None, which means residual scaling matches
+            output scaling.
         tags : str or list of strs
             User defined tags that can be used to filter what gets listed when calling
             list_outputs.
         """
+        if res_units is not None:
+            warn_deprecation("'res_units' has been deprecated and will be removed in a future version")
+        elif lower is not None:
+            warn_deprecation("'lower' has been deprecated and will be removed in a future version")
+        elif upper is not None:
+            warn_deprecation("'upper' has been deprecated and will be removed in a future version")
+        elif ref0:
+            warn_deprecation("'ref0' has been deprecated and will be removed in a future version")
+        elif res_ref is not None:
+            warn_deprecation("'res_ref' has been deprecated and will be removed in a future " + \
+                             "version")
+        elif ref:
+            warn_deprecation("'ref' has been deprecated and will be removed in a future version")
+
+        if res_ref is None:
+             res_ref = ref
+
         if tags is None:
             tags = {'indep_var'}
         else:
             tags = make_set(tags) | {'indep_var'}
 
-        kwargs = {'shape': shape, 'units': units, 'desc': desc, 'tags': tags}
+        kwargs = {'shape': shape, 'units': units, 'res_units': res_units, 'desc': desc,
+                  'lower': lower, 'upper': upper, 'ref': ref, 'ref0': ref0,
+                  'res_ref': res_ref, 'tags': tags
+                  }
         super(IndepVarComp, self).add_output(name, val, **kwargs)
 
     def add_discrete_output(self, name, val, desc='', tags=None):

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -152,7 +152,8 @@ class IndepVarComp(ExplicitComponent):
             list_outputs.
         """
         if res_units is not None:
-            warn_deprecation("'res_units' has been deprecated and will be removed in a future version")
+            warn_deprecation("'res_units' has been deprecated and will be removed in a future" +
+                             "version")
         elif lower is not None:
             warn_deprecation("'lower' has been deprecated and will be removed in a future version")
         elif upper is not None:
@@ -160,13 +161,13 @@ class IndepVarComp(ExplicitComponent):
         elif ref0:
             warn_deprecation("'ref0' has been deprecated and will be removed in a future version")
         elif res_ref is not None:
-            warn_deprecation("'res_ref' has been deprecated and will be removed in a future " + \
+            warn_deprecation("'res_ref' has been deprecated and will be removed in a future " +
                              "version")
         elif ref:
             warn_deprecation("'ref' has been deprecated and will be removed in a future version")
 
         if res_ref is None:
-             res_ref = ref
+            res_ref = ref
 
         if tags is None:
             tags = {'indep_var'}

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -564,7 +564,7 @@ class DiscreteTestCase(unittest.TestCase):
         model = prob.model
 
         indep = model.add_subsystem('indep', om.IndepVarComp())
-        indep.add_output('x', 1.0, ref=10.)
+        indep.add_output('x', 1.0)
 
         comp = model.add_subsystem('comp', CompDiscWDerivsImplicit(), promotes=['N'])
         sink = model.add_subsystem('sink', MixedCompDiscIn(1.0))

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -448,7 +448,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units='degF', lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units='degF')
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',
@@ -507,7 +507,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units='degF', lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units='degF')
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',
@@ -550,7 +550,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units='degF', lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units='degF')
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',
@@ -634,7 +634,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units='degF', lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units='degF')
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',
@@ -655,7 +655,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units='degF', lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units='degF')
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',
@@ -676,7 +676,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units=None, lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units=None)
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',
@@ -697,7 +697,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x', 35.0, units=None, lower=32.0, upper=212.0)
+        ivc.add_output('x', 35.0, units=None)
 
         model.add_subsystem('p', ivc, promotes=['x'])
         model.add_subsystem('comp1', om.ExecComp('y1 = 2.0*x',

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 class TestIndepVarComp(unittest.TestCase):
@@ -202,6 +202,61 @@ class TestIndepVarComp(unittest.TestCase):
 
         self.assertEqual(len(prob.get_val('num_x')), 4)
         self.assertEqual(prob.get_val('val_y'), 2.5)
+
+    def test_ivc_deprecations(self):
+        # ref0
+        prob = om.Problem()
+
+        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
+
+        msg = "'ref0' has been deprecated and will be removed in a future version"
+        with assert_warning(DeprecationWarning, msg):
+            indep.add_output('x', 12., ref=0.0, ref0=1.)
+
+        # res_units
+        prob = om.Problem()
+
+        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
+
+        msg = "'res_units' has been deprecated and will be removed in a future version"
+        with assert_warning(DeprecationWarning, msg):
+            indep.add_output('x', 12., res_units='m')
+
+        # upper
+        prob = om.Problem()
+
+        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
+
+        msg = "'upper' has been deprecated and will be removed in a future version"
+        with assert_warning(DeprecationWarning, msg):
+            indep.add_output('x', 12., upper=1.)
+
+        # lower
+        prob = om.Problem()
+
+        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
+
+        msg = "'lower' has been deprecated and will be removed in a future version"
+        with assert_warning(DeprecationWarning, msg):
+            indep.add_output('x', 12., lower=1.)
+
+        # res_ref
+        prob = om.Problem()
+
+        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
+
+        msg = "'res_ref' has been deprecated and will be removed in a future version"
+        with assert_warning(DeprecationWarning, msg):
+            indep.add_output('x', 12., res_ref=1.)
+
+        # res_ref
+        prob = om.Problem()
+
+        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
+
+        msg = "'ref' has been deprecated and will be removed in a future version"
+        with assert_warning(DeprecationWarning, msg):
+            indep.add_output('x', 12., ref=2.)
 
 
 if __name__ == '__main__':

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -218,7 +218,8 @@ class TestIndepVarComp(unittest.TestCase):
 
         indep = prob.model.add_subsystem('p1', om.IndepVarComp())
 
-        msg = "'res_units' has been deprecated and will be removed in a future version"
+        msg = "'res_units' has been deprecated and will be removed in a future " + \
+              "version"
         with assert_warning(DeprecationWarning, msg):
             indep.add_output('x', 12., res_units='m')
 

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -59,8 +59,8 @@ class TestIndepVarComp(unittest.TestCase):
         import openmdao.api as om
 
         comp = om.IndepVarComp()
-        comp.add_output('indep_var_1', val=1.0, lower=0, upper=10)
-        comp.add_output('indep_var_2', val=2.0, lower=1, upper=20)
+        comp.add_output('indep_var_1', val=1.0)
+        comp.add_output('indep_var_2', val=2.0)
 
         prob = om.Problem(comp).setup()
 
@@ -111,8 +111,8 @@ class TestIndepVarComp(unittest.TestCase):
         from openmdao.api import Problem, IndepVarComp
 
         comp = IndepVarComp()
-        comp.add_output('indep_var_1', val=1.0, lower=0, upper=10, tags="tag1")
-        comp.add_output('indep_var_2', val=2.0, lower=1, upper=20, tags="tag2")
+        comp.add_output('indep_var_1', val=1.0, tags="tag1")
+        comp.add_output('indep_var_2', val=2.0, tags="tag2")
 
         prob = Problem(comp).setup(check=False)
         prob.run_model()
@@ -175,7 +175,7 @@ class TestIndepVarComp(unittest.TestCase):
         model = prob.model
 
         ivc = om.IndepVarComp()
-        ivc.add_output('x1', val=[1, 2, 3], lower=0, upper=10)
+        ivc.add_output('x1', val=[1, 2, 3])
 
         model.add_subsystem('p', ivc)
 

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -1092,14 +1092,14 @@ class TestScalingOverhaul(unittest.TestCase):
         model = prob.model
 
         inputs_comp = om.IndepVarComp()
-        inputs_comp.add_output('x1_u_u', val=1.0)
-        inputs_comp.add_output('x1_u_s', val=1.0)
-        inputs_comp.add_output('x1_s_u', val=1.0, ref=3.0)
-        inputs_comp.add_output('x1_s_s', val=1.0, ref=3.0)
+        inputs_comp.add_output('x1_u_u',  val=1.0)
+        inputs_comp.add_output('x1_u_s',  val=1.0)
+        inputs_comp.add_output('x1_s_u',  val=1.0)
+        inputs_comp.add_output('x1_s_s',  val=1.0)
         inputs_comp.add_output('ox1_u_u', val=1.0)
         inputs_comp.add_output('ox1_u_s', val=1.0)
-        inputs_comp.add_output('ox1_s_u', val=1.0, ref=3.0)
-        inputs_comp.add_output('ox1_s_s', val=1.0, ref=3.0)
+        inputs_comp.add_output('ox1_s_u', val=1.0)
+        inputs_comp.add_output('ox1_s_s', val=1.0)
 
         model.add_subsystem('p', inputs_comp)
         mycomp = model.add_subsystem('comp', MyComp())


### PR DESCRIPTION
### Summary

Removed unused args from IndepVarComp.add_output

### Related Issues

- Resolves #1558

### Backwards incompatibilities

None

### New Dependencies

None
