### PR TITLE
Fix bogus units error

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4235,7 +4235,8 @@ class System(object):
         abs_name = abs_ins[0]
         src = conns[abs_name]
         if src in self._var_allprocs_discrete['output']:
-            return self._abs_get_val(src, get_remote, rank, vec_name, 'output', flat, from_root=True)
+            return self._abs_get_val(src, get_remote, rank, vec_name, 'output', flat,
+                                     from_root=True)
 
         # if we have multiple promoted inputs that are explicitly connected to an output and units
         # have not been specified, look for group input to disambiguate

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4187,7 +4187,7 @@ class System(object):
         if from_src and abs_names[0] in conns:  # pull input from source
             return self._get_input_from_src(name, abs_names, conns, units=units, indices=indices,
                                             get_remote=get_remote, rank=rank, vec_name='nonlinear',
-                                            kind='output', flat=flat)
+                                            flat=flat)
         else:
             val = self._abs_get_val(abs_names[0], get_remote, rank, vec_name, kind, flat)
 
@@ -4199,30 +4199,59 @@ class System(object):
 
         return val
 
-    def _get_input_from_src(self, name, abs_names, conns, units=None, indices=None,
-                            get_remote=False, rank=None, vec_name='nonlinear', kind=None,
-                            flat=False):
-        abs_name = abs_names[0]
+    def _get_input_from_src(self, name, abs_ins, conns, units=None, indices=None,
+                            get_remote=False, rank=None, vec_name='nonlinear', flat=False):
+        """
+        Given an input name, retrieve the value from its source output.
+
+        Parameters
+        ----------
+        name : str
+            Promoted or relative variable name in the root system's namespace.
+        abs_ins : list of str
+            List of absolute input names.
+        conns : dict
+            Mapping of absolute names of each input to its connected output across the whole model.
+        units : str, optional
+            Units to convert to before return.
+        indices : int or list of ints or tuple of ints or int ndarray or Iterable or None, optional
+            Indices or slice to return.
+        get_remote : bool
+            If True, retrieve the value even if it is on a remote process.  Note that if the
+            variable is remote on ANY process, this function must be called on EVERY process
+            in the Problem's MPI communicator.
+        rank : int or None
+            If not None, only gather the value to this rank.
+        vec_name : str
+            Name of the vector to use.   Defaults to 'nonlinear'.
+        flat : bool
+            If True, return the flattened version of the value.
+
+        Returns
+        -------
+        object
+            The value of the requested variable.
+        """
+        abs_name = abs_ins[0]
         src = conns[abs_name]
         if src in self._var_allprocs_discrete['output']:
-            return self._abs_get_val(src, get_remote, rank, vec_name, kind, flat, from_root=True)
+            return self._abs_get_val(src, get_remote, rank, vec_name, 'output', flat, from_root=True)
 
         # if we have multiple promoted inputs that are explicitly connected to an output and units
         # have not been specified, look for group input to disambiguate
-        if units is None and len(abs_names) > 1:
+        if units is None and len(abs_ins) > 1:
             if abs_name not in self._var_allprocs_discrete['input']:
-                # can't get here unless self is a Group because len(abs_names) always == 1 for comp
+                # can't get here unless self is a Group because len(abs_ins) always == 1 for comp
                 try:
                     units = self._group_inputs[name][0]['units']
                 except (KeyError, IndexError):
-                    for i, n in enumerate(abs_names):
-                        unit0 = self._var_allprocs_abs2meta[abs_names[0]]['units']
-                        for n in abs_names[1:]:
-                            if unit0 != self._var_allprocs_abs2meta[n]['units']:
-                                self._show_ambiguity_msg(name, ('units',), abs_names)
-                                break
+                    unit0 = self._var_allprocs_abs2meta[abs_ins[0]]['units']
+                    for n in abs_ins[1:]:
+                        if unit0 != self._var_allprocs_abs2meta[n]['units']:
+                            self._show_ambiguity_msg(name, ('units',), abs_ins)
+                            break
 
-        val = self._abs_get_val(src, get_remote, rank, vec_name, kind, flat, from_root=True)
+        val = self._abs_get_val(src, get_remote, rank, vec_name, 'output', flat, from_root=True)
 
         if abs_name in self._var_abs2meta:  # input is local
             vmeta = self._var_abs2meta[abs_name]

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4212,10 +4212,12 @@ class System(object):
         if units is None and len(abs_names) > 1:
             if abs_name not in self._var_allprocs_discrete['input']:
                 # can't get here unless self is a Group because len(abs_names) always == 1 for comp
-                try:
-                    units = self._group_inputs[name][0]['units']
-                except (KeyError, IndexError):
-                    self._show_ambiguity_msg(name, ('units',), abs_names)
+                unitset = set(self._var_allprocs_abs2meta[n]['units'] for n in abs_names)
+                if len(unitset) > 1:
+                    try:
+                        units = self._group_inputs[name][0]['units']
+                    except (KeyError, IndexError):
+                        self._show_ambiguity_msg(name, ('units',), abs_names)
 
         val = self._abs_get_val(src, get_remote, rank, vec_name, kind, flat, from_root=True)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4216,11 +4216,11 @@ class System(object):
                     units = self._group_inputs[name][0]['units']
                 except (KeyError, IndexError):
                     for i, n in enumerate(abs_names):
-                        if i == 0:
-                            unit0 = self._var_allprocs_abs2meta[n]['units']
-                        elif unit0 != self._var_allprocs_abs2meta[n]['units']:
-                            self._show_ambiguity_msg(name, ('units',), abs_names)
-                            break
+                        unit0 = self._var_allprocs_abs2meta[abs_names[0]]['units']
+                        for n in abs_names[1:]:
+                            if unit0 != self._var_allprocs_abs2meta[n]['units']:
+                                self._show_ambiguity_msg(name, ('units',), abs_names)
+                                break
 
         val = self._abs_get_val(src, get_remote, rank, vec_name, kind, flat, from_root=True)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4212,12 +4212,15 @@ class System(object):
         if units is None and len(abs_names) > 1:
             if abs_name not in self._var_allprocs_discrete['input']:
                 # can't get here unless self is a Group because len(abs_names) always == 1 for comp
-                unitset = set(self._var_allprocs_abs2meta[n]['units'] for n in abs_names)
-                if len(unitset) > 1:
-                    try:
-                        units = self._group_inputs[name][0]['units']
-                    except (KeyError, IndexError):
-                        self._show_ambiguity_msg(name, ('units',), abs_names)
+                try:
+                    units = self._group_inputs[name][0]['units']
+                except (KeyError, IndexError):
+                    for i, n in enumerate(abs_names):
+                        if i == 0:
+                            unit0 = self._var_allprocs_abs2meta[n]['units']
+                        elif unit0 != self._var_allprocs_abs2meta[n]['units']:
+                            self._show_ambiguity_msg(name, ('units',), abs_names)
+                            break
 
         val = self._abs_get_val(src, get_remote, rank, vec_name, kind, flat, from_root=True)
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1757,6 +1757,8 @@ class TestConnect(unittest.TestCase):
         p.model.connect('indeps.foo', 'x')
         p.setup()
         p.final_setup()
+
+        # before bug fix, the following generated an ambiguity error
         p['x']
 
     def test_invalid_target(self):

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1749,6 +1749,16 @@ class TestConnect(unittest.TestCase):
         with assert_warning(UserWarning, msg):
             self.prob.setup()
 
+    def test_explicit_conn_to_prom_inputs(self):
+        p = om.Problem()
+        p.model.add_subsystem('indeps', om.IndepVarComp('foo', val=10., units='ft'))
+        p.model.add_subsystem('C1', om.ExecComp('y=3*x', x={'units': 'ft', 'value': 1.}), promotes_inputs=['x'])
+        p.model.add_subsystem('C2', om.ExecComp('y=4*x', x={'units': 'ft', 'value': 1.}), promotes_inputs=['x'])
+        p.model.connect('indeps.foo', 'x')
+        p.setup()
+        p.final_setup()
+        p['x']
+
     def test_invalid_target(self):
         msg = "Group (sub): Attempted to connect from 'src.x' to 'tgt.z', but 'tgt.z' doesn't exist."
 


### PR DESCRIPTION
### Summary

When multiple inputs promoted  to the same name were explicitly connected to an output, a units ambiguity error was generated even if all of the inputs had the same units.

