### PR TITLE
Fixed bug in directional derivatives of implicit states when checking partials on a matrix-free component. 

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1118,10 +1118,15 @@ class Problem(object):
 
                             if directional:
                                 n_in = 1
-                                perturb = 2.0 * np.random.random(len(flat_view)) - 1.0
                                 if c_name not in mfree_directions:
                                     mfree_directions[c_name] = {}
-                                mfree_directions[c_name][inp] = perturb
+
+                                if inp in mfree_directions[c_name]:
+                                    perturb = mfree_directions[c_name][inp]
+                                else:
+                                    perturb = 2.0 * np.random.random(len(flat_view)) - 1.0
+                                    mfree_directions[c_name][inp] = perturb
+
                             else:
                                 n_in = len(flat_view)
                                 perturb = 1.0


### PR DESCRIPTION
### Summary

Fixed bug in directional derivatives of implicit states when checking partials on a matrix-free component.  (Old direction was getting overwritten because input and output key name are the same. Solution is to use the same one for both sides of the directional check.)

### Related Issues

- Resolves #1579

### Backwards incompatibilities

None

### New Dependencies

None
