### PR TITLE
Allow BalanceComp to be sized from rhs_val

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -314,7 +314,13 @@ class BalanceComp(ImplicitComponent):
 
         self._state_vars[name] = options
 
-        if val is not None:
+        if val is None:
+            # If user doesn't specify initial guess for val, we cann size problem from initial
+            # rhs_val.
+            if 'shape' not in kwargs and not np.isscalar(rhs_val):
+                kwargs['shape'] = rhs_val.shape
+
+        else:
             options['kwargs']['val'] = val
 
         meta = self.add_output(name, **options['kwargs'])

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -315,7 +315,7 @@ class BalanceComp(ImplicitComponent):
         self._state_vars[name] = options
 
         if val is None:
-            # If user doesn't specify initial guess for val, we cann size problem from initial
+            # If user doesn't specify initial guess for val, we can size problem from initial
             # rhs_val.
             if 'shape' not in kwargs and not np.isscalar(rhs_val):
                 kwargs['shape'] = rhs_val.shape

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -897,25 +897,16 @@ class TestBalanceComp(unittest.TestCase):
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_shape_from_rhs_val(self):
-        n = 5
         p = om.Problem()
-
-        p.model.add_subsystem('comp_A',
-                              om.ExecComp('y = x**2', y={'shape': (n, )}, x={'shape': (n, )}))
-        p.model.add_subsystem('comp_B',
-                              om.ExecComp('y = x + 7', y={'shape': (n, )}, x={'shape': (n, )}))
-
-        p.model.add_subsystem('bal', om.BalanceComp('x', rhs_val=np.ones((n, ))))
-        p.model.connect('bal.x', 'comp_A.x')
-        p.model.connect('bal.x', 'comp_B.x')
-        p.model.connect('comp_A.y', 'bal.lhs:x')
-        p.model.connect('comp_B.y', 'bal.rhs:x')
-
-        p.model.linear_solver = om.DirectSolver()
-        p.model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        init = np.ones((5, ))
+        p.model.add_subsystem('bal', om.BalanceComp('x', rhs_val=init))
 
         # Bug was a size mismatch exception raised during setup.
         p.setup()
+
+        self.assertTrue(p.get_val('bal.x').shape == init.shape)
+        self.assertTrue(p.get_val('bal.lhs:x').shape == init.shape)
+        self.assertTrue(p.get_val('bal.rhs:x').shape == init.shape)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
### Summary

Allow a BalanceComp to be specified with an initial value for 'rhs_val', but not 'val'.  The inputs and outputs will be created using the size from 'rhs_val'.

### Related Issues

- Resolves #1585 

### Backwards incompatibilities

None

### New Dependencies

None
