### PR TITLE
Fixed bug in group promotes with array src_indices

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1700,13 +1700,13 @@ class Group(System):
                     simple_warning(f"{self.msginfo}: src_indices have been specified with promotes"
                                    " 'any'. Note that src_indices only apply to matching inputs.")
 
-                # src_indices will applied when promotes are resolved
-                if inputs is not None:
-                    for inp in inputs:
-                        subsys._var_promotes_src_indices[inp] = (src_indices, flat_src_indices)
-                if any is not None:
-                    for inp in any:
-                        subsys._var_promotes_src_indices[inp] = (src_indices, flat_src_indices)
+            # src_indices will applied when promotes are resolved
+            if inputs is not None:
+                for inp in inputs:
+                    subsys._var_promotes_src_indices[inp] = (src_indices, flat_src_indices)
+            if any is not None:
+                for inp in any:
+                    subsys._var_promotes_src_indices[inp] = (src_indices, flat_src_indices)
 
         # check for attempt to promote with different alias
         list_comp = [i if isinstance(i, tuple) else (i, i) for i in subsys._var_promotes['input']]


### PR DESCRIPTION
### Summary

Fixed a bug where array src_indices would be ignored in group.promotes.

This was due to an indentation error in the code.

### Related Issues

- Resolves #1594

### Backwards incompatibilities

None

### New Dependencies

None
