### PR TITLE
Fix for Keyerror when debug printing pyoptsparse derivatives with auto_ivc design vars.

### DIFF
--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1623,10 +1623,10 @@ class _TotalJacInfo(object):
         Print out the derivatives when debug_print is True.
         """
         if self.return_format == 'dict':
-            J = self.J_dict
-            for of in self.of:
-                for wrt in self.wrt:
-                    pprint.pprint({(of, wrt): J[of][wrt]})
+            J_dict = self.J_dict
+            for of, wrt_dict in J_dict.items():
+                for wrt, J_sub in wrt_dict.items():
+                    pprint.pprint({(of, wrt): J_sub})
         else:
             J = self.J
             for i, of in enumerate(self.of):

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1590,6 +1590,77 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertTrue("('p2.y', [1])" in output)
         self.assertTrue('Elapsed Time:' in output)
 
+    def test_debug_print_option_totals_no_ivc(self):
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
+
+        model.set_input_defaults('x', 50.0)
+        model.set_input_defaults('y', 50.0)
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+        prob.driver.options['print_results'] = False
+
+        prob.driver.options['debug_print'] = ['totals']
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.0)
+
+        prob.setup(check=False, mode='rev')
+
+        failed, output = run_driver(prob)
+
+        self.assertFalse(failed, "Optimization failed, info = " +
+                                 str(prob.driver.pyopt_solution.optInform))
+
+        self.assertTrue('In mode: rev, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue("('comp.f_xy', [0])" in output)
+        self.assertTrue('Elapsed Time:' in output)
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+        if OPTIMIZER == 'SLSQP':
+            prob.driver.opt_settings['ACC'] = 1e-9
+        prob.driver.options['print_results'] = False
+
+        prob.driver.options['debug_print'] = ['totals']
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.0)
+
+        prob.setup(check=False, mode='fwd')
+
+        failed, output = run_driver(prob)
+
+        self.assertFalse(failed, "Optimization failed, info = " +
+                             str(prob.driver.pyopt_solution.optInform))
+
+        self.assertTrue('In mode: fwd, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue("('p2.y', [1])" in output)
+        self.assertTrue('Elapsed Time:' in output)
+
     def test_debug_print_option(self):
 
         prob = om.Problem()

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -15,7 +15,6 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import run_model
 from openmdao.utils.general_utils import printoptions
 


### PR DESCRIPTION
### Summary

Fix for Keyerror when debug printing pyoptsparse derivatives with auto_ivc design vars.

### Related Issues

- Resolves #1603 

### Backwards incompatibilities

None

### New Dependencies

None
