### PR TITLE
Added some knobs to the N2 pre-collapsing functionality

### DIFF
--- a/openmdao/visualization/n2_viewer/src/ModelData.js
+++ b/openmdao/visualization/n2_viewer/src/ModelData.js
@@ -16,6 +16,7 @@ class ModelData {
         this.autoivcSources = 0;
         this.nodePaths = {};
         this.nodeIds = [];
+        this.depthCount = [];
 
         startTimer('ModelData._convertToN2TreeNodes');
         this.root = this.tree = modelJSON.tree = this._convertToN2TreeNodes(modelJSON.tree);
@@ -99,6 +100,10 @@ class ModelData {
         node.parent = parent;
         node.id = this.nodeIds.length;
         this.nodeIds.push(node);
+
+        // Track # of nodes at each depth
+        if (depth > this.depthCount.length) { this.depthCount.push(1); }
+        else { this.depthCount[depth - 1]++; }
 
         if (node.parent) { // not root node? node.parent.absPathName : "";
             if (node.parent.absPathName != "") {

--- a/openmdao/visualization/n2_viewer/src/N2Layout.js
+++ b/openmdao/visualization/n2_viewer/src/N2Layout.js
@@ -237,8 +237,8 @@ class N2Layout {
         node.numLeaves = 0;
 
         if (! node.varIsHidden) {
-            if (this.model.nodeIds.length > ALLOW_PRECOLLAPSE_COUNT) {
-                node.minimizeIfLarge();
+            if (this.model.nodeIds.length > Precollapse.minimumNodes) {
+                node.minimizeIfLarge(this.model.depthCount[node.depth]);
             }
 
             if (node.hasChildren() && !node.isMinimized) {

--- a/openmdao/visualization/n2_viewer/src/N2TreeNode.js
+++ b/openmdao/visualization/n2_viewer/src/N2TreeNode.js
@@ -246,12 +246,16 @@ class N2TreeNode {
     /**
      * If the node has a lot of descendants and it wasn't manually expanded,
      * minimize it.
+     * @param {Number} depthCount The number of nodes at the next depth down.
      * @returns {Boolean} True if minimized here, false otherwise.
      */
-    minimizeIfLarge() {
+    minimizeIfLarge(depthCount) {
         if ( ! (this.isRoot() || this.manuallyExpanded) &&
-            (this.numDescendants > PRECOLLAPSE_THRESHOLD &&
-                this.children.length > 1 ) ) {
+            ( this.depth >= (this.isComponent()?
+                Precollapse.cmpDepthStart : Precollapse.grpDepthStart) &&
+                this.numDescendants > Precollapse.threshold &&
+                this.children.length > Precollapse.children - this.depth &&
+                depthCount > Precollapse.depthLimit )) {
             debugInfo(`Precollapsing node ${this.absPathName}`)
             this.minimize();
             return true;

--- a/openmdao/visualization/n2_viewer/src/defaults.js
+++ b/openmdao/visualization/n2_viewer/src/defaults.js
@@ -1,7 +1,5 @@
 // Constants and default valus
 const EMBEDDED = (d3.selectAll("#all_pt_n2_content_div").classed("embedded-n2"));
-const ALLOW_PRECOLLAPSE_COUNT = 200; // Consider precollapsing nodes in models larger than this
-const PRECOLLAPSE_THRESHOLD = 10; // Pre-collapse nodes with more descendants than this
 const _DEFAULT_N2_DIAGRAM_UNIT = 'px';
 const _DEFAULT_N2_DIAGRAM_HEIGHT = window.innerHeight * .95;
 const _DEFAULT_FONT_SIZE = 11;
@@ -42,6 +40,18 @@ let N2TransitionDefaults = {
     'durationSlow': 1500,
     'maxNodes': 150
 }
+
+const Precollapse = {
+    'minimumNodes': 200, // Precollapse nodes in models larger than this
+    'threshold': 0, // Only precollapse nodes with more descendants than this
+    'grpDepthStart': 3, // Only precollapse group nodes at least this deep
+    'cmpDepthStart': 2, // Only precollapse component nodes at least this deep
+    'depthLimit': 6, // Only precollapse nodes with more than this many others at the same depth
+    'children': 6, // Only precollapse nodes with more direct children than this
+                   // (decreases by 1 w/each depth level)
+}
+
+Object.freeze(Precollapse);
 
 let DebugFlags = {
     'timings': false,


### PR DESCRIPTION
### Summary

Previously, the N2 diagram only considered the size of the model and number of descendants of a node when deciding to pre-collapse it. This update:
- takes into account the total number of nodes at the same depth of a node's immediate children
- doesn't pre-collapse nodes higher in the tree if they only have a few children (this effect diminishes the deeper the node is in the tree)
- never pre-collapses components at depth 2 or above, or groups depth 3 or above

Original behavior:
![image](https://user-images.githubusercontent.com/12797795/90156125-1b1e7f00-dd5a-11ea-83be-edbff3cd0263.png)

New behavior:
![image](https://user-images.githubusercontent.com/12797795/90156048-03df9180-dd5a-11ea-860a-88a248e0cda8.png)


### Related Issues

- Resolves #1611
