### PR TITLE
fixed equality test for _UNDEFINED in N2 code getting tree dict

### DIFF
--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -197,7 +197,7 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
         if k in ['linear_solver', 'nonlinear_solver']:
             options[k] = system.options[k].SOLVER
         else:
-            if system.options._dict[k]['value'] == _UNDEFINED:
+            if system.options._dict[k]['value'] is _UNDEFINED:
                 options[k] = str(system.options._dict[k]['value'])
             else:
                 options[k] = system.options._dict[k]['value']

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -13,7 +13,7 @@ from tempfile import mkdtemp
 
 import numpy
 
-from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver
+from openmdao.api import Problem, IndepVarComp, ScipyOptimizeDriver, ExplicitComponent
 from openmdao.test_suite.components.sellar import SellarStateConnection
 from openmdao.visualization.n2_viewer.n2_viewer import _get_viewer_data, n2
 from openmdao.recorders.sqlite_recorder import SqliteRecorder
@@ -290,6 +290,26 @@ class TestViewModelData(unittest.TestCase):
             expected_design_vars_names,
             expected_responses_names,
         )
+
+    def test_handle_ndarray_system_option(self):
+        class SystemWithNdArrayOption(ExplicitComponent):
+            def initialize(self):
+                self.options.declare('arr', types=(numpy.ndarray,))
+
+            def setup(self):
+                self.add_input('x', val=0.0)
+                self.add_output('f_x', val=0.0)
+
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                outputs['f_x'] = (x - 3.0) ** 2
+
+        prob = Problem()
+        prob.model.add_subsystem('comp', SystemWithNdArrayOption(arr=numpy.ones(2)))
+        prob.setup()
+        model_viewer_data = _get_viewer_data(prob)
+        numpy.testing.assert_equal(model_viewer_data['tree']['children'][0]['options']['arr'],
+                                   numpy.ones(2))
 
     def test_n2_from_problem(self):
         """


### PR DESCRIPTION
### Summary

Fixed equality test for _UNDEFINED in the N2 viewer code.  The previous test `system.options._dict[k]['value'] == _UNDEFINED` would cause an exception if the value was a Numpy array

### Related Issues

- Resolves #1624

### Backwards incompatibilities

None

### New Dependencies

None
