### PR TITLE
Fix for unserializable object failure when running n2

### DIFF
--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -26,10 +26,6 @@ try:
 except ImportError:
     PETScVector = None
 
-try:
-    from openmdao.vectors.petsc_vector import PETScVector
-except ImportError:
-    PETScVector = None
 
 arr_order_1x1 = np.array([1, 2, 3, 4])
 arr_2x4 = np.array([[0, 1, 2, 3], [10, 11, 12, 13]])

--- a/openmdao/core/tests/test_serialize.py
+++ b/openmdao/core/tests/test_serialize.py
@@ -1,0 +1,28 @@
+import unittest
+
+import openmdao.api as om
+
+class BadOptionComp(om.ExplicitComponent):
+
+    def initialize(self):
+        self.options.declare('bad', recordable=False)
+
+    def setup(self):
+        self.add_input('x')
+        self.add_output('y')
+
+
+class SerializeTestCase(unittest.TestCase):
+    def test_serialize_n2(self):
+        p = om.Problem()
+
+        p.model.add_subsystem('foo', BadOptionComp(bad=object()))
+
+        p.setup()
+        p.final_setup()
+
+        om.n2(p, show_browser=False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -19,7 +19,7 @@ from openmdao.recorders.case_recorder import CaseRecorder
 from openmdao.utils.mpi import MPI
 from openmdao.utils.record_util import dict_to_structured_array
 from openmdao.utils.options_dictionary import OptionsDictionary
-from openmdao.utils.general_utils import simple_warning, make_serializable
+from openmdao.utils.general_utils import simple_warning, make_serializable, default_noraise
 from openmdao.core.driver import Driver
 from openmdao.core.system import System
 from openmdao.core.problem import Problem
@@ -612,7 +612,7 @@ class SqliteRecorder(CaseRecorder):
             The unique ID to use for this data in the table.
         """
         if self.connection:
-            json_data = json.dumps(model_viewer_data, default=make_serializable)
+            json_data = json.dumps(model_viewer_data, default=default_noraise)
 
             # Note: recorded to 'driver_metadata' table for legacy/compatibility reasons.
             try:

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -24,7 +24,7 @@ from openmdao.drivers.doe_driver import DOEDriver
 from openmdao.recorders.case_reader import CaseReader
 from openmdao.solvers.nonlinear.newton import NewtonSolver
 from openmdao.utils.class_util import overrides_method
-from openmdao.utils.general_utils import simple_warning, make_serializable
+from openmdao.utils.general_utils import simple_warning, default_noraise
 from openmdao.utils.mpi import MPI
 from openmdao.visualization.html_utils import read_files, write_script, DiagramWriter
 from openmdao.utils.general_utils import warn_deprecation
@@ -416,7 +416,7 @@ def n2(data_source, outfile='n2.html', show_browser=True, embeddable=False,
         warn_deprecation("'use_declare_partial_info' is now the"
                          " default and the option is ignored.")
 
-    raw_data = json.dumps(model_data, default=make_serializable).encode('utf8')
+    raw_data = json.dumps(model_data, default=default_noraise).encode('utf8')
     b64_data = str(base64.b64encode(zlib.compress(raw_data)).decode("ascii"))
     model_data = 'var compressedModel = "%s";' % b64_data
 


### PR DESCRIPTION
### Summary

Existing function being passed to json.dumps was just returning objects as-is if it couldn't convert them and resulted in a cryptic error from json that gave no indication where the problem was.  The new behavior is that unserializable objects are
converted to a string, 'unserializable object (<type>)'.  That string will then show up in the n2 in place of unserializable option values for example.

### Related Issues

- Resolves #1637

### Backwards incompatibilities

None

### New Dependencies

None
