### PR TITLE
fix for typo in handling of flat_src_indices

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1872,7 +1872,7 @@ class System(object):
                                            (self.msginfo, name, str(src_indices),
                                             str(meta['src_indices'])))
                 if 'flat_src_indices' in meta and meta['flat_src_indices'] is not None:
-                    if not meta['flat_src_indices'] == src_indices:
+                    if not meta['flat_src_indices'] == flat_src_indices:
                         raise RuntimeError("%s: Trying to promote input '%s' with flat_src_indices"
                                            "=%s but flat_src_indices has already been specified as"
                                            " %s." %

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -280,3 +280,34 @@ class SrcIndicesTests(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
+
+    def test_flat_src_inds_2_levels(self):
+        # this test passes if it doesn't raise an exception.
+        class Burn1(om.Group):
+            def setup(self):
+                self.add_subsystem('comp1', om.ExecComp(['y1=x*2'], y1=np.ones(4), x=np.ones(4)),
+                                promotes_outputs=['*'])
+
+                self.add_subsystem('comp2', om.ExecComp(['y2=x*2'], y2=np.ones(4), x=np.ones(4)),
+                                promotes_outputs=['*'])
+
+            def configure(self):
+                self.promotes('comp1', inputs=[('x', 'design:x')],
+                            src_indices=[0, 0, 0, 0], flat_src_indices=True)
+
+                self.set_input_defaults('design:x', 75.3)
+
+
+        class Traj(om.Group):
+            def setup(self):
+                self.add_subsystem('burn1', Burn1(),
+                                promotes_outputs=['*'])
+
+            def configure(self):
+                self.promotes('burn1', inputs=['design:x'],
+                            src_indices=[0, 0, 0, 0], flat_src_indices=True)
+
+        prob = om.Problem(model=Traj())
+
+        prob.setup()
+        prob.run_model()


### PR DESCRIPTION
### Summary

Simple typo was causing an error when promotes set src_indices at multiple levels.

### Related Issues

- Resolves #1641

### Backwards incompatibilities

None

### New Dependencies

None
