### PR TITLE
Fix for problem with src_indices applied during promotes called from parent when multiple subsystem inputs are promoted to the same name.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1859,32 +1859,31 @@ class System(object):
             if key in self._var_promotes_src_indices:
                 src_indices, flat_src_indices = self._var_promotes_src_indices[key]
 
-                abs_name = self._var_allprocs_prom2abs_list['input'][name][0]
-                meta = self._var_abs2meta[abs_name]
+                for abs_name in self._var_allprocs_prom2abs_list['input'][name]:
+                    meta = self._var_abs2meta[abs_name]
 
-                _, _, src_indices = ensure_compatible(name, meta['value'], meta['shape'],
-                                                      src_indices)
+                    _, _, src_indices = ensure_compatible(name, meta['value'], meta['shape'],
+                                                          src_indices)
 
-                if 'src_indices' in meta and meta['src_indices'] is not None:
-                    if not np.array_equal(meta['src_indices'], src_indices):
-                        raise RuntimeError("%s: Trying to promote input '%s' with src_indices %s,"
-                                           " but src_indices have already been specified as %s." %
-                                           (self.msginfo, name, str(src_indices),
-                                            str(meta['src_indices'])))
-                if 'flat_src_indices' in meta and meta['flat_src_indices'] is not None:
-                    if not meta['flat_src_indices'] == flat_src_indices:
-                        raise RuntimeError("%s: Trying to promote input '%s' with flat_src_indices"
-                                           "=%s but flat_src_indices has already been specified as"
-                                           " %s." %
-                                           (self.msginfo, name, str(flat_src_indices),
-                                            str(meta['flat_src_indices'])))
+                    if 'src_indices' in meta and meta['src_indices'] is not None:
+                        if not np.array_equal(meta['src_indices'], src_indices):
+                            raise RuntimeError(f"{self.msginfo}: Trying to promote input '{name}' "
+                                               f"with src_indices {str(src_indices)},"
+                                               f" but src_indices have already been specified as "
+                                               f"{str(meta['src_indices'])}.")
+                    if 'flat_src_indices' in meta and meta['flat_src_indices'] is not None:
+                        if not meta['flat_src_indices'] == flat_src_indices:
+                            raise RuntimeError(f"{self.msginfo}: Trying to promote input '{name}' "
+                                               f"with flat_src_indices={str(flat_src_indices)} but "
+                                               f"flat_src_indices has already been specified as"
+                                               f" {str(meta['flat_src_indices'])}.")
 
-                if src_indices.dtype == object:
-                    meta['src_indices'] = src_indices
-                else:
-                    meta['src_indices'] = np.asarray(src_indices, dtype=INT_DTYPE)
+                    if src_indices.dtype == object:
+                        meta['src_indices'] = src_indices
+                    else:
+                        meta['src_indices'] = np.asarray(src_indices, dtype=INT_DTYPE)
 
-                meta['flat_src_indices'] = flat_src_indices
+                    meta['flat_src_indices'] = flat_src_indices
 
         def resolve(to_match, io_types, matches, proms):
             """

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -311,3 +311,47 @@ class SrcIndicesTests(unittest.TestCase):
 
         prob.setup()
         prob.run_model()
+
+    def test_src_inds_2_subs(self):
+        # this test passes if it doesn't raise an exception.
+
+        class RHS(om.Group):
+
+            def initialize(self):
+                self.options.declare('size', 1)
+
+            def setup(self):
+                size = self.options['size']
+                self.add_subsystem('comp1', om.ExecComp(['y1=x*2'], y1=np.ones(size), x=np.ones(size)),
+                                promotes_inputs=['*'], promotes_outputs=['*'])
+
+                # Works if you comment out this comp.
+                self.add_subsystem('comp2', om.ExecComp(['y2=x*2'], y2=np.ones(size), x=np.ones(size)),
+                                promotes_inputs=['*'], promotes_outputs=['*'])
+
+
+        class Phase(om.Group):
+            def setup(self):
+                self.add_subsystem('rhs', RHS(size=4))
+
+            def configure(self):
+                self.promotes('rhs', inputs=[('x', 'design:x')],
+                            src_indices=[0, 0, 0, 0], flat_src_indices=True)
+
+                self.set_input_defaults('design:x', 75.3)
+
+
+        class Traj(om.Group):
+            def setup(self):
+                self.add_subsystem('src', om.ExecComp(['q = b*3']))
+
+                self.add_subsystem('phase', Phase())
+
+                self.connect('src.q', 'phase.design:x')
+
+
+        prob = om.Problem(model=Traj())
+
+        prob.setup()
+
+        prob.run_model()

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -325,7 +325,7 @@ class SrcIndicesTests(unittest.TestCase):
                 self.add_subsystem('comp1', om.ExecComp(['y1=x*2'], y1=np.ones(size), x=np.ones(size)),
                                 promotes_inputs=['*'], promotes_outputs=['*'])
 
-                # Works if you comment out this comp.
+                # test with second absolute path for 'x'
                 self.add_subsystem('comp2', om.ExecComp(['y2=x*2'], y2=np.ones(size), x=np.ones(size)),
                                 promotes_inputs=['*'], promotes_outputs=['*'])
 


### PR DESCRIPTION
### Summary

During conversion from promoted to absolute name, only the first absolute name was used when setting src_indices into the metadata.

### Related Issues

- Resolves #1643

### Backwards incompatibilities

None

### New Dependencies

None
