### PR TITLE
clarify deprecation warnings for IndepVarComp args

### DIFF
--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -98,10 +98,9 @@ class IndepVarComp(ExplicitComponent):
         Do any error checking on i/o configuration.
         """
         if len(self._static_var_rel2meta) + len(self._var_rel2meta) == 0:
-            raise RuntimeError("{}: No outputs (independent variables) have been declared. "
-                               "They must either be declared during "
-                               "instantiation or by calling add_output or add_discrete_output "
-                               "afterwards.".format(self.msginfo))
+            raise RuntimeError(f"{self.msginfo}: No outputs (independent variables) have been "
+                               "declared. They must either be declared during instantiation or "
+                               "by calling add_output or add_discrete_output afterwards.")
 
         super(IndepVarComp, self)._configure_check()
 
@@ -141,19 +140,29 @@ class IndepVarComp(ExplicitComponent):
             list_outputs.
         """
         if res_units is not None:
-            warn_deprecation(
-                "'res_units' has been deprecated and will be removed in a future version")
-        elif lower is not None:
-            warn_deprecation("'lower' has been deprecated and will be removed in a future version")
-        elif upper is not None:
-            warn_deprecation("'upper' has been deprecated and will be removed in a future version")
-        elif ref0 is not None:
-            warn_deprecation("'ref0' has been deprecated and will be removed in a future version")
-        elif res_ref is not None:
-            warn_deprecation(
-                "'res_ref' has been deprecated and will be removed in a future version")
-        elif ref is not None:
-            warn_deprecation("'ref' has been deprecated and will be removed in a future version")
+            warn_deprecation(f"{self.msginfo}: The 'res_units' argument was used when adding "
+                             f"output '{name}'. This argument has been deprecated and will be "
+                             "removed in a future version.")
+        if lower is not None:
+            warn_deprecation(f"{self.msginfo}: The 'lower' argument was used when adding "
+                             f"output '{name}'. This argument has been deprecated and will be "
+                             "removed in a future version.")
+        if upper is not None:
+            warn_deprecation(f"{self.msginfo}: The 'upper' argument was used when adding "
+                             f"output '{name}'. This argument has been deprecated and will be "
+                             "removed in a future version.")
+        if ref0 is not None:
+            warn_deprecation(f"{self.msginfo}: The 'ref0' argument was used when adding "
+                             f"output '{name}'. This argument has been deprecated and will be "
+                             "removed in a future version.")
+        if res_ref is not None:
+            warn_deprecation(f"{self.msginfo}: The 'res_ref' argument was used when adding "
+                             f"output '{name}'. This argument has been deprecated and will be "
+                             "removed in a future version.")
+        if ref is not None:
+            warn_deprecation(f"{self.msginfo}: The 'ref' argument was used when adding "
+                             f"output '{name}'. This argument has been deprecated and will be "
+                             "removed in a future version.")
 
         ref = 1.0
         ref0 = 0.0

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
 
 
 class TestIndepVarComp(unittest.TestCase):
@@ -215,60 +215,37 @@ class TestIndepVarComp(unittest.TestCase):
         self.assertEqual(prob.get_val('val_y'), 2.5)
 
     def test_ivc_deprecations(self):
-        # ref0
+        msg = "IndepVarComp (p1): The '{}' argument was used when adding output '{}'. " + \
+              "This argument has been deprecated and will be removed in a future version."
+
+        # ref, ref0
         prob = om.Problem()
 
         indep = prob.model.add_subsystem('p1', om.IndepVarComp())
 
-        msg = "'ref0' has been deprecated and will be removed in a future version"
-        with assert_warning(DeprecationWarning, msg):
-            indep.add_output('x', 12., ref=0.0, ref0=1.)
+        with assert_warnings([(DeprecationWarning, msg.format('ref', 'a')),
+                              (DeprecationWarning, msg.format('ref0', 'a'))]):
+            indep.add_output('a', 12., ref=0.0, ref0=1.)
 
         # res_units
-        prob = om.Problem()
-
-        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
-
-        msg = "'res_units' has been deprecated and will be removed in a future " + \
-              "version"
-        with assert_warning(DeprecationWarning, msg):
-            indep.add_output('x', 12., res_units='m')
+        with assert_warning(DeprecationWarning, msg.format('res_units', 'b')):
+            indep.add_output('b', 12., res_units='m')
 
         # upper
-        prob = om.Problem()
-
-        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
-
-        msg = "'upper' has been deprecated and will be removed in a future version"
-        with assert_warning(DeprecationWarning, msg):
-            indep.add_output('x', 12., upper=1.)
+        with assert_warning(DeprecationWarning, msg.format('upper', 'c')):
+            indep.add_output('c', 12., upper=1.)
 
         # lower
-        prob = om.Problem()
-
-        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
-
-        msg = "'lower' has been deprecated and will be removed in a future version"
-        with assert_warning(DeprecationWarning, msg):
-            indep.add_output('x', 12., lower=1.)
+        with assert_warning(DeprecationWarning, msg.format('lower', 'd')):
+            indep.add_output('d', 12., lower=1.)
 
         # res_ref
-        prob = om.Problem()
-
-        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
-
-        msg = "'res_ref' has been deprecated and will be removed in a future version"
-        with assert_warning(DeprecationWarning, msg):
-            indep.add_output('x', 12., res_ref=1.)
+        with assert_warning(DeprecationWarning, msg.format('res_ref', 'e')):
+            indep.add_output('e', 12., res_ref=1.)
 
         # res_ref
-        prob = om.Problem()
-
-        indep = prob.model.add_subsystem('p1', om.IndepVarComp())
-
-        msg = "'ref' has been deprecated and will be removed in a future version"
-        with assert_warning(DeprecationWarning, msg):
-            indep.add_output('x', 12., ref=2.)
+        with assert_warning(DeprecationWarning, msg.format('ref', 'f')):
+            indep.add_output('f', 12., ref=2.)
 
 
 if __name__ == '__main__':

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -49,7 +49,7 @@ def assert_warning(category, msg):
 @contextmanager
 def assert_warnings(expected_warnings):
     """
-    Context manager asserting that a warning is issued.
+    Context manager asserting that expected warnings are issued.
 
     Parameters
     ----------

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -47,6 +47,34 @@ def assert_warning(category, msg):
 
 
 @contextmanager
+def assert_warnings(expected_warnings):
+    """
+    Context manager asserting that a warning is issued.
+
+    Parameters
+    ----------
+    expected_warnings : iterable of (class, str)
+        The category and text of the expected warnings.
+
+    Raises
+    ------
+    AssertionError
+        If all the expected warnings are not raised.
+    """
+    with reset_warning_registry():
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            yield
+
+    for category, msg in expected_warnings:
+        for warn in w:
+            if (issubclass(warn.category, category) and str(warn.message) == msg):
+                break
+        else:
+            raise AssertionError("Did not see expected %s: %s" % (category.__name__, msg))
+
+
+@contextmanager
 def assert_no_warning(category, msg=None):
     """
     Context manager asserting that a warning is not issued.


### PR DESCRIPTION
### Summary

Clarify warning messages for deprecated  IndepVarComp arguments

### Related Issues

- Resolves #1648

### Backwards incompatibilities

None

### New Dependencies

None
