### PR TITLE
Ga test accuracy

### DIFF
--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -1234,8 +1234,8 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
         prob.driver.options['bits'] = {'x': 16, 'y': 16}  # use enough bits to get accurate answer
-        prob.driver.options['max_gen'] = 25
-        # prob.driver.options['pop_size'] = 25  # use default pop_size of 4x number of bits
+        prob.driver.options['max_gen'] = 30
+        prob.driver.options['pop_size'] = 150
 
         prob.setup()
         prob.run_driver()

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -1233,15 +1233,22 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         prob.driver = om.SimpleGADriver()
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
-        prob.driver.options['bits'] = {'x': 8, 'y': 8}
+        prob.driver.options['bits'] = {'x': 16, 'y': 16}  # use enough bits to get accurate answer
         prob.driver.options['max_gen'] = 25
-        prob.driver.options['pop_size'] = 25
+        # prob.driver.options['pop_size'] = 25  # use default pop_size of 4x number of bits
 
         prob.setup()
         prob.run_driver()
 
-        assert_near_equal(np.sum(prob.get_val('f_xy', get_remote=True))/3,
-                          2.396642317057536, 1e-6)
+        # optimal solution for minimize (x-a)^2 +x*y +(y+4)^2 - 3 for a=[-3, -2.4, -1.8] is:
+        # x =    [ 6.66667,  5.86667,  5.06667]
+        # y =    [-7.33333, -6.93333, -6.53333]
+        # f_xy = [-27.3333, -23.0533, -19.0133]  mean f_xy = -23.1333
+        # loose tests so that few generations are required
+        # assert_near_equal(prob.get_val('x', get_remote=True),    [ 6.66667,  5.86667,  5.06667], 0.2)
+        # assert_near_equal(prob.get_val('y', get_remote=True),    [-7.33333, -6.93333, -6.53333], 0.25)
+        # assert_near_equal(prob.get_val('f_xy', get_remote=True), [-27.3333, -23.0533, -19.0133], 0.2)
+        assert_near_equal(np.sum(prob.get_val('f_xy', get_remote=True))/3, -23.1333, 0.15)
 
 
 class TestFeatureSimpleGA(unittest.TestCase):


### PR DESCRIPTION
### Summary

The SimpleGA MPI unit test_distributed_obj test computes and checks for a result that is inaccurate by an order of magnitude.

This is due to insufficient setting for the bits, max_gen and pop_size options. Increasing those options allows checking for the correct result.

### Related Issues

Increasing these values by too much triggers timeout errors in the Travis tests. This should not happen with the small changes I have tried. If the Travis tests pass for this merge request, the new options are small enough to avoid timeouts but large enough to get the correct answer.

- (Possibly) resolves #1625

### Backwards incompatibilities

None

### New Dependencies

None
