### PR TITLE
Added a new iteration counter for apply_nonlinear.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2049,9 +2049,10 @@ class Group(System):
 
         self._transfer('nonlinear', 'fwd')
         # Apply recursion
-        with Recording(name + '._apply_nonlinear', self.iter_count, self):
-            for subsys in self._subsystems_myproc:
-                subsys._apply_nonlinear()
+        for subsys in self._subsystems_myproc:
+            subsys._apply_nonlinear()
+
+        self.iter_count_apply += 1
 
     def _solve_nonlinear(self):
         """
@@ -2061,6 +2062,8 @@ class Group(System):
 
         with Recording(name + '._solve_nonlinear', self.iter_count, self):
             self._nonlinear_solver.solve()
+
+        # Iteration counter is incremented in the Recording context manager at exit.
 
     def _guess_nonlinear(self):
         """

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -66,16 +66,17 @@ class ImplicitComponent(Component):
         Compute residuals. The model is assumed to be in a scaled state.
         """
         with self._unscaled_context(outputs=[self._outputs], residuals=[self._residuals]):
-            with Recording(self.pathname + '._apply_nonlinear', self.iter_count, self):
-                self._inputs.read_only = self._outputs.read_only = True
-                try:
-                    if self._discrete_inputs or self._discrete_outputs:
-                        self.apply_nonlinear(self._inputs, self._outputs, self._residuals,
-                                             self._discrete_inputs, self._discrete_outputs)
-                    else:
-                        self.apply_nonlinear(self._inputs, self._outputs, self._residuals)
-                finally:
-                    self._inputs.read_only = self._outputs.read_only = False
+            self._inputs.read_only = self._outputs.read_only = True
+            try:
+                if self._discrete_inputs or self._discrete_outputs:
+                    self.apply_nonlinear(self._inputs, self._outputs, self._residuals,
+                                         self._discrete_inputs, self._discrete_outputs)
+                else:
+                    self.apply_nonlinear(self._inputs, self._outputs, self._residuals)
+            finally:
+                self._inputs.read_only = self._outputs.read_only = False
+
+        self.iter_count_apply += 1
 
     def _solve_nonlinear(self):
         """
@@ -97,6 +98,8 @@ class ImplicitComponent(Component):
                             self.solve_nonlinear(self._inputs, self._outputs)
         finally:
             self._inputs.read_only = False
+
+        # Iteration counter is incremented in the Recording context manager at exit.
 
     def _guess_nonlinear(self):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -134,11 +134,16 @@ class System(object):
     under_approx : bool
         When True, this system is undergoing approximation.
     iter_count : int
-        Int that holds the number of times this system has iterated
-        in a recording run.
+        Counts the number of times this system has called _solve_nonlinear. This also
+        corresponds to the number of times that the system's outputs are recorded if a recorder
+        is present.
+    iter_count_apply : int
+        Counts the number of times the system has called _apply_nonlinear. For ExplicitComponent,
+        calls to apply_nonlinear also call compute, so number of executions can be found by adding
+        this and iter_count together. Recorders do no record calls to apply_nonlinear.
     iter_count_without_approx : int
-        Int that holds the number of times this system has iterated
-        in a recording run excluding any calls due to approximation schemes.
+        Counts the number of times the system has iterated but excludes any that occur during
+        approximation of derivatives.
     cite : str
         Listing of relevant citations that should be referenced when
         publishing work that uses this class.
@@ -366,8 +371,9 @@ class System(object):
 
         self._problem_meta = None
 
-        # Case recording related
+        # Counting iterations.
         self.iter_count = 0
+        self.iter_count_apply = 0
         self.iter_count_without_approx = 0
 
         self.cite = ""
@@ -3871,6 +3877,7 @@ class System(object):
 
             self._rec_mgr.record_iteration(self, data, metadata)
 
+        # All calls to _solve_nonlinear are recorded, The counter is incremented after recording.
         self.iter_count += 1
         if not self.under_approx:
             self.iter_count_without_approx += 1
@@ -3900,6 +3907,9 @@ class System(object):
         """
         for s in self.system_iter(include_self=True, recurse=True):
             s.iter_count = 0
+            s.iter_count_apply = 0
+            s.iter_count_without_approx = 0
+
             if s._linear_solver:
                 s._linear_solver._iter_count = 0
             if s._nonlinear_solver:

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -111,7 +111,8 @@ class TestGroupFiniteDifference(unittest.TestCase):
         # 1. run_model; 2. step x; 3. step y
         self.assertEqual(model.parab.count, 3)
         self.assertEqual(model.parab.iter_count_without_approx, 1)
-        self.assertEqual(model.parab.iter_count, 3)
+        self.assertEqual(model.parab.iter_count, 1)
+        self.assertEqual(model.parab.iter_count_apply, 2)
 
     def test_fd_count_driver(self):
         # Make sure we aren't doing FD wrt any var that isn't in the driver desvar set.

--- a/openmdao/docs/theory_manual/index.rst
+++ b/openmdao/docs/theory_manual/index.rst
@@ -18,6 +18,7 @@ mathematical manner to help users gain a deeper understanding of how the framewo
    setup_stack.rst
    solver_api.rst
    scaling.rst
+   iter_count.rst
 
 
 Total Derivatives Theory

--- a/openmdao/docs/theory_manual/iter_count.rst
+++ b/openmdao/docs/theory_manual/iter_count.rst
@@ -1,0 +1,35 @@
+************************************************
+Determining How Many Times a System was Executed
+************************************************
+
+All OpenMDAO `Systems` have a set of local counters that keep track of how many times they have
+been executed.
+
+**iter_count**
+
+    Counts the number of times this system has called _solve_nonlinear. This also
+    corresponds to the number of times that the system's outputs are recorded if a recorder
+    is present.
+
+**iter_count_apply**
+
+    Counts the number of times the system has called _apply_nonlinear. For ExplicitComponent,
+    calls to apply_nonlinear also call compute, so number of executions can be found by adding
+    this and iter_count together. Recorders do no record calls to _apply_nonlinear.
+
+**iter_count_without_approx**
+
+    Counts the number of times the system has iterated but excludes any that occur during
+    approximation of derivatives.
+
+When you have an `ExplicitComponent`, the number stored in iter_count may not match the total
+number of times that the "compute" function has been called.  This is because compute is also
+called whenever '_apply_nonlinear' is called to compute the norm of the current residual. For
+and explicit equation, the residual is defined as the difference in the value of the outputs
+before and after execution, and an additional execution is required to compute this.
+
+The correct execution count for an ExplicitComponent can always be obtained by adding iter_count
+and iter_count_apply.
+
+The recorder iteration coordinate will always match the iter_count because calls to apply_nonlinear
+are not recorded.

--- a/openmdao/docs/theory_manual/iter_count.rst
+++ b/openmdao/docs/theory_manual/iter_count.rst
@@ -25,7 +25,7 @@ been executed.
 When you have an `ExplicitComponent`, the number stored in iter_count may not match the total
 number of times that the "compute" function has been called.  This is because compute is also
 called whenever '_apply_nonlinear' is called to compute the norm of the current residual. For
-and explicit equation, the residual is defined as the difference in the value of the outputs
+an explicit equation, the residual is defined as the difference in the value of the outputs
 before and after execution, and an additional execution is required to compute this.
 
 The correct execution count for an ExplicitComponent can always be obtained by adding iter_count


### PR DESCRIPTION
### Summary

1. Added a new iteration counter 'iter_count_apply' for apply_nonlinear. Summing this and `iter_count` will give you the total number of calls to `execute` on an ExplicitComponent.
2. Removed context manager from all calls to apply_nonlinear, as we don't want to record these anyway.
3, Added a short explanation on counting component executions to the Theory manual.
4. Fixed a bug where `iter_count_without_approx` was not reset.

### Related Issues

- Resolves #1651

### Backwards incompatibilities

None

### New Dependencies

None
