### PR TITLE
Added error checks for a couple of get_val corner cases, plus some cleanups.

### DIFF
--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -80,9 +80,10 @@ class TestBalanceComp(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
-        self.assertEqual(prob._metadata['meta']['balance.x']['units'], 'm')
-        self.assertEqual(prob._metadata['meta']['balance.rhs:x']['units'], 'm')
-        self.assertEqual(prob._metadata['meta']['balance.lhs:x']['units'], 'm')
+        meta = prob.model._var_abs2meta
+        self.assertEqual(meta['balance.x']['units'], 'm')
+        self.assertEqual(meta['balance.rhs:x']['units'], 'm')
+        self.assertEqual(meta['balance.lhs:x']['units'], 'm')
 
     def test_create_on_init(self):
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -10,8 +10,9 @@ from scipy.sparse import issparse
 
 from openmdao.core.system import System, _supported_methods, _DEFAULT_COLORING_META, \
     global_meta_names
+from openmdao.core.constants import INT_DTYPE
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
-from openmdao.vectors.vector import INT_DTYPE, _full_slice
+from openmdao.vectors.vector import _full_slice
 from openmdao.utils.units import valid_units
 from openmdao.utils.name_maps import rel_key2abs_key, abs_key2rel_key, rel_name2abs_name
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -451,11 +451,10 @@ class Component(System):
         if src_indices is not None:
             if _is_slicer_op(src_indices):
                 src_slice = src_indices
-                if flat_src_indices or flat_src_indices is None:
-                    flat_src_indices = True
-                else:
-                    raise RuntimeError(f"{self.msginfo}: when setting src_indices to a slice, "
-                                       "flat_src_indices must not be False.")
+                if flat_src_indices is not None:
+                    simple_warning(f"{self.msginfo}: Input '{name}' was added with slice "
+                                   "src_indices, so flat_src_indices is ignored.")
+                flat_src_indices = True
             else:
                 src_indices = np.asarray(src_indices, dtype=INT_DTYPE)
 
@@ -466,9 +465,9 @@ class Component(System):
             'value': value,
             'shape': shape,
             'size': np.prod(shape),
-            'src_indices': src_indices,
+            'src_indices': src_indices,  # these will ultimately be converted to a flat index array
             'flat_src_indices': flat_src_indices,
-            'src_slice': src_slice,
+            'src_slice': src_slice,  # store slice def here, if any.  This is never overwritten
             'units': units,
             'desc': desc,
             'distributed': self.options['distributed'],

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -262,7 +262,8 @@ class Component(System):
             allprocs_abs2meta[abs_name]['has_src_indices'] = metadata['src_indices'] is not None
 
             # ensure that if src_indices is a slice we reset it to that instead of
-            # the converted array value (in case this is a re-setup)
+            # the converted array value (in case this is a re-setup), so that we can
+            # re-convert using potentially different sizing information.
             if metadata['src_slice'] is not None:
                 metadata['src_indices'] = metadata['src_slice']
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -320,8 +320,6 @@ class Component(System):
 
         self._owned_sizes = self._var_sizes['nonlinear']['output']
 
-        self._setup_global_shapes()
-
     def _setup_partials(self):
         """
         Process all partials and approximations that the user declared.

--- a/openmdao/core/constants.py
+++ b/openmdao/core/constants.py
@@ -2,7 +2,15 @@
 Various objects to be used as constants.
 """
 
+import os
 from enum import IntEnum
+import numpy as np
+
+# This is the dtype we use for index arrays.  Petsc by default uses 32 bit ints
+if os.environ.get('OPENMDAO_USE_BIG_INTS'):
+    INT_DTYPE = np.dtype(np.int64)
+else:
+    INT_DTYPE = np.dtype(np.int32)
 
 
 class _SetupStatus(IntEnum):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -8,6 +8,7 @@ import weakref
 import numpy as np
 
 from openmdao.core.total_jac import _TotalJacInfo
+from openmdao.core.constants import INT_DTYPE
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.record_util import create_local_meta, check_path
@@ -16,7 +17,7 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.array_utils import sizes2offsets, convert_neg
-from openmdao.vectors.vector import INT_DTYPE, _full_slice
+from openmdao.vectors.vector import _full_slice
 
 
 def _check_debug_print_opts_valid(name, opts):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -597,10 +597,6 @@ class Group(System):
         return prom2abs
 
     def _top_level_setup(self, mode):
-        self._problem_meta['connections'] = conns = self._conn_global_abs_in2out
-        self._problem_meta['all_meta'] = self._var_allprocs_abs2meta
-        self._problem_meta['meta'] = self._var_abs2meta
-
         rsystems = self._find_remote_sys_owners()
         self._problem_meta['remote_vars'] = self._find_remote_var_owners(rsystems)
         self._problem_meta['prom2abs'] = self._get_all_promotes(rsystems)
@@ -615,7 +611,7 @@ class Group(System):
         """
         prom2abs_in = self._var_allprocs_prom2abs_list['input']
         prom2abs_out = self._var_allprocs_prom2abs_list['output']
-        abs2meta = self._problem_meta['all_meta']
+        abs2meta = self._problem_meta['model_ref']()._var_allprocs_abs2meta
 
         for absname in abs2meta:
             if absname in prom2abs_in:
@@ -2813,7 +2809,7 @@ class Group(System):
         abs2prom = self._var_allprocs_abs2prom['input']
         abs2meta = self._var_abs2meta
         all_abs2meta = self._var_allprocs_abs2meta
-        conns = self._problem_meta['connections']
+        conns = self._conn_global_abs_in2out
         auto_tgts = [n for n in self._var_allprocs_abs_names['input'] if n not in conns]
         for tgt in auto_tgts:
             prom = abs2prom[tgt]
@@ -2931,7 +2927,7 @@ class Group(System):
         # This should only be called on the top level Group.
 
         srcconns = defaultdict(list)
-        for tgt, src in self._problem_meta['connections'].items():
+        for tgt, src in self._conn_global_abs_in2out.items():
             if src.startswith('_auto_ivc.'):
                 srcconns[src].append(tgt)
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -13,9 +13,9 @@ import numpy as np
 import networkx as nx
 
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
-from openmdao.core.system import System, INT_DTYPE
+from openmdao.core.system import System
 from openmdao.core.component import Component, _DictValues, _full_slice
-from openmdao.core.constants import _UNDEFINED
+from openmdao.core.constants import _UNDEFINED, INT_DTYPE
 from openmdao.proc_allocators.default_allocator import DefaultAllocator, ProcAllocationError
 from openmdao.jacobians.jacobian import SUBJAC_META_DEFAULTS
 from openmdao.recorders.recording_iteration_stack import Recording
@@ -1240,7 +1240,7 @@ class Group(System):
                             else:
                                 simple_warning(msg)
                                 continue
-                        meta['src_indices'] = np.atleast_1d(src_indices)
+                        meta['src_indices'] = src_indices
                         meta['flat_src_indices'] = flat_src_indices
 
                     src_ind_inputs.add(abs_in)
@@ -1481,9 +1481,8 @@ class Group(System):
                         global_size = self._var_allprocs_abs2meta[abs_out]['global_size']
                         global_shape = self._var_allprocs_abs2meta[abs_out]['global_shape']
                         src_indices = _slice_indices(src_indices, global_size, global_shape)
+                        abs2meta[abs_in]['src_indices'] = src_indices  # store converted value
                         shape = True
-                    else:
-                        src_indices = np.atleast_1d(src_indices)
 
                     if np.prod(src_indices.shape) == 0:
                         continue
@@ -1930,9 +1929,7 @@ class Group(System):
             src_indices = np.atleast_1d(src_indices)
 
         if isinstance(src_indices, np.ndarray):
-            if not np.issubdtype(src_indices.dtype, np.integer) and not \
-                    any(i == ... for i in src_indices):
-
+            if not np.issubdtype(src_indices.dtype, np.integer):
                 raise TypeError("%s: src_indices must contain integers, but src_indices for "
                                 "connection from '%s' to '%s' is %s." %
                                 (self.msginfo, src_name, tgt_name, src_indices.dtype.type))

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -608,10 +608,12 @@ class Group(System):
     def _check_prom_masking(self):
         """
         Raise exception if any promoted variable name masks an absolute variable name.
+
+        Only called on the top level group.
         """
         prom2abs_in = self._var_allprocs_prom2abs_list['input']
         prom2abs_out = self._var_allprocs_prom2abs_list['output']
-        abs2meta = self._problem_meta['model_ref']()._var_allprocs_abs2meta
+        abs2meta = self._var_allprocs_abs2meta
 
         for absname in abs2meta:
             if absname in prom2abs_in:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1474,6 +1474,7 @@ class Group(System):
                 in_shape = meta_in['shape']
                 src_indices = self._get_src_inds_array(abs_in)
                 flat = meta_in['flat_src_indices']
+                has_slice = meta_in['src_slice'] is not None
 
                 if src_indices is None and out_shape != in_full_shape:
                     # out_shape != in_shape is allowed if
@@ -1494,8 +1495,12 @@ class Group(System):
                     if np.prod(src_indices.shape) == 0:
                         continue
 
-                    flat_array_slice_check = not (meta_in['src_slice'] is not None and
+                    flat_array_slice_check = not (has_slice and
                                                   src_indices.size == np.prod(in_shape))
+
+                    if has_slice and meta_in['flat_src_indices'] is not None:
+                        simple_warning(f"{self.msginfo}: flat_src_indices has no effect when "
+                                       "using om_slicer to slice array.")
 
                     if flat_array_slice_check:
                         # initial dimensions of indices shape must be same shape as target

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -422,7 +422,7 @@ class Problem(object):
         """
         model = self.model
         if self._metadata is not None:
-            conns = self._metadata['connections']
+            conns = model._conn_global_abs_in2out
         else:
             raise RuntimeError(f"{self.msginfo}: '{name}' Cannot call set_val before setup.")
 
@@ -860,7 +860,6 @@ class Problem(object):
             'solver_info': SolverInfo(),
             'use_derivatives': derivatives,
             'force_alloc_complex': force_alloc_complex,
-            'connections': {},  # all connections in the model (after setup)
             'remote_vars': {},  # vars that are remote somewhere. does not include distrib vars
             'prom2abs': {'input': {}, 'output': {}},  # includes ALL promotes including buried ones
             'static_mode': False,  # used to determine where various 'static'
@@ -873,11 +872,9 @@ class Problem(object):
             'parallel_groups': [],  # list of pathnames of parallel groups in this model (all procs)
             'setup_status': _SetupStatus.PRE_SETUP,
             'vec_names': None,  # names of all nonlinear and linear vectors
-            'line_vec_names': None,  # names of linear vectors
-            'abs2idx': None,  # mapping of var name to index into var sizes array
-            'sizes': None,  # var size arrays
-            'owning_rank': None,  # MPI rank that 'owns' a given non-distributed variable
-            'model_ref': weakref.ref(model)
+            'lin_vec_names': None,  # names of linear vectors
+            'model_ref': weakref.ref(model)  # ref to the model (needed to get out-of-scope
+                                             # src data for inputs)
         }
         model._setup(model_comm, mode, self._metadata)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1872,11 +1872,10 @@ class System(object):
                     meta['src_indices'] = src_indices
                     if _is_slicer_op(src_indices):
                         meta['src_slice'] = src_indices
-                        if flat_src_indices or flat_src_indices is None:
-                            flat_src_indices = True
-                        else:
-                            raise RuntimeError(f"{self.msginfo}: when setting src_indices to a "
-                                               f"slice, flat_src_indices must not be False.")
+                        if flat_src_indices is not None:
+                            simple_warning(f"{self.msginfo}: Input '{name}' was promoted with "
+                                           "slice src_indices, so flat_src_indices is ignored.")
+                        flat_src_indices = True
                     meta['flat_src_indices'] = flat_src_indices
 
         def resolve(to_match, io_types, matches, proms):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -645,7 +645,7 @@ class System(object):
         self._setup_global_connections()
 
         if self.pathname == '':
-            self._top_level_setup(mode)
+            self._top_level_post_connections(mode)
 
         # Now that connections are setup, we need to convert relevant vector names into their
         # auto_ivc source where applicable.
@@ -664,15 +664,17 @@ class System(object):
         self._setup_var_sizes()
 
         if self.pathname == '':
-            self._top_level_setup2()
+            self._top_level_post_sizes()
 
         self._setup_connections()
 
-    def _top_level_setup(self, mode):
+    def _top_level_post_connections(self, mode):
+        # this runs after all connections are known
         pass
 
-    def _top_level_setup2(self):
-        pass
+    def _top_level_post_sizes(self):
+        # this runs after the variable sizes are known
+        self._setup_global_shapes()
 
     def _configure_check(self):
         """
@@ -1338,10 +1340,10 @@ class System(object):
         meta = self._var_allprocs_abs2meta
         loc_meta = self._var_abs2meta
 
-        for typ in ('input', 'output'):
+        for io in ('input', 'output'):
             # now set global sizes and shapes into metadata for distributed variables
-            sizes = self._var_sizes['nonlinear'][typ]
-            for idx, abs_name in enumerate(self._var_allprocs_abs_names[typ]):
+            sizes = self._var_sizes['nonlinear'][io]
+            for idx, abs_name in enumerate(self._var_allprocs_abs_names[io]):
                 mymeta = meta[abs_name]
                 local_shape = mymeta['shape']
                 if mymeta['distributed']:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4338,11 +4338,15 @@ class System(object):
                         if src_indices.size > 0:
                             src_indices = src_indices - np.min(src_indices)
                         val = val.ravel()[src_indices]
+                        fail = 0
                     else:
+                        fail = 1
+                    if self.comm.allreduce(fail) > 0:
                         raise RuntimeError(f"{self.msginfo}: Can't retrieve distributed variable "
-                                           f"'{abs_name}' without setting 'get_remote=True' "
-                                           f"because its src_indices reference entries from other "
-                                           "ranks.")
+                                           f"'{abs_name}' because its src_indices reference "
+                                           "entries from other processes. You can retrieve values "
+                                           "from all processes using "
+                                           "`get_val(<name>, get_remote=True)`.")
                 else:
                     val = val.ravel()[src_indices]
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -73,7 +73,7 @@ _recordable_funcs = frozenset(['_apply_linear', '_apply_nonlinear', '_solve_line
 
 # the following are local metadata that will also be accessible for vars on all procs
 global_meta_names = {
-    'input': ('units', 'shape', 'size', 'distributed', 'tags', 'desc', 'src_slice'),
+    'input': ('units', 'shape', 'size', 'distributed', 'tags', 'desc'),
     'output': ('units', 'shape', 'size', 'desc',
                'ref', 'ref0', 'res_ref', 'distributed', 'lower', 'upper', 'tags'),
 }

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1028,6 +1028,7 @@ class MatMultMultipointTestCase(unittest.TestCase):
 
         model.add_objective('obj.y')
 
+        #import wingdbstub
         p.setup()
 
         p.run_driver()
@@ -1037,11 +1038,10 @@ class MatMultMultipointTestCase(unittest.TestCase):
         for i in range(num_pts):
             cname = 'par2.comp%d' % i
             vname = cname + '.A'
-            if vname in model._var_abs_names['input']:
-                A1 = p.get_val('par1.comp%d.A'%i)
-                A2 = p.get_val('par2.comp%d.A'%i)
-                norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] - A2.dot(A1))
-                self.assertLess(norm, 1.e-7)
+            A1 = p.get_val('par1.comp%d.A'%i, get_remote=True)
+            A2 = p.get_val('par2.comp%d.A'%i, get_remote=True)
+            norm = np.linalg.norm(J['par2.comp%d.y'%i,'indep%d.x'%i] - A2.dot(A1))
+            self.assertLess(norm, 1.e-7)
 
         print("final obj:", p['obj.y'])
 

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -1028,7 +1028,6 @@ class MatMultMultipointTestCase(unittest.TestCase):
 
         model.add_objective('obj.y')
 
-        #import wingdbstub
         p.setup()
 
         p.run_driver()

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -347,6 +347,30 @@ class MPITests(unittest.TestCase):
 
     N_PROCS = 2
 
+    def test_dist_to_nondist_err(self):
+        size = 5
+        p = om.Problem()
+        model = p.model
+        model.add_subsystem('indep', om.IndepVarComp('x', np.ones(size)))
+        model.add_subsystem("Cdist", DistribInputDistribOutputComp(arr_size=size))
+        model.add_subsystem("Cserial", InOutArrayComp(arr_size=size))
+        model.connect('indep.x', 'Cdist.invec')
+        model.connect('Cdist.outvec', 'Cserial.invec')
+        p.setup()
+        p.run_model()
+        msg = "Group (<model>): Non-distributed variable 'Cserial.invec' has a distributed source, 'Cdist.outvec', so you must retrieve its value using 'get_remote=True'."
+        with self.assertRaises(Exception) as cm:
+            p['Cserial.invec']
+        self.assertEqual(str(cm.exception), msg)
+
+        with self.assertRaises(Exception) as cm:
+            p.get_val('Cserial.invec')
+        self.assertEqual(str(cm.exception), msg)
+
+        with self.assertRaises(Exception) as cm:
+            p.get_val('Cserial.invec', get_remote=False)
+        self.assertEqual(str(cm.exception), msg)
+
     def test_distrib_full_in_out(self):
         size = 11
 

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -371,6 +371,23 @@ class MPITests(unittest.TestCase):
             p.get_val('Cserial.invec', get_remote=False)
         self.assertEqual(str(cm.exception), msg)
 
+    def test_dist_to_dist_get_remote_False_err(self):
+        size = 5
+        p = om.Problem()
+        model = p.model
+        model.add_subsystem('indep', om.IndepVarComp('x', np.ones(size*2)))
+        model.add_subsystem("Cdist", DistribInputDistribOutputComp(arr_size=size*2))
+        model.add_subsystem("Cdist2", DistribInputDistribOutputComp(arr_size=size))
+        model.connect('indep.x', 'Cdist.invec')
+        model.connect('Cdist.outvec', 'Cdist2.invec')
+        #import wingdbstub
+        p.setup()
+        p.run_model()
+        msg = "Group (<model>): Can't retrieve distributed variable 'Cdist2.invec' because its src_indices reference entries from other processes. You can retrieve values from all processes using `get_val(<name>, get_remote=True)`."
+        with self.assertRaises(Exception) as cm:
+            p.get_val('Cdist2.invec', get_remote=False)
+        self.assertEqual(str(cm.exception), msg)
+
     def test_distrib_full_in_out(self):
         size = 11
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1354,7 +1354,8 @@ class TestGroupMPISlice(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        assert_near_equal(p['C1.x'], np.array([3, 3, 3, 3]))
+        val = p.get_val('C1.x', get_remote=False)
+        assert_near_equal(val, np.array([3, 3, 3, 3]))
 
     def test_om_slice_3d_mpi(self):
         class MyComp1(om.ExplicitComponent):

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -598,7 +598,7 @@ class TestGroup(unittest.TestCase):
         p.model.connect('indep.x', 'row123_comp.x', src_indices=om.slicer[idxs, ...],
                         flat_src_indices=True)
 
-        msg = "Group (<model>): flat_src_indices has no effect when using om_slicer to slice array."
+        msg = "Group (<model>): Connection from 'indep.x' to 'row123_comp.x' was added with slice src_indices, so flat_src_indices is ignored."
         with assert_warning(UserWarning, msg):
             p.setup()
         p.run_model()

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -10,7 +10,7 @@ import time
 
 import numpy as np
 
-from openmdao.vectors.vector import INT_DTYPE
+from openmdao.core.constants import INT_DTYPE
 from openmdao.utils.general_utils import ContainsAll, simple_warning, prom2ivc_src_dict
 
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -124,7 +124,7 @@ class _TotalJacInfo(object):
         driver = problem.driver
         prom2abs = problem.model._var_allprocs_prom2abs_list['output']
         prom2abs_in = problem.model._var_allprocs_prom2abs_list['input']
-        conns = problem._metadata['connections']
+        conns = problem.model._conn_global_abs_in2out
 
         self.model = model = problem.model
         self.comm = problem.comm

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -10,7 +10,6 @@ from openmdao.matrices.coo_matrix import COOMatrix
 from openmdao.matrices.csr_matrix import CSRMatrix
 from openmdao.matrices.csc_matrix import CSCMatrix
 from openmdao.utils.units import unit_conversion
-from openmdao.utils.array_utils import _flatten_src_indices
 
 _empty_dict = {}
 
@@ -160,12 +159,7 @@ class AssembledJacobian(Jacobian):
                         # instead of d(output)/d(input).  int_mtx is a square matrix whose
                         # rows and columns map to output/resid vars only.
                         abs_key2 = (res_abs_name, out_abs_name)
-
                         shape = abs_key2shape(abs_key2)
-                        if len(src_indices.shape) > 1:
-                            src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
-                                                               all_out_meta['global_shape'],
-                                                               all_out_meta['global_size'])
 
                     int_mtx._add_submat(abs_key, info, res_offset, out_offset,
                                         src_indices, shape, factor)

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -382,7 +382,7 @@ class SqliteRecorder(CaseRecorder):
             abs2prom = json.dumps(self._abs2prom)
             prom2abs = json.dumps(self._prom2abs)
             abs2meta = json.dumps(self._abs2meta)
-            conns = json.dumps(system._problem_meta.get('connections', {}))
+            conns = json.dumps(system._problem_meta['model_ref']()._conn_global_abs_in2out)
 
             var_settings = {}
             var_settings.update(desvars)

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -77,15 +77,17 @@ def take_nth(rank, size, seq):
                     return
 
 
-def convert_neg(arr, dim):
+def convert_neg(arr, size):
     """
     Convert any negative indices into their positive equivalent.
+
+    This only works for a 1D array.
 
     Parameters
     ----------
     arr : ndarray
         Array having negative indices converted.
-    dim : int
+    size : int
         Dimension of the array.
 
     Returns
@@ -93,7 +95,7 @@ def convert_neg(arr, dim):
     ndarray
         The converted array.
     """
-    arr[arr < 0] += dim
+    arr[arr < 0] += size
     return arr
 
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -22,6 +22,7 @@ import importlib
 import numpy as np
 import openmdao
 
+from openmdao.core.constants import INT_DTYPE
 
 # Certain command line tools can make use of this to allow visualization of models when errors
 # are present that would normally cause setup to abort.
@@ -245,11 +246,12 @@ def ensure_compatible(name, value, shape=None, indices=None):
         value = np.asarray(value)
 
     if indices is not None:
-        indices = np.atleast_1d(indices)
         contains_slicer = _is_slicer_op(indices)
-        ind_shape = indices.shape
+        if not contains_slicer:
+            indices = np.atleast_1d(np.asarray(indices, dtype=INT_DTYPE))
+            ind_shape = indices.shape
     else:
-        contains_slicer = None
+        contains_slicer = False
 
     # if shape is not given, infer from value (if not scalar) or indices
     if shape is not None:
@@ -284,7 +286,7 @@ def ensure_compatible(name, value, shape=None, indices=None):
                                  "Expected %s but got %s." %
                                  (name, shape, value.shape))
 
-    if indices is not None and shape != ind_shape[:len(shape)] and not contains_slicer:
+    if indices is not None and not contains_slicer and shape != ind_shape[:len(shape)]:
         raise ValueError("Shape of indices does not match shape for '%s': "
                          "Expected %s but got %s." %
                          (name, shape, ind_shape[:len(shape)]))
@@ -1059,13 +1061,10 @@ def _is_slicer_op(indices):
     bool
         Returns True if indices contains a colon or ellipsis operator.
     """
-    if isinstance(indices, Iterable):
-        if isinstance(indices, (tuple, list, range, str)):
-            return any(isinstance(i, slice) or i is ... for i in indices)
-        else:
-            return any(isinstance(i, slice) or i is ... for i in indices.flatten())
-    else:
-        return isinstance(indices, slice)
+    if isinstance(indices, tuple):
+        return any(isinstance(i, slice) or i is ... for i in indices)
+
+    return isinstance(indices, slice)
 
 
 def _slice_indices(slicer, out_size, out_shape):

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1085,7 +1085,7 @@ def _slice_indices(slicer, arr_size, arr_shape):
     array
         Returns the sliced indices.
     """
-    return np.arange(arr_size, dtype=INT_DTYPE).reshape(arr_shape)[tuple(slicer)]
+    return np.arange(arr_size, dtype=INT_DTYPE).reshape(arr_shape)[slicer]
 
 
 def prom2ivc_src_dict(prom_dict):

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -45,7 +45,7 @@ def ignore_errors(flag=None):
     """
     global _ignore_errors
     if flag is not None:
-        _ignore_errors = True
+        _ignore_errors = flag
     return _ignore_errors
 
 
@@ -1067,17 +1067,17 @@ def _is_slicer_op(indices):
     return isinstance(indices, slice)
 
 
-def _slice_indices(slicer, out_size, out_shape):
+def _slice_indices(slicer, arr_size, arr_shape):
     """
-    Check if an array of indices contains a slice object.
+    Return an index array based on a slice or slice tuple and the array size and shape.
 
     Parameters
     ----------
-    slicer : slice
+    slicer : slice or tuple containing slices
         Slice object to slice array
-    out_size : int
+    arr_size : int
         Size of output array
-    out_shape : tuple
+    arr_shape : tuple
         Tuple of output array shape
 
     Returns
@@ -1085,7 +1085,7 @@ def _slice_indices(slicer, out_size, out_shape):
     array
         Returns the sliced indices.
     """
-    return np.arange(out_size, dtype=int).reshape(out_shape)[tuple(slicer)]
+    return np.arange(arr_size, dtype=INT_DTYPE).reshape(arr_shape)[tuple(slicer)]
 
 
 def prom2ivc_src_dict(prom_dict):

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -5,10 +5,10 @@ from collections import defaultdict
 
 import numpy as np
 
-from openmdao.vectors.vector import INT_DTYPE
+from openmdao.core.constants import INT_DTYPE
 from openmdao.vectors.transfer import Transfer
 from openmdao.utils.array_utils import convert_neg, _global2local_offsets, _flatten_src_indices
-from openmdao.utils.general_utils import _is_slicer_op, _slice_indices
+from openmdao.utils.general_utils import _is_slicer_op
 from openmdao.utils.mpi import MPI
 
 _empty_idx_array = np.array([], dtype=INT_DTYPE)
@@ -93,22 +93,13 @@ class DefaultTransfer(Transfer):
 
                     # Read in and process src_indices
                     src_indices = meta_in['src_indices']
-                    if src_indices is None:
-                        pass
-                    elif src_indices.ndim == 1:
-                        if isinstance(src_indices, tuple) or \
-                                     (isinstance(src_indices, np.ndarray) and
-                                      src_indices.dtype == object):
-                            if _is_slicer_op(src_indices):
-                                indices = _slice_indices(src_indices, meta_out['global_size'],
-                                                         meta_out['global_shape'])
-                                src_indices = convert_neg(indices, meta_out['global_size'])
-                        else:
+                    if not (src_indices is None or _is_slicer_op(src_indices)):
+                        if src_indices.ndim == 1:
                             src_indices = convert_neg(src_indices, meta_out['global_size'])
-                    else:
-                        src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
-                                                           meta_out['global_shape'],
-                                                           meta_out['global_size'])
+                        else:
+                            src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
+                                                               meta_out['global_shape'],
+                                                               meta_out['global_size'])
                         meta_in['src_indices'] = src_indices
 
                     # 1. Compute the output indices

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from openmdao.core.constants import INT_DTYPE
 from openmdao.vectors.transfer import Transfer
-from openmdao.utils.array_utils import convert_neg, _global2local_offsets, _flatten_src_indices
+from openmdao.utils.array_utils import convert_neg, _global2local_offsets
 from openmdao.utils.general_utils import _is_slicer_op
 from openmdao.utils.mpi import MPI
 
@@ -96,10 +96,6 @@ class DefaultTransfer(Transfer):
                     if src_indices is not None:
                         if src_indices.ndim == 1:
                             src_indices = convert_neg(src_indices, meta_out['global_size'])
-                        else:
-                            src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
-                                                               meta_out['global_shape'],
-                                                               meta_out['global_size'])
 
                     # 1. Compute the output indices
                     offset = offsets_out[iproc, idx_out]

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -93,14 +93,13 @@ class DefaultTransfer(Transfer):
 
                     # Read in and process src_indices
                     src_indices = meta_in['src_indices']
-                    if not (src_indices is None or _is_slicer_op(src_indices)):
+                    if src_indices is not None:
                         if src_indices.ndim == 1:
                             src_indices = convert_neg(src_indices, meta_out['global_size'])
                         else:
                             src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
                                                                meta_out['global_shape'],
                                                                meta_out['global_size'])
-                        meta_in['src_indices'] = src_indices
 
                     # 1. Compute the output indices
                     offset = offsets_out[iproc, idx_out]

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -4,7 +4,8 @@ import numbers
 
 import numpy as np
 
-from openmdao.vectors.vector import Vector, INT_DTYPE, _full_slice
+from openmdao.core.constants import INT_DTYPE
+from openmdao.vectors.vector import Vector, _full_slice
 from openmdao.vectors.default_transfer import DefaultTransfer
 from openmdao.utils.mpi import MPI, multi_proc_exception_check
 

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -8,7 +8,7 @@ from openmdao.vectors.transfer import Transfer
 from openmdao.vectors.default_transfer import DefaultTransfer, _merge
 from openmdao.core.constants import INT_DTYPE
 from openmdao.utils.mpi import MPI
-from openmdao.utils.array_utils import convert_neg, _flatten_src_indices
+from openmdao.utils.array_utils import convert_neg
 from openmdao.utils.general_utils import _is_slicer_op
 
 _empty_idx_array = np.array([], dtype=INT_DTYPE)
@@ -126,10 +126,6 @@ class PETScTransfer(DefaultTransfer):
                             src_indices = np.arange(meta_in['size'], dtype=INT_DTYPE)
                     elif src_indices.ndim == 1:
                         src_indices = convert_neg(src_indices, meta_out['global_size'])
-                    else:
-                        src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
-                                                           meta_out['global_shape'],
-                                                           meta_out['global_size'])
 
                     # 1. Compute the output indices
                     # NOTE: src_indices are relative to a single, possibly distributed variable,

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -124,14 +124,12 @@ class PETScTransfer(DefaultTransfer):
                         # is defined.
                         if meta_in['size'] > sizes_out[owner, idx_out]:
                             src_indices = np.arange(meta_in['size'], dtype=INT_DTYPE)
-                    elif not _is_slicer_op(src_indices):
-                        if src_indices.ndim == 1:
-                            src_indices = convert_neg(src_indices, meta_out['global_size'])
-                        else:
-                            src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
-                                                               meta_out['global_shape'],
-                                                               meta_out['global_size'])
-                        meta_in['src_indices'] = src_indices
+                    elif src_indices.ndim == 1:
+                        src_indices = convert_neg(src_indices, meta_out['global_size'])
+                    else:
+                        src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
+                                                           meta_out['global_shape'],
+                                                           meta_out['global_size'])
 
                     # 1. Compute the output indices
                     # NOTE: src_indices are relative to a single, possibly distributed variable,

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -6,10 +6,10 @@ from collections import defaultdict
 
 from openmdao.vectors.transfer import Transfer
 from openmdao.vectors.default_transfer import DefaultTransfer, _merge
-from openmdao.vectors.vector import INT_DTYPE
+from openmdao.core.constants import INT_DTYPE
 from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import convert_neg, _flatten_src_indices
-from openmdao.utils.general_utils import _is_slicer_op, _slice_indices
+from openmdao.utils.general_utils import _is_slicer_op
 
 _empty_idx_array = np.array([], dtype=INT_DTYPE)
 
@@ -124,15 +124,14 @@ class PETScTransfer(DefaultTransfer):
                         # is defined.
                         if meta_in['size'] > sizes_out[owner, idx_out]:
                             src_indices = np.arange(meta_in['size'], dtype=INT_DTYPE)
-                    elif src_indices.ndim == 1:
-                        if _is_slicer_op(src_indices):
-                            indices = _slice_indices(src_indices, meta_out['global_size'],
-                                                     meta_out['global_shape'])
-                            src_indices = convert_neg(indices, meta_out['global_size'])
-                    else:
-                        src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
-                                                           meta_out['global_shape'],
-                                                           meta_out['global_size'])
+                    elif not _is_slicer_op(src_indices):
+                        if src_indices.ndim == 1:
+                            src_indices = convert_neg(src_indices, meta_out['global_size'])
+                        else:
+                            src_indices = _flatten_src_indices(src_indices, meta_in['shape'],
+                                                               meta_out['global_shape'],
+                                                               meta_out['global_size'])
+                        meta_in['src_indices'] = src_indices
 
                     # 1. Compute the output indices
                     # NOTE: src_indices are relative to a single, possibly distributed variable,

--- a/openmdao/vectors/petsc_vector.py
+++ b/openmdao/vectors/petsc_vector.py
@@ -3,7 +3,8 @@ import sys
 import numpy as np
 from petsc4py import PETSc
 
-from openmdao.vectors.default_vector import DefaultVector, INT_DTYPE, _full_slice
+from openmdao.core.constants import INT_DTYPE
+from openmdao.vectors.default_vector import DefaultVector, _full_slice
 from openmdao.vectors.petsc_transfer import PETScTransfer
 from openmdao.utils.mpi import MPI
 

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -15,12 +15,6 @@ _type_map = {
     'residual': 'output'
 }
 
-# This is the dtype we use for index arrays.  Petsc by default uses 32 bit ints
-if os.environ.get('OPENMDAO_USE_BIG_INTS'):
-    INT_DTYPE = np.dtype(np.int64)
-else:
-    INT_DTYPE = np.dtype(np.int32)
-
 
 class Vector(object):
     """

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -63,7 +63,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
     else:
         system = root
 
-    connections = system._problem_meta['connections']
+    connections = system._problem_meta['model_ref']()._conn_global_abs_in2out
 
     src2tgts = defaultdict(list)
     units = defaultdict(lambda: '')


### PR DESCRIPTION
-Calling get_val with get_remote=False or None won't give the correct result in a couple of cases. 1) when getting a non-distrib input value when that input is connected to a distributed output, and 2) when getting a distributed input (local value only) if the src_indices for that input reference into entries in the corresponding output that are outside of the current process.

- moved INT_DTYPE from vectory.py into constants.py
- refactored handling of slice src_indices to avoid redundant _is_slicer_op checks, and got rid of potentially expensive checks in _is_slicer_op that are now unnecessary.
- replaced a number of entries in the problem metadata tied to the model with a weak ref to the model itself to allow retrieval of out-of-scope source values if get_val called from systems below the top level after connections have been resolved.
- renamed the _top_level_setup* functions to have more descriptive names

### Backwards incompatibilities

Nothing user facing, but I had to modify 2 lines in dymos to account for changes to _problem_meta because dymos was accessing _problem_meta directly.

### New Dependencies

None
