### PR TITLE
Tagging capability added to AddSubtractComp

### DIFF
--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -106,7 +106,7 @@ class AddSubtractComp(ExplicitComponent):
 
     def add_equation(self, output_name, input_names, vec_size=1, length=1, val=1.0,
                      units=None, res_units=None, desc='', lower=None, upper=None, ref=1.0,
-                     ref0=0.0, res_ref=None, scaling_factors=None):
+                     ref0=0.0, res_ref=None, scaling_factors=None, tags=None):
         """
         Add an addition/subtraction relation.
 
@@ -158,10 +158,13 @@ class AddSubtractComp(ExplicitComponent):
         res_ref : float or ndarray
             Scaling parameter. The value in the user-defined res_units of this output's residual
             when the scaled value is 1. Default is 1.
+        tags : str or list of strs
+            User defined tags that can be used to filter what gets listed when calling 
+            list_inputs and list_outputs and also when listing results from case recorders.
         """
         kwargs = {'units': units, 'res_units': res_units, 'desc': desc,
                   'lower': lower, 'upper': upper, 'ref': ref, 'ref0': ref0,
-                  'res_ref': res_ref}
+                  'res_ref': res_ref, 'tags': tags}
 
         if (not isinstance(input_names, (list, tuple))) or len(input_names) < 2:
             raise ValueError(self.msginfo + ': must specify more than one input name for '

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -159,7 +159,7 @@ class AddSubtractComp(ExplicitComponent):
             Scaling parameter. The value in the user-defined res_units of this output's residual
             when the scaled value is 1. Default is 1.
         tags : str or list of strs
-            User defined tags that can be used to filter what gets listed when calling 
+            User defined tags that can be used to filter what gets listed when calling
             list_inputs and list_outputs and also when listing results from case recorders.
         """
         kwargs = {'units': units, 'res_units': res_units, 'desc': desc,


### PR DESCRIPTION
### Summary

As the API has changed over time, the feature comps have not always kept up. This became apparent recently when I needed to tag an output of an AddSubtractComp, but the add_equation method didn't support the tag kwarg. 

There are a number of components (e.g. CrossProduct, MuxDemux) that should be completely generic and support most or all of the kwargs that ExplicitComponent.add_output() or add_input() takes. This PR just fixes the AddSubtractComp, but if it's appropriate to fix most or all of the components at the same time, or if this is a POEM-level change, then we can close this without a merge for now.

### Backwards incompatibilities

None

### New Dependencies

None

Note:  This PR supercedes #1580 