### PR TITLE
Raise UserWarning each time a failure is reached in Pyoptsparse driver

### DIFF
--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -202,7 +202,8 @@ class MetaModelStructuredComp(ExplicitComponent):
                     "was out of bounds ('{}', '{}') with " \
                     "value '{}'".format(self.msginfo, out_name, varname_causing_error,
                                         err.lower, err.upper, err.value)
-                raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()))
+                raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()),
+                                    self.msginfo)
 
             except ValueError as err:
                 raise ValueError("{}: Error interpolating output '{}':\n{}".format(self.msginfo,

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1101,7 +1101,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
       p = om.Problem(model=om.Group())
 
       p.driver = om.pyOptSparseDriver(optimizer=OPTIMIZER)
-      # p.driver.opt_settings['iSumm'] = 6
 
       mm = om.MetaModelStructuredComp(extrapolate=False)
       mm.add_input('x', val=1.0, training_data=x_tr)
@@ -1116,7 +1115,8 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
       p.set_val('x', 0.75)
 
-      msg = "Analysis Error: Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
+      msg = "Analysis Error: MetaModelStructuredComp " \
+            "(interp) Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
       with assert_warning(UserWarning, msg):
         p.run_driver()
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1118,7 +1118,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
       msg = "Analysis Error: MetaModelStructuredComp " \
             "(interp) Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
       with assert_warning(UserWarning, msg):
-        p.run_driver()
+          p.run_driver()
 
 
 @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1101,6 +1101,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
       p = om.Problem(model=om.Group())
 
       p.driver = om.pyOptSparseDriver(optimizer=OPTIMIZER)
+      # p.driver.opt_settings['iSumm'] = 6
 
       mm = om.MetaModelStructuredComp(extrapolate=False)
       mm.add_input('x', val=1.0, training_data=x_tr)
@@ -1117,7 +1118,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
       msg = "Analysis Error: Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
       with assert_warning(UserWarning, msg):
-          p.run_driver()
+        p.run_driver()
 
 
 @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -25,6 +25,8 @@ class AnalysisError(Exception):
             Error message.
         location : None or inspect.currentframe()
             inspect.currentframe of error being raised.
+        msginfo : str
+            Name of component that raise the AnalysisError.
         """
         super(AnalysisError, self).__init__(error)
         if location is not None:

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -3,7 +3,8 @@ OpenMDAO custom error: AnalysisError.
 """
 import inspect
 from openmdao.utils.general_utils import simple_warning
-
+from openmdao.utils.general_utils import _warn_simple_format, reset_warning_registry
+import warnings
 
 class AnalysisError(Exception):
     """
@@ -26,4 +27,8 @@ class AnalysisError(Exception):
         """
         super(AnalysisError, self).__init__(error)
         if location is not None:
-            simple_warning(f"Analysis Error: Line {location.lineno} of file {location.filename}")
+            with reset_warning_registry():
+                warnings.formatwarning = _warn_simple_format
+                msg = (f"Analysis Error: Line {location.lineno} of file "
+                       f"{location.filename}")
+                warnings.warn(msg, UserWarning, 2)

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -6,6 +6,7 @@ from openmdao.utils.general_utils import simple_warning
 from openmdao.utils.general_utils import _warn_simple_format, reset_warning_registry
 import warnings
 
+
 class AnalysisError(Exception):
     """
     Analysis Error.
@@ -14,7 +15,7 @@ class AnalysisError(Exception):
     code or a subsolver.
     """
 
-    def __init__(self, error, location=None):
+    def __init__(self, error, location=None, msginfo=None):
         """
         Initialize AnalysisError.
 
@@ -29,6 +30,6 @@ class AnalysisError(Exception):
         if location is not None:
             with reset_warning_registry():
                 warnings.formatwarning = _warn_simple_format
-                msg = (f"Analysis Error: Line {location.lineno} of file "
+                msg = (f"Analysis Error: {msginfo} Line {location.lineno} of file "
                        f"{location.filename}")
                 warnings.warn(msg, UserWarning, 2)


### PR DESCRIPTION
### Summary

- Now raising a UserWarning each time a failure is reached in Pyoptsparse driver
- Added msginfo so user knows where error is propagating from

### Related Issues

- Resolves #1669

### Backwards incompatibilities

None

### New Dependencies

None
