### PR TITLE
Handle Windows, where signal package may not have SIGUSR1.

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -66,6 +66,11 @@ CITATIONS = """@article{Hwang_maud_2018
 }
 """
 
+try:
+    DEFAULT_SIGNAL = signal.SIGUSR1
+except AttributeError:
+    DEFAULT_SIGNAL = None
+
 
 class UserRequestedException(Exception):
     """
@@ -188,7 +193,7 @@ class pyOptSparseDriver(Driver):
         self.options.declare('gradient method', default='openmdao',
                              values={'openmdao', 'pyopt_fd', 'snopt_fd'},
                              desc='Finite difference implementation to use')
-        self.options.declare('user_terminate_signal', default=signal.SIGUSR1, allow_none=True,
+        self.options.declare('user_terminate_signal', default=DEFAULT_SIGNAL, allow_none=True,
                              desc='OS signal that triggers a clean user-termination. Only SNOPT'
                              'supports this option.')
 


### PR DESCRIPTION
### Summary

Fixed a bug in pyoptsparse where, on certain Windows setups, the signal package may not have SIGUSR1 defined and the user gets an AttributeError when instantiating the Driver.

### Related Issues

- Resolves #1621

### Backwards incompatibilities

None

### New Dependencies

None
