### PR TITLE
Fix bug where the N2 was gathering options that are not recordable.

### DIFF
--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -197,7 +197,9 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
         if k in ['linear_solver', 'nonlinear_solver']:
             options[k] = system.options[k].SOLVER
         else:
-            if system.options._dict[k]['value'] is _UNDEFINED:
+            if not system.options._dict[k]['recordable']:
+                options[k] = "Unrecordable"
+            elif system.options._dict[k]['value'] is _UNDEFINED:
                 options[k] = str(system.options._dict[k]['value'])
             else:
                 options[k] = system.options._dict[k]['value']

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -197,12 +197,13 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
         if k in ['linear_solver', 'nonlinear_solver']:
             options[k] = system.options[k].SOLVER
         else:
+            val = system.options._dict[k]['value']
             if not system.options._dict[k]['recordable']:
-                options[k] = "Unrecordable"
-            elif system.options._dict[k]['value'] is _UNDEFINED:
-                options[k] = str(system.options._dict[k]['value'])
+                options[k] = default_noraise(val)
+            elif val is _UNDEFINED:
+                options[k] = str(val)
             else:
-                options[k] = system.options._dict[k]['value']
+                options[k] = val
     tree_dict['options'] = options
 
     if not tree_dict['name']:


### PR DESCRIPTION
### Summary

Fix bug under MPI where the N2 was gathering options that are not recordable.

### Related Issues

- Resolves #1674

### Backwards incompatibilities

None

### New Dependencies

None
