### PR TITLE
Added declaration for distributed design variables to the `supports` dictionary. 

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -176,6 +176,7 @@ class Driver(object):
         self.supports.declare('active_set', types=bool, default=False)
         self.supports.declare('simultaneous_derivatives', types=bool, default=False)
         self.supports.declare('total_jac_sparsity', types=bool, default=False)
+        self.supports.declare('distributed_design_vars', types=bool, default=False)
 
         self.iter_count = 0
         self.cite = ""

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -296,12 +296,14 @@ class Driver(object):
 
                 # For Auto-ivcs, we need to check the distributed metadata on the target instead.
                 if meta['ivc_source'].startswith('_auto_ivc.'):
-                    abs_name = model._var_allprocs_prom2abs_list['input'][dv][0]
-                    if abs_name in model._var_allprocs_abs_names_discrete['input']:
-                        # Discrete vars aren't distributed.
-                        dist = False
-                    else:
-                        dist = model._var_allprocs_abs2meta[abs_name]['distributed']
+                    abs_names = model._var_allprocs_prom2abs_list['input'][dv]
+                    dist = False
+                    for abs_name in abs_names:
+                        if abs_name in model._var_allprocs_abs_names_discrete['input']:
+                            # Discrete vars aren't distributed.
+                            break
+
+                        dist = dist or model._var_allprocs_abs2meta[abs_name]['distributed']
                 else:
                     dist = meta['distributed']
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -290,7 +290,7 @@ class Driver(object):
         responses = prom2ivc_src_dict(self._responses)
 
         # Only allow distributed design variables on drivers that support it.
-        if True or self.supports['distributed_design_vars'] is False:
+        if self.supports['distributed_design_vars'] is False:
             dist_vars = []
             for dv, meta in self._designvars.items():
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -176,7 +176,7 @@ class Driver(object):
         self.supports.declare('active_set', types=bool, default=False)
         self.supports.declare('simultaneous_derivatives', types=bool, default=False)
         self.supports.declare('total_jac_sparsity', types=bool, default=False)
-        self.supports.declare('distributed_design_vars', types=bool, default=True)
+        self.supports.declare('distributed_design_vars', types=bool, default=False)
 
         self.iter_count = 0
         self.cite = ""

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -821,8 +821,6 @@ class TestDriverMPI(unittest.TestCase):
                 self.supports['distributed_design_vars'] = False
                 self.supports._read_only = True
 
-        doe_parallel = 2
-
         prob = om.Problem()
         model = prob.model
 

--- a/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
+++ b/openmdao/devtools/docs_experiment/experimental_source/core/experimental_driver.py
@@ -120,6 +120,7 @@ class ExperimentalDriver(object):
         self.supports.declare('gradients', types=bool, default=False)
         self.supports.declare('active_set', types=bool, default=False)
         self.supports.declare('simultaneous_derivatives', types=bool, default=False)
+        self.supports.declare('distributed_design_vars', types=bool, default=False)
 
         self.iter_count = 0
         self.options = None

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -68,6 +68,7 @@ class DifferentialEvolutionDriver(Driver):
         self.supports['linear_constraints'] = False
         self.supports['simultaneous_derivatives'] = False
         self.supports['active_set'] = False
+        self.supports['distributed_design_vars'] = False
         self.supports._read_only = True
 
         self._desvar_idx = {}

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -58,6 +58,13 @@ class DOEDriver(Driver):
 
         super(DOEDriver, self).__init__(**kwargs)
 
+        # What we support
+        self.supports['integer_design_vars'] = True
+
+        # What we don't support
+        self.supports['distributed_design_vars'] = False
+        self.supports._read_only = True
+
         if generator is not None:
             self.options['generator'] = generator
 

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -74,6 +74,7 @@ class SimpleGADriver(Driver):
         self.supports['linear_constraints'] = False
         self.supports['simultaneous_derivatives'] = False
         self.supports['active_set'] = False
+        self.supports['distributed_design_vars'] = False
         self.supports._read_only = True
 
         self._desvar_idx = {}

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -151,6 +151,7 @@ class pyOptSparseDriver(Driver):
         # What we don't support yet
         self.supports['active_set'] = False
         self.supports['integer_design_vars'] = False
+        self.supports['distributed_design_vars'] = False
         self.supports._read_only = True
 
         # The user places optimizer-specific settings in here.

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -132,6 +132,7 @@ class ScipyOptimizeDriver(Driver):
         self.supports['multiple_objectives'] = False
         self.supports['active_set'] = False
         self.supports['integer_design_vars'] = False
+        self.supports['distributed_design_vars'] = False
         self.supports._read_only = True
 
         # The user places optimizer-specific settings in here.

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1314,56 +1314,56 @@ class TestParallelDOE(unittest.TestCase):
         failed, output = run_driver(prob)
 
         from openmdao.utils.mpi import multi_proc_exception_check
-        
+
         with multi_proc_exception_check(prob.comm):
             self.assertFalse(failed)
-    
+
             prob.cleanup()
-    
+
             expected = [
                 {'x1': np.array([0.]), 'x2': np.array([0.]), 'c3.y': np.array([0.0])},
                 {'x1': np.array([.5]), 'x2': np.array([0.]), 'c3.y': np.array([-3.0])},
                 {'x1': np.array([1.]), 'x2': np.array([0.]), 'c3.y': np.array([-6.0])},
-    
+
                 {'x1': np.array([0.]), 'x2': np.array([.5]), 'c3.y': np.array([17.5])},
                 {'x1': np.array([.5]), 'x2': np.array([.5]), 'c3.y': np.array([14.5])},
                 {'x1': np.array([1.]), 'x2': np.array([.5]), 'c3.y': np.array([11.5])},
-    
+
                 {'x1': np.array([0.]), 'x2': np.array([1.]), 'c3.y': np.array([35.0])},
                 {'x1': np.array([.5]), 'x2': np.array([1.]), 'c3.y': np.array([32.0])},
                 {'x1': np.array([1.]), 'x2': np.array([1.]), 'c3.y': np.array([29.0])},
             ]
-    
+
             rank = prob.comm.rank
             size = prob.comm.size // doe_parallel
-    
+
             num_cases = 0
-    
+
             # cases will be split across files for each proc up to the number requested
             if rank < doe_parallel:
                 filename = "cases.sql_%d" % rank
-    
+
                 expect_msg = "Cases from rank %d are being written to %s." % (rank, filename)
                 self.assertTrue(expect_msg in output)
-    
+
                 cr = om.CaseReader(filename)
                 cases = cr.list_cases('driver')
-    
+
                 # cases recorded on this proc
                 num_cases = len(cases)
                 self.assertEqual(num_cases, len(expected) // size+(rank < len(expected) % size))
-    
+
                 for n, case in enumerate(cases):
                     idx = n * size + rank  # index of expected case
-    
+
                     outputs = cr.get_case(case).outputs
-    
+
                     for name in ('x1', 'x2', 'c3.y'):
-    
+
                         # TODO - Remove this when issue 1498 is fixed.
                         if name in ['x1', 'x2']:
                             continue
-    
+
                         self.assertEqual(outputs[name], expected[idx][name])
             else:
                 self.assertFalse("Cases from rank %d are being written" % rank in output)


### PR DESCRIPTION
### Summary

Added declaration for distributed design variables to the `supports` dictionary. No current drivers support this feature, so an error is raised if any distributed design variables are added.

### Related Issues

- Resolves #1630

### Backwards incompatibilities

None

### New Dependencies

None
