### PR TITLE
add equivalent unit conversion check and tests

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -25,7 +25,7 @@ from openmdao.utils.array_utils import convert_neg, array_connection_compatible,
     _flatten_src_indices
 from openmdao.utils.general_utils import ContainsAll, all_ancestors, simple_warning, \
     common_subpath, conditional_error, _is_slicer_op, _slice_indices
-from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismatch
+from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismatch, _find_unit
 from openmdao.utils.mpi import MPI, check_mpi_exceptions, multi_proc_exception_check
 from openmdao.utils.coloring import Coloring, _STD_COLORING_FNAME
 import openmdao.utils.coloring as coloring_mod
@@ -3196,12 +3196,7 @@ class Group(System):
                     tmeta = abs2meta[tgt] if tgt in abs2meta else all_abs2meta[tgt]
                     tunits = tmeta['units'] if 'units' in tmeta else None
                     if 'units' not in gmeta and sunits != tunits:
-                        try:
-                            test_conv = unit_conversion(sunits, tunits)
-                            if abs(test_conv[0] - 1.0) > 1e-9 or abs(test_conv[1] - 0.0) > 1e-9:
-                                errs.add('units')
-                                metadata.add('units')
-                        except TypeError:
+                        if _find_unit(sunits) != _find_unit(tunits):
                             errs.add('units')
                             metadata.add('units')
                     if 'value' not in gmeta:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3196,8 +3196,14 @@ class Group(System):
                     tmeta = abs2meta[tgt] if tgt in abs2meta else all_abs2meta[tgt]
                     tunits = tmeta['units'] if 'units' in tmeta else None
                     if 'units' not in gmeta and sunits != tunits:
-                        errs.add('units')
-                        metadata.add('units')
+                        try:
+                            test_conv = unit_conversion(sunits, tunits)
+                            if abs(test_conv[0] - 1.0) > 1e-9 or abs(test_conv[1] - 0.0) > 1e-9:
+                                errs.add('units')
+                                metadata.add('units')
+                        except TypeError:
+                            errs.add('units')
+                            metadata.add('units')
                     if 'value' not in gmeta:
                         if tval.shape == sval.shape:
                             if _has_val_mismatch(tunits, tval, sunits, sval):

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -914,8 +914,9 @@ class TestUnitConversion(unittest.TestCase):
                                             z={'value': 1.0, 'units': 'J/s'}),
                                             promotes_inputs=['x', 'z'])
         # trying to convert J/s/s to m/s**2 should cause Incompatible units TypeError exception
-        with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError) as e:
             p.setup()
+        self.assertEqual(str(e.exception), 'Incompatible units')
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -880,6 +880,43 @@ class TestUnitConversion(unittest.TestCase):
         #self.assertTrue(iter_count < 20)
         #self.assertTrue(not np.isnan(prob['sub.cc2.y']))
 
+    def test_promotes_equivalent_units(self):
+        # multiple Group.set_input_defaults calls at same tree level with conflicting units args
+        p = om.Problem()
+
+        g1 = p.model.add_subsystem("G1", om.Group(), promotes_inputs=['x'])
+        g1.add_subsystem("C1", om.ExecComp("y = 2. * x * z",
+                                            x={'value': 5.0, 'units': 'm/s/s'},
+                                            y={'value': 1.0, 'units': None},
+                                            z={'value': 1.0, 'units': 'W'}),
+                                            promotes_inputs=['x', 'z'])
+        g1.add_subsystem("C2", om.ExecComp("y = 3. * x * z",
+                                            x={'value': 5.0, 'units': 'm/s**2'},
+                                            y={'value': 1.0, 'units': None},
+                                            z={'value': 1.0, 'units': 'J/s'}),
+                                            promotes_inputs=['x', 'z'])
+        # converting m/s/s to m/s**2 is allowed
+        p.setup()
+
+    def test_promotes_non_equivalent_units(self):
+        # multiple Group.set_input_defaults calls at same tree level with conflicting units args
+        p = om.Problem()
+
+        g1 = p.model.add_subsystem("G1", om.Group(), promotes_inputs=['x'])
+        g1.add_subsystem("C1", om.ExecComp("y = 2. * x * z",
+                                            x={'value': 5.0, 'units': 'J/s/s'},
+                                            y={'value': 1.0, 'units': None},
+                                            z={'value': 1.0, 'units': 'W'}),
+                                            promotes_inputs=['x', 'z'])
+        g1.add_subsystem("C2", om.ExecComp("y = 3. * x * z",
+                                            x={'value': 5.0, 'units': 'm/s**2'},
+                                            y={'value': 1.0, 'units': None},
+                                            z={'value': 1.0, 'units': 'J/s'}),
+                                            promotes_inputs=['x', 'z'])
+        # trying to convert J/s/s to m/s**2 should cause Incompatible units TypeError exception
+        with self.assertRaises(TypeError):
+            p.setup()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Variables promoted with equivalent but different units (such as 'm/s/s' vs. 'm/s**2' will raise an exception without set_input_defaults. Before raising the exception, make sure the units not equivalent.

### Related Issues

- Resolves #1687

### Backwards incompatibilities

None

### New Dependencies

None
