### PR TITLE
Change calls to super to use Python3 syntax.

### DIFF
--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -37,7 +37,7 @@ class ComplexStep(ApproximationScheme):
         """
         Initialize the ApproximationScheme.
         """
-        super(ComplexStep, self).__init__()
+        super().__init__()
 
         # Only used when nested under complex step.
         self._fd = None

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -90,7 +90,7 @@ class FiniteDifference(ApproximationScheme):
         """
         Initialize the ApproximationScheme.
         """
-        super(FiniteDifference, self).__init__()
+        super().__init__()
         self._starting_ins = self._starting_outs = self._results_tmp = None
 
     def add_approximation(self, abs_key, system, kwargs, vector=None):

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -69,7 +69,7 @@ class AddSubtractComp(ExplicitComponent):
             (same as add_output method for ExplicitComponent)
             Examples include units (str or None), desc (str)
         """
-        super(AddSubtractComp, self).__init__()
+        super().__init__()
 
         # Add systems is used to store those systems provided upon initialization
         self._equations = []
@@ -181,7 +181,7 @@ class AddSubtractComp(ExplicitComponent):
         else:
             shape = (vec_size, length)
 
-        super(AddSubtractComp, self).add_output(output_name, val, shape=shape, **kwargs)
+        super().add_output(output_name, val, shape=shape, **kwargs)
 
         self._equations.append((output_name, input_names, vec_size, length, val,
                                 scaling_factors, kwargs))

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -132,10 +132,10 @@ class BalanceComp(ImplicitComponent):
             (see `add_output` method).
         """
         if 'guess_func' in kwargs:
-            super(BalanceComp, self).__init__(guess_func=kwargs['guess_func'])
+            super().__init__(guess_func=kwargs['guess_func'])
             kwargs.pop('guess_func')
         else:
-            super(BalanceComp, self).__init__()
+            super().__init__()
 
         self._state_vars = {}
 

--- a/openmdao/components/cross_product_comp.py
+++ b/openmdao/components/cross_product_comp.py
@@ -40,7 +40,7 @@ class CrossProductComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(CrossProductComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._products = []
 

--- a/openmdao/components/demux_comp.py
+++ b/openmdao/components/demux_comp.py
@@ -27,7 +27,7 @@ class DemuxComp(ExplicitComponent):
         **kwargs : dict
             Arguments to be passed to the component initialization method.
         """
-        super(DemuxComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._vars = {}
         self._output_names = {}

--- a/openmdao/components/dot_product_comp.py
+++ b/openmdao/components/dot_product_comp.py
@@ -34,7 +34,7 @@ class DotProductComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(DotProductComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._products = []
 

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -96,7 +96,7 @@ class EQConstraintComp(ExplicitComponent):
             Additional arguments to be passed for the creation of the output variable.
             (see `add_output` method).
         """
-        super(EQConstraintComp, self).__init__()
+        super().__init__()
         self._output_vars = {}
         if name is not None:
             self.add_eq_output(name, eq_units, lhs_name, rhs_name, rhs_val,

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -209,7 +209,7 @@ class ExecComp(ExplicitComponent):
             if name in kwargs:
                 options[name] = kwargs.pop(name)
 
-        super(ExecComp, self).__init__(**options)
+        super().__init__(**options)
 
         # if complex step is used for derivatives, this is the stepsize
         self.complex_stepsize = 1.e-40

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -263,7 +263,7 @@ class ExternalCodeComp(ExplicitComponent):
             Keyword arguments that will be mapped into the Component options.
         """
         self._external_code_runner = ExternalCodeDelegate(self)
-        super(ExternalCodeComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.stdin = DEV_NULL
         self.stdout = None
@@ -278,7 +278,7 @@ class ExternalCodeComp(ExplicitComponent):
         Options are declared here because this class is intended to be subclassed by
         the end user. The `initialize` method is left available for user-defined options.
         """
-        super(ExternalCodeComp, self)._declare_options()
+        super()._declare_options()
         self._external_code_runner.declare_options()
 
     def check_config(self, logger):
@@ -340,7 +340,7 @@ class ExternalCodeImplicitComp(ImplicitComponent):
             Keyword arguments that will be mapped into the Component options.
         """
         self._external_code_runner = ExternalCodeDelegate(self)
-        super(ExternalCodeImplicitComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.stdin = DEV_NULL
         self.stdout = None
@@ -355,7 +355,7 @@ class ExternalCodeImplicitComp(ImplicitComponent):
         Options are declared here because this class is intended to be subclassed by
         the end user. The `initialize` method is left available for user-defined options.
         """
-        super(ExternalCodeImplicitComp, self)._declare_options()
+        super()._declare_options()
         self._external_code_runner.declare_options()
 
         # ImplicitComponent has two separate commands to run.

--- a/openmdao/components/interp_util/interp_akima.py
+++ b/openmdao/components/interp_util/interp_akima.py
@@ -95,7 +95,7 @@ class InterpAkima(InterpAlgorithm):
         **kwargs : dict
             Interpolator-specific options to pass onward.
         """
-        super(InterpAkima, self).__init__(grid, values, interp, **kwargs)
+        super().__init__(grid, values, interp, **kwargs)
         self.k = 4
         self._name = 'akima'
 

--- a/openmdao/components/interp_util/interp_bsplines.py
+++ b/openmdao/components/interp_util/interp_bsplines.py
@@ -45,7 +45,7 @@ class InterpBSplines(InterpAlgorithm):
         **kwargs : dict
             Interpolator-specific options to pass onward.
         """
-        super(InterpBSplines, self).__init__(grid, values, interp, **kwargs)
+        super().__init__(grid, values, interp, **kwargs)
 
         self._vectorized = True
         self.k = self.options['order'] + 1

--- a/openmdao/components/interp_util/interp_cubic.py
+++ b/openmdao/components/interp_util/interp_cubic.py
@@ -37,7 +37,7 @@ class InterpCubic(InterpAlgorithm):
         **kwargs : dict
             Interpolator-specific options to pass onward.
         """
-        super(InterpCubic, self).__init__(grid, values, interp)
+        super().__init__(grid, values, interp)
         self.second_derivs = None
         self.k = 4
         self._name = 'cubic'

--- a/openmdao/components/interp_util/interp_lagrange2.py
+++ b/openmdao/components/interp_util/interp_lagrange2.py
@@ -28,7 +28,7 @@ class InterpLagrange2(InterpAlgorithm):
         **kwargs : dict
             Interpolator-specific options to pass onward.
         """
-        super(InterpLagrange2, self).__init__(grid, values, interp, **kwargs)
+        super().__init__(grid, values, interp, **kwargs)
         self.k = 3
         self._name = 'lagrange2'
 

--- a/openmdao/components/interp_util/interp_lagrange3.py
+++ b/openmdao/components/interp_util/interp_lagrange3.py
@@ -28,7 +28,7 @@ class InterpLagrange3(InterpAlgorithm):
         **kwargs : dict
             Interpolator-specific options to pass onward.
         """
-        super(InterpLagrange3, self).__init__(grid, values, interp, **kwargs)
+        super().__init__(grid, values, interp, **kwargs)
         self.k = 4
         self._name = 'lagrange3'
 

--- a/openmdao/components/interp_util/interp_slinear.py
+++ b/openmdao/components/interp_util/interp_slinear.py
@@ -28,7 +28,7 @@ class InterpLinear(InterpAlgorithm):
         **kwargs : dict
             Interpolator-specific options to pass onward.
         """
-        super(InterpLinear, self).__init__(grid, values, interp, **kwargs)
+        super().__init__(grid, values, interp, **kwargs)
         self.k = 2
         self._name = 'slinear'
 

--- a/openmdao/components/interp_util/outofbounds_error.py
+++ b/openmdao/components/interp_util/outofbounds_error.py
@@ -34,7 +34,7 @@ class OutOfBoundsError(Exception):
         upper : double
             upper bounds of the variable that is out of bounds.
         """
-        super(OutOfBoundsError, self).__init__(message)
+        super().__init__(message)
         self.idx = idx
         self.value = value
         self.lower = lower

--- a/openmdao/components/ks_comp.py
+++ b/openmdao/components/ks_comp.py
@@ -146,7 +146,7 @@ class KSComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(KSComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.cite = CITATIONS
 

--- a/openmdao/components/linear_system_comp.py
+++ b/openmdao/components/linear_system_comp.py
@@ -29,7 +29,7 @@ class LinearSystemComp(ImplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(LinearSystemComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._lup = None
 
     def initialize(self):

--- a/openmdao/components/matrix_vector_product_comp.py
+++ b/openmdao/components/matrix_vector_product_comp.py
@@ -44,7 +44,7 @@ class MatrixVectorProductComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(MatrixVectorProductComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._products = []
 

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -48,7 +48,7 @@ class MetaModelStructuredComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(MetaModelStructuredComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.pnames = []
         self.inputs = []
@@ -95,7 +95,7 @@ class MetaModelStructuredComp(ExplicitComponent):
                 msg = "{}: Input {} must either be scalar, or of length equal to vec_size."
                 raise ValueError(msg.format(self.msginfo, name))
 
-        super(MetaModelStructuredComp, self).add_input(name, val * np.ones(n), **kwargs)
+        super().add_input(name, val * np.ones(n), **kwargs)
 
         self.pnames.append(name)
         self.inputs.append(np.asarray(training_data))
@@ -124,13 +124,12 @@ class MetaModelStructuredComp(ExplicitComponent):
                 msg = "{}: Output {} must either be scalar, or of length equal to vec_size."
                 raise ValueError(msg.format(self.msginfo, name))
 
-        super(MetaModelStructuredComp, self).add_output(name, val * np.ones(n), **kwargs)
+        super().add_output(name, val * np.ones(n), **kwargs)
 
         self.training_outputs[name] = training_data
 
         if self.options['training_data_gradients']:
-            super(MetaModelStructuredComp, self).add_input("%s_train" % name,
-                                                           val=training_data, **kwargs)
+            super().add_input("%s_train" % name, val=training_data, **kwargs)
 
     def _setup_var_data(self):
         """
@@ -149,7 +148,7 @@ class MetaModelStructuredComp(ExplicitComponent):
         if self.options['training_data_gradients']:
             self.grad_shape = tuple([self.options['vec_size']] + [i.size for i in self.inputs])
 
-        super(MetaModelStructuredComp, self)._setup_var_data()
+        super()._setup_var_data()
 
     def _setup_partials(self):
         """
@@ -157,7 +156,7 @@ class MetaModelStructuredComp(ExplicitComponent):
 
         Metamodel needs to declare its partials after inputs and outputs are known.
         """
-        super(MetaModelStructuredComp, self)._setup_partials()
+        super()._setup_partials()
         arange = np.arange(self.options['vec_size'])
         pnames = tuple(self.pnames)
         dct = {
@@ -198,17 +197,15 @@ class MetaModelStructuredComp(ExplicitComponent):
 
             except OutOfBoundsError as err:
                 varname_causing_error = '.'.join((self.pathname, self.pnames[err.idx]))
-                errmsg = "{}: Error interpolating output '{}' because input '{}' " \
-                    "was out of bounds ('{}', '{}') with " \
-                    "value '{}'".format(self.msginfo, out_name, varname_causing_error,
-                                        err.lower, err.upper, err.value)
+                errmsg = (f"{self.msginfo}: Error interpolating output '{out_name}' "
+                          f"because input '{varname_causing_error}' was out of bounds "
+                          f"('{ err.lower}', '{err.upper}') with value '{err.value}'")
                 raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()),
                                     self.msginfo)
 
             except ValueError as err:
-                raise ValueError("{}: Error interpolating output '{}':\n{}".format(self.msginfo,
-                                                                                   out_name,
-                                                                                   str(err)))
+                raise ValueError(f"{self.msginfo}: Error interpolating output '{out_name}':\n"
+                                 f"{str(err)}")
             outputs[out_name] = val
 
     def compute_partials(self, inputs, partials):

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -53,7 +53,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(MetaModelUnStructuredComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # keep list of inputs and outputs that are not the training vars
         self._surrogate_input_names = []
@@ -95,7 +95,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         self._surrogate_output_names.extend(self._static_surrogate_output_names)
         self._input_size = self._static_input_size
 
-        super(MetaModelUnStructuredComp, self)._setup_procs(pathname, comm, mode, prob_meta)
+        super()._setup_procs(pathname, comm, mode, prob_meta)
 
     def initialize(self):
         """
@@ -128,7 +128,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         dict
             metadata for added variable
         """
-        metadata = super(MetaModelUnStructuredComp, self).add_input(name, val, **kwargs)
+        metadata = super().add_input(name, val, **kwargs)
         vec_size = self.options['vec_size']
 
         if vec_size > 1:
@@ -177,7 +177,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         dict
             metadata for added variable
         """
-        metadata = super(MetaModelUnStructuredComp, self).add_output(name, val, **kwargs)
+        metadata = super().add_output(name, val, **kwargs)
         vec_size = self.options['vec_size']
 
         if vec_size > 1:
@@ -235,7 +235,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         # training will occur on first execution after setup
         self.train = True
 
-        super(MetaModelUnStructuredComp, self)._setup_var_data()
+        super()._setup_var_data()
 
     def _setup_partials(self):
         """
@@ -243,7 +243,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
 
         Metamodel needs to declare its partials after inputs and outputs are known.
         """
-        super(MetaModelUnStructuredComp, self)._setup_partials()
+        super()._setup_partials()
 
         vec_size = self.options['vec_size']
         if vec_size > 1:
@@ -502,8 +502,8 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         """
         if method == 'cs':
             raise ValueError('Complex step has not been tested for MetaModelUnStructuredComp')
-        super(MetaModelUnStructuredComp, self).declare_partials(of, wrt, dependent, rows, cols,
-                                                                val, method, step, form, step_calc)
+        super().declare_partials(of, wrt, dependent, rows, cols,
+                                 val, method, step, form, step_calc)
 
     def compute_partials(self, inputs, partials):
         """

--- a/openmdao/components/multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/multifi_meta_model_unstructured_comp.py
@@ -91,7 +91,7 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(MultiFiMetaModelUnStructuredComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         nfi = self._nfi = self.options['nfi']
 
@@ -105,7 +105,7 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         """
         Declare options.
         """
-        super(MultiFiMetaModelUnStructuredComp, self).initialize()
+        super().initialize()
 
         self.options.declare('nfi', types=int, default=1, lower=1,
                              desc='Number of levels of fidelity.')
@@ -130,7 +130,7 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         """
         self._input_sizes = list(self._static_input_sizes)
 
-        super(MultiFiMetaModelUnStructuredComp, self)._setup_procs(pathname, comm, mode, prob_meta)
+        super()._setup_procs(pathname, comm, mode, prob_meta)
 
     def add_input(self, name, val=1.0, shape=None, src_indices=None, flat_src_indices=None,
                   units=None, desc=''):
@@ -162,10 +162,9 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         desc : str
             description of the variable
         """
-        item = MultiFiMetaModelUnStructuredComp
-        metadata = super(item, self).add_input(name, val, shape=shape, src_indices=src_indices,
-                                               flat_src_indices=flat_src_indices, units=units,
-                                               desc=desc)
+        metadata = super().add_input(name, val, shape=shape, src_indices=src_indices,
+                                     flat_src_indices=flat_src_indices, units=units,
+                                     desc=desc)
         if self.options['vec_size'] > 1:
             input_size = metadata['value'][0].size
         else:
@@ -240,14 +239,14 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
             If a str, that str is the name of a variable. Shape this output to match that of
             the named variable.
         """
-        super(MultiFiMetaModelUnStructuredComp, self).add_output(name, val, shape=shape,
-                                                                 units=units, res_units=res_units,
-                                                                 desc=desc, lower=lower,
-                                                                 upper=upper, ref=ref,
-                                                                 ref0=ref0, res_ref=res_ref,
-                                                                 surrogate=surrogate, tags=tags,
-                                                                 shape_by_conn=shape_by_conn,
-                                                                 copy_shape=copy_shape)
+        super().add_output(name, val, shape=shape,
+                           units=units, res_units=res_units,
+                           desc=desc, lower=lower,
+                           upper=upper, ref=ref,
+                           ref0=ref0, res_ref=res_ref,
+                           surrogate=surrogate, tags=tags,
+                           shape_by_conn=shape_by_conn,
+                           copy_shape=copy_shape)
         self._training_output[name] = self._nfi * [np.empty(0)]
 
         # Add train:<outvar>_fi<n>
@@ -263,7 +262,7 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         """
         if self._nfi == 1:
             # shortcut: fallback to base class behaviour immediatly
-            super(MultiFiMetaModelUnStructuredComp, self)._train()
+            super()._train()
             return
 
         num_sample = self._nfi * [None]

--- a/openmdao/components/mux_comp.py
+++ b/openmdao/components/mux_comp.py
@@ -27,7 +27,7 @@ class MuxComp(ExplicitComponent):
         **kwargs : dict
             Arguments to be passed to the component initialization method.
         """
-        super(MuxComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._vars = {}
         self._input_names = {}

--- a/openmdao/components/spline_comp.py
+++ b/openmdao/components/spline_comp.py
@@ -31,7 +31,7 @@ class SplineComp(ExplicitComponent):
         **kwargs : dict
             Interpolator options to pass onward.
         """
-        super(SplineComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.interp_to_cp = {}
         self.interps = {}
@@ -42,7 +42,7 @@ class SplineComp(ExplicitComponent):
         """
         Declare options.
         """
-        super(SplineComp, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('vec_size', types=int, default=1,
                              desc='Number of points to evaluate at once.')

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -287,7 +287,7 @@ class ParaboloidExternalCodeComp(om.ExternalCodeComp):
             input_file.write('%.16f\n%.16f\n' % (x, y))
 
         # the parent compute function actually runs the external code
-        super(ParaboloidExternalCodeComp, self).compute(inputs, outputs)
+        super().compute(inputs, outputs)
 
         # parse the output file from the external code and set the value of f_xy
         with open(self.output_file, 'r') as output_file:
@@ -328,7 +328,7 @@ class ParaboloidExternalCodeCompFD(om.ExternalCodeComp):
             input_file.write('%.16f\n%.16f\n' % (x, y))
 
         # the parent compute function actually runs the external code
-        super(ParaboloidExternalCodeCompFD, self).compute(inputs, outputs)
+        super().compute(inputs, outputs)
 
         # parse the output file from the external code and set the value of f_xy
         with open(self.output_file, 'r') as output_file:
@@ -371,7 +371,7 @@ class ParaboloidExternalCodeCompDerivs(om.ExternalCodeComp):
             input_file.write('%.16f\n%.16f\n' % (x, y))
 
         # the parent compute function actually runs the external code
-        super(ParaboloidExternalCodeCompDerivs, self).compute(inputs, outputs)
+        super().compute(inputs, outputs)
 
         # parse the output file from the external code and set the value of f_xy
         with open(self.output_file, 'r') as output_file:
@@ -383,7 +383,7 @@ class ParaboloidExternalCodeCompDerivs(om.ExternalCodeComp):
         outputs = {}
 
         # the parent compute function actually runs the external code
-        super(ParaboloidExternalCodeCompDerivs, self).compute(inputs, outputs)
+        super().compute(inputs, outputs)
 
         # parse the derivs file from the external code and set partials
         with open(self.derivs_file, 'r') as derivs_file:
@@ -581,7 +581,7 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
                     input_file.write('{}\n'.format(outputs['mach'][0]))
 
                 # the parent apply_nonlinear function actually runs the external code
-                super(MachExternalCodeComp, self).apply_nonlinear(inputs, outputs, residuals)
+                super().apply_nonlinear(inputs, outputs, residuals)
 
                 # parse the output file from the external code and set the value of mach
                 with open(self.output_file, 'r') as output_file:
@@ -594,7 +594,7 @@ class TestExternalCodeImplicitCompFeature(unittest.TestCase):
                     input_file.write('{}\n'.format(inputs['area_ratio'][0]))
                     input_file.write('{}\n'.format(self.options['super_sonic']))
                 # the parent apply_nonlinear function actually runs the external code
-                super(MachExternalCodeComp, self).solve_nonlinear(inputs, outputs)
+                super().solve_nonlinear(inputs, outputs)
 
                 # parse the output file from the external code and set the value of mach
                 with open(self.output_file, 'r') as output_file:

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1116,7 +1116,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
       p.set_val('x', 0.75)
 
       msg = "Analysis Error: MetaModelStructuredComp " \
-            "(interp) Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
+            "(interp) Line 203 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
       with assert_warning(UserWarning, msg):
           p.run_driver()
 

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -951,7 +951,7 @@ class MetaModelTestCase(unittest.TestCase):
     def test_metamodel_setup_called_twice_bug_called_outside_setup(self):
         class Trig(om.MetaModelUnStructuredComp):
             def __init__(self):
-                super(Trig, self).__init__()
+                super().__init__()
                 self.add_input('x', 0.,
                                training_data=np.linspace(0, 10, 20))
 

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -8,7 +8,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 class MockSurrogate(om.MultiFiSurrogateModel):
 
     def __init__(self):
-        super(MockSurrogate, self).__init__()
+        super().__init__()
         self.xtrain = None
         self.ytrain = None
 

--- a/openmdao/components/vector_magnitude_comp.py
+++ b/openmdao/components/vector_magnitude_comp.py
@@ -31,7 +31,7 @@ class VectorMagnitudeComp(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(VectorMagnitudeComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._magnitudes = []
 

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -28,7 +28,7 @@ class AnalysisError(Exception):
         msginfo : str
             Name of component that raise the AnalysisError.
         """
-        super(AnalysisError, self).__init__(error)
+        super().__init__(error)
         if location is not None:
             with reset_warning_registry():
                 warnings.formatwarning = _warn_simple_format

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -87,7 +87,7 @@ class Component(System):
         **kwargs : dict of keyword arguments
             available here and in all descendants of this system.
         """
-        super(Component, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._var_rel_names = {'input': [], 'output': []}
         self._var_rel2meta = {}
@@ -102,7 +102,7 @@ class Component(System):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(Component, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('distributed', types=bool, default=False,
                              desc='True if the component has variables that are distributed '
@@ -138,7 +138,7 @@ class Component(System):
         prob_meta : dict
             Problem level metadata.
         """
-        super(Component, self)._setup_procs(pathname, comm, mode, prob_meta)
+        super()._setup_procs(pathname, comm, mode, prob_meta)
 
         orig_comm = comm
         if self._num_par_fd > 1:
@@ -206,14 +206,14 @@ class Component(System):
                                "using default metadata and method='%s'." % (self.msginfo, method))
                 self.declare_partials('*', '*', method=method)
 
-        super(Component, self)._configure_check()
+        super()._configure_check()
 
     def _setup_var_data(self):
         """
         Compute the list of abs var names, abs/prom name maps, and metadata dictionaries.
         """
         global global_meta_names
-        super(Component, self)._setup_var_data()
+        super()._setup_var_data()
 
         allprocs_prom2abs_list = self._var_allprocs_prom2abs_list
         abs2prom = self._var_allprocs_abs2prom = self._var_abs2prom
@@ -1100,10 +1100,11 @@ class Component(System):
         show_sparsity : bool
             If True, display sparsity with coloring info after generating coloring.
         """
-        super(Component, self).declare_coloring(wrt, method, form, step, per_instance,
-                                                num_full_jacs,
-                                                tol, orders, perturb_size, min_improve_pct,
-                                                show_summary, show_sparsity)
+        super().declare_coloring(wrt, method, form, step, per_instance,
+                                 num_full_jacs,
+                                 tol, orders, perturb_size, min_improve_pct,
+                                 show_summary, show_sparsity)
+
         # create approx partials for all matches
         meta = self.declare_partials('*', wrt, method=method, step=step, form=form)
         meta['coloring'] = True

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1143,7 +1143,7 @@ class RecordingDebugging(Recording):
         self : object
             self
         """
-        super(RecordingDebugging, self).__enter__()
+        super().__enter__()
         self.recording_requester()._pre_run_model_debug_print()
         return self
 
@@ -1157,7 +1157,7 @@ class RecordingDebugging(Recording):
             Solver recording requires extra args.
         """
         self.recording_requester()._post_run_model_debug_print()
-        super(RecordingDebugging, self).__exit__()
+        super().__exit__()
 
 
 def record_iteration(requester, prob, case_name):

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -31,7 +31,7 @@ class ExplicitComponent(Component):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(ExplicitComponent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._inst_functs = {name: getattr(self, name, None) for name in _inst_functs}
         self._has_compute_partials = overrides_method('compute_partials', self, ExplicitComponent)
@@ -105,7 +105,7 @@ class ExplicitComponent(Component):
         """
         Call setup_partials in components.
         """
-        super(ExplicitComponent, self)._setup_partials()
+        super()._setup_partials()
 
         abs2prom_out = self._var_abs2prom['output']
 
@@ -209,13 +209,12 @@ class ExplicitComponent(Component):
         if res_ref is None:
             res_ref = ref
 
-        return super(ExplicitComponent, self).add_output(name,
-                                                         val=val, shape=shape, units=units,
-                                                         res_units=res_units, desc=desc,
-                                                         lower=lower, upper=upper,
-                                                         ref=ref, ref0=ref0, res_ref=res_ref,
-                                                         tags=tags, shape_by_conn=shape_by_conn,
-                                                         copy_shape=copy_shape)
+        return super().add_output(name, val=val, shape=shape, units=units,
+                                  res_units=res_units, desc=desc,
+                                  lower=lower, upper=upper,
+                                  ref=ref, ref0=ref0, res_ref=res_ref,
+                                  tags=tags, shape_by_conn=shape_by_conn,
+                                  copy_shape=copy_shape)
 
     def _approx_subjac_keys_iter(self):
         for abs_key, meta in self._subjacs_info.items():

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -119,7 +119,7 @@ class Group(System):
         self._mpi_proc_allocator = DefaultAllocator()
         self._proc_info = {}
 
-        super(Group, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._subgroups_myproc = None
         self._manual_connections = {}
@@ -277,7 +277,7 @@ class Group(System):
         dict
             Mapping of each absolute var name to its corresponding scaling factor tuple.
         """
-        scale_factors = super(Group, self)._compute_root_scale_factors()
+        scale_factors = super()._compute_root_scale_factors()
 
         if self._has_input_scaling:
             abs2meta_in = self._var_abs2meta['input']
@@ -394,7 +394,7 @@ class Group(System):
         prob_meta : dict
             Problem level metadata.
         """
-        super(Group, self)._setup_procs(pathname, comm, mode, prob_meta)
+        super()._setup_procs(pathname, comm, mode, prob_meta)
         self._setup_procs_finished = False
 
         nproc = comm.size
@@ -513,7 +513,7 @@ class Group(System):
         for subsys in self._subsystems_myproc:
             subsys._configure_check()
 
-        super(Group, self)._configure_check()
+        super()._configure_check()
 
     def _list_states(self):
         """
@@ -686,7 +686,7 @@ class Group(System):
         else:
             old_prom2abs = self._var_allprocs_prom2abs_list['input']
 
-        super(Group, self)._setup_var_data()
+        super()._setup_var_data()
 
         var_discrete = self._var_discrete
         allprocs_discrete = self._var_allprocs_discrete
@@ -2701,7 +2701,7 @@ class Group(System):
                 yield of, offset, end, sub_of_idx
                 offset = end
         else:
-            for tup in super(Group, self)._jacobian_of_iter():
+            for tup in super()._jacobian_of_iter():
                 yield tup
 
     def _jacobian_wrt_iter(self, wrt_matches=None):
@@ -2748,7 +2748,7 @@ class Group(System):
                     yield wrt, offset, end, sub_wrt_idx
                     offset = end
         else:
-            yield from super(Group, self)._jacobian_wrt_iter(wrt_matches)
+            yield from super()._jacobian_wrt_iter(wrt_matches)
 
     def _update_wrt_matches(self, info):
         """

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -28,7 +28,7 @@ class ImplicitComponent(Component):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super(ImplicitComponent, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._inst_functs = {name: getattr(self, name, None) for name in _inst_functs}
 

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -26,7 +26,7 @@ class IndepVarComp(ExplicitComponent):
         **kwargs : dict
             keyword arguments.
         """
-        super(IndepVarComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if 'tags' not in kwargs:
             kwargs['tags'] = {'indep_var'}
@@ -35,7 +35,7 @@ class IndepVarComp(ExplicitComponent):
 
         # A single variable is declared during instantiation
         if isinstance(name, str):
-            super(IndepVarComp, self).add_output(name, val, **kwargs)
+            super().add_output(name, val, **kwargs)
 
         elif name is None:
             pass
@@ -103,7 +103,7 @@ class IndepVarComp(ExplicitComponent):
                                "declared. They must either be declared during instantiation or "
                                "by calling add_output or add_discrete_output afterwards.")
 
-        super(IndepVarComp, self)._configure_check()
+        super()._configure_check()
 
     def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
                    lower=None, upper=None, ref=None, ref0=None, res_ref=None, tags=None,
@@ -187,7 +187,7 @@ class IndepVarComp(ExplicitComponent):
                   'res_ref': res_ref, 'tags': tags, 'shape_by_conn': shape_by_conn,
                   'copy_shape': copy_shape,
                   }
-        super(IndepVarComp, self).add_output(name, val, **kwargs)
+        super().add_output(name, val, **kwargs)
 
     def add_discrete_output(self, name, val, desc='', tags=None):
         """
@@ -211,7 +211,7 @@ class IndepVarComp(ExplicitComponent):
             tags = make_set(tags, name='tags') | {'indep_var'}
 
         kwargs = {'desc': desc, 'tags': tags}
-        super(IndepVarComp, self).add_discrete_output(name, val, **kwargs)
+        super().add_discrete_output(name, val, **kwargs)
 
     def _linearize(self, jac=None, sub_do_ln=False):
         """
@@ -252,7 +252,7 @@ class _AutoIndepVarComp(IndepVarComp):
         **kwargs : dict
             keyword arguments.
         """
-        super(_AutoIndepVarComp, self).__init__(name, val, **kwargs)
+        super().__init__(name, val, **kwargs)
         self._remotes = set()
 
     def _add_remote(self, name):
@@ -271,7 +271,7 @@ class _AutoIndepVarComp(IndepVarComp):
             for name in all_remotes:
                 self._static_var_rel2meta[name]['distributed'] = True
 
-        super(_AutoIndepVarComp, self)._set_vector_class()
+        super()._set_vector_class()
 
     def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
                    lower=None, upper=None, ref=None, ref0=None, res_ref=None, tags=None,

--- a/openmdao/core/parallel_group.py
+++ b/openmdao/core/parallel_group.py
@@ -18,5 +18,5 @@ class ParallelGroup(Group):
             dict of arguments available here and in all descendants of this
             Group.
         """
-        super(ParallelGroup, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._mpi_proc_allocator.parallel = True

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -299,7 +299,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         class TestImplCompArrayDense(TestImplCompArray):
 
             def setup(self):
-                super(TestImplCompArrayDense, self).setup()
+                super().setup()
                 self.declare_partials('*', '*', method='fd')
 
         prob = om.Problem()
@@ -1862,7 +1862,7 @@ class TestComponentComplexStep(unittest.TestCase):
         class TestImplCompArrayDense(TestImplCompArray):
 
             def setup(self):
-                super(TestImplCompArrayDense, self).setup()
+                super().setup()
                 self.declare_partials('*', '*', method='cs')
 
         prob = self.prob = om.Problem()

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -38,7 +38,7 @@ def _test_func_name(func, num, param):
 
 class PathCompEx(om.ExplicitComponent):
     def __init__(self, s=''):
-        super(PathCompEx, self).__init__()
+        super().__init__()
         self.s = s
 
     def setup(self):

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -361,7 +361,7 @@ class TestProblemCheckPartials(unittest.TestCase):
             """
 
             def __init__(self, i_var, o_var, val, units=None):
-                super(PassThrough, self).__init__()
+                super().__init__()
                 self.i_var = i_var
                 self.o_var = o_var
                 self.units = units
@@ -1381,7 +1381,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         class ArrayCompCS(ArrayComp):
             def setup(self):
-                super(ArrayCompCS, self).setup()
+                super().setup()
                 self.set_check_partial_options('x*', directional=True, method='cs')
 
         prob = om.Problem()

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -52,18 +52,18 @@ class CounterGroup(om.Group):
         self._solve_count = 0
         self._solve_nl_count = 0
         self._apply_nl_count = 0
-        super(CounterGroup, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def _solve_linear(self, *args, **kwargs):
-        super(CounterGroup, self)._solve_linear(*args, **kwargs)
+        super()._solve_linear(*args, **kwargs)
         self._solve_count += 1
 
     def _solve_nonlinear(self, *args, **kwargs):
-        super(CounterGroup, self)._solve_nonlinear(*args, **kwargs)
+        super()._solve_nonlinear(*args, **kwargs)
         self._solve_nl_count += 1
 
     def _apply_nonlinear(self, *args, **kwargs):
-        super(CounterGroup, self)._apply_nonlinear(*args, **kwargs)
+        super()._apply_nonlinear(*args, **kwargs)
         self._apply_nl_count += 1
 
 
@@ -73,7 +73,7 @@ SIZE = 10
 
 class DynPartialsComp(om.ExplicitComponent):
     def __init__(self, size):
-        super(DynPartialsComp, self).__init__()
+        super().__init__()
         self.size = size
         self.num_computes = 0
 
@@ -361,7 +361,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
     def test_size_zero_array_in_component(self):
         class DynamicPartialsComp(om.ExplicitComponent):
             def __init__(self, size):
-                super(DynamicPartialsComp, self).__init__()
+                super().__init__()
                 self.size = size
                 self.num_computes = 0
 
@@ -401,7 +401,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
     def test_size_zero_array_declare_partials(self):
         class DynamicPartialsComp(om.ExplicitComponent):
             def __init__(self, size):
-                super(DynamicPartialsComp, self).__init__()
+                super().__init__()
                 self.size = size
                 self.num_computes = 0
 
@@ -710,7 +710,7 @@ class SimulColoringScipyTestCase(unittest.TestCase):
 
         class DynamicPartialsComp(om.ExplicitComponent):
             def __init__(self, size):
-                super(DynamicPartialsComp, self).__init__()
+                super().__init__()
                 self.size = size
                 self.num_computes = 0
 
@@ -1118,7 +1118,7 @@ class SimulColoringVarOutputTestClass(unittest.TestCase):
 
 class DumbComp(om.ExplicitComponent):
     def __init__(self, inputs, outputs, isizes, osizes, **kwargs):
-        super(DumbComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._inames = inputs[:]
         self._onames = outputs[:]
         self._isizes = isizes[:]

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -190,11 +190,11 @@ class TestExplicitComponent(unittest.TestCase):
 
         class NewBase(ExplicitComponent):
             def __init__(self, **kwargs):
-                super(NewBase, self).__init__(**kwargs)
+                super().__init__(**kwargs)
 
         class MyComp(NewBase):
             def __init__(self, **kwargs):
-                super(MyComp, self).__init__(**kwargs)
+                super().__init__(**kwargs)
 
             def setup(self):
                 self.add_input('x', val=0.0)
@@ -315,7 +315,7 @@ class TestRangePartials(unittest.TestCase):
     def test_range_partials(self):
         class RangePartialsComp(ExplicitComponent):
             def __init__(self, size=4):
-                super(RangePartialsComp, self).__init__()
+                super().__init__()
                 self.size = size
 
             def setup(self):

--- a/openmdao/core/tests/test_compute_jacvec_prod.py
+++ b/openmdao/core/tests/test_compute_jacvec_prod.py
@@ -22,7 +22,7 @@ class SubProbComp(om.ExplicitComponent):
     together.
     """
     def __init__(self, input_size, num_nodes, mode, **kwargs):
-        super(SubProbComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.prob = None
         self.size = input_size
         self.num_nodes = num_nodes

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -19,7 +19,7 @@ from openmdao.utils.logger_utils import TestLogger
 
 class ModCompEx(om.ExplicitComponent):
     def __init__(self, modval, **kwargs):
-        super(ModCompEx, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.modval = modval
 
     def setup(self):
@@ -35,7 +35,7 @@ class ModCompEx(om.ExplicitComponent):
 
 class ModCompIm(om.ImplicitComponent):
     def __init__(self, modval, **kwargs):
-        super(ModCompIm, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.modval = modval
 
     def setup(self):
@@ -67,25 +67,25 @@ class CompDiscWDerivs(om.ExplicitComponent):
 
 class CompDiscWDerivsImplicit(StateConnection):
     def setup(self):
-        super(CompDiscWDerivsImplicit, self).setup()
+        super().setup()
         self.add_discrete_input('N', 2)
         self.add_discrete_output('Nout', 2)
 
     def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs, discrete_outputs):
-        super(CompDiscWDerivsImplicit, self).apply_nonlinear(inputs, outputs, residuals)
+        super().apply_nonlinear(inputs, outputs, residuals)
         discrete_outputs['Nout'] = discrete_inputs['N'] * 2
 
     def solve_nonlinear(self, inputs, outputs, discrete_inputs, discrete_outputs):
-        super(CompDiscWDerivsImplicit, self).solve_nonlinear(inputs, outputs)
+        super().solve_nonlinear(inputs, outputs)
         discrete_outputs['Nout'] = discrete_inputs['N'] * 2
 
     def linearize(self, inputs, outputs, J, discrets_inputs, discrete_outputs):
-        super(CompDiscWDerivsImplicit, self).linearize(inputs, outputs, J)
+        super().linearize(inputs, outputs, J)
 
 
 class MixedCompDiscIn(om.ExplicitComponent):
     def __init__(self, mult, **kwargs):
-        super(MixedCompDiscIn, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mult = mult
 
     def setup(self):
@@ -98,7 +98,7 @@ class MixedCompDiscIn(om.ExplicitComponent):
 
 class MixedCompDiscOut(om.ExplicitComponent):
     def __init__(self, mult, **kwargs):
-        super(MixedCompDiscOut, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mult = mult
 
     def setup(self):
@@ -122,7 +122,7 @@ class InternalDiscreteGroup(om.Group):
 class DiscreteDriver(Driver):
 
     def __init__(self):
-        super(DiscreteDriver, self).__init__()
+        super().__init__()
         self.supports.declare('integer_design_vars', types=bool, default=True)
 
     def run(self):
@@ -171,7 +171,7 @@ class PathCompEx(om.ExplicitComponent):
 
 class ObjAdderCompEx(om.ExplicitComponent):
     def __init__(self, val, **kwargs):
-        super(ObjAdderCompEx, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.val = val
 
     def setup(self):

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -41,7 +41,7 @@ class DistribExecComp(om.ExecComp):
     """
 
     def __init__(self, exprs, arr_size=11, **kwargs):
-        super(DistribExecComp, self).__init__(exprs, **kwargs)
+        super().__init__(exprs, **kwargs)
         self.arr_size = arr_size
         self.options['distributed'] = True
 
@@ -86,12 +86,12 @@ class DistribExecComp(om.ExecComp):
                 meta['value'] = np.ones(sizes[rank], float)
                 meta['src_indices'] = np.arange(start, end, dtype=int)
 
-        super(DistribExecComp, self).setup()
+        super().setup()
 
 
 class DistribCoordComp(om.ExplicitComponent):
     def __init__(self, **kwargs):
-        super(DistribCoordComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.options['distributed'] = True
 

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -224,11 +224,11 @@ class DistribCompWithDerivs(om.ExplicitComponent):
 class DistribInputDistribOutputDiscreteComp(DistribInputDistribOutputComp):
 
     def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
-        super(DistribInputDistribOutputDiscreteComp, self).compute(inputs, outputs)
+        super().compute(inputs, outputs)
         discrete_outputs['disc_out'] = discrete_inputs['disc_in'] + 'bar'
 
     def setup(self):
-        super(DistribInputDistribOutputDiscreteComp, self).setup()
+        super().setup()
         self.add_discrete_input('disc_in', 'foo')
         self.add_discrete_output('disc_out', 'foobar')
 

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -817,7 +817,7 @@ class TestDriverMPI(unittest.TestCase):
         class MyDriver(Driver):
 
             def __init__(self, generator=None, **kwargs):
-                super(MyDriver, self).__init__(**kwargs)
+                super().__init__(**kwargs)
                 self.supports['distributed_design_vars'] = False
                 self.supports._read_only = True
 

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -322,7 +322,7 @@ class TestPassSizeDistributed(unittest.TestCase):
 class ResizableComp(om.ExplicitComponent):
     # this is just a component that allows us to resize between setups
     def __init__(self, n_inputs=1, size=5, mult=2.):
-        super(ResizableComp, self).__init__()
+        super().__init__()
         self.n_inputs = n_inputs
         self.size = size
         self.mult = mult
@@ -340,7 +340,7 @@ class ResizableComp(om.ExplicitComponent):
 class DynShapeComp(om.ExplicitComponent):
     # component whose inputs and outputs are dynamically shaped
     def __init__(self, n_inputs=1):
-        super(DynShapeComp, self).__init__()
+        super().__init__()
         self.n_inputs = n_inputs
 
         for i in range(self.n_inputs):
@@ -355,7 +355,7 @@ class DynShapeComp(om.ExplicitComponent):
 class DistribDynShapeComp(om.ExplicitComponent):
     # a distributed component whose inputs and outputs are dynamically shaped
     def __init__(self, n_inputs=1):
-        super(DistribDynShapeComp, self).__init__()
+        super().__init__()
         self.n_inputs = n_inputs
         self.options['distributed'] = True
 
@@ -372,7 +372,7 @@ class DistribDynShapeComp(om.ExplicitComponent):
 class DistribComp(om.ExplicitComponent):
     # a distributed component with inputs and outputs that are not dynamically shaped
     def __init__(self, global_size, n_inputs=2):
-        super(DistribComp, self).__init__()
+        super().__init__()
         self.n_inputs = n_inputs
         self.global_size = global_size
         self.options['distributed'] = True
@@ -395,7 +395,7 @@ class DynShapeGroupSeries(om.Group):
     # strings together some number of components in series.
     # component type is determined by comp_class
     def __init__(self, n_comps, n_inputs, comp_class):
-        super(DynShapeGroupSeries, self).__init__()
+        super().__init__()
         self.n_comps = n_comps
         self.n_inputs = n_inputs
         self.comp_class = comp_class
@@ -412,7 +412,7 @@ class DynShapeGroupConnectedInputs(om.Group):
     # contains some number of components with all of their matching inputs connected.
     # component type is determined by comp_class
     def __init__(self, n_comps, n_inputs, comp_class):
-        super(DynShapeGroupConnectedInputs, self).__init__()
+        super().__init__()
         self.n_comps = n_comps
         self.n_inputs = n_inputs
         self.comp_class = comp_class

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -514,7 +514,7 @@ class ExplCompTestCase(unittest.TestCase):
             """
 
             def __init__(self, size):
-                super(ArrayAdder, self).__init__()
+                super().__init__()
                 self.size = size
 
             def setup(self):
@@ -693,7 +693,7 @@ class ExplCompTestCase(unittest.TestCase):
             """
 
             def __init__(self, size):
-                super(ArrayAdder, self).__init__()
+                super().__init__()
                 self.size = size
 
             def setup(self):
@@ -870,7 +870,7 @@ class ExplCompTestCase(unittest.TestCase):
     def test_compute_inputs_read_only(self):
         class BadComp(TestExplCompSimple):
             def compute(self, inputs, outputs):
-                super(BadComp, self).compute(inputs, outputs)
+                super().compute(inputs, outputs)
                 inputs['length'] = 0.  # should not be allowed
 
         prob = om.Problem(BadComp())
@@ -885,7 +885,7 @@ class ExplCompTestCase(unittest.TestCase):
     def test_compute_inputs_read_only_reset(self):
         class BadComp(TestExplCompSimple):
             def compute(self, inputs, outputs):
-                super(BadComp, self).compute(inputs, outputs)
+                super().compute(inputs, outputs)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem(BadComp())
@@ -899,7 +899,7 @@ class ExplCompTestCase(unittest.TestCase):
     def test_compute_partials_inputs_read_only(self):
         class BadComp(TestExplCompSimpleDense):
             def compute_partials(self, inputs, partials):
-                super(BadComp, self).compute_partials(inputs, partials)
+                super().compute_partials(inputs, partials)
                 inputs['length'] = 0.  # should not be allowed
 
         prob = om.Problem(BadComp())
@@ -916,7 +916,7 @@ class ExplCompTestCase(unittest.TestCase):
     def test_compute_partials_inputs_read_only_reset(self):
         class BadComp(TestExplCompSimpleDense):
             def compute_partials(self, inputs, partials):
-                super(BadComp, self).compute_partials(inputs, partials)
+                super().compute_partials(inputs, partials)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem(BadComp())
@@ -932,7 +932,7 @@ class ExplCompTestCase(unittest.TestCase):
     def test_compute_jacvec_product_inputs_read_only(self):
         class BadComp(RectangleJacVec):
             def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
-                super(BadComp, self).compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
+                super().compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
                 inputs['length'] = 0.  # should not be allowed
 
         prob = om.Problem(BadComp())
@@ -949,7 +949,7 @@ class ExplCompTestCase(unittest.TestCase):
     def test_compute_jacvec_product_inputs_read_only_reset(self):
         class BadComp(RectangleJacVec):
             def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
-                super(BadComp, self).compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
+                super().compute_jacvec_product(inputs, d_inputs, d_outputs, mode)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem(BadComp())

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -80,18 +80,18 @@ def setup_indeps(isplit, ninputs, indeps_name, comp_name):
 
 class CounterGroup(Group):
     def __init__(self, *args, **kwargs):
-        super(CounterGroup, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self._nruns = 0
 
     def _solve_nonlinear(self, *args, **kwargs):
-        super(CounterGroup, self)._solve_nonlinear(*args, **kwargs)
+        super()._solve_nonlinear(*args, **kwargs)
         self._nruns += 1
 
 
 class SparseCompImplicit(ImplicitComponent):
 
     def __init__(self, sparsity, method='fd', isplit=1, osplit=1, **kwargs):
-        super(SparseCompImplicit, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.sparsity = sparsity
         self.isplit = isplit
         self.osplit = osplit
@@ -127,7 +127,7 @@ class SparseCompImplicit(ImplicitComponent):
 class SparseCompExplicit(ExplicitComponent):
 
     def __init__(self, sparsity, method='fd', isplit=1, osplit=1, **kwargs):
-        super(SparseCompExplicit, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.sparsity = sparsity
         self.isplit = isplit
         self.osplit = osplit

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -69,7 +69,7 @@ class SetOrderGroup(om.Group):
 
 class ReportOrderComp(om.ExplicitComponent):
     def __init__(self, order_list):
-        super(ReportOrderComp, self).__init__()
+        super().__init__()
         self._order_list = order_list
 
     def setup(self):
@@ -2031,7 +2031,7 @@ class TestGroupPromotes(unittest.TestCase):
 
 class MyComp(om.ExplicitComponent):
     def __init__(self, input_shape, src_indices=None, flat_src_indices=False):
-        super(MyComp, self).__init__()
+        super().__init__()
         self._input_shape = input_shape
         self._src_indices = src_indices
         self._flat_src_indices = flat_src_indices
@@ -2785,7 +2785,7 @@ class MultComp(om.ExplicitComponent):
     of times _setup_var_data is called.
     """
     def __init__(self, mults=(), inits=None, **kwargs):
-        super(MultComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mults = list(mults)
         self.var_setup_count = 0
         if inits is None:
@@ -2793,7 +2793,7 @@ class MultComp(om.ExplicitComponent):
         self.inits = inits
 
     def _setup_var_data(self):
-        super(MultComp, self)._setup_var_data()
+        super()._setup_var_data()
         self.var_setup_count += 1
 
     def add_mult(self, inp, mult, out):
@@ -2825,7 +2825,7 @@ class ConfigGroup(om.Group):
     times _setup_var_data is called.
     """
     def __init__(self, parallel=False, *args, **kwargs):
-        super(ConfigGroup, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.cfgproms = []
         self.cfg_group_ins = []
         self.cfgio = {}
@@ -2838,7 +2838,7 @@ class ConfigGroup(om.Group):
             self._mpi_proc_allocator.parallel = True
 
     def _setup_var_data(self):
-        super(ConfigGroup, self)._setup_var_data()
+        super()._setup_var_data()
         self.var_setup_count += 1
 
     def add_config_prom(self, child, prom):
@@ -3529,7 +3529,7 @@ class TestFeatureSetOrder(unittest.TestCase):
             """Adds name to list."""
 
             def __init__(self, order_list):
-                super(ReportOrderComp, self).__init__()
+                super().__init__()
                 self._order_list = order_list
 
             def compute(self, inputs, outputs):

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -877,7 +877,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_nonlinear_inputs_read_only(self):
         class BadComp(QuadraticComp):
             def apply_nonlinear(self, inputs, outputs, residuals):
-                super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)
+                super().apply_nonlinear(inputs, outputs, residuals)
                 inputs['a'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -896,7 +896,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_nonlinear_outputs_read_only(self):
         class BadComp(QuadraticComp):
             def apply_nonlinear(self, inputs, outputs, residuals):
-                super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)
+                super().apply_nonlinear(inputs, outputs, residuals)
                 outputs['x'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -915,7 +915,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_nonlinear_read_only_reset(self):
         class BadComp(QuadraticComp):
             def apply_nonlinear(self, inputs, outputs, residuals):
-                super(BadComp, self).apply_nonlinear(inputs, outputs, residuals)
+                super().apply_nonlinear(inputs, outputs, residuals)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem()
@@ -933,7 +933,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_solve_nonlinear_inputs_read_only(self):
         class BadComp(QuadraticComp):
             def solve_nonlinear(self, inputs, outputs):
-                super(BadComp, self).solve_nonlinear(inputs, outputs)
+                super().solve_nonlinear(inputs, outputs)
                 inputs['a'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -951,7 +951,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_solve_nonlinear_inputs_read_only_reset(self):
         class BadComp(QuadraticComp):
             def solve_nonlinear(self, inputs, outputs):
-                super(BadComp, self).solve_nonlinear(inputs, outputs)
+                super().solve_nonlinear(inputs, outputs)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem()
@@ -967,7 +967,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_linearize_inputs_read_only(self):
         class BadComp(QuadraticLinearize):
             def linearize(self, inputs, outputs, partials):
-                super(BadComp, self).linearize(inputs, outputs, partials)
+                super().linearize(inputs, outputs, partials)
                 inputs['a'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -986,7 +986,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_linearize_outputs_read_only(self):
         class BadComp(QuadraticLinearize):
             def linearize(self, inputs, outputs, partials):
-                super(BadComp, self).linearize(inputs, outputs, partials)
+                super().linearize(inputs, outputs, partials)
                 outputs['x'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -1005,7 +1005,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_linearize_read_only_reset(self):
         class BadComp(QuadraticLinearize):
             def linearize(self, inputs, outputs, partials):
-                super(BadComp, self).linearize(inputs, outputs, partials)
+                super().linearize(inputs, outputs, partials)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem()
@@ -1023,7 +1023,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_linear_inputs_read_only(self):
         class BadComp(QuadraticJacVec):
             def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
-                super(BadComp, self).apply_linear(inputs, outputs,
+                super().apply_linear(inputs, outputs,
                                                   d_inputs, d_outputs, d_residuals, mode)
                 inputs['a'] = 0.  # should not be allowed
 
@@ -1043,7 +1043,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_linear_outputs_read_only(self):
         class BadComp(QuadraticJacVec):
             def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
-                super(BadComp, self).apply_linear(inputs, outputs,
+                super().apply_linear(inputs, outputs,
                                                   d_inputs, d_outputs, d_residuals, mode)
                 outputs['x'] = 0.  # should not be allowed
 
@@ -1063,7 +1063,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_linear_dinputs_read_only(self):
         class BadComp(QuadraticJacVec):
             def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
-                super(BadComp, self).apply_linear(inputs, outputs,
+                super().apply_linear(inputs, outputs,
                                                   d_inputs, d_outputs, d_residuals, mode)
                 d_inputs['a'] = 0.  # should not be allowed
 
@@ -1083,7 +1083,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_linear_doutputs_read_only(self):
         class BadComp(QuadraticJacVec):
             def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
-                super(BadComp, self).apply_linear(inputs, outputs,
+                super().apply_linear(inputs, outputs,
                                                   d_inputs, d_outputs, d_residuals, mode)
                 d_outputs['x'] = 0.  # should not be allowed
 
@@ -1103,7 +1103,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_linear_dresids_read_only(self):
         class BadComp(QuadraticJacVec):
             def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
-                super(BadComp, self).apply_linear(inputs, outputs,
+                super().apply_linear(inputs, outputs,
                                                   d_inputs, d_outputs, d_residuals, mode)
                 d_residuals['x'] = 0.  # should not be allowed
 
@@ -1123,7 +1123,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_apply_linear_read_only_reset(self):
         class BadComp(QuadraticJacVec):
             def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
-                super(BadComp, self).apply_linear(inputs, outputs,
+                super().apply_linear(inputs, outputs,
                                                   d_inputs, d_outputs, d_residuals, mode)
                 raise om.AnalysisError("It's just a scratch.")
 
@@ -1143,7 +1143,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_solve_linear_doutputs_read_only(self):
         class BadComp(QuadraticJacVec):
             def solve_linear(self, d_outputs, d_residuals, mode):
-                super(BadComp, self).solve_linear(d_outputs, d_residuals, mode)
+                super().solve_linear(d_outputs, d_residuals, mode)
                 d_outputs['x'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -1163,7 +1163,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_solve_linear_dresids_read_only(self):
         class BadComp(QuadraticJacVec):
             def solve_linear(self, d_outputs, d_residuals, mode):
-                super(BadComp, self).solve_linear(d_outputs, d_residuals, mode)
+                super().solve_linear(d_outputs, d_residuals, mode)
                 d_residuals['x'] = 0.  # should not be allowed
 
         prob = om.Problem()
@@ -1183,7 +1183,7 @@ class ImplicitCompReadOnlyTestCase(unittest.TestCase):
     def test_solve_linear_read_only_reset(self):
         class BadComp(QuadraticJacVec):
             def solve_linear(self, d_outputs, d_residuals, mode):
-                super(BadComp, self).solve_linear(d_outputs, d_residuals, mode)
+                super().solve_linear(d_outputs, d_residuals, mode)
                 raise om.AnalysisError("It's just a scratch.")
 
         prob = om.Problem()

--- a/openmdao/core/tests/test_matmat.py
+++ b/openmdao/core/tests/test_matmat.py
@@ -83,7 +83,7 @@ class QCVProblem(om.Problem):
     """
 
     def __init__(self, comp_class=QuadraticCompVectorized):
-        super(QCVProblem, self).__init__()
+        super().__init__()
 
         model = self.model
 
@@ -786,7 +786,7 @@ class MatMatTestCase(unittest.TestCase):
 class JacVec(om.ExplicitComponent):
 
     def __init__(self, size):
-        super(JacVec, self).__init__()
+        super().__init__()
         self.size = size
 
     def setup(self):

--- a/openmdao/core/tests/test_mpi_coloring_bug.py
+++ b/openmdao/core/tests/test_mpi_coloring_bug.py
@@ -18,7 +18,7 @@ if OPTIMIZER:
 class TrajDesignParameterOptionsDictionary(om.OptionsDictionary):
 
     def __init__(self, read_only=False):
-        super(TrajDesignParameterOptionsDictionary, self).__init__(read_only)
+        super().__init__(read_only)
 
         self.declare(name='name')
         self.declare(name='val', default=np.zeros(1))
@@ -29,7 +29,7 @@ class TrajDesignParameterOptionsDictionary(om.OptionsDictionary):
 class StateOptionsDictionary(om.OptionsDictionary):
 
     def __init__(self, read_only=False):
-        super(StateOptionsDictionary, self).__init__(read_only)
+        super().__init__(read_only)
 
         self.declare(name='name')
         self.declare(name='val', default=0.0)
@@ -286,7 +286,7 @@ class StateIndependentsComp(om.ImplicitComponent):
 class Trajectory(om.Group):
 
     def __init__(self):
-        super(Trajectory, self).__init__()
+        super().__init__()
 
         self.design_parameter_options = {}
         self._phases = {}
@@ -314,7 +314,7 @@ class Trajectory(om.Group):
                                  shape=(1, np.prod(options['shape'])))
 
     def setup(self):
-        super(Trajectory, self).setup()
+        super().setup()
         self._setup_design_parameters()
 
         phases_group = self.add_subsystem('phases', subsys=om.ParallelGroup(), promotes_inputs=['*'],
@@ -334,7 +334,7 @@ class Phase(om.Group):
         self.state_options = {}
         self._objectives = {}
 
-        super(Phase, self).__init__(**_kwargs)
+        super().__init__(**_kwargs)
 
     def initialize(self):
         self.options.declare('ode_class', default=None)

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -584,7 +584,7 @@ class MatMatTestCase(unittest.TestCase):
 
 class SumComp(om.ExplicitComponent):
     def __init__(self, size):
-        super(SumComp, self).__init__()
+        super().__init__()
         self.size = size
 
     def setup(self):
@@ -606,7 +606,7 @@ class SlowComp(om.ExplicitComponent):
     """
 
     def __init__(self, delay=1.0, size=3, mult=2.0):
-        super(SlowComp, self).__init__()
+        super().__init__()
         self.delay = delay
         self.size = size
         self.mult = mult
@@ -625,7 +625,7 @@ class SlowComp(om.ExplicitComponent):
 
     def _apply_linear(self, jac, vec_names, rel_systems, mode, scope_out=None, scope_in=None):
         time.sleep(self.delay)
-        super(SlowComp, self)._apply_linear(jac, vec_names, rel_systems, mode, scope_out, scope_in)
+        super()._apply_linear(jac, vec_names, rel_systems, mode, scope_out, scope_in)
 
 
 class PartialDependGroup(om.Group):

--- a/openmdao/core/tests/test_parallel_fd.py
+++ b/openmdao/core/tests/test_parallel_fd.py
@@ -26,7 +26,7 @@ except ImportError:
 class ScalableComp(om.ExplicitComponent):
 
     def __init__(self, size, mult=2.0, add=1.0):
-        super(ScalableComp, self).__init__()
+        super().__init__()
 
         self._size = size
         self._mult = mult
@@ -485,7 +485,7 @@ class ParFDErrorsMPITestCase(unittest.TestCase):
         p = _setup_problem(self.mat, partial_num_par_fd = 3, approx_totals=False)
         with self.assertRaises(RuntimeError) as ctx:
             p.final_setup()
-            
+
         self.assertEqual(str(ctx.exception), "MatMultComp (comp): num_par_fd is > 1 but no FD is active.")
 
 

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -241,7 +241,7 @@ class TestParallelGroups(unittest.TestCase):
         class MultComp(ExplicitComponent):
             def __init__(self, mult):
                 self.mult = mult
-                super(MultComp, self).__init__()
+                super().__init__()
 
             def setup(self):
                 if self.comm.rank == 0:
@@ -431,7 +431,7 @@ class ExComp(om.ExplicitComponent):
 
 class SubGroup(om.Group):
     def __init__(self, size, **kwargs):
-        super(SubGroup, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.size = size
 
     def setup(self):

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2090,7 +2090,7 @@ class NestedProblemTestCase(unittest.TestCase):
                 p.setup()
                 p.run_model()
 
-                return super(_ProblemSolver, self).solve()
+                return super().solve()
 
         p = om.Problem()
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -515,7 +515,7 @@ class TestScaling(unittest.TestCase):
                 self.add_output('total_volume', val=1.)
 
             def compute(self, inputs, outputs):
-                super(ExpCompArrayScale, self).compute(inputs, outputs)
+                super().compute(inputs, outputs)
                 outputs['stuff'] = inputs['widths'] + inputs['lengths']
 
         prob = om.Problem()
@@ -557,7 +557,7 @@ class TestScaling(unittest.TestCase):
                 self.add_output('total_volume', val=1.)
 
             def compute(self, inputs, outputs):
-                super(ExpCompArrayScale, self).compute(inputs, outputs)
+                super().compute(inputs, outputs)
                 outputs['stuff'] = inputs['widths'] + inputs['lengths']
 
         prob = om.Problem()
@@ -603,7 +603,7 @@ class TestScaling(unittest.TestCase):
                 self.declare_partials(['*'], ['*'], method='cs')
 
             def compute(self, inputs, outputs):
-                super(ExpCompArrayScale, self).compute(inputs, outputs)
+                super().compute(inputs, outputs)
                 outputs['stuff'] = inputs['widths'] + inputs['lengths']
 
         prob = om.Problem()
@@ -679,7 +679,7 @@ class TestScaling(unittest.TestCase):
                 self.declare_partials('*', '*')
 
             def apply_nonlinear(self, inputs, outputs, residuals):
-                super(ImpCompArrayScale, self).apply_nonlinear(inputs, outputs, residuals)
+                super().apply_nonlinear(inputs, outputs, residuals)
                 residuals['extra'] = 2.0*self.mtx.dot(outputs['x']) - 3.0*inputs['rhs']
 
             def linearize(self, inputs, outputs, jacobian):
@@ -738,7 +738,7 @@ class TestScaling(unittest.TestCase):
                                 ref0=np.array([14.0, 17.0]))
 
             def apply_nonlinear(self, inputs, outputs, residuals):
-                super(ImpCompArrayScale, self).apply_nonlinear(inputs, outputs, residuals)
+                super().apply_nonlinear(inputs, outputs, residuals)
                 residuals['extra'] = 2.0*self.mtx.dot(outputs['x']) - 3.0*inputs['rhs']
 
             def linearize(self, inputs, outputs, jacobian):
@@ -811,7 +811,7 @@ class TestScaling(unittest.TestCase):
 
             def compute(self, inputs, outputs):
                 """ Don't need to do much."""
-                #super(ExpCompArrayScale, self).compute(inputs, outputs)
+                #super().compute(inputs, outputs)
                 outputs['stuff'] = inputs['widths'] * 2
                 outputs['areas'] = inputs['lengths'] * 2
 

--- a/openmdao/core/tests/test_simple_impl_comp.py
+++ b/openmdao/core/tests/test_simple_impl_comp.py
@@ -72,7 +72,7 @@ class CompB(ImplicitComponent):
 class GroupG(Group):
 
     def __init__(self, **kwargs):
-        super(GroupG, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.add_subsystem('CA', CompA(), promotes=['*'])
         self.add_subsystem('CB', CompB(), promotes=['*'])
 

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -458,7 +458,7 @@ class TestUnitConversion(unittest.TestCase):
             #"""
 
             #def __init__(self, n=2):
-                #super(Attitude_Angular, self).__init__()
+                #super().__init__()
 
                 #self.n = n
 
@@ -721,7 +721,7 @@ class TestUnitConversion(unittest.TestCase):
         #class TestComp(Component):
 
             #def __init__(self):
-                #super(TestComp, self).__init__()
+                #super().__init__()
 
                 ## Params
                 #self.add_param('x1', 1.0, units='mm')

--- a/openmdao/devtools/iprofile_app/iprofile_app.py
+++ b/openmdao/devtools/iprofile_app/iprofile_app.py
@@ -152,7 +152,7 @@ else:
                  static_path=os.path.join(os.path.dirname(__file__), "static"),
             )
 
-            super(_Application, self).__init__(handlers, **settings)
+            super().__init__(handlers, **settings)
 
         def get_nodes(self, idx):
             """

--- a/openmdao/docs/other/api_translation.rst
+++ b/openmdao/docs/other/api_translation.rst
@@ -25,7 +25,7 @@ Declare a Component with distributed variables
     class DistribComp(ExplicitComponent):
 
         def __init__(self, size):
-            super(DistribComp, self).__init__()
+            super().__init__()
             self.distributed = True
 
 

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -55,7 +55,7 @@ class DifferentialEvolutionDriver(Driver):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
         """
-        super(DifferentialEvolutionDriver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # What we support
         self.supports['inequality_constraints'] = True
@@ -124,7 +124,7 @@ class DifferentialEvolutionDriver(Driver):
         problem : <Problem>
             Pointer to the containing problem.
         """
-        super(DifferentialEvolutionDriver, self)._setup_driver(problem)
+        super()._setup_driver(problem)
 
         model_mpi = None
         comm = problem.comm

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -56,7 +56,7 @@ class DOEDriver(Driver):
                                 "but an instance of %s was found."
                                 % type(generator).__name__)
 
-        super(DOEDriver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # What we support
         self.supports['integer_design_vars'] = True
@@ -248,7 +248,7 @@ class DOEDriver(Driver):
         # if we end up running in parallel
         self._recorders.append(recorder)
 
-        super(DOEDriver, self).add_recorder(recorder)
+        super().add_recorder(recorder)
 
     def _setup_recording(self):
         """
@@ -272,7 +272,7 @@ class DOEDriver(Driver):
                         else:
                             recorder._record_on_proc = False
 
-        super(DOEDriver, self)._setup_recording()
+        super()._setup_recording()
 
     def _get_recorder_metadata(self, case_name):
         """

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -63,7 +63,7 @@ class ListGenerator(DOEGenerator):
         data : list
             list of collections of name, value pairs for the design variables
         """
-        super(ListGenerator, self).__init__()
+        super().__init__()
 
         if not isinstance(data, list):
             msg = "Invalid DOE case data, expected a list but got a {}."
@@ -145,7 +145,7 @@ class CSVGenerator(DOEGenerator):
         filename : str
                the name of the file from which to read cases
         """
-        super(CSVGenerator, self).__init__()
+        super().__init__()
 
         if not isinstance(filename, str):
             raise RuntimeError("'%s' is not a valid file name." % str(filename))
@@ -229,7 +229,7 @@ class UniformGenerator(DOEGenerator):
         seed : int or None, optional
             Seed for random number generator.
         """
-        super(UniformGenerator, self).__init__()
+        super().__init__()
 
         self._num_samples = num_samples
         self._seed = seed
@@ -294,7 +294,7 @@ class _pyDOE_Generator(DOEGenerator):
             The number of evenly spaced levels between each design variable
             lower and upper bound. Defaults to 2.
         """
-        super(_pyDOE_Generator, self).__init__()
+        super().__init__()
         self._levels = levels
 
     def __call__(self, design_vars, model=None):
@@ -402,7 +402,7 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
         """
         Initialize the PlackettBurmanGenerator.
         """
-        super(PlackettBurmanGenerator, self).__init__(levels=2)
+        super().__init__(levels=2)
 
     def _generate_design(self, size):
         """
@@ -444,7 +444,7 @@ class BoxBehnkenGenerator(_pyDOE_Generator):
         center : int, optional
             The number of center points to include (default = None).
         """
-        super(BoxBehnkenGenerator, self).__init__(levels=3)
+        super().__init__(levels=3)
         self._center = center
 
     def _generate_design(self, size):
@@ -517,7 +517,7 @@ class LatinHypercubeGenerator(DOEGenerator):
         seed : int, optional
             Random seed to use if design is randomized. Defaults to None.
         """
-        super(LatinHypercubeGenerator, self).__init__()
+        super().__init__()
 
         if criterion not in self._supported_criterion:
             raise ValueError("Invalid criterion '%s' specified for %s. "

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -61,7 +61,7 @@ class SimpleGADriver(Driver):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
         """
-        super(SimpleGADriver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # What we support
         self.supports['integer_design_vars'] = True
@@ -149,7 +149,7 @@ class SimpleGADriver(Driver):
         problem : <Problem>
             Pointer to the containing problem.
         """
-        super(SimpleGADriver, self)._setup_driver(problem)
+        super()._setup_driver(problem)
 
         model_mpi = None
         comm = problem.comm

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -142,7 +142,7 @@ class pyOptSparseDriver(Driver):
         if Optimization is None:
             raise RuntimeError('pyOptSparseDriver is not available, pyOptsparse is not installed.')
 
-        super(pyOptSparseDriver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # What we support
         self.supports['inequality_constraints'] = True
@@ -216,7 +216,7 @@ class pyOptSparseDriver(Driver):
         problem : <Problem>
             Pointer to the containing problem.
         """
-        super(pyOptSparseDriver, self)._setup_driver(problem)
+        super()._setup_driver(problem)
 
         self.supports._read_only = False
         self.supports['gradients'] = self.options['optimizer'] in grad_drivers

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -119,7 +119,7 @@ class ScipyOptimizeDriver(Driver):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
         """
-        super(ScipyOptimizeDriver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # What we support
         self.supports['inequality_constraints'] = True
@@ -187,7 +187,7 @@ class ScipyOptimizeDriver(Driver):
         problem : <Problem>
             Pointer
         """
-        super(ScipyOptimizeDriver, self)._setup_driver(problem)
+        super()._setup_driver(problem)
         opt = self.options['optimizer']
 
         self.supports._read_only = False

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -32,7 +32,7 @@ class ParaboloidAE(om.ExplicitComponent):
     The AE in ParaboloidAE stands for AnalysisError."""
 
     def __init__(self):
-        super(ParaboloidAE, self).__init__()
+        super().__init__()
         self.fail_hard = False
 
     def setup(self):
@@ -2459,7 +2459,7 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
 
 class MatMultCompExact(om.ExplicitComponent):
     def __init__(self, mat, sparse=False, **kwargs):
-        super(MatMultCompExact, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mat = mat
         self.sparse = sparse
 
@@ -2497,7 +2497,7 @@ class MatMultCompExact(om.ExplicitComponent):
 
 class MyGroup(om.Group):
     def __init__(self, size=5):
-        super(MyGroup, self).__init__()
+        super().__init__()
         self.size = size
 
     def setup(self):

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -15,7 +15,7 @@ from openmdao.utils.logger_utils import TestLogger
 
 class MyComp(om.ExecComp):
     def __init__(self):
-        super(MyComp, self).__init__(["y = 2.0*a", "z = 3.0*b"])
+        super().__init__(["y = 2.0*a", "z = 3.0*b"])
 
 
 class TestCheckConfig(unittest.TestCase):

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -55,7 +55,7 @@ class AssembledJacobian(Jacobian):
         # avoid circular imports
         from openmdao.core.component import Component
 
-        super(AssembledJacobian, self).__init__(system)
+        super().__init__(system)
         self._view_ranges = {}
         self._int_mtx = None
         self._ext_mtx = {}
@@ -414,7 +414,7 @@ class AssembledJacobian(Jacobian):
         active : bool
             Complex mode flag; set to True prior to commencing complex step.
         """
-        super(AssembledJacobian, self).set_complex_step_mode(active)
+        super().set_complex_step_mode(active)
 
         if self._int_mtx is not None:
             self._int_mtx.set_complex_step_mode(active)
@@ -437,7 +437,7 @@ class DenseJacobian(AssembledJacobian):
         system : System
             Parent system to this jacobian.
         """
-        super(DenseJacobian, self).__init__(DenseMatrix, system=system)
+        super().__init__(DenseMatrix, system=system)
 
 
 class COOJacobian(AssembledJacobian):
@@ -454,7 +454,7 @@ class COOJacobian(AssembledJacobian):
         system : System
             Parent system to this jacobian.
         """
-        super(COOJacobian, self).__init__(COOMatrix, system=system)
+        super().__init__(COOMatrix, system=system)
 
 
 class CSRJacobian(AssembledJacobian):
@@ -471,7 +471,7 @@ class CSRJacobian(AssembledJacobian):
         system : System
             Parent system to this jacobian.
         """
-        super(CSRJacobian, self).__init__(CSRMatrix, system=system)
+        super().__init__(CSRMatrix, system=system)
 
 
 class CSCJacobian(AssembledJacobian):
@@ -488,4 +488,4 @@ class CSCJacobian(AssembledJacobian):
         system : System
             Parent system to this jacobian.
         """
-        super(CSCJacobian, self).__init__(CSCMatrix, system=system)
+        super().__init__(CSCMatrix, system=system)

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -27,7 +27,7 @@ class DictionaryJacobian(Jacobian):
         **kwargs : dict
             options dictionary.
         """
-        super(DictionaryJacobian, self).__init__(system, **kwargs)
+        super().__init__(system, **kwargs)
         self._iter_keys = {}
 
     def _iter_abs_keys(self, system, vec_name):

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -23,7 +23,7 @@ except ImportError:
 
 class MyExplicitComp(ExplicitComponent):
     def __init__(self, jac_type):
-        super(MyExplicitComp, self).__init__()
+        super().__init__()
         self._jac_type = jac_type
 
     def setup(self):
@@ -71,7 +71,7 @@ class MyExplicitComp(ExplicitComponent):
 
 class MyExplicitComp2(ExplicitComponent):
     def __init__(self, jac_type):
-        super(MyExplicitComp2, self).__init__()
+        super().__init__()
         self._jac_type = jac_type
 
     def setup(self):
@@ -117,7 +117,7 @@ class ExplicitSetItemComp(ExplicitComponent):
         self._shape = shape
         self._value = value
         self._constructor = constructor
-        super(ExplicitSetItemComp, self).__init__()
+        super().__init__()
 
     def setup(self):
         if self._shape == 'scalar':

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -117,7 +117,7 @@ class SimpleCompConst(om.ExplicitComponent):
 
 class SimpleCompFD(SimpleComp):
     def __init__(self, **kwargs):
-        super(SimpleCompFD, self).__init__()
+        super().__init__()
         self.kwargs = kwargs
 
     def setup_partials(self):
@@ -129,7 +129,7 @@ class SimpleCompFD(SimpleComp):
 
 class SimpleCompMixedFD(SimpleComp):
     def __init__(self, **kwargs):
-        super(SimpleCompMixedFD, self).__init__()
+        super().__init__()
         self.kwargs = kwargs
 
     def setup_partials(self):
@@ -152,7 +152,7 @@ class SimpleCompMixedFD(SimpleComp):
 class SimpleCompKwarg(SimpleComp):
     def __init__(self, partial_kwargs):
         self.partial_kwargs = partial_kwargs
-        super(SimpleCompKwarg, self).__init__()
+        super().__init__()
 
     def setup_partials(self):
         self.declare_partials(**self.partial_kwargs)

--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -29,7 +29,7 @@ class COOMatrix(Matrix):
         is_internal : bool
             If True, this is the int_mtx of an AssembledJacobian.
         """
-        super(COOMatrix, self).__init__(comm, is_internal)
+        super().__init__(comm, is_internal)
         self._coo = None
 
     def _build_coo(self, system):

--- a/openmdao/matrices/csc_matrix.py
+++ b/openmdao/matrices/csc_matrix.py
@@ -24,7 +24,7 @@ class CSCMatrix(COOMatrix):
         system : <System>
             owning system.
         """
-        super(CSCMatrix, self)._build(num_rows, num_cols, system)
+        super()._build(num_rows, num_cols, system)
         self._coo = self._matrix
 
     def _pre_update(self):

--- a/openmdao/matrices/csr_matrix.py
+++ b/openmdao/matrices/csr_matrix.py
@@ -24,7 +24,7 @@ class CSRMatrix(COOMatrix):
         out_ranges : dict
             Maps output var name to row range.
         """
-        super(CSRMatrix, self)._build(num_rows, num_cols, in_ranges, out_ranges)
+        super()._build(num_rows, num_cols, in_ranges, out_ranges)
 
         self._coo = self._matrix
 

--- a/openmdao/matrices/dense_matrix.py
+++ b/openmdao/matrices/dense_matrix.py
@@ -27,7 +27,7 @@ class DenseMatrix(COOMatrix):
         system : <System>
             owning system.
         """
-        super(DenseMatrix, self)._build(num_rows, num_cols)
+        super()._build(num_rows, num_cols)
         self._coo = self._matrix
 
     def _prod(self, in_vec, mode, mask=None):

--- a/openmdao/proc_allocators/proc_allocator.py
+++ b/openmdao/proc_allocators/proc_allocator.py
@@ -25,7 +25,7 @@ class ProcAllocationError(Exception):
         sub_inds : list of int
             Indices of subsystems in _subsystems_allprocs in parent.
         """
-        super(ProcAllocationError, self).__init__(msg)
+        super().__init__(msg)
         self.msg = msg
         self.sub_inds = sub_inds
 

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -792,7 +792,7 @@ class PromAbsDict(dict):
             connections or a promoted input name for multiple connections. This is for output
             display.
         """
-        super(PromAbsDict, self).__init__()
+        super().__init__()
 
         self._prom2abs = prom2abs
         self._abs2prom = abs2prom
@@ -812,27 +812,27 @@ class PromAbsDict(dict):
                     # key is auto_ivc, so translate to a readable input name.
                     self._values[key] = values[key]
                     in_key = auto_ivc_map[key]
-                    super(PromAbsDict, self).__setitem__(in_key, values[key])
+                    super().__setitem__(in_key, values[key])
                 elif key in abs2prom:
                     # key is absolute name
                     self._values[key] = values[key]
                     prom_key = abs2prom[key]
-                    super(PromAbsDict, self).__setitem__(prom_key, values[key])
+                    super().__setitem__(prom_key, values[key])
                 elif key in prom2abs:
                     # key is promoted name
                     for abs_key in prom2abs[key]:
                         self._values[abs_key] = values[key]
-                    super(PromAbsDict, self).__setitem__(key, values[key])
+                    super().__setitem__(key, values[key])
                 elif isinstance(key, tuple) or DERIV_KEY_SEP in key:
                     # derivative keys can be either (of, wrt) or 'of!wrt'
                     abs_keys, prom_key = self._deriv_keys(key)
                     for abs_key in abs_keys:
                         self._values[abs_key] = values[key]
-                    super(PromAbsDict, self).__setitem__(prom_key, values[key])
+                    super().__setitem__(prom_key, values[key])
                 elif in_prom2abs is not None and key in in_prom2abs:
                     # Auto-ivc outputs, use abs source (which is prom source.)
                     self._values[key] = values[key]
-                    super(PromAbsDict, self).__setitem__(key, values[key])
+                    super().__setitem__(key, values[key])
             self._keys = self._values.keys()
         else:
             # numpy structured array, which will always use absolute names
@@ -842,24 +842,24 @@ class PromAbsDict(dict):
                 if key in auto_ivc_map:
                     # key is auto_ivc, so translate to a readable input name.
                     in_key = auto_ivc_map[key]
-                    super(PromAbsDict, self).__setitem__(in_key, self._values[key])
+                    super().__setitem__(in_key, self._values[key])
                 elif key in abs2prom:
                     prom_key = abs2prom[key]
                     if prom_key in self:
                         # We already set a value for this promoted name, which means
                         # it is an input that maps to multiple absolute names. Set the
                         # value to AMBIGOUS and require access via absolute name.
-                        super(PromAbsDict, self).__setitem__(prom_key, _AMBIGOUS_PROM_NAME)
+                        super().__setitem__(prom_key, _AMBIGOUS_PROM_NAME)
                     else:
-                        super(PromAbsDict, self).__setitem__(prom_key, self._values[key])
+                        super().__setitem__(prom_key, self._values[key])
                 elif DERIV_KEY_SEP in key:
                     # derivative keys will be a string in the form of 'of!wrt'
                     abs_keys, prom_key = self._deriv_keys(key)
-                    super(PromAbsDict, self).__setitem__(prom_key, self._values[key])
+                    super().__setitem__(prom_key, self._values[key])
                 elif in_prom2abs is not None and key in in_prom2abs:
                     # Auto-ivc outputs, use abs source (which is prom source.)
                     # TODO - maybe get rid of this by always saving the source name
-                    super(PromAbsDict, self).__setitem__(key, self._values[key])
+                    super().__setitem__(key, self._values[key])
 
     def __str__(self):
         """
@@ -870,7 +870,7 @@ class PromAbsDict(dict):
         str
             String representation of the dictionary.
         """
-        return super(PromAbsDict, self).__str__()
+        return super().__str__()
 
     def _deriv_keys(self, key):
         """
@@ -944,7 +944,7 @@ class PromAbsDict(dict):
 
         elif key in self:
             # promoted name
-            val = super(PromAbsDict, self).__getitem__(key)
+            val = super().__getitem__(key)
             if val is _AMBIGOUS_PROM_NAME:
                 msg = "The promoted name '%s' is invalid because it refers to multiple " + \
                       "inputs: %s. Access the value using an absolute path name or the " + \
@@ -956,7 +956,7 @@ class PromAbsDict(dict):
         elif isinstance(key, tuple) or self._DERIV_KEY_SEP in key:
             # derivative keys can be either (of, wrt) or 'of!wrt'
             abs_keys, prom_key = self._deriv_keys(key)
-            return super(PromAbsDict, self).__getitem__(prom_key)
+            return super().__getitem__(prom_key)
 
         raise KeyError('Variable name "%s" not found.' % key)
 
@@ -982,28 +982,28 @@ class PromAbsDict(dict):
             for abs_key in abs_keys:
                 self._values[abs_key] = value
 
-            super(PromAbsDict, self).__setitem__(prom_key, value)
+            super().__setitem__(prom_key, value)
 
         elif key in abs2prom:
             if key in auto_ivc_map:
                 # key is auto_ivc, so translate to a readable input name.
                 self._values[key] = value
                 in_key = auto_ivc_map[key]
-                super(PromAbsDict, self).__setitem__(in_key, self._values[key])
+                super().__setitem__(in_key, self._values[key])
             else:
                 # absolute name
                 self._values[key] = value
-                super(PromAbsDict, self).__setitem__(self._abs2prom[key], value)
+                super().__setitem__(self._abs2prom[key], value)
         elif key in prom2abs:
             # promoted name, propagate to all connected absolute names
             for abs_key in self._prom2abs[key]:
                 if abs_key in self._keys:
                     self._values[abs_key] = value
-            super(PromAbsDict, self).__setitem__(key, value)
+            super().__setitem__(key, value)
         else:
             # Design variable by promoted input name.
             self._values[key] = value
-            super(PromAbsDict, self).__setitem__(key, value)
+            super().__setitem__(key, value)
 
     def absolute_names(self):
         """

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -77,7 +77,7 @@ class SqliteCaseReader(BaseCaseReader):
         pre_load : bool
             If True, load all the data into memory during initialization.
         """
-        super(SqliteCaseReader, self).__init__(filename, pre_load)
+        super().__init__(filename, pre_load)
 
         check_valid_sqlite3_db(filename)
 
@@ -1196,10 +1196,10 @@ class DriverCases(CaseTable):
         var_info : dict
             Dictionary with information about variables (scaling, indices, execution order).
         """
-        super(DriverCases, self).__init__(filename, format_version,
-                                          'driver_iterations', 'iteration_coordinate', giter,
-                                          prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
-                                          var_info)
+        super().__init__(filename, format_version,
+                         'driver_iterations', 'iteration_coordinate', giter,
+                         prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
+                         var_info)
         self._var_info = var_info
 
     def cases(self, cache=False):
@@ -1376,10 +1376,10 @@ class SystemCases(CaseTable):
         var_info : dict
             Dictionary with information about variables (scaling, indices, execution order).
         """
-        super(SystemCases, self).__init__(filename, format_version,
-                                          'system_iterations', 'iteration_coordinate', giter,
-                                          prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
-                                          var_info)
+        super().__init__(filename, format_version,
+                         'system_iterations', 'iteration_coordinate', giter,
+                         prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
+                         var_info)
 
 
 class SolverCases(CaseTable):
@@ -1415,10 +1415,10 @@ class SolverCases(CaseTable):
         var_info : dict
             Dictionary with information about variables (scaling, indices, execution order).
         """
-        super(SolverCases, self).__init__(filename, format_version,
-                                          'solver_iterations', 'iteration_coordinate', giter,
-                                          prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
-                                          var_info)
+        super().__init__(filename, format_version,
+                         'solver_iterations', 'iteration_coordinate', giter,
+                         prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
+                         var_info)
 
     def _get_source(self, iteration_coordinate):
         """
@@ -1482,10 +1482,10 @@ class ProblemCases(CaseTable):
         var_info : dict
             Dictionary with information about variables (scaling, indices, execution order).
         """
-        super(ProblemCases, self).__init__(filename, format_version,
-                                           'problem_cases', 'case_name', giter,
-                                           prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
-                                           var_info)
+        super().__init__(filename, format_version,
+                         'problem_cases', 'case_name', giter,
+                         prom2abs, abs2prom, abs2meta, conns, auto_ivc_map,
+                         var_info)
 
     def list_sources(self):
         """

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -162,7 +162,7 @@ class SqliteRecorder(CaseRecorder):
         # default to record on all procs when running in parallel
         self._record_on_proc = True
 
-        super(SqliteRecorder, self).__init__(record_viewer_data)
+        super().__init__(record_viewer_data)
 
     def _initialize_database(self):
         """
@@ -272,7 +272,7 @@ class SqliteRecorder(CaseRecorder):
         recording_requester : object
             Object to which this recorder is attached.
         """
-        super(SqliteRecorder, self).startup(recording_requester)
+        super().startup(recording_requester)
 
         if not self._database_initialized:
             self._initialize_database()

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -29,7 +29,7 @@ class DistributedAdder(ExplicitComponent):
     """
 
     def __init__(self, size):
-        super(DistributedAdder, self).__init__()
+        super().__init__()
 
         self.options['distributed'] = True
 
@@ -72,7 +72,7 @@ class Summer(ExplicitComponent):
     """
 
     def __init__(self, size):
-        super(Summer, self).__init__()
+        super().__init__()
         self.size = size
 
     def setup(self):

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2661,7 +2661,7 @@ class TestSqliteCaseReader(unittest.TestCase):
             A simple component that has array inputs and outputs
             """
             def __init__(self, size):
-                super(ArrayAdder, self).__init__()
+                super().__init__()
                 self.size = size
 
             def setup(self):

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -174,7 +174,7 @@ class DirectSolver(LinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(DirectSolver, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('err_on_singular', types=bool, default=True,
                              desc="Raise an error if LU decomposition is singular.")
@@ -200,7 +200,7 @@ class DirectSolver(LinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(DirectSolver, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
         self._disallow_distrib_solve()
 
     def _linearize_children(self):

--- a/openmdao/solvers/linear/linear_block_gs.py
+++ b/openmdao/solvers/linear/linear_block_gs.py
@@ -30,7 +30,7 @@ class LinearBlockGS(BlockLinearSolver):
         **kwargs : dict
             options dictionary.
         """
-        super(LinearBlockGS, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._theta_n_1 = {}
         self._delta_d_n_1 = {}
@@ -39,7 +39,7 @@ class LinearBlockGS(BlockLinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(LinearBlockGS, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('use_aitken', types=bool, default=False,
                              desc='set to True to use Aitken relaxation')
@@ -72,7 +72,7 @@ class LinearBlockGS(BlockLinearSolver):
                 self._delta_d_n_1[vec_name] = d_vec[vec_name].asarray(copy=True)
                 self._theta_n_1[vec_name] = 1.0
 
-        return super(LinearBlockGS, self)._iter_initialize()
+        return super()._iter_initialize()
 
     def _single_iteration(self):
         """

--- a/openmdao/solvers/linear/linear_runonce.py
+++ b/openmdao/solvers/linear/linear_runonce.py
@@ -38,7 +38,7 @@ class LinearRunOnce(LinearBlockGS):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(LinearRunOnce, self)._declare_options()
+        super()._declare_options()
 
         # Remove unused options from base options here, so that users
         # attempting to set them will get KeyErrors.

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -194,7 +194,7 @@ class PETScKrylov(LinearSolver):
         **kwargs : dict
             dictionary of options set by the instantiating class/script.
         """
-        super(PETScKrylov, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         if PETSc is None:
             raise RuntimeError("{}: PETSc is not available.".format(self.msginfo))
@@ -209,7 +209,7 @@ class PETScKrylov(LinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(PETScKrylov, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('ksp_type', default='fgmres', values=KSP_TYPES,
                              desc="KSP algorithm to use. Default is 'fgmres'.")
@@ -245,7 +245,7 @@ class PETScKrylov(LinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(PETScKrylov, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
 
         if self.precon is not None:
             self.precon._setup_solvers(self._system(), self._depth + 1)
@@ -263,7 +263,7 @@ class PETScKrylov(LinearSolver):
         type_ : str
             Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
         """
-        super(PETScKrylov, self)._set_solver_print(level=level, type_=type_)
+        super()._set_solver_print(level=level, type_=type_)
 
         if self.precon is not None and type_ != 'NL':
             self.precon._set_solver_print(level=level, type_=type_)

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -37,7 +37,7 @@ class ScipyKrylov(LinearSolver):
         **kwargs : {}
             dictionary of options set by the instantiating class/script.
         """
-        super(ScipyKrylov, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # initialize preconditioner to None
         self.precon = None
@@ -56,7 +56,7 @@ class ScipyKrylov(LinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(ScipyKrylov, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('solver', default='gmres', values=tuple(_SOLVER_TYPES.keys()),
                              desc='function handle for actual solver')
@@ -81,7 +81,7 @@ class ScipyKrylov(LinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(ScipyKrylov, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
 
         if self.precon is not None:
             self.precon._setup_solvers(self._system(), self._depth + 1)
@@ -99,7 +99,7 @@ class ScipyKrylov(LinearSolver):
         type_ : str
             Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
         """
-        super(ScipyKrylov, self)._set_solver_print(level=level, type_=type_)
+        super()._set_solver_print(level=level, type_=type_)
 
         if self.precon is not None and type_ != 'NL':
             self.precon._set_solver_print(level=level, type_=type_)

--- a/openmdao/solvers/linear/user_defined.py
+++ b/openmdao/solvers/linear/user_defined.py
@@ -30,7 +30,7 @@ class LinearUserDefined(LinearSolver):
         **kwargs : dict
             Options dictionary.
         """
-        super(LinearUserDefined, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.solve_function = solve_function
 

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -67,7 +67,7 @@ class LinesearchSolver(NonlinearSolver):
         **kwargs : dict
             Options dictionary.
         """
-        super(LinesearchSolver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # Parent solver sets this to control whether to solve subsystems.
         self._do_subsolve = False
         self._lower_bounds = None
@@ -77,7 +77,7 @@ class LinesearchSolver(NonlinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(LinesearchSolver, self)._declare_options()
+        super()._declare_options()
         opt = self.options
         opt.declare(
             'bound_enforcement', default='scalar', values=['vector', 'scalar', 'wall'],
@@ -102,7 +102,7 @@ class LinesearchSolver(NonlinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(LinesearchSolver, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
         if system._has_bounds:
             abs2meta_out = system._var_abs2meta['output']
             start = end = 0
@@ -189,7 +189,7 @@ class BoundsEnforceLS(LinesearchSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(BoundsEnforceLS, self)._declare_options()
+        super()._declare_options()
         opt = self.options
 
         # Remove unused options from base options here, so that users
@@ -253,7 +253,7 @@ class ArmijoGoldsteinLS(LinesearchSolver):
         **kwargs : dict
             Options dictionary.
         """
-        super(ArmijoGoldsteinLS, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._analysis_error_raised = False
 
@@ -321,7 +321,7 @@ class ArmijoGoldsteinLS(LinesearchSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(ArmijoGoldsteinLS, self)._declare_options()
+        super()._declare_options()
         opt = self.options
         opt['maxiter'] = 5
         opt.declare('c', default=0.1, lower=0.0, upper=1.0, desc="Slope parameter for line of "

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -606,7 +606,7 @@ class SellarDis1withDerivativesMod(SellarDis1):
 class SubSellarMod(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
-        super(SubSellarMod, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('d1', SellarDis1withDerivativesMod(units=units, scaling=scaling),
                            promotes=['x', 'z', 'y1', 'y2'])
@@ -617,7 +617,7 @@ class SubSellarMod(om.Group):
 class DoubleSellarMod(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
-        super(DoubleSellarMod, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('g1', SubSellarMod(units=units, scaling=scaling))
         self.add_subsystem('g2', SubSellarMod(units=units, scaling=scaling))

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -70,7 +70,7 @@ class BroydenSolver(NonlinearSolver):
         **kwargs : dict
             options dictionary.
         """
-        super(BroydenSolver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Slot for linear solver
         self.linear_solver = None
@@ -98,7 +98,7 @@ class BroydenSolver(NonlinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(BroydenSolver, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('alpha', default=0.4,
                              desc="Value to scale the starting Jacobian, which is Identity. This "
@@ -149,7 +149,7 @@ class BroydenSolver(NonlinearSolver):
         depth : int
             Depth of the current system (already incremented).
         """
-        super(BroydenSolver, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
         self._recompute_jacobian = True
         self._computed_jacobians = 0
         iproc = system.comm.rank
@@ -261,7 +261,7 @@ class BroydenSolver(NonlinearSolver):
         type_ : str
             Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
         """
-        super(BroydenSolver, self)._set_solver_print(level=level, type_=type_)
+        super()._set_solver_print(level=level, type_=type_)
 
         if self.linear_solver is not None and type_ != 'NL':
             self.linear_solver._set_solver_print(level=level, type_=type_)
@@ -650,7 +650,7 @@ class BroydenSolver(NonlinearSolver):
         """
         Clean up resources prior to exit.
         """
-        super(BroydenSolver, self).cleanup()
+        super().cleanup()
 
         if self.linear_solver:
             self.linear_solver.cleanup()

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -35,7 +35,7 @@ class NewtonSolver(NonlinearSolver):
         **kwargs : dict
             options dictionary.
         """
-        super(NewtonSolver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Slot for linear solver
         self.linear_solver = None
@@ -47,7 +47,7 @@ class NewtonSolver(NonlinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(NewtonSolver, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('solve_subsystems', types=bool,
                              desc='Set to True to turn on sub-solvers (Hybrid Newton).')
@@ -75,7 +75,7 @@ class NewtonSolver(NonlinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(NewtonSolver, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
         rank = MPI.COMM_WORLD.rank if MPI is not None else 0
 
         self._disallow_discrete_outputs()
@@ -113,7 +113,7 @@ class NewtonSolver(NonlinearSolver):
         type_ : str
             Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
         """
-        super(NewtonSolver, self)._set_solver_print(level=level, type_=type_)
+        super()._set_solver_print(level=level, type_=type_)
 
         if self.linear_solver is not None and type_ != 'NL':
             self.linear_solver._set_solver_print(level=level, type_=type_)
@@ -285,7 +285,7 @@ class NewtonSolver(NonlinearSolver):
         """
         Clean up resources prior to exit.
         """
-        super(NewtonSolver, self).cleanup()
+        super().cleanup()
 
         if self.linear_solver:
             self.linear_solver.cleanup()

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -31,7 +31,7 @@ class NonlinearBlockGS(NonlinearSolver):
         **kwargs : dict
             options dictionary.
         """
-        super(NonlinearBlockGS, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self._theta_n_1 = 1.0
         self._delta_outputs_n_1 = None
@@ -47,7 +47,7 @@ class NonlinearBlockGS(NonlinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(NonlinearBlockGS, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
 
         rank = MPI.COMM_WORLD.rank if MPI is not None else 0
 
@@ -59,7 +59,7 @@ class NonlinearBlockGS(NonlinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(NonlinearBlockGS, self)._declare_options()
+        super()._declare_options()
 
         self.options.declare('use_aitken', types=bool, default=False,
                              desc='set to True to use Aitken relaxation')
@@ -106,7 +106,7 @@ class NonlinearBlockGS(NonlinearSolver):
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()
 
-        return super(NonlinearBlockGS, self)._iter_initialize()
+        return super()._iter_initialize()
 
     def _single_iteration(self):
         """

--- a/openmdao/solvers/nonlinear/nonlinear_block_jac.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_jac.py
@@ -60,6 +60,6 @@ class NonlinearBlockJac(NonlinearSolver):
         # If this is a parallel group, check for analysis errors and reraise.
         if len(system._subsystems_myproc) != len(system._subsystems_allprocs):
             with multi_proc_fail_check(system.comm):
-                super(NonlinearBlockJac, self)._run_apply()
+                super()._run_apply()
         else:
-            super(NonlinearBlockJac, self)._run_apply()
+            super()._run_apply()

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -549,23 +549,23 @@ class TestNewton(unittest.TestCase):
             """ This version of Newton also counts how many times it runs in total."""
 
             def __init__(self, **kwargs):
-                super(CountNewton, self).__init__(**kwargs)
+                super().__init__(**kwargs)
                 self.options['solve_subsystems'] = True
                 self.total_count = 0
 
             def _single_iteration(self):
-                super(CountNewton, self)._single_iteration()
+                super()._single_iteration()
                 self.total_count += 1
 
         class CountDS(om.DirectSolver):
             """ This version of Newton also counts how many times it linearizes"""
 
             def __init__(self, **kwargs):
-                super(CountDS, self).__init__(**kwargs)
+                super().__init__(**kwargs)
                 self.lin_count = 0
 
             def _linearize(self):
-                super(CountDS, self)._linearize()
+                super()._linearize()
                 self.lin_count += 1
 
         prob = om.Problem(model=DoubleSellar())
@@ -871,7 +871,7 @@ class TestNewtonFeatures(unittest.TestCase):
         model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
 
         prob.setup()
-        
+
         prob.set_val('x', 1.)
         prob.set_val('z', np.array([5.0, 2.0]))
 
@@ -908,7 +908,7 @@ class TestNewtonFeatures(unittest.TestCase):
 
         prob.set_val('x', 1.)
         prob.set_val('z', np.array([5.0, 2.0]))
-        
+
         prob.run_model()
 
         assert_near_equal(prob.get_val('y1'), 25.5878516779, .00001)

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
@@ -334,7 +334,7 @@ class TestNLBGaussSeidel(unittest.TestCase):
             with derivatives."""
 
             def __init__(self):
-                super(SellarModified, self).__init__()
+                super().__init__()
 
                 self.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
                 self.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
@@ -481,10 +481,10 @@ class TestNLBGaussSeidel(unittest.TestCase):
         class ContrivedSellarDis1(SellarDis1):
 
             def setup(self):
-                super(ContrivedSellarDis1, self).setup()
+                super().setup()
                 self.add_output('highly_nonlinear', val=1.0, res_ref=1e-4)
             def compute(self, inputs, outputs):
-                super(ContrivedSellarDis1, self).compute(inputs, outputs)
+                super().compute(inputs, outputs)
                 outputs['highly_nonlinear'] = 10*np.sin(10*inputs['y2'])
 
         p = om.Problem()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -515,7 +515,7 @@ class NonlinearSolver(Solver):
         **kwargs : dict
             options dictionary.
         """
-        super(NonlinearSolver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self._err_cache = OrderedDict()
 
     def _declare_options(self):
@@ -755,7 +755,7 @@ class LinearSolver(Solver):
         """
         self._rel_systems = None
         self._assembled_jac = None
-        super(LinearSolver, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
     def _assembled_jac_solver_iter(self):
         """
@@ -795,7 +795,7 @@ class LinearSolver(Solver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(LinearSolver, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
         if self.options['assemble_jac'] and not self.supports['assembled_jac']:
             raise RuntimeError("Linear solver %s doesn't support assembled "
                                "jacobians." % self.msginfo)
@@ -910,7 +910,7 @@ class BlockLinearSolver(LinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super(BlockLinearSolver, self)._declare_options()
+        super()._declare_options()
         self.supports['assembled_jac'] = False
 
     def _setup_solvers(self, system, depth):
@@ -924,7 +924,7 @@ class BlockLinearSolver(LinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super(BlockLinearSolver, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
         if system._use_derivatives:
             self._create_rhs_vecs()
 

--- a/openmdao/surrogate_models/kriging.py
+++ b/openmdao/surrogate_models/kriging.py
@@ -52,7 +52,7 @@ class KrigingSurrogate(SurrogateModel):
         **kwargs : dict
             options dictionary.
         """
-        super(KrigingSurrogate, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.n_dims = 0                 # number of independent
         self.n_samples = 0              # number of training points
@@ -102,7 +102,7 @@ class KrigingSurrogate(SurrogateModel):
         y : array-like
             Model responses at given inputs.
         """
-        super(KrigingSurrogate, self).train(x, y)
+        super().train(x, y)
 
         x, y = np.atleast_2d(x, y)
 
@@ -225,7 +225,7 @@ class KrigingSurrogate(SurrogateModel):
         ndarray, optional (if eval_rmse is True)
             Root mean square of the prediction error.
         """
-        super(KrigingSurrogate, self).predict(x)
+        super().predict(x)
 
         thetas = self.thetas
         if isinstance(x, list):

--- a/openmdao/surrogate_models/multifi_cokriging.py
+++ b/openmdao/surrogate_models/multifi_cokriging.py
@@ -937,7 +937,7 @@ class MultiFiCoKrigingSurrogate(MultiFiSurrogateModel):
         **kwargs : keyword args
             Some implementations of record_derivatives need additional args.
         """
-        super(MultiFiCoKrigingSurrogate, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.model = None
 
     def _declare_options(self):

--- a/openmdao/surrogate_models/nearest_neighbor.py
+++ b/openmdao/surrogate_models/nearest_neighbor.py
@@ -39,7 +39,7 @@ class NearestNeighbor(SurrogateModel):
         **kwargs : dict
             options dictionary.
         """
-        super(NearestNeighbor, self).__init__()
+        super().__init__()
 
         # Note: don't pass kwargs to parent because most of them are specific to choice of
         # interpolant.
@@ -67,7 +67,7 @@ class NearestNeighbor(SurrogateModel):
         y : array-like
             Model responses at given inputs.
         """
-        super(NearestNeighbor, self).train(x, y)
+        super().train(x, y)
         nn_opts = self.interpolant_init_args
         nn_opts['parent_name'] = self._parent_name
         self.interpolant = _interpolators[self.options['interpolant_type']](
@@ -89,7 +89,7 @@ class NearestNeighbor(SurrogateModel):
         float
             Predicted value.
         """
-        super(NearestNeighbor, self).predict(x)
+        super().predict(x)
         return self.interpolant(x, **kwargs)
 
     def linearize(self, x, **kwargs):

--- a/openmdao/surrogate_models/nn_interpolators/rbf_interpolator.py
+++ b/openmdao/surrogate_models/nn_interpolators/rbf_interpolator.py
@@ -45,8 +45,7 @@ class RBFInterpolator(NNBase):
             <-2> uses an 11th order, <-1> uses a 9th order, and any value from <0> to <4> uses an
             order equal to <floor((dimensions-1)/2) + (3*comp) +1>.
         """
-        super(RBFInterpolator, self).__init__(training_points, training_values, num_leaves,
-                                              parent_name=parent_name)
+        super().__init__(training_points, training_values, num_leaves, parent_name=parent_name)
 
         if self._ntpts < num_neighbors:
             self._raise('RBFInterpolator only given {0} training points, '

--- a/openmdao/surrogate_models/response_surface.py
+++ b/openmdao/surrogate_models/response_surface.py
@@ -26,7 +26,7 @@ class ResponseSurface(SurrogateModel):
         """
         Initialize all attributes.
         """
-        super(ResponseSurface, self).__init__()
+        super().__init__()
 
         self.m = 0  # number of training points
         self.n = 0  # number of independents
@@ -44,7 +44,7 @@ class ResponseSurface(SurrogateModel):
         y : array-like
             Model responses at given inputs.
         """
-        super(ResponseSurface, self).train(x, y)
+        super().train(x, y)
 
         m = self.m = x.shape[0]
         n = self.n = x.shape[1]
@@ -86,7 +86,7 @@ class ResponseSurface(SurrogateModel):
         float
             Predicted response.
         """
-        super(ResponseSurface, self).predict(x)
+        super().predict(x)
 
         n = x.size
 

--- a/openmdao/surrogate_models/surrogate_model.py
+++ b/openmdao/surrogate_models/surrogate_model.py
@@ -134,7 +134,7 @@ class MultiFiSurrogateModel(SurrogateModel):
         y : array-like
             Model responses at given inputs.
         """
-        super(MultiFiSurrogateModel, self).train(x, y)
+        super().train(x, y)
         self.train_multifi([x], [y])
 
     def train_multifi(self, x, y):

--- a/openmdao/surrogate_models/tests/test_map.py
+++ b/openmdao/surrogate_models/tests/test_map.py
@@ -8,7 +8,7 @@ import unittest
 class CompressorMap(MetaModelUnStructuredComp):
 
     def __init__(self):
-        super(CompressorMap, self).__init__()
+        super().__init__()
 
         self.add_input('Nc', val=1.0)
         self.add_input('Rline', val=2.0)

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -21,7 +21,7 @@ class DynComp(ExplicitComponent):
     def __init__(self, ninputs, noutputs,
                  nl_sleep=0.001, ln_sleep=0.001,
                  var_factory=float, vf_args=()):
-        super(DynComp, self).__init__()
+        super().__init__()
 
         self.ninputs = ninputs
         self.noutputs = noutputs

--- a/openmdao/test_suite/components/cycle_comps.py
+++ b/openmdao/test_suite/components/cycle_comps.py
@@ -316,7 +316,7 @@ class ExplicitFirstComp(ExplicitCycleComp):
         self.add_input('psi', val=1.)
         self.angle_param = 'psi'
         self._cycle_names['psi'] = 'psi'
-        super(ExplicitFirstComp, self).setup()
+        super().setup()
 
     def compute(self, inputs, outputs):
         theta = inputs[self._cycle_names['theta']]
@@ -332,14 +332,14 @@ class ExplicitLastComp(ExplicitFirstComp):
         return 'Explicit Cycle Component - Last'
 
     def setup(self):
-        super(ExplicitLastComp, self).setup()
+        super().setup()
 
         self.add_output('x_norm2', shape=(1,))
         self._n = 1
 
     def setup_partials(self):
         # Setup partials
-        super(ExplicitLastComp, self).setup_partials()
+        super().setup_partials()
 
         pd_type = self.options['partial_type']
         method = self.options['partial_method']

--- a/openmdao/test_suite/components/double_sellar.py
+++ b/openmdao/test_suite/components/double_sellar.py
@@ -9,7 +9,7 @@ from openmdao.test_suite.components.sellar import SellarImplicitDis1
 class SubSellar(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
-        super(SubSellar, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('d1', SellarDis1withDerivatives(units=units, scaling=scaling),
                            promotes=['x', 'z', 'y1', 'y2'])
@@ -23,7 +23,7 @@ class SubSellar(om.Group):
 class DoubleSellar(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
-        super(DoubleSellar, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('g1', SubSellar(units=units, scaling=scaling))
         self.add_subsystem('g2', SubSellar(units=units, scaling=scaling))
@@ -39,7 +39,7 @@ class DoubleSellar(om.Group):
 class SubSellarImplicit(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
-        super(SubSellarImplicit, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('d1', SellarImplicitDis1(units=units, scaling=scaling),
                            promotes=['x', 'z', 'y1', 'y2'])
@@ -50,7 +50,7 @@ class SubSellarImplicit(om.Group):
 class DoubleSellarImplicit(om.Group):
 
     def __init__(self, units=None, scaling=None, **kwargs):
-        super(DoubleSellarImplicit, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('g1', SubSellar(units=units, scaling=scaling))
         self.add_subsystem('g2', SubSellar(units=units, scaling=scaling))

--- a/openmdao/test_suite/components/exec_comp_for_test.py
+++ b/openmdao/test_suite/components/exec_comp_for_test.py
@@ -41,7 +41,7 @@ class ExecComp4Test(ExecComp):
                  req_procs=(1,1), fail_rank=-1, fails=(),
                  fail_hard=False, **kwargs):
 
-        super(ExecComp4Test, self).__init__(exprs, **kwargs)
+        super().__init__(exprs, **kwargs)
         self.nl_delay = nl_delay
         self.lin_delay = lin_delay
         self.num_nl_solves = 0
@@ -71,7 +71,7 @@ class ExecComp4Test(ExecComp):
                     raise RuntimeError("OMG, a critical error!")
                 else:
                     raise AnalysisError("just an analysis error")
-            super(ExecComp4Test, self).compute(inputs, outputs)
+            super().compute(inputs, outputs)
             time.sleep(self.nl_delay)
         finally:
             self.num_nl_solves += 1
@@ -88,6 +88,6 @@ class ExecComp4Test(ExecComp):
         partials : `Jacobian`
             Contains sub-jacobians.
         """
-        super(ExecComp4Test, self).compute_partials(inputs, partials)
+        super().compute_partials(inputs, partials)
         time.sleep(self.lin_delay)
         self.num_compute_partials += 1

--- a/openmdao/test_suite/components/matmultcomp.py
+++ b/openmdao/test_suite/components/matmultcomp.py
@@ -10,7 +10,7 @@ import openmdao.api as om
 
 class MatMultComp(om.ExplicitComponent):
     def __init__(self, mat, approx_method='exact', sleep_time=0.1, **kwargs):
-        super(MatMultComp, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.mat = mat
         self.approx_method = approx_method
         self.sleep_time = sleep_time

--- a/openmdao/test_suite/components/paraboloid_problem.py
+++ b/openmdao/test_suite/components/paraboloid_problem.py
@@ -8,7 +8,7 @@ class ParaboloidProblem(om.Problem):
     """
 
     def __init__(self, **kwargs):
-        super(ParaboloidProblem, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         model = self.model
         model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])

--- a/openmdao/test_suite/components/sellar.py
+++ b/openmdao/test_suite/components/sellar.py
@@ -20,7 +20,7 @@ class SellarDis1(om.ExplicitComponent):
     """
 
     def __init__(self, units=None, scaling=None):
-        super(SellarDis1, self).__init__()
+        super().__init__()
         self.execution_count = 0
         self._units = units
         self._do_scaling = scaling
@@ -103,7 +103,7 @@ class SellarDis2(om.ExplicitComponent):
     """
 
     def __init__(self, units=None, scaling=None):
-        super(SellarDis2, self).__init__()
+        super().__init__()
         self.execution_count = 0
         self._units = units
         self._do_scaling = scaling
@@ -528,7 +528,7 @@ class SellarImplicitDis1(om.ImplicitComponent):
     """
 
     def __init__(self, units=None, scaling=None):
-        super(SellarImplicitDis1, self).__init__()
+        super().__init__()
         self.execution_count = 0
         self._units = units
         self._do_scaling = scaling
@@ -591,7 +591,7 @@ class SellarImplicitDis2(om.ImplicitComponent):
     """
 
     def __init__(self, units=None, scaling=None):
-        super(SellarImplicitDis2, self).__init__()
+        super().__init__()
         self.execution_count = 0
         self._units = units
         self._do_scaling = scaling
@@ -661,7 +661,7 @@ class SellarProblem(om.Problem):
     """
 
     def __init__(self, model_class=SellarDerivatives, **kwargs):
-        super(SellarProblem, self).__init__(model_class(**kwargs))
+        super().__init__(model_class(**kwargs))
 
         model = self.model
         model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
@@ -680,7 +680,7 @@ class SellarProblemWithArrays(om.Problem):
     """
 
     def __init__(self, model_class=SellarDerivatives, **kwargs):
-        super(SellarProblemWithArrays, self).__init__(model_class(**kwargs))
+        super().__init__(model_class(**kwargs))
 
         model = self.model
         model.add_design_var('z', lower=np.array([-10.0, 0.0]),

--- a/openmdao/test_suite/components/simple_comps.py
+++ b/openmdao/test_suite/components/simple_comps.py
@@ -11,7 +11,7 @@ class DoubleArrayComp(om.ExplicitComponent):
     """
 
     def __init__(self):
-        super(DoubleArrayComp, self).__init__()
+        super().__init__()
 
         self.JJ = np.array([[1.0, 3.0, -2.0, 7.0],
                             [6.0, 2.5, 2.0, 4.0],
@@ -56,7 +56,7 @@ class NonSquareArrayComp(om.ExplicitComponent):
     """
 
     def __init__(self):
-        super(NonSquareArrayComp, self).__init__()
+        super().__init__()
 
         self.JJ = np.array([[1.0, 3.0, -2.0, 7.0],
                             [6.0, 2.5, 2.0, 4.0],

--- a/openmdao/test_suite/components/unit_conv.py
+++ b/openmdao/test_suite/components/unit_conv.py
@@ -178,7 +178,7 @@ class UnitConvGroup(om.Group):
     conversion."""
 
     def __init__(self, **kwargs):
-        super(UnitConvGroup, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         self.add_subsystem('px1', om.IndepVarComp('x1', 100.0))
         self.add_subsystem('src', SrcComp())
@@ -201,7 +201,7 @@ class UnitConvGroupImplicitConns(om.Group):
     """
 
     def __init__(self):
-        super(UnitConvGroupImplicitConns, self).__init__()
+        super().__init__()
 
         self.add_subsystem('px1', om.IndepVarComp('x1', 100.0), promotes_outputs=['x1'])
         self.add_subsystem('src', SrcComp(), promotes_inputs=['x1'], promotes_outputs=['x2'])

--- a/openmdao/test_suite/groups/implicit_group.py
+++ b/openmdao/test_suite/groups/implicit_group.py
@@ -79,7 +79,7 @@ class TestImplicitGroup(om.Group):
     def __init__(self, lnSolverClass=om.LinearBlockGS,
                        nlSolverClass=om.NonlinearBlockGS):
 
-        super(TestImplicitGroup, self).__init__()
+        super().__init__()
 
         self.add_subsystem("C1", Comp())
         self.add_subsystem("C2", Comp())

--- a/openmdao/test_suite/groups/parallel_groups.py
+++ b/openmdao/test_suite/groups/parallel_groups.py
@@ -9,7 +9,7 @@ class FanOut(om.Group):
     """
 
     def __init__(self):
-        super(FanOut, self).__init__()
+        super().__init__()
 
         self.add_subsystem('p', om.IndepVarComp('x', 1.0))
         self.add_subsystem('comp1', om.ExecComp(['y=3.0*x']))
@@ -28,7 +28,7 @@ class FanOutGrouped(om.Group):
     """
 
     def __init__(self):
-        super(FanOutGrouped, self).__init__()
+        super().__init__()
 
         self.add_subsystem('iv', om.IndepVarComp('x', 1.0))
         self.add_subsystem('c1', om.ExecComp(['y=3.0*x']))
@@ -55,7 +55,7 @@ class FanIn(om.Group):
     """
 
     def __init__(self):
-        super(FanIn, self).__init__()
+        super().__init__()
 
         self.add_subsystem('p1', om.IndepVarComp('x1', 1.0))
         self.add_subsystem('p2', om.IndepVarComp('x2', 1.0))
@@ -76,7 +76,7 @@ class FanInGrouped(om.Group):
     """
 
     def __init__(self):
-        super(FanInGrouped, self).__init__()
+        super().__init__()
 
         self.set_input_defaults('x1', 1.0)
         self.set_input_defaults('x2', 1.0)
@@ -104,7 +104,7 @@ class FanInGrouped2(om.Group):
     """
 
     def __init__(self):
-        super(FanInGrouped2, self).__init__()
+        super().__init__()
 
         p1 = self.add_subsystem('p1', om.IndepVarComp('x', 1.0))
         p2 = self.add_subsystem('p2', om.IndepVarComp('x', 1.0))
@@ -129,7 +129,7 @@ class DiamondFlat(om.Group):
     This one is flat."""
 
     def __init__(self):
-        super(DiamondFlat, self).__init__()
+        super().__init__()
 
         self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
@@ -158,7 +158,7 @@ class Diamond(om.Group):
     """
 
     def __init__(self):
-        super(Diamond, self).__init__()
+        super().__init__()
 
         self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
@@ -191,7 +191,7 @@ class ConvergeDivergeFlat(om.Group):
     """
 
     def __init__(self):
-        super(ConvergeDivergeFlat, self).__init__()
+        super().__init__()
 
         self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
@@ -234,7 +234,7 @@ class ConvergeDiverge(om.Group):
     """
 
     def __init__(self):
-        super(ConvergeDiverge, self).__init__()
+        super().__init__()
 
         self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 
@@ -281,7 +281,7 @@ class ConvergeDivergeGroups(om.Group):
     """
 
     def __init__(self):
-        super(ConvergeDivergeGroups, self).__init__()
+        super().__init__()
 
         self.add_subsystem('iv', om.IndepVarComp('x', 2.0))
 

--- a/openmdao/test_suite/groups/parametric_group.py
+++ b/openmdao/test_suite/groups/parametric_group.py
@@ -32,7 +32,7 @@ class ParametericTestGroup(Group):
             'jacobian_type': ['matvec', 'dense', 'sparse-csc'],
         }
 
-        super(ParametericTestGroup, self).__init__()
+        super().__init__()
 
         self.options.declare('local_vector_class', default='default',
                              values=['default', 'petsc'],

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -84,9 +84,16 @@ class _SelfCallCollector(ast.NodeVisitor):
             n = _get_long_name(callnode.func)
             # if this is a 'super' call, get the base of the specified class
             if n == 'super':  # this only works for a single call level
-                sup_1 = _get_long_name(callnode.args[1])
-                sup_0 = _get_long_name(callnode.args[0])
-                if sup_1 == 'self' and sup_0 is not None and len(sup_0.split('.')) == 1:
+                if len(callnode.args) == 0:
+                    sup_0 = self.mro[0].__name__
+                    visit_super = True
+                else:
+                    sup_1 = _get_long_name(callnode.args[1])
+                    sup_0 = _get_long_name(callnode.args[0])
+                    visit_super = (sup_1 == 'self' and
+                                   sup_0 is not None and len(sup_0.split('.')) == 1)
+
+                if visit_super:
                     for i, c in enumerate(self.mro[:-1]):
                         if sup_0 == c.__name__:
                             # we need super of the specified class

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -42,7 +42,7 @@ class _SelfCallCollector(ast.NodeVisitor):
     """
 
     def __init__(self, class_):
-        super(_SelfCallCollector, self).__init__()
+        super().__init__()
         self.self_calls = defaultdict(list)
         self.class_ = class_
         self.mro = inspect.getmro(class_)
@@ -78,7 +78,7 @@ class _SelfCallCollector(ast.NodeVisitor):
                     self.generic_visit(node)
             else:
                 self.generic_visit(node)
-        # check for super(Class, self) call
+        # check for super() call
         elif isinstance(node.func, ast.Attribute) and isinstance(node.func.value, ast.Call):
             callnode = node.func.value
             n = _get_long_name(callnode.func)

--- a/openmdao/utils/scaffolding_templates/BaseCaseReader_template
+++ b/openmdao/utils/scaffolding_templates/BaseCaseReader_template
@@ -17,7 +17,7 @@ class {class_name}(BaseCaseReader):
         pre_load : bool
             If True, load all the data into memory during initialization.
         """
-        super({class_name}, self).__init__(filename, pre_load)
+        super().__init__(filename, pre_load)
 
         # initialize attributes here...
 

--- a/openmdao/utils/scaffolding_templates/CaseRecorder_template
+++ b/openmdao/utils/scaffolding_templates/CaseRecorder_template
@@ -17,7 +17,7 @@ class {class_name}(CaseRecorder):
         record_viewer_data : bool, optional
             If True, record data needed for visualization.
         """
-        super({class_name}, self).__init__(record_viewer_data)
+        super().__init__(record_viewer_data)
 
         # initialize attributes here...
 
@@ -30,7 +30,7 @@ class {class_name}(CaseRecorder):
         recording_requester : object
             Object to which this recorder is attached.
         """
-        super({class_name}, self).startup(recording_requester)
+        super().startup(recording_requester)
 
         # put any necessary startup code here...
 

--- a/openmdao/utils/scaffolding_templates/Driver_template
+++ b/openmdao/utils/scaffolding_templates/Driver_template
@@ -15,7 +15,7 @@ class {class_name}(Driver):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Driver options.
         """
-        super({class_name}, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # Specify what we support and what we don't
         self.supports['integer_design_vars'] = False
@@ -49,7 +49,7 @@ class {class_name}(Driver):
         problem : <Problem>
             Pointer to the containing problem.
         """
-        super({class_name}, self)._setup_driver(problem)
+        super()._setup_driver(problem)
 
         # perform setup actions here...
 

--- a/openmdao/utils/scaffolding_templates/ExplicitComponent_template
+++ b/openmdao/utils/scaffolding_templates/ExplicitComponent_template
@@ -22,7 +22,7 @@ class {class_name}(ExplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super({class_name}, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # set attributes here...
 
     def initialize(self):

--- a/openmdao/utils/scaffolding_templates/ImplicitComponent_template
+++ b/openmdao/utils/scaffolding_templates/ImplicitComponent_template
@@ -23,7 +23,7 @@ class {class_name}(ImplicitComponent):
         **kwargs : dict of keyword arguments
             Keyword arguments that will be mapped into the Component options.
         """
-        super({class_name}, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         # set attributes here...
 
     def initialize(self):

--- a/openmdao/utils/scaffolding_templates/LinearSolver_template
+++ b/openmdao/utils/scaffolding_templates/LinearSolver_template
@@ -21,7 +21,7 @@ class {class_name}(LinearSolver):
         **kwargs : dict
             Options dictionary.
         """
-        super({class_name}, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # initialize needed atributes here...
 
@@ -36,7 +36,7 @@ class {class_name}(LinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super({class_name}, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
 
         # perform any necessary setup here...
 
@@ -44,7 +44,7 @@ class {class_name}(LinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super({class_name}, self)._declare_options()
+        super()._declare_options()
 
         # for example...
         # self.options.declare('cs_reconverge', types=bool, default=True,

--- a/openmdao/utils/scaffolding_templates/NonlinearSolver_template
+++ b/openmdao/utils/scaffolding_templates/NonlinearSolver_template
@@ -19,7 +19,7 @@ class {class_name}(NonlinearSolver):
         **kwargs : dict
             options dictionary.
         """
-        super({class_name}, self).__init__(**kwargs)
+        super().__init__(**kwargs)
 
         # set other attributes here...
 
@@ -34,7 +34,7 @@ class {class_name}(NonlinearSolver):
         depth : int
             depth of the current system (already incremented).
         """
-        super({class_name}, self)._setup_solvers(system, depth)
+        super()._setup_solvers(system, depth)
 
         # perform any necessary setup here...
 
@@ -42,7 +42,7 @@ class {class_name}(NonlinearSolver):
         """
         Declare options before kwargs are processed in the init method.
         """
-        super({class_name}, self)._declare_options()
+        super()._declare_options()
 
         # for example...
         # self.options.declare('cs_reconverge', types=bool, default=True,
@@ -60,7 +60,7 @@ class {class_name}(NonlinearSolver):
         float
             error at the first iteration.
         """
-        return super({class_name}, self)._iter_initialize()
+        return super()._iter_initialize()
 
     def _single_iteration(self):
         """

--- a/openmdao/utils/scaffolding_templates/SurrogateModel_template
+++ b/openmdao/utils/scaffolding_templates/SurrogateModel_template
@@ -26,7 +26,7 @@ class {class_name}(SurrogateModel):
         **kwargs : dict
             options dictionary.
         """
-        super({class_name}, self).__init__()
+        super().__init__()
 
         # set any necessary attributes here...
 
@@ -54,7 +54,7 @@ class {class_name}(SurrogateModel):
         x : array-like
             Point(s) at which the surrogate is evaluated.
         """
-        super({class_name}, self).predict(x)
+        super().predict(x)
 
         # calculate predicted value here...
 

--- a/openmdao/utils/shell_proc.py
+++ b/openmdao/utils/shell_proc.py
@@ -36,7 +36,7 @@ class CalledProcessError(subprocess.CalledProcessError):
         errormsg : str
             Error message for this error.
         """
-        super(CalledProcessError, self).__init__(returncode, cmd)
+        super().__init__(returncode, cmd)
         self.errormsg = errormsg
 
     def __str__(self):

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -43,7 +43,7 @@ class PETScTransfer(DefaultTransfer):
         comm : MPI.Comm or <FakeComm>
             communicator of the system that owns this transfer.
         """
-        super(PETScTransfer, self).__init__(in_vec, out_vec, in_inds, out_inds, comm)
+        super().__init__(in_vec, out_vec, in_inds, out_inds, comm)
         in_indexset = PETSc.IS().createGeneral(self._in_inds, comm=self._comm)
         out_indexset = PETSc.IS().createGeneral(self._out_inds, comm=self._comm)
 

--- a/openmdao/vectors/petsc_vector.py
+++ b/openmdao/vectors/petsc_vector.py
@@ -57,8 +57,8 @@ class PETScVector(DefaultVector):
         ncol : int
             Number of columns for multi-vectors.
         """
-        super(PETScVector, self).__init__(name, kind, system, root_vector=root_vector,
-                                          alloc_complex=alloc_complex, ncol=ncol)
+        super().__init__(name, kind, system, root_vector=root_vector,
+                         alloc_complex=alloc_complex, ncol=ncol)
 
         self._dup_inds = None
 
@@ -71,7 +71,7 @@ class PETScVector(DefaultVector):
         root_vector : Vector or None
             the root's vector instance or None, if we are at the root.
         """
-        super(PETScVector, self)._initialize_data(root_vector)
+        super()._initialize_data(root_vector)
 
         self._petsc = {}
         self._imag_petsc = {}

--- a/openmdao/visualization/html_utils.py
+++ b/openmdao/visualization/html_utils.py
@@ -606,8 +606,7 @@ class DiagramWriter(TemplateWriter):
         styles : dict
             Dictionary of CSS styles.
         """
-        super(DiagramWriter, self).__init__(filename=filename, embeddable=embeddable, title=title,
-                                            styles=styles)
+        super().__init__(filename=filename, embeddable=embeddable, title=title, styles=styles)
         self.toolbar = Toolbar()
         self.help = None
 
@@ -647,4 +646,4 @@ class DiagramWriter(TemplateWriter):
         self.insert('{{toolbar}}', self.toolbar.write())
         if self.help is not None:
             self._replace('{{help}}', self.help)
-        super(DiagramWriter, self).write(outfile)
+        super().write(outfile)


### PR DESCRIPTION
### Summary

Change calls to super to use Python3 syntax.

### Related Issues

- Resolves #1683
- Resolves #1681

### Backwards incompatibilities

None

### New Dependencies

None
