### PR TITLE
Fix relevancy issue when computing partials with wrt or of that are outside of the declared desvar/responses.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -176,7 +176,7 @@ class Driver(object):
         self.supports.declare('active_set', types=bool, default=False)
         self.supports.declare('simultaneous_derivatives', types=bool, default=False)
         self.supports.declare('total_jac_sparsity', types=bool, default=False)
-        self.supports.declare('distributed_design_vars', types=bool, default=False)
+        self.supports.declare('distributed_design_vars', types=bool, default=True)
 
         self.iter_count = 0
         self.cite = ""

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -492,6 +492,18 @@ class _TotalJacInfo(object):
         start = 0
         end = 0
 
+        # If we call compute_totals with any 'wrt' or 'of' that is outside of an existing driver
+        # var set, then we need to ignore the computed relevancy and perform GS iterations on all
+        # comps. Note, the inputs are handled individually by direct check vs the relevancy dict,
+        # so we just bulk check the outputs here.
+        qoi_i = self.input_meta[mode]
+        qoi_o = self.output_meta[mode]
+        if qoi_i and qoi_o:
+            non_rel_outs = [out for out in self.output_list[mode]
+                            if out not in qoi_i and out not in qoi_o]
+        else:
+            non_rel_outs = None
+
         for name in input_list:
             rhsname = 'linear'
             if name not in abs2meta_out:
@@ -625,7 +637,7 @@ class _TotalJacInfo(object):
                 imeta['idx_list'] = np.arange(start, end, dtype=INT_DTYPE)
                 idx_iter_dict[name] = (imeta, self.single_index_iter)
 
-            if name in relevant:
+            if name in relevant and not non_rel_outs:
                 tup = (rhsname, relevant[name]['@all'][1], cache_lin_sol)
             else:
                 tup = (rhsname, _contains_all, cache_lin_sol)

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -869,9 +869,7 @@ class TestJacobian(unittest.TestCase):
 
             def compute(self, inputs, outputs):
                 x = inputs['x']
-                local_y = np.sum((x-5)**2)
-                y_g = np.zeros(self.comm.size)
-                self.comm.Allgather(local_y, y_g)
+                y_g = np.sum((x-5)**2)
                 outputs['y'] = np.sum(y_g) + (inputs['w']-10)**2
                 outputs['z'] = x**2
 
@@ -883,13 +881,13 @@ class TestJacobian(unittest.TestCase):
 
         p = Problem()
         d_ivc = p.model.add_subsystem('distrib_ivc',
-                                       IndepVarComp(distributed=False),
+                                       IndepVarComp(),
                                        promotes=['*'])
         ndvs = 3
         d_ivc.add_output('x', 2*np.ones(ndvs))
 
         ivc = p.model.add_subsystem('ivc',
-                                    IndepVarComp(distributed=False),
+                                    IndepVarComp(),
                                     promotes=['*'])
         ivc.add_output('w', 2.0)
         p.model.add_subsystem('dp', DParaboloid(), promotes=['*'])


### PR DESCRIPTION
### Summary

Fixed an issue with calling compute_partials with user-specified 'wrt' and 'of' on a model that has some design variables and responses declared. If the 'of' or 'wrt' required the derivatives to be computed across any components that were not in the relevant set for the driver vars, the answers would be correct in one direction (mode), but zero in the other direction. This was because we were only checking one side to determine if we should include the entire model in the linear solution.

Note: I also changed the default value of "distributed_design_vars" in driver.supports.  This is because the user expects to be able to compute derivatives on any model, including one with distributed design variables, even if they are using the base driver.

### Related Issues

- Resolves #https://github.com/OpenMDAO/OpenMDAO/issues/1632

### Backwards incompatibilities

None

### New Dependencies

None
