### PR TITLE
added support for colons in variable names in ExecComp

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -44,6 +44,7 @@ def _valid_name(s, exprs):
             return n
         i += 1
 
+
 def check_option(option, value):
     """
     Check option for validity.

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -11,7 +11,6 @@ from openmdao.utils.general_utils import warn_deprecation
 from openmdao.utils import cs_safe
 
 # regex to check for variable names.
-# VAR_RGX = re.compile(r'([.]*[_a-zA-Z]\w*[ ]*\(?)')
 VAR_RGX = re.compile('([_a-zA-Z]\w*(?::[_a-zA-Z]\w*)*[ ]*\(?)')
 
 # Names of metadata entries allowed for ExecComp variables.
@@ -24,17 +23,26 @@ _disallowed_names = {'has_diag_partials', 'units', 'shape'}
 
 
 def _valid_name(s, exprs):
-    """Replace colons with numbers such that the new name does not exist in any
-    of the given expressions.
+    """
+    Replace colons with numbers.
+
+    Replace colons with numbers such that the new name
+    does not exist in any of the given expressions.
+
+    Parameters
+    ----------
+    s: str
+        variable name
+    exprs: list
+        list of expressions
     """
     i = 0
     check = ' '.join(exprs)
     while True:
-        n = s.replace(':','%d'%i)
+        n = s.replace(':', '%d' % i)
         if n not in check:
             return n
         i += 1
-
 
 def check_option(option, value):
     """
@@ -362,8 +370,8 @@ class ExecComp(ExplicitComponent):
                     else:
                         self.declare_partials(of=out, wrt=inp)
 
-        self._to_colons = {} 
-        from_colons = self._from_colons = {} 
+        self._to_colons = {}
+        from_colons = self._from_colons = {}
         for n in allvars:
             if ':' in n:
                 no_colon = _valid_name(n, exprs)
@@ -372,7 +380,7 @@ class ExecComp(ExplicitComponent):
             self._to_colons[no_colon] = n
             from_colons[n] = no_colon
 
-        self._colon_names = { n for n in allvars if ':' in n }
+        self._colon_names = {n for n in allvars if ':' in n}
 
         self._codes = self._compile_exprs(self._exprs)
 

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -11,7 +11,7 @@ from openmdao.utils.general_utils import warn_deprecation
 from openmdao.utils import cs_safe
 
 # regex to check for variable names.
-VAR_RGX = re.compile('([_a-zA-Z]\w*(?::[_a-zA-Z]\w*)*[ ]*\(?)')
+VAR_RGX = re.compile('([_a-zA-Z]\\w*(?::[_a-zA-Z]\\w*)*[ ]*\\(?)')
 
 # Names of metadata entries allowed for ExecComp variables.
 _allowed_meta = {'value', 'shape', 'units', 'res_units', 'desc',

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -290,6 +290,25 @@ class TestExecComp(unittest.TestCase):
         prob.run_model()
         assert_near_equal(prob['C1.foo:bar'], 3.0, 0.00001)
 
+    def test_multiple_colon_vars(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp('foo:bar=tree:leaf_count + tree:leaf_count'))
+        prob.setup()
+        prob['C1.tree:leaf_count'] = 2.
+        prob.run_model()
+        assert_near_equal(prob['C1.foo:bar'], 4.0, 0.00001)
+
+    def test_multiple_colon_exprs(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('C1', om.ExecComp(['foo:bar=tree:leaf_count + tree:leaf_count',
+                                                    'tree:bats=cave:size / 2.']))
+        prob.setup()
+        prob['C1.tree:leaf_count'] = 2.
+        prob['C1.cave:size'] = 5.5
+        prob.run_model()
+        assert_near_equal(prob['C1.foo:bar'], 4.0, 0.00001)
+        assert_near_equal(prob['C1.tree:bats'], 2.75, 0.00001)
+
     def test_bad_kwargs(self):
         prob = om.Problem()
         prob.model.add_subsystem('C1', om.ExecComp('y=x+1.', xx=2.0))

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -285,11 +285,10 @@ class TestExecComp(unittest.TestCase):
 
     def test_colon_vars(self):
         prob = om.Problem()
-        prob.model.add_subsystem('C1', om.ExecComp('y=foo:bar+1.'))
-        with self.assertRaises(Exception) as context:
-            prob.setup()
-        self.assertEqual(str(context.exception),
-                         "'C1' <class ExecComp>: failed to compile expression 'y=foo:bar+1.'.")
+        prob.model.add_subsystem('C1', om.ExecComp('foo:bar=x+1.', x=2.0))
+        prob.setup()
+        prob.run_model()
+        assert_near_equal(prob['C1.foo:bar'], 3.0, 0.00001)
 
     def test_bad_kwargs(self):
         prob = om.Problem()


### PR DESCRIPTION
### Summary

ExecComp does not support colons in variable names, but the rest of the framework does. This commit ports this functionality from OpenMDAO1.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
