### PR TITLE
Fixed two bugs in check_totals.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1471,9 +1471,16 @@ class Problem(object):
         # TODO: Once we're tracking iteration counts, run the model if it has not been run before.
 
         # Calculate Total Derivatives
-        total_info = _TotalJacInfo(self, of, wrt, False, return_format='flat_dict',
-                                   driver_scaling=driver_scaling)
-        Jcalc = total_info.compute_totals()
+        if model._owns_approx_jac:
+            # Support this, even though it is a bit silly (though you could compare fd with cs.)
+            total_info = _TotalJacInfo(self, of, wrt, False, return_format='flat_dict',
+                                       approx=True, driver_scaling=driver_scaling)
+            Jcalc = total_info.compute_totals_approx(initialize=True)
+
+        else:
+            total_info = _TotalJacInfo(self, of, wrt, False, return_format='flat_dict',
+                                       driver_scaling=driver_scaling)
+            Jcalc = total_info.compute_totals()
 
         if step is None:
             if method == 'cs':

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -2780,6 +2780,36 @@ class TestProblemCheckTotals(unittest.TestCase):
         for key, val in totals.items():
             assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
+    def test_cs_around_newton_top_sparse(self):
+        prob = om.Problem()
+        prob.model = SellarDerivatives()
+
+        prob.setup(force_alloc_complex=True)
+
+        prob.model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+        prob.run_model()
+
+        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs', out_stream=None)
+
+        for key, val in totals.items():
+            assert_near_equal(val['rel error'][0], 0.0, 3e-8)
+
+    def test_cs_around_broyden_top_sparse(self):
+        prob = om.Problem()
+        prob.model = SellarDerivatives()
+
+        prob.setup(force_alloc_complex=True)
+
+        prob.model.nonlinear_solver = om.BroydenSolver()
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+        prob.run_model()
+
+        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs', out_stream=None)
+
+        for key, val in totals.items():
+            assert_near_equal(val['rel error'][0], 0.0, 3e-8)
+
     def test_cs_error_allocate(self):
         prob = om.Problem()
         model = prob.model

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -2810,6 +2810,23 @@ class TestProblemCheckTotals(unittest.TestCase):
         for key, val in totals.items():
             assert_near_equal(val['rel error'][0], 0.0, 3e-8)
 
+    def test_check_totals_on_approx_model(self):
+        prob = om.Problem()
+        prob.model = SellarDerivatives()
+
+        prob.model.approx_totals(method='cs')
+
+        prob.setup(force_alloc_complex=True)
+
+        prob.model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
+        prob.model.linear_solver = om.DirectSolver()
+        prob.run_model()
+
+        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs', out_stream=None)
+
+        for key, val in totals.items():
+            assert_near_equal(val['rel error'][0], 0.0, 3e-8)
+
     def test_cs_error_allocate(self):
         prob = om.Problem()
         model = prob.model

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -2808,7 +2808,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs', out_stream=None)
 
         for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 3e-8)
+            assert_near_equal(val['rel error'][0], 0.0, 7e-8)
 
     def test_check_totals_on_approx_model(self):
         prob = om.Problem()

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1378,12 +1378,14 @@ class _TotalJacInfo(object):
             vec_dresid[vec_name].set_val(0.0)
 
         # Linearize Model
+        ln_solver = model._linear_solver
         with model._scaled_context_all():
             model._linearize(model._assembled_jac,
-                             sub_do_ln=model._linear_solver._linearize_children())
-        if model.linear_solver._assembled_jac is not None:
+                             sub_do_ln=ln_solver._linearize_children())
+        if ln_solver._assembled_jac is not None and \
+           ln_solver._assembled_jac._under_complex_step:
             model.linear_solver._assembled_jac._update(model)
-        model._linear_solver._linearize()
+        ln_solver._linearize()
         self.J[:] = 0.0
 
         # Main loop over columns (fwd) or rows (rev) of the jacobian

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1381,6 +1381,8 @@ class _TotalJacInfo(object):
         with model._scaled_context_all():
             model._linearize(model._assembled_jac,
                              sub_do_ln=model._linear_solver._linearize_children())
+        if model.linear_solver._assembled_jac is not None:
+            model.linear_solver._assembled_jac._update(model)
         model._linear_solver._linearize()
         self.J[:] = 0.0
 

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -357,6 +357,11 @@ class AssembledJacobian(Jacobian):
         if ext_mtx is not None:
             ext_mtx._post_update()
 
+        if self._under_complex_step:
+            # If we create a new _int_mtx while under complex step, we need to convert it to a
+            # complex data type.
+            self._int_mtx.set_complex_step_mode(True)
+
     def _apply(self, system, d_inputs, d_outputs, d_residuals, mode):
         """
         Compute matrix-vector product.

--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -271,8 +271,9 @@ class COOMatrix(Matrix):
             Complex mode flag; set to True prior to commencing complex step.
         """
         if active:
-            self._coo.data = self._coo.data.astype(np.complex)
-            self._coo.dtype = np.complex
+            if 'complex' not in self._coo.dtype.__str__():
+                self._coo.data = self._coo.data.astype(np.complex)
+                self._coo.dtype = np.complex
         else:
             self._coo.data = self._coo.data.real
             self._coo.dtype = np.float

--- a/openmdao/matrices/csc_matrix.py
+++ b/openmdao/matrices/csc_matrix.py
@@ -61,3 +61,27 @@ class CSCMatrix(COOMatrix):
         coo = self._coo
         csc = csc_matrix((mask, (coo.row, coo.col)), shape=coo.shape)
         return csc.data
+
+    def set_complex_step_mode(self, active):
+        """
+        Turn on or off complex stepping mode.
+
+        When turned on, the value in each subjac is cast as complex, and when turned
+        off, they are returned to real values.
+
+        Parameters
+        ----------
+        active : bool
+            Complex mode flag; set to True prior to commencing complex step.
+        """
+        if active:
+            if 'complex' not in self._matrix.dtype.__str__():
+                self._matrix.data = self._matrix.data.astype(np.complex)
+                self._matrix.dtype = np.complex
+                self._coo.data = self._coo.data.astype(np.complex)
+                self._coo.dtype = np.complex
+        else:
+            self._matrix.data = self._matrix.data.real
+            self._matrix.dtype = np.float
+            self._coo.data = self._coo.data.real
+            self._coo.dtype = np.float

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -227,6 +227,7 @@ class NewtonSolver(NonlinearSolver):
         system._linearize(my_asm_jac, sub_do_ln=do_sub_ln)
         if (my_asm_jac is not None and system.linear_solver._assembled_jac is not my_asm_jac):
             my_asm_jac._update(system)
+
         self._linearize()
 
         self.linear_solver.solve(['linear'], 'fwd')


### PR DESCRIPTION
### Summary

1. Fixed a bug where complex step around newton wasn't working for sparse assembled jacobians.
2. Added support for performing check_totals on a model that is already approximating its total derivatives.

### Related Issues

- Resolves #1726 

### Backwards incompatibilities

None

### New Dependencies

None
