### PR TITLE
OpenMDAO library components are ignored by the check_partials() function.

### DIFF
--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -92,6 +92,8 @@ class AddSubtractComp(ExplicitComponent):
             raise ValueError(self.msginfo + ": first argument to adder init must be either of "
                              "type `str' or 'None'")
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -144,6 +144,8 @@ class BalanceComp(ImplicitComponent):
             self.add_balance(name, eq_units, lhs_name, rhs_name, rhs_val,
                              use_mult, mult_name, mult_val, normalize, val, **kwargs)
 
+        self._no_check_partials = True
+
     def apply_nonlinear(self, inputs, outputs, residuals):
         """
         Calculate the residual for each balance.

--- a/openmdao/components/cross_product_comp.py
+++ b/openmdao/components/cross_product_comp.py
@@ -49,6 +49,8 @@ class CrossProductComp(ExplicitComponent):
                          c_units=opt['c_units'], a_units=opt['a_units'], b_units=opt['b_units'],
                          vec_size=opt['vec_size'])
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/demux_comp.py
+++ b/openmdao/components/demux_comp.py
@@ -32,6 +32,8 @@ class DemuxComp(ExplicitComponent):
         self._vars = {}
         self._output_names = {}
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/dot_product_comp.py
+++ b/openmdao/components/dot_product_comp.py
@@ -43,6 +43,8 @@ class DotProductComp(ExplicitComponent):
                          c_units=opt['c_units'], a_units=opt['a_units'], b_units=opt['b_units'],
                          vec_size=opt['vec_size'], length=opt['length'])
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -104,6 +104,8 @@ class EQConstraintComp(ExplicitComponent):
                                use_mult, mult_name, mult_val, normalize, add_constraint, ref, ref0,
                                adder, scaler, **kwargs)
 
+        self._no_check_partials = True
+
     def compute(self, inputs, outputs):
         """
         Calculate the output for each equality constraint.

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -222,6 +222,8 @@ class ExecComp(ExplicitComponent):
         self._codes = None
         self._kwargs = kwargs
 
+        self._no_check_partials = True
+
     def setup(self):
         """
         Set up variable name and metadata lists.

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -74,7 +74,6 @@ class ExecComp(ExplicitComponent):
         Default is None, which means units are provided for variables individually.
     complex_stepsize : double
         Step size used for complex step which is used for derivatives.
-
     """
 
     def initialize(self):

--- a/openmdao/components/ks_comp.py
+++ b/openmdao/components/ks_comp.py
@@ -150,6 +150,8 @@ class KSComp(ExplicitComponent):
 
         self.cite = CITATIONS
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/linear_system_comp.py
+++ b/openmdao/components/linear_system_comp.py
@@ -32,6 +32,8 @@ class LinearSystemComp(ImplicitComponent):
         super().__init__(**kwargs)
         self._lup = None
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/matrix_vector_product_comp.py
+++ b/openmdao/components/matrix_vector_product_comp.py
@@ -53,6 +53,8 @@ class MatrixVectorProductComp(ExplicitComponent):
                          b_units=opt['b_units'], A_units=opt['A_units'], x_units=opt['x_units'],
                          vec_size=opt['vec_size'], A_shape=opt['A_shape'])
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -37,8 +37,6 @@ class MetaModelStructuredComp(ExplicitComponent):
         Cached list of input names.
     training_outputs : dict
         Dictionary of training data each output.
-    _no_check_partials : bool
-        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, **kwargs):

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -37,6 +37,8 @@ class MetaModelStructuredComp(ExplicitComponent):
         Cached list of input names.
     training_outputs : dict
         Dictionary of training data each output.
+    _no_check_partials : bool
+        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, **kwargs):
@@ -55,6 +57,8 @@ class MetaModelStructuredComp(ExplicitComponent):
         self.training_outputs = {}
         self.interps = {}
         self.grad_shape = ()
+
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -42,8 +42,6 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         Training data for inputs.
     _training_output : dict
         Training data for outputs.
-    _no_check_partials : bool
-        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, **kwargs):

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -42,6 +42,8 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         Training data for inputs.
     _training_output : dict
         Training data for outputs.
+    _no_check_partials : bool
+        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, **kwargs):
@@ -69,6 +71,8 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         self._static_surrogate_input_names = []
         self._static_surrogate_output_names = []
         self._static_input_size = 0
+
+        self._no_check_partials = True
 
     def _setup_procs(self, pathname, comm, mode, prob_meta):
         """

--- a/openmdao/components/multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/multifi_meta_model_unstructured_comp.py
@@ -80,8 +80,6 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         number of levels of fidelity
     _training_input : dict
         Training data for inputs.
-    _no_check_partials : bool
-        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, **kwargs):

--- a/openmdao/components/multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/multifi_meta_model_unstructured_comp.py
@@ -80,6 +80,8 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         number of levels of fidelity
     _training_input : dict
         Training data for inputs.
+    _no_check_partials : bool
+        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, **kwargs):
@@ -100,6 +102,8 @@ class MultiFiMetaModelUnStructuredComp(MetaModelUnStructuredComp):
         self._input_sizes = nfi * [0]
 
         self._static_input_sizes = nfi * [0]
+
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/openmdao/components/mux_comp.py
+++ b/openmdao/components/mux_comp.py
@@ -32,6 +32,8 @@ class MuxComp(ExplicitComponent):
         self._vars = {}
         self._input_names = {}
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/components/spline_comp.py
+++ b/openmdao/components/spline_comp.py
@@ -38,6 +38,8 @@ class SplineComp(ExplicitComponent):
         self._spline_cache = []
         self._n_cp = None
 
+        self._no_check_partials = True
+
     def _declare_options(self):
         """
         Declare options.

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -61,6 +61,8 @@ class TestKSFunction(unittest.TestCase):
         assert_near_equal(prob.get_val('ks.KS', indices=1), 34.0)
         assert_near_equal(prob.get_val('ks.KS', indices=2), 51.0)
 
+        prob.model.ks._no_check_partials = False  # override skipping of check_partials
+
         partials = prob.check_partials(includes=['ks'], out_stream=None)
 
         for (of, wrt) in partials['ks']:

--- a/openmdao/components/tests/test_linear_system_comp.py
+++ b/openmdao/components/tests/test_linear_system_comp.py
@@ -166,6 +166,8 @@ class TestLinearSystemComp(unittest.TestCase):
         sol = d_residuals['lin.x']
         assert_near_equal(sol, x, .0001)
 
+        prob.model.lingrp.lin._no_check_partials = False  # override skipping of check_partials
+
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b', 'lin.x'], return_format='flat_dict')
         assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
@@ -226,6 +228,8 @@ class TestLinearSystemComp(unittest.TestCase):
         lingrp.run_solve_linear(['linear'], 'rev')
         sol = d_residuals['lin.x']
         assert_near_equal(sol, x, .0001)
+
+        prob.model.lingrp.lin._no_check_partials = False  # override skipping of check_partials
 
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b'], return_format='flat_dict')
         assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
@@ -296,6 +300,8 @@ class TestLinearSystemComp(unittest.TestCase):
         lingrp.run_solve_linear(['linear'], 'rev')
         sol = d_residuals['lin.x']
         assert_near_equal(sol, x, .0001)
+
+        prob.model.lingrp.lin._no_check_partials = False  # override skipping of check_partials
 
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b'], return_format='flat_dict')
         assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -631,6 +631,9 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         """Runs check_partials and compares to analytic derivatives."""
 
         prob.run_model()
+
+        prob.model.comp._no_check_partials = False  # override skipping of check_partials
+
         derivs = prob.check_partials(out_stream=None)
 
         for i in derivs['comp'].keys():
@@ -714,6 +717,9 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         """Runs check_partials and compares to analytic derivatives."""
 
         prob.run_model()
+
+        prob.model.comp._no_check_partials = False  # override skipping of check_partials
+
         derivs = prob.check_partials(method='cs', out_stream=None)
 
         for i in derivs['comp'].keys():
@@ -1116,9 +1122,9 @@ class TestMetaModelStructuredPython(unittest.TestCase):
       p.set_val('x', 0.75)
 
       msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> " \
-            "Line 203 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
+            "Line 207 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
       with assert_warning(UserWarning, msg):
-          p.run_driver()
+        p.run_driver()
 
 
 @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -671,7 +671,8 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         with self.assertRaises(om.AnalysisError) as cm:
             p.run_model()
 
-        msg = ("'MM' <class MMComp>: Error interpolating output 'y' because input 'MM.x' was out of bounds ('0.0', '1.0') with value '1.1'")
+        msg = ("'MM' <class MMComp>: Error interpolating output 'y' because "
+               "input 'MM.x' was out of bounds ('0.0', '1.0') with value '1.1'")
         self.assertEqual(str(cm.exception), msg)
 
 
@@ -1122,7 +1123,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         p.set_val('x', 0.75)
 
         msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> " \
-              "Line 207 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
+              "Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
         with assert_warning(UserWarning, msg):
             p.run_driver()
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1101,30 +1101,30 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
     @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
     def test_analysis_error_warning_msg(self):
-      x_tr = np.linspace(0, 2*np.pi, 100)
-      y_tr = np.sin(x_tr)
+        x_tr = np.linspace(0, 2*np.pi, 100)
+        y_tr = np.sin(x_tr)
 
-      p = om.Problem(model=om.Group())
+        p = om.Problem(model=om.Group())
 
-      p.driver = om.pyOptSparseDriver(optimizer=OPTIMIZER)
+        p.driver = om.pyOptSparseDriver(optimizer=OPTIMIZER)
 
-      mm = om.MetaModelStructuredComp(extrapolate=False)
-      mm.add_input('x', val=1.0, training_data=x_tr)
-      mm.add_output('y', val=1.0, training_data=y_tr)
-      p.model.add_subsystem('interp', mm, promotes_inputs=['x'], promotes_outputs=['y'])
+        mm = om.MetaModelStructuredComp(extrapolate=False)
+        mm.add_input('x', val=1.0, training_data=x_tr)
+        mm.add_output('y', val=1.0, training_data=y_tr)
+        p.model.add_subsystem('interp', mm, promotes_inputs=['x'], promotes_outputs=['y'])
 
-      p.model.add_objective('y', scaler=-1)
-      p.model.add_design_var('x', lower=6, upper=10)
+        p.model.add_objective('y', scaler=-1)
+        p.model.add_design_var('x', lower=6, upper=10)
 
-      p.set_solver_print(level=0)
-      p.setup()
+        p.set_solver_print(level=0)
+        p.setup()
 
-      p.set_val('x', 0.75)
+        p.set_val('x', 0.75)
 
-      msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> " \
-            "Line 207 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
-      with assert_warning(UserWarning, msg):
-        p.run_driver()
+        msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> " \
+              "Line 207 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
+        with assert_warning(UserWarning, msg):
+            p.run_driver()
 
 
 @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -404,6 +404,8 @@ class MetaModelTestCase(unittest.TestCase):
         prob['x'] = 0.125
         prob.run_model()
 
+        mm._no_check_partials = False  # override skipping of check_partials
+
         data = prob.check_partials(out_stream=None)
 
         Jf = data['mm'][('f', 'x')]['J_fwd']

--- a/openmdao/components/vector_magnitude_comp.py
+++ b/openmdao/components/vector_magnitude_comp.py
@@ -39,6 +39,8 @@ class VectorMagnitudeComp(ExplicitComponent):
         self.add_magnitude(mag_name=opt['mag_name'], in_name=opt['in_name'], units=opt['units'],
                            vec_size=opt['vec_size'], length=opt['length'])
 
+        self._no_check_partials = True
+
     def initialize(self):
         """
         Declare options.

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -76,6 +76,8 @@ class Component(System):
         Cached storage of user-declared partials.
     _declared_partial_checks : list
         Cached storage of user-declared check partial options.
+    _no_check_partials : bool
+        If True, the check_partials function will ignore this component.
     """
 
     def __init__(self, **kwargs):
@@ -97,6 +99,7 @@ class Component(System):
 
         self._declared_partials = defaultdict(dict)
         self._declared_partial_checks = []
+        self._no_check_partials = False
 
     def _declare_options(self):
         """

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -10,11 +10,6 @@ from openmdao.utils.general_utils import make_set, warn_deprecation, ensure_comp
 class IndepVarComp(ExplicitComponent):
     """
     Class to use when all output variables are independent.
-
-    Attributes
-    ----------
-    _no_check_partials : bool
-        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, name=None, val=1.0, **kwargs):

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -10,6 +10,11 @@ from openmdao.utils.general_utils import make_set, warn_deprecation, ensure_comp
 class IndepVarComp(ExplicitComponent):
     """
     Class to use when all output variables are independent.
+
+    Attributes
+    ----------
+    _no_check_partials : bool
+        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, name=None, val=1.0, **kwargs):
@@ -50,6 +55,8 @@ class IndepVarComp(ExplicitComponent):
             if illegal in kwargs:
                 raise ValueError("IndepVarComp init: '%s' is not supported "
                                  "in IndepVarComp." % illegal)
+
+        self._no_check_partials = True
 
     def initialize(self):
         """

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1049,7 +1049,7 @@ class Problem(object):
 
         comps = []
         for comp in model.system_iter(typ=Component, include_self=True):
-            if hasattr(comp, '_no_check_partials') and comp._no_check_partials:
+            if comp._no_check_partials:
                 continue
 
             name = comp.pathname

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1049,8 +1049,7 @@ class Problem(object):
 
         comps = []
         for comp in model.system_iter(typ=Component, include_self=True):
-            if isinstance(comp, IndepVarComp) or \
-               (hasattr(comp, '_no_partials') and comp._no_partials):
+            if hasattr(comp, '_no_check_partials') and comp._no_check_partials:
                 continue
 
             name = comp.pathname

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1049,7 +1049,8 @@ class Problem(object):
 
         comps = []
         for comp in model.system_iter(typ=Component, include_self=True):
-            if isinstance(comp, IndepVarComp):
+            if isinstance(comp, IndepVarComp) or \
+               (hasattr(comp, '_no_partials') and comp._no_partials):
                 continue
 
             name = comp.pathname

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -302,6 +302,8 @@ class System(object):
         If True, this is the first call to _linearize.
     _is_local : bool
         If True, this system is local to this mpi process.
+    _no_check_partials : bool
+        When this attribute exists and is True, check_partials will ignore this system.
     """
 
     def __init__(self, num_par_fd=1, **kwargs):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -302,8 +302,6 @@ class System(object):
         If True, this is the first call to _linearize.
     _is_local : bool
         If True, this system is local to this mpi process.
-    _no_check_partials : bool
-        If True, the check_partials function will ignore this system.
     """
 
     def __init__(self, num_par_fd=1, **kwargs):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -303,7 +303,7 @@ class System(object):
     _is_local : bool
         If True, this system is local to this mpi process.
     _no_check_partials : bool
-        When this attribute exists and is True, check_partials will ignore this system.
+        If True, the check_partials function will ignore this system.
     """
 
     def __init__(self, num_par_fd=1, **kwargs):

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -194,7 +194,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         model = prob.model
 
         model.add_subsystem("indep", om.IndepVarComp('x', 5.))
-        model.add_subsystem("comp1", om.ExecComp("y=2*x"))
+        model.add_subsystem("comp1", Paraboloid())
 
         comp2 = model.add_subsystem("comp2", om.ExplicitComponent())
         comp2.add_input('x', val=0.)
@@ -216,17 +216,17 @@ class TestProblemCheckPartials(unittest.TestCase):
         # but we still get good derivative data for 'comp1'
         self.assertTrue('comp1' in data)
 
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
+        assert_near_equal(data['comp1'][('f_xy', 'x')]['J_fd'][0][0], 4., 1e-6)
+        assert_near_equal(data['comp1'][('f_xy', 'x')]['J_fwd'][0][0], 4., 1e-15)
 
     def test_component_no_check_partials(self):
         prob = om.Problem()
         model = prob.model
 
         model.add_subsystem("indep", om.IndepVarComp('x', 5.))
-        model.add_subsystem("comp1", om.ExecComp("y=2*x"))
+        model.add_subsystem("comp1", Paraboloid())
 
-        comp2 = model.add_subsystem("comp2", om.ExecComp("y=4*x"))
+        comp2 = model.add_subsystem("comp2", Paraboloid())
 
         model.connect('indep.x', ['comp1.x', 'comp2.x'])
 
@@ -239,14 +239,14 @@ class TestProblemCheckPartials(unittest.TestCase):
         comp2._no_check_partials = True
         data = prob.check_partials(out_stream=None)
 
-        # we still get good derivative data for 'comp1'
+        # no derivative data for 'comp2'
+        self.assertFalse('comp2' in data)
+
+        # but we still get good derivative data for 'comp1'
         self.assertTrue('comp1' in data)
 
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
-
-        # but no derivative data for 'comp2'
-        self.assertFalse('comp2' in data)
+        assert_near_equal(data['comp1'][('f_xy', 'x')]['J_fd'][0][0], 4., 1e-6)
+        assert_near_equal(data['comp1'][('f_xy', 'x')]['J_fwd'][0][0], 4., 1e-15)
 
         #
         # re-enable partials on comp2
@@ -254,17 +254,17 @@ class TestProblemCheckPartials(unittest.TestCase):
         comp2._no_check_partials = False
         data = prob.check_partials(out_stream=None)
 
-        # still get good derivative data for 'comp1'
-        self.assertTrue('comp1' in data)
-
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
-
-        # and now we should have derivative data for 'comp2' as well
+        # now we should have derivative data for 'comp2'
         self.assertTrue('comp2' in data)
 
-        assert_near_equal(data['comp2'][('y', 'x')]['J_fd'][0][0], 4., 1e-9)
-        assert_near_equal(data['comp2'][('y', 'x')]['J_fwd'][0][0], 4., 1e-15)
+        assert_near_equal(data['comp2'][('f_xy', 'x')]['J_fd'][0][0], 4., 1e-6)
+        assert_near_equal(data['comp2'][('f_xy', 'x')]['J_fwd'][0][0], 4., 1e-15)
+
+        # and still get good derivative data for 'comp1'
+        self.assertTrue('comp1' in data)
+
+        assert_near_equal(data['comp1'][('f_xy', 'x')]['J_fd'][0][0], 4., 1e-6)
+        assert_near_equal(data['comp1'][('f_xy', 'x')]['J_fwd'][0][0], 4., 1e-15)
 
     def test_missing_entry(self):
         class MyComp(om.ExplicitComponent):
@@ -1361,15 +1361,15 @@ class TestProblemCheckPartials(unittest.TestCase):
         model = prob.model
 
         sub = model.add_subsystem('c1c', om.Group())
-        sub.add_subsystem('d1', om.ExecComp('y=2*x'))
-        sub.add_subsystem('e1', om.ExecComp('y=2*x'))
+        sub.add_subsystem('d1', Paraboloid())
+        sub.add_subsystem('e1', Paraboloid())
 
         sub2 = model.add_subsystem('sss', om.Group())
         sub3 = sub2.add_subsystem('sss2', om.Group())
-        sub2.add_subsystem('d1', om.ExecComp('y=2*x'))
-        sub3.add_subsystem('e1', om.ExecComp('y=2*x'))
+        sub2.add_subsystem('d1', Paraboloid())
+        sub3.add_subsystem('e1', Paraboloid())
 
-        model.add_subsystem('abc1cab', om.ExecComp('y=2*x'))
+        model.add_subsystem('abc1cab', Paraboloid())
 
         prob.setup()
         prob.run_model()
@@ -2155,20 +2155,21 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
     def test_includes_excludes(self):
         import openmdao.api as om
+        from openmdao.test_suite.components.paraboloid import Paraboloid
 
         prob = om.Problem()
         model = prob.model
 
         sub = model.add_subsystem('c1c', om.Group())
-        sub.add_subsystem('d1', om.ExecComp('y=2*x'))
-        sub.add_subsystem('e1', om.ExecComp('y=2*x'))
+        sub.add_subsystem('d1', Paraboloid())
+        sub.add_subsystem('e1', Paraboloid())
 
         sub2 = model.add_subsystem('sss', om.Group())
         sub3 = sub2.add_subsystem('sss2', om.Group())
-        sub2.add_subsystem('d1', om.ExecComp('y=2*x'))
-        sub3.add_subsystem('e1', om.ExecComp('y=2*x'))
+        sub2.add_subsystem('d1', Paraboloid())
+        sub3.add_subsystem('e1', Paraboloid())
 
-        model.add_subsystem('abc1cab', om.ExecComp('y=2*x'))
+        model.add_subsystem('abc1cab', Paraboloid())
 
         prob.setup()
         prob.run_model()

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -219,7 +219,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
         assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
 
-    def test_component_no_partials(self):
+    def test_component_no_check_partials(self):
         prob = om.Problem()
         model = prob.model
 
@@ -227,40 +227,44 @@ class TestProblemCheckPartials(unittest.TestCase):
         model.add_subsystem("comp1", om.ExecComp("y=2*x"))
 
         comp2 = model.add_subsystem("comp2", om.ExecComp("y=4*x"))
-        comp2._no_partials = True
 
         model.connect('indep.x', ['comp1.x', 'comp2.x'])
 
         prob.setup()
         prob.run_model()
 
+        #
+        # disable partials on comp2
+        #
+        comp2._no_check_partials = True
         data = prob.check_partials(out_stream=None)
 
-        # no derivative data for 'comp2'
-        self.assertFalse('comp2' in data)
-
-        # but we still get good derivative data for 'comp1'
+        # we still get good derivative data for 'comp1'
         self.assertTrue('comp1' in data)
 
         assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
         assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
 
-        comp2._no_partials = False
+        # but no derivative data for 'comp2'
+        self.assertFalse('comp2' in data)
 
+        #
+        # re-enable partials on comp2
+        #
+        comp2._no_check_partials = False
         data = prob.check_partials(out_stream=None)
 
-        # now we should have derivative data for 'comp2'
+        # still get good derivative data for 'comp1'
+        self.assertTrue('comp1' in data)
+
+        assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
+        assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
+
+        # and now we should have derivative data for 'comp2' as well
         self.assertTrue('comp2' in data)
 
         assert_near_equal(data['comp2'][('y', 'x')]['J_fd'][0][0], 4., 1e-9)
         assert_near_equal(data['comp2'][('y', 'x')]['J_fwd'][0][0], 4., 1e-15)
-
-        # and still get good derivative data for 'comp1'
-        self.assertTrue('comp1' in data)
-
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fd'][0][0], 2., 1e-9)
-        assert_near_equal(data['comp1'][('y', 'x')]['J_fwd'][0][0], 2., 1e-15)
-
 
     def test_missing_entry(self):
         class MyComp(om.ExplicitComponent):


### PR DESCRIPTION
### Summary

OpenMDAO library components are ignored by the check_partials() function.

### Related Issues

- Resolves #1710

### Backwards incompatibilities

None

### New Dependencies

None
