### PR TITLE
change default to get_remote=True for Driver.get_design_var_values()

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -602,7 +602,7 @@ class Driver(object):
 
         return val
 
-    def get_design_var_values(self, get_remote=False):
+    def get_design_var_values(self, get_remote=True):
         """
         Return the design variable values.
 


### PR DESCRIPTION
### Summary

Change the default to `get_remote=True` for `Driver.get_design_var_values()`
add test case 

### Related Issues

- Resolves #1737

### Backwards incompatibilities

Reverts the default that was changed in #1727 

### New Dependencies

None
