### PR TITLE
Serialize all openmdao content that might contain non-standard types before it is dumped to JSON for the n2 while recording.

### DIFF
--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -798,6 +798,34 @@ class ExplCompTestCase(unittest.TestCase):
         outputs = prob.model.list_outputs(out_stream=None, tags="tag3")
         self.assertEqual(sorted(outputs), [])
 
+    def test_tags_error_messages(self):
+
+        class Comp1(om.ExplicitComponent):
+            def setup(self):
+                self.add_input('a', 1.0, tags=['a', dict()])
+
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', Comp1())
+
+        with self.assertRaises(TypeError) as cm:
+            prob.setup(self)
+
+        msg = "Items in tags should be of type string, but type 'dict' was found."
+        self.assertEqual(str(cm.exception), msg)
+
+        class Comp1(om.ExplicitComponent):
+            def setup(self):
+                self.add_input('a', 1.0, tags=333)
+
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', Comp1())
+
+        with self.assertRaises(TypeError) as cm:
+            prob.setup(self)
+
+        msg = "The tags argument should be a str or list"
+        self.assertEqual(str(cm.exception), msg)
+
     def test_feature_simple_var_tags(self):
         from openmdao.api import Problem, ExplicitComponent
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -391,7 +391,7 @@ class SqliteRecorder(CaseRecorder):
             var_settings.update(constraints)
             var_settings = self._cleanup_var_settings(var_settings)
             var_settings['execution_order'] = var_order
-            var_settings_json = json.dumps(var_settings)
+            var_settings_json = json.dumps(var_settings, default=default_noraise)
 
             with self.connection as c:
                 c.execute("UPDATE metadata SET " +

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -856,7 +856,7 @@ def make_serializable(o):
         return o.item()
     elif isinstance(o, (str, float, int)):
         return o
-    elif isinstance(o, bool):
+    elif isinstance(o, bool) or np.iscomplex(o):
         return str(o)
     elif hasattr(o, '__dict__'):
         return o.__class__.__name__
@@ -921,7 +921,7 @@ def default_noraise(o):
         return o.item()
     elif isinstance(o, (str, float, int)):
         return o
-    elif isinstance(o, bool):
+    elif isinstance(o, bool) or np.iscomplex(o):
         return str(o)
     elif hasattr(o, '__dict__'):
         return o.__class__.__name__
@@ -952,10 +952,19 @@ def make_set(str_data, name=None):
         return set()
     elif isinstance(str_data, str):
         return {str_data}
-    elif isinstance(str_data, set):
-        return str_data
-    elif isinstance(str_data, list):
-        return set(str_data)
+    elif isinstance(str_data, (set, list)):
+
+        for item in str_data:
+            if not isinstance(item, str):
+                typ = type(item).__name__
+                msg = f"Items in tags should be of type string, but type '{typ}' was found."
+                raise TypeError(msg)
+
+        if isinstance(str_data, set):
+            return str_data
+        elif isinstance(str_data, list):
+            return set(str_data)
+
     elif name:
         raise TypeError("The {} argument should be str, set, or list: {}".format(name, str_data))
     else:

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -846,14 +846,49 @@ def make_serializable(o):
     """
     if isinstance(o, _container_classes):
         return [make_serializable(item) for item in o]
+    elif isinstance(o, dict):
+        s_key = [make_serializable_key(item) for item in o.keys()]
+        s_val = [make_serializable(item) for item in o.values()]
+        return dict(zip(s_key, s_val))
     elif isinstance(o, np.ndarray):
         return o.tolist()
+    elif isinstance(o, np.number):
+        return o.item()
+    elif isinstance(o, (str, float, int)):
+        return o
+    elif isinstance(o, bool):
+        return str(o)
+    elif hasattr(o, '__dict__'):
+        return o.__class__.__name__
+    else:
+        return o
+
+
+def make_serializable_key(o):
+    """
+    Recursively convert numpy types to native types for JSON serialization.
+
+    This function is for making serizializable dictionary keys, so no containers.
+    This function should NOT be passed into json.dump or json.dumps as the 'default' arg.
+
+    Parameters
+    ----------
+    o : object
+        the object to be converted
+
+    Returns
+    -------
+    object
+        The converted object.
+    """
+    if isinstance(o, str):
+        return o
     elif isinstance(o, np.number):
         return o.item()
     elif hasattr(o, '__dict__'):
         return o.__class__.__name__
     else:
-        return o
+        return str(o)
 
 
 def default_noraise(o):
@@ -875,13 +910,23 @@ def default_noraise(o):
         The converted object.
     """
     if isinstance(o, _container_classes):
-        return [make_serializable(item) for item in o]
+        return [default_noraise(item) for item in o]
+    elif isinstance(o, dict):
+        s_key = [make_serializable_key(item) for item in o.keys()]
+        s_val = [default_noraise(item) for item in o.values()]
+        return dict(zip(s_key, s_val))
     elif isinstance(o, np.ndarray):
         return o.tolist()
     elif isinstance(o, np.number):
         return o.item()
+    elif isinstance(o, (str, float, int)):
+        return o
+    elif isinstance(o, bool):
+        return str(o)
     elif hasattr(o, '__dict__'):
         return o.__class__.__name__
+    elif o is None:
+        return None
     else:
         return f"unserializable object ({type(o).__name__})"
 

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -251,7 +251,8 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
             elif val is _UNDEFINED:
                 options[k] = str(val)
             else:
-                options[k] = val
+                options[k] = default_noraise(val)
+
     tree_dict['options'] = options
 
     if not tree_dict['name']:

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -120,8 +120,7 @@ def _get_var_dict(system, typ, name):
 
     if is_discrete:
         if isinstance(meta['value'], (int, str, list, dict, complex, np.ndarray)):
-            val = meta['value']
-            var_dict['value'] = val
+            var_dict['value'] = default_noraise(meta['value'])
         else:
             var_dict['value'] = type(meta['value']).__name__
     else:
@@ -131,6 +130,34 @@ def _get_var_dict(system, typ, name):
             var_dict['value'] = None
 
     return var_dict
+
+
+def _serialize_single_option(option):
+    """
+    Return a json-safe equivalent of the option.
+
+    The default_noraise function performs the datatype serialization, while this function takes
+    care of attributes specific to options dicts.
+
+    Parameters
+    ----------
+    option : object
+        Option to be serialized.
+
+    Returns
+    -------
+    object
+       JSON-safe serialized object.
+    """
+    val = option['value']
+    if not option['recordable']:
+        serialized_option = 'Not Recordable'
+    elif val is _UNDEFINED:
+        serialized_option = str(val)
+    else:
+        serialized_option = default_noraise(val)
+
+    return serialized_option
 
 
 def _get_tree_dict(system, component_execution_orders, component_execution_index,
@@ -199,7 +226,8 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
             tree_dict['linear_solver_options'] = None
         elif system.linear_solver:
             tree_dict['linear_solver'] = system.linear_solver.SOLVER
-            options = {k: system.linear_solver.options[k] for k in system.linear_solver.options}
+            options = {k: _serialize_single_option(system.linear_solver.options._dict[k])
+                       for k in system.linear_solver.options}
             tree_dict['linear_solver_options'] = options
         else:
             tree_dict['linear_solver'] = ""
@@ -210,7 +238,7 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
             tree_dict['nonlinear_solver_options'] = None
         elif system.nonlinear_solver:
             tree_dict['nonlinear_solver'] = system.nonlinear_solver.SOLVER
-            options = {k: system.nonlinear_solver.options[k]
+            options = {k: _serialize_single_option(system.nonlinear_solver.options._dict[k])
                        for k in system.nonlinear_solver.options}
             tree_dict['nonlinear_solver_options'] = options
         else:
@@ -219,7 +247,8 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
     else:
         if system.linear_solver:
             tree_dict['linear_solver'] = system.linear_solver.SOLVER
-            options = {k: system.linear_solver.options[k] for k in system.linear_solver.options}
+            options = {k: _serialize_single_option(system.linear_solver.options._dict[k])
+                       for k in system.linear_solver.options}
             tree_dict['linear_solver_options'] = options
         else:
             tree_dict['linear_solver'] = ""
@@ -227,7 +256,7 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
 
         if system.nonlinear_solver:
             tree_dict['nonlinear_solver'] = system.nonlinear_solver.SOLVER
-            options = {k: system.nonlinear_solver.options[k]
+            options = {k: _serialize_single_option(system.nonlinear_solver.options._dict[k])
                        for k in system.nonlinear_solver.options}
             tree_dict['nonlinear_solver_options'] = options
 
@@ -245,13 +274,7 @@ def _get_tree_dict(system, component_execution_orders, component_execution_index
         if k in ['linear_solver', 'nonlinear_solver']:
             options[k] = system.options[k].SOLVER
         else:
-            val = system.options._dict[k]['value']
-            if not system.options._dict[k]['recordable']:
-                options[k] = default_noraise(val)
-            elif val is _UNDEFINED:
-                options[k] = str(val)
-            else:
-                options[k] = default_noraise(val)
+            options[k] = _serialize_single_option(system.options._dict[k])
 
     tree_dict['options'] = options
 
@@ -319,7 +342,8 @@ def _get_viewer_data(data_source):
         driver_name = driver.__class__.__name__
         driver_type = 'doe' if isinstance(driver, DOEDriver) else 'optimization'
 
-        driver_options = {key: val for key, val in driver.options.items()}
+        driver_options = {key: _serialize_single_option(driver.options._dict[key])
+                          for key in driver.options}
 
         if driver_type == 'optimization' and 'opt_settings' in dir(driver):
             driver_opt_settings = driver.opt_settings

--- a/openmdao/visualization/n2_viewer/tests/test_serialization.py
+++ b/openmdao/visualization/n2_viewer/tests/test_serialization.py
@@ -1,0 +1,157 @@
+"""
+This test assures that the use of nonstandard datatypes anywhere that they are allowed in a model
+does not break the recording of the JSON data structures needed for the model viewer.
+"""
+
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+from openmdao.core.driver import Driver
+from openmdao.utils.testing_utils import use_tempdirs
+
+
+class BadOpt(object):
+    def junk(self):
+        pass
+
+
+class NonSerComp(om.ExplicitComponent):
+
+    def setup(self):
+        self.add_input('x', np.zeros((6, )),
+                       tags=['a', 'c'])
+        self.add_output('y', np.zeros((6, )),
+                       tags=['a', 'b'])
+
+        self.add_discrete_input('dx', [{('Discrete_i', BadOpt): (2, {((1, ), (2, )): 'stuff'})}])
+        self.add_discrete_input('dy', [{('Discrete_o', BadOpt): (2, {((1, ), (2, )): 'stuff'})}])
+        self.add_discrete_input('dcomplex', 3 + 5j)
+
+    def initialize(self):
+        self.options.declare('good', 'good_string')
+        self.options.declare('bad', [{(1, BadOpt): (2, 3)}])
+        self.options.declare('bad2', {((1, ), (2, )): 'stuff'})
+        self.options.declare('nonrec', 3.0, recordable=False)
+        self.options.declare('cx', 3 + 7j)
+
+
+class NonSerIComp(om.ImplicitComponent):
+
+    def setup(self):
+        self.add_input('xx', np.zeros((6, )))
+        self.add_output('yy', np.zeros((6, )))
+
+        self.add_discrete_input('problem', None)
+
+    def initialize(self):
+        self.options.declare('good', 'good_string')
+        self.options.declare('bad', [{(1, BadOpt): (2, 3)}])
+        self.options.declare('bad2', {((1, ), (2, )): 'stuff'})
+        self.options.declare('nonrec', 3.0, recordable=False)
+        self.options.declare('problem')
+
+
+class NonSerNL(om.NonlinearRunOnce):
+
+    def _declare_options(self):
+        super()._declare_options()
+        self.options.declare('bad', [{(1, BadOpt): (2, 3)}])
+        self.options.declare('bad2', {((1, ), (2, )): 'stuff'})
+        self.options.declare('nonrec', 3.0, recordable=False)
+
+
+class NonSerLN(om.LinearRunOnce):
+
+    def _declare_options(self):
+        super()._declare_options()
+        self.options.declare('bad', [{(1, BadOpt): (2, 3)}])
+        self.options.declare('bad2', {((1, ), (2, )): 'stuff'})
+        self.options.declare('nonrec', 3.0, recordable=False)
+
+
+class NonSerDriver(Driver):
+
+    def _declare_options(self):
+        super()._declare_options()
+        self.options.declare('bad', [{(1, BadOpt): (2, 3)}])
+        self.options.declare('bad2', {((1, ), (2, )): 'stuff'})
+        self.options.declare('nonrec', 3.0, recordable=False)
+
+
+@use_tempdirs
+class TestSerialization(unittest.TestCase):
+
+    def test_exhaustive_model(self):
+        em_prob = om.Problem()
+        em_model = em_prob.model
+        em_model.add_subsystem('ns', NonSerComp())
+        em_model.add_subsystem('nsi', NonSerIComp())
+        em_prob.setup()
+        em_prob.final_setup()
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('ns', NonSerComp())
+        nsi = model.add_subsystem('nsi', NonSerIComp())
+
+        nsi.options['problem'] = em_prob
+
+        model.nonlinear_solver = NonSerNL()
+        model.linear_solver = NonSerLN()
+        nsi.nonlinear_solver = NonSerNL()
+        nsi.linear_solver = NonSerLN()
+
+        model.add_design_var('ns.x', indices=om.slicer[2:])
+        model.add_design_var('ns.dx')
+        model.add_constraint('ns.y', indices=om.slicer[2:])
+        model.add_objective('nsi.yy', index=om.slicer[-1])
+
+        prob.driver = NonSerDriver()
+
+        prob.add_recorder(om.SqliteRecorder("cases1.sql"))
+        prob.driver.add_recorder(om.SqliteRecorder("cases2.sql"))
+        prob.model.add_recorder(om.SqliteRecorder("cases3.sql"))
+        prob.model.nonlinear_solver.add_recorder(om.SqliteRecorder("cases4.sql"))
+
+        prob.setup()
+        prob.set_val('nsi.problem', em_prob)
+
+        prob.run_model()
+
+        cr = om.CaseReader("cases1.sql")
+
+        dval = cr.problem_metadata['tree']['children'][1]['options']['bad']
+        key, val = [(k, v) for k, v in dval[0].items()][0]
+        self.assertTrue("(1, <class" in key)
+        self.assertEqual(val, [2, 3])
+
+        self.assertEqual(cr.problem_metadata['tree']['children'][1]['options']['bad2'],
+                         {'((1,), (2,))': 'stuff'})
+        self.assertEqual(cr.problem_metadata['tree']['children'][1]['options']['nonrec'],
+                         'Not Recordable')
+        self.assertEqual(cr.problem_metadata['tree']['children'][1]['options']['cx'],
+                         '(3+7j)')
+
+        dval = cr.problem_metadata['tree']['children'][1]['children'][2]['value']
+        key, val = [(k, v) for k, v in dval[0].items()][0]
+        self.assertTrue("Discrete_o', <class" in key)
+        self.assertEqual(val, [2, {'((1,), (2,))': 'stuff'}])
+
+        dval = cr.problem_metadata['tree']['children'][1]['children'][1]['value']
+        key, val = [(k, v) for k, v in dval[0].items()][0]
+        self.assertTrue("Discrete_i', <class" in key)
+        self.assertEqual(val, [2, {'((1,), (2,))': 'stuff'}])
+
+        self.assertEqual(cr.problem_metadata['tree']['children'][1]['children'][3]['value'],
+                         '(3+5j)')
+
+
+
+        print('done')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/visualization/n2_viewer/tests/test_serialization.py
+++ b/openmdao/visualization/n2_viewer/tests/test_serialization.py
@@ -26,7 +26,7 @@ class NonSerComp(om.ExplicitComponent):
                        tags=['a', 'b'])
 
         self.add_discrete_input('dx', [{('Discrete_i', BadOpt): (2, {((1, ), (2, )): 'stuff'})}])
-        self.add_discrete_input('dy', [{('Discrete_o', BadOpt): (2, {((1, ), (2, )): 'stuff'})}])
+        self.add_discrete_output('dy', [{('Discrete_o', BadOpt): (2, {((1, ), (2, )): 'stuff'})}])
         self.add_discrete_input('dcomplex', 3 + 5j)
 
     def initialize(self):
@@ -135,7 +135,7 @@ class TestSerialization(unittest.TestCase):
         self.assertEqual(cr.problem_metadata['tree']['children'][1]['options']['cx'],
                          '(3+7j)')
 
-        dval = cr.problem_metadata['tree']['children'][1]['children'][2]['value']
+        dval = cr.problem_metadata['tree']['children'][1]['children'][4]['value']
         key, val = [(k, v) for k, v in dval[0].items()][0]
         self.assertTrue("Discrete_o', <class" in key)
         self.assertEqual(val, [2, {'((1,), (2,))': 'stuff'}])
@@ -145,7 +145,7 @@ class TestSerialization(unittest.TestCase):
         self.assertTrue("Discrete_i', <class" in key)
         self.assertEqual(val, [2, {'((1,), (2,))': 'stuff'}])
 
-        self.assertEqual(cr.problem_metadata['tree']['children'][1]['children'][3]['value'],
+        self.assertEqual(cr.problem_metadata['tree']['children'][1]['children'][2]['value'],
                          '(3+5j)')
 
 

--- a/openmdao/visualization/n2_viewer/tests/test_serialization.py
+++ b/openmdao/visualization/n2_viewer/tests/test_serialization.py
@@ -149,9 +149,5 @@ class TestSerialization(unittest.TestCase):
                          '(3+5j)')
 
 
-
-        print('done')
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Serialize all openmdao content that might contain non-standard types before it is dumped to JSON for the n2 while recording.

Also added better error checking for 'tags', since they can only be strings or lists/sets of strings.

### Related Issues

- Resolves #1734
- Resolves #1736

### Backwards incompatibilities

None

### New Dependencies

None
