### PR TITLE
Fix for bug in parallel setup in version 3.4 

### DIFF
--- a/openmdao/core/configinfo.py
+++ b/openmdao/core/configinfo.py
@@ -91,7 +91,8 @@ class _ConfigInfo(object):
         len_prefix = len(group.pathname) + 1 if group.pathname else 0
 
         # sort into longest first order so the systems will get updated bottom up
-        for path, _ in sorted(_descendents(group, allpaths), key=lambda t: t[1], reverse=True):
+        for path, _ in sorted(_descendents(group, allpaths), key=lambda t: (t[1], t[0]),
+                              reverse=True):
             s = group._get_subsystem(path[len_prefix:])
             if s is not None and s._is_local:
                 yield s

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -946,30 +946,30 @@ class Group(System):
         dists = {}
 
         if self.comm.size > 1:
-            locality = {}
-            snames = {}
-            for io in ('input', 'output'):
-                # var order must be same on all procs
-                snames[io] = sorted(self._var_allprocs_abs2prom[io])
-                nvars = len(snames[io])
-                locality[io] = locs = np.zeros(nvars, dtype=bool)
-                abs2prom = self._var_abs2prom[io]
-                for i, name in enumerate(snames[io]):
-                    if name in abs2prom:
-                        locs[i] = True
+            myproc = self.comm.rank
+            nprocs = self.comm.size
 
-            proc_locs = self.comm.allgather(locality)
             for io in ('input', 'output'):
                 all_abs2prom = self._var_allprocs_abs2prom[io]
-                if proc_locs[0][io].size > 0:
-                    abs2meta = self._var_allprocs_abs2meta[io]
-                    locs = np.vstack([loc[io] for loc in proc_locs])
-                    for i, name in enumerate(snames[io]):
-                        nzs = np.nonzero(locs[:, i])[0]
-                        if name in abs2meta and abs2meta[name]['distributed']:
-                            dists[name] = nzs
-                        elif (nzs.size > 0 and nzs.size < locs.shape[0] and name in all_abs2prom):
-                            remote_vars[name] = nzs[0]
+                abs2prom = self._var_abs2prom[io]
+                abs2meta = self._var_allprocs_abs2meta[io]
+
+                # var order must be same on all procs
+                sorted_names = sorted(all_abs2prom)
+                locality = np.zeros((nprocs, len(sorted_names)), dtype=bool)
+                for i, name in enumerate(sorted_names):
+                    if name in abs2prom:
+                        locality[myproc, i] = True
+
+                my_loc = locality[myproc, :].copy()
+                self.comm.Allgather(my_loc, locality)
+
+                for i, name in enumerate(sorted_names):
+                    nzs = np.nonzero(locality[:, i])[0]
+                    if name in abs2meta and abs2meta[name]['distributed']:
+                        dists[name] = nzs
+                    elif 0 < nzs.size < nprocs:
+                        remote_vars[name] = nzs[0]
 
         return remote_vars, dists
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -3794,6 +3794,59 @@ class TestFeatureConfigure(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
 
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class TestConfigureMPI(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_sorting_bug(self):
+        class MyComp(om.ExplicitComponent):
+            def __init__(self, count, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.count = count
+
+            def setup(self):
+                for i in range(self.count):
+                    self.add_input(f"x{i+1}", np.ones(i + 1))
+                    self.add_output(f"y{i+1}", np.ones(i + 1))
+
+            def compute(self, inputs, outputs):
+                pass
+
+        class MyGroup(om.Group):
+            def __init__(self, count, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.count = count
+
+            def setup(self):
+                for i in range(self.count):
+                    self.add_subsystem(f"C{i+1}", MyComp(i + 1, distributed=True), promotes_inputs=['*'])
+
+            def configure(self):
+                for s in self._subsystems_myproc:
+                    s.add_output('b')
+
+        class MyGroupUpper(om.Group):
+            def setup(self):
+                self.add_subsystem("G1", MyGroup(1), promotes_inputs=['*'])
+                self.add_subsystem("G2", MyGroup(2), promotes_inputs=['*'])
+
+            def configure(self):
+                for s in self._subsystems_myproc:
+                    s.promotes('C1', inputs=['*'])
+
+        p = om.Problem()
+        indep = p.model.add_subsystem('indep', om.IndepVarComp(distributed=True))
+        indep.add_output("x1", np.ones(1))
+        indep.add_output("x2", np.ones(2))
+
+        p.model.add_subsystem('G', MyGroupUpper())
+
+        p.model.connect("indep.x1", "G.x1")
+        p.model.connect("indep.x2", "G.x2")
+
+        p.setup()
+
+
 class TestFeatureGuessNonlinear(unittest.TestCase):
 
     def test_guess_nonlinear(self):


### PR DESCRIPTION
### Summary

There was an ordering mismatch on different procs between subsystems needing to re-run _setup_var_data, resulting sometimes in an MPI truncation error.  Old set of (name, depth) tuples was only being sorted by depth but needed to be sorted by depth *and* name to get correct order across procs.

- also cleaned up the routine that determines which variables are remote on at least one proc.

### Related Issues

- Resolves #1748

### Backwards incompatibilities

None

### New Dependencies

None
