### PR TITLE
Internal refactor of vector to have real and complex step modes share memory.

### DIFF
--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -194,7 +194,6 @@ class ComplexStep(ApproximationScheme):
         """
         for vec, idxs in idx_info:
             if vec is not None:
-                # vec._data.imag[:] = 0.0
                 vec.iadd(delta, idxs)
 
         if total:

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -121,9 +121,9 @@ class ComplexStep(ApproximationScheme):
 
         saved_inputs = system._inputs._get_data().copy()
         system._inputs._data.imag[:] = 0.0
-        saved_outputs = system._outputs._get_data().copy()
+        saved_outputs = system._outputs.asarray(copy=True)
         system._outputs._data.imag[:] = 0.0
-        saved_resids = system._residuals._get_data().copy()
+        saved_resids = system._residuals.asarray(copy=True)
         system._residuals._data.imag[:] = 0.0
 
         # Turn on complex step.

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -120,8 +120,11 @@ class ComplexStep(ApproximationScheme):
             return
 
         saved_inputs = system._inputs._get_data().copy()
+        system._inputs._data.imag[:] = 0.0
         saved_outputs = system._outputs._get_data().copy()
+        system._outputs._data.imag[:] = 0.0
         saved_resids = system._residuals._get_data().copy()
+        system._residuals._data.imag[:] = 0.0
 
         # Turn on complex step.
         system._set_complex_step_mode(True)
@@ -191,6 +194,7 @@ class ComplexStep(ApproximationScheme):
         """
         for vec, idxs in idx_info:
             if vec is not None:
+                # vec._data.imag[:] = 0.0
                 vec.iadd(delta, idxs)
 
         if total:

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -119,6 +119,10 @@ class ComplexStep(ApproximationScheme):
             self._fd.compute_approximations(system, jac, total=total)
             return
 
+        saved_inputs = system._inputs._get_data().copy()
+        saved_outputs = system._outputs._get_data().copy()
+        saved_resids = system._residuals._get_data().copy()
+
         # Turn on complex step.
         system._set_complex_step_mode(True)
 
@@ -126,6 +130,10 @@ class ComplexStep(ApproximationScheme):
 
         # Turn off complex step.
         system._set_complex_step_mode(False)
+
+        system._inputs.set_val(saved_inputs)
+        system._outputs.set_val(saved_outputs)
+        system._residuals.set_val(saved_resids)
 
     def _get_multiplier(self, delta):
         """

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -232,7 +232,7 @@ class FiniteDifference(ApproximationScheme):
         array
             The givan array, unchanged.
         """
-        return array
+        return array.real
 
     def _run_point(self, system, idx_info, data, results_array, total):
         """

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -261,7 +261,7 @@ class FiniteDifference(ApproximationScheme):
         if current_coeff:
             current_vec = system._outputs if total else system._residuals
             # copy data from outputs (if doing total derivs) or residuals (if doing partials)
-            results_array[:] = current_vec._data
+            results_array[:] = current_vec._get_data()
             results_array *= current_coeff
         else:
             results_array[:] = 0.

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -261,7 +261,7 @@ class FiniteDifference(ApproximationScheme):
         if current_coeff:
             current_vec = system._outputs if total else system._residuals
             # copy data from outputs (if doing total derivs) or residuals (if doing partials)
-            results_array[:] = current_vec._get_data()
+            results_array[:] = current_vec.asarray()
             results_array *= current_coeff
         else:
             results_array[:] = 0.

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -563,6 +563,8 @@ class Driver(object):
                 local_val = local_val[local_indices]
 
             if get_remote:
+                if not local_val.flags['C_CONTIGUOUS']:
+                    local_val = np.ascontiguousarray(local_val)
                 offsets = np.zeros(sizes.size, dtype=INT_DTYPE)
                 offsets[1:] = np.cumsum(sizes[:-1])
                 val = np.zeros(np.sum(sizes))

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2631,9 +2631,9 @@ class Group(System):
         complex_step = self._inputs._under_complex_step
 
         if complex_step:
-            self._inputs.set_complex_step_mode(False, keep_real=True)
-            self._residuals.set_complex_step_mode(False, keep_real=True)
-            self._outputs.set_complex_step_mode(False, keep_real=True)
+            self._inputs.set_complex_step_mode(False)
+            self._residuals.set_complex_step_mode(False)
+            self._outputs.set_complex_step_mode(False)
 
         if self._discrete_inputs or self._discrete_outputs:
             self.guess_nonlinear(self._inputs, self._outputs, self._residuals,

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2636,8 +2636,7 @@ class Group(System):
 
             # The Group outputs vector contains imaginary numbers from other components, so we need
             # to save a cache and restore it later.
-            imag_cache = np.empty(len(self._outputs._data))
-            imag_cache[:] = self._outputs._data.imag
+            imag_cache = self._outputs._data.imag.copy()
             self._outputs.set_complex_step_mode(False, keep_real=True)
 
         if self._discrete_inputs or self._discrete_outputs:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2633,10 +2633,6 @@ class Group(System):
         if complex_step:
             self._inputs.set_complex_step_mode(False, keep_real=True)
             self._residuals.set_complex_step_mode(False, keep_real=True)
-
-            # The Group outputs vector contains imaginary numbers from other components, so we need
-            # to save a cache and restore it later.
-            #imag_cache = self._outputs._data.imag.copy()
             self._outputs.set_complex_step_mode(False, keep_real=True)
 
         if self._discrete_inputs or self._discrete_outputs:
@@ -2646,17 +2642,9 @@ class Group(System):
             self.guess_nonlinear(self._inputs, self._outputs, self._residuals)
 
         if complex_step:
-            ## Note: passing in False swaps back to the complex vector, which is valid since
-            ## the inputs and residuals value cannot be edited by guess_nonlinear.
-            #self._inputs.set_complex_step_mode(False)
-            #self._residuals.set_complex_step_mode(False)
-            #self._inputs._under_complex_step = True
-            #self._residuals._under_complex_step = True
-
             self._inputs.set_complex_step_mode(True)
             self._residuals.set_complex_step_mode(True)
             self._outputs.set_complex_step_mode(True)
-            #self._outputs.iadd(imag_cache * 1j)
 
     def guess_nonlinear(self, inputs, outputs, residuals,
                         discrete_inputs=None, discrete_outputs=None):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2636,7 +2636,7 @@ class Group(System):
 
             # The Group outputs vector contains imaginary numbers from other components, so we need
             # to save a cache and restore it later.
-            imag_cache = self._outputs._data.imag.copy()
+            #imag_cache = self._outputs._data.imag.copy()
             self._outputs.set_complex_step_mode(False, keep_real=True)
 
         if self._discrete_inputs or self._discrete_outputs:
@@ -2646,15 +2646,17 @@ class Group(System):
             self.guess_nonlinear(self._inputs, self._outputs, self._residuals)
 
         if complex_step:
-            # Note: passing in False swaps back to the complex vector, which is valid since
-            # the inputs and residuals value cannot be edited by guess_nonlinear.
-            self._inputs.set_complex_step_mode(False)
-            self._residuals.set_complex_step_mode(False)
-            self._inputs._under_complex_step = True
-            self._residuals._under_complex_step = True
+            ## Note: passing in False swaps back to the complex vector, which is valid since
+            ## the inputs and residuals value cannot be edited by guess_nonlinear.
+            #self._inputs.set_complex_step_mode(False)
+            #self._residuals.set_complex_step_mode(False)
+            #self._inputs._under_complex_step = True
+            #self._residuals._under_complex_step = True
 
+            self._inputs.set_complex_step_mode(True)
+            self._residuals.set_complex_step_mode(True)
             self._outputs.set_complex_step_mode(True)
-            self._outputs.iadd(imag_cache * 1j)
+            #self._outputs.iadd(imag_cache * 1j)
 
     def guess_nonlinear(self, inputs, outputs, residuals,
                         discrete_inputs=None, discrete_outputs=None):

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -105,9 +105,9 @@ class ImplicitComponent(Component):
             try:
                 with self._unscaled_context(outputs=[self._outputs], residuals=[self._residuals]):
                     if complex_step:
-                        self._inputs.set_complex_step_mode(False, keep_real=True)
-                        self._outputs.set_complex_step_mode(False, keep_real=True)
-                        self._residuals.set_complex_step_mode(False, keep_real=True)
+                        self._inputs.set_complex_step_mode(False)
+                        self._outputs.set_complex_step_mode(False)
+                        self._residuals.set_complex_step_mode(False)
 
                     with self._call_user_function('guess_nonlinear', protect_residuals=True):
                         if self._discrete_inputs or self._discrete_outputs:

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -117,13 +117,9 @@ class ImplicitComponent(Component):
                             self.guess_nonlinear(self._inputs, self._outputs, self._residuals)
             finally:
                 if complex_step:
-                    # Note: passing in False swaps back to the complex vector, which is valid since
-                    # the inputs and residuals value cannot be edited.
-                    self._inputs.set_complex_step_mode(False)
-                    self._inputs._under_complex_step = True
+                    self._inputs.set_complex_step_mode(True)
                     self._outputs.set_complex_step_mode(True)
-                    self._residuals.set_complex_step_mode(False)
-                    self._residuals._under_complex_step = True
+                    self._residuals.set_complex_step_mode(True)
 
     def _apply_linear(self, jac, vec_names, rel_systems, mode, scope_out=None, scope_in=None):
         """

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -723,7 +723,7 @@ class Problem(object):
 
         # We apply a -1 here because the derivative of the output is minus the derivative of
         # the residual in openmdao.
-        data = rvec._get_data()
+        data = rvec.asarray()
         data *= -1.
 
         self.model.run_solve_linear(['linear'], mode)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -723,7 +723,8 @@ class Problem(object):
 
         # We apply a -1 here because the derivative of the output is minus the derivative of
         # the residual in openmdao.
-        rvec._data *= -1.
+        data = rvec._get_data()
+        data *= -1.
 
         self.model.run_solve_linear(['linear'], mode)
 

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -103,7 +103,7 @@ class SparseCompImplicit(ImplicitComponent):
 
     # this is defined for easier testing of coloring of approx partials
     def apply_nonlinear(self, inputs, outputs, residuals):
-        prod = self.sparsity.dot(inputs._data) - outputs._data
+        prod = self.sparsity.dot(inputs._get_data()) - outputs._get_data()
         start = end = 0
         for i in range(self.osplit):
             outname = 'y%d' % i
@@ -114,7 +114,7 @@ class SparseCompImplicit(ImplicitComponent):
 
     # this is defined so we can more easily test coloring of approx totals in a Group above this comp
     def solve_nonlinear(self, inputs, outputs):
-        prod = self.sparsity.dot(inputs._data)
+        prod = self.sparsity.dot(inputs._get_data())
         start = end = 0
         for i in range(self.osplit):
             outname = 'y%d' % i
@@ -138,7 +138,7 @@ class SparseCompExplicit(ExplicitComponent):
         setup_vars(self, ofs='*', wrts='*')
 
     def compute(self, inputs, outputs):
-        prod = self.sparsity.dot(inputs._data)
+        prod = self.sparsity.dot(inputs._get_data())
         start = end = 0
         for i in range(self.osplit):
             outname = 'y%d' % i

--- a/openmdao/core/tests/test_fd_color.py
+++ b/openmdao/core/tests/test_fd_color.py
@@ -103,7 +103,7 @@ class SparseCompImplicit(ImplicitComponent):
 
     # this is defined for easier testing of coloring of approx partials
     def apply_nonlinear(self, inputs, outputs, residuals):
-        prod = self.sparsity.dot(inputs._get_data()) - outputs._get_data()
+        prod = self.sparsity.dot(inputs.asarray()) - outputs.asarray()
         start = end = 0
         for i in range(self.osplit):
             outname = 'y%d' % i
@@ -114,7 +114,7 @@ class SparseCompImplicit(ImplicitComponent):
 
     # this is defined so we can more easily test coloring of approx totals in a Group above this comp
     def solve_nonlinear(self, inputs, outputs):
-        prod = self.sparsity.dot(inputs._get_data())
+        prod = self.sparsity.dot(inputs.asarray())
         start = end = 0
         for i in range(self.osplit):
             outname = 'y%d' % i
@@ -138,7 +138,7 @@ class SparseCompExplicit(ExplicitComponent):
         setup_vars(self, ofs='*', wrts='*')
 
     def compute(self, inputs, outputs):
-        prod = self.sparsity.dot(inputs._get_data())
+        prod = self.sparsity.dot(inputs.asarray())
         start = end = 0
         for i in range(self.osplit):
             outname = 'y%d' % i

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1294,7 +1294,7 @@ class TestGroup(unittest.TestCase):
 
             def guess_nonlinear(self, inputs, outputs, residuals):
 
-                if outputs._data.dtype == np.complex:
+                if outputs._get_data().dtype == np.complex:
                     raise RuntimeError('Vector should not be complex when guess_nonlinear is called.')
 
                 # inputs are addressed using full path name, regardless of promotion

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1294,7 +1294,7 @@ class TestGroup(unittest.TestCase):
 
             def guess_nonlinear(self, inputs, outputs, residuals):
 
-                if outputs._get_data().dtype == np.complex:
+                if outputs.asarray().dtype == np.complex:
                     raise RuntimeError('Vector should not be complex when guess_nonlinear is called.')
 
                 # inputs are addressed using full path name, regardless of promotion

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -472,7 +472,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
             def guess_nonlinear(self, inputs, outputs, resids):
 
-                if outputs._data.dtype == np.complex:
+                if outputs._get_data().dtype == np.complex:
                     raise RuntimeError('Vector should not be complex when guess_nonlinear is called.')
 
                 # Default initial state of zero for x takes us to x=1 solution.

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -472,7 +472,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
             def guess_nonlinear(self, inputs, outputs, resids):
 
-                if outputs._get_data().dtype == np.complex:
+                if outputs.asarray().dtype == np.complex:
                     raise RuntimeError('Vector should not be complex when guess_nonlinear is called.')
 
                 # Default initial state of zero for x takes us to x=1 solution.

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1181,7 +1181,7 @@ class _TotalJacInfo(object):
         """
         vecname, _, _ = self.in_idx_map[mode][i]
         deriv_idxs, jac_idxs, _ = self.sol2jac_map[mode]
-        deriv_val = self.output_vec[mode][vecname]._data
+        deriv_val = self.output_vec[mode][vecname]._get_data()
         if mode == 'fwd':
             self.J[jac_idxs[vecname], i] = deriv_val[deriv_idxs[vecname]]
         else:  # rev
@@ -1265,7 +1265,7 @@ class _TotalJacInfo(object):
         # because simul_coloring cannot be used with vectorized derivs (matmat) or parallel
         # deriv coloring, vecname will always be 'linear', and we don't need to check
         # vecname for each index.
-        deriv_val = self.output_vec[mode]['linear']._data
+        deriv_val = self.output_vec[mode]['linear']._get_data()
         if self.jac_scratch is None:
             reduced_derivs = deriv_val[deriv_idxs['linear']]
         else:
@@ -1305,7 +1305,7 @@ class _TotalJacInfo(object):
 
         deriv_idxs, jac_idxs, _ = self.sol2jac_map[mode]
         jac_inds = jac_idxs[vecname]
-        outvec = self.output_vec[mode][vecname]._data
+        outvec = self.output_vec[mode][vecname]._get_data()
         ilen = len(inds)
         if fwd:
             for col, i in enumerate(inds):
@@ -1578,7 +1578,7 @@ class _TotalJacInfo(object):
         else:
             lin_sol_cache[key] = lin_sol = []
             for vec_name in vec_names:
-                lin_sol.append(deepcopy(self.output_vec[mode][vec_name]._data))
+                lin_sol.append(deepcopy(self.output_vec[mode][vec_name]._get_data()))
 
     def _save_linear_solution(self, vec_names, key, mode):
         """
@@ -1597,7 +1597,7 @@ class _TotalJacInfo(object):
         for i, vec_name in enumerate(vec_names):
             save_vec = lin_sol[i]
             doutputs = self.output_vec[mode][vec_name]
-            save_vec[:] = doutputs._data
+            save_vec[:] = doutputs._get_data()
 
     def _do_driver_scaling(self, J):
         """

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1181,7 +1181,7 @@ class _TotalJacInfo(object):
         """
         vecname, _, _ = self.in_idx_map[mode][i]
         deriv_idxs, jac_idxs, _ = self.sol2jac_map[mode]
-        deriv_val = self.output_vec[mode][vecname]._get_data()
+        deriv_val = self.output_vec[mode][vecname].asarray()
         if mode == 'fwd':
             self.J[jac_idxs[vecname], i] = deriv_val[deriv_idxs[vecname]]
         else:  # rev
@@ -1265,7 +1265,7 @@ class _TotalJacInfo(object):
         # because simul_coloring cannot be used with vectorized derivs (matmat) or parallel
         # deriv coloring, vecname will always be 'linear', and we don't need to check
         # vecname for each index.
-        deriv_val = self.output_vec[mode]['linear']._get_data()
+        deriv_val = self.output_vec[mode]['linear'].asarray()
         if self.jac_scratch is None:
             reduced_derivs = deriv_val[deriv_idxs['linear']]
         else:
@@ -1298,14 +1298,13 @@ class _TotalJacInfo(object):
         # in plain matmat, all inds are for a single variable for each iteration of the outer loop,
         # so any relevance can be determined only once.
         vecname, _, _ = self.in_idx_map[mode][inds[0]]
-        # ncol = self.output_vec[mode][vecname]._ncol
         dist = self.comm.size > 1
         fwd = mode == 'fwd'
         J = self.J
 
         deriv_idxs, jac_idxs, _ = self.sol2jac_map[mode]
         jac_inds = jac_idxs[vecname]
-        outvec = self.output_vec[mode][vecname]._get_data()
+        outvec = self.output_vec[mode][vecname].asarray()
         ilen = len(inds)
         if fwd:
             for col, i in enumerate(inds):
@@ -1578,7 +1577,7 @@ class _TotalJacInfo(object):
         else:
             lin_sol_cache[key] = lin_sol = []
             for vec_name in vec_names:
-                lin_sol.append(deepcopy(self.output_vec[mode][vec_name]._get_data()))
+                lin_sol.append(deepcopy(self.output_vec[mode][vec_name].asarray()))
 
     def _save_linear_solution(self, vec_names, key, mode):
         """
@@ -1595,9 +1594,7 @@ class _TotalJacInfo(object):
         """
         lin_sol = self.lin_sol_cache[key]
         for i, vec_name in enumerate(vec_names):
-            save_vec = lin_sol[i]
-            doutputs = self.output_vec[mode][vec_name]
-            save_vec[:] = doutputs._get_data()
+            lin_sol[i][:] = self.output_vec[mode][vec_name].asarray()
 
     def _do_driver_scaling(self, J):
         """

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -137,8 +137,6 @@ class TestMPIScatter(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')
 
-        #import wingdbstub
-        
         prob.setup(force_alloc_complex=True)
 
         prob.run_driver()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -137,6 +137,8 @@ class TestMPIScatter(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')
 
+        import wingdbstub
+        
         prob.setup(force_alloc_complex=True)
 
         prob.run_driver()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -137,7 +137,7 @@ class TestMPIScatter(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')
 
-        import wingdbstub
+        #import wingdbstub
         
         prob.setup(force_alloc_complex=True)
 

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -394,21 +394,19 @@ class AssembledJacobian(Jacobian):
                     mask = ext_mtx._create_mask_cache(d_inputs)
                     self._mask_caches[(d_inputs._names, mode)] = mask
 
-            dresids = d_residuals._get_data()
+            dresids = d_residuals.asarray()
 
             if mode == 'fwd':
                 if d_outputs._names:
-                    dresids += int_mtx._prod(d_outputs._get_data(), mode)
+                    dresids += int_mtx._prod(d_outputs.asarray(), mode)
                 if do_mask:
-                    dresids += ext_mtx._prod(d_inputs._get_data(), mode, mask=mask)
+                    dresids += ext_mtx._prod(d_inputs.asarray(), mode, mask=mask)
 
             else:  # rev
                 if d_outputs._names:
-                    data = d_outputs._get_data()
-                    data += int_mtx._prod(dresids, mode)
+                    d_outputs += int_mtx._prod(dresids, mode)
                 if do_mask:
-                    data = d_inputs._get_data()
-                    data += ext_mtx._prod(dresids, mode, mask=mask)
+                    d_inputs += ext_mtx._prod(dresids, mode, mask=mask)
 
     def set_complex_step_mode(self, active):
         """

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -394,18 +394,21 @@ class AssembledJacobian(Jacobian):
                     mask = ext_mtx._create_mask_cache(d_inputs)
                     self._mask_caches[(d_inputs._names, mode)] = mask
 
+            dresids = d_residuals._get_data()
+
             if mode == 'fwd':
                 if d_outputs._names:
-                    d_residuals._data += int_mtx._prod(d_outputs._data, mode)
+                    dresids += int_mtx._prod(d_outputs._get_data(), mode)
                 if do_mask:
-                    d_residuals._data += ext_mtx._prod(d_inputs._data, mode, mask=mask)
+                    dresids += ext_mtx._prod(d_inputs._get_data(), mode, mask=mask)
 
             else:  # rev
-                dresids = d_residuals._data
                 if d_outputs._names:
-                    d_outputs._data += int_mtx._prod(dresids, mode)
+                    data = d_outputs._get_data()
+                    data += int_mtx._prod(dresids, mode)
                 if do_mask:
-                    d_inputs._data += ext_mtx._prod(dresids, mode, mask=mask)
+                    data = d_inputs._get_data()
+                    data += ext_mtx._prod(dresids, mode, mask=mask)
 
     def set_complex_step_mode(self, active):
         """

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -292,7 +292,7 @@ class TestJacobian(unittest.TestCase):
         # fwd apply_linear test
         d_outputs.set_val(1.0)
         prob.model.run_apply_linear(['linear'], 'fwd')
-        d_residuals.set_val(d_residuals._get_data() - check_vec)
+        d_residuals.set_val(d_residuals.asarray() - check_vec)
         self.assertAlmostEqual(d_residuals.get_norm(), 0)
 
         # fwd solve_linear test
@@ -312,7 +312,7 @@ class TestJacobian(unittest.TestCase):
         # rev apply_linear test
         d_residuals.set_val(1.0)
         prob.model.run_apply_linear(['linear'], 'rev')
-        d_outputs.set_val(d_outputs._get_data() - check_vec)
+        d_outputs.set_val(d_outputs.asarray() - check_vec)
         self.assertAlmostEqual(d_outputs.get_norm(), 0)
 
         # rev solve_linear test

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -292,7 +292,7 @@ class TestJacobian(unittest.TestCase):
         # fwd apply_linear test
         d_outputs.set_val(1.0)
         prob.model.run_apply_linear(['linear'], 'fwd')
-        d_residuals.set_val(d_residuals._data - check_vec)
+        d_residuals.set_val(d_residuals._get_data() - check_vec)
         self.assertAlmostEqual(d_residuals.get_norm(), 0)
 
         # fwd solve_linear test
@@ -312,7 +312,7 @@ class TestJacobian(unittest.TestCase):
         # rev apply_linear test
         d_residuals.set_val(1.0)
         prob.model.run_apply_linear(['linear'], 'rev')
-        d_outputs.set_val(d_outputs._data - check_vec)
+        d_outputs.set_val(d_outputs._get_data() - check_vec)
         self.assertAlmostEqual(d_outputs.get_norm(), 0)
 
         # rev solve_linear test

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -247,7 +247,7 @@ class DirectSolver(LinearSolver):
                                  scope_out, scope_in)
 
             # put new value in out_vec
-            mtx[:, i] = bvec._get_data()
+            mtx[:, i] = bvec.asarray()
 
         # Restore the backed-up vectors
         bvec.set_val(b_data)
@@ -430,13 +430,13 @@ class DirectSolver(LinearSolver):
 
         # assign x and b vectors based on mode
         if mode == 'fwd':
-            x_vec = d_outputs._get_data()
-            b_vec = d_residuals._get_data()
+            x_vec = d_outputs.asarray()
+            b_vec = d_residuals.asarray()
             trans_lu = 0
             trans_splu = 'N'
         else:  # rev
-            x_vec = d_residuals._get_data()
-            b_vec = d_outputs._get_data()
+            x_vec = d_residuals.asarray()
+            b_vec = d_outputs.asarray()
             trans_lu = 1
             trans_splu = 'T'
 

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -247,7 +247,7 @@ class DirectSolver(LinearSolver):
                                  scope_out, scope_in)
 
             # put new value in out_vec
-            mtx[:, i] = bvec._data
+            mtx[:, i] = bvec._get_data()
 
         # Restore the backed-up vectors
         bvec.set_val(b_data)
@@ -430,13 +430,13 @@ class DirectSolver(LinearSolver):
 
         # assign x and b vectors based on mode
         if mode == 'fwd':
-            x_vec = d_outputs._data
-            b_vec = d_residuals._data
+            x_vec = d_outputs._get_data()
+            b_vec = d_residuals._get_data()
             trans_lu = 0
             trans_splu = 'N'
         else:  # rev
-            x_vec = d_residuals._data
-            b_vec = d_outputs._data
+            x_vec = d_residuals._get_data()
+            b_vec = d_outputs._get_data()
             trans_lu = 1
             trans_splu = 'T'
 

--- a/openmdao/solvers/linear/linear_block_gs.py
+++ b/openmdao/solvers/linear/linear_block_gs.py
@@ -161,7 +161,7 @@ class LinearBlockGS(BlockLinearSolver):
                 theta_n = self.options['aitken_initial_factor']
 
                 # compute the change in the outputs after the NLBGS iteration
-                delta_d_n[vec_name] -= d_out_vec._get_data()
+                delta_d_n[vec_name] -= d_out_vec.asarray()
                 delta_d_n[vec_name] *= -1
 
                 if self._iter_count >= 2:

--- a/openmdao/solvers/linear/linear_block_gs.py
+++ b/openmdao/solvers/linear/linear_block_gs.py
@@ -120,7 +120,7 @@ class LinearBlockGS(BlockLinearSolver):
                     if vec_name in subsys._rel_vec_names:
                         b_vec = system._vectors['residual'][vec_name]
                         b_vec *= -1.0
-                        b_vec._data += self._rhs_vecs[vec_name]
+                        b_vec += self._rhs_vecs[vec_name]
                 subsys._solve_linear(vec_names, mode, self._rel_systems)
 
         else:  # rev
@@ -161,7 +161,7 @@ class LinearBlockGS(BlockLinearSolver):
                 theta_n = self.options['aitken_initial_factor']
 
                 # compute the change in the outputs after the NLBGS iteration
-                delta_d_n[vec_name] -= d_out_vec._data
+                delta_d_n[vec_name] -= d_out_vec._get_data()
                 delta_d_n[vec_name] *= -1
 
                 if self._iter_count >= 2:
@@ -209,7 +209,7 @@ class LinearBlockGS(BlockLinearSolver):
                 d_out_vec.set_val(d_n[vec_name])
 
                 # compute relaxed outputs
-                d_out_vec._data += theta_n * delta_d_n[vec_name]
+                d_out_vec += theta_n * delta_d_n[vec_name]
 
                 # save update to use in next iteration
                 delta_d_n_1[vec_name][:] = delta_d_n[vec_name]

--- a/openmdao/solvers/linear/linear_block_jac.py
+++ b/openmdao/solvers/linear/linear_block_jac.py
@@ -32,7 +32,7 @@ class LinearBlockJac(BlockLinearSolver):
             for vec_name in vec_names:
                 b_vec = system._vectors['residual'][vec_name]
                 b_vec *= -1.0
-                b_vec._data += self._rhs_vecs[vec_name]
+                b_vec += self._rhs_vecs[vec_name]
 
             for subsys in subs:
                 subsys._solve_linear(vec_names, mode, self._rel_systems)
@@ -48,7 +48,7 @@ class LinearBlockJac(BlockLinearSolver):
 
                 b_vec = system._vectors['output'][vec_name]
                 b_vec *= -1.0
-                b_vec._data += self._rhs_vecs[vec_name]
+                b_vec += self._rhs_vecs[vec_name]
 
             for subsys in subs:
                 subsys._solve_linear(vec_names, mode, self._rel_systems)

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -311,7 +311,7 @@ class PETScKrylov(LinearSolver):
                              scope_out, scope_in)
 
         # stuff resulting value of b vector into result for KSP
-        result.array[:] = b_vec._data
+        result.array[:] = b_vec._get_data()
 
     def _linearize_children(self):
         """
@@ -431,7 +431,7 @@ class PETScKrylov(LinearSolver):
             self._solver_info.pop()
 
             # stuff resulting value of x vector into result for KSP
-            result.array[:] = x_vec._data
+            result.array[:] = x_vec._get_data()
         else:
             # no preconditioner, just pass back the incoming vector
             result.array[:] = _get_petsc_vec_array(in_vec)

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -311,7 +311,7 @@ class PETScKrylov(LinearSolver):
                              scope_out, scope_in)
 
         # stuff resulting value of b vector into result for KSP
-        result.array[:] = b_vec._get_data()
+        result.array[:] = b_vec.asarray()
 
     def _linearize_children(self):
         """
@@ -431,7 +431,7 @@ class PETScKrylov(LinearSolver):
             self._solver_info.pop()
 
             # stuff resulting value of x vector into result for KSP
-            result.array[:] = x_vec._get_data()
+            result.array[:] = x_vec.asarray()
         else:
             # no preconditioner, just pass back the incoming vector
             result.array[:] = _get_petsc_vec_array(in_vec)

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -154,9 +154,9 @@ class ScipyKrylov(LinearSolver):
 
         # DO NOT REMOVE: frequently used for debugging
         # print('in', in_arr)
-        # print('out', b_vec._get_data())
+        # print('out', b_vec.asarray())
 
-        return b_vec._get_data()
+        return b_vec.asarray()
 
     def _monitor(self, res):
         """
@@ -215,7 +215,7 @@ class ScipyKrylov(LinearSolver):
                 x_vec = system._vectors['residual'][vec_name]
                 b_vec = system._vectors['output'][vec_name]
 
-            x_vec_combined = x_vec._get_data()
+            x_vec_combined = x_vec.asarray()
             size = x_vec_combined.size
             linop = LinearOperator((size, size), dtype=float,
                                    matvec=self._mat_vec)

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -154,9 +154,9 @@ class ScipyKrylov(LinearSolver):
 
         # DO NOT REMOVE: frequently used for debugging
         # print('in', in_arr)
-        # print('out', b_vec._data)
+        # print('out', b_vec._get_data())
 
-        return b_vec._data
+        return b_vec._get_data()
 
     def _monitor(self, res):
         """
@@ -215,7 +215,7 @@ class ScipyKrylov(LinearSolver):
                 x_vec = system._vectors['residual'][vec_name]
                 b_vec = system._vectors['output'][vec_name]
 
-            x_vec_combined = x_vec._data
+            x_vec_combined = x_vec._get_data()
             size = x_vec_combined.size
             linop = LinearOperator((size, size), dtype=float,
                                    matvec=self._mat_vec)

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -129,7 +129,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
@@ -140,7 +140,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_rev_mode_bug(self):

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -129,7 +129,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
@@ -140,7 +140,7 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_rev_mode_bug(self):

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -49,7 +49,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -57,7 +57,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_ksp_gmres(self):
@@ -80,7 +80,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -88,7 +88,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_ksp_maxiter(self):
@@ -140,7 +140,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         self.assertTrue(precon._iter_count > 0)
@@ -150,7 +150,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
         self.assertTrue(precon._iter_count > 0)
@@ -170,7 +170,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -179,7 +179,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
     def test_solve_linear_ksp_precon_left(self):
@@ -205,7 +205,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_linearize()
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -214,7 +214,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_linearize()
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
         # test the direct solver and make sure KSP correctly recurses for _linearize
@@ -235,7 +235,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -244,7 +244,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
     def test_solve_on_subsystem(self):
@@ -272,7 +272,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         g1.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
@@ -283,7 +283,7 @@ class TestPETScKrylov(unittest.TestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_linear_solution_cache(self):

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -49,7 +49,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -57,7 +57,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_ksp_gmres(self):
@@ -80,7 +80,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -88,7 +88,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_ksp_maxiter(self):
@@ -140,7 +140,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         self.assertTrue(precon._iter_count > 0)
@@ -150,7 +150,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
         self.assertTrue(precon._iter_count > 0)
@@ -170,7 +170,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -179,7 +179,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
     def test_solve_linear_ksp_precon_left(self):
@@ -205,7 +205,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_linearize()
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -214,7 +214,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.run_linearize()
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
         # test the direct solver and make sure KSP correctly recurses for _linearize
@@ -235,7 +235,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
@@ -244,7 +244,7 @@ class TestPETScKrylov(unittest.TestCase):
         group.linear_solver._linearize()
         group.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 3e-15)
 
     def test_solve_on_subsystem(self):
@@ -272,7 +272,7 @@ class TestPETScKrylov(unittest.TestCase):
         d_outputs.set_val(0.0)
         g1.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
@@ -283,7 +283,7 @@ class TestPETScKrylov(unittest.TestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_linear_solution_cache(self):

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -50,14 +50,14 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         d_residuals.set_val(1.0)
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_val(1.0)
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_scipy_maxiter(self):
@@ -115,7 +115,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         d_outputs.set_val(0.0)
         g1.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._get_data()
+        output = d_outputs.asarray()
         assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
@@ -126,7 +126,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._get_data()
+        output = d_residuals.asarray()
         assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_linear_solution_cache(self):

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -50,14 +50,14 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         d_residuals.set_val(1.0)
         d_outputs.set_val(0.0)
         group.run_solve_linear(['linear'], 'fwd')
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
         # reverse
         d_outputs.set_val(1.0)
         d_residuals.set_val(0.0)
         group.run_solve_linear(['linear'], 'rev')
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, group.expected_solution, 1e-15)
 
     def test_solve_linear_scipy_maxiter(self):
@@ -115,7 +115,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         d_outputs.set_val(0.0)
         g1.run_solve_linear(['linear'], 'fwd')
 
-        output = d_outputs._data
+        output = d_outputs._get_data()
         assert_near_equal(output, g1.expected_solution, 1e-15)
 
         # reverse
@@ -126,7 +126,7 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         g1.linear_solver._linearize()
         g1.run_solve_linear(['linear'], 'rev')
 
-        output = d_residuals._data
+        output = d_residuals._get_data()
         assert_near_equal(output, g1.expected_solution, 3e-15)
 
     def test_linear_solution_cache(self):

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -550,7 +550,7 @@ def _enforce_bounds_scalar(u, du, alpha, lower_bounds, upper_bounds):
     # the step vector directly.
 
     # enforce bounds on step in-place.
-    u_data = u._data
+    u_data = u._get_data()
 
     # If u > lower, we're just adding zero. Otherwise, we're adding
     # the step required to get up to the lower bound.
@@ -564,9 +564,8 @@ def _enforce_bounds_scalar(u, du, alpha, lower_bounds, upper_bounds):
     change_upper = 0. if upper_bounds is None else np.minimum(u_data, upper_bounds) - u_data
 
     change = change_lower + change_upper
-
     u_data += change
-    du._data += change / alpha
+    du += change / alpha
 
 
 def _enforce_bounds_wall(u, du, alpha, lower_bounds, upper_bounds):
@@ -595,8 +594,8 @@ def _enforce_bounds_wall(u, du, alpha, lower_bounds, upper_bounds):
     # the step vector directly.
 
     # enforce bounds on step in-place.
-    u_data = u._data
-    du_data = du._data
+    u_data = u._get_data()
+    du_data = du._get_data()
 
     # If u > lower, we're just adding zero. Otherwise, we're adding
     # the step required to get up to the lower bound.

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -550,7 +550,7 @@ def _enforce_bounds_scalar(u, du, alpha, lower_bounds, upper_bounds):
     # the step vector directly.
 
     # enforce bounds on step in-place.
-    u_data = u._get_data()
+    u_data = u.asarray()
 
     # If u > lower, we're just adding zero. Otherwise, we're adding
     # the step required to get up to the lower bound.
@@ -594,8 +594,8 @@ def _enforce_bounds_wall(u, du, alpha, lower_bounds, upper_bounds):
     # the step vector directly.
 
     # enforce bounds on step in-place.
-    u_data = u._get_data()
-    du_data = du._get_data()
+    u_data = u.asarray()
+    du_data = du.asarray()
 
     # If u > lower, we're just adding zero. Otherwise, we're adding
     # the step required to get up to the lower bound.

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -315,7 +315,7 @@ class BroydenSolver(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration of Broyden.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs._data += np.linalg.norm(system._outputs._data) * 1e-10
+            system._outputs += np.linalg.norm(system._outputs._get_data()) * 1e-10
 
         # Start with initial states.
         self.xm = self.get_vector(system._outputs)
@@ -347,7 +347,7 @@ class BroydenSolver(NonlinearSolver):
         self.fxm = fxm = self.get_vector(self._system()._residuals)
         if not self._full_inverse:
             # Use full model residual for driving the main loop convergence.
-            fxm = self._system()._residuals._data
+            fxm = self._system()._residuals._get_data()
 
         return self.compute_norm(fxm)
 

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -315,7 +315,7 @@ class BroydenSolver(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration of Broyden.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs += np.linalg.norm(system._outputs._get_data()) * 1e-10
+            system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
         # Start with initial states.
         self.xm = self.get_vector(system._outputs)
@@ -347,7 +347,7 @@ class BroydenSolver(NonlinearSolver):
         self.fxm = fxm = self.get_vector(self._system()._residuals)
         if not self._full_inverse:
             # Use full model residual for driving the main loop convergence.
-            fxm = self._system()._residuals._get_data()
+            fxm = self._system()._residuals.asarray()
 
         return self.compute_norm(fxm)
 

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -184,7 +184,7 @@ class NewtonSolver(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration of Newton.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs += np.linalg.norm(system._outputs._get_data()) * 1e-10
+            system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -184,7 +184,7 @@ class NewtonSolver(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration of Newton.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs._data += np.linalg.norm(system._outputs._data) * 1e-10
+            system._outputs += np.linalg.norm(system._outputs._get_data()) * 1e-10
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -101,7 +101,7 @@ class NonlinearBlockGS(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs += np.linalg.norm(system._outputs._get_data()) * 1e-10
+            system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()
@@ -144,7 +144,7 @@ class NonlinearBlockGS(NonlinearSolver):
 
         if use_aitken:
             # compute the change in the outputs after the NLBGS iteration
-            delta_outputs_n -= outputs._get_data()
+            delta_outputs_n -= outputs.asarray()
             delta_outputs_n *= -1
 
             if self._iter_count >= 2:
@@ -203,7 +203,7 @@ class NonlinearBlockGS(NonlinearSolver):
         if not self.options['use_apply_nonlinear']:
             # Residual is the change in the outputs vector.
             with system._unscaled_context(outputs=[outputs], residuals=[residuals]):
-                residuals.set_val(outputs._get_data() - outputs_n)
+                residuals.set_val(outputs.asarray() - outputs_n)
 
     def _run_apply(self):
         """
@@ -242,7 +242,7 @@ class NonlinearBlockGS(NonlinearSolver):
 
             self._solver_info.pop()
             with system._unscaled_context(residuals=[residuals]):
-                residuals.set_val(outputs._get_data() - outputs_n)
+                residuals.set_val(outputs.asarray() - outputs_n)
 
     def _mpi_print_header(self):
         """

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -101,7 +101,7 @@ class NonlinearBlockGS(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs._data += np.linalg.norm(system._outputs._data) * 1e-10
+            system._outputs += np.linalg.norm(system._outputs._get_data()) * 1e-10
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()
@@ -144,7 +144,7 @@ class NonlinearBlockGS(NonlinearSolver):
 
         if use_aitken:
             # compute the change in the outputs after the NLBGS iteration
-            delta_outputs_n -= outputs._data
+            delta_outputs_n -= outputs._get_data()
             delta_outputs_n *= -1
 
             if self._iter_count >= 2:
@@ -195,7 +195,7 @@ class NonlinearBlockGS(NonlinearSolver):
                 outputs.set_val(outputs_n)
 
             # compute relaxed outputs
-            outputs._data += theta_n * delta_outputs_n
+            outputs += theta_n * delta_outputs_n
 
             # save update to use in next iteration
             delta_outputs_n_1[:] = delta_outputs_n
@@ -203,7 +203,7 @@ class NonlinearBlockGS(NonlinearSolver):
         if not self.options['use_apply_nonlinear']:
             # Residual is the change in the outputs vector.
             with system._unscaled_context(outputs=[outputs], residuals=[residuals]):
-                residuals.set_val(outputs._data - outputs_n)
+                residuals.set_val(outputs._get_data() - outputs_n)
 
     def _run_apply(self):
         """
@@ -242,7 +242,7 @@ class NonlinearBlockGS(NonlinearSolver):
 
             self._solver_info.pop()
             with system._unscaled_context(residuals=[residuals]):
-                residuals.set_val(outputs._data - outputs_n)
+                residuals.set_val(outputs._get_data() - outputs_n)
 
     def _mpi_print_header(self):
         """

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -941,9 +941,9 @@ class BlockLinearSolver(LinearSolver):
         system = self._system()
         for vec_name in system._lin_rel_vec_name_list:
             if self._mode == 'fwd':
-                self._rhs_vecs[vec_name][:] = system._vectors['residual'][vec_name]._data
+                self._rhs_vecs[vec_name][:] = system._vectors['residual'][vec_name].asarray()
             else:
-                self._rhs_vecs[vec_name][:] = system._vectors['output'][vec_name]._data
+                self._rhs_vecs[vec_name][:] = system._vectors['output'][vec_name].asarray()
 
     def _set_complex_step_mode(self, active):
         """
@@ -1003,7 +1003,7 @@ class BlockLinearSolver(LinearSolver):
 
         norm = 0
         for vec_name in system._lin_rel_vec_name_list:
-            b_vecs[vec_name]._data -= self._rhs_vecs[vec_name]
+            b_vecs[vec_name] -= self._rhs_vecs[vec_name]
             norm += b_vecs[vec_name].get_norm()**2
 
         return norm ** 0.5

--- a/openmdao/solvers/tests/test_solver_parametric_suite.py
+++ b/openmdao/solvers/tests/test_solver_parametric_suite.py
@@ -62,13 +62,13 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
             d_residuals.set_val(2.0)
             d_outputs.set_val(0.0)
             prob.model.run_solve_linear(['linear'], 'fwd')
-            result = d_outputs._get_data()
+            result = d_outputs.asarray()
             assert_near_equal(result, [-2., 2.])
 
             d_outputs.set_val(2.0)
             d_residuals.set_val(0.0)
             prob.model.run_solve_linear(['linear'], 'rev')
-            result = d_residuals._get_data()
+            result = d_residuals.asarray()
             assert_near_equal(result, [2., -2.])
 
     def test_direct_solver_group(self):
@@ -92,13 +92,13 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
         d_residuals.set_val(1.0)
         d_outputs.set_val(0.0)
         prob.model.run_solve_linear(['linear'], 'fwd')
-        result = d_outputs._get_data()
+        result = d_outputs.asarray()
         assert_near_equal(result, prob.model.expected_solution, 1e-15)
 
         d_outputs.set_val(1.0)
         d_residuals.set_val(0.0)
         prob.model.run_solve_linear(['linear'], 'rev')
-        result = d_residuals._get_data()
+        result = d_residuals.asarray()
         assert_near_equal(result, prob.model.expected_solution, 1e-15)
 
     @parametric_suite(

--- a/openmdao/solvers/tests/test_solver_parametric_suite.py
+++ b/openmdao/solvers/tests/test_solver_parametric_suite.py
@@ -62,13 +62,13 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
             d_residuals.set_val(2.0)
             d_outputs.set_val(0.0)
             prob.model.run_solve_linear(['linear'], 'fwd')
-            result = d_outputs._data
+            result = d_outputs._get_data()
             assert_near_equal(result, [-2., 2.])
 
             d_outputs.set_val(2.0)
             d_residuals.set_val(0.0)
             prob.model.run_solve_linear(['linear'], 'rev')
-            result = d_residuals._data
+            result = d_residuals._get_data()
             assert_near_equal(result, [2., -2.])
 
     def test_direct_solver_group(self):
@@ -92,13 +92,13 @@ class TestLinearSolverParametricSuite(unittest.TestCase):
         d_residuals.set_val(1.0)
         d_outputs.set_val(0.0)
         prob.model.run_solve_linear(['linear'], 'fwd')
-        result = d_outputs._data
+        result = d_outputs._get_data()
         assert_near_equal(result, prob.model.expected_solution, 1e-15)
 
         d_outputs.set_val(1.0)
         d_residuals.set_val(0.0)
         prob.model.run_solve_linear(['linear'], 'rev')
-        result = d_residuals._data
+        result = d_residuals._get_data()
         assert_near_equal(result, prob.model.expected_solution, 1e-15)
 
     @parametric_suite(

--- a/openmdao/test_suite/test_examples/beam_optimization/components/multi_states_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/multi_states_comp.py
@@ -93,7 +93,7 @@ class MultiStatesComp(om.ImplicitComponent):
         num_entry = num_elements * 12 + 4
         ndim = num_entry + 4
 
-        data = np.zeros((ndim, ), dtype=inputs._data.dtype)
+        data = np.zeros((ndim, ), dtype=inputs._get_data().dtype)
         cols = np.empty((ndim, ))
         rows = np.empty((ndim, ))
 

--- a/openmdao/test_suite/test_examples/beam_optimization/components/states_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/states_comp.py
@@ -73,7 +73,7 @@ class StatesComp(om.ImplicitComponent):
         num_entry = num_elements * 12 + 4
         ndim = num_entry + 4
 
-        data = np.zeros((ndim, ), dtype=inputs._data.dtype)
+        data = np.zeros((ndim, ), dtype=inputs._get_data().dtype)
         cols = np.empty((ndim, ))
         rows = np.empty((ndim, ))
 

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -272,7 +272,7 @@ class DefaultTransfer(Transfer):
 
         else:  # rev
             if out_vec._ncol == 1:
-                out_vec.iadd(np.bincount(self._out_inds, in_vec._data[self._in_inds],
+                out_vec.iadd(np.bincount(self._out_inds, in_vec._get_data()[self._in_inds],
                                          minlength=out_vec._data.size))
             else:  # matrix-matrix   (bincount only works with 1d arrays)
-                np.add.at(out_vec._data, self._out_inds, in_vec._data[self._in_inds])
+                np.add.at(out_vec._get_data(), self._out_inds, in_vec._get_data()[self._in_inds])

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -275,4 +275,4 @@ class DefaultTransfer(Transfer):
                 out_vec.iadd(np.bincount(self._out_inds, in_vec._get_data()[self._in_inds],
                                          minlength=out_vec._data.size))
             else:  # matrix-matrix   (bincount only works with 1d arrays)
-                np.add.at(out_vec._get_data(), self._out_inds, in_vec._get_data()[self._in_inds])
+                np.add.at(out_vec.asarray(), self._out_inds, in_vec._get_data()[self._in_inds])

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -59,9 +59,6 @@ class DefaultVector(Vector):
 
         data = root_vec._data[myslice]
 
-        # # Extract view for complex storage too.
-        # cplx_data = root_vec._cplx_data[myslice] if self._alloc_complex else None
-
         scaling = {}
         if self._do_scaling:
             scaling['phys'] = {}
@@ -75,7 +72,7 @@ class DefaultVector(Vector):
                 else:
                     scaling[typ] = (rs0[myslice], root_scale[1][myslice])
 
-        # return data, cplx_data, scaling
+        # return data, scaling
         return data, scaling
 
     def _initialize_data(self, root_vector):
@@ -104,11 +101,6 @@ class DefaultVector(Vector):
                 else:
                     self._scaling['phys'] = (None, np.ones(data.size))
                     self._scaling['norm'] = (None, np.ones(data.size))
-
-            # # Allocate imaginary for complex step
-            # if self._alloc_complex:
-            #     self._cplx_data = np.zeros(self._data.shape, dtype=np.complex)
-
         else:
             self._data, self._scaling = self._extract_root_data()
 
@@ -133,10 +125,6 @@ class DefaultVector(Vector):
         self._views = views = {}
         self._views_flat = views_flat = {}
 
-        # # alloc_complex = self._alloc_complex
-        # self._cplx_views = cplx_views = {}
-        # self._cplx_views_flat = cplx_views_flat = {}
-
         abs2meta = system._var_abs2meta[io]
         start = end = 0
         for abs_name in system._var_relevant_names[self._name][io]:
@@ -153,13 +141,6 @@ class DefaultVector(Vector):
                 v = v.view()
                 v.shape = shape
             views[abs_name] = v
-
-            # if alloc_complex:
-            #     cplx_views_flat[abs_name] = v = self._cplx_data[start:end]
-            #     if shape != v.shape:
-            #         v = v.view()
-            #         v.shape = shape
-            #     cplx_views[abs_name] = v
 
             if do_scaling:
                 for scaleto in ('phys', 'norm'):

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -283,15 +283,16 @@ class PETScTransfer(DefaultTransfer):
             # the petsc vector does not directly reference the _data.
 
             if in_vec._alloc_complex:
-                in_petsc.array = in_vec._data
+                in_petsc.array = in_vec._get_data()
 
             if out_vec._alloc_complex:
-                out_petsc.array = out_vec._data
+                out_petsc.array = out_vec._get_data()
 
             self._scatter(out_petsc, in_petsc, addv=flag, mode=flag)
 
             if in_vec._alloc_complex:
-                in_vec._data[:] = in_petsc.array
+                data = in_vec._get_data()
+                data[:] = in_petsc.array
 
     def _multi_transfer(self, in_vec, out_vec, mode='fwd'):
         """
@@ -330,17 +331,21 @@ class PETScTransfer(DefaultTransfer):
                     in_vec._data[:, i] = in_petsc.array + in_petsc_imag.array * 1j
 
             else:
+                in_data = in_vec._get_data()
+                out_data = out_vec._get_data()
                 for i in range(in_vec._ncol):
-                    in_petsc.array = in_vec._data[:, i]
-                    out_petsc.array = out_vec._data[:, i]
+                    in_petsc.array = in_data[:, i]
+                    out_petsc.array = out_data[:, i]
                     self._scatter(out_petsc, in_petsc, addv=False, mode=False)
-                    in_vec._data[:, i] = in_petsc.array
+                    in_data[:, i] = in_petsc.array
 
         elif mode == 'rev':
             in_petsc = in_vec._petsc
             out_petsc = out_vec._petsc
+            in_data = in_vec._get_data()
+            out_data = out_vec._get_data()
             for i in range(in_vec._ncol):
-                in_petsc.array = in_vec._data[:, i]
-                out_petsc.array = out_vec._data[:, i]
+                in_petsc.array = in_data[:, i]
+                out_petsc.array = out_data[:, i]
                 self._scatter(in_petsc, out_petsc, addv=True, mode=True)
-                out_vec._data[:, i] = out_petsc.array
+                out_data[:, i] = out_petsc.array

--- a/openmdao/vectors/petsc_vector.py
+++ b/openmdao/vectors/petsc_vector.py
@@ -75,7 +75,7 @@ class PETScVector(DefaultVector):
 
         self._petsc = {}
         self._imag_petsc = {}
-        data = self._data
+        data = self._data.real
 
         if self._ncol == 1:
             if self._alloc_complex:
@@ -93,7 +93,7 @@ class PETScVector(DefaultVector):
 
         # Allocate imaginary for complex step
         if self._alloc_complex:
-            data = self._cplx_data.imag
+            data = self._data.imag
             if self._ncol == 1:
                 self._imag_petsc = PETSc.Vec().createWithArray(data, comm=self._system().comm)
             else:
@@ -150,18 +150,18 @@ class PETScVector(DefaultVector):
                 data_cache = self.asarray(copy=True)
                 data_cache[dup_inds] = 0.0
             else:
-                data_cache = self._data
+                data_cache = self._get_data()
         else:
             # With Vectorized derivative solves, data contains multiple columns.
             icol = self._icol
             if icol is None:
                 icol = 0
             if has_dups:
-                data_cache = self._data.flatten()
+                data_cache = self._get_data().flatten()
                 data_cache[dup_inds] = 0.0
-                data_cache = data_cache.reshape(self._data.shape)[:, icol]
+                data_cache = data_cache.reshape(self._get_data().shape)[:, icol]
             else:
-                data_cache = self._data[:, icol]
+                data_cache = self._get_data()[:, icol]
 
         return data_cache
 
@@ -173,13 +173,13 @@ class PETScVector(DefaultVector):
         values.
         """
         if self._ncol == 1:
-            self._petsc.array = self._data
+            self._petsc.array = self._get_data()
         else:
             # With Vectorized derivative solves, data contains multiple columns.
             icol = self._icol
             if icol is None:
                 icol = 0
-            self._petsc.array = self._data[:, icol]
+            self._petsc.array = self._get_data()[:, icol]
 
     def get_norm(self):
         """
@@ -212,4 +212,4 @@ class PETScVector(DefaultVector):
         """
         nodup = self._get_nodup()
         # we don't need to _resore_dups here since we don't modify _petsc.array.
-        return self._system().comm.allreduce(np.dot(nodup, vec._data))
+        return self._system().comm.allreduce(np.dot(nodup, vec._get_data()))

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -640,8 +640,10 @@ class Vector(object):
         #     arr = None
 
         self._under_complex_step = active
-        if not active:
-            self._data.imag[:] = 0.0
+        # if not active:
+        #     self._data.imag[:] = 0.0
+        #     if not keep_real:
+        #         self._data.real[:] = 0.0
 
         # if arr is not None:
         #     self.set_val(arr)

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -610,7 +610,7 @@ class Vector(object):
         raise NotImplementedError('_in_matvec_context not defined for vector type %s' %
                                   type(self).__name__)
 
-    def set_complex_step_mode(self, active, keep_real=False):
+    def set_complex_step_mode(self, active):
         """
         Turn on or off complex stepping mode.
 
@@ -621,23 +621,5 @@ class Vector(object):
         ----------
         active : bool
             Complex mode flag; set to True prior to commencing complex step.
-
-        keep_real : bool
-            When this flag is True, keep the real value when turning off complex step. You only
-            need to do this when temporarily disabling complex step for guess_nonlinear.
         """
-        # if active:
-        #     arr = self._data
-        # elif keep_real:
-        #     arr = self._data.real
-        # else:
-        #     arr = None
-
         self._under_complex_step = active
-        # if not active:
-        #     self._data.imag[:] = 0.0
-        #     if not keep_real:
-        #         self._data.real[:] = 0.0
-
-        # if arr is not None:
-        #     self.set_val(arr)

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -70,6 +70,9 @@ class Vector(object):
         When True, values in the vector cannot be changed via the user __setitem__ API.
     _len : int
         Total length of data vector (including shared memory parts).
+    _get_data : method or None
+        Reference to the function to retrieve the _data array or the real part of it depending
+        on the value of _under_complex_step.
     """
 
     # Listing of relevant citations that should be referenced when

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -70,9 +70,6 @@ class Vector(object):
         When True, values in the vector cannot be changed via the user __setitem__ API.
     _len : int
         Total length of data vector (including shared memory parts).
-    _get_data : method or None
-        Reference to the function to retrieve the _data array or the real part of it depending
-        on the value of _under_complex_step.
     """
 
     # Listing of relevant citations that should be referenced when
@@ -121,11 +118,6 @@ class Vector(object):
         self._alloc_complex = alloc_complex
         self._under_complex_step = False
 
-        if alloc_complex:
-            self._get_data = self._get_data_cs
-        else:
-            self._get_data = self._get_data_real
-
         self._do_scaling = ((kind == 'input' and system._has_input_scaling) or
                             (kind == 'output' and system._has_output_scaling) or
                             (kind == 'residual' and system._has_resid_scaling))
@@ -163,14 +155,6 @@ class Vector(object):
             Total flattened length of this vector.
         """
         return self._len
-
-    def _get_data_real(self):
-        return self._data
-
-    def _get_data_cs(self):
-        if self._under_complex_step:
-            return self._data
-        return self._data.real
 
     def _copy_views(self):
         """

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -205,7 +205,6 @@ class Vector(object):
         else:
             return [v.real for n, v in self._views.items() if n in self._names]
 
-
     def _name2abs_name(self, name):
         """
         Map the given promoted or relative name to the absolute name.
@@ -559,26 +558,18 @@ class Vector(object):
         value = np.asarray(val)
 
         try:
-            if self._under_complex_step:
-                if flat:
-                    self._views_flat[abs_name][idxs] = value.flat
-                else:
-                    self._views[abs_name][idxs] = value
+            if flat:
+                self._views_flat[abs_name][idxs] = value.flat
             else:
-                if flat:
-                    self._views_flat[abs_name][idxs].real = value.flat
-                else:
-                    self._views[abs_name][idxs].real = value
+                self._views[abs_name][idxs] = value
+
         except Exception as err:
             try:
                 value = value.reshape(self._views[abs_name][idxs].shape)
             except Exception:
                 raise ValueError(f"{self._system().msginfo}: Failed to set value of "
                                  f"'{name}': {str(err)}.")
-            if self._under_complex_step:
-                self._views[abs_name][idxs] = value
-            else:
-                self._views[abs_name][idxs].real = value
+            self._views[abs_name][idxs] = value
 
     def dot(self, vec):
         """

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -598,9 +598,6 @@ class Vector(object):
         """
         Turn on or off complex stepping mode.
 
-        When turned on, the default real ndarray is replaced with a complex ndarray and all
-        pointers are updated to point to it.
-
         Parameters
         ----------
         active : bool


### PR DESCRIPTION
### Summary

We used to allocate separate real and complex data arrays within a Vector.  Now, if complex step is being done, we allocate a complex data array and return/set the real part of it if the vector is not currently under a complex step operation.

### Related Issues

- Resolves #1767

### Backwards incompatibilities

None

### New Dependencies

None
