### PR TITLE
Fixed deprecation warning when user passed dataframe to discrete input

### DIFF
--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -698,7 +698,6 @@ class DiscreteTestCase(unittest.TestCase):
         prob.add_recorder(rec)
 
         prob.setup()
-
         msg = ("DeprecationWarning: The truth value of an empty array is ambiguous. Returning"
                "False, but in future this will result in an error. Use `array.size > 0` to check "
                "that an array is not empty.")

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -12,7 +12,7 @@ from openmdao.core.driver import Driver
 from openmdao.visualization.n2_viewer.n2_viewer import _get_viewer_data
 from openmdao.test_suite.components.sellar import StateConnection, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_no_warning
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.utils.logger_utils import TestLogger
 
@@ -675,6 +675,36 @@ class DiscreteTestCase(unittest.TestCase):
         msg = ("'g0.g1.broken' <class BrokenComp>: Error calling compute(), "
                "compute() takes 3 positional arguments but 5 were given")
         self.assertEqual(str(cm.exception), msg)
+
+    def test_discrete_input_dataframe(self):
+        class OMDataFrame:
+            def __dict__(self):
+                pass
+
+        class ModCompEx2(ModCompEx):
+            def setup(self):
+                super().setup()
+                self.add_discrete_input('test', OMDataFrame())
+
+        prob = om.Problem()
+        model = prob.model
+
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes=['*'])
+        indep.add_discrete_output('x', 11)
+        model.add_subsystem('comp', ModCompEx2(3), promotes=['*'])
+
+        rec = om.SqliteRecorder('test')
+        prob.driver.add_recorder(rec)
+        prob.add_recorder(rec)
+
+        prob.setup()
+
+        msg = ("DeprecationWarning: The truth value of an empty array is ambiguous. Returning"
+               "False, but in future this will result in an error. Use `array.size > 0` to check "
+               "that an array is not empty.")
+
+        with assert_no_warning(DeprecationWarning, msg):
+            prob.run_model()
 
 class SolverDiscreteTestCase(unittest.TestCase):
     def _setup_model(self, solver_class):

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -945,6 +945,8 @@ def default_noraise(o):
         return o
     elif isinstance(o, bool) or isinstance(o, complex):
         return str(o)
+    elif hasattr(o, '__dict__'):
+        return o.__class__.__name__
     elif o is None:
         return None
     else:

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -943,10 +943,8 @@ def default_noraise(o):
         return o.item()
     elif isinstance(o, (str, float, int)):
         return o
-    elif isinstance(o, bool) or np.iscomplex(o):
+    elif isinstance(o, bool) or isinstance(o, complex):
         return str(o)
-    elif hasattr(o, '__dict__'):
-        return o.__class__.__name__
     elif o is None:
         return None
     else:

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -878,7 +878,7 @@ def make_serializable(o):
         return o.item()
     elif isinstance(o, (str, float, int)):
         return o
-    elif isinstance(o, bool) or np.iscomplex(o):
+    elif isinstance(o, bool) or isinstance(o, complex):
         return str(o)
     elif hasattr(o, '__dict__'):
         return o.__class__.__name__


### PR DESCRIPTION
### Summary

Fixed deprecation warning when user passed dataframe to discrete input

### Related Issues

- Resolves #1771

### Backwards incompatibilities

None

### New Dependencies

None
