### PR TITLE
Fixed setup() memory leak

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -241,7 +241,10 @@ class Group(System):
         (set, set)
             Sets of output and input variables.
         """
-        cache_key = excl_sub.msginfo
+        if excl_sub is None:
+            cache_key = None
+        else:
+            cache_key = excl_sub.pathname
 
         try:
             io_vars = self._scope_cache[cache_key]

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -279,7 +279,7 @@ class Group(System):
 
         # Use the pathname as the dict key instead of the object itself. When
         # the object is used as the key, memory leaks result from multiple
-        # calls to setup(). 
+        # calls to setup().
         self._scope_cache[cache_key] = (scope_out, scope_in, excl_sub)
         return scope_out, scope_in
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -242,7 +242,11 @@ class Group(System):
             Sets of output and input variables.
         """
         try:
-            return self._scope_cache[id(excl_sub)]
+            io_vars = self._scope_cache[excl_sub.pathname]
+
+            # Make sure they're the same subsystem instance before returning
+            if io_vars[2] is excl_sub:
+                return (io_vars[:2])
         except KeyError:
             pass
 
@@ -268,7 +272,10 @@ class Group(System):
                         scope_in.add(abs_in)
             scope_in = frozenset(scope_in)
 
-        self._scope_cache[id(excl_sub)] = (scope_out, scope_in)
+        # Use the pathname as the dict key instead of the object itself. When
+        # the object is used as the key, memory leaks result from multiple
+        # calls to setup(). 
+        self._scope_cache[excl_sub.pathname] = (scope_out, scope_in, excl_sub)
         return scope_out, scope_in
 
     def _compute_root_scale_factors(self):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -242,7 +242,7 @@ class Group(System):
             Sets of output and input variables.
         """
         try:
-            return self._scope_cache[excl_sub]
+            return self._scope_cache[id(excl_sub)]
         except KeyError:
             pass
 
@@ -268,7 +268,7 @@ class Group(System):
                         scope_in.add(abs_in)
             scope_in = frozenset(scope_in)
 
-        self._scope_cache[excl_sub] = (scope_out, scope_in)
+        self._scope_cache[id(excl_sub)] = (scope_out, scope_in)
         return scope_out, scope_in
 
     def _compute_root_scale_factors(self):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -241,8 +241,10 @@ class Group(System):
         (set, set)
             Sets of output and input variables.
         """
+        cache_key = excl_sub.msginfo
+
         try:
-            io_vars = self._scope_cache[excl_sub.pathname]
+            io_vars = self._scope_cache[cache_key]
 
             # Make sure they're the same subsystem instance before returning
             if io_vars[2] is excl_sub:
@@ -275,7 +277,7 @@ class Group(System):
         # Use the pathname as the dict key instead of the object itself. When
         # the object is used as the key, memory leaks result from multiple
         # calls to setup(). 
-        self._scope_cache[excl_sub.pathname] = (scope_out, scope_in, excl_sub)
+        self._scope_cache[cache_key] = (scope_out, scope_in, excl_sub)
         return scope_out, scope_in
 
     def _compute_root_scale_factors(self):

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -1,0 +1,62 @@
+import unittest
+import tracemalloc
+import gc
+import openmdao.api as om
+from openmdao.test_suite.components.sellar_feature import SellarMDA
+
+# Compare memory usage after running setup 10 times to
+# running setup 100 times
+ITERS = [ 10, 100 ]
+
+# The code with the leak problem would report a difference of memory
+# used between 10 and 100 iter runs of 36.9MiB. After fixing, it was
+# 0.2 KiB.
+MAX_MEM_DIFF_KB = 10
+
+class TestSetupMemLeak(unittest.TestCase):
+    """ Test for memory leaks when calling setup() multiple times """
+
+    def test_setup_memleak(self):
+        # Record the memory still in use after each run
+        mem_used = []
+
+        # Setup of the Sellar poblem
+        prob = om.Problem()
+
+        tracemalloc.start()
+
+        for memtest in ITERS:
+            prob.model = SellarMDA()
+            snapshots = []
+
+            for i in range(memtest):
+                prob.setup(check=False) # called here causes memory leak   
+                prob.run_driver()
+                totals = prob.compute_totals("z", "x")
+                del totals
+
+                # Force garbage collection now instead of waiting for an
+                # optimal/arbitrary point since we're tracking memory usage
+                gc.collect()
+                snapshots.append(tracemalloc.take_snapshot())
+
+            top_stats = snapshots[memtest - 1].compare_to(snapshots[0], 'lineno')
+
+            total_mem = 0
+            for stat in top_stats:
+                tb_str = str(stat.traceback)
+                # Ignore memory allocations by tracemalloc itself, which throw things off:
+                if "/tracemalloc.py:" not in tb_str:
+                    total_mem += stat.size
+            
+            mem_used.append(total_mem)
+
+        tracemalloc.stop()    
+        mem_diff = (mem_used[1] - mem_used[0])/1024
+
+        self.assertLess(mem_diff, MAX_MEM_DIFF_KB,
+            "Memory leak in setup(): %.1f KiB difference between %d and %d iter runs" %
+                (mem_diff, ITERS[0], ITERS[1]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -11,7 +11,7 @@ ITERS = [ 10, 100 ]
 # The code with the leak problem would report a difference of memory
 # used between 10 and 100 iter runs of 36.9MiB. After fixing, it was
 # 0.2 KiB.
-MAX_MEM_DIFF_KB = 10
+MAX_MEM_DIFF_KB = 200
 
 class TestSetupMemLeak(unittest.TestCase):
     """ Test for memory leaks when calling setup() multiple times """


### PR DESCRIPTION
### Summary

There were a couple of things causing the memory leak in `Group._get_scope()`. The big one was that `_scope_cache` was using refs to subsystem instances as dict keys. So when they were dereferenced elsewhere during `setup()`, the `_scope_cache` dict still held refs to the old objects because there's no automatic way to clear it out.

Initially, I addressed this by using the `id()` of the subsystem objects as dict keys, but there was still a small leak. This was because following a `setup()`, the subsystem instances were different even if the info in `_scope_cache` was the same. I ended up using the subsystem pathname as the key, and testing on cache hits to make sure it still referred to the same object.

I added a test that runs `setup()` 10 times and then 100 times and checks for differences in memory usage afterwards. If the difference is more than 10k, it fails.

### Related Issues

- Resolves #1746


