### PR TITLE
removed double indexing of src_indices from view_connections

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4489,7 +4489,7 @@ class System(object):
                 else:
                     val = val.ravel()[src_indices]
 
-            if get_remote:
+            if get_remote and self.comm.size > 1:
                 if distrib:
                     if rank is None:
                         parts = self.comm.allgather(val)

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -84,18 +84,13 @@ def view_connections(root, outfile='connections.html', show_browser=True,
     with printoptions(precision=precision, suppress=True, threshold=10000):
 
         for t, meta in all_vars['input']:
-            if t in system._var_abs2meta['input']:
-                idxs = meta['src_indices']
-            else:
-                idxs = None
-
             s = connections[t]
             if show_values:
                 if s.startswith('_auto_ivc.'):
-                    val = system.get_val(t, indices=idxs, flat=True, get_remote=True,
+                    val = system.get_val(t, flat=True, get_remote=True,
                                          from_src=False)
                 else:
-                    val = system.get_val(t, indices=idxs, flat=True, get_remote=True)
+                    val = system.get_val(t, flat=True, get_remote=True)
 
                     # if there's a unit conversion, express the value in the
                     # units of the target


### PR DESCRIPTION
### Summary

When view_connections was called programmatically on a dymos model an exception was raised due to indexing of the source value twice using src_indices.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
