### PR TITLE
release notes for 3.5.0

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,35 @@
 **********************************
+# Release Notes for OpenMDAO 3.5.0
+
+December 04, 2020
+
+OpenMDAO 3.5.0 adds the ability for users to complex-step across an OpenMDAO model externally,
+as well as a few performance tweaks.
+
+## Backwards Incompatible API Changes:
+
+- None
+
+## Backwards Incompatible NON-API Changes:
+
+- None
+
+## New Features:
+
+- Allow user to complex step across a Problem. [#1777](https://github.com/OpenMDAO/dymos/pull/1777)
+- Internal refactor of vector to have real and complex step modes share memory. [#1778](https://github.com/OpenMDAO/dymos/pull/1778)
+- Fixed deprecation warning when user passed a pandas dataframe to discrete input [#1780](https://github.com/OpenMDAO/dymos/pull/1780)
+- Added a 'get_remote' arg to compute_totals [#1783](https://github.com/OpenMDAO/dymos/pull/1783)
+
+## Bug Fixes:
+
+- Fixed setup() memory leak [#1782](https://github.com/OpenMDAO/dymos/pull/1782)
+- Fixed an indexing bug dealing with src_indices in view_connections [#1788](https://github.com/OpenMDAO/dymos/pull/1788)
+
+## Miscellaneous:
+- Rearranged an mpi test and added fwd test [#1781](https://github.com/OpenMDAO/dymos/pull/1781)
+
+**********************************
 # Release Notes for OpenMDAO 3.4.1
 
 November 13, 2020


### PR DESCRIPTION
### Summary

Release notes for the December 2020 release of OpenMDAO (3.5.0)
This is a minor version bump because we've added a new feature, the ability to complex step across your model without relying on OpenMDAO's drivers.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
