### PR TITLE
Fix typo s/add_input/add_output/

### DIFF
--- a/openmdao/docs/features/experimental/dynamic_shapes.rst
+++ b/openmdao/docs/features/experimental/dynamic_shapes.rst
@@ -51,7 +51,7 @@ follows:
 .. code-block:: python
 
     self.add_input('x', shape_by_conn=True, copy_shape='y')
-    self.add_input('y', shape_by_conn=True, copy_shape='x')
+    self.add_output('y', shape_by_conn=True, copy_shape='x')
 
 
 This way, `y` can be used to determine the shape of `x`, or `x` can determine the shape of `y`.


### PR DESCRIPTION
Correct the very short "input + output"  example to have both an input and an output.

### Summary

Summary of PR.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
