### PR TITLE
Fixed shape bug in DVs when indices were used

### DIFF
--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -792,6 +792,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
 
         p.driver = pyOptSparseDriver()
         p.driver.options['print_results'] = False
+
         p.model.approx_totals(method='fd')
 
         p.model.add_design_var('x')
@@ -1255,8 +1256,6 @@ class TestGroupComplexStep(unittest.TestCase):
 
         prob = om.Problem()
         model = prob.model
-        model.add_subsystem('x_param1', om.IndepVarComp('x1', np.ones((4))),
-                            promotes=['x1'])
         mycomp = model.add_subsystem('mycomp', ArrayComp2D(), promotes=['x1', 'y1'])
 
         model.add_design_var('x1', indices=[1, 3])

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1164,7 +1164,49 @@ def _slice_indices(slicer, arr_size, arr_shape):
     return np.arange(arr_size, dtype=INT_DTYPE).reshape(arr_shape)[slicer]
 
 
-def prom2ivc_src_dict(prom_dict):
+def _prom2ivc_src_name_iter(prom_dict):
+    """
+    Yield keys from prom_dict with promoted input names converted to ivc source names.
+
+    Parameters
+    ----------
+    prom_dict : dict
+        Original dict with some promoted paths.
+
+    Yields
+    ------
+    str
+        name
+    """
+    for name, meta in prom_dict.items():
+        if meta['ivc_source'] is not None:
+            yield meta['ivc_source']
+        else:
+            yield name
+
+
+def _prom2ivc_src_item_iter(prom_dict):
+    """
+    Yield items from prom_dict with promoted input names converted to ivc source names.
+
+    Parameters
+    ----------
+    prom_dict : dict
+        Original dict with some promoted paths.
+
+    Yields
+    ------
+    tuple
+        name, metadata
+    """
+    for name, meta in prom_dict.items():
+        if meta['ivc_source'] is not None:
+            yield meta['ivc_source'], meta
+        else:
+            yield name, meta
+
+
+def _prom2ivc_src_dict(prom_dict):
     """
     Convert a dictionary with promoted input names into one with ivc source names.
 
@@ -1178,15 +1220,7 @@ def prom2ivc_src_dict(prom_dict):
     dict
         New dict with ivc source pathnames.
     """
-    src_dict = {}
-    for name, meta in prom_dict.items():
-        if meta['ivc_source'] is not None:
-            src_name = meta['ivc_source']
-            src_dict[src_name] = meta
-        else:
-            src_dict[name] = meta
-
-    return src_dict
+    return {name: meta for name, meta in _prom2ivc_src_item_iter(prom_dict)}
 
 
 def convert_src_inds(parent_src_inds, parent_src_shape, my_src_inds, my_src_shape):


### PR DESCRIPTION
### Summary

_owns_approx_?_idx was using keys that had not been converted to ivc_src names, causing indices to be ignored in some cases when used with DVs.

Summary of PR.

### Related Issues

- Resolves #1808

### Backwards incompatibilities

None

### New Dependencies

None
