### PR TITLE
Always record solver metadata for all solvers in the model

### DIFF
--- a/openmdao/docs/_utils/docutil.py
+++ b/openmdao/docs/_utils/docutil.py
@@ -461,6 +461,7 @@ def insert_output_start_stop_indicators(src):
         '.list_inputs(',
         '.list_outputs(',
         '.list_problem_vars(',
+        '.list_model_options(',
     ]
 
     newlines = []

--- a/openmdao/docs/features/recording/reading_metadata.rst
+++ b/openmdao/docs/features/recording/reading_metadata.rst
@@ -37,8 +37,7 @@ This function creates a dictionary of the latest model options available that we
 Solver Metadata
 ---------------
 
-Solvers record the solver options as metadata. Note that, because more than
-one solver's metadata may be recorded, each solver's metadata must be accessed through
+Solver options are recorded as metadata. Each solver's metadata is accessed using
 its absolute name within :code:`solver_metadata`, as shown in the example below.
 
 .. embed-code::

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -269,8 +269,20 @@ def record_system_options(problem):
             problem._system_options_recorded = True
 
         for recorder in recorders:
-            for sub in problem.model.system_iter(recurse=True, include_self=True):
+            for system in problem.model.system_iter(recurse=True, include_self=True):
+                # record system metadata (options)
                 if problem._run_counter >= 1:
-                    recorder.record_metadata_system(sub, problem._run_counter)
+                    recorder.record_metadata_system(system, problem._run_counter)
                 else:
-                    recorder.record_metadata_system(sub)
+                    recorder.record_metadata_system(system)
+
+                # record solver metadata (options) for this system's solvers
+                nl = system._nonlinear_solver
+                if nl:
+                    recorder.record_metadata_solver(nl)
+                    if hasattr(nl, 'linesearch') and nl.linesearch:
+                        recorder.record_metadata_solver(nl.linesearch)
+
+                ln = system._linear_solver
+                if ln:
+                    recorder.record_metadata_solver(ln)

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -474,9 +474,10 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         self.assertEqual(
             sorted(metadata.keys()),
-            ['d1.NonlinearBlockGS', 'root.NonlinearBlockGS']
+            ['d1.NonlinearBlockGS', 'root.LinearBlockGS', 'root.NonlinearBlockGS']
         )
         self.assertEqual(metadata['d1.NonlinearBlockGS']['solver_options']['maxiter'], 5)
+        self.assertEqual(metadata['root.LinearBlockGS']['solver_options']['maxiter'], 10)
         self.assertEqual(metadata['root.NonlinearBlockGS']['solver_options']['maxiter'], 10)
 
     def test_reading_driver_recording_with_system_vars(self):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2625,9 +2625,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         self.assertEqual(sorted(options.keys()),
                          sorted(['root']))
 
-        self.assertEqual(sorted(options['root'].keys()),
-                         sorted(prob.model.options._dict.keys()))
-
+        # options for system 'root'
         self.assertEqual(options['root']['ln_maxiter'], None)
 
     def test_feature_system_recording_options(self):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -248,11 +248,13 @@ class TestSqliteRecorder(unittest.TestCase):
         driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
         driver.options['print_results'] = False
         driver.opt_settings['ACC'] = 1e-9
+
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True
         driver.recording_options['record_derivatives'] = True
         driver.recording_options['includes'] = ['*']
+
         driver.add_recorder(self.recorder)
 
         prob.setup()
@@ -2592,10 +2594,11 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         metadata = cr.solver_metadata
 
         self.assertEqual(sorted(metadata.keys()), [
-            'd1.NonlinearBlockGS', 'root.NonlinearBlockGS'
+            'd1.NonlinearBlockGS', 'root.NonlinearBlockGS', 'root.ScipyKrylov',
         ])
         self.assertEqual(metadata['d1.NonlinearBlockGS']['solver_options']['maxiter'], 5)
         self.assertEqual(metadata['root.NonlinearBlockGS']['solver_options']['maxiter'], 10)
+        self.assertEqual(metadata['root.ScipyKrylov']['solver_options']['maxiter'], 1000)
 
     def test_feature_recording_system_options(self):
         import openmdao.api as om

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -300,7 +300,6 @@ class Solver(object):
             return
 
         self._rec_mgr.startup(self)
-        self._rec_mgr.record_metadata(self)
 
         myoutputs = myresiduals = myinputs = []
         incl = self.recording_options['includes']


### PR DESCRIPTION
### Summary

Always record solver metadata for all solvers in the model.

### Related Issues

- Resolves #1569

### Backwards incompatibilities

None

### New Dependencies

None
