### PR TITLE
Make get_var_meta private, and fix a test failure introduced from the latest scipy.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4684,7 +4684,7 @@ class System(object):
         float or ndarray of float
             The value converted to the specified units.
         """
-        base_units = self.get_var_meta(name, 'units')
+        base_units = self._get_var_meta(name, 'units')
 
         if base_units == units:
             return val
@@ -4715,7 +4715,7 @@ class System(object):
         float or ndarray of float
             The value converted to the specified units.
         """
-        base_units = self.get_var_meta(name, 'units')
+        base_units = self._get_var_meta(name, 'units')
 
         if base_units == units:
             return val
@@ -4759,7 +4759,7 @@ class System(object):
 
         return (val + offset) * scale
 
-    def get_var_meta(self, name, key):
+    def _get_var_meta(self, name, key):
         """
         Get metadata for a variable.
 

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -710,7 +710,7 @@ class DynPartialsComp(om.ExplicitComponent):
         self.add_output('y', shape_by_conn=True, copy_shape='x')
 
     def setup_partials(self):
-        size = self.get_var_meta('x', 'size')
+        size = self._get_var_meta('x', 'size')
         self.mat = np.eye(size) * 3.
         rng = np.arange(size)
         self.declare_partials('y', 'x', rows=rng, cols=rng, val=3.0)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1633,32 +1633,6 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.run_driver()
         assert_near_equal(prob['x'], np.array([0.234171, -0.1000]), 1e-3)
         assert_near_equal(prob['f'], -0.907267, 1e-3)
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
-                         "scipy >= 1.2 is required.")
-    def test_dual_annealing(self):
-
-        import openmdao.api as om
-
-        prob = om.Problem()
-        model = prob.model
-
-        model.add_subsystem('indeps', om.IndepVarComp('x', np.ones(rosenbrock_size)), promotes=['*'])
-        model.add_subsystem('rosen', Rosenbrock(), promotes=['*'])
-
-        prob.driver = driver = om.ScipyOptimizeDriver()
-        driver.options['optimizer'] = 'dual_annealing'
-        driver.options['disp'] = False
-        driver.options['tol'] = 1e-9
-        driver.options['maxiter'] = 2000
-        driver.opt_settings['seed'] = 1234
-        driver.opt_settings['initial_temp'] = 5230
-
-        model.add_design_var('x', lower=-2*np.ones(rosenbrock_size), upper=2*np.ones(rosenbrock_size))
-        model.add_objective('f')
-        prob.setup()
-        prob.run_driver()
-        assert_near_equal(prob['x'], np.ones(rosenbrock_size), 1e-2)
-        assert_near_equal(prob['f'], 0.0, 1e-2)
 
     @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
                          "scipy >= 1.2 is required.")


### PR DESCRIPTION
### Summary

1. The method `get_var_meta` is used a couple of places internally, but is not documented or tested as a public API function (and partially duplicates `get_io_meta`, so it has been made private.
2. A recent bug fix in scipy 1.6 changed the behavior of the dual_annealing optimizer, and now it doesn't work as well on the Rosenbrock problem. This test has been removed, This optimizer is still covered by the Rastigrin problem.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
