### PR TITLE
fix for change in sphinx-doc v3.4.0 (PR 8445)

### DIFF
--- a/openmdao/docs/_theme/search.html
+++ b/openmdao/docs/_theme/search.html
@@ -12,6 +12,7 @@
 {%- block scripts %}
     {{ super() }}
     <script type="text/javascript" src="{{ pathto('_static/searchtools.js', 1) }}"></script>
+    <script type="text/javascript" src="{{ pathto('_static/language_data.js', 1) }}"></script>
 {%- endblock %}
 {% block extrahead %}
   <script type="text/javascript" src="{{ pathto('searchindex.js', 1) }}" defer></script>


### PR DESCRIPTION
### Summary

As of sphinx-doc v3.4.0,  `language_data.js` is not loaded by default.  
It has to be loaded on the theme's search page.

### Related Issues

- Resolves #1816

### Backwards incompatibilities

None

### New Dependencies

None
