### PR TITLE
Clarify you must be in MPI to run DOEDriver in parallel

### DIFF
--- a/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
+++ b/openmdao/docs/features/building_blocks/drivers/doe_driver.rst
@@ -65,7 +65,7 @@ Running a DOE in Parallel
 
 In a parallel processing environment, it is possible for `DOEDriver` to run
 cases concurrently. This is done by setting the `run_parallel` option to True as shown
-in the following example.
+in the following example and running your script using MPI.
 
 Here we are using the `FullFactorialGenerator` with 3 levels to generate inputs
 for our `Paraboloid` model. With two inputs, :math:`3^2=9` cases have been


### PR DESCRIPTION
### Summary

Very simple change to explicitly clarify that you must also be running in MPI to run DOEDriver in parallel to alleviate confusion from a user.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
