### PR TITLE
fixed bug that made Gatherv call fail

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -570,8 +570,7 @@ class Driver(object):
                 local_val = local_val[local_indices]
 
             if get_remote:
-                if not local_val.flags['C_CONTIGUOUS']:
-                    local_val = np.ascontiguousarray(local_val)
+                local_val = np.ascontiguousarray(local_val)
                 offsets = np.zeros(sizes.size, dtype=INT_DTYPE)
                 offsets[1:] = np.cumsum(sizes[:-1])
                 val = np.zeros(np.sum(sizes))

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1674,7 +1674,7 @@ class System(object):
         """
         pass
 
-    def _setup_vectors(self, root_vectors, alloc_complex=False):
+    def _setup_vectors(self, root_vectors):
         """
         Compute all vectors for all vec names and assign excluded variables lists.
 
@@ -1682,8 +1682,6 @@ class System(object):
         ----------
         root_vectors : dict of dict of Vector
             Root vectors: first key is 'input', 'output', or 'residual'; second key is vec_name.
-        alloc_complex : bool
-            Whether to allocate any imaginary storage to perform complex step. Default is False.
         """
         self._vectors = vectors = {'input': OrderedDict(),
                                    'output': OrderedDict(),
@@ -4273,7 +4271,10 @@ class System(object):
                     # TODO: could cache these offsets
                     offsets = np.zeros(sizes.size, dtype=INT_DTYPE)
                     offsets[1:] = np.cumsum(sizes[:-1])
-                    loc_val = val if val is not _UNDEFINED else np.zeros(sizes[myrank])
+                    if val is _UNDEFINED:
+                        loc_val = np.zeros(sizes[myrank])
+                    else:
+                        loc_val = np.ascontiguousarray(val)
                     val = np.zeros(np.sum(sizes))
                     self.comm.Allgatherv(loc_val, [val, sizes, offsets, MPI.DOUBLE])
                     if not flat:
@@ -4291,7 +4292,10 @@ class System(object):
                     # TODO: could cache these offsets
                     offsets = np.zeros(sizes.size, dtype=INT_DTYPE)
                     offsets[1:] = np.cumsum(sizes[:-1])
-                    loc_val = val if val is not _UNDEFINED else np.zeros(sizes[idx])
+                    if val is _UNDEFINED:
+                        loc_val = np.zeros(sizes[idx])
+                    else:
+                        loc_val = np.ascontiguousarray(val)
                     val = np.zeros(np.sum(sizes))
                     self.comm.Gatherv(loc_val, [val, sizes, offsets, MPI.DOUBLE], root=rank)
                     if not flat:

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -77,7 +77,7 @@ class DistributedListVarsTest(unittest.TestCase):
         prob.model.add_subsystem('plus', DistributedAdder(size=size), promotes=['x', 'y'])
         prob.model.add_subsystem('summer', Summer(size=size), promotes=[('invec', 'y'), 'sum'])
 
-        prob.setup()
+        prob.setup(force_alloc_complex=True)  # force complex array storage to detect mpi bug
 
         prob['x'] = np.arange(size)
 

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -651,7 +651,7 @@ def _check_config_cmd(options, user_args):
     _load_and_exec(options.file[0], user_args)
 
 
-def check_allocate_complex_ln(model, under_cs):
+def check_allocate_complex_ln(group, under_cs):
     """
     Return True if linear vector should be complex.
 
@@ -659,8 +659,8 @@ def check_allocate_complex_ln(model, under_cs):
 
     Parameters
     ----------
-    model : <Group>
-        Model to be checked, usually the root model.
+    group : <Group>
+        Group to be checked.
     under_cs : bool
         Flag indicates if complex vectors were allocated in a containing Group or were force
         allocated in setup.
@@ -670,16 +670,14 @@ def check_allocate_complex_ln(model, under_cs):
     bool
         True if linear vector should be complex.
     """
-    under_cs |= 'cs' in model._approx_schemes
+    under_cs |= 'cs' in group._approx_schemes
 
-    if under_cs and model.nonlinear_solver is not None and \
-       model.nonlinear_solver.supports['gradients']:
+    if under_cs and group.nonlinear_solver is not None and \
+       group.nonlinear_solver.supports['gradients']:
         return True
 
-    for sub, _ in model._subsystems_allprocs.values():
-        chk = check_allocate_complex_ln(sub, under_cs)
-
-        if chk:
+    for sub, _ in group._subsystems_allprocs.values():
+        if isinstance(sub, Group) and check_allocate_complex_ln(sub, under_cs):
             return True
 
     return False


### PR DESCRIPTION
### Summary

list_outputs on a distributed model was failing because we were doing a Gatherv on an array obtained from accessing .real on a complex array, which is not contiguous.

### Related Issues

- Resolves #1846

### Backwards incompatibilities

None

### New Dependencies

None
