### PR TITLE
copy data in case recorder output

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -733,7 +733,7 @@ class Case(object):
                     return_name = auto_ivc_map[name]
                 else:
                     return_name = name
-                ret_vars[return_name] = val = self.outputs[name]
+                ret_vars[return_name] = val = self.outputs[name].copy()
                 if update_vals and name in self._var_info:
                     meta = self._var_info[name]
                     if use_indices and meta['indices'] is not None:


### PR DESCRIPTION
### Summary

When getting constraints and design variables from a recorded case (e.g. `openmdao.recorders.case.Case.get_constraints`), these are by default returned scaled. When accessing these outputs subsequently, they remain scaled. This PR simply ensures that a copy of the output is created before returning it.

### Related Issues

None

### Backwards incompatibilities

It changes the behaviour of the case recorder as described above, but I would guess this is non-intentional behaviour.

### New Dependencies

None
