### PR TITLE
POEM 039 Implementation

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1278,15 +1278,12 @@ class Component(System):
             cases with large numbers of explicit components or indepvarcomps.
         """
         if quick_declare:
-            abs_key = rel_key2abs_key(self, (of, wrt))
-
-            meta = {}
-            meta['rows'] = np.array(dct['rows'], dtype=INT_DTYPE, copy=False)
-            meta['cols'] = np.array(dct['cols'], dtype=INT_DTYPE, copy=False)
-            meta['shape'] = (len(dct['rows']), len(dct['cols']))
-            meta['value'] = dct['value']
-
-            self._subjacs_info[abs_key] = meta
+            self._subjacs_info[rel_key2abs_key(self, (of, wrt))] = {
+                'rows': np.array(dct['rows'], dtype=INT_DTYPE, copy=False),
+                'cols': np.array(dct['cols'], dtype=INT_DTYPE, copy=False),
+                'shape': (len(dct['rows']), len(dct['cols'])),
+                'value': dct['value'],
+            }
             return
 
         val = dct['value'] if 'value' in dct else None

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -67,7 +67,8 @@ class DistribExecComp(om.ExecComp):
         for expr in exprs:
             lhs, _ = expr.split('=', 1)
             outs.update(self._parse_for_out_vars(lhs))
-            allvars.update(self._parse_for_vars(expr))
+            v, _ = self._parse_for_names(expr)
+            allvars.update(v)
 
         sizes, offsets = evenly_distrib_idxs(comm.size, self.arr_size)
         start = offsets[rank]

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -730,7 +730,6 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
         elapsed_rev = time.time() - elapsed_rev
 
         # run in fwd mode and compare times for deriv calculation
-        p = om.Problem(model=PartialDependGroup())
         p.setup(mode='fwd')
         p.run_model()
 

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -371,10 +371,11 @@ def profiling(outname='prof.out'):
     prof = cProfile.Profile()
     prof.enable()
 
-    yield prof
-
-    prof.disable()
-    prof.dump_stats(outname)
+    try:
+        yield prof
+    finally:
+        prof.disable()
+        prof.dump_stats(outname)
 
 
 def compare_jacs(Jref, J, rel_trigger=1.0):

--- a/openmdao/devtools/iprof_mem.py
+++ b/openmdao/devtools/iprof_mem.py
@@ -201,16 +201,18 @@ def memtrace(**kwargs):
 
     _setup(options)
     start()
-    yield
-    stop()
+    try:
+        yield
+    finally:
+        stop()
 
-    _file_line2qualname(options.outfile)
-    if options.tree:
-        postprocess_memtrace_tree(fname=options.outfile, min_mem=options.min_mem,
-                                  show_colors=options.show_colors, stream=options.stream)
-    else:
-        postprocess_memtrace_flat(fname=options.outfile, min_mem=options.min_mem,
-                                  show_colors=options.show_colors, stream=options.stream)
+        _file_line2qualname(options.outfile)
+        if options.tree:
+            postprocess_memtrace_tree(fname=options.outfile, min_mem=options.min_mem,
+                                    show_colors=options.show_colors, stream=options.stream)
+        else:
+            postprocess_memtrace_flat(fname=options.outfile, min_mem=options.min_mem,
+                                    show_colors=options.show_colors, stream=options.stream)
 
 
 def _mempost_setup_parser(parser):

--- a/openmdao/devtools/itrace.py
+++ b/openmdao/devtools/itrace.py
@@ -311,8 +311,10 @@ def tracing(methods=None, verbose=False, memory=False, leaks=False, show_ptrs=Fa
     """
     setup(methods=methods, verbose=verbose, memory=memory, leaks=leaks, show_ptrs=show_ptrs)
     start()
-    yield
-    stop()
+    try:
+        yield
+    finally:
+        stop()
 
 
 class tracedfunc(object):

--- a/openmdao/docs/features/building_blocks/components/exec_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/exec_comp.rst
@@ -9,7 +9,7 @@ ExecComp
 `ExecComp` is a component that provides a shortcut for building an ExplicitComponent that
 represents a set of simple mathematical relationships between inputs and outputs. The ExecComp
 automatically takes care of all of the component API methods, so you just need to instantiate
-it with an equation.
+it with an equation or a list of equations.
 
 ExecComp Options
 ----------------
@@ -46,6 +46,8 @@ Name              Description                                            Valid T
 ================  ====================================================== ============================================================= ==============  ========
 value             Initial value in user-defined units                    float, list, tuple, ndarray                                   input & output  1
 shape             Variable shape, only needed if not an array            int, tuple, list, None                                        input & output  None
+shape_by_conn     Determine variable shape based on its connection       bool                                                          input & output  False
+copy_shape        Determine variable shape based on named variable       str                                                           input & output  None
 units             Units of variable                                      str, None                                                     input & output  None
 desc              Description of variable                                str                                                           input & output  ""
 res_units         Units of residuals                                     str, None                                                     output          None
@@ -65,6 +67,19 @@ For more information about these metadata, see the documentation for the argumen
 - :meth:`add_input <openmdao.core.component.Component.add_input>`
 
 - :meth:`add_output <openmdao.core.component.Component.add_output>`
+
+Registering User Functions
+--------------------------
+
+To get your own functions added to the internal namespace of ExecComp so you can call them
+from within an ExecComp expression, you can use the :code:`ExecComp.register` function.
+
+.. automethod:: openmdao.components.exec_comp.ExecComp.register
+    :noindex:
+
+Note that you're required, when registering a new function, to indicate whether that function
+is complex safe or not.
+
 
 ExecComp Example: Simple
 ------------------------
@@ -88,7 +103,8 @@ ExecComp Example: Arrays
 ------------------------
 
 You can declare an ExecComp with arrays for inputs and outputs, but when you do, you must also
-pass in a correctly-sized array as an argument to the ExecComp call. This can be the initial value
+pass in a correctly-sized array as an argument to the ExecComp call, or set the 'shape' metadata
+for that variable as described earlier. If specifying the value directly, it can be the initial value
 in the case of unconnected inputs, or just an empty array with the correct size.
 
 .. embed-code::
@@ -139,5 +155,29 @@ common units that are specified by setting the option.
 .. embed-code::
     openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_options
     :layout: interleave
+
+
+ExecComp Example: User function registration
+--------------------------------------------
+
+If the function is complex safe, then you don't need to do anything differently than you
+would for any other ExecComp.
+
+.. embed-code::
+    openmdao.components.tests.test_exec_comp.TestFunctionRegistration.featuretest_register_simple
+    :layout: interleave
+
+
+ExecComp Example: Complex unsafe user function registration
+-----------------------------------------------------------
+
+If the function isn't complex safe, then derivatives involving that function
+will have to be computed using finite difference instead of complex step.  The way to specify
+that `fd` should be used for a given derivative is to call :code:`declare_partials`.
+
+.. embed-code::
+    openmdao.components.tests.test_exec_comp.TestFunctionRegistration.featuretest_register_simple_unsafe
+    :layout: interleave
+
 
 .. tags:: ExecComp, Component, Examples

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -86,7 +86,7 @@ class ParaboloidAE(om.ExplicitComponent):
         self.grad_iter_count += 1
 
 
-class DummyComp(om.ExecComp):
+class DummyComp(om.ExplicitComponent):
     """
     Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.
     """
@@ -96,7 +96,7 @@ class DummyComp(om.ExecComp):
 
         self.add_output('c', val=0.0)
 
-        self.declare_partials('*', '*')
+        self.declare_partials('*', '*', method='cs')
 
     def compute(self, inputs, outputs):
         """

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -41,7 +41,7 @@ def rastrigin(x):
     return np.sum(np.square(x) - a * np.cos(2 * np.pi * x)) + a * np.size(x)
 
 
-class DummyComp(om.ExecComp):
+class DummyComp(om.ExplicitComponent):
     """
     Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.
     """
@@ -52,7 +52,7 @@ class DummyComp(om.ExecComp):
 
         self.add_output('c', val=0.0)
 
-        self.declare_partials('*', '*')
+        self.declare_partials('*', '*', method='cs')
 
     def compute(self, inputs, outputs):
         """

--- a/openmdao/recorders/tests/sqlite_recorder_test_utils.py
+++ b/openmdao/recorders/tests/sqlite_recorder_test_utils.py
@@ -19,9 +19,10 @@ def database_cursor(filename):
     con = sqlite3.connect(filename)
     cur = con.cursor()
 
-    yield cur
-
-    con.close()
+    try:
+        yield cur
+    finally:
+        con.close()
 
 
 def get_format_version_abs2meta(db_cur):

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -361,6 +361,7 @@ class TestSqliteRecorder(unittest.TestCase):
             "        has_diag_partials : False",
             "        units : None",
             "        shape : None",
+            "        shape_by_conn : False",
             ""
         ]
 
@@ -451,6 +452,7 @@ class TestSqliteRecorder(unittest.TestCase):
             "        has_diag_partials : False",
             "        units : None",
             "        shape : None",
+            "        shape_by_conn : False",
             ""
         ]
 

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -1373,14 +1373,15 @@ def _compute_total_coloring_context(top):
         if jac is not None:
             jac._randomize = True
 
-    yield
-
-    for system in top.system_iter(recurse=True, include_self=True):
-        jac = system._assembled_jac
-        if jac is None:
-            jac = system._jacobian
-        if jac is not None:
-            jac._randomize = False
+    try:
+        yield
+    finally:
+        for system in top.system_iter(recurse=True, include_self=True):
+            jac = system._assembled_jac
+            if jac is None:
+                jac = system._jacobian
+            if jac is not None:
+                jac._randomize = False
 
 
 def _get_bool_total_jac(prob, num_full_jacs=_DEF_COMP_SPARSITY_ARGS['num_full_jacs'],

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -102,8 +102,10 @@ def ignore_errors_context(flag=True):
     """
     save = ignore_errors()
     ignore_errors(flag)
-    yield
-    ignore_errors(save)
+    try:
+        yield
+    finally:
+        ignore_errors(save)
 
 
 def warn_deprecation(msg):

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -4,7 +4,6 @@ import inspect
 import json
 import os
 import zlib
-from collections import OrderedDict
 from itertools import chain
 import networkx as nx
 
@@ -94,7 +93,7 @@ def _get_var_dict(system, typ, name, is_parallel):
         name = system._var_abs2prom[typ][name]
         is_discrete = False
 
-    var_dict = OrderedDict()
+    var_dict = {}
 
     var_dict['name'] = name
     var_dict['type'] = typ
@@ -179,7 +178,7 @@ def _serialize_single_option(option):
 def _get_tree_dict(system, component_execution_orders, component_execution_index,
                    is_parallel=False):
     """Get a dictionary representation of the system hierarchy."""
-    tree_dict = OrderedDict()
+    tree_dict = {}
     tree_dict['name'] = system.name
     tree_dict['type'] = 'subsystem'
     tree_dict['class'] = system.__class__.__name__

--- a/openmdao/visualization/n2_viewer/tests/sellar_tree.json
+++ b/openmdao/visualization/n2_viewer/tests/sellar_tree.json
@@ -399,7 +399,8 @@
                 "distributed": false,
                 "has_diag_partials": false,
                 "units": null,
-                "shape": null
+                "shape": null,
+                "shape_by_conn": false
             }
         },
         {
@@ -447,7 +448,8 @@
                 "distributed": false,
                 "has_diag_partials": false,
                 "units": null,
-                "shape": null
+                "shape": null,
+                "shape_by_conn": false
             }
         },
         {
@@ -495,7 +497,8 @@
                 "distributed": false,
                 "has_diag_partials": false,
                 "units": null,
-                "shape": null
+                "shape": null,
+                "shape_by_conn": false
             }
         }
     ],


### PR DESCRIPTION
### Summary

Adds function registration and the shape_by_conn option to ExecComp.  Also, ExecComp can now use it's built-in 'cs' implementation for partials or it can use openmdao's 'fd' or 'cs' implementations.

- also added try-finally blocks to a bunch of our context managers

### Related Issues

- Resolves #1824

### Backwards incompatibilities

None

### New Dependencies

None
