### PR TITLE
openmdao now reports an error if there is a dashed arg other than -h or --version before the command or filename

### DIFF
--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -495,6 +495,7 @@ def openmdao_cmd():
         user_args = []
 
     parser = argparse.ArgumentParser(description='OpenMDAO Command Line Tools',
+                                     usage='openmdao [-h] [--version] command [command_options] filename',
                                      epilog='Use -h after any sub-command for sub-command help.'
                                      ' If using a tool on a script that takes its own command line'
                                      ' arguments, place those arguments after a "--". For example:'
@@ -538,7 +539,7 @@ def openmdao_cmd():
 
     # handle case where someone just runs `openmdao <script> [dashed-args]`
     args = [a for a in sys.argv[1:] if not a.startswith('-')]
-    if not set(args).intersection(subs.choices) and len(args) == 1 and os.path.isfile(args[0]):
+    if not set(args).intersection(subs.choices) and len(args) == 1 and os.path.isfile(sys.argv[1]):
         _load_and_exec(args[0], user_args)
     else:
         hooks.use_hooks = True

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -539,7 +539,8 @@ def openmdao_cmd():
 
     # handle case where someone just runs `openmdao <script> [dashed-args]`
     args = [a for a in sys.argv[1:] if not a.startswith('-')]
-    if not set(args).intersection(subs.choices) and len(args) == 1 and os.path.isfile(sys.argv[1]):
+    cmdargs = [a for a in sys.argv[1:] if a not in ('-h', '--version')]
+    if not set(args).intersection(subs.choices) and len(args) == 1 and os.path.isfile(cmdargs[0]):
         _load_and_exec(args[0], user_args)
     else:
         hooks.use_hooks = True

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -495,7 +495,8 @@ def openmdao_cmd():
         user_args = []
 
     parser = argparse.ArgumentParser(description='OpenMDAO Command Line Tools',
-                                     usage='openmdao [-h] [--version] command [command_options] filename',
+                                     usage='openmdao [-h] [--version] command [command_options] '
+                                     'filename',
                                      epilog='Use -h after any sub-command for sub-command help.'
                                      ' If using a tool on a script that takes its own command line'
                                      ' arguments, place those arguments after a "--". For example:'

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -121,7 +121,7 @@ test_cmd_err = [
 class CmdlineTestErrTestCase(unittest.TestCase):
     @parameterized.expand(test_cmd_err, name_func=_test_func_name)
     def test_cmd(self, cmd):
-        proc = subprocess.run(cmd.split(), capture_output=True, text=True)
+        proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
         if 'argument : invalid choice:' not in proc.stderr:
             self.fail(f"Command '{cmd}' didn't fail in the expected way.\n"
                       f"Return code: {proc.returncode}.\nstderr: {proc.stderr}\nstdout: {proc.stdout}")

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -113,5 +113,19 @@ class CmdlineTestfuncTestCase(unittest.TestCase):
             self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
 
 
+test_cmd_err = [
+    f"openmdao -scaling {os.path.join(scriptdir, 'circle_opt.py')}",
+]
+
+@use_tempdirs
+class CmdlineTestErrTestCase(unittest.TestCase):
+    @parameterized.expand(test_cmd_err, name_func=_test_func_name)
+    def test_cmd(self, cmd):
+        proc = subprocess.run(cmd.split(), capture_output=True, text=True)
+        print(proc.stderr)
+        if 'argument : invalid choice:' not in proc.stderr:
+            self.fail(f"Command '{cmd}' didn't fail in the expected way.\n"
+                      f"Return code: {proc.returncode}.\nstderr: {proc.stderr}\nstdout: {proc.stdout}")
+
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -121,7 +121,7 @@ test_cmd_err = [
 class CmdlineTestErrTestCase(unittest.TestCase):
     @parameterized.expand(test_cmd_err, name_func=_test_func_name)
     def test_cmd(self, cmd):
-        proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        proc = subprocess.run(cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding='UTF-8')
         if 'argument : invalid choice:' not in proc.stderr:
             self.fail(f"Command '{cmd}' didn't fail in the expected way.\n"
                       f"Return code: {proc.returncode}.\nstderr: {proc.stderr}\nstdout: {proc.stdout}")

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -122,7 +122,6 @@ class CmdlineTestErrTestCase(unittest.TestCase):
     @parameterized.expand(test_cmd_err, name_func=_test_func_name)
     def test_cmd(self, cmd):
         proc = subprocess.run(cmd.split(), capture_output=True, text=True)
-        print(proc.stderr)
         if 'argument : invalid choice:' not in proc.stderr:
             self.fail(f"Command '{cmd}' didn't fail in the expected way.\n"
                       f"Return code: {proc.returncode}.\nstderr: {proc.stderr}\nstdout: {proc.stdout}")


### PR DESCRIPTION

### Related Issues

- Resolves #1855

### Backwards incompatibilities

None

### New Dependencies

None
