### PR TITLE
fixed svg gradient bug on firefox

### DIFF
--- a/openmdao/visualization/scaling_viewer/scaling_table.html
+++ b/openmdao/visualization/scaling_viewer/scaling_table.html
@@ -552,7 +552,7 @@ function heatmap(ofEntries, wrtEntries, jac_data, parent_id, is_top) {
         {"color": subjacColor(maxcolor), "value": maxcolor},
     ];
 
-    var grad_id = parent_id + "-lingrad";
+    var grad_id = parent_id.slice(1) + "lingrad";
     var defs = parent.select(".heatmap").append("defs");
     var grad = defs.append("linearGradient")
         .attr('x1', '0%')


### PR DESCRIPTION
### Summary

Jacobian heatmap legend colormap was not showing up on firefox.

### Related Issues

- Resolves #1857 

### Backwards incompatibilities

None

### New Dependencies

None
