### PR TITLE
switch from mock to the stdlib unittest.mock

### DIFF
--- a/openmdao/devtools/docs_experiment/Makefile
+++ b/openmdao/devtools/docs_experiment/Makefile
@@ -28,7 +28,7 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest coverage gettext
 
 #first item in makefile is default action of "make"
-html-update: mock redbaron
+html-update: redbaron
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS)  $(BUILDDIR)/html
 
 single:
@@ -42,15 +42,11 @@ clean:
 	rm -rf tags
 	rm -rf tmp
 
-mock:
-	@(python -c "import mock" >/dev/null 2>&1) || (echo "The 'mock' package \
-	is required to build the docs. Install with:\n pip install mock"; exit 1)
-
 redbaron:
 	@(python -c "import redbaron" >/dev/null 2>&1) || (echo "The 'redbaron' package \
 	is required to build the docs. Install with:\n pip install redbaron"; exit 1)
 
-all: mock redbaron
+all: redbaron
 	# Cleaning up previously-generated files before docbuild
 	rm -rf _srcdocs/*
 

--- a/openmdao/devtools/docs_experiment/conf.py
+++ b/openmdao/devtools/docs_experiment/conf.py
@@ -7,7 +7,7 @@ import importlib
 import textwrap
 
 from numpydoc.docscrape import NumpyDocString, Reader
-from mock import Mock
+from unittest.mock import Mock
 
 from openmdao.docs.config_params import MOCK_MODULES
 from openmdao.docs._utils.patch import do_monkeypatch

--- a/openmdao/devtools/docs_experiment/requirements.txt
+++ b/openmdao/devtools/docs_experiment/requirements.txt
@@ -1,4 +1,3 @@
-mock==2.0.0
 redbaron==0.6.3
 networkx==1.11
 numpy==1.12.1

--- a/openmdao/docs/Makefile
+++ b/openmdao/docs/Makefile
@@ -28,16 +28,16 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(SPHINXOPTS) .
 
 # to remake only recently-changed files, not the entire document base.
 #  note - first item in makefile is default action of "make"
-html-update: mock redbaron matplotlib build
+html-update: redbaron matplotlib build
 
 # to force the rebuild a file when its dependecy (e.g. code-embed) changes, not its rst file
 single: touch buildone
 
 # build it all over again (note: make all == make html)
-all html: make_srcdocs n2html mock redbaron matplotlib tagg buildall post_remove
+all html: make_srcdocs n2html redbaron matplotlib tagg buildall post_remove
 
 # build it all on CI machines; all warnings are raised as errors.
-travis: make_srcdocs n2html mock redbaron matplotlib tagg buildalltravis post_remove
+travis: make_srcdocs n2html redbaron matplotlib tagg buildalltravis post_remove
 
 clean:
 	rm -rf $(BUILDDIR)/*
@@ -95,10 +95,6 @@ post_remove:
 	rm -rf make_sourcedocs
 
 # installation testers
-mock:
-	@(python -c "import mock" >/dev/null 2>&1) || (echo "The 'mock' package \
-	is required to build the docs. Install with:\n pip install mock"; exit 1)
-
 redbaron:
 	@(python -c "import redbaron" >/dev/null 2>&1) || (echo "The 'redbaron' package \
 	is required to build the docs. Install with:\n pip install redbaron"; exit 1)

--- a/openmdao/docs/conf.py
+++ b/openmdao/docs/conf.py
@@ -5,7 +5,7 @@ import sys
 import os
 import importlib
 
-from mock import Mock
+from unittest.mock import Mock
 
 from openmdao.docs.config_params import MOCK_MODULES
 from openmdao.docs._utils.patch import do_monkeypatch

--- a/openmdao/docs/other/repo_guide/docs_with_sphinx.rst
+++ b/openmdao/docs/other/repo_guide/docs_with_sphinx.rst
@@ -72,16 +72,16 @@ can rebuild an .rst file whose embed-code dependency has changed, though the .rs
 
     # to remake only recently-changed files, not the entire document base.
     #  note - first item in makefile is default action of "make"
-    html-update: mock redbaron matplotlib build
+    html-update: redbaron matplotlib build
 
     # to force the rebuild a file when its dependecy (e.g. code-embed) changes, not its rst file
-    single: mock redbaron matplotlib touch build
+    single: redbaron matplotlib touch build
 
     # build it all over again (note: make all == make html)
-    all html: make_srcdocs mock redbaron matplotlib tagg buildall post_remove
+    all html: make_srcdocs redbaron matplotlib tagg buildall post_remove
 
     # build it all on CI machines; all warnings are raised as errors.
-    travis: make_srcdocs mock redbaron matplotlib tagg buildalltravis post_remove
+    travis: make_srcdocs redbaron matplotlib tagg buildalltravis post_remove
 
     clean:
         rm -rf $(BUILDDIR)/*

--- a/openmdao/docs/other/repo_guide/travis.rst
+++ b/openmdao/docs/other/repo_guide/travis.rst
@@ -56,7 +56,7 @@ That file looks something like this:
       fi
 
     install:
-    - conda install --yes python=$PY numpy scipy nose sphinx mock swig pip;
+    - conda install --yes python=$PY numpy scipy nose sphinx swig pip;
     - pip install --upgrade pip
     - sudo apt-get install gfortran
     - pip install numpy==1.14.1

--- a/openmdao/docs/requirements.txt
+++ b/openmdao/docs/requirements.txt
@@ -1,4 +1,3 @@
-mock==2.0.0
 redbaron==0.6.3
 networkx==1.11
 numpy==1.12.1

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -409,10 +409,7 @@ def set_pyoptsparse_opt(optname, fallback=True):
     if force:
         optname = force
 
-    try:
-        from mock import Mock
-    except ImportError:
-        Mock = None
+    from unittest.mock import Mock
 
     try:
         from pyoptsparse import OPT
@@ -428,7 +425,7 @@ def set_pyoptsparse_opt(optname, fallback=True):
                 except Exception:
                     pass
         else:
-            if fallback and Mock and isinstance(opt, Mock):
+            if fallback and isinstance(opt, Mock):
                 try:
                     opt = OPT('SLSQP')
                     OPTIMIZER = 'SLSQP'
@@ -437,7 +434,7 @@ def set_pyoptsparse_opt(optname, fallback=True):
     except Exception:
         pass
 
-    if Mock and isinstance(opt, Mock):
+    if isinstance(opt, Mock):
         OPT = OPTIMIZER = None
 
     if not fallback and OPTIMIZER != optname:

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ __version__ = re.findall(
 optional_dependencies = {
     'docs': [
         'matplotlib',
-        'mock',
         'numpydoc>=0.9.1',
         'redbaron',
         'sphinx>=1.8.5',


### PR DESCRIPTION
Available wherever python is >=3.3

### Backwards incompatibilities

None, only python >=3.6 is supported

### New Dependencies

Quite the opposite. :)