### PR TITLE
Fixed a bug where declaring partials wrt '*' caused extra subjacs for outputs wrt other outputs to be added to the subjacs.

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1181,16 +1181,11 @@ class Component(System):
         self._declared_partial_checks.append((wrt_list, method, form, step, step_calc,
                                               directional))
 
-    def _get_check_partial_options(self, include_wrt_outputs=True):
+    def _get_check_partial_options(self):
         """
         Return dictionary of partial options with pattern matches processed.
 
         This is called by check_partials.
-
-        Parameters
-        ----------
-        include_wrt_outputs : bool
-            If True, include outputs in the wrt list.
 
         Returns
         -------
@@ -1198,7 +1193,7 @@ class Component(System):
             Dictionary keyed by name with tuples of options (method, form, step, step_calc)
         """
         opts = {}
-        of, wrt = self._get_potential_partials_lists(include_wrt_outputs=include_wrt_outputs)
+        of, wrt = self._get_partials_varlists()
         invalid_wrt = []
         matrix_free = self.matrix_free
 
@@ -1434,7 +1429,7 @@ class Component(System):
         """
         of_list = [of] if isinstance(of, str) else of
         wrt_list = [wrt] if isinstance(wrt, str) else wrt
-        of, wrt = self._get_potential_partials_lists()
+        of, wrt = self._get_partials_varlists()
 
         of_pattern_matches = [(pattern, find_matches(pattern, of)) for pattern in of_list]
         wrt_pattern_matches = [(pattern, find_matches(pattern, wrt)) for pattern in wrt_list]

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -67,6 +67,13 @@ class ExplicitComponent(Component):
         """
         of = list(self._var_rel_names['output'])
         wrt = list(self._var_rel_names['input'])
+
+        # filter out any discrete inputs or outputs
+        if self._discrete_outputs:
+            of = [n for n in of if n not in self._discrete_outputs]
+        if self._discrete_inputs:
+            wrt = [n for n in wrt if n not in self._discrete_inputs]
+
         return of, wrt
 
     def _get_partials_var_sizes(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1129,14 +1129,13 @@ class Problem(object):
 
                 with comp._unscaled_context():
 
-                    imp = not explicit
-                    of_list, wrt_list = comp._get_potential_partials_lists(include_wrt_outputs=imp)
+                    of_list, wrt_list = comp._get_partials_varlists()
 
                     # Matrix-free components need to calculate their Jacobian by matrix-vector
                     # product.
                     if matrix_free:
                         print_reverse = True
-                        local_opts = comp._get_check_partial_options(include_wrt_outputs=imp)
+                        local_opts = comp._get_check_partial_options()
 
                         dstate = comp._vectors['output']['linear']
                         if mode == 'fwd':
@@ -1309,12 +1308,11 @@ class Problem(object):
 
             c_name = comp.pathname
             all_fd_options[c_name] = {}
-            explicit = isinstance(comp, ExplicitComponent)
 
             approximations = {'fd': FiniteDifference(),
                               'cs': ComplexStep()}
 
-            of, wrt = comp._get_potential_partials_lists(include_wrt_outputs=not explicit)
+            of, wrt = comp._get_partials_varlists()
 
             # Load up approximation objects with the requested settings.
             local_opts = comp._get_check_partial_options()

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2014,38 +2014,6 @@ class System(object):
             self._scope_cache[None] = (frozenset(self._var_abs2meta['output']), _empty_frozen_set)
             return self._scope_cache[None]
 
-    def _get_potential_partials_lists(self, include_wrt_outputs=True):
-        """
-        Return full lists of possible 'of' and 'wrt' variables.
-
-        Filters out any discrete variables.
-
-        Parameters
-        ----------
-        include_wrt_outputs : bool
-            If True, include outputs in the wrt list.
-
-        Returns
-        -------
-        list
-            List of 'of' variable names.
-        list
-            List of 'wrt' variable names.
-        """
-        of_list = list(self._var_allprocs_prom2abs_list['output'])
-        wrt_list = list(self._var_allprocs_prom2abs_list['input'])
-
-        # filter out any discrete inputs or outputs
-        if self._discrete_outputs:
-            of_list = [n for n in of_list if n not in self._discrete_outputs]
-        if self._discrete_inputs:
-            wrt_list = [n for n in wrt_list if n not in self._discrete_inputs]
-
-        if include_wrt_outputs:
-            wrt_list = of_list + wrt_list
-
-        return of_list, wrt_list
-
     @contextmanager
     def _unscaled_context(self, outputs=(), residuals=()):
         """
@@ -4110,6 +4078,12 @@ class System(object):
         """
         of = list(self._var_allprocs_prom2abs_list['output'])
         wrt = list(self._var_allprocs_prom2abs_list['input'])
+
+        # filter out any discrete inputs or outputs
+        if self._discrete_outputs:
+            of = [n for n in of if n not in self._discrete_outputs]
+        if self._discrete_inputs:
+            wrt = [n for n in wrt if n not in self._discrete_inputs]
 
         # wrt should include implicit states
         return of, of + wrt

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -972,9 +972,10 @@ class System(object):
                     self.declare_partials('*', '*', method=self._coloring_info['method'])
                 except AttributeError:  # this system must be a group
                     from openmdao.core.component import Component
+                    from openmdao.core.indepvarcomp import IndepVarComp
                     from openmdao.components.exec_comp import ExecComp
                     for s in self.system_iter(recurse=True, typ=Component):
-                        if not isinstance(s, ExecComp):
+                        if not isinstance(s, ExecComp) and not isinstance(s, IndepVarComp):
                             s.declare_partials('*', '*', method=self._coloring_info['method'])
                 self._setup_partials()
 


### PR DESCRIPTION
### Summary

Fixed a bug where declaring partials wrt '*' caused extra subjacs for outputs wrt other outputs to be added to the subjac dictionary. These were zero, so derivative computation was fine, but if total coloring was computed, the randomization sees all declared partials as nonzero values even if they were declared as zero.

To fix this, ExplicitComponents now no longer add outputs wrt outputs when the partials are declared with wildcards.


### Related Issues

- Resolves #1856

### Backwards incompatibilities

None

### New Dependencies

None
