### PR TITLE
Small bug fix to give better error message when promoting unit together with unitless inputs.

### DIFF
--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -123,7 +123,7 @@ class TestKSFunction(unittest.TestCase):
         stress0 = prob['parallel.sub_0.stress_comp.stress_0']
         stress1 = prob['parallel.sub_0.stress_comp.stress_1']
 
-        # Test that the the maximum constraint prior to aggregation is close to "active".
+        # Test that the maximum constraint prior to aggregation is close to "active".
         assert_near_equal(max(stress0), 100.0, tolerance=5e-2)
         assert_near_equal(max(stress1), 100.0, tolerance=5e-2)
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3468,8 +3468,11 @@ class Group(System):
         return auto_ivc
 
     def _resolve_ambiguous_input_meta(self):
-        # This should only be called on the top level Group.
+        """
+        Resolve ambiguous input units and values for auto_ivcs with multiple targets.
 
+        This should only be called on the top level Group.
+        """
         srcconns = {}
         for tgt, src in self._conn_global_abs_in2out.items():
             if src.startswith('_auto_ivc.'):
@@ -3514,9 +3517,16 @@ class Group(System):
                     tmeta = all_abs2meta_in[tgt]
                     tunits = tmeta['units'] if 'units' in tmeta else None
                     if 'units' not in gmeta and sunits != tunits:
-                        if _find_unit(sunits) != _find_unit(tunits):
+
+                        # Detect if either Source or Targe units are None.
+                        if sunits is None or tunits is None:
                             errs.add('units')
                             metadata.add('units')
+
+                        elif _find_unit(sunits) != _find_unit(tunits):
+                            errs.add('units')
+                            metadata.add('units')
+
                     if 'value' not in gmeta:
                         if tval.shape == sval.shape:
                             if _has_val_mismatch(tunits, tval, sunits, sval):

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1402,6 +1402,20 @@ class TestGroup(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
+    def test_promote_units_and_none(self):
+        p = om.Problem()
+
+        p.model.add_subsystem('c1', om.ExecComp('y1=x', x={'units': None}),
+                              promotes=['*'])
+        p.model.add_subsystem('c2', om.ExecComp('y2=x', x={'units': 's'}),
+                              promotes=['*'])
+
+        with self.assertRaises(Exception) as cm:
+            p.setup()
+
+        self.assertEqual(cm.exception.args[0],
+                         "<model> <class Group>: The following inputs, ['c1.x', 'c2.x'], promoted to 'x', are connected but their metadata entries ['units', 'value'] differ. Call <group>.set_input_defaults('x', units=?, val=?), where <group> is the model to remove the ambiguity.")
+
 
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestGroupMPISlice(unittest.TestCase):


### PR DESCRIPTION
Small bug fix to give better error message when promoting unit together with unitless inputs.

### Summary

Summary of PR.

### Related Issues

- Resolves #1865

### Backwards incompatibilities

None

### New Dependencies

None
