### PR TITLE
Fix to ensure that IPython is an optional import in the N2 viewer and connection viewer

### DIFF
--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -8,7 +8,10 @@ from collections import defaultdict
 
 import numpy as np
 
-from IPython.display import IFrame, display
+try:
+    from IPython.display import IFrame, display
+except ImportError:
+    IFrame = display = None
 
 import openmdao
 from openmdao.core.problem import Problem

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -4,12 +4,14 @@ import inspect
 import json
 import os
 import zlib
-from itertools import chain
 import networkx as nx
 
 import numpy as np
 
-from IPython.display import IFrame, display
+try:
+    from IPython.display import IFrame, display
+except ImportError:
+    IFrame = display = None
 
 from openmdao.components.exec_comp import ExecComp
 from openmdao.components.meta_model_structured_comp import MetaModelStructuredComp


### PR DESCRIPTION
### Summary

Fixes import error when loading n2_viewer.py and viewconns.py.
Since these are used in an `if notebook` block, the failure of `notebook_mode` to load IPython will ensure that those blocks are never executed if IPython is unavailable.

### Related Issues

- Resolves #1868 

### Backwards incompatibilities

None

### New Dependencies

None
