### PR TITLE
Fix for bug in doe when desvars have indices defined.

### DIFF
--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -314,7 +314,8 @@ class _pyDOE_Generator(DOEGenerator):
         list
             list of name, value tuples for the design variables.
         """
-        size = sum([meta['global_size'] for name, meta in design_vars.items()])
+        size = sum([meta['global_size'] if meta['distributed'] else meta['size']
+                    for name, meta in design_vars.items()])
 
         doe = self._generate_design(size)
 
@@ -326,7 +327,7 @@ class _pyDOE_Generator(DOEGenerator):
 
         row = 0
         for name, meta in design_vars.items():
-            size = meta['global_size']
+            size = meta['global_size'] if meta['distributed'] else meta['size']
 
             for k in range(size):
                 lower = meta['lower']
@@ -345,7 +346,7 @@ class _pyDOE_Generator(DOEGenerator):
             retval = []
             row = 0
             for name, meta in design_vars.items():
-                size = meta['global_size']
+                size = meta['global_size'] if meta['distributed'] else meta['size']
                 val = np.empty(size)
                 for k in range(size):
                     idx = idxs[row + k]

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1160,6 +1160,20 @@ class TestDOEDriver(unittest.TestCase):
                 self.assertEqual(outputs[name], expected_case[name])
                 self.assertTrue(isinstance(outputs[name], int))
 
+    def test_desvar_indices(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', om.ExecComp('y=x**2',
+                                                x=np.array([1., 2., 3.]),
+                                                y=np.zeros(3)), promotes=['*'])
+        prob.model.add_design_var('x', lower=7.0, upper=11.0, indices=[0])
+        prob.model.add_objective('y', index=0)
+        prob.driver = om.DOEDriver(om.FullFactorialGenerator(levels=3))
+        prob.setup()
+        prob.run_driver()
+
+        # Last value in fullfactorial DOE is 11, which gives 121.
+        assert_near_equal(prob.get_val('y'), np.array([121., 4., 9.]))
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 @use_tempdirs


### PR DESCRIPTION
### Summary

Fix for bug in doe when desvars have indices defined.

### Related Issues

- Resolves #1872

### Backwards incompatibilities

None

### New Dependencies

None
