### PR TITLE
Parallel analysis error fix

### DIFF
--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -654,15 +654,15 @@ class NonlinearSolver(Solver):
         # conditionals.
         if np.isinf(norm) or np.isnan(norm):
             msg = "Solver '{}' on system '{}': residuals contain 'inf' or 'NaN' after {} " + \
-                    "iterations."
+                  "iterations."
             if iprint > -1 and print_flag:
                 print(prefix + msg.format(self.SOLVER, system.pathname,
-                                            self._iter_count))
+                                          self._iter_count))
 
             # Raise AnalysisError if requested.
             if self.options['err_on_non_converge']:
                 raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                self._iter_count))
+                                               self._iter_count))
 
         # Solver hit maxiter without meeting desired tolerances.
         # Or solver stalled.
@@ -675,12 +675,12 @@ class NonlinearSolver(Solver):
 
             if iprint > -1 and print_flag:
                 print(prefix + msg.format(self.SOLVER, system.pathname,
-                                            self._iter_count))
+                                          self._iter_count))
 
             # Raise AnalysisError if requested.
             if self.options['err_on_non_converge']:
                 raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                self._iter_count))
+                                               self._iter_count))
 
         # Solver converged
         elif iprint == 1 and print_flag:
@@ -883,15 +883,15 @@ class LinearSolver(Solver):
         # conditionals.
         if np.isinf(norm) or np.isnan(norm):
             msg = "Solver '{}' on system '{}': residuals contain 'inf' or 'NaN' after {} " + \
-                    "iterations."
+                  "iterations."
             if iprint > -1 and print_flag:
                 print(prefix + msg.format(self.SOLVER, system.pathname,
-                                            self._iter_count))
+                                          self._iter_count))
 
             # Raise AnalysisError if requested.
             if self.options['err_on_non_converge']:
                 raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                self._iter_count))
+                                               self._iter_count))
 
         # Solver hit maxiter without meeting desired tolerances.
         elif (norm > atol and norm / norm0 > rtol):
@@ -899,12 +899,12 @@ class LinearSolver(Solver):
 
             if iprint > -1 and print_flag:
                 print(prefix + msg.format(self.SOLVER, system.pathname,
-                                            self._iter_count))
+                                          self._iter_count))
 
             # Raise AnalysisError if requested.
             if self.options['err_on_non_converge']:
                 raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                self._iter_count))
+                                               self._iter_count))
 
         # Solver converged
         elif iprint == 1 and print_flag:

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -644,46 +644,49 @@ class NonlinearSolver(Solver):
             self._mpi_print(self._iter_count, norm, norm / norm0)
 
         system = self._system()
-        if system.comm.rank == 0 or os.environ.get('USE_PROC_FILES'):
-            prefix = self._solver_info.prefix + self.SOLVER
 
-            # Solver terminated early because a Nan in the norm doesn't satisfy the while-loop
-            # conditionals.
-            if np.isinf(norm) or np.isnan(norm):
-                msg = "Solver '{}' on system '{}': residuals contain 'inf' or 'NaN' after {} " + \
-                      "iterations."
-                if iprint > -1:
-                    print(prefix + msg.format(self.SOLVER, system.pathname,
-                                              self._iter_count))
+        # flag for the print statements. we only print on root if USE_PROC_FILES is not set to True
+        print_flag = system.comm.rank == 0 or os.environ.get('USE_PROC_FILES')
 
-                # Raise AnalysisError if requested.
-                if self.options['err_on_non_converge']:
-                    raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                   self._iter_count))
+        prefix = self._solver_info.prefix + self.SOLVER
 
-            # Solver hit maxiter without meeting desired tolerances.
-            # Or solver stalled.
-            elif (norm > atol and norm / norm0 > rtol) or stalled:
+        # Solver terminated early because a Nan in the norm doesn't satisfy the while-loop
+        # conditionals.
+        if np.isinf(norm) or np.isnan(norm):
+            msg = "Solver '{}' on system '{}': residuals contain 'inf' or 'NaN' after {} " + \
+                    "iterations."
+            if iprint > -1 and print_flag:
+                print(prefix + msg.format(self.SOLVER, system.pathname,
+                                            self._iter_count))
 
-                if stalled:
-                    msg = "Solver '{}' on system '{}' stalled after {} iterations."
-                else:
-                    msg = "Solver '{}' on system '{}' failed to converge in {} iterations."
+            # Raise AnalysisError if requested.
+            if self.options['err_on_non_converge']:
+                raise AnalysisError(msg.format(self.SOLVER, system.pathname,
+                                                self._iter_count))
 
-                if iprint > -1:
-                    print(prefix + msg.format(self.SOLVER, system.pathname,
-                                              self._iter_count))
+        # Solver hit maxiter without meeting desired tolerances.
+        # Or solver stalled.
+        elif (norm > atol and norm / norm0 > rtol) or stalled:
 
-                # Raise AnalysisError if requested.
-                if self.options['err_on_non_converge']:
-                    raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                   self._iter_count))
+            if stalled:
+                msg = "Solver '{}' on system '{}' stalled after {} iterations."
+            else:
+                msg = "Solver '{}' on system '{}' failed to converge in {} iterations."
 
-            # Solver converged
-            elif iprint == 1:
-                print(prefix + ' Converged in {} iterations'.format(self._iter_count))
-            elif iprint == 2:
-                print(prefix + ' Converged')
+            if iprint > -1 and print_flag:
+                print(prefix + msg.format(self.SOLVER, system.pathname,
+                                            self._iter_count))
+
+            # Raise AnalysisError if requested.
+            if self.options['err_on_non_converge']:
+                raise AnalysisError(msg.format(self.SOLVER, system.pathname,
+                                                self._iter_count))
+
+        # Solver converged
+        elif iprint == 1 and print_flag:
+            print(prefix + ' Converged in {} iterations'.format(self._iter_count))
+        elif iprint == 2 and print_flag:
+            print(prefix + ' Converged')
 
     def _run_apply(self):
         """
@@ -870,41 +873,44 @@ class LinearSolver(Solver):
             self._mpi_print(self._iter_count, norm, norm / norm0)
 
         system = self._system()
-        if system.comm.rank == 0 or os.environ.get('USE_PROC_FILES'):
-            prefix = self._solver_info.prefix + self.SOLVER
 
-            # Solver terminated early because a Nan in the norm doesn't satisfy the while-loop
-            # conditionals.
-            if np.isinf(norm) or np.isnan(norm):
-                msg = "Solver '{}' on system '{}': residuals contain 'inf' or 'NaN' after {} " + \
-                      "iterations."
-                if iprint > -1:
-                    print(prefix + msg.format(self.SOLVER, system.pathname,
-                                              self._iter_count))
+        # flag for the print statements. we only print on root if USE_PROC_FILES is not set to True
+        print_flag = system.comm.rank == 0 or os.environ.get('USE_PROC_FILES')
 
-                # Raise AnalysisError if requested.
-                if self.options['err_on_non_converge']:
-                    raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                   self._iter_count))
+        prefix = self._solver_info.prefix + self.SOLVER
 
-            # Solver hit maxiter without meeting desired tolerances.
-            elif (norm > atol and norm / norm0 > rtol):
-                msg = "Solver '{}' on system '{}' failed to converge in {} iterations."
+        # Solver terminated early because a Nan in the norm doesn't satisfy the while-loop
+        # conditionals.
+        if np.isinf(norm) or np.isnan(norm):
+            msg = "Solver '{}' on system '{}': residuals contain 'inf' or 'NaN' after {} " + \
+                    "iterations."
+            if iprint > -1 and print_flag:
+                print(prefix + msg.format(self.SOLVER, system.pathname,
+                                            self._iter_count))
 
-                if iprint > -1:
-                    print(prefix + msg.format(self.SOLVER, system.pathname,
-                                              self._iter_count))
+            # Raise AnalysisError if requested.
+            if self.options['err_on_non_converge']:
+                raise AnalysisError(msg.format(self.SOLVER, system.pathname,
+                                                self._iter_count))
 
-                # Raise AnalysisError if requested.
-                if self.options['err_on_non_converge']:
-                    raise AnalysisError(msg.format(self.SOLVER, system.pathname,
-                                                   self._iter_count))
+        # Solver hit maxiter without meeting desired tolerances.
+        elif (norm > atol and norm / norm0 > rtol):
+            msg = "Solver '{}' on system '{}' failed to converge in {} iterations."
 
-            # Solver converged
-            elif iprint == 1:
-                print(prefix + ' Converged in {} iterations'.format(self._iter_count))
-            elif iprint == 2:
-                print(prefix + ' Converged')
+            if iprint > -1 and print_flag:
+                print(prefix + msg.format(self.SOLVER, system.pathname,
+                                            self._iter_count))
+
+            # Raise AnalysisError if requested.
+            if self.options['err_on_non_converge']:
+                raise AnalysisError(msg.format(self.SOLVER, system.pathname,
+                                                self._iter_count))
+
+        # Solver converged
+        elif iprint == 1 and print_flag:
+            print(prefix + ' Converged in {} iterations'.format(self._iter_count))
+        elif iprint == 2 and print_flag:
+            print(prefix + ' Converged')
 
     def _run_apply(self):
         """


### PR DESCRIPTION
### Summary

This PR fixes how the `AnalysisError` is raised in parallel runs with both linear and nonlinear solvers. Before this PR, the error was only raised on root unless the environment variable `USE_PROC_FILES` was set to True. The PR fixes it so that the convergence checks are performed on all procs in the comm, and similarly, all procs in the comm raise this error if desired. The behavior of the print statements are preserved; if `USE_PROC_FILES` is false or not set, only root prints, else, all procs print to their files.

I also added tests to check if the analysis error is raised properly on all procs when nonlinear or linear solvers fail. However, without this fix, these tests actually just hang and not explicitly fail. This is because the process hangs without the fix. Is there a way to trigger a failure for this case @JustinSGray? 

### Related Issues

- Resolves #1877

### Backwards incompatibilities

None

### New Dependencies

None
