### PR TITLE
Fixed N2 connections toolbar show/hide buttons

### DIFF
--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -75,18 +75,7 @@
                         <i class="fas icon-model-height" id="model-slider-button"></i>
                         <i class="fas icon-caret-right caret"></i>
                         <div class="toolbar-group-expandable" id="model-height-expandable">
-                            <input type="range" class="slider" id="model-slider" list="model-slider-data" min='50'
-                                max='200' value='95' />
-                            <datalist id="model-slider-data">
-                                <option value='50'></option>
-                                <option value='75'></option>
-                                <option value='95'></option>
-                                <option value='100'></option>
-                                <option value='125'></option>
-                                <option value='150'></option>
-                                <option value='175'></option>
-                                <option value='200'></option>
-                            </datalist>
+                            <input type="range" min='50' max='200' value='95' class="slider" id="model-slider"/>
                             <p id='model-slider-label'>95%</p>
                             <button id='model-slider-fit'>Fit</button>
                         </div>

--- a/openmdao/visualization/n2_viewer/src/N2Toolbar.js
+++ b/openmdao/visualization/n2_viewer/src/N2Toolbar.js
@@ -262,7 +262,7 @@ class N2Toolbar {
             });
 
         new N2ToolbarButtonClick('#hide-connections', tooltipBox,
-            "Remove all connection arrows",
+            "Control connection arrows",
             function (target) {
                 n2ui.n2Diag.clearArrows();
                 self._setRootButton(target);
@@ -283,7 +283,7 @@ class N2Toolbar {
             });
 
         new N2ToolbarButtonClick('#linear-solver-button', tooltipBox,
-            "Control Solver Tree Display",
+            "Control solver tree display",
             function (target) {
                 n2ui.setSolvers(true);
                 n2ui.showSolvers();

--- a/openmdao/visualization/n2_viewer/src/N2Toolbar.js
+++ b/openmdao/visualization/n2_viewer/src/N2Toolbar.js
@@ -261,6 +261,27 @@ class N2Toolbar {
                 self._setRootButton(target);
             });
 
+        new N2ToolbarButtonClick('#hide-connections', tooltipBox,
+            "Remove all connection arrows",
+            function (target) {
+                n2ui.n2Diag.clearArrows();
+                self._setRootButton(target);
+            });
+
+        new N2ToolbarButtonClick('#hide-connections-2', tooltipBox,
+            "Remove all connection arrows",
+            function (target) {
+                n2ui.n2Diag.clearArrows();
+                self._setRootButton(target);
+            });
+
+        new N2ToolbarButtonClick('#show-all-connections', tooltipBox,
+            "Show all connections in view",
+            function (target) {
+                n2ui.n2Diag.showAllArrows();
+                self._setRootButton(target);
+            });
+
         new N2ToolbarButtonClick('#linear-solver-button', tooltipBox,
             "Control Solver Tree Display",
             function (target) {

--- a/openmdao/visualization/n2_viewer/style/toolbar.css
+++ b/openmdao/visualization/n2_viewer/style/toolbar.css
@@ -417,11 +417,6 @@
     cursor: pointer;
 }
 
-.slider datalist {
-    color: white;
-    display: flex;
-}
-
 #model-slider-label {
     min-width: 30px;
     text-align: center;

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -203,6 +203,40 @@ n2_gui_test_scripts = {
             "selector": "g#n2elements > g.n2cell",
             "count": 40
         },
+        {
+            "desc": "Expand toolbar connections menu",
+            "test": "hover",
+            "selector": ".group-3 > div.expandable:first-child"
+        },
+        {
+            "desc": "Press toolbar show all connections button",
+            "test": "click",
+            "selector": "#show-all-connections",
+            "button": "left"
+        },
+        {
+            "desc": "Check number of arrows",
+            "test": "count",
+            "selector": "g#n2arrows > g",
+            "count": 44
+        },
+        {
+            "desc": "Expand toolbar connections menu",
+            "test": "hover",
+            "selector": ".group-3 > div.expandable:first-child"
+        },
+        {
+            "desc": "Press toolbar hide all connections button",
+            "test": "click",
+            "selector": "#hide-connections-2",
+            "button": "left"
+        },
+        {
+            "desc": "Check number of arrows",
+            "test": "count",
+            "selector": "g#n2arrows > g",
+            "count": 0
+        }
     ],
     "bug_arrow": [
         {
@@ -624,7 +658,7 @@ class n2_gui_test_case(unittest.TestCase):
 
         return handle
 
-    async def hover(self, options, log_test = True):
+    async def hover(self, options, log_test=True):
         """
         Hover over the specified element.
         """
@@ -674,7 +708,7 @@ class n2_gui_test_case(unittest.TestCase):
                       "Dragging '" + options['selector'] + "' to " + options['x'] + "," + options['y'])
 
         hndl = await self.get_handle(options['selector'])
-        
+
         pre_drag_bbox = await hndl.boundingBox()
 
         await hndl.hover()
@@ -686,8 +720,8 @@ class n2_gui_test_case(unittest.TestCase):
         post_drag_bbox = await hndl.boundingBox()
 
         moved = ((pre_drag_bbox['x'] != post_drag_bbox['x']) or
-            (pre_drag_bbox['y'] != post_drag_bbox['y']))
-        
+                 (pre_drag_bbox['y'] != post_drag_bbox['y']))
+
         self.assertIsNot(moved, False,
                          "The '" + options['selector'] + "' element did not move.")
 
@@ -703,12 +737,14 @@ class n2_gui_test_case(unittest.TestCase):
 
         win_hndl = await self.get_handle(options['selector'])
         pre_resize_bbox = await win_hndl.boundingBox()
-        
+
         edge_hndl = await self.get_handle(options['selector'] + ' div.rsz-' + options['side'])
         edge_bbox = await edge_hndl.boundingBox()
 
-        new_x = edge_bbox['x'] + resize_dirs[options['side']][0] * options['distance']
-        new_y = edge_bbox['y'] + resize_dirs[options['side']][1] * options['distance']
+        new_x = edge_bbox['x'] + \
+            resize_dirs[options['side']][0] * options['distance']
+        new_y = edge_bbox['y'] + \
+            resize_dirs[options['side']][1] * options['distance']
 
         await edge_hndl.hover()
         await self.page.mouse.down()
@@ -722,10 +758,10 @@ class n2_gui_test_case(unittest.TestCase):
         resized = ((dw != 0) or (dh != 0))
         if options['expectChange']:
             self.assertIsNot(resized, False,
-                         "The '" + options['selector'] + "' element was NOT resized and should have been.")
+                             "The '" + options['selector'] + "' element was NOT resized and should have been.")
         else:
             self.assertIsNot(resized, True,
-                         "The '" + options['selector'] + "' element was resized and should NOT have been.")
+                             "The '" + options['selector'] + "' element was resized and should NOT have been.")
 
         # await self.page.screenshot({'path': 'postresize.png'})
 


### PR DESCRIPTION
### Summary

The code for the toolbar connections buttons was accidentally removed when the hide solvers button was added. This fix restores it and adds a test for the buttons.

The positioning of the model height slider was also fixed (the slider button had been offset downwards).

### Related Issues

- Resolves #1879

### Backwards incompatibilities

None

### New Dependencies

None
