### PR TITLE
Defined _mpi_print_header() in Solver instead of subclasses

### DIFF
--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -630,22 +630,6 @@ class BroydenSolver(NonlinearSolver):
 
         return inv_jac
 
-    def _mpi_print_header(self):
-        """
-        Print header text before solving.
-        """
-        if self.options['iprint'] > 0 and self._system().comm.rank == 0:
-
-            pathname = self._system().pathname
-            if pathname:
-                nchar = len(pathname)
-                prefix = self._solver_info.prefix
-                header = prefix + "\n"
-                header += prefix + nchar * "=" + "\n"
-                header += prefix + pathname + "\n"
-                header += prefix + nchar * "="
-                print(header)
-
     def cleanup(self):
         """
         Clean up resources prior to exit.

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -266,22 +266,6 @@ class NewtonSolver(NonlinearSolver):
             if self.linear_solver._assembled_jac is not None:
                 self.linear_solver._assembled_jac.set_complex_step_mode(active)
 
-    def _mpi_print_header(self):
-        """
-        Print header text before solving.
-        """
-        if (self.options['iprint'] > 0 and self._system().comm.rank == 0):
-
-            pathname = self._system().pathname
-            if pathname:
-                nchar = len(pathname)
-                prefix = self._solver_info.prefix
-                header = prefix + "\n"
-                header += prefix + nchar * "=" + "\n"
-                header += prefix + pathname + "\n"
-                header += prefix + nchar * "="
-                print(header)
-
     def cleanup(self):
         """
         Clean up resources prior to exit.

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -243,19 +243,3 @@ class NonlinearBlockGS(NonlinearSolver):
             self._solver_info.pop()
             with system._unscaled_context(residuals=[residuals]):
                 residuals.set_val(outputs.asarray() - outputs_n)
-
-    def _mpi_print_header(self):
-        """
-        Print header text before solving.
-        """
-        if (self.options['iprint'] > 0 and self._system().comm.rank == 0):
-
-            pathname = self._system().pathname
-            if pathname:
-                nchar = len(pathname)
-                prefix = self._solver_info.prefix
-                header = prefix + "\n"
-                header += prefix + nchar * "=" + "\n"
-                header += prefix + pathname + "\n"
-                header += prefix + nchar * "="
-                print(header)

--- a/openmdao/solvers/nonlinear/nonlinear_block_jac.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_jac.py
@@ -35,22 +35,6 @@ class NonlinearBlockJac(NonlinearSolver):
 
         self._solver_info.pop()
 
-    def _mpi_print_header(self):
-        """
-        Print header text before solving.
-        """
-        if (self.options['iprint'] > 0):
-
-            pathname = self._system().pathname
-            if pathname:
-                nchar = len(pathname)
-                prefix = self._solver_info.prefix
-                header = prefix + "\n"
-                header += prefix + nchar * "=" + "\n"
-                header += prefix + pathname + "\n"
-                header += prefix + nchar * "="
-                print(header)
-
     def _run_apply(self):
         """
         Run the apply_nonlinear method on the system.

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -356,8 +356,8 @@ class Solver(object):
         rel_res : float
             current relative residual norm.
         """
-        if self.options['iprint'] == 2 and \
-        (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES')):
+        if (self.options['iprint'] == 2 and
+            (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES'))):
 
             prefix = self._solver_info.prefix
             solver_name = self.SOLVER
@@ -373,8 +373,8 @@ class Solver(object):
         """
         Print header text before solving.
         """
-        if self.options['iprint'] > 0 and \
-        (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES')):
+        if (self.options['iprint'] > 0 and
+            (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES'))):
 
             pathname = self._system().pathname
             if pathname:

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -357,7 +357,7 @@ class Solver(object):
             current relative residual norm.
         """
         if (self.options['iprint'] == 2 and
-            (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES'))):
+                (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES'))):
 
             prefix = self._solver_info.prefix
             solver_name = self.SOLVER
@@ -374,7 +374,7 @@ class Solver(object):
         Print header text before solving.
         """
         if (self.options['iprint'] > 0 and
-            (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES'))):
+                (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES'))):
 
             pathname = self._system().pathname
             if pathname:

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -356,7 +356,8 @@ class Solver(object):
         rel_res : float
             current relative residual norm.
         """
-        if (self.options['iprint'] == 2 and self._system().comm.rank == 0):
+        if self.options['iprint'] == 2 and \
+        (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES')):
 
             prefix = self._solver_info.prefix
             solver_name = self.SOLVER
@@ -372,7 +373,18 @@ class Solver(object):
         """
         Print header text before solving.
         """
-        pass
+        if self.options['iprint'] > 0 and \
+        (self._system().comm.rank == 0 or os.environ.get('USE_PROC_FILES')):
+
+            pathname = self._system().pathname
+            if pathname:
+                nchar = len(pathname)
+                prefix = self._solver_info.prefix
+                header = prefix + "\n"
+                header += prefix + nchar * "=" + "\n"
+                header += prefix + pathname + "\n"
+                header += prefix + nchar * "="
+                print(header)
 
     def _iter_initialize(self):
         """


### PR DESCRIPTION
### Summary

`_mpi_print_header()` was defined redundantly in four different Solver subclasses. This change moves it to the Solver base class, and adds a check for USE_PROC_FILES. The check was also added to `Solver._mpi_print()`.

### Related Issues

- Resolves #1876 

### Backwards incompatibilities

None

### New Dependencies

None
