### PR TITLE
Added debug printing for totals for approx_totals

### DIFF
--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -319,8 +319,8 @@ class TestDriver(unittest.TestCase):
         finally:
             sys.stdout = stdout
         output = strout.getvalue().split('\n')
-        self.assertEqual(output[8], "{('obj_cmp.obj', '_auto_ivc.v0'): array([[9.61001157, 1.78448532]])}")
-        self.assertEqual(output[9], "{('con_cmp1.con1', '_auto_ivc.v0'): array([[-9.61002287, -0.78449156]])}")
+        self.assertIn("{('obj_cmp.obj', '_auto_ivc.v0'):", output[12])
+        self.assertIn("{('con_cmp1.con1', '_auto_ivc.v0'):", output[13])
 
     def test_debug_print_desvar_physical_with_indices(self):
         prob = om.Problem()

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -288,6 +288,39 @@ class TestDriver(unittest.TestCase):
             prob.driver.options['debug_print'] = ['bad_option']
         self.assertEqual(str(context.exception),
                          "Option 'debug_print' contains value 'bad_option' which is not one of ['desvars', 'nl_cons', 'ln_cons', 'objs', 'totals'].")
+                         
+    def test_debug_print_approx(self):
+
+        prob = om.Problem()
+        prob.model = model = SellarDerivatives()
+
+        model.add_design_var('z')
+        model.add_objective('obj')
+        model.add_constraint('con1', lower=0)
+        model.add_constraint('con2', lower=0, linear=True)
+        prob.set_solver_print(level=0)
+        
+        prob.driver = om.ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.options['tol'] = 1e-9
+        prob.driver.options['disp'] = False
+        prob.driver.options['maxiter'] = 0
+        
+        prob.model.approx_totals()
+        prob.driver.options['debug_print'] = ['totals']
+
+        prob.setup()
+
+        stdout = sys.stdout
+        strout = StringIO()
+        sys.stdout = strout
+        try:
+            prob.run_driver()
+        finally:
+            sys.stdout = stdout
+        output = strout.getvalue().split('\n')
+        self.assertEqual(output[8], "{('obj_cmp.obj', '_auto_ivc.v0'): array([[9.61001157, 1.78448532]])}")
+        self.assertEqual(output[9], "{('con_cmp1.con1', '_auto_ivc.v0'): array([[-9.61002287, -0.78449156]])}")
 
     def test_debug_print_desvar_physical_with_indices(self):
         prob = om.Problem()

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1519,7 +1519,7 @@ class _TotalJacInfo(object):
                                 model._solve_linear(model._lin_vec_names, mode, rel_systems)
 
                     if debug_print:
-                        print('Elapsed Time:', time.time() - t0, '\n', flush=True)
+                        print(f'Elapsed Time: {time.time() - t0} secs\n', flush=True)
 
                     jac_setter(inds, mode)
 
@@ -1601,6 +1601,8 @@ class _TotalJacInfo(object):
         wrt_idx = model._owns_approx_wrt_idx
         wrt_meta = self.wrt_meta
 
+        t0 = time.time()
+
         totals = self.J_dict
         if return_format == 'flat_dict':
             for prom_out, output_name in zip(self.prom_of, of):
@@ -1653,9 +1655,13 @@ class _TotalJacInfo(object):
                         tot[prom_in][:] = _get_subjac(approx_jac[output_name, input_name],
                                                       prom_out, prom_in, ofidx, wrtidx,
                                                       dist_resp, comm)
+
         else:
             msg = "Unsupported return format '%s." % return_format
             raise NotImplementedError(msg)
+
+        if debug_print:
+            print(f'Elapsed time to approx totals: {time.time() - t0} secs\n', flush=True)
 
         # Driver scaling.
         if self.has_scaling:
@@ -1663,7 +1669,7 @@ class _TotalJacInfo(object):
 
         if return_format == 'array':
             totals = self.J  # change back to array version
-            
+
         if debug_print:
             # Debug outputs scaled derivatives.
             self._print_derivatives()

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1557,6 +1557,7 @@ class _TotalJacInfo(object):
         model = self.model
         comm = model.comm
         return_format = self.return_format
+        debug_print = self.debug_print
 
         # Prepare model for calculation by cleaning out the derivatives
         # vectors.
@@ -1662,6 +1663,10 @@ class _TotalJacInfo(object):
 
         if return_format == 'array':
             totals = self.J  # change back to array version
+            
+        if debug_print:
+            # Debug outputs scaled derivatives.
+            self._print_derivatives()
 
         return totals
 


### PR DESCRIPTION
### Summary

The `totals` option for `debug_print` did nothing if using `approx_totals`, until this PR.
Please let me know if I missed some other logic necessary for this to be correct -- it's working for our problems.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
