### PR TITLE
Updated docstrings for check argument in Problem methods setup and check_config

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -829,8 +829,15 @@ class Problem(object):
 
         Parameters
         ----------
-        check : boolean
-            whether to run config check after setup is complete.
+        check : None, boolean, list of strings, or the string ‘all’
+           Determines what config checks, if any, are run after setup is complete.
+           If None or False, no checks are run
+           If True, the default checks ('out_of_order', 'system', 'solvers', 'dup_inputs',
+             'missing_recorders', 'comp_has_no_outputs', 'auto_ivc_warnings') are run
+           If list of str, run those config checks
+           If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
+             'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
+             'system', 'unconnected_inputs') are run
         logger : object
             Object for logging config checks if check is True.
         mode : string
@@ -1850,7 +1857,7 @@ class Problem(object):
                                    "found in the model".format(self.msginfo, name))
                 self[name] = outputs[name]
 
-    def check_config(self, logger=None, checks=None, out_file='openmdao_checks.out'):
+    def check_config(self, logger=None, checks=_default_checks, out_file='openmdao_checks.out'):
         """
         Perform optional error checks on a Problem.
 
@@ -1858,17 +1865,23 @@ class Problem(object):
         ----------
         logger : object
             Logging object.
-        checks : list of str or None
-            List of specific checks to be performed.
+        checks : list of str or None or the string 'all'
+           Determines what config checks are run.
+           If None, no checks are run
+           If list of str, run those config checks
+           If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
+             'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
+             'system', 'unconnected_inputs') are run
         out_file : str or None
             If not None, output will be written to this file in addition to stdout.
         """
+        if checks is None:
+            return
+
         if logger is None:
             logger = get_logger('check_config', out_file=out_file, use_format=True)
 
-        if checks is None:
-            checks = sorted(_default_checks)
-        elif checks == 'all':
+        if checks == 'all':
             checks = sorted(_all_checks)
 
         for c in checks:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -833,11 +833,11 @@ class Problem(object):
             Determines what config checks, if any, are run after setup is complete.
             If None or False, no checks are run
             If True, the default checks ('out_of_order', 'system', 'solvers', 'dup_inputs',
-             'missing_recorders', 'comp_has_no_outputs', 'auto_ivc_warnings') are run
+            'missing_recorders', 'comp_has_no_outputs', 'auto_ivc_warnings') are run
             If list of str, run those config checks
             If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
-             'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
-             'system', 'unconnected_inputs') are run
+            'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
+            'system', 'unconnected_inputs') are run
         logger : object
             Object for logging config checks if check is True.
         mode : string
@@ -1870,8 +1870,8 @@ class Problem(object):
             If None, no checks are run
             If list of str, run those config checks
             If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
-             'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
-             'system', 'unconnected_inputs') are run
+            'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
+            'system', 'unconnected_inputs') are run
         out_file : str or None
             If not None, output will be written to this file in addition to stdout.
         """

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -830,12 +830,12 @@ class Problem(object):
         Parameters
         ----------
         check : None, boolean, list of strings, or the string ‘all’
-           Determines what config checks, if any, are run after setup is complete.
-           If None or False, no checks are run
-           If True, the default checks ('out_of_order', 'system', 'solvers', 'dup_inputs',
+            Determines what config checks, if any, are run after setup is complete.
+            If None or False, no checks are run
+            If True, the default checks ('out_of_order', 'system', 'solvers', 'dup_inputs',
              'missing_recorders', 'comp_has_no_outputs', 'auto_ivc_warnings') are run
-           If list of str, run those config checks
-           If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
+            If list of str, run those config checks
+            If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
              'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
              'system', 'unconnected_inputs') are run
         logger : object
@@ -1866,10 +1866,10 @@ class Problem(object):
         logger : object
             Logging object.
         checks : list of str or None or the string 'all'
-           Determines what config checks are run.
-           If None, no checks are run
-           If list of str, run those config checks
-           If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
+            Determines what config checks are run.
+            If None, no checks are run
+            If list of str, run those config checks
+            If ‘all’, all the checks ('auto_ivc_warnings', 'comp_has_no_outputs', 'cycles',
              'dup_inputs', 'missing_recorders', 'out_of_order', 'promotions', 'solvers',
              'system', 'unconnected_inputs') are run
         out_file : str or None

--- a/openmdao/docs/theory_manual/setup_stack.rst
+++ b/openmdao/docs/theory_manual/setup_stack.rst
@@ -16,8 +16,9 @@ Setup also performs some level of model checking, mainly for critical errors. Mo
 checking can be done by setting "check" when calling `setup`, or by using the :ref:`openmdao command
 line check<om-command>`. It is recommended that you do this after making any changes to the configuration
 of your model.  The "check" argument to `setup` can be set to `True`, which will cause a default
-set of checks to run.  It can also be set to 'all', which will run all available checks.  Finally,
-it can be set to a specific list of checks to run.  The checks that are available can be
+set of checks to run.  It can also be set to 'all', which will run all available checks.
+A value of `None` or `True` will result in no checks being run. Finally,
+it can be set to a specific list of checks to run as a list of strings.  The checks that are available can be
 determined by running the following command:
 
 .. embed-shell-cmd::


### PR DESCRIPTION
### Summary

The docstrings for the check_config and setup methods of Problem needed updating to reflect the current code. 

Also modified the default for check argument and behavior of the check_config method to match that of the setup method

### Related Issues

- Resolves #1657 

### Backwards incompatibilities

None

### New Dependencies

None
