### PR TITLE
Cleaned up pyoptSparseDriver error handling so that unhandled exceptions are re-raised in place of the cryptic pyoptsparse one.

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -422,7 +422,6 @@ class pyOptSparseDriver(Driver):
             opt.setOption(option, value)
 
         self._exc_info = None
-        pyopt_exception = False
         try:
 
             # Execute the optimization problem
@@ -455,7 +454,6 @@ class pyOptSparseDriver(Driver):
                           storeHistory=self.hist_file, hotStart=self.hotstart_file)
 
         except Exception as _:
-            pyopt_exception = True
             if not self._exc_info:
                 raise()
 

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -9,8 +9,6 @@ additional MPI capability.
 from collections import OrderedDict
 import json
 import signal
-import sys
-import traceback
 
 import numpy as np
 from scipy.sparse import coo_matrix

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -128,6 +128,8 @@ class pyOptSparseDriver(Driver):
         Dictionary for setting optimizer-specific options.
     pyopt_solution : Solution
         Pyopt_sparse solution object.
+    _exc_info : None or <Exception>
+        Cached exception that was raised in the _objfunc or _gradfunc callbacks.
     _in_user_function :bool
         This is set to True at the start of a pyoptsparse callback to _objfunc and _gradfunc, and
         restored to False at the finish of each callback.
@@ -190,6 +192,7 @@ class pyOptSparseDriver(Driver):
         self._signal_cache = None
         self._user_termination_flag = False
         self._in_user_function = False
+        self._exc_info = None
 
         self.cite = CITATIONS
 
@@ -418,33 +421,46 @@ class pyOptSparseDriver(Driver):
         for option, value in self.opt_settings.items():
             opt.setOption(option, value)
 
-        # Execute the optimization problem
-        if self.options['gradient method'] == 'pyopt_fd':
+        self._exc_info = None
+        pyopt_exception = False
+        try:
 
-            # Use pyOpt's internal finite difference
-            # TODO: Need to get this from OpenMDAO
-            # fd_step = problem.model.deriv_options['step_size']
-            fd_step = 1e-6
-            sol = opt(opt_prob, sens='FD', sensStep=fd_step, storeHistory=self.hist_file,
-                      hotStart=self.hotstart_file)
+            # Execute the optimization problem
+            if self.options['gradient method'] == 'pyopt_fd':
 
-        elif self.options['gradient method'] == 'snopt_fd':
-            if self.options['optimizer'] == 'SNOPT':
-
-                # Use SNOPT's internal finite difference
+                # Use pyOpt's internal finite difference
                 # TODO: Need to get this from OpenMDAO
                 # fd_step = problem.model.deriv_options['step_size']
                 fd_step = 1e-6
-                sol = opt(opt_prob, sens=None, sensStep=fd_step, storeHistory=self.hist_file,
+                sol = opt(opt_prob, sens='FD', sensStep=fd_step, storeHistory=self.hist_file,
                           hotStart=self.hotstart_file)
 
-            else:
-                raise Exception("SNOPT's internal finite difference can only be used with SNOPT")
-        else:
+            elif self.options['gradient method'] == 'snopt_fd':
+                if self.options['optimizer'] == 'SNOPT':
 
-            # Use OpenMDAO's differentiator for the gradient
-            sol = opt(opt_prob, sens=weak_method_wrapper(self, '_gradfunc'),
-                      storeHistory=self.hist_file, hotStart=self.hotstart_file)
+                    # Use SNOPT's internal finite difference
+                    # TODO: Need to get this from OpenMDAO
+                    # fd_step = problem.model.deriv_options['step_size']
+                    fd_step = 1e-6
+                    sol = opt(opt_prob, sens=None, sensStep=fd_step, storeHistory=self.hist_file,
+                              hotStart=self.hotstart_file)
+
+                else:
+                    msg = "SNOPT's internal finite difference can only be used with SNOPT"
+                    self._exc_info = Exception(msg)
+            else:
+
+                # Use OpenMDAO's differentiator for the gradient
+                sol = opt(opt_prob, sens=weak_method_wrapper(self, '_gradfunc'),
+                          storeHistory=self.hist_file, hotStart=self.hotstart_file)
+
+        except Exception as _:
+            pyopt_exception = True
+            if not self._exc_info:
+                raise()
+
+        if self._exc_info:
+            raise self._exc_info
 
         # Print results
         if self.options['print_results']:
@@ -561,13 +577,8 @@ class pyOptSparseDriver(Driver):
                 rec.abs = 0.0
                 rec.rel = 0.0
 
-        except Exception as msg:
-            tb = traceback.format_exc()
-
-            # Exceptions seem to be swallowed by the C code, so this
-            # should give the user more info than the dreaded "segfault"
-            print("Exception: %s" % str(msg))
-            print(70 * "=", tb, 70 * "=")
+        except Exception as raised:
+            self._exc_info = raised
             fail = 1
             func_dict = {}
 
@@ -658,13 +669,9 @@ class pyOptSparseDriver(Driver):
                         isize = len(ival)
                         sens_dict[okey][ikey] = np.zeros((osize, isize))
 
-        except Exception as msg:
-            tb = traceback.format_exc()
-
-            # Exceptions seem to be swallowed by the C code, so this
-            # should give the user more info than the dreaded "segfault"
-            print("Exception: %s" % str(msg))
-            print(70 * "=", tb, 70 * "=", flush=True)
+        except Exception as raised:
+            self._exc_info = raised
+            fail = 1
             sens_dict = {}
 
         # print("Derivatives calculated")

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2071,7 +2071,7 @@ class TestPyoptSparse(unittest.TestCase):
         p.model.add_design_var('comp.x')
 
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['optimizer'] = 'SLSQP'
 
         p.setup()
 
@@ -2102,7 +2102,7 @@ class TestPyoptSparse(unittest.TestCase):
         p.model.add_design_var('comp.x')
 
         p.driver = om.pyOptSparseDriver()
-        p.driver.options['optimizer'] = 'SNOPT'
+        p.driver.options['optimizer'] = 'SLSQP'
 
         p.setup()
 

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2050,6 +2050,68 @@ class TestPyoptSparse(unittest.TestCase):
         assert_near_equal(prob['obj_cmp.obj'][0], 3.183, 1e-3)
 
 
+    def test_error_objfun_reraise(self):
+        # Tests that we re-raise any unclassified error encountered during callback eval.
+
+        class EComp(om.ExplicitComponent):
+
+            def setup(self):
+                self.add_input('x', 1.0)
+                self.add_output('y', 1.0)
+
+                self.declare_partials('*', '*', method='fd')
+
+            def compute(self, inputs, outputs):
+                raise RuntimeError('This comp will fail.')
+
+        p = om.Problem()
+        p.model.add_subsystem('comp', EComp())
+
+        p.model.add_objective('comp.y')
+        p.model.add_design_var('comp.x')
+
+        p.driver = om.pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+
+        p.setup()
+
+        with self.assertRaises(RuntimeError) as msg:
+            p.run_driver()
+
+        self.assertTrue("This comp will fail." in msg.exception.args[0])
+
+    def test_error_gradfun_reraise(self):
+        # Tests that we re-raise any unclassified error encountered during callback eval.
+
+        class EComp(om.ExplicitComponent):
+
+            def setup(self):
+                self.add_input('x', 1.0)
+                self.add_output('y', 1.0)
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = 4.8 * inputs['x'] - 3.0
+
+            def compute_partials(self, inputs, partials):
+                raise RuntimeError('This gradient will fail.')
+
+        p = om.Problem()
+        p.model.add_subsystem('comp', EComp())
+
+        p.model.add_objective('comp.y')
+        p.model.add_design_var('comp.x')
+
+        p.driver = om.pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'SNOPT'
+
+        p.setup()
+
+        with self.assertRaises(RuntimeError) as msg:
+            p.run_driver()
+
+        self.assertTrue("This gradient will fail." in msg.exception.args[0])
+
+
 @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
 @use_tempdirs
 class TestPyoptSparseFeature(unittest.TestCase):


### PR DESCRIPTION
### Summary

Changed error handling in pyoptsparse so that any unhandled errors that are raised during function or gradient evaluation are cached and reraised at the top. This eliminates the need to scroll back past a cryptic pyoptsparse exception to find the real printed exception.

### Related Issues

- Resolves #1922

### Backwards incompatibilities

None

### New Dependencies

None
