### PR TITLE
Added `to_table` method to OptionsDictionary to provide `embed_options` replacement capability in Jupyter.

### DIFF
--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -105,15 +105,39 @@ class OptionsDictionary(object):
         list of str
             A rendition of the options as an rST table.
         """
-        outputs = []
-        for option_name, option_data in sorted(self._dict.items()):
-            name = option_name
-            default = option_data['value'] if option_data['value'] is not _UNDEFINED \
-                else '**Required**'
-            values = option_data['values']
-            types = option_data['types']
-            desc = option_data['desc']
+        lines = self.to_table(fmt='rst').split('\n')
+        return lines
 
+    def to_table(self, fmt='github', missingval='N/A'):
+        """
+        Get a table representation of this OptionsDictionary as a table in the requested format.
+
+        Parameters
+        ----------
+        fmt : str
+            The formatting of the requested table.  Options are the same as those available
+            to the tabulate package.  See tabulate.tabulate_formats for a complete list.
+            Default value of 'github' produces a table in GitHub-flavored markdown.
+        missingval : str
+            The value to be displayed in place of None.
+
+        Returns
+        -------
+        str
+            A string representation of the table in the requested format.
+        """
+        try:
+            from tabulate import tabulate
+        except ImportError as e:
+            msg = "'to_table' requires the tabulate package but it is not currently installed." \
+                  " Use `pip install tablulate` or install openmdao with" \
+                  " `pip install openmdao[notebooks]`."
+            raise ImportError(msg)
+
+        tlist = [['Option', 'Default', 'Acceptable Values', 'Acceptable Types', 'Description']]
+        for key in sorted(self._dict.keys()):
+            options = self._dict[key]
+            default = options['value'] if options['value'] is not _UNDEFINED else '**Required**'
             # if the default is an object instance, replace with the (unqualified) object type
             default_str = str(default)
             idx = default_str.find(' object at ')
@@ -121,72 +145,21 @@ class OptionsDictionary(object):
                 parts = default_str[:idx].split('.')
                 default = parts[-1]
 
-            if types is None:
-                types = "N/A"
+            acceptable_values = options['values']
+            if acceptable_values is not None:
+                if not isinstance(acceptable_values, (set, tuple, list)):
+                    acceptable_values = (acceptable_values,)
+                acceptable_values = [value for value in acceptable_values]
 
-            elif types is not None:
-                if not isinstance(types, (set, tuple, list)):
-                    types = (types,)
+            acceptable_types = options['types']
+            if acceptable_types is not None:
+                if not isinstance(acceptable_types, (set, tuple, list)):
+                    acceptable_types = (acceptable_types,)
+                acceptable_types = [type_.__name__ for type_ in acceptable_types]
 
-                types = [type_.__name__ for type_ in types]
-
-            if values is None:
-                values = "N/A"
-
-            elif values is not None:
-                if not isinstance(values, (set, tuple, list)):
-                    values = (values,)
-
-                values = [value for value in values]
-
-            outputs.append([name, default, values, types, desc])
-
-        lines = []
-
-        col_heads = ['Option', 'Default', 'Acceptable Values', 'Acceptable Types', 'Description']
-
-        max_sizes = {}
-        for j, col in enumerate(col_heads):
-            max_sizes[j] = len(col)
-
-        for output in outputs:
-            for j, item in enumerate(output):
-                length = len(str(item))
-                if max_sizes[j] < length:
-                    max_sizes[j] = length
-
-        header = ""
-        titles = ""
-        for key, val in max_sizes.items():
-            header += '=' * val + ' '
-
-        for j, head in enumerate(col_heads):
-            titles += "%s " % head
-            size = max_sizes[j]
-            space = size - len(head)
-            if space > 0:
-                titles += space * ' '
-
-        lines.append(header)
-        lines.append(titles)
-        lines.append(header)
-
-        n = 3
-        for output in outputs:
-            line = ""
-            for j, item in enumerate(output):
-                line += "%s " % str(item)
-                size = max_sizes[j]
-                space = size - len(str(item))
-                if space > 0:
-                    line += space * ' '
-
-            lines.append(line)
-            n += 1
-
-        lines.append(header)
-
-        return lines
+            desc = options['desc']
+            tlist.append([key, default, acceptable_values, acceptable_types, desc])
+        return tabulate(tlist, headers='firstrow', tablefmt=fmt, missingval=missingval)
 
     def __str__(self, width=100):
         """
@@ -202,9 +175,9 @@ class OptionsDictionary(object):
         str
             A text representation of the options table.
         """
-        rst = self.__rst__()
+        rst = self.to_table(fmt='rst').split('\n')
         cols = [len(header) for header in rst[0].split()]
-        desc_col = sum(cols[:-1]) + len(cols) - 1
+        desc_col = sum(cols[:-1]) + 2 * (len(cols) - 1)
         desc_len = width - desc_col
 
         # if it won't fit in allowed width, just return the rST

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -6,6 +6,11 @@ from openmdao.utils.assert_utils import assert_warning, assert_no_warning
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 
+try:
+    import tabulate
+except ImportError:
+    tabulate = None
+
 
 def check_even(name, value):
     if value % 2 != 0:
@@ -17,6 +22,7 @@ class TestOptionsDict(unittest.TestCase):
     def setUp(self):
         self.dict = OptionsDictionary()
 
+    @unittest.skipIf(tabulate is None, reason="package 'tabulate' is not installed")
     def test_reprs(self):
         class MyComp(ExplicitComponent):
             pass
@@ -63,6 +69,7 @@ class TestOptionsDict(unittest.TestCase):
             "====================================================================",
         ]))
 
+    @unittest.skipIf(tabulate is None, reason="package 'tabulate' is not installed")
     def test_to_table(self):
         class MyComp(ExplicitComponent):
             pass

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -32,40 +32,70 @@ class TestOptionsDict(unittest.TestCase):
 
         self.assertEqual(repr(self.dict), repr(self.dict._dict))
 
-        self.assertEqual(self.dict.__str__(width=83), '\n'.join([
-            "========= ============ ================= ===================== ====================",
-            "Option    Default      Acceptable Values Acceptable Types      Description         ",
-            "========= ============ ================= ===================== ====================",
-            "comp      MyComp       N/A               ['ExplicitComponent']                     ",
-            "flag      False        [True, False]     ['bool']                                  ",
-            "long_desc **Required** N/A               ['str']               This description is ",
-            "                                                               long and verbose, so",
-            "                                                                it takes up multipl",
-            "                                                               e lines in the optio",
-            "                                                               ns table.",
-            "test      **Required** ['a', 'b']        N/A                   Test integer value  ",
-            "========= ============ ================= ===================== ====================",
+        self.assertEqual(self.dict.__str__(width=89), '\n'.join([
+            "=========  ============  ===================  =====================  ====================",
+            "Option     Default       Acceptable Values    Acceptable Types       Description",
+            "=========  ============  ===================  =====================  ====================",
+            "comp       MyComp        N/A                  ['ExplicitComponent']",
+            "flag       False         [True, False]        ['bool']",
+            "long_desc  **Required**  N/A                  ['str']                This description is ",
+            "                                                                     long and verbose, so",
+            "                                                                      it takes up multipl",
+            "                                                                     e lines in the optio",
+            "                                                                     ns table.",
+            "test       **Required**  ['a', 'b']           N/A                    Test integer value",
+            "=========  ============  ===================  =====================  ====================",
         ]))
 
         # if the table can't be represented in specified width, then we get the full width version
         self.assertEqual(self.dict.__str__(width=40), '\n'.join([
-            "========= ============ ================= ===================== ====================="
-            "==================================================================== ",
-            "Option    Default      Acceptable Values Acceptable Types      Description          "
-            "                                                                     ",
-            "========= ============ ================= ===================== ====================="
-            "==================================================================== ",
-            "comp      MyComp       N/A               ['ExplicitComponent']                      "
-            "                                                                     ",
-            "flag      False        [True, False]     ['bool']                                   "
-            "                                                                     ",
-            "long_desc **Required** N/A               ['str']               This description is l"
-            "ong and verbose, so it takes up multiple lines in the options table. ",
-            "test      **Required** ['a', 'b']        N/A                   Test integer value   "
-            "                                                                     ",
-            "========= ============ ================= ===================== ====================="
-            "==================================================================== ",
+            "=========  ============  ===================  =====================  ====================="
+            "====================================================================",
+            "Option     Default       Acceptable Values    Acceptable Types       Description",
+            "=========  ============  ===================  =====================  ====================="
+            "====================================================================",
+            "comp       MyComp        N/A                  ['ExplicitComponent']",
+            "flag       False         [True, False]        ['bool']",
+            "long_desc  **Required**  N/A                  ['str']                This description is l"
+            "ong and verbose, so it takes up multiple lines in the options table.",
+            "test       **Required**  ['a', 'b']           N/A                    Test integer value",
+            "=========  ============  ===================  =====================  ====================="
+            "====================================================================",
         ]))
+
+    def test_to_table(self):
+        class MyComp(ExplicitComponent):
+            pass
+
+        my_comp = MyComp()
+
+        self.dict.declare('test', values=['a', 'b'], desc='Test integer value')
+        self.dict.declare('flag', default=False, types=bool)
+        self.dict.declare('comp', default=my_comp, types=ExplicitComponent)
+        self.dict.declare('long_desc', types=str,
+                          desc='This description is long and verbose, so it '
+                               'takes up multiple lines in the options table.')
+
+        expected = "| Option    | Default      | Acceptable Values   | Acceptable Types      " \
+                   "| Description                                                            " \
+                   "                   |\n" \
+                   "|-----------|--------------|---------------------|-----------------------|--" \
+                   "----------------------------------------------------------------------------" \
+                   "-------------|\n" \
+                   "| comp      | MyComp       | N/A                 | ['ExplicitComponent'] |   " \
+                   "                                                                             " \
+                   "           |\n" \
+                   "| flag      | False        | [True, False]       | ['bool']              |   " \
+                   "                                                                             " \
+                   "           |\n" \
+                   "| long_desc | **Required** | N/A                 | ['str']               | Th" \
+                   "is description is long and verbose, so it takes up multiple lines in the opti" \
+                   "ons table. |\n" \
+                   "| test      | **Required** | ['a', 'b']          | N/A                   | Te" \
+                   "st integer value                                                             " \
+                   "           |"
+
+        self.assertEqual(self.dict.to_table(fmt='github'), expected)
 
     def test_type_checking(self):
         self.dict.declare('test', types=int, desc='Test integer value')

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,6 @@
 import re
-import sys
 
 from setuptools import setup
-from subprocess import check_call
-import distutils.spawn
 
 __version__ = re.findall(
     r"""__version__ = ["']+([0-9\.\-dev]*)["']+""",
@@ -16,6 +13,7 @@ optional_dependencies = {
         'numpydoc>=0.9.1',
         'redbaron',
         'sphinx>=1.8.5',
+        'tabulate'
     ],
     'notebooks': [
         'notebook',


### PR DESCRIPTION
### Summary

OptionsDictionary now has a new method `to_table()` which can output a table representation using the tabulate package.
The `__rst__()` method now uses tabulate to build the underlying restructured text.
Tests for repr changed because tabulate includes two spaces between columns instead of one.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

tabulate is now used when building the Sphinx documentation.
It is included when pip installed with [notebooks] or [all].
