### PR TITLE
Fix for bug when using InterpND to interpolate on 1D data.

### DIFF
--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -82,14 +82,14 @@ class InterpND(object):
         """
         Initialize an InterpND object.
 
-        This object can be setup and used to interpolate on a curve or multi-dimensional table
+        This object can be setup and used to interpolate on a curve or multi-dimensional table.
 
         It can also be used to setup an interpolating spline that can be evaluated at fixed
         locations.
 
         For interpolation, specify values and points.
 
-        For spline evaulation, specifiy x_interp and either points or num_cp.
+        For spline evaluation, specifiy x_interp and either points or num_cp.
 
         Parameters
         ----------
@@ -99,8 +99,8 @@ class InterpND(object):
             The points defining the regular grid in n dimensions.
             For 1D interpolation, this can be an ndarray of table locations.
             For table interpolation, it can be a tuple or an ndarray. If it is a tuple, it should
-            contain one ndarry for each table dimension.
-            For spline evaulation, num_cp can be specified instead of points.
+            contain one ndarray for each table dimension.
+            For spline evaluation, num_cp can be specified instead of points.
         values : ndarray or tuple of ndarray or None
             These must be specified for interpolation.
             The data on the regular grid in n dimensions.
@@ -126,8 +126,7 @@ class InterpND(object):
                              '%s.' % (method, all_m))
         self.extrapolate = extrapolate
 
-        # The table points are always defined, either by specifying the number of the points
-        # directly.
+        # The table points are always defined, by specifying either the points directly, or num_cp.
         if points is None:
             if num_cp is not None:
                 points = [np.linspace(0.0, 1.0, num_cp)]

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -80,17 +80,30 @@ class InterpND(object):
     def __init__(self, method="slinear", points=None, values=None, x_interp=None, extrapolate=False,
                  num_cp=None, **kwargs):
         """
-        Initialize instance of interpolation class.
+        Initialize an InterpND object.
+
+        This object can be setup and used to interpolate on a curve or multi-dimensional table
+
+        It can also be used to setup an interpolating spline that can be evaluated at fixed
+        locations.
+
+        For interpolation, specify values and points.
+
+        For spline evaulation, specifiy x_interp and either points or num_cp.
 
         Parameters
         ----------
-        points : ndarray or tuple of ndarray of float, with shapes (m1, ), ..., (mn, )
-            The points defining the regular grid in n dimensions.  For 1D interpolation, this
-            can be an ndarray.
-        values : array_like, shape (m1, ..., mn, ...)
-            The data on the regular grid in n dimensions.
         method : str
-            Name of interpolation method(s).
+            Name of interpolation method.
+        points : ndarray or tuple of ndarray
+            The points defining the regular grid in n dimensions.
+            For 1D interpolation, this can be an ndarray of table locations.
+            For table interpolation, it can be a tuple or an ndarray. If it is a tuple, it should
+            contain one ndarry for each table dimension.
+            For spline evaulation, num_cp can be specified instead of points.
+        values : ndarray or tuple of ndarray or None
+            These must be specified for interpolation.
+            The data on the regular grid in n dimensions.
         x_interp : ndarray or None
             If we are always interpolating at a fixed set of locations, then they can be
             specified here.
@@ -113,7 +126,34 @@ class InterpND(object):
                              '%s.' % (method, all_m))
         self.extrapolate = extrapolate
 
+        # The table points are always defined, either by specifying the number of the points
+        # directly.
+        if points is None:
+            if num_cp is not None:
+                points = [np.linspace(0.0, 1.0, num_cp)]
+            else:
+                msg = "Either 'points' or 'num_cp' must be specified."
+                raise ValueError(msg)
+        else:
+
+            if isinstance(points, np.ndarray):
+                points = [points]
+
+            for i, p in enumerate(points):
+                n_p = len(p)
+                if not np.all(np.diff(p) > 0.):
+                    raise ValueError("The points in dimension %d must be strictly "
+                                     "ascending" % i)
+                if not np.asarray(p).ndim == 1:
+                    raise ValueError("The points in dimension %d must be "
+                                     "1-dimensional" % i)
+
+        # Table Interpolation
         if x_interp is None:
+
+            if values is None:
+                msg = "Either 'values' or 'x_interp' must be specified."
+                raise ValueError(msg)
 
             if method == 'bsplines':
                 msg = "Method 'bsplines' is not supported for table interpolation."
@@ -135,26 +175,9 @@ class InterpND(object):
                 msg = "Interpolation method '%s' does not support complex values." % method
                 raise ValueError(msg)
 
-        if points is None:
-            if num_cp is not None:
-                points = [np.linspace(0.0, 1.0, num_cp)]
-            else:
-                msg = "Either 'points' or 'num_cp' must be specified."
-                raise ValueError(msg)
-        else:
-
-            if isinstance(points, np.ndarray):
-                points = [points]
-
             for i, p in enumerate(points):
                 n_p = len(p)
-                if not np.all(np.diff(p) > 0.):
-                    raise ValueError("The points in dimension %d must be strictly "
-                                     "ascending" % i)
-                if not np.asarray(p).ndim == 1:
-                    raise ValueError("The points in dimension %d must be "
-                                     "1-dimensional" % i)
-                if values is not None and not values.shape[i] == n_p:
+                if values.shape[i] != n_p:
                     raise ValueError("There are %d points and %d values in "
                                      "dimension %d" % (len(p), values.shape[i], i))
 
@@ -186,8 +209,8 @@ class InterpND(object):
 
         Parameters
         ----------
-        x : ndarray of shape (..., ndim)
-            Location to provide interpolation.
+        x : ndarray or tuple
+            Locations to interpolate.
         compute_derivative : bool
             Set to True to compute derivatives with respect to x.
 
@@ -203,7 +226,19 @@ class InterpND(object):
         self.table._compute_d_dx = compute_derivative
         self.table._compute_d_dvalues = False
 
-        xnew = self._interpolate(np.atleast_1d(x))
+        if isinstance(x, np.ndarray):
+            if len(x.shape) < 2:
+                if len(self.grid) > 1:
+                    # Input is an array containing multi-D coordinates of a single point.
+                    x = np.atleast_2d(x)
+                else:
+                    # Input is an array of separate points on a 1D table.
+                    x = np.atleast_2d(x).T
+        else:
+            # Input is a list or tuple of separate points.
+            x = np.atleast_2d(x)
+
+        xnew = self._interpolate(x)
 
         if compute_derivative:
             return xnew, self._d_dx
@@ -217,7 +252,7 @@ class InterpND(object):
         Parameters
         ----------
         values : ndarray(n_points)
-            The data on the regular grid in n dimensions.
+            New data values for all points on the regular grid.
         compute_derivative : bool
             Set to True to compute derivatives with respect to x.
 
@@ -252,7 +287,7 @@ class InterpND(object):
         """
         Interpolate at the sample coordinates.
 
-        This method is called from OpenMDAO
+        This method is called from OpenMDAO, and is not meant for standalone use.
 
         Parameters
         ----------
@@ -328,7 +363,7 @@ class InterpND(object):
         """
         Interpolate at all fixed output coordinates given the new table values.
 
-        This method is called from OpenMDAO.
+        This method is called from OpenMDAO, and is not meant for standalone use.
 
         Parameters
         ----------

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -368,7 +368,7 @@ class TestInterpNDPython(unittest.TestCase):
             assert r_err < 2.5 * self.tol[method]
 
             # test that gradients have been cached
-            assert_equal_arrays(interp._xi, test_pt)
+            assert_equal_arrays(interp._xi.flatten(), test_pt.flatten())
             assert_equal_arrays(interp._d_dx.flatten(), computed.flatten())
 
     def test_gradients_returned_by_xi(self):
@@ -564,6 +564,33 @@ class TestInterpNDPython(unittest.TestCase):
         self.assertEqual(err.lower, 0)
         self.assertEqual(err.upper, 1)
 
+    def test_interp_1Dflat(self):
+
+        x = np.array([0.,1.,2.,3.,4.])
+        y = x**2
+        f = InterpND(points=x, values=y)
+
+        computed = f.interpolate(np.array([2.5, 3.5]))
+        assert_equal_arrays(computed, np.array([6.5, 12.5]))
+
+    def test_interp_1Dflat_list_points(self):
+
+        x = np.array([0.,1.,2.,3.,4.])
+        y = x**2
+        f = InterpND(points=[x], values=y)
+
+        computed = f.interpolate(np.array([2.5, 3.5]))
+        assert_equal_arrays(computed, np.array([6.5, 12.5]))
+
+    def test_interp_1Dflat_list_x(self):
+
+        x = np.array([0.,1.,2.,3.,4.])
+        y = x**2
+        f = InterpND(points=x, values=y)
+
+        computed = f.interpolate([np.array([2.5]), np.array([3.5])])
+        assert_equal_arrays(computed, np.array([6.5, 12.5]))
+
     def test_error_messages(self):
         points, values = self._get_sample_4d_large()
 
@@ -629,6 +656,12 @@ class TestInterpNDPython(unittest.TestCase):
             interp = InterpND(method='bsplines', points=points, values=values)
 
         msg = "Method 'bsplines' is not supported for table interpolation."
+        self.assertTrue(str(cm.exception).startswith(msg))
+
+        with self.assertRaises(ValueError) as cm:
+            interp = InterpND(method='bsplines', points=points)
+
+        msg = "Either 'values' or 'x_interp' must be specified."
         self.assertTrue(str(cm.exception).startswith(msg))
 
 if __name__ == '__main__':

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2049,7 +2049,6 @@ class TestPyoptSparse(unittest.TestCase):
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['obj_cmp.obj'][0], 3.183, 1e-3)
 
-
     def test_error_objfun_reraise(self):
         # Tests that we re-raise any unclassified error encountered during callback eval.
 

--- a/openmdao/surrogate_models/multifi_cokriging.py
+++ b/openmdao/surrogate_models/multifi_cokriging.py
@@ -185,9 +185,9 @@ class MultiFiCoKriging(object):
     ----------
     corr : Object
         Correlation function to use, default is squared_exponential_correlation.
-    n_features : ndarry
+    n_features : ndarray
         Number of features for each fidelity level.
-    n_samples : ndarry
+    n_samples : ndarray
         Number of samples for each fidelity level.
     nlevel : int
         Number of fidelity levels.


### PR DESCRIPTION
### Summary

Fix for bug when using InterpND to interpolate on 1D data.  It now works when you 1-dimensional arrays as any input. Formerly those arrays needed to be 2D.

### Related Issues

- Resolves #1936

### Backwards incompatibilities

None

### New Dependencies

None
