### PR TITLE
Fix NaNs that may still show up in the N2 diagram

### DIFF
--- a/openmdao/visualization/n2_viewer/src/ModelData.js
+++ b/openmdao/visualization/n2_viewer/src/ModelData.js
@@ -47,7 +47,9 @@ class ModelData {
 
     static uncompressModel(b64str) {
         const compressedData = atob(b64str);
-        const jsonStr = window.pako.inflate(compressedData, { to: 'string' });
+        const jsonStr = window.pako.inflate(compressedData, { to: 'string' })
+            .replace(/([^'"])nan([^'"])/ig, '$1"nan"$2'); // Catch any remaining bare NaNs
+            
         /* for ( let pos = 0; pos < jsonStr.length; pos += 100) {
             console.log(pos, jsonStr.substring(pos, pos+99));
         } */

--- a/openmdao/visualization/n2_viewer/style/legend.css
+++ b/openmdao/visualization/n2_viewer/style/legend.css
@@ -85,7 +85,7 @@
 
 .n2-symbols-container {
     height: 90px;
-    min-height: 45px;
+    min-height: 90px;
     border-radius: 15px;
     border: 1px solid #66b48e;
     display: flex;
@@ -93,7 +93,7 @@
     padding-right: 45px;
     background-color: white;
     z-index: 2;
-    overflow: scroll;
+    overflow: hidden;
     margin-left: -20px;
 }
 
@@ -174,7 +174,7 @@
     margin-right: 0;
     background-color: white;
     z-index: 3;
-    overflow-y: scroll;
+    overflow: hidden;
 }
 
 #solvers-legend {


### PR DESCRIPTION
### Summary

Even though `n2_viewer.py` checks for and converts NaNs to strings so JSON can handle them, it's possible that some are slipping through if they're stored as some type we're not aware of. This adds a check to the JavaScript side so that if some do slip through, they're converted to strings before the model structure is parsed into JSON.

### Related Issues

- Resolves #1940

### Backwards incompatibilities

None

### New Dependencies

None
