### PR TITLE
Added code to show view_connections in nb/colab/docs

### DIFF
--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -9,13 +9,13 @@ from collections import defaultdict
 import numpy as np
 
 try:
-    from IPython.display import IFrame, display
+    from IPython.display import IFrame, display, HTML
 except ImportError:
     IFrame = display = None
 
 import openmdao
 from openmdao.core.problem import Problem
-from openmdao.core.notebook_mode import notebook
+from openmdao.core.notebook_mode import notebook, colab
 from openmdao.utils.units import convert_units
 from openmdao.utils.mpi import MPI
 from openmdao.utils.webview import webview
@@ -197,8 +197,10 @@ def view_connections(root, outfile='connections.html', show_browser=True,
         s = s.replace("<tabulator_style>", tabulator_style)
         f.write(s)
 
-    if notebook:
+    if notebook and not colab:
         display(IFrame(src=outfile, width=1000, height=1000))
+    else:
+        display(HTML(outfile))
 
     if show_browser and not notebook:
         webview(outfile)


### PR DESCRIPTION
### Summary

Added code to automagically show view_connections HTML in a notebook, Colab, or docs

### Related Issues

- Resolves #1939

### Backwards incompatibilities

None

### New Dependencies

None
