### PR TITLE
Fix text mistake when a linesearch prints its violations.

### DIFF
--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -36,7 +36,7 @@ def _print_violations(outputs, lower, upper):
             simple_warning(msg)
 
         if lower is not None and any(val < lower[start:end]):
-            msg = (f"'{name}' exceeds lower bounds\n  Val: {val}\n  Upper: {lower[start:end]}\n")
+            msg = (f"'{name}' exceeds lower bounds\n  Val: {val}\n  Lower: {lower[start:end]}\n")
             simple_warning(msg)
 
         start = end

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -442,7 +442,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         for ind in range(3):
             assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
-        msg = (f"'comp.z' exceeds lower bounds\n  Val: [1.33333333 1.33333333 1.33333333]\n  Upper: [1.5 1.5 1.5]\n")
+        msg = (f"'comp.z' exceeds lower bounds\n  Val: [1.33333333 1.33333333 1.33333333]\n  Lower: [1.5 1.5 1.5]\n")
         with assert_warning(UserWarning, msg):
             top.run_model()
 


### PR DESCRIPTION
### Summary

Fix a text mistake where a linesearch printed the word "Upper" when a lower bound was violated.

### Related Issues

- Resolves #1928

### Backwards incompatibilities

None

### New Dependencies

None
