### PR TITLE
Fix for a couple of small debug print bugs.

### DIFF
--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -319,8 +319,8 @@ class TestDriver(unittest.TestCase):
         finally:
             sys.stdout = stdout
         output = strout.getvalue().split('\n')
-        self.assertIn("{('obj_cmp.obj', '_auto_ivc.v0'):", output[12])
-        self.assertIn("{('con_cmp1.con1', '_auto_ivc.v0'):", output[13])
+        self.assertIn("{('obj_cmp.obj', 'z'):", output[12])
+        self.assertIn("{('con_cmp1.con1', 'z'):", output[13])
 
     def test_debug_print_desvar_physical_with_indices(self):
         prob = om.Problem()

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -178,7 +178,7 @@ class ParDerivTestCase(unittest.TestCase):
 
         if not prob.comm.rank:
             self.assertTrue('Solving color: par_dv (x1, x2)' in output)
-            self.assertTrue('In mode: fwd, Solving variable(s) using simul coloring:' in output)
+            self.assertTrue('In mode: fwd.' in output)
             self.assertTrue("('p.x3', [2])" in output)
 
     def test_fan_out_parallel_sets_rev(self):

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1830,6 +1830,8 @@ class _TotalJacInfo(object):
             J_dict = self.J_dict
             for of, wrt_dict in J_dict.items():
                 for wrt, J_sub in wrt_dict.items():
+                    if wrt in self.ivc_print_names:
+                        wrt = self.ivc_print_names[wrt]
                     pprint.pprint({(of, wrt): J_sub})
         else:
             J = self.J
@@ -1839,7 +1841,10 @@ class _TotalJacInfo(object):
                 out_slice = self.of_meta[of][0]
                 for j, wrt in enumerate(self.wrt):
                     if wrt not in self.remote_vois:
-                        pprint.pprint({(of, wrt): J[out_slice, self.wrt_meta[wrt][0]]})
+                        deriv = J[out_slice, self.wrt_meta[wrt][0]]
+                        if wrt in self.ivc_print_names:
+                            wrt = self.ivc_print_names[wrt]
+                        pprint.pprint({(of, wrt): deriv})
 
         print('')
         sys.stdout.flush()

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1488,12 +1488,13 @@ class _TotalJacInfo(object):
                             varlist = '(' + ', '.join([name for name in par_print[key]]) + ')'
                             print('Solving color:', key, varlist)
                         else:
-                            print('In mode: %s, Solving variable(s) using simul coloring:' % mode)
                             if key == '@simul_coloring':
+                                print('In mode: %s, Solving variable(s) using simul coloring:' % mode)
                                 for local_ind in imeta['coloring']._local_indices(inds=inds,
                                                                                   mode=self.mode):
                                     print("   {}".format(local_ind))
                             else:
+                                print('In mode: %s.' % mode)
                                 print_key = key
                                 if key in self.ivc_print_names:
                                     print_key = self.ivc_print_names[key]

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1489,7 +1489,8 @@ class _TotalJacInfo(object):
                             print('Solving color:', key, varlist)
                         else:
                             if key == '@simul_coloring':
-                                print('In mode: %s, Solving variable(s) using simul coloring:' % mode)
+                                print(f'In mode: {mode}, Solving variable(s) using simul '
+                                      'coloring:')
                                 for local_ind in imeta['coloring']._local_indices(inds=inds,
                                                                                   mode=self.mode):
                                     print("   {}".format(local_ind))

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1554,7 +1554,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
 
-        self.assertTrue('In mode: rev, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('comp.f_xy', [0])" in output)
         self.assertTrue('Elapsed Time:' in output)
 
@@ -1588,7 +1588,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                              str(prob.driver.pyopt_solution.optInform))
 
-        self.assertTrue('In mode: fwd, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('p2.y', [1])" in output)
         self.assertTrue('Elapsed Time:' in output)
 
@@ -1625,7 +1625,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                                  str(prob.driver.pyopt_solution.optInform))
 
-        self.assertTrue('In mode: rev, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('comp.f_xy', [0])" in output)
         self.assertTrue('Elapsed Time:' in output)
 
@@ -1659,7 +1659,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertFalse(failed, "Optimization failed, info = " +
                              str(prob.driver.pyopt_solution.optInform))
 
-        self.assertTrue('In mode: fwd, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('p2.y', [1])" in output)
         self.assertTrue('Elapsed Time:' in output)
 

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1338,7 +1338,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         self.assertFalse(failed, "Optimization failed.")
 
-        self.assertTrue('In mode: rev, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue('In mode: rev.' in output)
         self.assertTrue("('comp.f_xy', [0])" in output)
         self.assertTrue('Elapsed Time:' in output)
 
@@ -1370,7 +1370,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         self.assertFalse(failed, "Optimization failed.")
 
-        self.assertTrue('In mode: fwd, Solving variable(s) using simul coloring:' in output)
+        self.assertTrue('In mode: fwd.' in output)
         self.assertTrue("('p1.x', [0])" in output)
         self.assertTrue('Elapsed Time:' in output)
 


### PR DESCRIPTION
### Summary

Fixed bug in debug printing of derivatives  where it printed "using simul coloring" when no coloring was being used.
Fixed bug in debug printing of derivatives where wrt was still the auto_ivc output name.

### Related Issues

- Resolves #1918

### Backwards incompatibilities

None

### New Dependencies

None
