### PR TITLE
Test all combinations of dynamic variable sizing in parallel runs

### DIFF
--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -946,6 +946,30 @@ class TestDistribDynShapeCombos(unittest.TestCase):
 
         # test all of the i/o sizes set by shape_by_conn
 
+        # ivc => serial
+        self.assertEqual(p.get_val('ser2.ivc_ser_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ivc.ivc_ser_bwd').size, var_shape)
+
+        # ivc => parallel
+        self.assertEqual(p.get_val('par2.ivc_par_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ivc.ivc_par_bwd').size, var_shape)
+
+        # serial => serial
+        self.assertEqual(p.get_val('ser2.ser_ser_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ser1.ser_ser_bwd').size, var_shape)
+
+        # serial => parallel
+        self.assertEqual(p.get_val('par2.ser_par_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ser1.ser_par_bwd').size, var_shape)
+
+        # parallel => serial
+        self.assertEqual(p.get_val('ser2.par_ser_fwd').size, var_shape)
+        self.assertEqual(p.get_val('par1.par_ser_bwd').size, var_shape)
+
+        # parallel => parallel
+        self.assertEqual(p.get_val('par2.par_par_fwd').size, var_shape)
+        self.assertEqual(p.get_val('par1.par_par_bwd').size, var_shape)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -939,9 +939,7 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.model.add_subsystem('ser2', ser2(), promotes=["*"])
         p.model.add_subsystem('par2', par2(), promotes=["*"])
 
-        # setup
         p.setup()
-
         p.run_model()
 
         # test all of the i/o sizes set by shape_by_conn


### PR DESCRIPTION
### Summary

This PR adds a test to check if all possible connection sizes can be resolved with `shape_by_conn` feature in parallel runs. See the detailed explanation of the issue at: https://github.com/anilyil/OpenMDAO/blob/c760c3728ac403b163b0556aab4553322d8cb622/openmdao/core/tests/test_dyn_sizing.py#L858-L917 

To summarize, we have 3 different type of components in parallel runs: independent variable component, serial component, parallel component. IVCs only connect downstream (no inputs, just outputs), so we end up with 6 combinations of connections. We also have 2 directions the dynamic sizing can be resolved: fwd and bwd. As a result, we have 12 individual cases where the feature must be tested. 

The only current tests for parallel runs are defined in: https://github.com/anilyil/OpenMDAO/blob/c760c3728ac403b163b0556aab4553322d8cb622/openmdao/core/tests/test_dyn_sizing.py#L202 (there is a separate parallel group test but I am not including that here in this discussion). 
These parallel tests do not check some of the combinations. Here is a table to clarify which connections are tested in the current tests:
```
Connection:    Forward    Backward
ivc => ser       No         No
ivc => par       No         Yes
ser => ser       No         No
ser => par       Yes        No
par => ser       Yes        Yes
par => par       Yes        Yes
```

In this PR, I add a test that checks every single combination in the table. I am pretty sure some of these combinations result in an "unexpected" connection size. I think this PR is a good place to also fix these issues.

Once the code is modified and all tests work, we can also try to improve the documentation of `shape_by_conn` feature's parallel behavior by pointing the users to this test. 

### Related Issues

The documentation issue is in #1920. If we update the docs, we can also close that issue.