### PR TITLE
fix test_cmdline for windows

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3574,9 +3574,11 @@ class System(object):
         list of (name, metadata)
             List of output names and other optional information about those outputs.
         """
-        keynames = np.array(['value', 'units', 'shape', 'global_shape', 'desc', 'tags'])
-        keys = [str(n) for n in keynames[np.array([values, units, shape, global_shape, desc, tags],
-                                                  dtype=bool)]]
+        keynames = ['value', 'units', 'shape', 'global_shape', 'desc', 'tags']
+        keyflags = [values, units, shape, global_shape, desc, tags]
+
+        keys = [name for i, name in enumerate(keynames) if keyflags[i]]
+
         if bounds:
             keys.extend(('lower', 'upper'))
         if scaling:

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -2,6 +2,7 @@
 import os
 import unittest
 import subprocess
+import re
 
 from openmdao.utils.testing_utils import use_tempdirs
 import openmdao.core.tests.test_coloring as coloring_test_mod
@@ -18,7 +19,8 @@ scriptdir = os.path.join(dname(dname(dname(os.path.abspath(__file__)))), 'test_s
 counter = 0
 
 def _test_func_name(func, num, param):
-    return func.__name__ + '_' + '_'.join(param.args[0].split()[1:-1])
+    # test name is the command with spaces, colons and backslashes replaced by underscore
+    return func.__name__ + '_' + re.sub('[ \\:\\\]', '_', param.args[0])
 
 cmd_tests = [
     'openmdao call_tree openmdao.components.exec_comp.ExecComp.setup',


### PR DESCRIPTION
### Summary

- fixed test name generator in test_cmdline which resulted in invalid names for Windows
- fixed list generator in system.py that breaks with numpy 1.2

### Related Issues

- Resolves #1953

### Backwards incompatibilities

None

### New Dependencies

None
