### PR TITLE
Sort the list of recorded output variables

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -474,12 +474,10 @@ class Driver(object):
                 # sort the results since _var_allprocs_abs2prom isn't ordered
                 myinputs = sorted([n for n in model._var_allprocs_abs2prom['input']
                                   if check_path(n, incl, excl)])
-        myoutputs = list(myoutputs)
-        myoutputs.sort() # sorting the list ensures the outputs are iterated  
-                         # over in the same order even on mulitple procs
         vars2record = {
             'input': myinputs,
-            'output': myoutputs,
+            'output': sorted(myoutputs), # sorting the list ensures the outputs are iterated  
+                                         # over in the same order even on mulitple procs
             'residual': myresiduals
         }
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -476,8 +476,8 @@ class Driver(object):
                                   if check_path(n, incl, excl)])
         vars2record = {
             'input': myinputs,
-            'output': sorted(myoutputs), # sorting the list ensures the outputs are iterated  
-                                         # over in the same order even on mulitple procs
+            'output': sorted(myoutputs),  # sorting the list ensures the outputs are iterated
+                                          # over in the same order even on mulitple procs
             'residual': myresiduals
         }
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -477,7 +477,8 @@ class Driver(object):
 
         vars2record = {
             'input': myinputs,
-            'output': list(myoutputs),
+            'output': list(myoutputs).sort(), # sorting the list ensures the outputs are iterated  
+                                              # over in the same order even on mulitple procs
             'residual': myresiduals
         }
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -474,11 +474,12 @@ class Driver(object):
                 # sort the results since _var_allprocs_abs2prom isn't ordered
                 myinputs = sorted([n for n in model._var_allprocs_abs2prom['input']
                                   if check_path(n, incl, excl)])
-
+        myoutputs = list(myoutputs)
+        myoutputs.sort() # sorting the list ensures the outputs are iterated  
+                         # over in the same order even on mulitple procs
         vars2record = {
             'input': myinputs,
-            'output': list(myoutputs).sort(), # sorting the list ensures the outputs are iterated  
-                                              # over in the same order even on mulitple procs
+            'output': myoutputs,
             'residual': myresiduals
         }
 


### PR DESCRIPTION
### Summary

I was encountering an error when I added a recorder to a case with distributed variables 
```
====================================================================== Traceback (most recent call last):
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/drivers/pyoptsparse_driver.py", line 565, in _objfunc
    rec.rel = 0.0
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/core/driver.py", line 1226, in __exit__
    super().__exit__()
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/recorders/recording_iteration_stack.py", line 175, in __exit__
    requester.record_iteration()
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/core/driver.py", line 929, in record_iteration
    record_iteration(self, self._problem(), self._get_name())
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/core/driver.py", line 1261, in record_iteration
    data['output'] = model._retrieve_data_of_kind(filt, 'output', 'nonlinear', parallel)
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/core/system.py", line 4696, in _retrieve_data_of_kind
    vec_name=vec_name, kind=kind, from_src=False)
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/core/system.py", line 4371, in get_val
    val = self._abs_get_val(abs_names[0], get_remote, rank, vec_name, kind, flat)
  File "/home/mdolabuser/miniconda/lib/python3.7/site-packages/openmdao/core/system.py", line 4298, in _abs_get_val
    self.comm.Gatherv(loc_val, [val, sizes, offsets, MPI.DOUBLE], root=rank)
  File "mpi4py/MPI/Comm.pyx", line 602, in mpi4py.MPI.Comm.Gatherv
mpi4py.MPI.Exception: MPI_ERR_TRUNCATE: message truncated
 ======================================================================
```
Because the list of output variables wasn't sorted, different procs were trying to get the value of different distributed variables at the same time. 
https://github.com/OpenMDAO/OpenMDAO/blob/ae969b72d7fb32ac8bd78f2133d082e8619dd2cc/openmdao/core/system.py#L4681-L4692

Simply sorting the list of recorded outputs fixed the issue for me. 

### Backwards incompatibilities

None

### New Dependencies

None
