### PR TITLE
The unit 'as' for attoseconds now works.

### DIFF
--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -929,6 +929,25 @@ class TestUnitConversion(unittest.TestCase):
         msg = ("<class Group>: The units 'in**2' are invalid.")
         self.assertEqual(cm.exception.args[0], msg)
 
+    def test_attoseconds(self):
+        # Attoseconds (as) didn't originally work because of collision with the python keyword.
+        p = om.Problem()
+
+        p.model.add_subsystem("C1", om.ExecComp("y = 2*x",
+                                                y={'value': 1.0, 'units': 'as'}),
+                              promotes=['x', 'y'])
+        p.model.add_subsystem("C2", om.ExecComp("z = 3*y",
+                                                y={'value': 1.0, 'units': 'zs'},
+                                                z={'value': 1.0, 'units': 'zs'}),
+                              promotes=['z', 'y'])
+
+        p.setup()
+        p.set_val('x', 25.0)
+        p.run_model()
+
+        assert_near_equal(p.get_val('z'), 150000.0)
+        assert_near_equal(p.get_val('z', units='as'), 150.0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -289,6 +289,23 @@ class TestPhysicalUnit(unittest.TestCase):
             simplified_str = simplify_unit(test_str)
             self.assertEqual(simplified_str, correct_str)
 
+    def test_atto_seconds(self):
+        # The unit 'as' was bugged because it is a python keyword.
+
+        fact = unit_conversion('s', 'as')
+        assert_near_equal(fact[0], 1e18)
+
+        # Make sure regex for 'as' doesn't pick up partial words.
+        fact = unit_conversion('aslug*as*as', 'aslug*zs*zs')
+        assert_near_equal(fact[0], 1e6)
+
+        # Make sure simplification works.
+        simple = simplify_unit('m*as/as')
+        self.assertEqual(simple, 'm')
+
+        simple = simplify_unit('as**6/as**4')
+        self.assertEqual(simple, 'as**2')
+
 
 class TestModuleFunctions(unittest.TestCase):
     def test_add_unit(self):


### PR DESCRIPTION
### Summary

The unit 'as' for attoseconds now works.

This was addressed internally by replacing `as` with `as_` during eval calls, so there's no impact to the user.

### Related Issues

- Resolves #1925

### Backwards incompatibilities

None

### New Dependencies

None
