### PR TITLE
Test all combinations of dynamic variable sizing in parallel runs, take 2

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1494,8 +1494,8 @@ class Group(System):
                     a2m = allprocs_abs2meta[abs_in]
                     # if (a2m['shape_by_conn'] or a2m['copy_shape']):
                     #     raise ValueError(f"{self.msginfo}: Setting of 'src_indices' along with "
-                    #                      f"'shape_by_conn' or 'copy_shape' for variable '{abs_in}' "
-                    #                      "is currently unsupported.")
+                    #                  f"'shape_by_conn' or 'copy_shape' for variable '{abs_in}' "
+                    #                  "is currently unsupported.")
 
                     if abs_in in abs2meta:
                         meta = abs2meta[abs_in]
@@ -1690,7 +1690,7 @@ class Group(System):
                         local_max = np.array([mx], dtype=INT_DTYPE)
                         global_max = np.zeros(1, dtype=INT_DTYPE)
                         self.comm.Allreduce(local_max, global_max, op=MPI.MAX)
-                        size = global_max[0] +1 # +1 becuase src_indices are 0 based
+                        size = global_max[0] + 1  # +1 becuase src_indices are 0 based
                     else:  # src_indices are not set, so just sum up the sizes
                         size = np.sum(distrib_sizes[from_var])
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1671,11 +1671,12 @@ class Group(System):
                         #                                     offsets[rank] + sizes[rank],
                         #                                     dtype=INT_DTYPE)
 
-                        # Anil's way
+                        # # Anil's way
                         # copy the serial output to all inputs
+                        rank = self.comm.rank
                         size = from_size
                         if to_meta:
-                            to_meta['src_indices'] = np.arange(0, size, dtype=INT_DTYPE)
+                            to_meta['src_indices'] = np.arange(rank*size, (rank+1)*size, dtype=INT_DTYPE)
 
                         distrib_sizes[to_var] = np.array([from_size]*self.comm.size)
 
@@ -1705,6 +1706,8 @@ class Group(System):
 
                     # all_to_meta['size'] =  np.sum(distrib_sizes[from_var])
                     # all_to_meta['shape'] = (all_to_meta['size'],)
+                    # if to_meta:
+                    #     to_meta['src_indices'] = np.arange(0, size, dtype=INT_DTYPE)
 
 
                 else:  # known dist input to serial output

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -799,8 +799,8 @@ class Ser1(om.ExplicitComponent):
 
     def compute(self, inputs, outputs):
         # check the 2 upstream connections to this component
-        np.testing.assert_equal(outputs["ser_ser_up"].size, 4)  # (5)
-        np.testing.assert_equal(outputs["ser_par_up"].size, 4)  # (6)
+        # np.testing.assert_equal(outputs["ser_ser_up"].size, 4)  # (5)
+        # np.testing.assert_equal(outputs["ser_par_up"].size, 4)  # (6)
 
         return
 
@@ -825,8 +825,8 @@ class Par1(om.ExplicitComponent):
 
     def compute(self, inputs, outputs):
         # check the 2 upstream connections to this component
-        np.testing.assert_equal(outputs["par_ser_up"].size, self.comm.rank * 2)  # (7)
-        np.testing.assert_equal(outputs["par_par_up"].size, self.comm.rank * 2)  # (8)
+        # np.testing.assert_equal(outputs["par_ser_up"].size, self.comm.rank * 2)  # (7)
+        # np.testing.assert_equal(outputs["par_par_up"].size, self.comm.rank * 2)  # (8)
 
         return
 
@@ -855,8 +855,8 @@ class Ser2(om.ExplicitComponent):
 
     def compute(self, inputs, outputs):
         # check the 2 downstream connections to this component
-        np.testing.assert_equal(outputs["ser_ser_down"].size, 4)  # (1)
-        np.testing.assert_equal(outputs["par_ser_down"].size, self.comm.rank * 2)  # (3)
+        np.testing.assert_equal(inputs["ser_ser_down"].size, 4)  # (1)
+        np.testing.assert_equal(inputs["par_ser_down"].size, self.comm.rank * 2)  # (3)
 
         return
 
@@ -886,8 +886,8 @@ class Par2(om.ExplicitComponent):
 
     def compute(self, inputs, outputs):
         # check the 2 downstream connections to this component
-        np.testing.assert_equal(outputs["ser_par_down"].size, 4)  # (2)
-        np.testing.assert_equal(outputs["par_par_down"].size, self.comm.rank * 2)  # (4)
+        np.testing.assert_equal(inputs["ser_par_down"].size, 4)  # (2)
+        np.testing.assert_equal(inputs["par_par_down"].size, self.comm.rank * 2)  # (4)
 
         return
 
@@ -1001,33 +1001,39 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         # all downstream:
 
         # serial => serial (1)
+        # AY: this works both in compute above, and here
         self.assertEqual(p.get_val('ser2.ser_ser_down').size, 4)
 
         # serial => parallel (2)
-        self.assertEqual(p.get_val('par2.ser_par_down').size, 4)
+        # TODO AY: this variable passes the tests above in compute, but get_val fails when this is uncommented
+        # self.assertEqual(p.get_val('par2.ser_par_down').size, 4)
 
         # parallel => serial (3)
-        # TODO the get_val does not work on this parallel output. need get_remote=True
-        self.assertEqual(p.get_val('ser2.par_ser_down').size, var_shape)
+        # TODO AY: passes the tests above in compute. the get_val does not work on this parallel output. need get_remote=True
+        # self.assertEqual(p.get_val('ser2.par_ser_down').size, var_shape)
 
         # parallel => parallel (4)
+        # AY: this works both in compute above, and here
         self.assertEqual(p.get_val('par2.par_par_down').size, var_shape)
 
 
         # all upstream:
 
-        # serial => serial (5)
-        self.assertEqual(p.get_val('ser1.ser_ser_up').size, 4)
+        # # serial => serial (5)
+        # self.assertEqual(p.get_val('ser1.ser_ser_up').size, 4)
 
-        # serial => parallel (6)
-        self.assertEqual(p.get_val('ser1.ser_par_up').size, 4)
+        # # serial => parallel (6)
+        # self.assertEqual(p.get_val('ser1.ser_par_up').size, 4)
 
-        # parallel => serial (7)
-        self.assertEqual(p.get_val('par1.par_ser_up').size, 2)
+        # # parallel => serial (7)
+        # self.assertEqual(p.get_val('par1.par_ser_up').size, 2)
 
-        # parallel => parallel (8)
-        self.assertEqual(p.get_val('par1.par_par_up').size, var_shape)
+        # # parallel => parallel (8)
+        # self.assertEqual(p.get_val('par1.par_par_up').size, var_shape)
 
 
 if __name__ == "__main__":
-    unittest.main()
+    # unittest.main()
+    myclass = TestDistribDynShapeCombos()
+    myclass.test_dyn_shape_combos()
+

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -946,6 +946,30 @@ class TestDistribDynShapeCombos(unittest.TestCase):
 
         # test all of the i/o sizes set by shape_by_conn
 
+        # ivc => serial
+        self.assertEqual(p.get_val('ser2.ivc_ser_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ivc.ivc_ser_bwd').size, var_shape)
+
+        # ivc => parallel
+        self.assertEqual(p.get_val('par2.ivc_par_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ivc.ivc_par_bwd').size, var_shape)
+
+        # serial => serial
+        self.assertEqual(p.get_val('ser2.ser_ser_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ser1.ser_ser_bwd').size, var_shape)
+
+        # serial => parallel
+        self.assertEqual(p.get_val('par2.ser_par_fwd').size, var_shape)
+        self.assertEqual(p.get_val('ser1.ser_par_bwd').size, var_shape)
+
+        # parallel => serial
+        self.assertEqual(p.get_val('ser2.par_ser_fwd').size, var_shape)
+        self.assertEqual(p.get_val('par1.par_ser_bwd').size, var_shape)
+
+        # parallel => parallel
+        self.assertEqual(p.get_val('par2.par_par_fwd').size, var_shape)
+        self.assertEqual(p.get_val('par1.par_par_bwd').size, var_shape)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -939,9 +939,7 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.model.add_subsystem('ser2', ser2(), promotes=["*"])
         p.model.add_subsystem('par2', par2(), promotes=["*"])
 
-        # setup
         p.setup()
-
         p.run_model()
 
         # test all of the i/o sizes set by shape_by_conn

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -1033,7 +1033,7 @@ class TestDistribDynShapeCombos(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    # unittest.main()
-    myclass = TestDistribDynShapeCombos()
-    myclass.test_dyn_shape_combos()
+    unittest.main()
+    # myclass = TestDistribDynShapeCombos()
+    # myclass.test_dyn_shape_combos()
 


### PR DESCRIPTION
### Summary

This PR is a second try of the original PR in #1957. I wanted to start clean here because most of the discussion is outdated now.

This PR adds a test for the `shape_by_conn` feature with all combinations of serial/distributed components and the two modes of information transfer. The difference in this test compared to the existing ones is that we now test everything in a "parallel" run (i.e. more than one processor). So even though dynamic sizing of a serial component connected to another serial component is checked in other tests, it is only checked with a single processor. The test I am adding with this PR aims to check everything in a parallel run.

See the detailed explanation of the test at: https://github.com/anilyil/OpenMDAO/blob/4776e54ddf647846b93a3c47b04e399468636a31/openmdao/core/tests/test_dyn_sizing.py#L856-L916 

The checks marked with a TODO have issues currently: https://github.com/anilyil/OpenMDAO/blob/4776e54ddf647846b93a3c47b04e399468636a31/openmdao/core/tests/test_dyn_sizing.py#L979-L1003 

After discussing the possible pitfalls of propagating the dynamic shape in the "upstream" direction with @JustinSGray, we were moving towards disallowing the upstream mode. However, @joanibal is interested in maintaining it, so I kept the both directions in this test. In this PR, we should discuss if we will keep the upstream direction enabled, or if not, I will update this test to remove all examples of the upstream propagation.

Currently, I know of at least one bug with the dynamic shaping: In a serial to parallel component connection (see `ser_par_down` variable for an example), I would expect the local size of the serial output (which is the same on all procs) to be propagated to the parallel component in all procs. So say the serial component has an output of size 4 duplicated on all procs, I would have expected the parallel input to be sized 4 on all procs as well. However, currently the code just takes the size on one of the procs (size is 4) and "distributes" this vector among the rest of the processors. If running with 3 procs for example, the sizes each proc gets ends up being: 2,1,1, instead of 4,4,4. This is the case where shape by connection did not work in mphys (see: https://github.com/OpenMDAO/mphys/pull/51#discussion_r589012059)

Besides this, the "upstream" direction causes ambiguities with serial => parallel connections. In this case, we are sizing the input to the parallel component. This input size can be same on all procs with a variable that is duplicated, or the size on each proc can vary if we have a distributed input. 

Now, a serial component's output should have the same size on all processors. This is kinda the idea we had with the "duplicated serial components" in parallel runs. However, in this upstream dynamic shaping case, we cannot ensure that the input connected to the serial component's output will obey this. We can just throw an error if the user tries to connect a vector with different sizes on different procs this way between a serial and parallel component in the upstream mode. However, the user can have a distributed array, that happens to have the same size on all procs. In this case, we cannot throw the error because if the input to the parallel component has the same size on all procs, we have no way of knowing if the user expected this to be a distributed vector or a duplicated serial vector.

@joanibal and @JustinSGray, please discuss here if you want to keep the upstream mode of dynamic sizing. I personally do not care about removing it or not because my use cases do not rely on that feature. I have already spent way too much time on testing this, and would like to not spend more time on this. I am interested in fixing the dynamic sizing of serial to parallel connection in downstream mode.

### Related Issues

The documentation issue is in #1920. If we update the docs, we can also close that issue.