### PR TITLE
Add OpenMDAO version to case recorder file

### DIFF
--- a/openmdao/recorders/base_case_reader.py
+++ b/openmdao/recorders/base_case_reader.py
@@ -34,6 +34,7 @@ class BaseCaseReader(object):
             If True, load all the data into memory during initialization.
         """
         self._format_version = None
+        self._openmdao_version = None
         self.problem_metadata = {}
         self.solver_metadata = {}
         self._system_options = {}
@@ -65,6 +66,18 @@ class BaseCaseReader(object):
         warn_deprecation("The BaseCaseReader.system_metadata attribute is deprecated. "
                          "Use `list_model_options` instead.")
         return self._system_options
+
+    @property
+    def openmdao_version(self):
+        """
+        Provide the version of OpenMDAO that was used to record this file.
+
+        Returns
+        -------
+        str
+            version of OpenMDAO that was used to record this file.
+        """
+        return self._openmdao_version
 
     def get_cases(self, source, recurse=True, flat=False):
         """

--- a/openmdao/recorders/base_case_reader.py
+++ b/openmdao/recorders/base_case_reader.py
@@ -14,6 +14,8 @@ class BaseCaseReader(object):
     ----------
     _format_version : int
         The version of the format assumed when loading the file.
+    _openmdao_version : str
+        The version of OpenMDAO used to generate the case recorder file.
     problem_metadata : dict
         Metadata about the problem, including the system hierachy and connections.
     solver_metadata : dict

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -101,6 +101,7 @@ class SqliteCaseReader(BaseCaseReader):
 
             # collect data from the metadata table. this includes:
             #   format_version
+            #   openmdao_version
             #   VOI metadata, which is added to problem_metadata
             #   var name maps and metadata for all vars, which are saved as private attributes
             self._collect_metadata(cur)
@@ -163,8 +164,10 @@ class SqliteCaseReader(BaseCaseReader):
 
         row = cur.fetchone()
 
-        # get format_version
         self._format_version = version = row['format_version']
+
+        if version >= 13:
+            self._openmdao_version = row['openmdao_version']
 
         if version not in range(1, format_version + 1):
             raise ValueError('SqliteCaseReader encountered an unhandled '

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -203,7 +203,7 @@ class SqliteRecorder(CaseRecorder):
                           "conns TEXT)")
                 c.execute("INSERT INTO metadata(format_version, openmdao_version, abs2prom,"
                           " prom2abs) VALUES(?,?,?,?)", (format_version, openmdao_version,
-                                                       None, None))
+                                                         None, None))
 
                 # used to keep track of the order of the case records across all case tables
                 c.execute("CREATE TABLE global_iterations(id INTEGER PRIMARY KEY, "

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -15,6 +15,7 @@ import numpy as np
 
 import pickle
 
+from openmdao import __version__ as openmdao_version
 from openmdao.recorders.case_recorder import CaseRecorder
 from openmdao.utils.mpi import MPI
 from openmdao.utils.record_util import dict_to_structured_array
@@ -29,6 +30,8 @@ from openmdao.solvers.solver import Solver
 """
 SQL case database version history.
 ----------------------------------
+13-- OpenMDAO 3.8.1
+     Added OpenMDAO version number to recorder file
 12-- OpenMDAO 3.6.1
      Change key for system metadata to use non-ambiguous separator
 11-- OpenMDAO 3.2
@@ -56,7 +59,7 @@ SQL case database version history.
 1 -- Through OpenMDAO 2.3
      Original implementation.
 """
-format_version = 12
+format_version = 13
 
 # separator, cannot be a legal char for names
 META_KEY_SEP = '!'
@@ -195,11 +198,12 @@ class SqliteRecorder(CaseRecorder):
 
             self.connection = sqlite3.connect(filepath)
             with self.connection as c:
-                c.execute("CREATE TABLE metadata(format_version INT, "
+                c.execute("CREATE TABLE metadata(format_version INT, openmdao_version TEXT, "
                           "abs2prom TEXT, prom2abs TEXT, abs2meta TEXT, var_settings TEXT,"
                           "conns TEXT)")
-                c.execute("INSERT INTO metadata(format_version, abs2prom, prom2abs) "
-                          "VALUES(?,?,?)", (format_version, None, None))
+                c.execute("INSERT INTO metadata(format_version, openmdao_version, abs2prom,"
+                          " prom2abs) VALUES(?,?,?,?)", (format_version, openmdao_version,
+                                                       None, None))
 
                 # used to keep track of the order of the case records across all case tables
                 c.execute("CREATE TABLE global_iterations(id INTEGER PRIMARY KEY, "

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -14,6 +14,7 @@ import numpy as np
 from io import StringIO
 
 import openmdao.api as om
+from openmdao import __version__ as openmdao_version
 import openmdao
 from openmdao.recorders.sqlite_recorder import format_version
 from openmdao.recorders.sqlite_reader import SqliteCaseReader
@@ -3268,6 +3269,22 @@ class TestSqliteCaseReader(unittest.TestCase):
         for i, line in enumerate(expected_cases):
             self.assertEqual(text[i], line)
 
+    def test_get_openmdao_version(self):
+        prob = SellarProblem()
+        prob.setup()
+
+        prob.add_recorder(self.recorder)
+        prob.driver.add_recorder(self.recorder)
+        prob.model.d1.add_recorder(self.recorder)
+
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader(self.filename)
+
+        print(cr.openmdao_version)
+        self.assertEqual(openmdao_version, cr.openmdao_version)
+
 
 @use_tempdirs
 class TestFeatureSqliteReader(unittest.TestCase):
@@ -4036,6 +4053,9 @@ def _assert_model_matches_case(case, system):
 class TestSqliteCaseReaderLegacy(unittest.TestCase):
 
     legacy_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'legacy_sql')
+
+    # the change from v12 to v13 is just adding the openmdao version.
+    # the tests below should already be able to test the ability to read a file without that
 
     def test_options_v12(self):
 


### PR DESCRIPTION
### Summary

Added the version of OpenMDAO used to write the case recorder file to the metadata in the file.

### Related Issues

- Resolves #1951 

### Backwards incompatibilities

None - code can handle previous versions of the sqlite recorder files

### New Dependencies

None
