### PR TITLE
add _setup_check() hook

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -173,7 +173,9 @@ class Component(System):
         self._var_rel2meta.update(self._static_var_rel2meta)
         for io in ['input', 'output']:
             self._var_rel_names[io].extend(self._static_var_rel_names[io])
+
         self.setup()
+        self._setup_check()
 
         self._set_vector_class()
 
@@ -195,9 +197,9 @@ class Component(System):
         """
         Do any error checking on i/o configuration.
         """
-        # check here if declare_coloring was called during setup but declare_partials
-        # wasn't.  If declare partials wasn't called, call it with of='*' and wrt='*' so we'll
-        # have something to color.
+        # Check here if declare_coloring was called during setup but declare_partials wasn't.
+        # If declare partials wasn't called, call it with of='*' and wrt='*' so we'll have
+        # something to color.
         if self._coloring_info['coloring'] is not None:
             for key, meta in self._declared_partials.items():
                 if 'method' in meta and meta['method'] is not None:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -540,6 +540,7 @@ class Group(System):
 
         # Call setup function for this group.
         self.setup()
+        self._setup_check()
 
         # need to save these because _setup_var_data can be called multiple times
         # during the config process and we don't want to wipe out any group_inputs

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -763,6 +763,12 @@ class System(object):
         # this runs after the variable sizes are known
         self._setup_global_shapes()
 
+    def _setup_check(self):
+        """
+        Do any error checking on user's setup, before any other recursion happens.
+        """
+        pass
+
     def _configure_check(self):
         """
         Do any error checking on i/o and connections.


### PR DESCRIPTION
### Summary

add a `_setup_check` method (mirroring `_configure_check`) that gets called right after setup

### Related Issues

- Resolves #1973

### Backwards incompatibilities

None

### New Dependencies

None
