### PR TITLE
User can now add expressions to ExecComp using "add_expr".

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -441,7 +441,8 @@ class ExecComp(ExplicitComponent):
             Initial values of variables can be set by setting a named arg with the var name.  If
             the value is a dict it is assumed to contain metadata.  To set the initial value in
             addition to other metadata, assign the initial value to the 'value' entry of the dict.
-            Do not include for inputs that have been declared on previous expressions.
+            Do not include for inputs whose default kwargs have been declared on previous
+            expressions.
         """
         if not isinstance(expr, str):
             typ = type(expr).__name__

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -235,6 +235,35 @@ class ExecComp(ExplicitComponent):
                              desc='If True, shape all inputs and outputs based on their '
                                   'connection. Default is False.')
 
+    def add_expr(self, expr, **kwargs):
+        """
+        Add an expression to the ExecComp.
+
+        Parameters
+        ----------
+        expr : str
+            An assignment statement that expresses how the outputs are calculated based on the
+            inputs. In addition to standard Python operators, a subset of numpy and scipy
+            functions is supported.
+        **kwargs : dict of named args
+            Initial values of variables can be set by setting a named arg with the var name.  If
+            the value is a dict it is assumed to contain metadata.  To set the initial value in
+            addition to other metadata, assign the initial value to the 'value' entry of the dict.
+            Do not include for inputs that have been declared on previous expressions.
+        """
+        if not isinstance(expr, str):
+            typ = type(expr).__name__
+            msg = f"Argument 'expr' must be of type 'str', but type '{typ}' was found."
+            raise TypeError(msg)
+
+        self._exprs.append(expr)
+        for name in kwargs:
+            if name in self._kwargs:
+                raise NameError(f"Defaults for '{name}' have already been defined in a previous "
+                                "expression.")
+
+        self._kwargs.update(kwargs)
+
     @classmethod
     def register(cls, name, callable_obj, complex_safe):
         """

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -280,6 +280,9 @@ class ExecComp(ExplicitComponent):
 
     def _setup_expressions(self):
         """
+        Set up the expressions.
+
+        This is called during setup_procs and after each call to "add_expr" from configure.
         """
         global _not_complex_safe
 

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -235,35 +235,6 @@ class ExecComp(ExplicitComponent):
                              desc='If True, shape all inputs and outputs based on their '
                                   'connection. Default is False.')
 
-    def add_expr(self, expr, **kwargs):
-        """
-        Add an expression to the ExecComp.
-
-        Parameters
-        ----------
-        expr : str
-            An assignment statement that expresses how the outputs are calculated based on the
-            inputs. In addition to standard Python operators, a subset of numpy and scipy
-            functions is supported.
-        **kwargs : dict of named args
-            Initial values of variables can be set by setting a named arg with the var name.  If
-            the value is a dict it is assumed to contain metadata.  To set the initial value in
-            addition to other metadata, assign the initial value to the 'value' entry of the dict.
-            Do not include for inputs that have been declared on previous expressions.
-        """
-        if not isinstance(expr, str):
-            typ = type(expr).__name__
-            msg = f"Argument 'expr' must be of type 'str', but type '{typ}' was found."
-            raise TypeError(msg)
-
-        self._exprs.append(expr)
-        for name in kwargs:
-            if name in self._kwargs:
-                raise NameError(f"Defaults for '{name}' have already been defined in a previous "
-                                "expression.")
-
-        self._kwargs.update(kwargs)
-
     @classmethod
     def register(cls, name, callable_obj, complex_safe):
         """
@@ -302,11 +273,16 @@ class ExecComp(ExplicitComponent):
         """
         Set up variable name and metadata lists.
         """
-        global _not_complex_safe
-
         if not self._exprs:
             raise RuntimeError("%s: No valid expressions provided to ExecComp(): %s."
                                % (self.msginfo, self._exprs))
+        self._setup_expressions()
+
+    def _setup_expressions(self):
+        """
+        """
+        global _not_complex_safe
+
         exprs = self._exprs
         kwargs = self._kwargs
 
@@ -407,6 +383,11 @@ class ExecComp(ExplicitComponent):
             else:
                 init_vals[arg] = val
 
+        if self._static_mode:
+            var_rel2meta = self._static_var_rel2meta
+        else:
+            var_rel2meta = self._var_rel2meta
+
         for var in sorted(allvars):
             meta = kwargs2.get(var, {
                 'units': units,
@@ -419,15 +400,66 @@ class ExecComp(ExplicitComponent):
             else:
                 val = 1.0
 
-            if var in outs:
-                dct = self.add_output(var, val, **meta)
+            if var in var_rel2meta:
+                # Input/Output already exists, but we may be setting defaults for the first time.
+                # Note that there is only one submitted dictionary of defaults.
+                if var in outs:
+                    # Can't add two equations with the same output.
+                    raise RuntimeError(f"{self.msginfo}: The outout '{var}' has already been "
+                                       "defined by an expression.")
+
+                current_meta = var_rel2meta[var]
+
+                for kname, kvalue in meta.items():
+                    if kvalue is not None:
+                        current_meta[kname] = kvalue
+
+                new_val = kwargs[var].get('value')
+                if new_val is not None:
+                    current_meta['value'] = new_val
             else:
-                dct = self.add_input(var, val, **meta)
+                # new input and/or output.
+                if var in outs:
+                    dct = self.add_output(var, val, **meta)
+                else:
+                    dct = self.add_input(var, val, **meta)
 
             if var not in init_vals:
                 init_vals[var] = dct['value']
 
         self._codes = self._compile_exprs(self._exprs)
+
+    def add_expr(self, expr, **kwargs):
+        """
+        Add an expression to the ExecComp.
+
+        Parameters
+        ----------
+        expr : str
+            An assignment statement that expresses how the outputs are calculated based on the
+            inputs. In addition to standard Python operators, a subset of numpy and scipy
+            functions is supported.
+        **kwargs : dict of named args
+            Initial values of variables can be set by setting a named arg with the var name.  If
+            the value is a dict it is assumed to contain metadata.  To set the initial value in
+            addition to other metadata, assign the initial value to the 'value' entry of the dict.
+            Do not include for inputs that have been declared on previous expressions.
+        """
+        if not isinstance(expr, str):
+            typ = type(expr).__name__
+            msg = f"Argument 'expr' must be of type 'str', but type '{typ}' was found."
+            raise TypeError(msg)
+
+        self._exprs.append(expr)
+        for name in kwargs:
+            if name in self._kwargs:
+                raise NameError(f"Defaults for '{name}' have already been defined in a previous "
+                                "expression.")
+
+        self._kwargs.update(kwargs)
+
+        if not self._static_mode:
+            self._setup_expressions()
 
     def _compile_exprs(self, exprs):
         compiled = []

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -403,11 +403,6 @@ class ExecComp(ExplicitComponent):
             if var in var_rel2meta:
                 # Input/Output already exists, but we may be setting defaults for the first time.
                 # Note that there is only one submitted dictionary of defaults.
-                if var in outs:
-                    # Can't add two equations with the same output.
-                    raise RuntimeError(f"{self.msginfo}: The outout '{var}' has already been "
-                                       "defined by an expression.")
-
                 current_meta = var_rel2meta[var]
 
                 for kname, kvalue in meta.items():
@@ -463,7 +458,18 @@ class ExecComp(ExplicitComponent):
 
     def _compile_exprs(self, exprs):
         compiled = []
+        outputs = []
         for i, expr in enumerate(exprs):
+
+            # Quick dupe check.
+            lhs_name = expr.split('=', 1)[0].strip()
+            if lhs_name in outputs:
+                # Can't add two equations with the same output.
+                raise RuntimeError(f"{self.msginfo}: The output '{lhs_name}' has already been "
+                                   "defined by an expression.")
+            else:
+                outputs.append(lhs_name)
+
             try:
                 compiled.append(compile(expr, expr, 'exec'))
             except Exception:

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1347,23 +1347,25 @@ class TestExecComp(unittest.TestCase):
         import numpy as np
         import openmdao.api as om
 
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp('y=x',
+                                     x={'value' : 3.0, 'units' : 'mm'},
+                                     y={'shape' : (1, ), 'units' : 'cm'})
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                self.excomp.add_expr('z = 2.9*x',
+                                     z={'shape' : (1, ), 'units' : 's'})
+
         p = om.Problem()
-
-        excomp = om.ExecComp()
-
-        excomp.add_expr('z = 2.9*x',
-                        x={'value' : 3.0, 'units' : 'mm'},
-                        z={'shape' : (1, ), 'units' : 's'})
-
-        excomp.add_expr('y = 3.7*x',
-                        y={'value' : 9.0, 'units' : 'km'})
-
-        p.model.add_subsystem('comp', excomp, promotes=['*'])
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
         p.setup()
         p.run_model()
 
         assert_almost_equal(p.get_val('z'), 8.7, 1e-8)
-        assert_almost_equal(p.get_val('y'), 11.1, 1e-8)
+        assert_almost_equal(p.get_val('y'), 3.0, 1e-8)
 
 
 class TestFunctionRegistration(unittest.TestCase):

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1335,6 +1335,14 @@ class TestExecComp(unittest.TestCase):
         self.assertEquals(cm.exception.args[0],
                           "Argument 'expr' must be of type 'str', but type 'Problem' was found.")
 
+        excomp.add_expr('y = 2.9*x')
+        p.model.add_subsystem('zzz', excomp)
+        with self.assertRaises(RuntimeError) as cm:
+            p.setup()
+
+        self.assertEquals(cm.exception.args[0],
+                          "'zzz' <class ExecComp>: The output 'y' has already been defined by an expression.")
+
     def test_feature_add_expr(self):
         import numpy as np
         import openmdao.api as om

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1267,6 +1267,52 @@ class TestExecComp(unittest.TestCase):
 
         assert_almost_equal(p.get_val('z'), 8.7, 1e-8)
 
+    def test_add_expr_configure(self):
+
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp('y=x',
+                                     x={'value' : 3.0, 'units' : 'mm'},
+                                     y={'shape' : (1, ), 'units' : 'cm'})
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                self.excomp.add_expr('z = 2.9*x',
+                                     z={'shape' : (1, ), 'units' : 's'})
+
+
+        p = om.Problem()
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
+        p.setup()
+        p.run_model()
+
+        assert_almost_equal(p.get_val('z'), 8.7, 1e-8)
+        assert_almost_equal(p.get_val('y'), 3.0, 1e-8)
+
+    def test_add_expr_configure_delay_defaults(self):
+
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp('y=x',
+                                     y={'shape' : (1, ), 'units' : 'cm'})
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                self.excomp.add_expr('z = 2.9*x',
+                                     x={'value' : 3.0, 'units' : 'mm'},
+                                     z={'shape' : (1, ), 'units' : 's'})
+
+
+        p = om.Problem()
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
+        p.setup()
+        p.run_model()
+
+        assert_almost_equal(p.get_val('z'), 8.7, 1e-8)
+        assert_almost_equal(p.get_val('y'), 3.0, 1e-8)
+
     def test_add_expr_errors(self):
         p = om.Problem()
 

--- a/openmdao/docs/features/building_blocks/components/exec_comp.rst
+++ b/openmdao/docs/features/building_blocks/components/exec_comp.rst
@@ -179,5 +179,14 @@ that `fd` should be used for a given derivative is to call :code:`declare_partia
     openmdao.components.tests.test_exec_comp.TestFunctionRegistration.featuretest_register_simple_unsafe
     :layout: interleave
 
+ExecComp Example: Adding Expressions
+------------------------------------
+
+You can add additional expressions to an `ExecComp` with the "add_expr" method.
+
+.. embed-code::
+    openmdao.components.tests.test_exec_comp.TestExecComp.test_feature_add_expr
+    :layout: interleave
+
 
 .. tags:: ExecComp, Component, Examples


### PR DESCRIPTION
### Summary

1. User can now add expressions to ExecComp using "add_expr".
(1a) Expressions can be added during "configure" on a higher group.
2. Fixed a bug where we allowed multiple expression with the same output to be declared.

### Related Issues

- Resolves #1966

### Backwards incompatibilities

None

### New Dependencies

None
