### PR TITLE
Fixed a bug where the global_size was incorrect for a design variable that is specified with indices on an IVC output declared as a distributed component.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3049,12 +3049,12 @@ class System(object):
                 if src_name in abs2idx:
                     indices = meta['indices']
                     meta = abs2meta_out[src_name]
+                    out[name]['distributed'] = meta['distributed']
                     if indices is not None:
                         # Index defined in this response.
                         out[name]['global_size'] = len(indices) if meta['distributed'] \
                             else meta['global_size']
                     else:
-                        out[name]['distributed'] = meta['distributed']
                         out[name]['global_size'] = meta['global_size']
                 else:
                     out[name]['global_size'] = 0  # discrete var

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3041,9 +3041,15 @@ class System(object):
                 meta['size'] = int(meta['size'])  # make default int so will be json serializable
 
                 if src_name in abs2idx:
+                    indices = meta['indices']
                     meta = abs2meta_out[src_name]
-                    out[name]['distributed'] = meta['distributed']
-                    out[name]['global_size'] = meta['global_size']
+                    if indices is not None:
+                        # Index defined in this response.
+                        out[name]['global_size'] = len(indices) if meta['distributed'] \
+                            else meta['global_size']
+                    else:
+                        out[name]['distributed'] = meta['distributed']
+                        out[name]['global_size'] = meta['global_size']
                 else:
                     out[name]['global_size'] = 0  # discrete var
 

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -1357,6 +1357,40 @@ class DeclarePartialsWithoutRowCol(unittest.TestCase):
         assert_near_equal(data[('execcomp.z', 'dvs.x')]['abs error'][0], 0.0, 1e-6)
 
 
+class TestBugs(unittest.TestCase):
+
+    def test_distributed_ivc_as_desvar(self):
+        # Covers a case where a distributed IVC output is used as a desvar with indices.
+
+        class DVS(om.IndepVarComp):
+            def initialize(self):
+                self.options['distributed'] = True
+            def setup(self):
+                self.add_output('state', np.ones(4))
+
+        class SolverComp(om.ExplicitComponent):
+            def initialize(self):
+                self.options['distributed'] = True
+            def setup(self):
+                self.add_input('state',shape_by_conn=True)
+                self.add_output('func')
+                self.declare_partials('func','state',method='fd')
+
+            def compute(self, inputs, outputs):
+                outputs['func'] += np.sum(inputs['state'])
+
+        prob = om.Problem()
+        dvs = prob.model.add_subsystem('dvs',DVS())
+        prob.model.add_subsystem('solver', SolverComp())
+        prob.model.connect('dvs.state','solver.state')
+        prob.model.add_design_var('dvs.state', indices=[0,2])
+        prob.model.add_objective('solver.func')
+
+        prob.setup()
+        prob.run_model()
+        totals = prob.check_totals(wrt='dvs.state')
+        assert_near_equal(totals['solver.func', 'dvs.state']['abs error'][0], 0.0, tolerance=1e-7)
+
 if __name__ == "__main__":
     from openmdao.utils.mpi import mpirun_tests
     mpirun_tests()


### PR DESCRIPTION
### Summary

Fixed a bug where the global_size was incorrect for a design variable that is specified with indices on an IVC output declared as a distributed component.

### Related Issues

- Resolves #1965

### Backwards incompatibilities

None

### New Dependencies

None
