### PR TITLE
Generate more informative error message if a src_indices containing slicing operators was incorrectly set

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1548,7 +1548,14 @@ class Component(System):
                                                 meta['src_indices'], src_shape)
                 elif _is_slicer_op(src_inds):
                     meta['src_slice'] = src_inds
-                    src_inds = _slice_indices(src_inds, np.prod(parent_src_shape), parent_src_shape)
+                    try:
+                        src_inds = _slice_indices(src_inds, np.prod(parent_src_shape),
+                                                  parent_src_shape)
+                    except IndexError as err:
+                        raise IndexError(f"In component {self.msginfo}: \nError '{err}'\n  in "
+                                         f"resolving source indices in connection "
+                                         f"between source='{oldprom}' "
+                                         f"and target='{tgt}'\n  with src_indices='{src_inds}'")
                     meta['flat_src_indices'] = True
                 elif src_inds.ndim == 1:
                     meta['flat_src_indices'] = True

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1552,7 +1552,7 @@ class Component(System):
                         src_inds = _slice_indices(src_inds, np.prod(parent_src_shape),
                                                   parent_src_shape)
                     except IndexError as err:
-                        raise IndexError(f"In component {self.msginfo}: \nError '{err}'\n  in "
+                        raise IndexError(f"{self.msginfo}:\nError '{err}'\n  in "
                                          f"resolving source indices in connection "
                                          f"between source='{oldprom}' "
                                          f"and target='{tgt}'\n  with src_indices='{src_inds}'")

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2516,11 +2516,16 @@ class TestSrcIndices(unittest.TestCase):
         # the 4 should be a 3
         p.model.connect('indep.x', 'row4_comp.x', src_indices=om.slicer[4, ...])
 
-        with self.assertRaises(IndexError) as e:
+        with self.assertRaises(IndexError) as err:
             p.setup()
 
-        self.assertTrue(str(e.exception).startswith("In component 'row4_comp'"))
-        self.assertTrue(str(e.exception).endswith("with src_indices='(4, Ellipsis)'"))
+        expected_error_msg = ( "'row4_comp' <class SlicerComp>:\n"
+                               "Error 'index 4 is out of bounds for axis 0 with size 4'\n"
+                               "  in resolving source indices in connection between"
+                               " source='indep.x' and target='row4_comp.x'\n"
+                               "  with src_indices='(4, Ellipsis)'" )
+        self.assertEqual(str(err.exception), expected_error_msg)
+
 
 class TestGroupAddInput(unittest.TestCase):
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2506,6 +2506,22 @@ class TestSrcIndices(unittest.TestCase):
                                 flat_src_indices=True,
                                 raise_connection_errors=False)
 
+    def test_om_slice_with_ellipsis_error_in_connect(self):
+
+        p = om.Problem()
+
+        p.model.add_subsystem('indep', om.IndepVarComp('x', arr_large_4x4))
+        p.model.add_subsystem('row4_comp', SlicerComp())
+
+        # the 4 should be a 3
+        p.model.connect('indep.x', 'row4_comp.x', src_indices=om.slicer[4, ...])
+
+        with self.assertRaises(IndexError) as e:
+            p.setup()
+
+        self.assertTrue(str(e.exception).startswith("In component 'row4_comp'"))
+        self.assertTrue(str(e.exception).endswith("with src_indices='(4, Ellipsis)'"))
+
 class TestGroupAddInput(unittest.TestCase):
 
     def _make_tree_model(self, diff_units=False, diff_vals=False):


### PR DESCRIPTION

### Summary

If the src_indices uses a slicing operator like a colon or ellipsis, and the user makes an error with the src_indices such that an exception occurs, the user only gets a very unhelpful error message like this:

IndexError: index 4 is out of bounds for axis 0 with size 4

A better error message needs to be generated so the user has some hint as to where the problem is.

This PR does that and also includes a test for it.

### Related Issues

- Resolves #1987 

### Backwards incompatibilities

None

### New Dependencies

None
