### PR TITLE
New decorator package v5 breaks networkx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,6 +152,7 @@ setup(
     },
     python_requires=">=3.6",
     install_requires=[
+        'decorator<5',
         'networkx>=2.0',
         'numpy',
         'pyDOE2',


### PR DESCRIPTION
### Summary

install older version of `decorator` before `network` due to incompatibility with new decorator v5
### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
