### PR TITLE
Order shouldn't matter when promoting wildcards and aliased names on add_subsystem.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2423,12 +2423,20 @@ class Group(System):
 
         prominfo = None
 
+        # Note, the declared order in any of these promotes arguments shouldn't matter. However,
+        # the order does matter when using system.promotes during configure. There, you are
+        # permitted to promote '*' then promote_to an alias afterwards, but not in the reverse.
+        # To make this work, we sort the promotes lists for this subsystem to put the wild card
+        # entries at the beginning.
         if promotes:
-            subsys._var_promotes['any'] = [(p, prominfo) for p in promotes]
+            subsys._var_promotes['any'] = [(p, prominfo) for p in
+                                           sorted(promotes, key=lambda x: '*' not in x)]
         if promotes_inputs:
-            subsys._var_promotes['input'] = [(p, prominfo) for p in promotes_inputs]
+            subsys._var_promotes['input'] = [(p, prominfo) for p in
+                                             sorted(promotes_inputs, key=lambda x: '*' not in x)]
         if promotes_outputs:
-            subsys._var_promotes['output'] = [(p, prominfo) for p in promotes_outputs]
+            subsys._var_promotes['output'] = [(p, prominfo) for p in
+                                              sorted(promotes_outputs, key=lambda x: '*' not in x)]
 
         if self._static_mode:
             subsystems_allprocs = self._static_subsystems_allprocs

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2041,6 +2041,34 @@ class TestGroupPromotes(unittest.TestCase):
         self.assertEqual(str(cm.exception),
             "In connection from 'ind.a' to 'sub.comp.a', input 'sub.a' src_indices are [0 1 2] and indexing into those failed using src_indices [0 2 4] from input 'sub.comp.a'. Error was: index 4 is out of bounds for axis 0 with size 3.")
 
+    def test_promotes_list_order(self):
+        # This test verifies that the order we promote in the arguments to add_subsystem doesn't
+        # trigger any of our exceptions when we have wildcards with promote_as.
+        class AllPatterns(om.Group):
+            def setup(self):
+                comp = om.ExecComp(['a1=b1+c1', 'g1=b1-c1'])
+                self.add_subsystem('comp1', comp,
+                                   promotes_inputs=['*',('c1','ialias1')],
+                                   promotes_outputs=['*',('g1','oalias1')])
+
+                comp = om.ExecComp(['a2=b2+c2', 'g2=b2-c2'])
+                self.add_subsystem('comp2', comp,
+                                   promotes_inputs=[('c2','ialias2'), '*'],
+                                   promotes_outputs=[('g2','oalias2'), '*'])
+
+                comp = om.ExecComp(['a3=b3+c3', 'g3=b3-c3'])
+                self.add_subsystem('comp3', comp,
+                                   promotes=[('c3','ialias3'), ('g3','oalias3'), '*'])
+
+                comp = om.ExecComp(['a4=b4+c4', 'g4=b4-c4'])
+                self.add_subsystem('comp4', comp,
+                                   promotes=['*', ('c4','ialias4'), ('g4','oalias4')])
+
+        p = om.Problem(model=AllPatterns())
+        p.setup()
+        p.run_model()
+        # If working correctly, no exception raised.
+
 
 class MyComp(om.ExplicitComponent):
     def __init__(self, input_shape, src_indices=None, flat_src_indices=False):


### PR DESCRIPTION
Order shouldn't matter when promoting wildcards and aliased names on add_subsystem.

### Summary

We originally proposed OpenMDAO/POEMs#101 as a solution to this. This would have changed the current behavior, where we currently disallow a wildcard promote to be used in `promotes` during configure if a variable covered by that wildcard has already been promoted with an alias.  However, we felt this change could lead to confusion if the user thought that later calls of promote could replace existing aliases.

A better solution was found to fix this. During the add_subsystem call, the contents of the variable names listed in `promotes`, `promotes_inputs`, and `promotes_outputs` are sorted so that wildcards come first. This way, the exception is never triggered.

### Related Issues

- Resolves #1935

### Backwards incompatibilities

None

### New Dependencies

None
