### PR TITLE
add minimal config to Actions

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -27,6 +27,7 @@ jobs:
             PETSc: 3.12
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
+            OPTIONAL: '[all]'
 
           # try latest versions
           - PY: 3
@@ -35,6 +36,7 @@ jobs:
             # PETSc: 3
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
+            OPTIONAL: '[test]'
 
           # oldest supported versions
           - PY: 3.6
@@ -43,6 +45,7 @@ jobs:
             PETSc: 3.10.2
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
+            OPTIONAL: '[all]'
 
     steps:
       - name: Create SSH key
@@ -136,13 +139,15 @@ jobs:
           echo "=============================================================";
           echo "Install OpenMDAO";
           echo "=============================================================";
-          pip install .[all];
+          pip install .${{ matrix.OPTIONAL }};
 
           echo "=============================================================";
           echo "Install optional packages for testing/coverage";
           echo "=============================================================";
-          pip install psutil objgraph git+https://github.com/mdolab/pyxdsm;
-          pyppeteer-install;
+          if [ "${{ matrix.OPTIONAL }}" == "[all]" ]; then
+            pip install psutil objgraph git+https://github.com/mdolab/pyxdsm;
+            pyppeteer-install;
+          fi
 
           echo "=============================================================";
           echo "List installed packages/versions";
@@ -156,7 +161,7 @@ jobs:
           cp ../../.coveragerc .
           testflo -n 1 openmdao --timeout=120 --show_skipped --coverage --coverpkg openmdao;
           
-          if [ "${{ matrix.PETSc }}" ]; then
+          if [ "${{ matrix.PETSc }}" && "${{ matrix.OPTIONAL }}" == "[all]" ]; then
             echo "=============================================================";
             echo "Make docs";
             echo "=============================================================";

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -3,8 +3,11 @@ import unittest
 
 import numpy as np
 
-import matplotlib.pyplot as plt
-plt.switch_backend('Agg')
+try:
+    import matplotlib.pyplot as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
 
 import openmdao.api as om
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
@@ -293,6 +296,7 @@ class TestKSFunctionFeatures(unittest.TestCase):
 
         assert_near_equal(prob.get_val('ks.KS'), [[-12.0]])
 
+    @unittest.skipIf(not plt, "requires matplotlib")
     def test_add_constraint(self):
         import numpy as np
         import openmdao.api as om

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -38,9 +38,12 @@ OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
-# do not show matplotlib plots
-import matplotlib
-matplotlib.use('Agg')
+try:
+    # do not show matplotlib plots
+    import matplotlib.pyplot as plt
+    plt.switch_backend('Agg')
+except ImportError:
+    plt = None
 
 
 class Cycle(om.Group):
@@ -3323,6 +3326,7 @@ class TestFeatureAdvancedExample(unittest.TestCase):
                            3.16, 3.16, 3.16, 3.16, 3.16, 3.16, 3.16],
                           tolerance=1e-1)
 
+    @unittest.skipIf(not plt, "requires matplotlib")
     def test_feature_solver_recorder(self):
         import numpy as np
         import matplotlib.pyplot as plt
@@ -3407,6 +3411,7 @@ class TestFeatureAdvancedExample(unittest.TestCase):
         assert_near_equal(case.get_constraints(), {'con1': 0., 'con2': -20.2447}, tolerance=1e-4)
         assert_near_equal(case.get_objectives(), {'obj': 3.18339395}, tolerance=1e-4)
 
+    @unittest.skipIf(not plt, "requires matplotlib")
     def test_feature_plot_des_vars(self):
         import matplotlib.pyplot as plt
         import numpy as np

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -12,6 +12,21 @@ try:
 except ImportError:
     from openmdao.utils.assert_utils import SkipParameterized as parameterized
 
+try:
+    import psutil
+except ImportError:
+    psutil = None
+
+try:
+    import matplotlib
+except ImportError:
+    matplotlib = None
+
+try:
+    import tornado
+except ImportError:
+    tornado = None
+
 dname = os.path.dirname
 
 scriptdir = os.path.join(dname(dname(dname(os.path.abspath(__file__)))), 'test_suite', 'scripts')
@@ -23,41 +38,55 @@ def _test_func_name(func, num, param):
     return func.__name__ + '_' + re.sub('[ \\:\\\]', '_', param.args[0])
 
 cmd_tests = [
-    'openmdao call_tree openmdao.components.exec_comp.ExecComp.setup',
-    'openmdao check {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao cite {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao compute_entry_points openmdao',
-    'openmdao iprof --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao iprof_totals {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao list_installed component command nl_solver lin_solver driver',
-    'openmdao list_installed component -d',
-    'openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'bad_connection.py')),
-    'openmdao n2 --no_browser {} -- -f bar'.format(os.path.join(scriptdir, 'circle_coloring_needs_args.py')),
-    'openmdao partial_coloring {}'.format(os.path.join(scriptdir, 'circle_coloring_dynpartials.py')),
-    'openmdao scaffold -b ExplicitComponent -c Foo',
-    'openmdao scaffold -b ImplicitComponent -c Foo',
-    'openmdao scaffold -p blahpkg --cmd=hello',
-    'openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao total_coloring {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao trace {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao tree -c {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao view_connections --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao view_dyn_shapes --no_display {}'.format(os.path.join(scriptdir, 'dyn_system.py')),
+    # tuple of (command line, dict of dependencies that might not be installed)
+    ('openmdao call_tree openmdao.components.exec_comp.ExecComp.setup', {}),
+    ('openmdao check {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao cite {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao compute_entry_points openmdao', {}),
+    ('openmdao iprof --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        {'tornado': tornado}),
+    ('openmdao iprof_totals {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao list_installed component command nl_solver lin_solver driver', {}),
+    ('openmdao list_installed component -d', {}),
+    ('openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'bad_connection.py')), {}),
+    ('openmdao n2 --no_browser {} -- -f bar'.format(os.path.join(scriptdir, 'circle_coloring_needs_args.py')), {}),
+    ('openmdao partial_coloring {}'.format(os.path.join(scriptdir, 'circle_coloring_dynpartials.py')), {}),
+    ('openmdao scaffold -b ExplicitComponent -c Foo', {}),
+    ('openmdao scaffold -b ImplicitComponent -c Foo', {}),
+    ('openmdao scaffold -p blahpkg --cmd=hello', {}),
+    ('openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao total_coloring {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao trace {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao tree -c {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao view_connections --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
+    ('openmdao view_dyn_shapes --no_display {}'.format(os.path.join(scriptdir, 'dyn_system.py')),
+        {'matplotlib': matplotlib}),
+    ('openmdao mem {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        {'psutil': psutil}),
+    ('openmdao mem --tree {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        {'psutil': psutil}),
+    ('openmdao trace -m {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
+        {'psutil': psutil})
 ]
 
 
-mem_cmd_tests = [
-    'openmdao mem {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao mem --tree {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-    'openmdao trace -m {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
-]
+@use_tempdirs
+class CmdlineTestCase(unittest.TestCase):
+    @parameterized.expand(cmd_tests, name_func=_test_func_name)
+    def test_cmd(self, cmd, dependencies):
+        # skip any commands for which we do not have required dependencies
+        for name, installed in dependencies.items():
+            if not installed:
+                raise unittest.SkipTest(f"{name} is not installed")
 
-
-try:
-    import psutil
-except ImportError:
-    psutil = None
+        # this only tests that a given command line tool returns a 0 return code. It doesn't
+        # check the expected output at all.  The underlying functions that implement the
+        # commands should be tested seperately.
+        try:
+            output = subprocess.check_output(cmd.split())
+        except subprocess.CalledProcessError as err:
+            self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
 
 
 class CmdlineTestCaseCheck(unittest.TestCase):
@@ -70,29 +99,6 @@ class CmdlineTestCaseCheck(unittest.TestCase):
         for i in out.decode('utf-8').split("\n"):
             if "WARNING:" in i:
                 self.assertEqual(i, msg)
-
-@use_tempdirs
-class CmdlineTestCase(unittest.TestCase):
-    @parameterized.expand(cmd_tests, name_func=_test_func_name)
-    def test_cmd(self, cmd):
-        # this only tests that a given command line tool returns a 0 return code. It doesn't
-        # check the expected output at all.  The underlying functions that implement the
-        # commands should be tested seperately.
-        try:
-            output = subprocess.check_output(cmd.split())
-        except subprocess.CalledProcessError as err:
-            self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
-
-    @parameterized.expand(mem_cmd_tests, name_func=_test_func_name)
-    @unittest.skipIf(psutil is None, 'psutil must be installed to run mem commands')
-    def test_cmd2(self, cmd):
-        # this only tests that a given command line tool returns a 0 return code. It doesn't
-        # check the expected output at all.  The underlying functions that implement the
-        # commands should be tested seperately.
-        try:
-            output = subprocess.check_output(cmd.split())
-        except subprocess.CalledProcessError as err:
-            self.fail("Command '{}' failed.  Return code: {}".format(cmd, err.returncode))
 
 
 col_test_file = coloring_test_mod.__file__


### PR DESCRIPTION
### Summary

Include a test configuration in the GitHub Actions matrix that does not install `[all]` optional dependencies, in order to make sure there are no errors when those optional dependencies are not installed.

### Related Issues

- Resolves #2007 

### Backwards incompatibilities

None

### New Dependencies

None
