### PR TITLE
Fix bug where the rel_err on a case was actually the abs_err.

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -123,7 +123,7 @@ class Case(object):
 
         # for a solver or problem case
         self.abs_err = data['abs_err'] if 'abs_err' in data.keys() else None
-        self.rel_err = data['abs_err'] if 'rel_err' in data.keys() else None
+        self.rel_err = data['rel_err'] if 'rel_err' in data.keys() else None
 
         # rename solver keys
         if 'solver_inputs' in data.keys():

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2778,7 +2778,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.cleanup()
 
         cr = om.CaseReader(self.filename)
-        case = cr.get_cases()[-1]
+        case = cr.get_case(cr.list_cases()[-1])
 
         norm =  nl._iter_get_norm()
         norm0 = nl._norm0

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2758,6 +2758,33 @@ class TestSqliteCaseReader(unittest.TestCase):
         for case in expected_cases:
             self.assertTrue(case in all_driver_cases)
 
+    def test_abs_rel_error(self):
+        prob = om.Problem()
+        model = prob.model
+        model.add_subsystem('comp', ImplCompTwoStates())
+
+        # mda solver
+        nl = model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        nl.options['maxiter'] = 2
+        nl.recording_options['record_abs_error'] = True
+        nl.recording_options['record_rel_error'] = True
+        nl.recording_options['record_solver_residuals'] = True
+        nl.add_recorder(self.recorder)
+
+        prob.setup()
+        prob.set_val('comp.y', 8.0)
+        prob.set_val('comp.z', 5.0)
+        prob.run_model()
+        prob.cleanup()
+
+        cr = om.CaseReader(self.filename)
+        case = cr.get_cases()[-1]
+
+        norm =  nl._iter_get_norm()
+        norm0 = nl._norm0
+        self.assertEqual(case.abs_err, norm)
+        self.assertEqual(case.rel_err, norm/norm0)
+
     def test_linesearch(self):
         prob = om.Problem()
 


### PR DESCRIPTION
### Summary

Fix bug where the rel_err on a case was actually the abs_err.  Simply a copy-paste error in the code.

### Related Issues

- Resolves #2011

### Backwards incompatibilities

None

### New Dependencies

None
