### PR TITLE
fix for scaffold test warnings and a KriggingSurrogate test failure

### DIFF
--- a/openmdao/surrogate_models/tests/test_kriging.py
+++ b/openmdao/surrogate_models/tests/test_kriging.py
@@ -147,7 +147,7 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         surrogate.train(x, y)
         jac = surrogate.linearize(np.array([[0.5, 0.5]]))
-        assert_near_equal(jac, np.array([[1, 1], [1, -1], [1, 2]]), 5e-4)
+        assert_near_equal(jac, np.array([[1, 1], [1, -1], [1, 2]]), 6e-4)
 
     def test_cache(self):
         x = np.array([[-2., 0.], [-0.5, 1.5], [1., 3.], [8.5, 4.5],

--- a/openmdao/utils/scaffold.py
+++ b/openmdao/utils/scaffold.py
@@ -131,8 +131,8 @@ def _scaffold_exec(options, user_args):
 
                 setup_dict = {
                     'name': dist_name,
-                    'version': '???',
-                    'description': '???',
+                    'version': '0.0.1',
+                    'description': '',
                     'keywords': keywords,
                     'license': '???',
                     'packages': [pkg_name, pkg_name + '.' + 'test'],


### PR DESCRIPTION
### Summary

'openmdao scaffold' was generating a setup.py file that set the version to '???' which violates PEP 440.

- also noticed a numerical failure in a KriggingSurrogate test when building using a new conda environment based on one of our travis builds, so I slightly updated the tolerance for that after discussing with @Kenneth-T-Moore .

### Related Issues

- Resolves #2017

### Backwards incompatibilities

None

### New Dependencies

None
