### PR TITLE
Upload documentation from GitHub Actions CI instead of Travis CI

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -114,7 +114,7 @@ jobs:
               PAROPT=-a
             fi
 
-            if [ "${{ matrix.SNOPT }}" == "7.7" ] && [ "${{ secrets.SNOPT_LOCATION_77 }}" ] then
+            if [ "${{ matrix.SNOPT }}" == "7.7" ] && [ "${{ secrets.SNOPT_LOCATION_77 }}" ]; then
               echo "  > Secure copying SNOPT 7.7 over SSH"
               mkdir SNOPT
               scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -178,10 +178,12 @@ jobs:
           coveralls --base_dir $SITE_DIR
           
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${{ matrix.UPLOAD_DOCS }}" ]]; then
-            echo "============================================================="
-            echo "Upload docs"
-            echo "============================================================="
-            python _utils/upload_doc_version.py ${{ secrets.DOCS_LOCATION }}
+            if [[ ${{ secrets.DOCS_LOCATION }} ]]; then
+              echo "============================================================="
+              echo "Upload docs"
+              echo "============================================================="
+              python _utils/upload_doc_version.py ${{ secrets.DOCS_LOCATION }}
+            fi
           fi
 
       - uses: act10ns/slack@v1

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -179,7 +179,7 @@ jobs:
           SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`;
           coveralls --base_dir $SITE_DIR;
           
-          if [[ "${GITHUB_EVENT_NAME} == "push" && "${{ matrix.UPLOAD_DOCS }}" ]]; then
+          if [[ "${GITHUB_EVENT_NAME}" == "push" && "${{ matrix.UPLOAD_DOCS }}" ]]; then
             echo "=============================================================";
             echo "Upload docs";
             echo "=============================================================";

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -38,7 +38,6 @@ jobs:
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
             OPTIONAL: '[test]'
-            UPLOAD_DOCS: False
 
           # oldest supported versions
           - PY: 3.6
@@ -48,7 +47,6 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             OPTIONAL: '[all]'
-            UPLOAD_DOCS: False
 
     steps:
       # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -76,112 +76,112 @@ jobs:
           COVERALLS_SERVICE_NAME: "github"
           COVERALLS_PARALLEL: True
         run: |
-          echo "=============================================================";
-          echo "Run #${GITHUB_RUN_NUMBER}";
-          echo "Run ID: ${GITHUB_RUN_ID}";
-          echo "Testing: ${GITHUB_REPOSITORY}";
-          echo "Triggered by: ${GITHUB_EVENT_NAME}";
-          echo "Initiated by: ${GITHUB_ACTOR}";
-          echo "=============================================================";
+          echo "============================================================="
+          echo "Run #${GITHUB_RUN_NUMBER}"
+          echo "Run ID: ${GITHUB_RUN_ID}"
+          echo "Testing: ${GITHUB_REPOSITORY}"
+          echo "Triggered by: ${GITHUB_EVENT_NAME}"
+          echo "Initiated by: ${GITHUB_ACTOR}"
+          echo "============================================================="
 
-          echo "=============================================================";
-          echo "Create conda environment";
-          echo "=============================================================";
-          source $CONDA/etc/profile.d/conda.sh;
-          echo $CONDA/bin >> $GITHUB_PATH;
-          conda create -n OpenMDAO python=${{ matrix.PY }} numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y;
-          conda activate OpenMDAO;
+          echo "============================================================="
+          echo "Create conda environment"
+          echo "============================================================="
+          source $CONDA/etc/profile.d/conda.sh
+          echo $CONDA/bin >> $GITHUB_PATH
+          conda create -n OpenMDAO python=${{ matrix.PY }} numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          conda activate OpenMDAO
 
           if [ "${{ matrix.PETSc }}" ]; then
-            echo "=============================================================";
-            echo "Install PETSc";
-            echo "=============================================================";
-            conda install -c anaconda mpi4py -q -y;
-            conda install -c conda-forge petsc=${{ matrix.PETSc }} petsc4py -q -y;
+            echo "============================================================="
+            echo "Install PETSc"
+            echo "============================================================="
+            conda install -c anaconda mpi4py -q -y
+            conda install -c conda-forge petsc=${{ matrix.PETSc }} petsc4py -q -y
           fi
 
           if [ "${{ matrix.PYOPTSPARSE }}" ]; then
-            echo "=============================================================";
-            echo "Install pyoptsparse";
-            echo "=============================================================";
+            echo "============================================================="
+            echo "Install pyoptsparse"
+            echo "============================================================="
 
-            git clone -q https://github.com/OpenMDAO/build_pyoptsparse;
+            git clone -q https://github.com/OpenMDAO/build_pyoptsparse
 
-            cd build_pyoptsparse;
-            chmod 755 ./build_pyoptsparse.sh;
+            cd build_pyoptsparse
+            chmod 755 ./build_pyoptsparse.sh
 
             if [ "${{ matrix.PETSc }}" ] && [ "${{ matrix.PYOPTSPARSE }}" == "v1.2"]; then
-              PAROPT=-a;
+              PAROPT=-a
             fi
 
-            if [ "${{ matrix.SNOPT }}" == "7.7" ] && [ "${{ secrets.SNOPT_LOCATION_77 }}" ]; then
-              echo "  > Secure copying SNOPT 7.7 over SSH";
-              mkdir SNOPT;
-              scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT;
-              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -s SNOPT/src;
+            if [ "${{ matrix.SNOPT }}" == "7.7" ] && [ "${{ secrets.SNOPT_LOCATION_77 }}" ] then
+              echo "  > Secure copying SNOPT 7.7 over SSH"
+              mkdir SNOPT
+              scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT
+              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -s SNOPT/src
 
             elif [ "${{ matrix.SNOPT }}" == "7.2" ] && [ "${{ secrets.SNOPT_LOCATION_72 }}" ]; then
-              echo "  > Secure copying SNOPT 7.2 over SSH";
-              mkdir SNOPT;
-              scp -qr ${{ secrets.SNOPT_LOCATION_72 }} SNOPT;
-              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -s SNOPT/source;
+              echo "  > Secure copying SNOPT 7.2 over SSH"
+              mkdir SNOPT
+              scp -qr ${{ secrets.SNOPT_LOCATION_72 }} SNOPT
+              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -s SNOPT/source
 
             else
               if [ "${{ matrix.SNOPT }}" ]; then
-                echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available";
+                echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
               fi
-              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}";
+              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}"
             fi
 
-            cd ..;
+            cd ..
 
-            export LD_LIBRARY_PATH=$HOME/ipopt/lib;
+            export LD_LIBRARY_PATH=$HOME/ipopt/lib
           fi
 
-          echo "=============================================================";
-          echo "Install OpenMDAO";
-          echo "=============================================================";
-          pip install .${{ matrix.OPTIONAL }};
+          echo "============================================================="
+          echo "Install OpenMDAO"
+          echo "============================================================="
+          pip install .${{ matrix.OPTIONAL }}
 
-          echo "=============================================================";
-          echo "Install optional packages for testing/coverage";
-          echo "=============================================================";
+          echo "============================================================="
+          echo "Install optional packages for testing/coverage"
+          echo "============================================================="
           if [[ "${{ matrix.OPTIONAL }}" == "[all]" ]]; then
-            pip install psutil objgraph git+https://github.com/mdolab/pyxdsm;
-            pyppeteer-install;
+            pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
+            pyppeteer-install
           fi
 
-          echo "=============================================================";
-          echo "List installed packages/versions";
-          echo "=============================================================";
-          conda list;
+          echo "============================================================="
+          echo "List installed packages/versions"
+          echo "============================================================="
+          conda list
 
-          echo "=============================================================";
-          echo "Run tests with coverage (from directory other than repo root)";
-          echo "=============================================================";
-          cd openmdao/docs;
+          echo "============================================================="
+          echo "Run tests with coverage (from directory other than repo root)"
+          echo "============================================================="
+          cd openmdao/docs
           cp ../../.coveragerc .
-          testflo -n 1 openmdao --timeout=120 --show_skipped --coverage --coverpkg openmdao;
+          testflo -n 1 openmdao --timeout=120 --show_skipped --coverage --coverpkg openmdao
           
           if [[ "${{ matrix.PETSc }}" && "${{ matrix.OPTIONAL }}" == "[all]" ]]; then
-            echo "=============================================================";
-            echo "Make docs";
-            echo "=============================================================";
-            make strict;
+            echo "============================================================="
+            echo "Make docs"
+            echo "============================================================="
+            make strict
           fi
 
-          echo "=============================================================";
-          echo "Submit coverage";
-          echo "=============================================================";
-          pip install git+https://github.com/swryan/coveralls-python;
-          SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`;
-          coveralls --base_dir $SITE_DIR;
+          echo "============================================================="
+          echo "Submit coverage"
+          echo "============================================================="
+          pip install git+https://github.com/swryan/coveralls-python
+          SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`
+          coveralls --base_dir $SITE_DIR
           
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${{ matrix.UPLOAD_DOCS }}" ]]; then
-            echo "=============================================================";
-            echo "Upload docs";
-            echo "=============================================================";
-            python _utils/upload_doc_version.py ${{ secrets.DOCS_LOCATION }};
+            echo "============================================================="
+            echo "Upload docs"
+            echo "============================================================="
+            python _utils/upload_doc_version.py ${{ secrets.DOCS_LOCATION }}
           fi
 
       - uses: act10ns/slack@v1
@@ -223,49 +223,49 @@ jobs:
           COVERALLS_SERVICE_NAME: "github"
           COVERALLS_PARALLEL: True
         run: |
-          echo "=============================================================";
-          echo "Run #$env:GITHUB_RUN_NUMBER";
-          echo "Run ID: $env:GITHUB_RUN_ID";
-          echo "Testing: $env:GITHUB_REPOSITORY";
-          echo "Triggered by: $env:GITHUB_EVENT_NAME";
-          echo "Initiated by: $env:GITHUB_ACTOR";
-          echo "=============================================================";
+          echo "============================================================="
+          echo "Run #$env:GITHUB_RUN_NUMBER"
+          echo "Run ID: $env:GITHUB_RUN_ID"
+          echo "Testing: $env:GITHUB_REPOSITORY"
+          echo "Triggered by: $env:GITHUB_EVENT_NAME"
+          echo "Initiated by: $env:GITHUB_ACTOR"
+          echo "============================================================="
 
-          echo "=============================================================";
-          echo "Create conda environment";
-          echo "=============================================================";
+          echo "============================================================="
+          echo "Create conda environment"
+          echo "============================================================="
           conda create -n OpenMDAO python=${{ matrix.PY }} numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y;
-          conda activate OpenMDAO;
+          conda activate OpenMDAO
 
-          echo "=============================================================";
-          echo "Install OpenMDAO";
-          echo "=============================================================";
-          pip install .[all];
+          echo "============================================================="
+          echo "Install OpenMDAO"
+          echo "============================================================="
+          pip install .[all]
 
-          echo "=============================================================";
-          echo "Install optional packages for testing/coverage";
-          echo "=============================================================";
-          pip install psutil objgraph git+https://github.com/mdolab/pyxdsm;
-          pyppeteer-install;
+          echo "============================================================="
+          echo "Install optional packages for testing/coverage"
+          echo "============================================================="
+          pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
+          pyppeteer-install
 
-          echo "=============================================================";
-          echo "List installed packages/versions";
-          echo "=============================================================";
-          conda list;
+          echo "============================================================="
+          echo "List installed packages/versions"
+          echo "============================================================="
+          conda list
 
-          echo "=============================================================";
-          echo "Run tests with coverage (from directory other than repo root)";
-          echo "=============================================================";
-          cd openmdao\docs;
+          echo "============================================================="
+          echo "Run tests with coverage (from directory other than repo root)"
+          echo "============================================================="
+          cd openmdao\docs
           copy ..\..\.coveragerc .
-          testflo -n 1 openmdao --timeout=120 --show_skipped --coverage  --coverpkg openmdao;
+          testflo -n 1 openmdao --timeout=120 --show_skipped --coverage  --coverpkg openmdao
 
-          echo "=============================================================";
-          echo "Submit coverage";
-          echo "=============================================================";
-          pip install git+https://github.com/swryan/coveralls-python;
-          $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))";
-          coveralls --base_dir $SITE_DIR;
+          echo "============================================================="
+          echo "Submit coverage"
+          echo "============================================================="
+          pip install git+https://github.com/swryan/coveralls-python
+          $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))"
+          coveralls --base_dir $SITE_DIR
 
       - uses: act10ns/slack@v1
         env:

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -178,7 +178,7 @@ jobs:
           coveralls --base_dir $SITE_DIR
           
           if [[ "${GITHUB_EVENT_NAME}" == "push" && "${{ matrix.UPLOAD_DOCS }}" ]]; then
-            if [[ ${{ secrets.DOCS_LOCATION }} ]]; then
+            if [[ "${{ secrets.DOCS_LOCATION }}" ]]; then
               echo "============================================================="
               echo "Upload docs"
               echo "============================================================="

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -28,6 +28,7 @@ jobs:
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
             OPTIONAL: '[all]'
+            UPLOAD_DOCS: True
 
           # try latest versions
           - PY: 3
@@ -37,6 +38,7 @@ jobs:
             PYOPTSPARSE: 'v2.1.5'
             SNOPT: 7.7
             OPTIONAL: '[test]'
+            UPLOAD_DOCS: False
 
           # oldest supported versions
           - PY: 3.6
@@ -46,6 +48,7 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             OPTIONAL: '[all]'
+            UPLOAD_DOCS: False
 
     steps:
       # TEMPORARY WHILE GITHUB FIXES THIS https://github.com/actions/virtual-environments/issues/3185
@@ -56,8 +59,8 @@ jobs:
       - name: Create SSH key
         shell: bash
         env:
-          SSH_PRIVATE_KEY: ${{secrets.SSH_PRIVATE_KEY}}
-          SSH_KNOWN_HOSTS: ${{secrets.SSH_KNOWN_HOSTS}}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
         run: |
           mkdir -p ~/.ssh/
           echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
@@ -175,6 +178,13 @@ jobs:
           pip install git+https://github.com/swryan/coveralls-python;
           SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`;
           coveralls --base_dir $SITE_DIR;
+          
+          if [[ "${GITHUB_EVENT_NAME} == "push" && "${{ matrix.UPLOAD_DOCS }}" ]]; then
+            echo "=============================================================";
+            echo "Upload docs";
+            echo "=============================================================";
+            python _utils/upload_doc_version.py ${{ secrets.DOCS_LOCATION }};
+          fi
 
       - uses: act10ns/slack@v1
         env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 branches:
   only:
   - master
-  - auto_ivc
 
 group: deprecated-2017Q4
 
@@ -17,7 +16,7 @@ env:
     # latest versions
     - PY=3   NUMPY=1    SCIPY=1   PYOPTSPARSE=v2.1.5 SNOPT=7.7 PETSc=3
     # baseline versions
-    - PY=3.8 NUMPY=1.18 SCIPY=1.4 PYOPTSPARSE=v2.1.5 SNOPT=7.7 PETSc=3.12 UPLOAD_DOCS=1
+    - PY=3.8 NUMPY=1.18 SCIPY=1.4 PYOPTSPARSE=v2.1.5 SNOPT=7.7 PETSc=3.12
     # older versions
     - PY=3.7 NUMPY=1.17 SCIPY=1.3 PYOPTSPARSE=v2.1.5 SNOPT=7.7
     - PY=3.6 NUMPY=1.16 SCIPY=1.2 PYOPTSPARSE=v1.2   SNOPT=7.2 PETSc=3.10.2
@@ -161,20 +160,4 @@ script:
   fi
 
 # run the tests from down here to see if it can work without being at top level
-# only do coverage on the upload machine (and show skipped tests).
-- if [ "$UPLOAD_DOCS" ]; then
-    testflo -n 1 openmdao --timeout=120 --show_skipped --coverage  --coverpkg openmdao --cover-omit \*tests/\*  --cover-omit \*devtools/\* --cover-omit \*test_suite/\* --cover-omit \*docs/\* --cover-omit \*code_review/\*;
-  else
-    testflo -n 1 openmdao --timeout=120 --show_skipped;
-  fi
-
-deploy:
-  provider: script
-  skip_cleanup: true
-  script:
-  # only deploy docs in a build after a PR or merge is accepted
-  - if [ "$MASTER_BUILD" ] && [ "$UPLOAD_DOCS" ]; then
-      python _utils/upload_doc_version.py;
-    fi
-  on:
-    branch: master
+- testflo -n 1 openmdao --timeout=120 --show_skipped --coverage  --coverpkg openmdao --cover-omit \*tests/\*  --cover-omit \*devtools/\* --cover-omit \*test_suite/\* --cover-omit \*docs/\* --cover-omit \*code_review/\*;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 [![GitHub Actions Test Badge][17]][18]
 [![TravisCI Badge][9]][10]
-[![AppVeyor Badge][11]][12]
 [![Coveralls Badge][13]][14]
 
 # [OpenMDAO][0]
@@ -159,8 +158,6 @@ browser.
 
 [9]: https://travis-ci.org/OpenMDAO/OpenMDAO.svg?branch=master "TravisCI Badge"
 [10]: https://travis-ci.org/OpenMDAO/OpenMDAO "OpenMDAO @TravisCI"
-[11]: https://ci.appveyor.com/api/projects/status/33kct0irhbgcg8m1?svg=true "Build Badge"
-[12]: https://ci.appveyor.com/project/OpenMDAO/blue/branch/master "OpenMDAO @AppVeyor"
 [13]: https://coveralls.io/repos/github/OpenMDAO/OpenMDAO/badge.svg?branch=master "Coverage Badge"
 [14]: https://coveralls.io/github/OpenMDAO/OpenMDAO?branch=master "OpenMDAO @Coveralls"
 

--- a/openmdao/docs/_utils/upload_doc_version.py
+++ b/openmdao/docs/_utils/upload_doc_version.py
@@ -1,3 +1,4 @@
+import sys
 import subprocess
 import pipes
 import os
@@ -61,12 +62,16 @@ def get_doc_version():
         return current_commit, 0
 
 
-def upload_doc_version():
+def upload_doc_version(destination):
     """
-    Perform operations, then upload properly-named docs to WebFaction
+    Upload properly-named docs.
+
+    Parameters
+    ----------
+    destination : str
+        The destination for the documentation, [USER@]HOST:DIRECTORY
     """
     name, rel = get_doc_version()
-    destination = "openmdao@web543.webfaction.com:/home/openmdao/webapps/twodocversions/"
 
     # if release, send to version-numbered dir
     if rel:
@@ -78,7 +83,7 @@ def upload_doc_version():
     # execute the rsync to upload docs
     cmd = "rsync -r --delete-after -v _build/html/* " + destination
     status = subprocess.call(cmd, stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE, shell=True)
+                                  stderr=subprocess.PIPE, shell=True)
 
     if status == 0:
         return True
@@ -87,4 +92,7 @@ def upload_doc_version():
 
 
 if __name__ == "__main__":
-    upload_doc_version()
+    if len(sys.argv) != 2:
+        print("Destination required, [USER@]HOST:DIRECTORY")
+    else:
+        upload_doc_version(sys.argv[1])

--- a/openmdao/docs/_utils/upload_doc_version.py
+++ b/openmdao/docs/_utils/upload_doc_version.py
@@ -86,6 +86,7 @@ def upload_doc_version(destination):
                                   stderr=subprocess.PIPE, shell=True)
 
     if status == 0:
+        print("Uploaded documentation for", name if rel else "latest")
         return True
     else:
         raise Exception('Doc transfer failed.')


### PR DESCRIPTION
### Summary

Upload documentation from GitHub Actions CI instead of Travis CI.

Also:
- remove unnecessary semicolons from workflow script
- remove AppVeyor badge from README

### Related Issues

- Resolves #2019

### Backwards incompatibilities

None

### New Dependencies

None
