### PR TITLE
Adds check for existence of state['_system'] in default_vector before trying to delete it

### DIFF
--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -445,5 +445,6 @@ class DefaultVector(Vector):
             state minus system member.
         """
         state = self.__dict__.copy()
-        del state['_system']
+        if '_system' in state:
+            del state['_system']
         return state


### PR DESCRIPTION
### Summary

When pickling and unpickling group and components, _system in the default_vector class state gets deleted. If you go to repickle without running anything, _system does not get re-created and therefor an error gets thrown when it tried to delete it again. This just adds a simple check to make sure it is there before trying to delete it.

### Related Issues

- Resolves #2033

### Backwards incompatibilities

None

### New Dependencies

None
