### PR TITLE
fixed check_totals approx bug

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -240,7 +240,7 @@ class ApproximationScheme(object):
                     if vec is None:
                         vec_idx = None
                     else:
-                        vec_idx = np.atleast_1d(approx_wrt_idx[wrt])  # local index into var
+                        vec_idx = np.atleast_1d(approx_wrt_idx[wrt]).copy()  # local index into var
                         # convert into index into input or output vector
                         vec_idx += slices[wrt].start
                         # Directional derivatives for quick partial checking.

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2388,5 +2388,39 @@ class CheckTotalsParallelGroup(unittest.TestCase):
         assert_near_equal(data[('pg.dc1.y', 'iv.x')]['abs error'][0], 0.0, 1e-6)
         assert_near_equal(data[('pg.dc3.y', 'iv.x')]['abs error'][0], 0.0, 1e-6)
 
+class CheckTotalsIndices(unittest.TestCase):
+
+    def test_w_indices(self):
+        class TopComp(om.ExplicitComponent):
+
+            def setup(self):
+
+                size = 10
+
+                self.add_input('c_ae_C', np.zeros(size))
+                self.add_input('theta_c2_C', np.zeros(size))
+                self.add_output('c_ae', np.zeros(size))
+
+            def compute(self, inputs, outputs):
+                pass
+
+            def compute_partials(self, inputs, partials):
+                pass
+
+        prob = om.Problem()
+        model = prob.model
+
+        geom = model.add_subsystem('tcomp', TopComp())
+
+        # setting indices here caused an indexing error later on
+        model.add_design_var('tcomp.theta_c2_C', lower=-20., upper=20., indices=range(2, 9))
+        model.add_constraint('tcomp.c_ae', lower=0.e0,)
+
+        prob.setup()
+
+        prob.run_model()
+        check = prob.check_totals(compact_print=True)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Local index array was using a reference to another array instead of making its own copy and resulted in the underlying array being modified unintentionally.

### Related Issues

- Resolves #2037

### Backwards incompatibilities

None

### New Dependencies

None
