### PR TITLE
Fix thread.isAlive

### DIFF
--- a/openmdao/devtools/iprofile_app/iprofile_app.py
+++ b/openmdao/devtools/iprofile_app/iprofile_app.py
@@ -225,5 +225,5 @@ else:
             serve_thread = _startThread(tornado.ioloop.IOLoop.current().start)
             launch_thread = _startThread(lambda: _launch_browser(options.port))
 
-            while serve_thread.isAlive():
+            while serve_thread.is_alive():
                 serve_thread.join(timeout=1)


### PR DESCRIPTION
### Summary

Changed deprecated `thread.isAlive` to `thread.is_alive`.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
