### PR TITLE
Added `--show_dependencies` to CLI so users can show dependencies when submitting an issue

### DIFF
--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -449,7 +449,6 @@ def _show_dependency_versions():
 
     setup_path = os.path.realpath(os.path.dirname(os.path.dirname(openmdao.__file__))) + "/"
     setup_file = os.path.join(setup_path, 'setup.py')
-    print(setup_file)
     if not os.path.exists(setup_file):
         print('--show_dependencies only works in a development environment.')
         return

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -453,8 +453,8 @@ def _show_dependency_versions_parser(parser):
     parser : argparse subparser
         The parser we're adding options to.
     """
-    parser.add_argument('--show_dependencies', action='store_true', help="Show dependency "
-                        "variables")
+    parser.add_argument('--show_dependencies', action='store_true', help="Show dependencies "
+                        "and versions")
 
 
 def _show_dependency_versions(options, user_args):

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -620,5 +620,6 @@ def openmdao_cmd():
         else:
             print("\nNothing to do.")
 
+
 if __name__ == '__main__':
     openmdao_cmd()

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -447,15 +447,12 @@ def _cite_cmd(options, user_args):
 def _show_dependency_versions():
     import openmdao
 
-    setup_path = os.path.realpath(os.path.dirname(os.path.dirname(openmdao.__file__)))
+    setup_path = os.path.realpath(os.path.dirname(os.path.dirname(openmdao.__file__))) + "/"
     setup_file = os.path.join(setup_path, 'setup.py')
+    print(setup_file)
     if not os.path.exists(setup_file):
         print('--show_dependencies only works in a development environment.')
         return
-
-    setup_path = os.getcwd() + "/"
-    if 'openmdao' in setup_path:
-        setup_path = setup_path[:setup_path.index('openmdao')]
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore")

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,6 @@ import os
 from setuptools import setup
 
 _root_path = os.path.realpath(os.path.dirname(__file__)) + "/"
-if 'openmdao' in _root_path:
-    _root_path = _root_path[:_root_path.index('openmdao')]
 
 __version__ = re.findall(
     r"""__version__ = ["']+([0-9\.\-dev]*)["']+""",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 import re
-from os import getcwd
+import os
 from setuptools import setup
 
-_root_path = getcwd() + "/"
+_root_path = os.path.realpath(os.path.dirname(__file__)) + "/"
 if 'openmdao' in _root_path:
     _root_path = _root_path[:_root_path.index('openmdao')]
 

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
 import re
-
+from os import getcwd
 from setuptools import setup
+
+_root_path = getcwd() + "/"
+if 'openmdao' in _root_path:
+    _root_path = _root_path[:_root_path.index('openmdao')]
 
 __version__ = re.findall(
     r"""__version__ = ["']+([0-9\.\-dev]*)["']+""",
-    open('openmdao/__init__.py').read(),
+    open(_root_path + 'openmdao/__init__.py').read(),
 )[0]
 
 optional_dependencies = {


### PR DESCRIPTION
### Summary

Added `openmdao --show_dependencies` to the cli for users to use when submitting an issue or just wanting to know their current openmdao dependencies/versions 

### Related Issues

- Resolves #2042

### Backwards incompatibilities

None

### New Dependencies

None
