### PR TITLE
Update pyOptSparseDriver to handle an API change in pyOptSparse in version 2.5.1

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -36,7 +36,7 @@ jobs:
             NUMPY: 1
             SCIPY: 1
             # PETSc: 3
-            PYOPTSPARSE: 'v2.1.5'
+            PYOPTSPARSE: 'v2.6.1'
             SNOPT: 7.7
             OPTIONAL: '[test]'
 

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -9,14 +9,17 @@ additional MPI capability.
 from collections import OrderedDict
 import json
 import signal
+from distutils.version import LooseVersion
 
 import numpy as np
 from scipy.sparse import coo_matrix
 
 try:
-    from pyoptsparse import Optimization
+    import pyoptsparse
+    Optimization = pyoptsparse.Optimization
 except ImportError:
     Optimization = None
+    pyoptsparse = None
 
 from openmdao.core.constants import INT_DTYPE
 from openmdao.core.analysis_error import AnalysisError
@@ -330,7 +333,11 @@ class pyOptSparseDriver(Driver):
                                  value=input_vals[name],
                                  lower=meta['lower'], upper=meta['upper'])
 
-        opt_prob.finalizeDesignVariables()
+        if not hasattr(pyoptsparse, '__version__') or \
+           LooseVersion(pyoptsparse.__version__) < LooseVersion('2.5.1'):
+            opt_prob.finalizeDesignVariables()
+        else:
+            opt_prob.finalize()
 
         # Add all objectives
         objs = self.get_objective_values()


### PR DESCRIPTION
### Summary

There have been two changes to the pyOptSparse API recently. 

- removed support for the "openmdao style" sensitivity dictionary, which is a tuple. Now the only supported way is to use a nested dict
- renamed the functions finalizeDesignVariables() and finalizeConstraints() and made them private (prepending with underscore). The preferred way now is to call finalize()

The first one doesn't affect OpenMDAO, as the code only used dicts, and not tuples, so no changes were needed.

The second one, which occurred in 2.5.1, requires detecting the version of pyOptSparse and calling the appropriate API call of pyOptSparse

### Related Issues

- Resolves #1990

### Backwards incompatibilities

None

### New Dependencies

None
