### PR TITLE
Fixed DemuxComp issue not handling 3D arrays

### DIFF
--- a/openmdao/components/demux_comp.py
+++ b/openmdao/components/demux_comp.py
@@ -105,7 +105,7 @@ class DemuxComp(ExplicitComponent):
                             desc=options['desc'])
 
             rs = np.arange(np.prod(out_shape))
-            cs = np.atleast_1d(np.take(template, indices=i, axis=axis))
+            cs = np.atleast_1d(np.take(template, indices=i, axis=axis)).flatten()
 
             self.declare_partials(of=out_name, wrt=name, rows=rs, cols=cs, val=1.0)
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1099,8 +1099,8 @@ class Component(System):
         if dependent:
             meta['value'] = val
             if rows is not None:
-                rows = np.array(rows, dtype=INT_DTYPE, copy=False).flatten()
-                cols = np.array(cols, dtype=INT_DTYPE, copy=False).flatten()
+                rows = np.array(rows, dtype=INT_DTYPE, copy=False)
+                cols = np.array(cols, dtype=INT_DTYPE, copy=False)
 
                 # Check the length of rows and cols to catch this easy mistake and give a
                 # clear message.


### PR DESCRIPTION
### Summary

Flattened arrays to support N-dimensional arrays 

### Related Issues

- Resolves #1926

### Backwards incompatibilities

None

### New Dependencies

None
