### PR TITLE
KeyError during recording setup when running under MPI when design variable was an input

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -463,7 +463,7 @@ class Driver(object):
 
         myoutputs = set(myoutputs)
         if recording_options['record_desvars']:
-            myoutputs.update(self._designvars)
+            myoutputs.update(model.get_source(n) for n in self._designvars)
         if recording_options['record_objectives'] or recording_options['record_responses']:
             myoutputs.update(self._objs)
         if recording_options['record_constraints'] or recording_options['record_responses']:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4694,12 +4694,13 @@ class System(object):
             offset = len(self.pathname) + 1 if self.pathname else 0
 
             if self.comm.size == 1:
+                get = vec._abs_get_val
                 srcget = self._vectors['output'][vec_name]._abs_get_val
                 vdict = {}
                 if discrete_vec:
                     for n in variables:
                         if vec._contains_abs(n):
-                            vdict[n] = vec._abs_get_val(n, False)
+                            vdict[n] = get(n, False)
                         elif n[offset:] in discrete_vec:
                             vdict[n] = discrete_vec[n[offset:]]['value']
                         else:
@@ -4711,27 +4712,28 @@ class System(object):
                 else:
                     for name in variables:
                         if vec._contains_abs(name):
-                            vdict[name] = vec._abs_get_val(name, False)
+                            vdict[name] = get(name, False)
                         else:
                             ivc_path = conns[prom2abs_in[name][0]]
                             vdict[ivc_path] = srcget(ivc_path, False)
             elif parallel:
+                get = self._abs_get_val
                 vdict = {}
                 if discrete_vec:
                     for name in variables:
                         if vec._contains_abs(name):
-                            vdict[name] = vec._abs_get_val(name, get_remote=True, rank=0,
+                            vdict[name] = get(name, get_remote=True, rank=0,
                                               vec_name=vec_name, kind=kind)
                         elif name[offset:] in discrete_vec and self._owning_rank[name] == rank:
                             vdict[name] = discrete_vec[name[offset:]]['value']
                 else:
                     for name in variables:
                         if vec._contains_abs(name):
-                            vdict[name] = vec._abs_get_val(name, get_remote=True, rank=0,
+                            vdict[name] = get(name, get_remote=True, rank=0,
                                               vec_name=vec_name, kind=kind)
                         else:
                             ivc_path = conns[prom2abs_in[name][0]]
-                            vdict[name] = vec._abs_get_val(ivc_path, get_remote=True, rank=0,
+                            vdict[name] = get(ivc_path, get_remote=True, rank=0,
                                               vec_name=vec_name, kind='output')
             else:
                 io = 'input' if kind == 'input' else 'output'

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4694,13 +4694,12 @@ class System(object):
             offset = len(self.pathname) + 1 if self.pathname else 0
 
             if self.comm.size == 1:
-                get = vec._abs_get_val
                 srcget = self._vectors['output'][vec_name]._abs_get_val
                 vdict = {}
                 if discrete_vec:
                     for n in variables:
                         if vec._contains_abs(n):
-                            vdict[n] = get(n, False)
+                            vdict[n] = vec._abs_get_val(n, False)
                         elif n[offset:] in discrete_vec:
                             vdict[n] = discrete_vec[n[offset:]]['value']
                         else:
@@ -4712,28 +4711,27 @@ class System(object):
                 else:
                     for name in variables:
                         if vec._contains_abs(name):
-                            vdict[name] = get(name, False)
+                            vdict[name] = vec._abs_get_val(name, False)
                         else:
                             ivc_path = conns[prom2abs_in[name][0]]
                             vdict[ivc_path] = srcget(ivc_path, False)
             elif parallel:
-                get = self._abs_get_val
                 vdict = {}
                 if discrete_vec:
                     for name in variables:
                         if vec._contains_abs(name):
-                            vdict[name] = get(name, get_remote=True, rank=0,
+                            vdict[name] = vec._abs_get_val(name, get_remote=True, rank=0,
                                               vec_name=vec_name, kind=kind)
                         elif name[offset:] in discrete_vec and self._owning_rank[name] == rank:
                             vdict[name] = discrete_vec[name[offset:]]['value']
                 else:
                     for name in variables:
                         if vec._contains_abs(name):
-                            vdict[name] = get(name, get_remote=True, rank=0,
+                            vdict[name] = vec._abs_get_val(name, get_remote=True, rank=0,
                                               vec_name=vec_name, kind=kind)
                         else:
                             ivc_path = conns[prom2abs_in[name][0]]
-                            vdict[name] = get(ivc_path, get_remote=True, rank=0,
+                            vdict[name] = vec._abs_get_val(ivc_path, get_remote=True, rank=0,
                                               vec_name=vec_name, kind='output')
             else:
                 io = 'input' if kind == 'input' else 'output'

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -722,17 +722,18 @@ class System(object):
         str
             The absolute name of the source variable.
         """
-        if self._problem_meta is None or 'prom2abs' not in self._problem_meta:
+        try:
+            prom2abs = self._problem_meta['prom2abs']
+        except StandardError:
             raise RuntimeError(f"{self.msginfo}: get_source cannot be called for variable {name} "
-                               "before Problem.setup is complete.")
+                               "before Problem.setup has been called.")
 
-        model = self._problem_meta['model_ref']()
-        prom2abs = self._problem_meta['prom2abs']
-        if name in prom2abs['input']:
-            name = prom2abs['input'][name][0]
-        elif name in prom2abs['output']:
+        if name in prom2abs['output']:
             return prom2abs['output'][name][0]
 
+        if name in prom2abs['input']:
+            name = prom2abs['input'][name][0]
+        model = self._problem_meta['model_ref']()
         if name in model._conn_global_abs_in2out:
             return model._conn_global_abs_in2out[name]
 


### PR DESCRIPTION
### Summary

Design var name wasn't being converted to its source name during recorder setup and resulted in a KeyError.

### Related Issues

- Resolves #2046

### Backwards incompatibilities

None

### New Dependencies

None
