### PR TITLE
require sphinx <4.0 for Py3.6 compatibility

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -35,7 +35,7 @@ jobs:
             PY: 3
             NUMPY: 1
             SCIPY: 1
-            # PETSc: 3
+            PETSc: 3
             PYOPTSPARSE: 'v2.6.1'
             SNOPT: 7.7
             OPTIONAL: '[test]'
@@ -43,7 +43,7 @@ jobs:
           # oldest supported versions
           - NAME: Oldest
             PY: 3.6
-            NUMPY: 1.16
+            NUMPY: 1.17
             SCIPY: 1.2
             PETSc: 3.10.2
             PYOPTSPARSE: 'v1.2'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ optional_dependencies = {
         'matplotlib',
         'numpydoc>=0.9.1',
         'redbaron',
-        'sphinx>=1.8.5',
+        'sphinx>=1.8.5,<4.0',
         'tabulate',
         'ipython'
     ],


### PR DESCRIPTION
### Summary

- sphinx 4.0 (released May 9, 2021) breaks our docs with Python 3.6, so require <4.0
- differential evolution driver uses `default_rng` from NumPy 1.1.7, so bump minimum version on CI
- Enable PETSc when testing latest versions on CI

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
