### PR TITLE
small fix to MetaModelUnStructuredComp for multiple nD array training inputs

### DIFF
--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -585,6 +585,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
                 for row_idx, v in enumerate(val):
                     v = np.asarray(v)
                     inputs[row_idx, idx:idx + sz] = v.flat
+                idx += sz
 
         # Assemble output data and train each output.
         for name, shape in self._surrogate_output_names:

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -237,6 +237,43 @@ class MetaModelTestCase(unittest.TestCase):
         assert_near_equal(prob['mm.y1'], 1.0, .00001)
         assert_near_equal(prob['mm.y2'], 7.0, .00001)
 
+    def test_two_vector_inputs(self):
+        mm = om.MetaModelUnStructuredComp()
+        mm.add_input('x1', np.zeros(4))
+        mm.add_input('x2', np.zeros(4))
+        mm.add_output('y1', 0.)
+        mm.add_output('y2', 0.)
+
+        mm.options['default_surrogate'] = om.KrigingSurrogate()
+
+        prob = om.Problem()
+        prob.model.add_subsystem('mm', mm)
+        prob.setup()
+
+        mm.options['train:x1'] = [
+            [1.0, 1.0, 1.0, 1.0],
+            [2.0, 1.0, 1.0, 1.0],
+            [1.0, 2.0, 1.0, 1.0],
+            [1.0, 1.0, 2.0, 1.0],
+            [1.0, 1.0, 1.0, 2.0]
+        ]
+        mm.options['train:x2'] = [
+            [1.0, 1.0, 1.0, 1.0],
+            [2.0, 1.0, 1.0, 1.0],
+            [1.0, 2.0, 1.0, 1.0],
+            [1.0, 1.0, 2.0, 1.0],
+            [1.0, 1.0, 1.0, 2.0]
+        ]
+        mm.options['train:y1'] = [3.0, 2.0, 1.0, 6.0, -2.0]
+        mm.options['train:y2'] = [1.0, 4.0, 7.0, -3.0, 3.0]
+
+        prob['mm.x1'] = [1.0, 2.0, 1.0, 1.0]
+        prob['mm.x2'] = [1.0, 2.0, 1.0, 1.0]
+        prob.run_model()
+
+        assert_near_equal(prob['mm.y1'], 1.0, .00001)
+        assert_near_equal(prob['mm.y2'], 7.0, .00001)
+
     def test_array_inputs(self):
         mm = om.MetaModelUnStructuredComp()
         mm.add_input('x', np.zeros((2,2)))


### PR DESCRIPTION
### Summary

There was a small bug in `MetaModelUnStructuredComp._train` for multiple training inputs of nD arrays, which was not tested.

### Related Issues

N/A

### Backwards incompatibilities

None

### New Dependencies

None
