### PR TITLE
_linearize was being called on linear solver unnecessarily during check_partials and partial sparsity computation

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1127,7 +1127,7 @@ class Problem(object):
 
                 # Only really need to linearize once.
                 if mode == 'fwd':
-                    comp.run_linearize()
+                    comp.run_linearize(sub_do_ln=False)
 
                 explicit = isinstance(comp, ExplicitComponent)
                 matrix_free = comp.matrix_free

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1133,7 +1133,7 @@ class System(object):
                     scheme._reset()  # force a re-initialization of approx
                     approx_scheme._during_sparsity_comp = True
 
-            self.run_linearize()
+            self.run_linearize(sub_do_ln=False)
 
         sparsity, sp_info = self._jacobian.get_sparsity()
 
@@ -3877,7 +3877,7 @@ class System(object):
         with self._scaled_context_all():
             do_ln = self._linear_solver is not None and self._linear_solver._linearize_children()
             self._linearize(self._assembled_jac, sub_do_ln=do_ln)
-            if self._linear_solver is not None:
+            if self._linear_solver is not None and sub_do_ln:
                 self._linear_solver._linearize()
 
     def _apply_nonlinear(self):

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -1912,6 +1912,45 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         assert_check_partials(partials)
 
+    def test_no_linsolve_during_check(self):
+        # ensure that solve_linear is not called during check partials
+        from openmdao.solvers.solver import LinearSolver
+
+        class ErrSolver(LinearSolver):
+            def _linearize(self):
+                raise RuntimeError("_linearize called")
+
+            def solve(self, vec_names, mode, rel_systems=None):
+                raise RuntimeError("solve called")
+
+            def _run_apply(self):
+                raise RuntimeError("_run_apply called")
+
+        class SingularImplicitComp(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('lhs', shape=10)
+                self.add_input('rhs', shape=10)
+
+                self.add_output('resid', shape=10)
+
+                self.declare_partials('*', '*', method='cs')
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+
+                residuals['resid'] = inputs['lhs'] - inputs['rhs']
+
+
+        p = om.Problem()
+
+        p.model.add_subsystem('sing_check', SingularImplicitComp())
+        p.model.sing_check.linear_solver = ErrSolver()
+        p.setup()
+
+        p.run_model()
+
+        p.check_partials(out_stream=None)
+
 
 class TestCheckPartialsFeature(unittest.TestCase):
 


### PR DESCRIPTION
### Summary

Now during check_partials when run_linearize is called, sub_do_ln=False is passed to prevent _linearize from being called on the linear solver of components being checked.  sub_do_ln=False is also being passed to run_linearize during computation of the sparsity matrix for the partial jacobian. In both of these contexts, calling _linearize on the linear solver is unnecessary and can lead to problems if a DirectSolver is used and the matrix is singular.

### Related Issues

- Resolves #2054
- Resolves #2056

### Backwards incompatibilities

The behavior of run_linearize is changed slightly.  Now, if sub_do_ln is False, _linearize is *not* called on the current system's linear solver.

### New Dependencies

None
