### PR TITLE
Added pyoptsparse decorator from dymos in

### DIFF
--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -165,7 +165,7 @@ class TestNotInstalled(unittest.TestCase):
 class TestMPIScatter(unittest.TestCase):
     N_PROCS = 2
 
-    @require_pyoptsparse()
+    @require_pyoptsparse(OPTIMIZER)
     def test_design_vars_on_all_procs_pyopt(self):
 
         prob = om.Problem()
@@ -191,7 +191,7 @@ class TestMPIScatter(unittest.TestCase):
         proc_vals = MPI.COMM_WORLD.allgather([prob['x'], prob['y'], prob['c'], prob['f_xy']])
         np.testing.assert_array_almost_equal(proc_vals[0], proc_vals[1])
 
-    @require_pyoptsparse()
+    @require_pyoptsparse(OPTIMIZER)
     def test_opt_distcomp(self):
         size = 7
 
@@ -233,9 +233,6 @@ class TestMPIScatter(unittest.TestCase):
 
     @require_pyoptsparse('ParOpt')
     def test_paropt_distcomp(self):
-        # _, local_opt = set_pyoptsparse_opt('ParOpt')
-        # if local_opt != 'ParOpt':
-        #     raise unittest.SkipTest("pyoptsparse is not providing ParOpt")
         size = 7
 
         prob = om.Problem()
@@ -274,7 +271,7 @@ class TestMPIScatter(unittest.TestCase):
                           1e-5)
 
 
-@unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
+@require_pyoptsparse(OPTIMIZER)
 @use_tempdirs
 class TestPyoptSparse(unittest.TestCase):
 
@@ -2030,9 +2027,6 @@ class TestPyoptSparse(unittest.TestCase):
 
     @require_pyoptsparse('ParOpt')
     def test_ParOpt_basic(self):
-        # _, local_opt = set_pyoptsparse_opt('ParOpt')
-        # if local_opt != 'ParOpt':
-        #     raise unittest.SkipTest("pyoptsparse is not providing ParOpt")
 
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -15,7 +15,7 @@ from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.mpi import MPI
 from openmdao.warnings import OMDeprecationWarning
 
@@ -161,11 +161,11 @@ class TestNotInstalled(unittest.TestCase):
                          'pyOptSparseDriver is not available, pyOptsparse is not installed.')
 
 
-@unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestMPIScatter(unittest.TestCase):
     N_PROCS = 2
 
+    @require_pyoptsparse()
     def test_design_vars_on_all_procs_pyopt(self):
 
         prob = om.Problem()
@@ -191,6 +191,7 @@ class TestMPIScatter(unittest.TestCase):
         proc_vals = MPI.COMM_WORLD.allgather([prob['x'], prob['y'], prob['c'], prob['f_xy']])
         np.testing.assert_array_almost_equal(proc_vals[0], proc_vals[1])
 
+    @require_pyoptsparse()
     def test_opt_distcomp(self):
         size = 7
 
@@ -230,10 +231,11 @@ class TestMPIScatter(unittest.TestCase):
                           np.zeros(7),
                           1e-5)
 
+    @require_pyoptsparse('ParOpt')
     def test_paropt_distcomp(self):
-        _, local_opt = set_pyoptsparse_opt('ParOpt')
-        if local_opt != 'ParOpt':
-            raise unittest.SkipTest("pyoptsparse is not providing ParOpt")
+        # _, local_opt = set_pyoptsparse_opt('ParOpt')
+        # if local_opt != 'ParOpt':
+        #     raise unittest.SkipTest("pyoptsparse is not providing ParOpt")
         size = 7
 
         prob = om.Problem()
@@ -2026,10 +2028,11 @@ class TestPyoptSparse(unittest.TestCase):
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
 
+    @require_pyoptsparse('ParOpt')
     def test_ParOpt_basic(self):
-        _, local_opt = set_pyoptsparse_opt('ParOpt')
-        if local_opt != 'ParOpt':
-            raise unittest.SkipTest("pyoptsparse is not providing ParOpt")
+        # _, local_opt = set_pyoptsparse_opt('ParOpt')
+        # if local_opt != 'ParOpt':
+        #     raise unittest.SkipTest("pyoptsparse is not providing ParOpt")
 
         prob = om.Problem()
         model = prob.model = SellarDerivativesGrouped()

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -1,5 +1,6 @@
 """Define utils for use in testing."""
 import json
+import functools
 
 import numpy as np
 

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -79,6 +79,55 @@ def use_tempdirs(cls):
     return cls
 
 
+def require_pyoptsparse(optimizer=None):
+    """
+    Decorate test to raise a skiptest if a required pyoptsparse optimizer cannot be imported.
+
+    Parameters
+    ----------
+    optimizer : String
+        Pyoptsparse optimizer string. Default is None, which just checks for pyoptsparse.
+
+    Returns
+    -------
+    TestCase or TestCase.method
+        The decorated TestCase class or method.
+    """
+    def decorator(obj):
+
+        import unittest
+        try:
+            from pyoptsparse import OPT
+
+        except Exception:
+            msg = "pyoptsparse is not installed."
+
+            if not isinstance(obj, type):
+                @functools.wraps(obj)
+                def skip_wrapper(*args, **kwargs):
+                    raise unittest.SkipTest(msg)
+                obj = skip_wrapper
+            obj.__unittest_skip__ = True
+            obj.__unittest_skip_why__ = msg
+            return obj
+
+        try:
+            OPT(optimizer)
+        except Exception:
+            msg = "pyoptsparse is not providing %s" % optimizer
+
+            if not isinstance(obj, type):
+                @functools.wraps(obj)
+                def skip_wrapper(*args, **kwargs):
+                    raise unittest.SkipTest(msg)
+                obj = skip_wrapper
+            obj.__unittest_skip__ = True
+            obj.__unittest_skip_why__ = msg
+
+        return obj
+    return decorator
+
+
 class _ModelViewerDataTreeEncoder(json.JSONEncoder):
     """Special JSON encoder for writing model viewer data."""
 


### PR DESCRIPTION
### Summary

Moved `require_pyoptsparse` decorator from Dymos into OpenMDAO to take advantage of this functionality without having to import Dymos. This PR needs to be merged in first before the linked PR. The linked PR to remove this decorator from Dymos is here: https://github.com/OpenMDAO/dymos/pull/595 

### Related Issues

- Resolves #2003

### Backwards incompatibilities

None

### New Dependencies

None
