### PR TITLE
improved error message when there are zero rows or cols in the total Jacobian

### DIFF
--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1691,7 +1691,7 @@ class _TotalJacInfo(object):
             if zero_idxs[0].size == 0:
                 return zero_idxs
             varr = np.zeros(shape, dtype=bool)
-            varr[inds[zero_idxs]] = True
+            varr.flat[inds[zero_idxs]] = True
             zero_idxs = np.nonzero(varr)
 
         return zero_idxs
@@ -1723,9 +1723,11 @@ class _TotalJacInfo(object):
 
                 if zero_idxs[0].size > 0:
                     if len(zero_idxs) == 1:
-                        zero_rows.append((self.ivc_print_names.get(name, name), list(zero_idxs[0])))
+                        zero_rows.append((self.ivc_print_names.get(name, name),
+                                          list(zero_idxs[0])))
                     else:
-                        zero_rows.append((self.ivc_print_names.get(name, name), list(zip(*zero_idxs))))
+                        zero_rows.append((self.ivc_print_names.get(name, name),
+                                          list(zip(*zero_idxs))))
 
             if zero_rows:
                 zero_rows = [f"('{n}', inds={idxs})" for n, idxs in zero_rows]
@@ -1746,13 +1748,16 @@ class _TotalJacInfo(object):
 
                 if zero_idxs[0].size > 0:
                     if len(zero_idxs) == 1:
-                        zero_cols.append((self.ivc_print_names.get(name, name), list(zero_idxs[0])))
+                        zero_cols.append((self.ivc_print_names.get(name, name),
+                                          list(zero_idxs[0])))
                     else:
-                        zero_cols.append((self.ivc_print_names.get(name, name), list(zip(*zero_idxs))))
+                        zero_cols.append((self.ivc_print_names.get(name, name),
+                                          list(zip(*zero_idxs))))
 
             if zero_cols:
-                msg = (f"Design variables {zero_cols} have no impact on the constraints or "
-                       "objective.")
+                zero_cols = [f"('{n}', inds={idxs})" for n, idxs in zero_cols]
+                msg = (f"Design variables [{', '.join(zero_cols)}] have no impact on the "
+                       "constraints or objective.")
                 if raise_error:
                     raise RuntimeError(msg)
                 else:

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2143,7 +2143,7 @@ class TestPyoptSparse(unittest.TestCase):
             prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         "Constraints or objectives ['parab.z'] cannot be impacted by the design " + \
+                         "Constraints or objectives [('parab.z', inds=[0])] cannot be impacted by the design " + \
                          "variables of the problem.")
 
     def test_singular_jac_error_desvars(self):
@@ -2174,45 +2174,11 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        #with self.assertRaises(RuntimeError) as msg:
-        prob.run_driver()
+        with self.assertRaises(RuntimeError) as msg:
+            prob.run_driver()
 
-        self.assertEqual(str(msg.exception),
-                         "Design variables ['z'] have no impact on the constraints or objective.")
-
-    def test_singular_jac_error_desvars_multidim(self):
-        prob = om.Problem()
-        prob.model.add_subsystem('parab',
-                                     om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0 - 0*z',
-                                                  ], shape=(3,2,2)),
-                                     promotes_inputs=['x', 'y', 'z'])
-
-        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(3,2,2)), promotes_inputs=['x', 'y'])
-
-        prob.model.set_input_defaults('x', 3.0)
-        prob.model.set_input_defaults('y', -4.0)
-
-        prob.driver = om.pyOptSparseDriver()
-        prob.driver.options['optimizer'] = 'SLSQP'
-        prob.driver.options['singular_jac_behavior'] = 'error'
-
-        prob.model.add_design_var('x', lower=-50, upper=50)
-        prob.model.add_design_var('y', lower=-50, upper=50)
-
-        # Design var z does not affect any quantities.
-        prob.model.add_design_var('z', lower=-50, upper=50)
-
-        prob.model.add_objective('parab.f_xy', index=6)
-
-        prob.model.add_constraint('const.g', lower=0, upper=10.)
-
-        prob.setup()
-
-        #with self.assertRaises(RuntimeError) as msg:
-        prob.run_driver()
-
-        self.assertEqual(str(msg.exception),
-                         "Design variables ['z'] have no impact on the constraints or objective.")
+        self.assertEqual(msg.exception.args[0],
+                         "Design variables [('z', inds=[0])] have no impact on the constraints or objective.")
 
     def test_singular_jac_ignore(self):
         prob = om.Problem()
@@ -2271,7 +2237,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        msg = "Constraints or objectives ['parab.z'] cannot be impacted by the design variables of the problem."
+        msg = "Constraints or objectives [('parab.z', inds=[0])] cannot be impacted by the design variables of the problem."
 
         with assert_warning(UserWarning, msg):
             prob.run_driver()

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2177,7 +2177,7 @@ class TestPyoptSparse(unittest.TestCase):
         with self.assertRaises(RuntimeError) as msg:
             prob.run_driver()
 
-        self.assertEqual(msg.exception.args[0],
+        self.assertEqual(str(msg.exception),
                          "Design variables [('z', inds=[0])] have no impact on the constraints or objective.")
 
     def test_singular_jac_ignore(self):

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2174,8 +2174,42 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        with self.assertRaises(RuntimeError) as msg:
-            prob.run_driver()
+        #with self.assertRaises(RuntimeError) as msg:
+        prob.run_driver()
+
+        self.assertEqual(str(msg.exception),
+                         "Design variables ['z'] have no impact on the constraints or objective.")
+
+    def test_singular_jac_error_desvars_multidim(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('parab',
+                                     om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0 - 0*z',
+                                                  ], shape=(3,2,2)),
+                                     promotes_inputs=['x', 'y', 'z'])
+
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(3,2,2)), promotes_inputs=['x', 'y'])
+
+        prob.model.set_input_defaults('x', 3.0)
+        prob.model.set_input_defaults('y', -4.0)
+
+        prob.driver = om.pyOptSparseDriver()
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.options['singular_jac_behavior'] = 'error'
+
+        prob.model.add_design_var('x', lower=-50, upper=50)
+        prob.model.add_design_var('y', lower=-50, upper=50)
+
+        # Design var z does not affect any quantities.
+        prob.model.add_design_var('z', lower=-50, upper=50)
+
+        prob.model.add_objective('parab.f_xy', index=6)
+
+        prob.model.add_constraint('const.g', lower=0, upper=10.)
+
+        prob.setup()
+
+        #with self.assertRaises(RuntimeError) as msg:
+        prob.run_driver()
 
         self.assertEqual(str(msg.exception),
                          "Design variables ['z'] have no impact on the constraints or objective.")

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1837,15 +1837,16 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_singular_jac_error_responses(self):
         prob = om.Problem()
+        size = 3
         prob.model.add_subsystem('parab',
                                  om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0',
-                                              'z = 12.0'],),
+                                              'z = 12.0'], shape=(3,)),
                                  promotes_inputs=['x', 'y'])
 
-        prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(3,)), promotes_inputs=['x', 'y'])
 
-        prob.model.set_input_defaults('x', 3.0)
-        prob.model.set_input_defaults('y', -4.0)
+        prob.model.set_input_defaults('x', 3.0 * np.ones(size))
+        prob.model.set_input_defaults('y', -4.0 * np.ones(size))
 
         prob.driver = om.ScipyOptimizeDriver()
         prob.driver.options['optimizer'] = 'SLSQP'
@@ -1853,7 +1854,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.model.add_design_var('x', lower=-50, upper=50)
         prob.model.add_design_var('y', lower=-50, upper=50)
-        prob.model.add_objective('parab.f_xy')
+        prob.model.add_objective('parab.f_xy', index=1)
 
         prob.model.add_constraint('const.g', lower=0, upper=10.)
 

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -2019,6 +2019,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         prob.model.add_design_var('y', lower=-50, upper=50)
         prob.model.add_design_var('z', lower=-50, upper=50)
 
+        # objective parab.f_z is not impacted by any quantities.
         prob.model.add_objective('parab.f_z', index=6)
 
         prob.model.add_constraint('const.g', lower=0, upper=10.)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1840,10 +1840,11 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         size = 3
         prob.model.add_subsystem('parab',
                                  om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0',
-                                              'z = 12.0'], shape=(3,)),
+                                              'z = 12.0'], shape=(size,)),
                                  promotes_inputs=['x', 'y'])
 
-        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(3,)), promotes_inputs=['x', 'y'])
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(size,)),
+                                 promotes_inputs=['x', 'y'])
 
         prob.model.set_input_defaults('x', 3.0 * np.ones(size))
         prob.model.set_input_defaults('y', -4.0 * np.ones(size))

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1867,14 +1867,14 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         "Constraints or objectives ['parab.z'] cannot be impacted by the design " + \
+                         "Constraints or objectives [('parab.z', inds=[0, 1, 2])] cannot be impacted by the design " + \
                          "variables of the problem.")
 
     def test_singular_jac_error_desvars(self):
         prob = om.Problem()
         prob.model.add_subsystem('parab',
                                      om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0 - 0*z',
-                                                  ]), #'foo = 0.0 * z'],),
+                                                  ]),
                                      promotes_inputs=['x', 'y', 'z'])
 
         prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
@@ -1902,7 +1902,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         "Design variables ['z'] have no impact on the constraints or objective.")
+                         "Design variables [('z', inds=[0])] have no impact on the constraints or objective.")
 
     def test_singular_jac_ignore(self):
         prob = om.Problem()
@@ -1961,10 +1961,75 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        msg = "Constraints or objectives ['parab.z'] cannot be impacted by the design variables of the problem."
+        msg = "Constraints or objectives [('parab.z', inds=[0])] cannot be impacted by the design variables of the problem."
 
         with assert_warning(UserWarning, msg):
             prob.run_driver()
+
+    def test_singular_jac_error_desvars_multidim_indices_dv(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('parab',
+                                 om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0 - 0*z'], shape=(3,2,2)),
+                                 promotes_inputs=['x', 'y', 'z'])
+
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(3,2,2)), promotes_inputs=['x', 'y'])
+
+        prob.model.set_input_defaults('x', np.ones((3,2,2)) * 3.0)
+        prob.model.set_input_defaults('y', np.ones((3,2,2)) * -4.0)
+
+        prob.driver = om.ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.options['singular_jac_behavior'] = 'error'
+
+        prob.model.add_design_var('x', lower=-50, upper=50)
+        prob.model.add_design_var('y', lower=-50, upper=50)
+
+        # Design var z does not affect any quantities.
+        prob.model.add_design_var('z', lower=-50, upper=50, indices=[2,5,6])
+
+        prob.model.add_objective('parab.f_xy', index=6)
+
+        prob.model.add_constraint('const.g', lower=0, upper=10.)
+
+        prob.setup()
+
+        with self.assertRaises(RuntimeError) as msg:
+            prob.run_driver()
+
+        self.assertEqual(str(msg.exception),
+                         "Design variables [('z', inds=[(0, 1, 0), (1, 0, 1), (1, 1, 0)])] have no impact on the constraints or objective.")
+
+    def test_singular_jac_error_desvars_multidim_indices_con(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('parab',
+                                 om.ExecComp(['f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0 - z',
+                                              'f_z = z * 0.0'], shape=(3,2,2)),
+                                 promotes_inputs=['x', 'y', 'z'])
+
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y', shape=(3,2,2)), promotes_inputs=['x', 'y'])
+
+        prob.model.set_input_defaults('x', np.ones((3,2,2)) * 3.0)
+        prob.model.set_input_defaults('y', np.ones((3,2,2)) * -4.0)
+
+        prob.driver = om.ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'SLSQP'
+        prob.driver.options['singular_jac_behavior'] = 'error'
+
+        prob.model.add_design_var('x', lower=-50, upper=50)
+        prob.model.add_design_var('y', lower=-50, upper=50)
+        prob.model.add_design_var('z', lower=-50, upper=50)
+
+        prob.model.add_objective('parab.f_z', index=6)
+
+        prob.model.add_constraint('const.g', lower=0, upper=10.)
+
+        prob.setup()
+
+        with self.assertRaises(RuntimeError) as msg:
+            prob.run_driver()
+
+        self.assertEqual(str(msg.exception),
+                         "Constraints or objectives [('parab.f_z', inds=[(1, 1, 0)])] cannot be impacted by the design variables of the problem.")
 
 
 class TestScipyOptimizeDriverFeatures(unittest.TestCase):

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -372,6 +372,27 @@ def _flatten_src_indices(src_indices, shape_in, shape_out, size_out):
     return np.ravel_multi_index(dimidxs, shape_out)
 
 
+def _flat_inds2var_inds(flat_inds, shape, sub_inds=None):
+    """
+    Convert flat indices into shaped indices.
+
+    Parameters
+    ----------
+    flat_inds : ndarray
+        The flat indices to be converted.
+    shape : tuple
+        Shape of the variable.
+    sub_inds : ndarray or None
+        For design vars or responses, indices they were declared with.
+
+    Returns
+    -------
+    list of ints if variable is scalar or 1D array else tuples
+        The converted indices.
+    """
+    pass
+
+
 def sizes2offsets(size_array):
     """
     For a given array of sizes, return an array of offsets.

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -372,27 +372,6 @@ def _flatten_src_indices(src_indices, shape_in, shape_out, size_out):
     return np.ravel_multi_index(dimidxs, shape_out)
 
 
-def _flat_inds2var_inds(flat_inds, shape, sub_inds=None):
-    """
-    Convert flat indices into shaped indices.
-
-    Parameters
-    ----------
-    flat_inds : ndarray
-        The flat indices to be converted.
-    shape : tuple
-        Shape of the variable.
-    sub_inds : ndarray or None
-        For design vars or responses, indices they were declared with.
-
-    Returns
-    -------
-    list of ints if variable is scalar or 1D array else tuples
-        The converted indices.
-    """
-    pass
-
-
 def sizes2offsets(size_array):
     """
     For a given array of sizes, return an array of offsets.


### PR DESCRIPTION
### Summary

Indices (relative to the unflattened variable) were added to the error message for each design variable or response that had a zero column or row.

### Related Issues

- Resolves #2057

### Backwards incompatibilities

None

### New Dependencies

None
