### PR TITLE
fix doc links in README; change coveralls base_dir arg

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -190,7 +190,7 @@ jobs:
           cp $HOME/.coverage .
           pip install git+https://github.com/swryan/coveralls-python
           SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`
-          coveralls --base_dir $SITE_DIR
+          coveralls --basedir $SITE_DIR
 
       - name: Make docs
         shell: bash -l {0}
@@ -340,7 +340,7 @@ jobs:
           copy $HOME\.coverage .
           pip install git+https://github.com/swryan/coveralls-python
           $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))"
-          coveralls --base_dir $SITE_DIR
+          coveralls --basedir $SITE_DIR
 
       - name: Notify slack
         uses: act10ns/slack@v1

--- a/README.md
+++ b/README.md
@@ -144,8 +144,8 @@ browser.
 [0]: http://openmdao.org/ "OpenMDAO"
 [1]: https://pypi.org/project/openmdao/ "OpenMDAO @PyPI"
 
-[2]: http://openmdao.org/twodocs/versions/latest "Latest Docs"
-[3]: http://openmdao.org/twodocs "Archived Docs"
+[2]: http://openmdao.org/newdocs/versions/latest "Latest Docs"
+[3]: http://openmdao.org/docs "Archived Docs"
 
 [4]: https://github.com/OpenMDAO/OpenMDAO "OpenMDAO Git Repo"
 [5]: https://github.com/OpenMDAO/OpenMDAO1 "OpenMDAO 1.x Git Repo"


### PR DESCRIPTION
### Summary

fix doc links in README to point to new docs pages
change coveralls `--base_dir` arg to `--basedir` at request of maintainer

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
