### PR TITLE
Updated `show_options_table` func

### DIFF
--- a/openmdao/utils/notebook_utils.py
+++ b/openmdao/utils/notebook_utils.py
@@ -99,7 +99,9 @@ def show_options_table(reference, recording_options=False):
     obj = _get_object_from_reference(reference)()
 
     if ipy:
-        if not recording_options:
+        if not hasattr(obj, "options"):
+            return display(HTML(obj.to_table(fmt='html')))
+        elif not recording_options:
             return display(HTML(obj.options.to_table(fmt='html')))
         else:
             return display(HTML(obj.recording_options.to_table(fmt='html')))

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -49,6 +49,9 @@ class TestNotebookUtils(unittest.TestCase):
         self.assertEqual(options, None)
 
     def test_show_options_table_warning(self):
+        from openmdao.utils import notebook_utils
+        notebook_utils.ipy = False
+
         msg = ("IPython is not installed. Run `pip install openmdao[notebooks]` or `pip install "
                "openmdao[docs]` to upgrade.")
 

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -17,14 +17,6 @@ from openmdao.utils.assert_utils import assert_warning
 @unittest.skipUnless(tabulate and IPython, "Tabulate and IPython are required")
 class TestNotebookUtils(unittest.TestCase):
 
-    def test_show_options_wo_attr(self):
-        from openmdao.utils import notebook_utils
-        notebook_utils.ipy = True
-
-        options = om.show_options_table("openmdao.components.cross_product_comp.CrossProductComp")
-
-        self.assertEqual(options, None)
-
     def test_show_options_w_attr(self):
         from openmdao.utils import notebook_utils
         notebook_utils.ipy = True

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -10,12 +10,6 @@ except ImportError:
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_warning
 
-class StandaloneOptionsDictionary(om.OptionsDictionary):
-    def __init__(self, read_only=False):
-        super(StandaloneOptionsDictionary, self).__init__(read_only)
-        self.declare('units', types=str, allow_none=True,
-                     default='s', desc='Units for the integration variable')
-
 @unittest.skipUnless(tabulate and IPython, "Tabulate and IPython are required")
 class TestNotebookUtils(unittest.TestCase):
 
@@ -23,7 +17,7 @@ class TestNotebookUtils(unittest.TestCase):
         from openmdao.utils import notebook_utils
         notebook_utils.ipy = True
 
-        options = om.show_options_table("openmdao.utils.test_notebook_utils.StandaloneOptionsDictionary")
+        options = om.show_options_table("openmdao.components.cross_product_comp.CrossProductComp")
 
         self.assertEqual(options, None)
 

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -1,0 +1,43 @@
+""" Unit tests for the notebook_utils."""
+
+import unittest
+import tabulate
+try:
+    import IPython
+except ImportError:
+    IPython = False
+
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_warning
+
+class StandaloneOptionsDictionary(om.OptionsDictionary):
+    def __init__(self, read_only=False):
+        super(StandaloneOptionsDictionary, self).__init__(read_only)
+        self.declare('units', types=str, allow_none=True,
+                     default='s', desc='Units for the integration variable')
+
+@unittest.skipUnless(tabulate and IPython, "Tabulate is required")
+class TestNotebookUtils(unittest.TestCase):
+
+    def test_show_options_wo_attr(self):
+        from openmdao.utils import notebook_utils
+        notebook_utils.ipy = True
+
+        options = om.show_options_table("openmdao.utils.test_notebook_utils.StandaloneOptionsDictionary")
+
+        self.assertEqual(options, None)
+
+    def test_show_options_w_attr(self):
+        from openmdao.utils import notebook_utils
+        notebook_utils.ipy = True
+
+        options = om.show_options_table("openmdao.components.balance_comp.BalanceComp")
+
+        self.assertEqual(options, None)
+
+    def test_show_options_table_warning(self):
+        msg = ("IPython is not installed. Run `pip install openmdao[notebooks]` or `pip install "
+               "openmdao[docs]` to upgrade.")
+
+        with assert_warning(UserWarning, msg):
+            om.show_options_table("openmdao.components.balance_comp.BalanceComp")

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -16,7 +16,7 @@ class StandaloneOptionsDictionary(om.OptionsDictionary):
         self.declare('units', types=str, allow_none=True,
                      default='s', desc='Units for the integration variable')
 
-@unittest.skipUnless(tabulate and IPython, "Tabulate is required")
+@unittest.skipUnless(tabulate and IPython, "Tabulate and IPython are required")
 class TestNotebookUtils(unittest.TestCase):
 
     def test_show_options_wo_attr(self):

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -1,7 +1,11 @@
 """ Unit tests for the notebook_utils."""
 
 import unittest
-import tabulate
+try:
+    from tabulate import tabulate
+except ImportError:
+    tabulate = None
+
 try:
     import IPython
 except ImportError:

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -14,8 +14,31 @@ except ImportError:
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_warning
 
+class StateOptionsDictionary(om.OptionsDictionary):
+    """
+    An OptionsDictionary specific to states.
+
+    Parameters
+    ----------
+    read_only : bool
+        If True, setting (via __setitem__ or update) is not permitted.
+    """
+    def __init__(self, read_only=False):
+        super(StateOptionsDictionary, self).__init__(read_only)
+
+        self.declare(name='name', types=str,
+                     desc='name of ODE state variable')
+
 @unittest.skipUnless(tabulate and IPython, "Tabulate and IPython are required")
 class TestNotebookUtils(unittest.TestCase):
+
+    def test_show_obj_options(self):
+        from openmdao.utils import notebook_utils
+        notebook_utils.ipy = True
+
+        options = om.show_options_table("openmdao.utils.tests.test_notebook_utils.StateOptionsDictionary")
+
+        self.assertEqual(options, None)
 
     def test_show_options_w_attr(self):
         from openmdao.utils import notebook_utils


### PR DESCRIPTION
### Summary

Updated the `show_options_table` func for Dymos cases where the options are held in the `__init__` class instead of an options dict.

### Related Issues

- Resolves # N/A

### Backwards incompatibilities

None

### New Dependencies

None
