### PR TITLE
In doing case recording, handle the case where the sql_meta file already exists

### DIFF
--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -171,6 +171,7 @@ class SqliteRecorder(CaseRecorder):
         self.metadata_connection = None
         self._record_metadata = True
         self._record_viewer_data = record_viewer_data
+        print("__init__")
 
         self._abs2prom = {'input': {}, 'output': {}}
         self._prom2abs = {'input': {}, 'output': {}}
@@ -198,6 +199,10 @@ class SqliteRecorder(CaseRecorder):
                 if rank == 0:
                     metadata_filepath = f'{self._filepath}_meta'
                     print(f"Note: Metadata is being recorded separately as {metadata_filepath}.")
+                    try:
+                        os.remove(metadata_filepath)
+                    except OSError:
+                        pass
                     self.metadata_connection = sqlite3.connect(metadata_filepath)
                 else:
                     self._record_metadata = False

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -200,6 +200,9 @@ class SqliteRecorder(CaseRecorder):
                     print(f"Note: Metadata is being recorded separately as {metadata_filepath}.")
                     try:
                         os.remove(metadata_filepath)
+                        issue_warning('The existing case recorder metadata file, '
+                                      f'{metadata_filepath}, is being overwritten.',
+                                      category=UserWarning)
                     except OSError:
                         pass
                     self.metadata_connection = sqlite3.connect(metadata_filepath)
@@ -215,6 +218,10 @@ class SqliteRecorder(CaseRecorder):
         if filepath:
             try:
                 os.remove(filepath)
+                issue_warning(
+                    f'The existing case recorder file, {filepath}, is being '
+                    'overwritten.',
+                    category=UserWarning)
             except OSError:
                 pass
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -171,7 +171,6 @@ class SqliteRecorder(CaseRecorder):
         self.metadata_connection = None
         self._record_metadata = True
         self._record_viewer_data = record_viewer_data
-        print("__init__")
 
         self._abs2prom = {'input': {}, 'output': {}}
         self._prom2abs = {'input': {}, 'output': {}}


### PR DESCRIPTION
### Summary

The case recording code doesn't check to see if there is an existing sql_meta code before trying to create and open it for another parallel run with case recording.

Code was added to remove the sql_meta file if it exists before a run.

### Related Issues

- Resolves #2062 

### Backwards incompatibilities

None

### New Dependencies

None
