### PR TITLE
get coveralls from pypi in actions workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -189,7 +189,7 @@ jobs:
           echo "Submit coverage"
           echo "============================================================="
           cp $HOME/.coverage .
-          pip install git+https://github.com/swryan/coveralls-python
+          pip install coveralls
           SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`
           coveralls --basedir $SITE_DIR
 
@@ -348,7 +348,7 @@ jobs:
           echo "Submit coverage"
           echo "============================================================="
           copy $HOME\.coverage .
-          pip install git+https://github.com/swryan/coveralls-python
+          pip install coveralls
           $SITE_DIR=python -c "import site; print(site.getsitepackages()[-1].replace('lib\\site-', 'Lib\\site-'))"
           coveralls --basedir $SITE_DIR
 


### PR DESCRIPTION
### Summary

the `--basedir` arg is now available on the pypi release of coveralls

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
