### PR TITLE
add tests for return values from add_input and add_output

### DIFF
--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -11,6 +11,7 @@ from openmdao.test_suite.components.impl_comp_array import TestImplCompArray
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.warnings import OMDeprecationWarning
 
+
 class TestExplicitComponent(unittest.TestCase):
 
     def test___init___simple(self):

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -92,11 +92,44 @@ class ExplCompTestCase(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-    def test_feature_simple(self):
+    def test_add_input_output_retval(self):
+        # check basic metadata expected in return value
+        expected = {
+            'value': 3,
+            'shape': (1,),
+            'size': 1,
+            'units': 'ft',
+            'desc': '',
+            'tags': set(),
+        }
+        expected_discrete = {
+            'value': 3,
+            'type': int,
+            'desc': '',
+            'tags': set(),
+        }
 
-        prob = om.Problem(RectangleComp())
+        class Comp(om.ExplicitComponent):
+            def setup(self):
+                meta = self.add_input('x', val=3.0, units='ft')
+                for key, val in expected.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_discrete_input('x_disc', val=3)
+                for key, val in expected_discrete.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_output('y', val=3.0, units='ft')
+                for key, val in expected.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_discrete_output('y_disc', val=3)
+                for key, val in expected_discrete.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', Comp())
         prob.setup()
-        prob.run_model()
 
     def test_compute_and_list(self):
         prob = om.Problem(RectangleGroup())

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -114,6 +114,48 @@ class QuadraticJacVec(QuadraticComp):
             d_residuals['x'] = self.inv_jac * d_outputs['x']
 
 
+class ImplCompTestCase(unittest.TestCase):
+
+    def test_add_input_output_retval(self):
+        # check basic metadata expected in return value
+        expected = {
+            'value': 3,
+            'shape': (1,),
+            'size': 1,
+            'units': 'ft',
+            'desc': '',
+            'tags': set(),
+        }
+        expected_discrete = {
+            'value': 3,
+            'type': int,
+            'desc': '',
+            'tags': set(),
+        }
+
+        class ImplComp(om.ImplicitComponent):
+            def setup(self):
+                meta = self.add_input('x', val=3.0, units='ft')
+                for key, val in expected.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_discrete_input('x_disc', val=3)
+                for key, val in expected_discrete.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_output('y', val=3.0, units='ft')
+                for key, val in expected.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_discrete_output('y_disc', val=3)
+                for key, val in expected_discrete.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', ImplComp())
+        prob.setup()
+
+
 class ImplicitCompTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -9,6 +9,37 @@ from openmdao.warnings import OMDeprecationWarning
 
 class TestIndepVarComp(unittest.TestCase):
 
+    def test_add_output_retval(self):
+        # check basic metadata expected in return value
+        expected = {
+            'value': 3,
+            'shape': (1,),
+            'size': 1,
+            'units': 'ft',
+            'desc': '',
+            'tags': {'indep_var'},
+        }
+        expected_discrete = {
+            'value': 3,
+            'type': int,
+            'desc': '',
+            'tags': {'indep_var'},
+        }
+
+        class IDVComp(om.IndepVarComp):
+            def setup(self):
+                meta = self.add_output('y', val=3.0, units='ft')
+                for key, val in expected.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+                meta = self.add_discrete_output('disc', val=3)
+                for key, val in expected_discrete.items():
+                    assert meta[key] == val, f'Expected {key}: {val} but got {key}: {meta[key]}'
+
+        prob = om.Problem()
+        prob.model.add_subsystem('idv', IDVComp())
+        prob.setup()
+
     def test_simple(self):
         """Define one independent variable and set its value."""
 


### PR DESCRIPTION
### Summary

This is an addendum to PR #2104, adding tests

### Related Issues

- Resolves #2103

### Backwards incompatibilities

None

### New Dependencies

None
