### PR TITLE
Fixed github repo information for JupyterBook docs

### DIFF
--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -24,9 +24,9 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/OpenMDAO/OpenMDAO_Book  # Online location of your book
-  path_to_book: openmdao_book  # Optional path to your book, relative to the repository root
-  branch: main  # Which branch of the repository should be used when creating links (optional)
+  url: https://github.com/OpenMDAO/OpenMDAO  # Online location of your book
+  path_to_book: openmdao/docs/openmdao_book  # Optional path to your book, relative to the repository root
+  branch: master  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
### Summary

Changes information about the git repo displayed in the documentation.

### Related Issues

- Resolves #2096

### Backwards incompatibilities

None

### New Dependencies

None
