### PR TITLE
Fixed Keplers equation example in docs to show better ordering

### DIFF
--- a/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
+++ b/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
@@ -93,14 +93,14 @@
     "                       E={'units': 'rad'},\n",
     "                       ecc={'units': None})\n",
     "\n",
-    "prob.model.add_subsystem(name='balance', subsys=bal,\n",
-    "                         promotes_inputs=['M'],\n",
-    "                         promotes_outputs=['E'])\n",
-    "\n",
     "prob.model.set_input_defaults('M', 85.0, units='deg')\n",
     "\n",
     "prob.model.add_subsystem(name='lhs_comp', subsys=lhs_comp,\n",
     "                         promotes_inputs=['E', 'ecc'])\n",
+    "\n",
+    "prob.model.add_subsystem(name='balance', subsys=bal,\n",
+    "                         promotes_inputs=['M'],\n",
+    "                         promotes_outputs=['E'])\n",
     "\n",
     "# Explicit connections\n",
     "prob.model.connect('lhs_comp.lhs', 'balance.lhs:E')\n",
@@ -121,6 +121,15 @@
     "E = prob.get_val('E')\n",
     "print(f'M = {M}')\n",
     "print(f'E = {E}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "BalanceComp should be placed after those components which compute its inputs.  Otherwise errors can arise due to timing issues.\n",
+    "```"
    ]
   },
   {
@@ -285,6 +294,13 @@
     "\n",
     "The ImplicitComponent involves only a single system, but writing the `solve_nonlinear` method with some error handling, initial guess generation, and print capability made for more coding on the part of the user."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -304,7 +320,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
…n example

### Summary

Previously the Kepler's equation example had a BalanceComp as the first component in its group.  This is bad practice and, while it works sometimes, will often result in problems due to ordering.  This example has been fixed and a note added telling users to place Balance components at the end of their group.

### Related Issues

- Resolves #2100 

### Backwards incompatibilities

None

### New Dependencies

None
