### PR TITLE
fixed a bug in ExecComp when expressions were added with missing value/shape info

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -419,12 +419,12 @@ class ExecComp(ExplicitComponent):
             else:
                 # new input and/or output.
                 if var in outs:
-                    dct = self.add_output(var, val, **meta)
+                    current_meta = self.add_output(var, val, **meta)
                 else:
-                    dct = self.add_input(var, val, **meta)
+                    current_meta = self.add_input(var, val, **meta)
 
             if var not in init_vals:
-                init_vals[var] = dct['value']
+                init_vals[var] = current_meta['value']
 
         self._codes = self._compile_exprs(self._exprs)
 

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1258,6 +1258,32 @@ class TestExecComp(unittest.TestCase):
         assert_almost_equal(p.get_val('z'), 8.7, 1e-8)
         assert_almost_equal(p.get_val('y'), 3.0, 1e-8)
 
+    def test_add_expr_configure_no_shape_or_val(self):
+
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp('x_constraint=x',
+                                     x_constraint={'units': None},
+                                     x={'units': 's'})
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                self.excomp.add_expr('y_constraint = y',
+                                     y_constraint={'units': None},
+                                     y={'units': 's'})
+
+
+        p = om.Problem()
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
+        p.setup()
+        p.set_val('x', 3.0)
+        p.set_val('y', 4.0)
+        p.run_model()
+
+        assert_almost_equal(p.get_val('x_constraint'), 3.0)
+        assert_almost_equal(p.get_val('y_constraint'), 4.0)
+
     def test_add_expr_configure_delay_defaults(self):
 
         class ConfigGroup(om.Group):

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1273,7 +1273,6 @@ class TestExecComp(unittest.TestCase):
                                      y_constraint={'units': None},
                                      y={'units': 's'})
 
-
         p = om.Problem()
         p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
         p.setup()


### PR DESCRIPTION
### Summary

When adding expressions to an ExecComp with missing value/shape information, OpenMDAO raises an error regarding an undefined variable `dct`.  When this value/shape information is omitted, `dct` is not necessarily created based on the wa the logic branches.  To fix the issue, this data is pulled from `current_meta`, and the variable `current_meta` is defined in both possible branches of the logic (`dct` is renamed `current_meta` in the `else` branch).

### Related Issues

- Resolves #2120 

### Backwards incompatibilities

None

### New Dependencies

None
