### PR TITLE
Fixed an issue where ExecComp was required to have at least one expression before configure is called.

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -68,6 +68,8 @@ class ExecComp(ExplicitComponent):
         List of expressions.
     _codes : list
         List of code objects.
+    _exprs_info : list
+        List of tuples containing output and inputs for each expression.
     _has_diag_partials : bool
         If True, treat all array/array partials as diagonal if both arrays have size > 1.
         All arrays with size > 1 must have the same flattened size or an exception will be raised.

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -206,7 +206,8 @@ class ExecComp(ExplicitComponent):
             exprs = [exprs]
 
         self._exprs = exprs[:]
-        self._codes = None
+        self._exprs_info = []
+        self._codes = []
         self._kwargs = kwargs
 
         self._manual_decl_partials = False
@@ -274,10 +275,8 @@ class ExecComp(ExplicitComponent):
         """
         Set up variable name and metadata lists.
         """
-        if not self._exprs:
-            raise RuntimeError("%s: No valid expressions provided to ExecComp(): %s."
-                               % (self.msginfo, self._exprs))
-        self._setup_expressions()
+        if self._exprs:
+            self._setup_expressions()
 
     def _setup_expressions(self):
         """

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1283,6 +1283,43 @@ class TestExecComp(unittest.TestCase):
         assert_almost_equal(p.get_val('x_constraint'), 3.0)
         assert_almost_equal(p.get_val('y_constraint'), 4.0)
 
+    def test_no_expressions_until_configure(self):
+
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp()
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                self.excomp.add_expr('y_constraint = y**2',
+                                     y_constraint={'units': None},
+                                     y={'units': 's'})
+
+        p = om.Problem()
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
+        p.setup()
+        p.set_val('y', 4.0)
+        p.run_model()
+
+        assert_almost_equal(p.get_val('y_constraint'), 16.0)
+
+    def test_no_expressions(self):
+
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp()
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                pass
+
+        p = om.Problem()
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
+        p.setup()
+        p.run_model()
+
     def test_add_expr_configure_delay_defaults(self):
 
         class ConfigGroup(om.Group):

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -311,14 +311,6 @@ class TestExecComp(unittest.TestCase):
         with assert_warning(UserWarning, "'comp' <class ExecComp>: The following partial derivatives have not been declared so they are assumed to be zero: ['z' wrt 'y']."):
             p.final_setup()
 
-    def test_no_expr(self):
-        prob = om.Problem()
-        prob.model.add_subsystem('C1', om.ExecComp())
-        with self.assertRaises(Exception) as context:
-            prob.setup()
-        self.assertEqual(str(context.exception),
-                         "'C1' <class ExecComp>: No valid expressions provided to ExecComp(): [].")
-
     def test_colon_vars(self):
         prob = om.Problem()
         prob.model.add_subsystem('C1', om.ExecComp('y=foo:bar+1.'))


### PR DESCRIPTION
### Summary

When adding expressions programmatically to ExecComp, the component is required to have at least one expression at setup, otherwise an exception is raised.  If a user wishes to add expressions during the configure stage, a dummy expression is required.

This PR makes it so that no expressions are required at setup time.  That check is removed entirely.  The user can instead rely on the OpenMDAO setup check process to detect that a component has no outputs.

### Related Issues

- Resolves #2122 

### Backwards incompatibilities

None

### New Dependencies

None
