### PR TITLE
Problem: Generalize Distributed Vector Check

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -868,16 +868,17 @@ class Problem(object):
         model = self.model
         comm = self.comm
 
-        # PETScVector is required for MPI
+        # A distributed vector type is required for MPI
         if comm.size > 1:
-            if PETScVector is None:
+            if distributed_vector_class is PETScVector and PETScVector is None:
                 raise ValueError(self.msginfo +
                                  ": Attempting to run in parallel under MPI but PETScVector "
                                  "could not be imported.")
-            elif distributed_vector_class is not PETScVector:
-                raise ValueError("%s: The `distributed_vector_class` argument must be "
-                                 "`PETScVector` when running in parallel under MPI but '%s' was "
-                                 "specified." % (self.msginfo, distributed_vector_class.__name__))
+            elif not distributed_vector_class.distributed:
+                raise ValueError("%s: The `distributed_vector_class` argument must be a "
+                                 "distributed vector class like `PETScVector` when running in "
+                                 "parallel under MPI but '%s' was specified which is not "
+                                 "distributed." % (self.msginfo, distributed_vector_class.__name__))
 
         if mode not in ['fwd', 'rev', 'auto']:
             msg = "%s: Unsupported mode: '%s'. Use either 'fwd' or 'rev'." % (self.msginfo, mode)

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -308,8 +308,9 @@ class TestParallelGroups(unittest.TestCase):
 
         # check that error is thrown if not using PETScVector
         if MPI:
-            msg = ("Problem: The `distributed_vector_class` argument must be `PETScVector` when "
-                   "running in parallel under MPI but 'DefaultVector' was specified.")
+            msg = ("Problem: The `distributed_vector_class` argument must be a distributed vector "
+                   "class like `PETScVector` when running in parallel under MPI but 'DefaultVector' "
+                   "was specified which is not distributed.")
             with self.assertRaises(ValueError) as cm:
                 prob.setup(check=False, mode='fwd', distributed_vector_class=om.DefaultVector)
 

--- a/openmdao/vectors/petsc_vector.py
+++ b/openmdao/vectors/petsc_vector.py
@@ -37,6 +37,7 @@ class PETScVector(DefaultVector):
 
     TRANSFER = PETScTransfer
     cite = CITATION
+    distributed = True
 
     def __init__(self, name, kind, system, root_vector=None, alloc_complex=False, ncol=1):
         """

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -77,6 +77,9 @@ class Vector(object):
     # Listing of relevant citations that should be referenced when
     cite = ""
 
+    """Indicator whether a vector class is MPI-distributed"""
+    distributed = False
+
     def __init__(self, name, kind, system, root_vector=None, alloc_complex=False, ncol=1):
         """
         Initialize all attributes.


### PR DESCRIPTION
### Summary

`Problem.setup()` allows to set a custom distributed vector class with its`distributed_vector_class` argument. Unfortunately, this argument could not be used effectively because were was check requiring `PETScVector` to be used for MPI distributed problems. This commit introduces a flag for vector classes to indicate whether they are MPI-distributed or not. `Problem.setup()` now uses this flag the perform the MPI check allowing to setup problems with custom distributed vector classes besides `PETScVector`.

This allows me to remove this gem from my project:

```
openmdao.core.problem.PETScVector = FSDMVector
problem.setup(local_vector_class=FSDMVector, distributed_vector_class=FSDMVector)
```

to get past the MPI check.

### Related Issues

None.

### Backwards incompatibilities

None

### New Dependencies

None
