### PR TITLE
fix deprecation warning; remove extraneous 'value' from metadata

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -9,7 +9,7 @@ from numpy import ndarray, isscalar, atleast_1d, atleast_2d, promote_types
 from scipy.sparse import issparse, coo_matrix
 
 from openmdao.core.system import System, _supported_methods, _DEFAULT_COLORING_META, \
-    global_meta_names
+    global_meta_names, _MetadataDict
 from openmdao.core.constants import INT_DTYPE
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.array_utils import shape_to_len
@@ -51,28 +51,6 @@ def _valid_var_name(name):
         if char in name:
             return False
     return name[0] not in _whitespace and name[-1] not in _whitespace
-
-
-class _MetadataDict(dict):
-    """
-    A dict wrapper for a dict of metadata, to throw deprecation if a user indexes in using value.
-    """
-
-    def __init__(self, *args):
-        dict.__init__(self, args)
-
-    def __getitem__(self, key):
-        if key == 'value':
-            warn_deprecation("The dict key 'value' will be deprecated in 4.0. Please use 'val'")
-            key = 'val'
-        val = dict.__getitem__(self, key)
-        return val
-
-    def __setitem__(self, key, val):
-        if key == 'value':
-            warn_deprecation("The dict key 'value' will be deprecated in 4.0. Please use 'val'")
-            key = 'val'
-        dict.__setitem__(self, key, val)
 
 
 class Component(System):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3318,7 +3318,7 @@ class System(object):
                     ret_meta = None
                 else:
                     if metadata_keys is None:
-                        ret_meta = _MetadataDict(meta.copy())
+                        ret_meta = _MetadataDict(meta)
                     else:
                         ret_meta = _MetadataDict()
                         for key in metadata_keys:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -122,6 +122,25 @@ class _MatchType(IntEnum):
     PATTERN = 2
 
 
+class _MetadataDict(dict):
+    """
+    A dict wrapper for a dict of metadata, to throw deprecation if a user indexes in using value.
+    """
+
+    def __getitem__(self, key):
+        if key == 'value':
+            warn_deprecation("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+            key = 'val'
+        val = dict.__getitem__(self, key)
+        return val
+
+    def __setitem__(self, key, val):
+        if key == 'value':
+            warn_deprecation("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+            key = 'val'
+        dict.__setitem__(self, key, val)
+
+
 class System(object):
     """
     Base class for all systems in OpenMDAO.
@@ -3299,9 +3318,9 @@ class System(object):
                     ret_meta = None
                 else:
                     if metadata_keys is None:
-                        ret_meta = meta.copy()
+                        ret_meta = _MetadataDict(meta.copy())
                     else:
-                        ret_meta = {}
+                        ret_meta = _MetadataDict()
                         for key in metadata_keys:
                             try:
                                 ret_meta[key] = meta[key]
@@ -3317,7 +3336,7 @@ class System(object):
 
                         if rank is None or self.comm.rank == rank:
                             if not ret_meta:
-                                ret_meta = {}
+                                ret_meta = _MetadataDict()
                             if distrib:
                                 if 'val' in metadata_keys:
                                     # assemble the full distributed value
@@ -3422,8 +3441,8 @@ class System(object):
             List of input names and other optional information about those inputs.
         """
         if values is not None:
-            issue_warning(f"{self.msginfo}: 'value' is deprecated and will be removed in 4.0. "
-                          "Please index in using 'val'")
+            warn_deprecation(f"{self.msginfo}: The 'values' argument to 'list_inputs()' is "
+                             "deprecated and will be removed in 4.0. Please use 'val' instead.")
         elif not val and values:
             values = True
         else:
@@ -3446,11 +3465,6 @@ class System(object):
                 to_remove.append('tags')
             if not prom_name:
                 to_remove.append('prom_name')
-            if metavalues:
-                for key, val in inputs.items():
-                    if 'val' in val:
-                        val['value'] = val['val']
-
             for _, meta in inputs.items():
                 for key in to_remove:
                     del meta[key]
@@ -3460,7 +3474,6 @@ class System(object):
             for n, meta in inputs.items():
                 meta['val'] = self._abs_get_val(n, get_remote=True,
                                                 rank=None if all_procs else 0, kind='input')
-                meta['value'] = meta['val']
 
         if not inputs or (not all_procs and self.comm.rank != 0):
             return []
@@ -3564,8 +3577,8 @@ class System(object):
             List of output names and other optional information about those outputs.
         """
         if values is not None:
-            issue_warning(f"{self.msginfo}: 'value' is deprecated and will be removed in 4.0. "
-                          "Please index in using 'val'")
+            warn_deprecation(f"{self.msginfo}: The 'values' argument to 'list_outputs()' is "
+                             "deprecated and will be removed in 4.0. Please use 'val' instead.")
         elif not val and values:
             values = True
         else:
@@ -3599,7 +3612,6 @@ class System(object):
                     # we want value from the input vector, not from the metadata
                     meta['val'] = self._abs_get_val(name, get_remote=True,
                                                     rank=None if all_procs else 0, kind='output')
-                    meta['value'] = meta['val']
                 if residuals or residuals_tol:
                     resids = self._abs_get_val(name, get_remote=True,
                                                rank=None if all_procs else 0,
@@ -3623,11 +3635,6 @@ class System(object):
             to_remove.append('tags')
         if not prom_name:
             to_remove.append('prom_name')
-        if values:
-            for key, val in outputs.items():
-                if 'val' in val and ('value' not in val):
-                    val['value'] = val['val']
-
         for _, meta in outputs.items():
             for key in to_remove:
                 del meta[key]

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -299,7 +299,7 @@ class TestExplicitComponent(unittest.TestCase):
         prob = Problem(comp).setup()
 
         # check optional metadata (desc)
-        msg = ("The dict key 'value' will be deprecated in 4.0. Please use 'val'")
+        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
 
         prob.setup()
         with assert_warning(OMDeprecationWarning, msg):
@@ -310,7 +310,7 @@ class TestExplicitComponent(unittest.TestCase):
         idv = prob.model.add_subsystem('idv', IndepVarComp())
         meta = idv.add_output('x', 1.0)
 
-        msg = ("The dict key 'value' will be deprecated in 4.0. Please use 'val'")
+        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
         with assert_warning(OMDeprecationWarning, msg):
             meta['value']
 

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -249,27 +249,27 @@ class DiscreteTestCase(unittest.TestCase):
         # expl_inputs = prob.model.expl.list_inputs(values=True, out_stream=None)
         expl_inputs = prob.model.expl.list_inputs(out_stream=None)
         expected = {
-            'a': {'val': [10.], 'value': [10.]},
-            'x': {'val': 10, 'value': 10}
+            'a': {'val': [10.]},
+            'x': {'val': 10}
         }
         self.assertEqual(dict(expl_inputs), expected)
 
         impl_inputs = prob.model.impl.list_inputs(out_stream=None)
         expected = {
-            'x': {'val': 10, 'value': 10}
+            'x': {'val': 10}
         }
         self.assertEqual(dict(impl_inputs), expected)
 
         expl_outputs = prob.model.expl.list_outputs(out_stream=None)
         expected = {
-            'b': {'val': [0.], 'value': [0.]},
-            'y': {'val': 0, 'value': 0}
+            'b': {'val': [0.]},
+            'y': {'val': 0}
         }
         self.assertEqual(dict(expl_outputs), expected)
 
         impl_outputs = prob.model.impl.list_outputs(out_stream=None)
         expected = {
-            'y': {'val': 0, 'value': 0}
+            'y': {'val': 0}
         }
         self.assertEqual(dict(impl_outputs), expected)
 

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -138,8 +138,8 @@ class ExplCompTestCase(unittest.TestCase):
         # list explicit outputs
         outputs = prob.model.list_outputs(implicit=False, out_stream=None)
         expected = {
-            'comp1.area': {'val': np.array([1.]), 'value': np.array([1.])},
-            'comp2.area': {'val': np.array([1.]), 'value': np.array([1.])}
+            'comp1.area': {'val': np.array([1.])},
+            'comp2.area': {'val': np.array([1.])}
         }
         self.assertEqual(dict(outputs), expected)
 
@@ -168,17 +168,17 @@ class ExplCompTestCase(unittest.TestCase):
         # list inputs
         inputs = prob.model.list_inputs(out_stream=None)
         self.assertEqual(sorted(inputs), [
-            ('comp1.length', {'val': [3.], 'value': [3.]}),
-            ('comp1.width',  {'val': [2.], 'value': [2.]}),
-            ('comp2.length', {'val': [3.], 'value': [3.]}),
-            ('comp2.width',  {'val': [2.], 'value': [2.]}),
+            ('comp1.length', {'val': [3.]}),
+            ('comp1.width',  {'val': [2.]}),
+            ('comp2.length', {'val': [3.]}),
+            ('comp2.width',  {'val': [2.]}),
         ])
 
         # list explicit outputs
         outputs = prob.model.list_outputs(implicit=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('comp1.area',   {'val': [6.], 'value': [6.]}),
-            ('comp2.area',   {'val': [6.], 'value': [6.]}),
+            ('comp1.area',   {'val': [6.]}),
+            ('comp2.area',   {'val': [6.]}),
         ])
 
         # list states
@@ -218,38 +218,38 @@ class ExplCompTestCase(unittest.TestCase):
         # list outputs before model has been run will raise an exception
         outputs = dict(prob.model.list_outputs(out_stream=None))
         expected = {
-            'p1.x': {'val': 12., 'value': 12.},
-            'p2.y': {'val': 1., 'value': 1.},
-            'comp.z': {'val': 0., 'value': 0.},
+            'p1.x': {'val': 12.},
+            'p2.y': {'val': 1.},
+            'comp.z': {'val': 0.},
         }
         self.assertEqual(outputs, expected)
 
         # list_inputs on a component before run is okay, using relative names
         expl_inputs = prob.model.comp.list_inputs(out_stream=None)
         expected = {
-            'x': {'val': 0., 'value': 0.},
-            'y': {'val': 0., 'value': 0.}
+            'x': {'val': 0.},
+            'y': {'val': 0.}
         }
         self.assertEqual(dict(expl_inputs), expected)
 
         expl_inputs = prob.model.comp.list_inputs(includes='x', out_stream=None)
-        self.assertEqual(dict(expl_inputs), {'x': {'val': 0., 'value': 0.}})
+        self.assertEqual(dict(expl_inputs), {'x': {'val': 0.}})
 
         expl_inputs = prob.model.comp.list_inputs(excludes='x', out_stream=None)
-        self.assertEqual(dict(expl_inputs), {'y': {'val': 0., 'value': 0.}})
+        self.assertEqual(dict(expl_inputs), {'y': {'val': 0.}})
 
         # specifying prom_name should not cause an error
         expl_inputs = prob.model.comp.list_inputs(prom_name=True, out_stream=None)
         self.assertEqual(dict(expl_inputs), {
-            'x': {'val': 0., 'value': 0., 'prom_name': 'x'},
-            'y': {'val': 0., 'value': 0., 'prom_name': 'y'},
+            'x': {'val': 0., 'prom_name': 'x'},
+            'y': {'val': 0., 'prom_name': 'y'},
         })
 
         # list_outputs on a component before run is okay, using relative names
         stream = StringIO()
         expl_outputs = prob.model.p1.list_outputs(out_stream=stream)
         expected = {
-            'x': {'val': 12., 'value': 12.}
+            'x': {'val': 12.}
         }
         self.assertEqual(dict(expl_outputs), expected)
 
@@ -281,7 +281,7 @@ class ExplCompTestCase(unittest.TestCase):
         # specifying prom_name should not cause an error
         expl_outputs = prob.model.p1.list_outputs(prom_name=True, out_stream=None)
         self.assertEqual(dict(expl_outputs), {
-            'x': {'val': 12., 'value': 12., 'prom_name': 'x'}
+            'x': {'val': 12., 'prom_name': 'x'}
         })
 
         # run model
@@ -294,8 +294,8 @@ class ExplCompTestCase(unittest.TestCase):
         inputs = prob.model.list_inputs(units=True, shape=True, out_stream=stream)
         tol = 1e-7
         for actual, expected in zip(sorted(inputs), [
-            ('comp.x', {'val': [12.], 'value': [12.], 'shape': (1,), 'units': 'inch'}),
-            ('comp.y', {'val': [12.], 'value': [12.], 'shape': (1,), 'units': 'inch'})
+            ('comp.x', {'val': [12.], 'shape': (1,), 'units': 'inch'}),
+            ('comp.y', {'val': [12.], 'shape': (1,), 'units': 'inch'})
         ]):
             self.assertEqual(expected[0], actual[0])
             self.assertEqual(expected[1]['units'], actual[1]['units'])
@@ -335,11 +335,11 @@ class ExplCompTestCase(unittest.TestCase):
                                           out_stream=stream)
 
         self.assertEqual([
-            ('comp.z', {'val': [24.], 'value': [24.], 'resids': [0.], 'units': 'inch', 'shape': (1,), 'desc': '',
+            ('comp.z', {'val': [24.], 'resids': [0.], 'units': 'inch', 'shape': (1,), 'desc': '',
                         'lower': None, 'upper': None, 'ref': 1.0, 'ref0': 0.0, 'res_ref': 1.0}),
-            ('p1.x', {'val': [12.], 'value': [12.], 'resids': [0.], 'units': 'inch', 'shape': (1,), 'desc': 'indep x',
+            ('p1.x', {'val': [12.], 'resids': [0.], 'units': 'inch', 'shape': (1,), 'desc': 'indep x',
                       'lower': [1.], 'upper': [100.], 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1}),
-            ('p2.y', {'val': [1.], 'value': [1.], 'value': [1.], 'resids': [0.], 'units': 'ft', 'shape': (1,), 'desc': 'indep y',
+            ('p2.y', {'val': [1.], 'resids': [0.], 'units': 'ft', 'shape': (1,), 'desc': 'indep y',
                       'lower': [2.], 'upper': [200.], 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
         ], sorted(outputs))
 
@@ -403,11 +403,11 @@ class ExplCompTestCase(unittest.TestCase):
                                           print_arrays=False)
 
         self.assertEqual(sorted(outputs), [
-            ('comp.z', {'val': [24.], 'value': [24.], 'resids': [0.], 'units': 'inch', 'shape': (1,),
+            ('comp.z', {'val': [24.], 'resids': [0.], 'units': 'inch', 'shape': (1,),
                         'lower': None, 'upper': None, 'ref': 1.0, 'ref0': 0.0, 'res_ref': 1.0}),
-            ('p1.x', {'val': [12.], 'value': [12.], 'resids': [0.], 'units': 'inch', 'shape': (1,),
+            ('p1.x', {'val': [12.], 'resids': [0.], 'units': 'inch', 'shape': (1,),
                       'lower': [1.], 'upper': [100.], 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1}),
-            ('p2.y', {'val': [1.], 'value': [1.], 'value': [1.], 'resids': [0.], 'units': 'ft', 'shape': (1,),
+            ('p2.y', {'val': [1.], 'resids': [0.], 'units': 'ft', 'shape': (1,),
                       'lower': [2.], 'upper': [200.], 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
         ])
 
@@ -876,25 +876,25 @@ class ExplCompTestCase(unittest.TestCase):
         # Inputs no tags
         inputs = prob.model.list_inputs(out_stream=None)
         self.assertEqual(sorted(inputs), [
-            ('length', {'val': [1.], 'value': [1.]}),
-            ('width', {'val': [1.], 'value': [1.]}),
+            ('length', {'val': [1.]}),
+            ('width', {'val': [1.]}),
         ])
 
         # Inputs with tags
         inputs = prob.model.list_inputs(out_stream=None, tags="tag1")
         self.assertEqual(sorted(inputs), [
-            ('length', {'val': [1.], 'value': [1.]}),
+            ('length', {'val': [1.]}),
         ])
 
         # Inputs with multiple tags
         inputs = prob.model.list_inputs(out_stream=None, tags=["tag1", "tag3"])
         self.assertEqual(sorted(inputs), [
-            ('length', {'val': [1.], 'value': [1.]}),
+            ('length', {'val': [1.]}),
         ])
         inputs = prob.model.list_inputs(out_stream=None, tags=["tag1", "tag2"])
         self.assertEqual(sorted(inputs), [
-            ('length', {'val': [1.], 'value': [1.]}),
-            ('width', {'val': [1.], 'value': [1.]}),
+            ('length', {'val': [1.]}),
+            ('width', {'val': [1.]}),
         ])
 
         # Inputs with tag that does not match
@@ -904,19 +904,19 @@ class ExplCompTestCase(unittest.TestCase):
         # Outputs no tags
         outputs = prob.model.list_outputs(out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('area', {'val': [1.], 'value': [1.]}),
+            ('area', {'val': [1.]}),
         ])
 
         # Outputs with tags
         outputs = prob.model.list_outputs(out_stream=None, tags="tag1")
         self.assertEqual(sorted(outputs), [
-            ('area', {'val': [1.], 'value': [1.]}),
+            ('area', {'val': [1.]}),
         ])
 
         # Outputs with multiple tags
         outputs = prob.model.list_outputs(out_stream=None, tags=["tag1", "tag3"])
         self.assertEqual(sorted(outputs), [
-            ('area', {'val': [1.], 'value': [1.]}),
+            ('area', {'val': [1.]}),
         ])
 
         # Outputs with tag that does not match

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -195,60 +195,60 @@ class ImplicitCompTestCase(unittest.TestCase):
         # cannot list_inputs on a Group before running
         model_inputs = self.prob.model.list_inputs(desc=True, out_stream=None)
         expected = {
-            'comp1.a': {'val': [1.], 'value':  [1.], 'desc': ''},
-            'comp1.b': {'val': [1.], 'value':  [1.], 'desc': ''},
-            'comp1.c': {'val': [1.], 'value':  [1.], 'desc': ''},
-            'comp2.a': {'val': [1.], 'value':  [1.], 'desc': ''},
-            'comp2.b': {'val': [1.], 'value':  [1.], 'desc': ''},
-            'comp2.c': {'val': [1.], 'value':  [1.], 'desc': ''},
+            'comp1.a': {'val': [1.], 'desc': ''},
+            'comp1.b': {'val': [1.], 'desc': ''},
+            'comp1.c': {'val': [1.], 'desc': ''},
+            'comp2.a': {'val': [1.], 'desc': ''},
+            'comp2.b': {'val': [1.], 'desc': ''},
+            'comp2.c': {'val': [1.], 'desc': ''},
         }
         self.assertEqual(dict(model_inputs), expected)
 
         # list_inputs on a component before running is okay
         c2_inputs = self.prob.model.comp2.list_inputs(desc=True, out_stream=None)
         expected = {
-            'a': {'val': [1.], 'value': [1.], 'desc': ''},
-            'b': {'val': [1.], 'value': [1.], 'desc': ''},
-            'c': {'val': [1.], 'value': [1.], 'desc': ''}
+            'a': {'val': [1.], 'desc': ''},
+            'b': {'val': [1.], 'desc': ''},
+            'c': {'val': [1.], 'desc': ''}
         }
         self.assertEqual(dict(c2_inputs), expected)
 
         # listing component inputs based on tags should work
         c2_inputs = self.prob.model.comp2.list_inputs(tags='tag_a', out_stream=None)
-        self.assertEqual(dict(c2_inputs), {'a': {'val': [1.], 'value': [1.]}})
+        self.assertEqual(dict(c2_inputs), {'a': {'val': [1.]}})
 
         # includes and excludes based on relative names should work
         c2_inputs = self.prob.model.comp2.list_inputs(includes='a', out_stream=None)
-        self.assertEqual(dict(c2_inputs), {'a': {'val': [1.], 'value': [1.]}})
+        self.assertEqual(dict(c2_inputs), {'a': {'val': [1.]}})
 
         c2_inputs = self.prob.model.comp2.list_inputs(excludes='c', out_stream=None)
         expected = {
-            'a': {'val': [1.], 'value': [1.]},
-            'b': {'val': [1.], 'value': [1.]},
+            'a': {'val': [1.]},
+            'b': {'val': [1.]},
         }
         self.assertEqual(dict(c2_inputs), expected)
 
         # specifying prom_name should not cause an error
         c2_inputs = self.prob.model.comp2.list_inputs(prom_name=True, out_stream=None)
         self.assertEqual(dict(c2_inputs), {
-            'a': {'val': [1.], 'value': [1.], 'prom_name': 'a'},
-            'b': {'val': [1.], 'value': [1.], 'prom_name': 'b'},
-            'c': {'val': [1.], 'value': [1.], 'prom_name': 'c'}
+            'a': {'val': [1.], 'prom_name': 'a'},
+            'b': {'val': [1.], 'prom_name': 'b'},
+            'c': {'val': [1.], 'prom_name': 'c'}
         })
 
     def test_list_outputs_before_run(self):
         # cannot list_outputs on a Group before running
         model_outputs = self.prob.model.list_outputs(out_stream=None)
         expected = {
-            'comp1.x': {'val': [0.], 'value': [0.]},
-            'comp2.x': {'val': [0.], 'value': [0.]},
+            'comp1.x': {'val': [0.]},
+            'comp2.x': {'val': [0.]},
         }
         self.assertEqual(dict(model_outputs), expected)
 
         # list_outputs on a component before running is okay
         c2_outputs = self.prob.model.comp2.list_outputs(out_stream=None)
         expected = {
-            'x': {'val': np.array([0.]), 'value': np.array([0.])}
+            'x': {'val': np.array([0.])}
         }
         self.assertEqual(dict(c2_outputs), expected)
 
@@ -267,13 +267,13 @@ class ImplicitCompTestCase(unittest.TestCase):
         # there are no residuals yet, so nothing should be filtered
         c2_outputs = self.prob.model.comp2.list_outputs(residuals_tol=.01, out_stream=None)
         self.assertEqual(dict(c2_outputs), {
-            'x': {'val': 0., 'value': 0.}
+            'x': {'val': 0.}
         })
 
         # specifying prom_name should not cause an error
         c2_outputs = self.prob.model.comp2.list_outputs(prom_name=True, out_stream=None)
         self.assertEqual(dict(c2_outputs), {
-            'x': {'val': 0., 'value': 0., 'prom_name': 'x'}
+            'x': {'val': 0., 'prom_name': 'x'}
         })
 
     def test_list_inputs(self):
@@ -282,12 +282,12 @@ class ImplicitCompTestCase(unittest.TestCase):
         stream = StringIO()
         inputs = self.prob.model.list_inputs(hierarchical=False, desc=True, out_stream=stream)
         self.assertEqual(sorted(inputs), [
-            ('comp1.a', {'val':  [1.], 'value':  [1.], 'desc': ''}),
-            ('comp1.b', {'val': [-4.], 'value':  [-4.], 'desc': ''}),
-            ('comp1.c', {'val':  [3.], 'value':  [3.], 'desc': ''}),
-            ('comp2.a', {'val':  [1.], 'value':  [1.], 'desc': ''}),
-            ('comp2.b', {'val': [-4.], 'value':  [-4.], 'desc': ''}),
-            ('comp2.c', {'val':  [3.], 'value':  [3.], 'desc': ''})
+            ('comp1.a', {'val':  [1.], 'desc': ''}),
+            ('comp1.b', {'val': [-4.], 'desc': ''}),
+            ('comp1.c', {'val':  [3.], 'desc': ''}),
+            ('comp2.a', {'val':  [1.], 'desc': ''}),
+            ('comp2.b', {'val': [-4.], 'desc': ''}),
+            ('comp2.c', {'val':  [3.], 'desc': ''})
         ])
         text = stream.getvalue()
         self.assertEqual(text.count('comp1.'), 3)
@@ -351,16 +351,16 @@ class ImplicitCompTestCase(unittest.TestCase):
         # No tags
         outputs = self.prob.model.list_outputs(explicit=False, hierarchical=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('comp1.x', {'val': [3.], 'value': [3.]}),
-            ('comp2.x', {'val': [3.], 'value': [3.]}),
+            ('comp1.x', {'val': [3.]}),
+            ('comp2.x', {'val': [3.]}),
         ])
 
         # With tag
         outputs = self.prob.model.list_outputs(explicit=False, hierarchical=False, out_stream=None,
                                                tags="tag_x")
         self.assertEqual(sorted(outputs), [
-            ('comp1.x', {'val': [3.], 'value': [3.]}),
-            ('comp2.x', {'val': [3.], 'value': [3.]}),
+            ('comp1.x', {'val': [3.]}),
+            ('comp2.x', {'val': [3.]}),
         ])
 
         # Wrong tag
@@ -374,8 +374,8 @@ class ImplicitCompTestCase(unittest.TestCase):
         stream = StringIO()
         states = self.prob.model.list_outputs(explicit=False, residuals=True,
                                               hierarchical=False, out_stream=stream)
-        self.assertEqual([('comp1.x', {'val': [3.], 'value': [3.], 'resids': [0.]}),
-                          ('comp2.x', {'val': [3.], 'value': [3.], 'resids': [0.]})], sorted(states))
+        self.assertEqual([('comp1.x', {'val': [3.], 'resids': [0.]}),
+                          ('comp2.x', {'val': [3.], 'resids': [0.]})], sorted(states))
         text = stream.getvalue()
         self.assertEqual(1, text.count('comp1.x'))
         self.assertEqual(1, text.count('comp2.x'))
@@ -1340,12 +1340,12 @@ class ListFeatureTestCase(unittest.TestCase):
         # list inputs
         inputs = prob.model.list_inputs(out_stream=None)
         self.assertEqual(sorted(inputs), [
-            ('sub.comp1.a', {'val': [1.], 'value': [1.]}),
-            ('sub.comp1.b', {'val': [-4.], 'value': [-4.]}),
-            ('sub.comp1.c', {'val': [3.], 'value': [3.]}),
-            ('sub.comp2.a', {'val': [1.], 'value': [1.]}),
-            ('sub.comp2.b', {'val': [-4.], 'value': [-4.]}),
-            ('sub.comp2.c', {'val': [3.], 'value': [3.]})
+            ('sub.comp1.a', {'val': [1.]}),
+            ('sub.comp1.b', {'val': [-4.]}),
+            ('sub.comp1.c', {'val': [3.]}),
+            ('sub.comp2.a', {'val': [1.]}),
+            ('sub.comp2.b', {'val': [-4.]}),
+            ('sub.comp2.c', {'val': [3.]})
         ])
 
     def test_for_docs_list_no_values(self):
@@ -1429,16 +1429,16 @@ class ListFeatureTestCase(unittest.TestCase):
         outputs = prob.model.list_outputs(explicit=False, out_stream=None)
         text = stream.getvalue()
         self.assertEqual(sorted(outputs), [
-            ('sub.comp2.x', {'val': [3.], 'value': [3.]}),
-            ('sub.comp3.x', {'val': [3.], 'value': [3.]})
+            ('sub.comp2.x', {'val': [3.]}),
+            ('sub.comp3.x', {'val': [3.]})
         ])
         # list explicit outputs
         stream = StringIO()
         outputs = prob.model.list_outputs(implicit=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('comp1.a', {'val': [1.], 'value': [1.]}),
-            ('comp1.b', {'val': [-4.], 'value': [-4.]}),
-            ('comp1.c', {'val': [3.], 'value': [3.]}),
+            ('comp1.a', {'val': [1.]}),
+            ('comp1.b', {'val': [-4.]}),
+            ('comp1.c', {'val': [3.]}),
         ])
 
     def test_list_residuals_with_tol(self):

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -154,28 +154,28 @@ class TestIndepVarComp(unittest.TestCase):
         # Outputs no tags
         outputs = prob.model.list_outputs(out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('indep_var_1', {'val': [1.], 'value': [1.]}),
-            ('indep_var_2', {'val': [2.], 'value': [2.]}),
+            ('indep_var_1', {'val': [1.]}),
+            ('indep_var_2', {'val': [2.]}),
         ])
 
         # Outputs with tags
         outputs = prob.model.list_outputs(out_stream=None, tags="tag1")
         self.assertEqual(sorted(outputs), [
-            ('indep_var_1', {'val': [1.], 'value': [1.]}),
+            ('indep_var_1', {'val': [1.]}),
         ])
 
         # Outputs with the indep_var tags
         outputs = prob.model.list_outputs(out_stream=None, tags="indep_var")
         self.assertEqual(sorted(outputs), [
-            ('indep_var_1', {'val': [1.], 'value': [1.]}),
-            ('indep_var_2', {'val': [2.], 'value': [2.]}),
+            ('indep_var_1', {'val': [1.]}),
+            ('indep_var_2', {'val': [2.]}),
         ])
 
         # Outputs with multiple tags
         outputs = prob.model.list_outputs(out_stream=None, tags=["tag1", "tag2"])
         self.assertEqual(sorted(outputs), [
-            ('indep_var_1', {'val': [1.], 'value': [1.]}),
-            ('indep_var_2', {'val': [2.], 'value': [2.]}),
+            ('indep_var_1', {'val': [1.]}),
+            ('indep_var_2', {'val': [2.]}),
         ])
 
         # Outputs with tag that does not match

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1716,17 +1716,17 @@ class TestProblem(unittest.TestCase):
 
             inputs = p.model.list_inputs(out_stream=None)
             self.assertEqual(sorted(inputs), [
-                ('comp3.a', {'val': [2.], 'value': [2.]}),
-                ('comp3.b', {'val': [3.], 'value': [3.]})
+                ('comp3.a', {'val': [2.]}),
+                ('comp3.b', {'val': [3.]})
             ], "Inputs don't match when added in %s." % where)
 
             outputs = p.model.list_outputs(out_stream=None)
             self.assertEqual(sorted(outputs), [
-                ('comp1.a',   {'val': [2.], 'value': [2.]}),
-                ('comp1.foo', {'val': [1.], 'value': [1.]}),
-                ('comp2.b',   {'val': [3.], 'value': [3.]}),
-                ('comp2.foo', {'val': [1.], 'value': [1.]}),
-                ('comp3.y',   {'val': [5.], 'value': [5.]})
+                ('comp1.a',   {'val': [2.]}),
+                ('comp1.foo', {'val': [1.]}),
+                ('comp2.b',   {'val': [3.]}),
+                ('comp2.foo', {'val': [1.]}),
+                ('comp3.y',   {'val': [5.]})
             ], "Outputs don't match when added in %s." % where)
 
     def test_configure_add_input_output(self):
@@ -1772,15 +1772,15 @@ class TestProblem(unittest.TestCase):
 
         inputs = p.model.list_inputs(out_stream=None)
         self.assertEqual(sorted(inputs), [
-            ('mcomp.a',     {'val': [2.], 'value': [2.]}),
-            ('sub.mcomp.a', {'val': [2.], 'value': [2.]}),
+            ('mcomp.a',     {'val': [2.]}),
+            ('sub.mcomp.a', {'val': [2.]}),
         ])
 
         outputs = p.model.list_outputs(out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('indep.a',      {'val': [2.], 'value': [2.]}),
-            ('mcomp.a2',     {'val': [4.], 'value': [4.]}),
-            ('sub.mcomp.a2', {'val': [4.], 'value': [4.]}),
+            ('indep.a',      {'val': [2.]}),
+            ('mcomp.a2',     {'val': [4.]}),
+            ('sub.mcomp.a2', {'val': [4.]}),
         ])
 
         # add inputs/outputs in configure
@@ -1790,20 +1790,20 @@ class TestProblem(unittest.TestCase):
 
         inputs = p.model.list_inputs(out_stream=None)
         self.assertEqual(sorted(inputs), [
-            ('mcomp.a',     {'val': [2.], 'value': [2.]}),
-            ('mcomp.b',     {'val': [3.], 'value': [3.]}),
-            ('sub.mcomp.a', {'val': [2.], 'value': [2.]}),
-            ('sub.mcomp.b', {'val': [3.], 'value': [3.]}),
+            ('mcomp.a',     {'val': [2.]}),
+            ('mcomp.b',     {'val': [3.]}),
+            ('sub.mcomp.a', {'val': [2.]}),
+            ('sub.mcomp.b', {'val': [3.]}),
         ])
 
         outputs= p.model.list_outputs(out_stream=None)
         self.assertEqual(sorted(outputs), [
-            ('indep.a',      {'val': [2.], 'value': [2.]}),
-            ('indep.b',      {'val': [3.], 'value': [3.]}),
-            ('mcomp.a2',     {'val': [4.], 'value': [4.]}),
-            ('mcomp.b2',     {'val': [6.], 'value': [6.]}),
-            ('sub.mcomp.a2', {'val': [4.], 'value': [4.]}),
-            ('sub.mcomp.b2', {'val': [6.], 'value': [6.]}),
+            ('indep.a',      {'val': [2.]}),
+            ('indep.b',      {'val': [3.]}),
+            ('mcomp.a2',     {'val': [4.]}),
+            ('mcomp.b2',     {'val': [6.]}),
+            ('sub.mcomp.a2', {'val': [4.]}),
+            ('sub.mcomp.b2', {'val': [6.]}),
         ])
 
     def test_feature_post_setup_solver_configure(self):

--- a/openmdao/core/tests/test_root_comp_list_outputs.py
+++ b/openmdao/core/tests/test_root_comp_list_outputs.py
@@ -21,9 +21,9 @@ class TestRootComponentListOutputs(unittest.TestCase):
         outputs = prob.model.list_outputs(hierarchical=False, out_stream=stream)
 
         self.assertEqual(sorted(outputs), [
-            ('comp1_a', {'val': [1.], 'value': [1.]}),
-            ('comp1_b', {'val': [2.], 'value': [2.]}),
-            ('comp1_c', {'val': [3.], 'value': [3.]})
+            ('comp1_a', {'val': [1.]}),
+            ('comp1_b', {'val': [2.]}),
+            ('comp1_c', {'val': [3.]})
         ])
         text = stream.getvalue()
         self.assertEqual(text.count('comp1_'), 3)

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -287,6 +287,11 @@ class TestSystem(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             self.assertEqual(outputs[0][1]['value'], 2)
 
+        meta = p.model.get_io_metadata(metadata_keys=('val',))
+        with assert_warning(OMDeprecationWarning, msg):
+            self.assertEqual(meta['comp.a']['value'], 1)
+
+
     def test_recording_options_deprecated(self):
         prob = Problem()
         msg = "The recording option, record_model_metadata, on System is deprecated. " \

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -251,6 +251,42 @@ class TestSystem(unittest.TestCase):
         outputs = model.list_outputs(excludes=['circuit*'], implicit=False, out_stream=None)
         self.assertEqual(len(outputs), 2)
 
+    def test_list_inputs_outputs_val_deprecation(self):
+        p = Problem()
+        p.model.add_subsystem('comp', ExecComp('b=2*a'), promotes=['a', 'b'])
+        p.setup()
+        p.run_model()
+
+        msg = "<model> <class Group>: The 'values' argument to 'list_inputs()' " \
+              "is deprecated and will be removed in 4.0. Please use 'val' instead."
+
+        with assert_warning(OMDeprecationWarning, msg):
+            inputs = p.model.list_inputs(values=False, out_stream=None)
+        self.assertEqual(inputs, [('comp.a', {})])
+
+        with assert_warning(OMDeprecationWarning, msg):
+            inputs = p.model.list_inputs(values=True, out_stream=None)
+        self.assertEqual(inputs, [('comp.a', {'val': 1})])
+
+        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'"
+        with assert_warning(OMDeprecationWarning, msg):
+            self.assertEqual(inputs[0][1]['value'], 1)
+
+        msg = "<model> <class Group>: The 'values' argument to 'list_outputs()' " \
+              "is deprecated and will be removed in 4.0. Please use 'val' instead."
+
+        with assert_warning(OMDeprecationWarning, msg):
+            outputs = p.model.list_outputs(values=False, out_stream=None)
+        self.assertEqual(outputs, [('comp.b', {})])
+
+        with assert_warning(OMDeprecationWarning, msg):
+            outputs = p.model.list_outputs(values=True, out_stream=None)
+        self.assertEqual(outputs, [('comp.b', {'val': 2})])
+
+        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'"
+        with assert_warning(OMDeprecationWarning, msg):
+            self.assertEqual(outputs[0][1]['value'], 2)
+
     def test_recording_options_deprecated(self):
         prob = Problem()
         msg = "The recording option, record_model_metadata, on System is deprecated. " \


### PR DESCRIPTION
### Summary

- metadata returned by `get_io_metadata`  will deprecate the `value` key
- fixed the message and warning type for the  deprecated `values` argument to the `list_inputs` and `list_outputs` functions
- removed redundant 'value' key from `list_inputs` & `list_outputs` return values

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
