### PR TITLE
Moved and renamed the openmdao warnings module. Fixed the issue with 

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -98,7 +98,7 @@ from openmdao.utils.notebook_utils import notebook_mode, display_source, show_op
 from openmdao.utils.units import convert_units, unit_conversion
 
 # Warning Options
-from openmdao.warnings import issue_warning, reset_warnings, OpenMDAOWarning, \
+from openmdao.utils.om_warnings import issue_warning, reset_warnings, OpenMDAOWarning, \
     SetupWarning, DistributedComponentWarning, CaseRecorderWarning,\
     DriverWarning, CacheWarning, PromotionWarning, UnusedOptionWarning, DerivativesWarning, \
     MPIWarning, UnitsWarning, SolverWarning, OMDeprecationWarning

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -4,7 +4,7 @@ from collections import defaultdict
 
 import numpy as np
 
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 from openmdao.approximation_schemes.approximation_scheme import ApproximationScheme
 
 

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -4,7 +4,7 @@ from collections import namedtuple, defaultdict
 import numpy as np
 
 from openmdao.approximation_schemes.approximation_scheme import ApproximationScheme
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 
 FDForm = namedtuple('FDForm', ['deltas', 'coeffs', 'current_coeff'])
 

--- a/openmdao/components/demux_comp.py
+++ b/openmdao/components/demux_comp.py
@@ -4,7 +4,7 @@
 import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 
 class DemuxComp(ExplicitComponent):

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -10,7 +10,7 @@ from openmdao.core.constants import INT_DTYPE
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.utils.units import valid_units
 from openmdao.utils import cs_safe
-from openmdao.warnings import issue_warning, DerivativesWarning, warn_deprecation
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation
 
 # regex to check for variable names.
 VAR_RGX = re.compile(r'([.]*[_a-zA-Z]\w*[ ]*\(?)')

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -8,7 +8,7 @@ from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.surrogate_models.surrogate_model import SurrogateModel
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.name_maps import rel_key2abs_key
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 
 
 class MetaModelUnStructuredComp(ExplicitComponent):

--- a/openmdao/components/tests/test_demux_comp.py
+++ b/openmdao/components/tests/test_demux_comp.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_warning
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestDemuxCompOptions(unittest.TestCase):

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -20,7 +20,7 @@ except ImportError:
 import openmdao.api as om
 from openmdao.components.exec_comp import _expr_dict, _temporary_expr_dict
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_warning
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 _ufunc_test_data = {
     'min': {

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -1,7 +1,7 @@
 """
 OpenMDAO custom error: AnalysisError.
 """
-from openmdao.warnings import _warn_simple_format, reset_warning_registry
+from openmdao.utils.om_warnings import _warn_simple_format, reset_warning_registry
 import warnings
 
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -20,7 +20,7 @@ from openmdao.utils.general_utils import format_as_float_or_array, ensure_compat
     find_matches, make_set, _is_slicer_op, convert_src_inds, \
     _slice_indices
 import openmdao.utils.coloring as coloring_mod
-from openmdao.warnings import issue_warning, MPIWarning, DistributedComponentWarning, \
+from openmdao.utils.om_warnings import issue_warning, MPIWarning, DistributedComponentWarning, \
     DerivativesWarning, UnusedOptionWarning, warn_deprecation
 
 _forbidden_chars = ['.', '*', '?', '!', '[', ']']

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -20,7 +20,7 @@ import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.array_utils import sizes2offsets, convert_neg
 from openmdao.vectors.vector import _full_slice
 from openmdao.utils.indexer import indexer
-from openmdao.warnings import issue_warning, DerivativesWarning, warn_deprecation
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation
 
 
 def _check_debug_print_opts_valid(name, opts):

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -10,7 +10,7 @@ from openmdao.utils.class_util import overrides_method
 from openmdao.utils.general_utils import ContainsAll
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.core.constants import INT_DTYPE
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 _inst_functs = ['compute_jacvec_product']
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -32,10 +32,10 @@ from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismat
 from openmdao.utils.mpi import MPI, check_mpi_exceptions, multi_proc_exception_check
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.warnings import issue_warning, UnitsWarning, UnusedOptionWarning, \
+from openmdao.utils.om_warnings import issue_warning, UnitsWarning, UnusedOptionWarning, \
     SetupWarning, PromotionWarning, MPIWarning
 from openmdao.core.constants import _SetupStatus
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 # regex to check for valid names.
 import re

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -5,7 +5,7 @@ import numpy as np
 from openmdao.core.component import Component
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.class_util import overrides_method
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 _inst_functs = ['apply_linear']
 

--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -5,7 +5,7 @@ import numpy as np
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.utils.array_utils import shape_to_len
 from openmdao.utils.general_utils import make_set, ensure_compatible
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 
 class IndepVarComp(ExplicitComponent):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -44,7 +44,7 @@ from openmdao.vectors.default_vector import DefaultVector
 from openmdao.utils.logger_utils import get_logger, TestLogger
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.hooks import _setup_hooks
-from openmdao.warnings import issue_warning, DerivativesWarning, warn_deprecation
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -34,7 +34,7 @@ from openmdao.utils.coloring import _compute_coloring, Coloring, \
     _STD_COLORING_FNAME, _DEF_COMP_SPARSITY_ARGS, _ColSparsityJac
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.indexer import indexer
-from openmdao.warnings import issue_warning, DerivativesWarning, PromotionWarning,\
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, PromotionWarning,\
     UnusedOptionWarning, warn_deprecation
 from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, ContainsAll, all_ancestors, _slice_indices, \

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -9,7 +9,7 @@ from openmdao.test_suite.components.expl_comp_array import TestExplCompArray
 from openmdao.test_suite.components.impl_comp_simple import TestImplCompSimple
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestExplicitComponent(unittest.TestCase):

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -15,7 +15,7 @@ from openmdao.test_suite.components.sellar import StateConnection, \
 from openmdao.utils.assert_utils import assert_near_equal, assert_no_warning
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class ModCompEx(om.ExplicitComponent):

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -9,7 +9,7 @@ from openmdao.test_suite.components.distributed_components import DistribComp, S
 from openmdao.utils.mpi import MPI, multi_proc_exception_check
 from openmdao.utils.array_utils import evenly_distrib_idxs, take_nth
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.warnings import DistributedComponentWarning
+from openmdao.utils.om_warnings import DistributedComponentWarning
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -17,7 +17,7 @@ from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp, NonSquareArrayComp
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 from openmdao.utils.mpi import MPI
 

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -5,7 +5,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.components.sellar_feature import SellarMDA
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 from openmdao.utils.mpi import MPI
 if MPI:

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -18,7 +18,7 @@ from openmdao.utils.mpi import MPI, multi_proc_exception_check
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.utils.general_utils import ignore_errors_context
-from openmdao.warnings import reset_warning_registry
+from openmdao.utils.om_warnings import reset_warning_registry
 from openmdao.utils.name_maps import name2abs_names
 
 try:

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestIndepVarComp(unittest.TestCase):

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -14,7 +14,7 @@ from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDeriv
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
-from openmdao.warnings import DerivativesWarning
+from openmdao.utils.om_warnings import DerivativesWarning
 
 try:
     from parameterized import parameterized

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestSystem(unittest.TestCase):

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -16,7 +16,7 @@ from openmdao.utils.general_utils import ContainsAll, _prom2ivc_src_dict
 
 from openmdao.utils.mpi import MPI, check_mpi_env, multi_proc_exception_check
 from openmdao.utils.coloring import _initialize_model_approx, Coloring
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 from openmdao.vectors.vector import _full_slice
 
 

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -18,7 +18,7 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.name_maps import abs_key2rel_key, rel_key2abs_key
 from openmdao.utils.general_utils import simple_warning
 from openmdao.core.constants import _SetupStatus
-from openmdao.warnings import issue_warning, MPIWarning
+from openmdao.utils.om_warnings import issue_warning, MPIWarning
 
 # an object used to detect when a named value isn't found
 _notfound = object()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -27,7 +27,7 @@ from openmdao.core.driver import Driver, RecordingDebugging
 import openmdao.utils.coloring as c_mod
 from openmdao.utils.class_util import weak_method_wrapper
 from openmdao.utils.mpi import FakeComm
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 
 
 # names of optimizers that use gradients

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -15,7 +15,7 @@ import openmdao.utils.coloring as coloring_mod
 from openmdao.core.driver import Driver, RecordingDebugging
 from openmdao.utils.class_util import weak_method_wrapper
 from openmdao.utils.mpi import MPI
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 
 # Optimizers in scipy.minimize
 _optimizers = {'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -16,7 +16,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.mpi import MPI
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 # check that pyoptsparse is installed
 # if it is, try to use SNOPT but fall back to SLSQP

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -17,7 +17,7 @@ from openmdao.utils.hooks import _register_hook
 from openmdao.utils.general_utils import printoptions, ignore_errors
 from openmdao.utils.units import _has_val_mismatch
 from openmdao.utils.file_utils import _load_and_exec
-from openmdao.warnings import issue_warning, SetupWarning
+from openmdao.utils.om_warnings import issue_warning, SetupWarning
 
 
 _UNSET = object()

--- a/openmdao/recorders/base_case_reader.py
+++ b/openmdao/recorders/base_case_reader.py
@@ -2,7 +2,7 @@
 Base class for all CaseReaders.
 """
 
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.core.constants import _DEFAULT_OUT_STREAM
 
 

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -16,7 +16,7 @@ from openmdao.utils.variable_table import write_var_table
 from openmdao.utils.general_utils import make_set, match_prom_or_abs
 from openmdao.utils.units import unit_conversion, simplify_unit
 from openmdao.recorders.sqlite_recorder import format_version as current_version
-from openmdao.warnings import issue_warning
+from openmdao.utils.om_warnings import issue_warning
 
 _AMBIGOUS_PROM_NAME = object()
 

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -4,7 +4,7 @@ RecordingManager class definition.
 import time
 
 from openmdao.utils.general_utils import simple_warning
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 try:
     from openmdao.utils.mpi import MPI

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -12,7 +12,7 @@ from openmdao.recorders.case import Case
 from openmdao.core.constants import _DEFAULT_OUT_STREAM
 from openmdao.utils.variable_table import write_source_table
 from openmdao.utils.record_util import check_valid_sqlite3_db, get_source_system
-from openmdao.warnings import issue_warning, CaseRecorderWarning
+from openmdao.utils.om_warnings import issue_warning, CaseRecorderWarning
 
 from openmdao.recorders.sqlite_recorder import format_version, META_KEY_SEP
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -27,7 +27,7 @@ from openmdao.core.driver import Driver
 from openmdao.core.system import System
 from openmdao.core.problem import Problem
 from openmdao.solvers.solver import Solver
-from openmdao.warnings import issue_warning, CaseRecorderWarning
+from openmdao.utils.om_warnings import issue_warning, CaseRecorderWarning
 
 
 """

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -34,7 +34,7 @@ from openmdao.utils.general_utils import set_pyoptsparse_opt, determine_adder_sc
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.units import convert_units
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 # check that pyoptsparse is installed
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -28,7 +28,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, 
     assert_warning, assert_no_warning
 from openmdao.utils.general_utils import determine_adder_scaler
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 # check that pyoptsparse is installed. if it is, try to use SLSQP.
 from openmdao.utils.general_utils import set_pyoptsparse_opt

--- a/openmdao/solvers/linesearch/backtracking.py
+++ b/openmdao/solvers/linesearch/backtracking.py
@@ -11,7 +11,7 @@ import numpy as np
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.solvers.solver import NonlinearSolver
 from openmdao.recorders.recording_iteration_stack import Recording
-from openmdao.warnings import issue_warning, SolverWarning
+from openmdao.utils.om_warnings import issue_warning, SolverWarning
 
 
 def _print_violations(outputs, lower, upper):

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -9,7 +9,7 @@ from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.solvers.linesearch.backtracking import BoundsEnforceLS
 from openmdao.solvers.solver import NonlinearSolver
 from openmdao.utils.class_util import overrides_method
-from openmdao.warnings import issue_warning, SetupWarning
+from openmdao.utils.om_warnings import issue_warning, SetupWarning
 from openmdao.utils.mpi import MPI
 
 

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -15,7 +15,7 @@ from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import create_local_meta, check_path
-from openmdao.warnings import issue_warning, SolverWarning
+from openmdao.utils.om_warnings import issue_warning, SolverWarning
 from openmdao.core.component import Component
 
 _emptyset = set()

--- a/openmdao/surrogate_models/kriging.py
+++ b/openmdao/surrogate_models/kriging.py
@@ -6,7 +6,7 @@ from hashlib import md5
 from scipy.optimize import minimize
 
 from openmdao.surrogate_models.surrogate_model import SurrogateModel
-from openmdao.warnings import issue_warning, CacheWarning
+from openmdao.utils.om_warnings import issue_warning, CacheWarning
 
 MACHINE_EPSILON = np.finfo(np.double).eps
 

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -14,7 +14,7 @@ from openmdao.core.component import Component
 from openmdao.core.group import Group
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.general_utils import pad_name
-from openmdao.warnings import warn_deprecation, reset_warning_registry
+from openmdao.utils.om_warnings import warn_deprecation, reset_warning_registry
 
 
 @contextmanager

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -27,7 +27,7 @@ from openmdao.utils.general_utils import _prom2ivc_src_dict, \
 import openmdao.utils.hooks as hooks
 from openmdao.utils.mpi import MPI
 from openmdao.utils.file_utils import _load_and_exec
-from openmdao.warnings import issue_warning, DerivativesWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 from openmdao.devtools.memory import mem_usage
 
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -20,7 +20,7 @@ import numbers
 import numpy as np
 
 from openmdao.core.constants import INT_DTYPE, INF_BOUND
-from openmdao.warnings import issue_warning, _warn_simple_format, warn_deprecation
+from openmdao.utils.om_warnings import issue_warning, _warn_simple_format, warn_deprecation
 
 # Certain command line tools can make use of this to allow visualization of models when errors
 # are present that would normally cause setup to abort.

--- a/openmdao/utils/mpi.py
+++ b/openmdao/utils/mpi.py
@@ -9,7 +9,7 @@ import unittest
 import functools
 
 from openmdao.core.analysis_error import AnalysisError
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.utils.notebook_utils import notebook
 
 

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -49,7 +49,7 @@ from openmdao.utils.entry_points import _list_installed_setup_parser, _list_inst
         _find_plugins_setup_parser, _find_plugins_exec
 from openmdao.core.component import Component
 from openmdao.utils.general_utils import ignore_errors
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 
 def _n2_setup_parser(parser):

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -1,6 +1,6 @@
 """Define the OptionsDictionary class."""
 
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.core.constants import _UNDEFINED
 
 

--- a/openmdao/utils/tests/test_om_warnings.py
+++ b/openmdao/utils/tests/test_om_warnings.py
@@ -1,0 +1,28 @@
+import unittest
+import warnings
+import io
+from contextlib import redirect_stdout, redirect_stderr
+
+from openmdao.utils.om_warnings import reset_warnings, OMDeprecationWarning
+
+
+class TestOMWarnings(unittest.TestCase):
+    def test_warnings_filters(self):
+        # OMDeprecationWarning should only generate one warning because it has the 'once'
+        #   filter
+
+        # first call should generate a warning
+        f = io.StringIO()
+        with redirect_stderr(f):
+            warnings.warn('msg', OMDeprecationWarning)
+        err = f.getvalue()
+        self.assertTrue(len(err) > 0 )
+
+        f.truncate(0)
+        f.seek(0)
+
+        # second call should not generate a warning
+        with redirect_stderr(f):
+            warnings.warn('msg', OMDeprecationWarning)
+        err = f.getvalue()
+        self.assertEqual(len(err), 0 )

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -3,7 +3,7 @@ from openmdao.api import OptionsDictionary
 import unittest
 
 from openmdao.utils.assert_utils import assert_warning, assert_no_warning
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -8,7 +8,7 @@ import openmdao.api as om
 from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, \
     add_unit, add_offset_unit, unit_conversion, get_conversion, simplify_unit
 from openmdao.utils.assert_utils import assert_warning, assert_near_equal
-from openmdao.warnings import OMDeprecationWarning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestNumberDict(unittest.TestCase):

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -16,7 +16,7 @@ import os.path
 from collections import OrderedDict
 
 from configparser import RawConfigParser as ConfigParser
-from openmdao.warnings import warn_deprecation
+from openmdao.utils.om_warnings import warn_deprecation
 
 # pylint: disable=E0611, F0401
 from math import floor, pi

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -20,7 +20,7 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.webview import webview
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.notebook_utils import notebook, colab
-from openmdao.warnings import issue_warning
+from openmdao.utils.om_warnings import issue_warning
 
 
 def _val2str(val):

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -26,7 +26,7 @@ from openmdao.utils.general_utils import default_noraise
 from openmdao.utils.mpi import MPI
 from openmdao.utils.notebook_utils import notebook, display, HTML, IFrame, colab
 from openmdao.visualization.html_utils import read_files, write_script, DiagramWriter
-from openmdao.warnings import issue_warning, warn_deprecation
+from openmdao.utils.om_warnings import issue_warning, warn_deprecation
 from openmdao.core.constants import _UNDEFINED
 from openmdao import __version__ as openmdao_version
 


### PR DESCRIPTION
### Summary

The OpenMDAO warnings module was at the top level of the openmdao directory and so it wasn't included in any testing and linting. The name was a little confusing too since there is also the Python warnings module. The module was moved into the utils directory and renamed `om_warnings`. 

There was also an issue with the way the OpenMDAO custom warnings were in  Python's warnings.filter list. Because of the way some OpenMDAO warnings inherit from others, the filter set in some warnings wasn't actually working. So added some sorting code based on the inheritance hierarchy to put things in the correct order. Added a test for that

### Related Issues

- Resolves #2161 

### Backwards incompatibilities

None

### New Dependencies

None
