### PR TITLE
Added explicit import of the om namespace to the getting_started and basic_user_guide docs

### DIFF
--- a/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/derivs_of_coupled_systems.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/derivs_of_coupled_systems.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_explicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_explicit.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ActuatorDisc(om.ExplicitComponent):\n",
     "    \"\"\"Simple wind turbine model based on actuator disc theory\"\"\"\n",
     "\n",
@@ -198,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_implicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_implicit.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class QuadraticComp(om.ImplicitComponent):\n",
     "    \"\"\"\n",
     "    A Simple Implicit Component representing a Quadratic Equation.\n",
@@ -130,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/advanced_user_guide/example/euler_integration_example.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/example/euler_integration_example.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -63,6 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "class FlightPathEOM2D(om.ExplicitComponent):\n",
@@ -533,7 +533,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/implicit_with_balancecomp.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/implicit_with_balancecomp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -62,6 +61,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Circuit\n",
     "\n",
     "p = om.Problem()\n",
@@ -197,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -59,6 +58,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class Resistor(om.ExplicitComponent):\n",
     "    \"\"\"Computes current across a resistor using Ohm's law.\"\"\"\n",
     "\n",
@@ -468,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/advanced_user_guide/recording/advanced_case_recording.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/recording/advanced_case_recording.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -36,6 +35,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "from openmdao.test_suite.components.sellar_feature import SellarMDAWithUnits\n",
     "\n",
@@ -417,7 +417,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/basic_user_guide.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/basic_user_guide.ipynb
@@ -48,7 +48,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/check_setup.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/check_setup.ipynb
@@ -55,6 +55,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
@@ -170,7 +171,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/check_setup.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/check_setup.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
@@ -40,6 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
@@ -166,7 +167,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
@@ -61,6 +61,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
     "\n",
@@ -382,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
@@ -80,6 +80,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarDis1(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    Component containing Discipline 1 -- no derivatives version.\n",
@@ -303,7 +306,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
@@ -43,6 +43,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarMDA(om.Group):\n",
     "    \"\"\"\n",
     "    Group containing the Sellar MDA.\n",
@@ -177,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/reading_recording/basic_recording_example.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/reading_recording/basic_recording_example.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/reading_recording/basic_recording_example.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/reading_recording/basic_recording_example.ipynb
@@ -60,6 +60,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar_feature import SellarMDAWithUnits\n",
     "import numpy as np\n",
     "\n",
@@ -182,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/component_types.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/component_types.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
@@ -50,6 +50,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class Paraboloid(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.\n",
@@ -244,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_optimization.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_optimization.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_optimization.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_optimization.ipynb
@@ -50,6 +50,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# We'll use the component that was defined in the last tutorial\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
@@ -179,7 +181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/examples/beam_optimization_example.ipynb
+++ b/openmdao/docs/openmdao_book/examples/beam_optimization_example.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/examples/beam_optimization_example_part_2.ipynb
+++ b/openmdao/docs/openmdao_book/examples/beam_optimization_example_part_2.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -64,6 +63,7 @@
     "for each loadcase.\n",
     "\"\"\"\n",
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.test_examples.beam_optimization.components.local_stiffness_matrix_comp import LocalStiffnessMatrixComp\n",
     "from openmdao.test_suite.test_examples.beam_optimization.components.moment_comp import MomentOfInertiaComp\n",
@@ -294,7 +294,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/examples/betz_limit.ipynb
+++ b/openmdao/docs/openmdao_book/examples/betz_limit.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -58,6 +57,8 @@
    "outputs": [],
    "source": [
     "import scipy\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class ActuatorDisc(om.ExplicitComponent):\n",
     "    \"\"\"Simple wind turbine model based on actuator disc theory\"\"\"\n",
@@ -262,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/examples/circuit_analysis_examples.ipynb
+++ b/openmdao/docs/openmdao_book/examples/circuit_analysis_examples.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/examples/hohmann_transfer/hohmann_transfer.ipynb
+++ b/openmdao/docs/openmdao_book/examples/hohmann_transfer/hohmann_transfer.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -283,6 +282,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class VCircComp(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    Computes the circular orbit velocity given a radius and gravitational\n",
@@ -603,7 +605,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
+++ b/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/examples/paraboloid.ipynb
+++ b/openmdao/docs/openmdao_book/examples/paraboloid.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -85,6 +84,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
     "\n",
@@ -325,7 +326,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/examples/simul_deriv_example.ipynb
+++ b/openmdao/docs/openmdao_book/examples/simul_deriv_example.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -25,7 +24,6 @@
    "metadata": {},
    "source": [
     "# Simple Optimization using Simultaneous Derivatives\n",
-    "",
     "\n",
     "Consider a set of points in 2-d space that are to be arranged along a circle such that the radius\n",
     "of the circle is maximized, subject to constraints.  We start out with the points randomly\n",
@@ -39,6 +37,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "SIZE = 10\n",
@@ -171,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/examples/tldr_paraboloid.ipynb
+++ b/openmdao/docs/openmdao_book/examples/tldr_paraboloid.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -33,6 +32,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
     "\n",
@@ -100,7 +101,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/add_subtract_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/add_subtract_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -64,6 +63,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "n = 3\n",
@@ -130,7 +130,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/balance_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/balance_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -40,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.balance_comp.BalanceComp\")"
    ]
   },
@@ -144,6 +144,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "bal = om.BalanceComp()\n",
@@ -420,7 +422,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/cross_product_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/cross_product_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -55,6 +54,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.cross_product_comp.CrossProductComp\")"
    ]
   },
@@ -104,6 +104,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "n = 24\n",
@@ -262,7 +263,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/dot_product_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/dot_product_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.dot_product_comp.DotProductComp\")"
    ]
   },
@@ -98,6 +98,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "n = 24\n",
@@ -257,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/eq_constraint_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/eq_constraint_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -104,6 +103,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarIDF(om.Group):\n",
     "    \"\"\"\n",
     "    Individual Design Feasible (IDF) architecture for the Sellar problem.\n",
@@ -241,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/exec_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/exec_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -44,6 +43,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.exec_comp.ExecComp\")"
    ]
   },
@@ -129,6 +129,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "model = prob.model\n",
     "\n",
@@ -612,7 +614,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -52,6 +51,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.external_code_comp.ExternalCodeComp\")"
    ]
   },
@@ -635,7 +635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_implicit_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_implicit_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -40,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.external_code_comp.ExternalCodeImplicitComp\")"
    ]
   },
@@ -176,6 +176,8 @@
    "outputs": [],
    "source": [
     "import sys\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class MachExternalCodeComp(om.ExternalCodeImplicitComp):\n",
     "\n",
@@ -316,7 +318,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/ks_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/ks_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -48,6 +47,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.ks_comp.KSComp\")"
    ]
   },
@@ -78,6 +78,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "prob = om.Problem()\n",
     "model = prob.model\n",
@@ -412,7 +413,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/linearsystem_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/linearsystem_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -24,12 +23,10 @@
    "metadata": {},
    "source": [
     "# LinearSystemComp\n",
-    "",
     "\n",
     "The LinearSystemComp solves the linear system Ax = b where A and b are inputs, and x is the output.\n",
     "\n",
-    "## LinearSystemComp Options\n",
-    ""
+    "## LinearSystemComp Options\n"
    ]
   },
   {
@@ -42,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.linear_system_comp.LinearSystemComp\")"
    ]
   },
@@ -50,7 +48,6 @@
    "metadata": {},
    "source": [
     "## LinearSystemComp Constructor\n",
-    "",
     "\n",
     "The call signature for the `LinearSystemComp` constructor is:\n",
     "\n",
@@ -59,8 +56,7 @@
     "        :noindex:\n",
     "```\n",
     "\n",
-    "## LinearSystemComp Example\n",
-    ""
+    "## LinearSystemComp Example\n"
    ]
   },
   {
@@ -70,6 +66,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "model = om.Group()\n",
     "\n",
@@ -229,7 +226,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/matrix_vector_product_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/matrix_vector_product_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.matrix_vector_product_comp.MatrixVectorProductComp\")"
    ]
   },
@@ -91,6 +91,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "nn = 2\n",
     "\n",
@@ -263,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelstructured_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -104,6 +103,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.meta_model_structured_comp.MetaModelStructuredComp\")"
    ]
   },
@@ -133,6 +133,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "# Create regular grid interpolator instance\n",
     "xor_interp = om.MetaModelStructuredComp(method='scipy_slinear')\n",
@@ -481,7 +482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelunstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelunstructured_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -53,6 +52,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.meta_model_unstructured_comp.MetaModelUnStructuredComp\")"
    ]
   },
@@ -98,6 +98,7 @@
    "source": [
     "# create a MetaModelUnStructuredComp, specifying surrogates for the outputs\n",
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "trig = om.MetaModelUnStructuredComp()\n",
     "\n",
@@ -397,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/multifi_metamodelunstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/multifi_metamodelunstructured_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -50,6 +49,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.multifi_meta_model_unstructured_comp.MultiFiMetaModelUnStructuredComp\")"
    ]
   },
@@ -84,6 +84,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "mm = om.MultiFiMetaModelUnStructuredComp(nfi=2)\n",
     "mm.add_input('x', np.zeros((1, 2)))\n",
@@ -206,7 +207,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/mux_demux_comps.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/mux_demux_comps.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -92,6 +91,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "# The number of elements to be demuxed\n",
     "n = 3\n",
@@ -296,7 +296,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/spline_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/spline_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -87,6 +86,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.spline_comp.SplineComp\")"
    ]
   },
@@ -126,6 +126,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",
@@ -554,7 +555,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/vector_magnitude_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/vector_magnitude_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.vector_magnitude_comp.VectorMagnitudeComp\")"
    ]
   },
@@ -95,6 +95,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "n = 100\n",
     "\n",
@@ -246,7 +247,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/differential_evolution.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/differential_evolution.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -60,6 +59,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.drivers.doe_driver.DOEDriver\")"
    ]
   },
@@ -760,7 +760,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/pyoptsparse_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/pyoptsparse_driver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/scipy_optimize_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/scipy_optimize_driver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/armijo_goldstein.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/armijo_goldstein.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays\n",
     "\n",
@@ -407,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/bounds_enforce.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/bounds_enforce.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/broyden.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/broyden.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -43,6 +42,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.nonlinear.broyden.BroydenSolver\")"
    ]
   },
@@ -79,6 +79,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Circuit\n",
     "\n",
     "p = om.Problem()\n",
@@ -427,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/direct_solver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -128,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_gs.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_gs.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -47,6 +46,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
@@ -384,7 +384,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_jac.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_jac.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
@@ -372,7 +372,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_runonce.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_runonce.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -46,6 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",
@@ -139,7 +139,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_user_defined.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_user_defined.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -61,6 +60,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.utils.array_utils import evenly_distrib_idxs\n",
     "\n",
@@ -243,7 +243,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/newton.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/newton.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -39,6 +38,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
@@ -741,7 +741,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_gs.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_gs.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -409,7 +410,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_jac.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_jac.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -48,6 +47,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
@@ -341,7 +341,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_runonce.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_runonce.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -45,6 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",
@@ -138,7 +138,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_krylov.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_krylov.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -44,7 +43,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np \n",
+    "import numpy as np\n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -598,7 +598,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -42,7 +41,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np \n",
+    "import numpy as np\n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -391,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/surrogates/kriging.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/surrogates/kriging.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/surrogates/nearestneighbor.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/surrogates/nearestneighbor.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/surrogates/responsesurface.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/surrogates/responsesurface.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
@@ -25,10 +25,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_design_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_design_variables.ipynb
@@ -19,10 +19,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_objective.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_objective.ipynb
@@ -19,10 +19,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
@@ -50,6 +50,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -169,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
@@ -37,6 +37,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.solver.Solver\")"
    ]
   },
@@ -56,6 +57,7 @@
    "outputs": [],
    "source": [
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "prob = om.Problem()\n",
@@ -471,7 +473,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_driver.ipynb
@@ -40,6 +40,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem(model=SellarDerivatives())\n",
@@ -136,7 +137,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_driver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_model.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_model.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_model.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_model.ipynb
@@ -40,6 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",
@@ -182,7 +183,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
@@ -46,6 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem(model=SellarDerivatives())\n",
@@ -1001,7 +1002,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/setup.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/setup.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/continuous_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/continuous_variables.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/continuous_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/continuous_variables.ipynb
@@ -36,6 +36,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class TestExplCompSimple(om.ExplicitComponent):\n",
     "\n",
     "    def setup(self):\n",
@@ -717,7 +720,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/discrete_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/discrete_variables.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/discrete_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/discrete_variables.ipynb
@@ -94,6 +94,7 @@
     "import numpy as np\n",
     "import openmdao.api as om\n",
     "\n",
+    "\n",
     "class BladeSolidity(om.ExplicitComponent):\n",
     "    def setup(self):\n",
     "\n",
@@ -250,7 +251,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
@@ -59,6 +59,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.component.Component\")"
    ]
   },
@@ -482,7 +483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
@@ -39,6 +39,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class RectangleComp(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    A simple Explicit Component that computes the area of a rectangle.\n",
@@ -183,7 +186,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
@@ -40,6 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class QuadraticComp(om.ImplicitComponent):\n",
     "    \"\"\"\n",
     "    A Simple Implicit Component representing a Quadratic Equation.\n",
@@ -341,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/indepvarcomp.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/indepvarcomp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/options.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/scaling.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/scaling.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/scaling.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/scaling.ipynb
@@ -90,6 +90,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ScalingExample1(om.ImplicitComponent):\n",
     "\n",
     "    def setup(self):\n",
@@ -364,7 +367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/units.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/units.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/units.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/units.ipynb
@@ -66,6 +66,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SpeedComp(om.ExplicitComponent):\n",
     "    \"\"\"Simple speed computation from distance and time with unit conversations.\"\"\"\n",
     "\n",
@@ -172,7 +175,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approx_flags.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approx_flags.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/assembled_jacobian.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/assembled_jacobian.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/basic_check_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/basic_check_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_subset.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_subset.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_total_derivatives.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_total_derivatives.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/compute_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/compute_totals.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "531459b3",
    "metadata": {
     "tags": [
      "remove-input",
@@ -21,7 +20,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4b54c4f0",
    "metadata": {},
    "source": [
     "# Computing Total Derivatives\n",
@@ -33,7 +31,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea53d488",
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
@@ -44,7 +41,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36ceafe4",
    "metadata": {},
    "source": [
     "## Usage\n",
@@ -55,10 +51,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d8b2a83",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",
@@ -80,7 +76,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39d1274e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,7 +85,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90ff1b64",
    "metadata": {
     "tags": [
      "remove-input",
@@ -109,7 +103,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2182c3c1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -120,7 +113,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a46764b3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +122,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6c08ff3",
    "metadata": {
     "tags": [
      "remove-input",
@@ -148,7 +139,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51eae12e",
    "metadata": {},
    "source": [
     "By default, `compute_totals` returns the derivatives unscaled, but you can also request that they be scaled by the driver scale values declared when the des_vars, objectives, or constraints are added:"
@@ -157,7 +147,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7188dd77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +176,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27399688",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +185,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73bf8c00",
    "metadata": {
     "tags": [
      "remove-input",
@@ -230,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/compute_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/compute_totals.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/linear_restart.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/linear_restart.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
@@ -20,10 +20,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "295bae4c",
    "metadata": {
     "tags": [
      "remove-input",
@@ -27,7 +26,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0e49f336",
    "metadata": {},
    "source": [
     "# Parallel Coloring for Multipoint or Fan-Out Problems\n",
@@ -43,7 +41,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da1b3527",
    "metadata": {},
    "source": [
     "## Usage Example\n",
@@ -56,10 +53,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a70b4f0c",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SumComp(om.ExplicitComponent):\n",
     "    def __init__(self, size):\n",
     "        super().__init__()\n",
@@ -81,7 +80,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "605c908c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +114,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db94b22e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +146,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a7dbbfb0",
    "metadata": {},
    "source": [
     "### Run script"
@@ -158,7 +154,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ca3e153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +182,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76ac364e",
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -225,7 +219,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_fd.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_fd.ipynb
@@ -20,10 +20,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/partial_derivative_viz.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/partial_derivative_viz.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/picking_mode.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/picking_mode.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/simul_derivs.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/simul_derivs.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/sparse_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/sparse_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/specifying_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/specifying_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/total_compute_jacvec_product.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/total_compute_jacvec_product.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2199e974",
    "metadata": {
     "tags": [
      "remove-input",
@@ -21,7 +20,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0eae820",
    "metadata": {},
    "source": [
     "# Matrix Free Total Derivatives\n",
@@ -31,7 +29,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4213239",
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
@@ -42,7 +39,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "223dfcbc",
    "metadata": {},
    "source": [
     "Below is an example of a component that embeds a sub-problem and uses `compute_jacvec_product` on that sub-problem to compute its Jacobian. The `SubProbComp` component computes derivatives in both ‘fwd’ and ‘rev’ directions, but in a realistic scenario, it would only compute them in a single direction.\n",
@@ -52,7 +48,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e2508bb1",
    "metadata": {},
    "source": [
     "![Model using 3 ExecComps](cjvp_xdsm.png)"
@@ -60,7 +55,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aad7aeb9",
    "metadata": {},
    "source": [
     "Instead of using 3 identical `ExecComps` as shown above and having OpenMDAO automatically compute the total derivatives for us, `SubProbComp` will use just a single `ExecComp` and will compute its derivatives internally. The model contained in the sub-problem looks like this:"
@@ -68,7 +62,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4b1daee",
    "metadata": {},
    "source": [
     "![Model using 3 ExecComps](cjvp_small_xdsm.png)"
@@ -76,7 +69,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a140fea",
    "metadata": {},
    "source": [
     "The code for `SubProbComp` is shown below:"
@@ -85,10 +77,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "568633f2",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SubProbComp(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    This component contains a sub-Problem with a component that will be solved over num_nodes\n",
@@ -209,7 +203,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "563199d9",
    "metadata": {
     "tags": [
      "remove-input",
@@ -281,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/total_compute_jacvec_product.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/total_compute_jacvec_product.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/unit_testing_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/unit_testing_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/add_subsystem.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/add_subsystem.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/add_subsystem.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/add_subsystem.ipynb
@@ -42,6 +42,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "p = om.Problem()\n",
     "p.model.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))\n",
     "\n",
@@ -515,7 +517,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/configure_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/configure_method.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/configure_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/configure_method.ipynb
@@ -49,6 +49,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ImplSimple(om.ImplicitComponent):\n",
     "\n",
     "    def setup(self):\n",
@@ -237,7 +240,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
@@ -50,6 +50,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "p = om.Problem()\n",
     "\n",
@@ -253,7 +254,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/get_subsystem.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/get_subsystem.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/get_subsystem.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/get_subsystem.ipynb
@@ -23,14 +23,12 @@
    "metadata": {},
    "source": [
     "# Accessing Subsystems Within a Group\n",
-    "",
     "\n",
     "To access a `Component` or another `Group` within a `Group`, just access the attribute with the name\n",
     "of the subsystem.\n",
     "\n",
     "\n",
     "Usage\n",
-    "",
     "\n",
     "The class `BranchGroup`, seen here, is used in the example that follows."
    ]
@@ -41,6 +39,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class BranchGroup(om.Group):\n",
     "\n",
     "    def setup(self):\n",
@@ -110,7 +111,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -51,6 +51,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class Discipline(om.Group):\n",
     "\n",
@@ -130,7 +132,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/post_setup_config.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/post_setup_config.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/post_setup_config.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/post_setup_config.ipynb
@@ -48,6 +48,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ImplSimple(om.ImplicitComponent):\n",
     "\n",
     "    def setup(self):\n",
@@ -125,7 +128,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/set_order.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/set_order.ipynb
@@ -23,7 +23,6 @@
    "metadata": {},
    "source": [
     "# Setting the Order of Subsystems in a Group\n",
-    "",
     "\n",
     "By default, subsystems are executed in the same order in which they were added to\n",
     "their parent Group.  In order to change this order, use the `set_order` method.\n",
@@ -45,7 +44,6 @@
     "```\n",
     "\n",
     "## Usage\n",
-    "",
     "\n",
     "Change the execution order of components *C1* and *C3*."
    ]
@@ -56,6 +54,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ReportOrderComp(om.ExplicitComponent):\n",
     "    \"\"\"Adds name to list.\"\"\"\n",
     "\n",
@@ -148,7 +149,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/set_order.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/set_order.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
@@ -52,6 +52,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class MyComp1(om.ExplicitComponent):\n",
     "    \"\"\" multiplies input array by 2. \"\"\"\n",
     "    def setup(self):\n",
@@ -331,7 +334,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/controlling_mpi.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/controlling_mpi.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_drivers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_drivers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_drivers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_drivers.ipynb
@@ -40,6 +40,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.driver.Driver\")"
    ]
   },
@@ -151,7 +152,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
@@ -40,6 +40,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.solver.NonlinearSolver\")"
    ]
   },
@@ -118,7 +119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -51,6 +51,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class QuadraticComp(om.ImplicitComponent):\n",
     "    \"\"\"\n",
     "    A Simple Implicit Component representing a Quadratic Equation.\n",
@@ -914,7 +917,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/newton_solver_not_converging.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/newton_solver_not_converging.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/index.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/index.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/inst_call_tracing.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/inst_call_tracing.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/inst_mem_profile.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/inst_mem_profile.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/inst_profile.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/inst_profile.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/experimental/approx_coloring.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/approx_coloring.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "described-buyer",
    "metadata": {
     "tags": [
      "remove-input",
@@ -21,7 +20,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "sensitive-mining",
    "metadata": {},
    "source": [
     "# Simultaneous Coloring of Approximated Derivatives\n",
@@ -70,11 +68,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dedicated-vatican",
    "metadata": {},
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "\n",
     "class DynamicPartialsComp(om.ExplicitComponent):\n",
@@ -102,7 +100,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "realistic-terrorism",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +176,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "approximate-immigration",
    "metadata": {},
    "source": [
     "Coloring info will be displayed during run_driver.  The number of colors in the partial coloring of arctan_yox should be 2 and the number of colors in the total coloring should be 5."
@@ -188,7 +184,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acquired-state",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +193,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "affiliated-newport",
    "metadata": {
     "tags": [
      "remove-input",
@@ -213,7 +207,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "surprised-helena",
    "metadata": {},
    "source": [
     "Let's see how many calls to compute we need to determine partials for arctan_yox. The partial derivatives are all diagonal, so we should be able to cover them using only 2 colors."
@@ -222,7 +215,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accessible-quick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +226,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "presidential-soldier",
    "metadata": {
     "tags": [
      "remove-input",
@@ -249,7 +240,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "short-petite",
    "metadata": {},
    "source": [
     "## Static Coloring\n",
@@ -280,7 +270,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/experimental/approx_coloring.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/approx_coloring.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/experimental/dyn_shapes.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/dyn_shapes.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/experimental/dyn_shapes.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/dyn_shapes.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "upset-transaction",
    "metadata": {
     "tags": [
      "remove-input",
@@ -21,7 +20,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "allied-means",
    "metadata": {},
    "source": [
     "# Determining Variable Shapes at Runtime\n",
@@ -58,10 +56,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acute-wellington",
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class DynPartialsComp(om.ExplicitComponent):\n",
     "    def setup(self):\n",
     "        self.add_input('x', shape_by_conn=True, copy_shape='y')\n",
@@ -79,7 +79,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "involved-advantage",
    "metadata": {},
    "source": [
     "The following example demonstrates the flow of shape information in the forward direction, where the IndepVarComp has a known size, and the DynPartialsComp and the ExecComp are sized dynamically."
@@ -88,7 +87,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "preliminary-liver",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +109,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5ae0ae9",
    "metadata": {
     "hide_input": true,
     "tags": [
@@ -128,7 +125,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "welcome-white",
    "metadata": {},
    "source": [
     "And the following shows shape information flowing in reverse, from the known shape of `sink.x` to the unknown shape of the output `comp.y`, then to the input `comp.x`, then on to the connected auto-IndepVarComp output."
@@ -137,7 +133,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "modified-allowance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +151,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd15ab26",
    "metadata": {
     "hide_input": true,
     "tags": [
@@ -173,7 +167,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "tight-mining",
    "metadata": {},
    "source": [
     "## Debugging\n",
@@ -202,7 +195,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "instant-state",
    "metadata": {
     "hide_input": true,
     "scrolled": true,
@@ -241,7 +233,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "residential-theme",
    "metadata": {},
    "source": [
     "## Connecting Serial and Distributed Variables\n",
@@ -270,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/model_visualization/meta_model_basics.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/meta_model_basics.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/model_visualization/meta_model_basics.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/meta_model_basics.ipynb
@@ -57,6 +57,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "num_train = 10\n",
     "\n",
@@ -258,7 +259,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/model_visualization/n2_basics/n2_basics.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/n2_basics/n2_basics.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/model_visualization/n2_basics/n2_basics.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/n2_basics/n2_basics.ipynb
@@ -50,6 +50,8 @@
    "outputs": [],
    "source": [
     "from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class Circuit(om.Group):\n",
     "\n",
@@ -233,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/model_visualization/n2_details/n2_details.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/n2_details/n2_details.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/model_visualization/n2_details/n2_details.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/n2_details/n2_details.ipynb
@@ -51,6 +51,8 @@
    "outputs": [],
    "source": [
     "from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class Circuit(om.Group):\n",
     "\n",
@@ -337,7 +339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/model_visualization/view_connections.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/view_connections.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/model_visualization/view_connections.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/view_connections.ipynb
@@ -51,6 +51,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarNoDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -108,7 +109,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/model_visualization/view_scaling_report.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/view_scaling_report.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_reader.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_reader_data.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader_data.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_reader_metadata.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader_metadata.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_recording_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_recording_options.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/driver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/driver_recording.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "collected-czech",
    "metadata": {
     "tags": [
      "remove-input",
@@ -22,7 +21,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alpha-suite",
    "metadata": {
     "tags": [
      "remove-input",
@@ -40,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "noticed-smile",
    "metadata": {},
    "source": [
     "# Driver Recording"
@@ -48,7 +45,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "lined-nursery",
    "metadata": {},
    "source": [
     "A CaseRecorder is commonly attached to the problem’s Driver in order to gain insight into the convergence of the model as the driver finds a solution. By default, a recorder attached to a driver will record the design variables, constraints and objectives.\n",
@@ -59,7 +55,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "senior-gravity",
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -68,12 +63,12 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.driver.Driver\", recording_options=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aboriginal-murray",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -83,7 +78,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "personal-measure",
    "metadata": {},
    "source": [
     "## Driver Recording Example\n",
@@ -98,7 +92,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "historic-bulletin",
    "metadata": {
     "scrolled": false
    },
@@ -138,7 +131,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "choice-dietary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -150,7 +142,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "governmental-cursor",
    "metadata": {
     "tags": [
      "remove-input",
@@ -165,7 +156,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "foster-sociology",
    "metadata": {
     "scrolled": false
    },
@@ -178,7 +168,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "static-butler",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +177,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "rural-overhead",
    "metadata": {
     "tags": [
      "remove-input",
@@ -203,7 +191,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "beautiful-default",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +200,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fewer-messenger",
    "metadata": {
     "tags": [
      "remove-input",
@@ -230,7 +216,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "available-imperial",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +225,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sweet-webster",
    "metadata": {
     "tags": [
      "remove-input",
@@ -257,7 +241,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "oriented-pregnancy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +250,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adult-charge",
    "metadata": {
     "tags": [
      "remove-input",
@@ -282,7 +264,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "naughty-control",
    "metadata": {
     "scrolled": true
    },
@@ -294,7 +275,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "together-johns",
    "metadata": {
     "tags": [
      "remove-input",
@@ -310,7 +290,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "quiet-insulation",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +299,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bizarre-companion",
    "metadata": {
     "tags": [
      "remove-input",
@@ -335,7 +313,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "handled-patrick",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +322,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "gothic-enforcement",
    "metadata": {
     "tags": [
      "remove-input",
@@ -375,7 +351,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/recording/driver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/driver_recording.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4993698a",
    "metadata": {
     "tags": [
      "remove-input",
@@ -21,7 +20,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82406308",
    "metadata": {},
    "source": [
     "# Reloading Case Data into a Model\n",
@@ -42,7 +40,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed7cecdc",
    "metadata": {},
    "source": [
     "## Why would you want to load case?\n",
@@ -58,7 +55,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5f8c50a",
    "metadata": {},
    "source": [
     "## Simple load case example\n",
@@ -69,11 +65,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f7d1bad",
    "metadata": {},
    "outputs": [],
    "source": [
     "from openmdao.test_suite.components.sellar import SellarProblem\n",
+    "import openmdao.api as om\n",
     "\n",
     "prob = SellarProblem()\n",
     "\n",
@@ -101,7 +97,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23d2d905",
    "metadata": {
     "tags": [
      "remove-input",
@@ -123,7 +118,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "095a128d",
    "metadata": {},
    "source": [
     "As was mentioned before, just the variables values in the case get updated in the model. In this example, the case  contains values for the model variables `x`,`z`,`y1`,`y2`,`con1`,`con2`, and `obj`. \n",
@@ -137,7 +131,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd72fb87",
    "metadata": {},
    "source": [
     "Here is a somewhat more realistic use case for `load_case`. In this example, an optimization is run and then the third case is used to load the model and start the optimization again. Notice how in the second optimization run, the optimization requires fewer iterations since it was given an initial guess."
@@ -146,7 +139,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1619972",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +195,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c23d20e",
    "metadata": {
     "tags": [
      "remove-input",
@@ -243,7 +234,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "conceptual-france",
    "metadata": {
     "tags": [
      "remove-input",
@@ -22,7 +21,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "correct-internship",
    "metadata": {
     "tags": [
      "remove-input",
@@ -40,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "synthetic-formula",
    "metadata": {},
    "source": [
     "# Problem Recording\n",
@@ -53,7 +50,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "alien-aquatic",
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -62,12 +58,12 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.problem.Problem\", recording_options=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "clean-works",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -77,7 +73,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "federal-element",
    "metadata": {},
    "source": [
     "## Problem Recording Example"
@@ -86,7 +81,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "useful-apparatus",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +115,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "agreed-monster",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +130,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "proof-helena",
    "metadata": {
     "tags": [
      "remove-input",
@@ -152,7 +144,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adjacent-scheduling",
    "metadata": {
     "scrolled": true
    },
@@ -165,7 +156,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "proprietary-guard",
    "metadata": {
     "tags": [
      "remove-input",
@@ -181,7 +171,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "authentic-tulsa",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +181,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "amended-springer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +190,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "partial-throw",
    "metadata": {
     "tags": [
      "remove-input",
@@ -217,7 +204,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "million-counter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +213,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "metropolitan-syracuse",
    "metadata": {
     "tags": [
      "remove-input",
@@ -244,7 +229,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "medieval-parking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +238,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "angry-tracy",
    "metadata": {
     "tags": [
      "remove-input",
@@ -286,7 +269,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "lightweight-teacher",
    "metadata": {
     "tags": [
      "remove-input",
@@ -22,7 +21,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reasonable-metro",
    "metadata": {
     "tags": [
      "remove-input",
@@ -40,7 +38,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "remarkable-corps",
    "metadata": {},
    "source": [
     "# Solver Recording\n",
@@ -51,7 +48,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "pressed-bones",
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -60,12 +56,12 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.solver.Solver\", recording_options=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "aging-sandwich",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -83,7 +79,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "polished-direction",
    "metadata": {},
    "source": [
     "## Solver Recording Example"
@@ -92,7 +87,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "vital-discrimination",
    "metadata": {
     "scrolled": true
    },
@@ -117,7 +111,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "entertaining-profile",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +122,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bottom-speaking",
    "metadata": {
     "tags": [
      "remove-input",
@@ -144,7 +136,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dynamic-protest",
    "metadata": {
     "scrolled": true
    },
@@ -157,7 +148,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "informal-strength",
    "metadata": {
     "tags": [
      "remove-input",
@@ -187,7 +177,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "clinical-authorization",
    "metadata": {
     "tags": [
      "remove-input",
@@ -22,7 +21,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "hidden-warehouse",
    "metadata": {
     "tags": [
      "remove-input",
@@ -38,7 +36,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bottom-surprise",
    "metadata": {},
    "source": [
     "# System Recording\n",
@@ -49,7 +46,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "foster-yacht",
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -58,12 +54,12 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.system.System\", recording_options=True)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "enclosed-explorer",
    "metadata": {},
    "source": [
     "```{note}\n",
@@ -73,7 +69,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "typical-budget",
    "metadata": {},
    "source": [
     "## System Recording Example"
@@ -82,7 +77,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "least-sculpture",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +101,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stainless-option",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +114,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "harmful-thompson",
    "metadata": {
     "tags": [
      "remove-input",
@@ -136,7 +128,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "stuffed-jimmy",
    "metadata": {
     "scrolled": true
    },
@@ -150,7 +141,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "generous-colleague",
    "metadata": {
     "tags": [
      "remove-input",
@@ -180,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/units.ipynb
+++ b/openmdao/docs/openmdao_book/features/units.ipynb
@@ -3,7 +3,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36a9f2d0",
    "metadata": {
     "tags": [
      "remove-input",
@@ -14,15 +13,13 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a9a6bc23",
    "metadata": {},
    "source": [
     "# Units Definitions\n",
@@ -37,7 +34,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7488c626",
    "metadata": {
     "tags": [
      "remove-input",
@@ -71,7 +67,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/features/warning_control/warnings.ipynb
+++ b/openmdao/docs/openmdao_book/features/warning_control/warnings.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/warning_control/warnings.ipynb
+++ b/openmdao/docs/openmdao_book/features/warning_control/warnings.ipynb
@@ -80,6 +80,8 @@
     "Test nominal UnitsWarning.\n",
     "\"\"\"\n",
     "import warnings\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class AComp(om.ExplicitComponent):\n",
     "\n",
@@ -296,7 +298,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/getting_started/getting_started.ipynb
+++ b/openmdao/docs/openmdao_book/getting_started/getting_started.ipynb
@@ -69,6 +69,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
@@ -183,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other/citing.ipynb
+++ b/openmdao/docs/openmdao_book/other/citing.ipynb
@@ -72,6 +72,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
     "\n",
@@ -164,7 +166,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other/citing.ipynb
+++ b/openmdao/docs/openmdao_book/other/citing.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other/template.ipynb
+++ b/openmdao/docs/openmdao_book/other/template.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -24,7 +23,6 @@
    "metadata": {},
    "source": [
     "# Upgrading from OpenMDAO 2.10 to OpenMDAO 3\n",
-    "",
     "\n",
     "In the OpenMDAO 3.0 release, a few changes were made to the API.  In addition, we removed all\n",
     "deprecation warnings and fully deprecated the old behavior for all API changes that were made\n",
@@ -40,7 +38,6 @@
    "metadata": {},
    "source": [
     "## Building Component Models\n",
-    "",
     "### Declare a Component with distributed variables\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -87,6 +84,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "class DistribComp(om.ExplicitComponent):\n",
     "\n",
     "    def __init__(self, size):\n",
@@ -336,7 +334,6 @@
    "metadata": {},
    "source": [
     "## Component Library\n",
-    "",
     "### Create an interpolating component using Akima spline with uniform grid\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -1265,7 +1262,6 @@
    "metadata": {},
    "source": [
     "## Solvers\n",
-    "",
     "### Declare a NewtonSolver with solve_subsystems set to False\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -1802,7 +1798,6 @@
    "metadata": {},
    "source": [
     "## Drivers\n",
-    "",
     "### Activate dynamic coloring on a Driver\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -1902,7 +1897,6 @@
    "metadata": {},
    "source": [
     "## Working with Derivatives\n",
-    "",
     "### Use a pre-computed coloring on a model\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -1955,7 +1949,6 @@
    "metadata": {},
    "source": [
     "## Case Reading\n",
-    "",
     "### Query the iteration coordinate for a case\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -2074,7 +2067,6 @@
    "metadata": {},
    "source": [
     "## Running a Model\n",
-    "",
     "### Run a Driver\n",
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
@@ -2189,7 +2181,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
@@ -104,6 +104,7 @@
    "outputs": [],
    "source": [
     "# Old way\n",
+    "import openmdao.api as om\n",
     "prob = om.Problem()\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
     "indeps.add_output('x', 3.0)\n",
@@ -242,6 +243,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",
@@ -284,6 +286,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "prob = om.Problem()\n",
     "prob.model.add_subsystem('parab', Paraboloid(),\n",
     "                         promotes_inputs=['x', 'y'])\n",
@@ -364,6 +367,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "prob = om.Problem()\n",
     "\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
@@ -390,6 +394,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",
@@ -488,6 +493,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np \n",
     "\n",
     "class MyComp1(om.ExplicitComponent):\n",
@@ -913,7 +919,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/github_pages.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/github_pages.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/release_process.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/release_process.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/repository_structure.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/repository_structure.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/travis.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/travis.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_build.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_build.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
@@ -147,10 +147,9 @@
     "\n",
     "```\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
     "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om\n",
     "```\n",
     "\n",
     "This cell should be tagged with the following metadata.  The \"remove-input\" and \"remove-output\" tags prevent it from showing up in the documentation, and the \"hide_input\" portion collapses the input cell. To add tags in Jupyter Notebook, navigate to `View` -> `Cell Toolbar` -> `Tags`.\n",
@@ -313,6 +312,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.display_source(\"openmdao.core.tests.test_expl_comp.RectangleComp\")"
    ]
   },
@@ -526,7 +526,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/sphinx_decorators.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/sphinx_decorators.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/writing_plugins.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/writing_plugins.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/file_wrap.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/file_wrap.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -156,6 +155,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Circuit\n",
     "\n",
     "p = om.Problem()\n",
@@ -630,7 +630,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
@@ -64,10 +64,9 @@ class LintJupyterOutputsTestCase(unittest.TestCase):
         Check Jupyter Notebooks for code cell installing openmdao.
         """
         header = ["try:\n",
-                  "    import openmdao.api as om\n",
+                  "    from openmdao.utils.notebook_utils import notebook_mode\n",
                   "except ImportError:\n",
-                  "    !python -m pip install openmdao[notebooks]\n",
-                  "    import openmdao.api as om"]
+                  "    !python -m pip install openmdao[notebooks]"]
 
         mpi_header = ['%pylab inline\n',
                       'from ipyparallel import Client, error\n',

--- a/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/fan_out.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/fan_out.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/separable.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/separable.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/class_structure.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/class_structure.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/implicit_transformation_of_vars.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/implicit_transformation_of_vars.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/iter_count.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/iter_count.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/scaling.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/scaling.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -159,6 +158,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "import numpy as np\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
@@ -279,6 +279,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarMDALinearSolver(om.Group):\n",
     "    \"\"\"\n",
     "    Group containing the Sellar MDA.\n",
@@ -486,7 +489,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/theory_manual/setup_stack.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/setup_stack.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/solver_api.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/solver_api.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/total_derivs_theory.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/total_derivs_theory.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {


### PR DESCRIPTION
### Summary

The getting_started and basic_user_guide docs will now explicitly show the import of the om namespace, which was previously hidden as part of the logic to install it on colab if necessary.

### Related Issues

- Resolves #2163 

### Backwards incompatibilities

None

### New Dependencies

None
