### PR TITLE
Added explicit om namespace import to docs.

### DIFF
--- a/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/derivs_of_coupled_systems.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/derivs_of_coupled_systems.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_explicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_explicit.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ActuatorDisc(om.ExplicitComponent):\n",
     "    \"\"\"Simple wind turbine model based on actuator disc theory\"\"\"\n",
     "\n",

--- a/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_implicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analytic_derivatives/partial_derivs_implicit.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class QuadraticComp(om.ImplicitComponent):\n",
     "    \"\"\"\n",
     "    A Simple Implicit Component representing a Quadratic Equation.\n",

--- a/openmdao/docs/openmdao_book/advanced_user_guide/example/euler_integration_example.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/example/euler_integration_example.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -64,6 +63,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class FlightPathEOM2D(om.ExplicitComponent):\n",
     "    \"\"\"\n",

--- a/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/implicit_with_balancecomp.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/implicit_with_balancecomp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -89,6 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Circuit\n",
     "\n",
     "p = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -59,6 +58,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class Resistor(om.ExplicitComponent):\n",
     "    \"\"\"Computes current across a resistor using Ohm's law.\"\"\"\n",
     "\n",

--- a/openmdao/docs/openmdao_book/advanced_user_guide/recording/advanced_case_recording.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/recording/advanced_case_recording.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -37,6 +36,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar_feature import SellarMDAWithUnits\n",
     "\n",
     "# build the model\n",

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/check_setup.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/check_setup.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -110,6 +109,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
     "\n",

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
@@ -99,7 +99,7 @@
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
     "\n",
     "\n",
-    "class SellarMDAConnect(om.gGroup):\n",
+    "class SellarMDAConnect(om.Group):\n",
     "\n",
     "    def setup(self):\n",
     "        cycle = self.add_subsystem('cycle', om.Group(), promotes_inputs=['x', 'z'])\n",
@@ -220,7 +220,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/command_line/make_n2.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -95,11 +94,12 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
     "\n",
     "\n",
-    "class SellarMDAConnect(om.Group):\n",
+    "class SellarMDAConnect(om.gGroup):\n",
     "\n",
     "    def setup(self):\n",
     "        cycle = self.add_subsystem('cycle', om.Group(), promotes_inputs=['x', 'z'])\n",

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/linking_vars.ipynb
@@ -114,6 +114,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
     "\n",
@@ -435,7 +436,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar.ipynb
@@ -79,6 +79,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarDis1(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    Component containing Discipline 1 -- no derivatives version.\n",
@@ -302,7 +305,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
@@ -42,6 +42,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarMDA(om.Group):\n",
     "    \"\"\"\n",
     "    Group containing the Sellar MDA.\n",

--- a/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/multidisciplinary_optimization/sellar_opt.ipynb
@@ -108,6 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar_feature import SellarMDA\n",
     "\n",
     "prob = om.Problem()\n",
@@ -203,7 +204,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/basic_user_guide/reading_recording/basic_recording_example.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/reading_recording/basic_recording_example.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -89,6 +88,7 @@
    "source": [
     "from openmdao.test_suite.components.sellar_feature import SellarMDAWithUnits\n",
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "# build the model\n",
     "prob = om.Problem(model=SellarMDAWithUnits())\n",

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/component_types.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/component_types.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -50,6 +49,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class Paraboloid(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3.\n",

--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_optimization.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_optimization.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -52,6 +51,8 @@
    "source": [
     "# We'll use the component that was defined in the last tutorial\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
+    "\n",
+    "import openmdao.api as om\n",
     "\n",
     "# build the model\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/examples/beam_optimization_example.ipynb
+++ b/openmdao/docs/openmdao_book/examples/beam_optimization_example.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/examples/beam_optimization_example_part_2.ipynb
+++ b/openmdao/docs/openmdao_book/examples/beam_optimization_example_part_2.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -199,6 +198,7 @@
     "for each loadcase.\n",
     "\"\"\"\n",
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.test_examples.beam_optimization.components.local_stiffness_matrix_comp import LocalStiffnessMatrixComp\n",
     "from openmdao.test_suite.test_examples.beam_optimization.components.moment_comp import MomentOfInertiaComp\n",

--- a/openmdao/docs/openmdao_book/examples/betz_limit.ipynb
+++ b/openmdao/docs/openmdao_book/examples/betz_limit.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -58,6 +57,8 @@
    "outputs": [],
    "source": [
     "import scipy\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class ActuatorDisc(om.ExplicitComponent):\n",
     "    \"\"\"Simple wind turbine model based on actuator disc theory\"\"\"\n",

--- a/openmdao/docs/openmdao_book/examples/circuit_analysis_examples.ipynb
+++ b/openmdao/docs/openmdao_book/examples/circuit_analysis_examples.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -45,6 +44,7 @@
     "import numpy as np\n",
     "\n",
     "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class Resistor(om.ExplicitComponent):\n",
     "    \"\"\"Computes current across a resistor using Ohm's law.\"\"\"\n",

--- a/openmdao/docs/openmdao_book/examples/hohmann_transfer/hohmann_transfer.ipynb
+++ b/openmdao/docs/openmdao_book/examples/hohmann_transfer/hohmann_transfer.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -284,6 +283,8 @@
    "outputs": [],
    "source": [
     "import numpy as np \n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class VCircComp(om.ExplicitComponent):\n",
     "    \"\"\"\n",

--- a/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
+++ b/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/examples/paraboloid.ipynb
+++ b/openmdao/docs/openmdao_book/examples/paraboloid.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -85,6 +84,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
     "\n",

--- a/openmdao/docs/openmdao_book/examples/simul_deriv_example.ipynb
+++ b/openmdao/docs/openmdao_book/examples/simul_deriv_example.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -40,6 +39,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "SIZE = 10\n",
     "\n",

--- a/openmdao/docs/openmdao_book/examples/tldr_paraboloid.ipynb
+++ b/openmdao/docs/openmdao_book/examples/tldr_paraboloid.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -33,6 +32,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/add_subtract_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/add_subtract_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -65,6 +64,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "n = 3\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/balance_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/balance_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -40,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.balance_comp.BalanceComp\")"
    ]
   },
@@ -144,6 +144,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "bal = om.BalanceComp()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/cross_product_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/cross_product_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -55,6 +54,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.cross_product_comp.CrossProductComp\")"
    ]
   },
@@ -105,6 +105,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "n = 24\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/dot_product_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/dot_product_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.dot_product_comp.DotProductComp\")"
    ]
   },
@@ -99,6 +99,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "n = 24\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/eq_constraint_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/eq_constraint_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -104,6 +103,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SellarIDF(om.Group):\n",
     "    \"\"\"\n",
     "    Individual Design Feasible (IDF) architecture for the Sellar problem.\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/exec_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/exec_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -44,6 +43,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.exec_comp.ExecComp\")"
    ]
   },
@@ -129,6 +129,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "model = prob.model\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -52,6 +51,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.external_code_comp.ExternalCodeComp\")"
    ]
   },
@@ -141,6 +141,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ParaboloidExternalCodeComp(om.ExternalCodeComp):\n",
     "    def setup(self):\n",
     "        self.add_input('x', val=0.0)\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_implicit_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/external_code_implicit_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -40,6 +39,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.external_code_comp.ExternalCodeImplicitComp\")"
    ]
   },
@@ -176,6 +176,8 @@
    "outputs": [],
    "source": [
     "import sys\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class MachExternalCodeComp(om.ExternalCodeImplicitComp):\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/ks_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/ks_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -48,6 +47,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.ks_comp.KSComp\")"
    ]
   },
@@ -78,6 +78,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "prob = om.Problem()\n",
     "model = prob.model\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/linearsystem_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/linearsystem_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -42,6 +41,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.linear_system_comp.LinearSystemComp\")"
    ]
   },
@@ -70,6 +70,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "model = om.Group()\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/matrix_vector_product_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/matrix_vector_product_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.matrix_vector_product_comp.MatrixVectorProductComp\")"
    ]
   },
@@ -91,6 +91,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "nn = 2\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelstructured_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -104,6 +103,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.meta_model_structured_comp.MetaModelStructuredComp\")"
    ]
   },
@@ -133,6 +133,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "# Create regular grid interpolator instance\n",
     "xor_interp = om.MetaModelStructuredComp(method='scipy_slinear')\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelunstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelunstructured_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -53,6 +52,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.meta_model_unstructured_comp.MetaModelUnStructuredComp\")"
    ]
   },
@@ -98,6 +98,7 @@
    "source": [
     "# create a MetaModelUnStructuredComp, specifying surrogates for the outputs\n",
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "trig = om.MetaModelUnStructuredComp()\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/multifi_metamodelunstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/multifi_metamodelunstructured_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -50,6 +49,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.multifi_meta_model_unstructured_comp.MultiFiMetaModelUnStructuredComp\")"
    ]
   },
@@ -84,6 +84,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "mm = om.MultiFiMetaModelUnStructuredComp(nfi=2)\n",
     "mm.add_input('x', np.zeros((1, 2)))\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/mux_demux_comps.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/mux_demux_comps.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -92,6 +91,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "# The number of elements to be demuxed\n",
     "n = 3\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/spline_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/spline_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -87,6 +86,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.spline_comp.SplineComp\")"
    ]
   },
@@ -126,6 +126,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/vector_magnitude_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/vector_magnitude_comp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.components.vector_magnitude_comp.VectorMagnitudeComp\")"
    ]
   },
@@ -95,6 +95,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "n = 100\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/differential_evolution.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/differential_evolution.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -60,6 +59,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.drivers.doe_driver.DOEDriver\")"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/pyoptsparse_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/pyoptsparse_driver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/scipy_optimize_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/scipy_optimize_driver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/armijo_goldstein.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/armijo_goldstein.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -68,6 +67,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTwoStatesArrays\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/bounds_enforce.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/bounds_enforce.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/broyden.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/broyden.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -43,6 +42,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.nonlinear.broyden.BroydenSolver\")"
    ]
   },
@@ -106,6 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Circuit\n",
     "\n",
     "p = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/direct_solver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -68,6 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_gs.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_gs.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -101,6 +100,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_jac.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_block_jac.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -95,6 +94,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_runonce.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_runonce.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -73,6 +72,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_user_defined.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/linear_user_defined.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -61,8 +60,10 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.utils.array_utils import evenly_distrib_idxs\n",
+    "\n",
     "\n",
     "class CustomSolveImplicit(om.ImplicitComponent):\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/newton.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/newton.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -93,6 +92,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_gs.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_gs.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -103,6 +102,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_jac.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_jac.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -102,6 +101,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_runonce.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_runonce.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -72,6 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_krylov.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_krylov.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -99,6 +98,7 @@
    "outputs": [],
    "source": [
     "import numpy as np \n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -97,6 +96,7 @@
    "outputs": [],
    "source": [
     "import numpy as np \n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/surrogates/kriging.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/surrogates/kriging.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/surrogates/nearestneighbor.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/surrogates/nearestneighbor.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/surrogates/responsesurface.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/surrogates/responsesurface.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
@@ -25,10 +25,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
@@ -261,6 +261,7 @@
    "outputs": [],
    "source": [
     "%%px\n",
+    "import openmdao.api as om\n",
     "om.display_source(\"openmdao.test_suite.components.paraboloid_distributed.DistParabFeature\")"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_design_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_design_variables.ipynb
@@ -19,10 +19,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_objective.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_objective.ipynb
@@ -19,10 +19,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/set_solvers.ipynb
@@ -77,6 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem()\n",
@@ -223,7 +224,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
@@ -37,6 +37,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.solver.Solver\")"
    ]
   },
@@ -109,6 +110,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "import numpy as np\n",
     "\n",
@@ -579,7 +581,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/controlling_solver_behavior/solver_options.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_driver.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -68,6 +67,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem(model=SellarDerivatives())\n",

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_model.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/run_model.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -68,6 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -74,6 +73,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDerivatives\n",
     "\n",
     "prob = om.Problem(model=SellarDerivatives())\n",

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/setup.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/setup.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/continuous_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/continuous_variables.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -37,6 +36,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class TestExplCompSimple(om.ExplicitComponent):\n",
     "\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/discrete_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/discrete_variables.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -94,6 +93,7 @@
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class BladeSolidity(om.ExplicitComponent):\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -60,6 +59,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.component.Component\")"
    ]
   },
@@ -88,6 +88,7 @@
     "\n",
     "from openmdao.utils.array_utils import evenly_distrib_idxs\n",
     "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class DistribComp(om.ExplicitComponent):\n",
     "    \"\"\"Simple Distributed Component.\"\"\"\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -40,6 +39,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class RectangleComp(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    A simple Explicit Component that computes the area of a rectangle.\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class QuadraticComp(om.ImplicitComponent):\n",
     "    \"\"\"\n",
     "    A Simple Implicit Component representing a Quadratic Equation.\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/indepvarcomp.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/indepvarcomp.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/options.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/scaling.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/scaling.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -91,6 +90,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ScalingExample1(om.ImplicitComponent):\n",
     "\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/units.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/units.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -67,6 +66,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SpeedComp(om.ExplicitComponent):\n",
     "    \"\"\"Simple speed computation from distance and time with unit conversations.\"\"\"\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approx_flags.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approx_flags.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -51,6 +50,7 @@
     "import numpy as np\n",
     "\n",
     "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class MyFDPartialComp(om.ExplicitComponent):\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/assembled_jacobian.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/assembled_jacobian.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/basic_check_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/basic_check_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_subset.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_subset.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_total_derivatives.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_total_derivatives.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/compute_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/compute_totals.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -82,6 +81,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/linear_restart.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/linear_restart.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -57,6 +56,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SumComp(om.ExplicitComponent):\n",
     "    def __init__(self, size):\n",
     "        super().__init__()\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_fd.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_fd.ipynb
@@ -20,10 +20,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -48,6 +47,8 @@
     "%%px\n",
     "\n",
     "import time\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class MatMultComp(om.ExplicitComponent):\n",
     "    def __init__(self, mat, approx_method='exact', sleep_time=0.1, **kwargs):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/partial_derivative_viz.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/partial_derivative_viz.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/picking_mode.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/picking_mode.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/simul_derivs.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/simul_derivs.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/sparse_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/sparse_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/specifying_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/specifying_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/total_compute_jacvec_product.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/total_compute_jacvec_product.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -90,6 +89,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class SubProbComp(om.ExplicitComponent):\n",
     "    \"\"\"\n",
     "    This component contains a sub-Problem with a component that will be solved over num_nodes\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/unit_testing_partials.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/unit_testing_partials.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/add_subsystem.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/add_subsystem.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -43,6 +42,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "p = om.Problem()\n",
     "p.model.add_subsystem('comp1', om.ExecComp('b=2.0*a', a=3.0, b=6.0))\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/configure_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/configure_method.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -50,6 +49,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ImplSimple(om.ImplicitComponent):\n",
     "\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -51,6 +50,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "p = om.Problem()\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/get_subsystem.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/get_subsystem.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -42,6 +41,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class BranchGroup(om.Group):\n",
     "\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -52,6 +51,8 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class Discipline(om.Group):\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/post_setup_config.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/post_setup_config.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -49,6 +48,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ImplSimple(om.ImplicitComponent):\n",
     "\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/set_order.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/set_order.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -57,6 +56,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class ReportOrderComp(om.ExplicitComponent):\n",
     "    \"\"\"Adds name to list.\"\"\"\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -53,6 +52,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class MyComp1(om.ExplicitComponent):\n",
     "    \"\"\" multiplies input array by 2. \"\"\"\n",
     "    def setup(self):\n",

--- a/openmdao/docs/openmdao_book/features/debugging/controlling_mpi.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/controlling_mpi.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_drivers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_drivers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.driver.Driver\")"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -41,6 +40,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.solver.NonlinearSolver\")"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -52,6 +51,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class QuadraticComp(om.ImplicitComponent):\n",
     "    \"\"\"\n",
     "    A Simple Implicit Component representing a Quadratic Equation.\n",

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -1050,7 +1050,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/newton_solver_not_converging.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/newton_solver_not_converging.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/index.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/index.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/inst_call_tracing.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/inst_call_tracing.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/inst_mem_profile.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/inst_mem_profile.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/debugging/profiling/inst_profile.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/profiling/inst_profile.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/experimental/approx_coloring.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/approx_coloring.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -76,6 +75,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "\n",
     "class DynamicPartialsComp(om.ExplicitComponent):\n",
@@ -107,6 +107,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "SIZE = 10\n",
     "\n",
     "p = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/experimental/dyn_shapes.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/dyn_shapes.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -63,6 +62,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class DynPartialsComp(om.ExplicitComponent):\n",
     "    def setup(self):\n",
     "        self.add_input('x', shape_by_conn=True, copy_shape='y')\n",

--- a/openmdao/docs/openmdao_book/features/model_visualization/meta_model_basics.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/meta_model_basics.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -58,6 +57,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "num_train = 10\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/model_visualization/n2_basics/n2_basics.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/n2_basics/n2_basics.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -131,7 +130,9 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node\n",
+    "\n",
     "\n",
     "class Circuit(om.Group):\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/model_visualization/n2_details/n2_details.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/n2_details/n2_details.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -132,7 +131,10 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Resistor, Diode, Node\n",
+    "\n",
     "\n",
     "class Circuit(om.Group):\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/model_visualization/view_connections.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/view_connections.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -79,6 +78,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarNoDerivatives\n",
     "\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/features/model_visualization/view_scaling_report.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/view_scaling_report.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_reader.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_reader_data.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader_data.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_reader_metadata.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader_metadata.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/case_recording_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_recording_options.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/driver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/driver_recording.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -64,6 +63,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.driver.Driver\", recording_options=True)"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -69,6 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarProblem\n",
     "\n",
     "prob = SellarProblem()\n",

--- a/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -59,6 +58,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.problem.Problem\", recording_options=True)"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -57,6 +56,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.solvers.solver.Solver\", recording_options=True)"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -55,6 +54,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.show_options_table(\"openmdao.core.system.System\", recording_options=True)"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/units.ipynb
+++ b/openmdao/docs/openmdao_book/features/units.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/warning_control/warnings.ipynb
+++ b/openmdao/docs/openmdao_book/features/warning_control/warnings.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -81,6 +80,9 @@
     "Test nominal UnitsWarning.\n",
     "\"\"\"\n",
     "import warnings\n",
+    "\n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class AComp(om.ExplicitComponent):\n",
     "\n",

--- a/openmdao/docs/openmdao_book/getting_started/getting_started.ipynb
+++ b/openmdao/docs/openmdao_book/getting_started/getting_started.ipynb
@@ -1,4 +1,4 @@
-{
+ {
  "cells": [
   {
    "cell_type": "markdown",
@@ -69,6 +69,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
@@ -116,6 +117,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "\n",
     "# build the model\n",
     "prob = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/other/citing.ipynb
+++ b/openmdao/docs/openmdao_book/other/citing.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -73,6 +72,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "# build the model\n",
     "prob = om.Problem()\n",
     "\n",

--- a/openmdao/docs/openmdao_book/other/template.ipynb
+++ b/openmdao/docs/openmdao_book/other/template.ipynb
@@ -14,10 +14,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
@@ -53,6 +53,9 @@
     "\n",
     "`````{tabbed} OpenMDAO 3.0\n",
     "````python\n",
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class DistribComp(om.ExplicitComponent):\n",
     "    \"\"\"Simple Distributed Component.\"\"\"\n",
     "\n",
@@ -84,6 +87,9 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class DistribComp(om.ExplicitComponent):\n",
     "\n",
     "    def __init__(self, size):\n",
@@ -102,6 +108,9 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class DistribComp(om.ExplicitComponent):\n",
     "    \"\"\"Simple Distributed Component.\"\"\"\n",
     "\n",
@@ -337,6 +346,8 @@
     "\n",
     "````{tabbed} OpenMDAO 2.x\n",
     "```python\n",
+    "import openmdao.api as om\n",
+    "\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",
     "ncp = len(ycp)\n",
     "n = 11\n",
@@ -2180,7 +2191,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
@@ -19,10 +19,9 @@
     "view.block=True\n",
     "\n",
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -42,6 +41,8 @@
     "````{tabbed} Pre Auto IVC\n",
     "This is what we used to do\n",
     "```python\n",
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
     "indeps.add_output('x', 3.0)\n",
@@ -105,6 +106,8 @@
    "outputs": [],
    "source": [
     "# Old way\n",
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
     "indeps.add_output('x', 3.0)\n",
@@ -140,6 +143,8 @@
    "outputs": [],
    "source": [
     "# New way\n",
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",
@@ -170,6 +175,8 @@
     "\n",
     "````{tabbed} Pre Auto IVC\n",
     "```python\n",
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
     "indeps.add_output('x', 3.0)\n",
@@ -243,6 +250,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
     "\n",
     "prob = om.Problem()\n",
@@ -285,6 +293,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "prob.model.add_subsystem('parab', Paraboloid(),\n",
     "                         promotes_inputs=['x', 'y'])\n",
@@ -365,6 +375,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
@@ -391,6 +403,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",
@@ -490,6 +504,8 @@
    "outputs": [],
    "source": [
     "import numpy as np \n",
+    "import openmdao.api as om\n",
+    "\n",
     "\n",
     "class MyComp1(om.ExplicitComponent):\n",
     "    def setup(self):\n",
@@ -532,6 +548,9 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
     "class MyComp1(om.ExplicitComponent):\n",
     "    def setup(self):\n",
     "        # this input will connect to entries 0, 1, and 2 of its source\n",
@@ -628,6 +647,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.components.unit_conv import TgtCompC, TgtCompF, TgtCompK\n",
     "\n",
     "prob = om.Problem()\n",
@@ -663,6 +683,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "# Input units in degF\n",
@@ -741,6 +763,8 @@
    "source": [
     "%%px\n",
     "\n",
+    "import openmdao.api as om\n",
+    "\n",
     "from openmdao.utils.array_utils import take_nth\n",
     "\n",
     "class DistribNoncontiguousComp(om.ExplicitComponent):\n",
@@ -780,6 +804,8 @@
     "%%px\n",
     "\n",
     "size = 4\n",
+    "\n",
+    "import openmdao.api as om\n",
     "\n",
     "prob = om.Problem()\n",
     "\n",
@@ -856,6 +882,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
     "indeps.add_output('x', 3.0)\n",
@@ -884,6 +912,8 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
+    "\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",

--- a/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
@@ -944,7 +944,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/github_pages.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/github_pages.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/release_process.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/release_process.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/repository_structure.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/repository_structure.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/travis.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/building_a_tool/travis.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_build.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_build.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/doc_style_guide.ipynb
@@ -313,6 +313,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "om.display_source(\"openmdao.core.tests.test_expl_comp.RectangleComp\")"
    ]
   },
@@ -526,7 +527,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/sphinx_decorators.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/sphinx_decorators.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/writing_plugins.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/writing_plugins.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/file_wrap.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/file_wrap.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {
@@ -183,6 +182,7 @@
    },
    "outputs": [],
    "source": [
+    "import openmdao.api as om\n",
     "from openmdao.test_suite.scripts.circuit_analysis import Circuit\n",
     "\n",
     "p = om.Problem()\n",

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
@@ -64,10 +64,9 @@ class LintJupyterOutputsTestCase(unittest.TestCase):
         Check Jupyter Notebooks for code cell installing openmdao.
         """
         header = ["try:\n",
-                  "    import openmdao.api as om\n",
+                  "    from openmdao.utils.notebook_utils import notebook_mode\n",
                   "except ImportError:\n",
-                  "    !python -m pip install openmdao[notebooks]\n",
-                  "    import openmdao.api as om"]
+                  "    !python -m pip install openmdao[notebooks]"]
 
         mpi_header = ['%pylab inline\n',
                       'from ipyparallel import Client, error\n',

--- a/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/fan_out.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/fan_out.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/separable.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/advanced_linear_solvers_special_cases/separable.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/class_structure.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/class_structure.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/implicit_transformation_of_vars.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/implicit_transformation_of_vars.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/iter_count.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/iter_count.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/scaling.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/scaling.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
@@ -150,26 +150,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "ename": "ImportError",
-     "evalue": "cannot import name 'get_code' from 'openmdao.utils.notebook_utils' (/Users/rfalck/Codes/OpenMDAO.git/openmdao/utils/notebook_utils.py)",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-8-c0d558b2d4db>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mopenmdao\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnotebook_utils\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mget_code\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mmyst_nb\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mglue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mglue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"code_src94\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mget_code\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"openmdao.test_suite.components.sellar.SellarDis1\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdisplay\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mImportError\u001b[0m: cannot import name 'get_code' from 'openmdao.utils.notebook_utils' (/Users/rfalck/Codes/OpenMDAO.git/openmdao/utils/notebook_utils.py)"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.notebook_utils import get_code\n",
     "from myst_nb import glue\n",

--- a/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/setup_linear_solvers.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "tags": [
      "remove-input",
@@ -150,14 +150,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ImportError",
+     "evalue": "cannot import name 'get_code' from 'openmdao.utils.notebook_utils' (/Users/rfalck/Codes/OpenMDAO.git/openmdao/utils/notebook_utils.py)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-8-c0d558b2d4db>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mopenmdao\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mutils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnotebook_utils\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mget_code\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mmyst_nb\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mglue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mglue\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"code_src94\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mget_code\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"openmdao.test_suite.components.sellar.SellarDis1\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdisplay\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mImportError\u001b[0m: cannot import name 'get_code' from 'openmdao.utils.notebook_utils' (/Users/rfalck/Codes/OpenMDAO.git/openmdao/utils/notebook_utils.py)"
+     ]
+    }
+   ],
    "source": [
     "from openmdao.utils.notebook_utils import get_code\n",
     "from myst_nb import glue\n",
@@ -213,6 +225,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "import openmdao.api as om\n",
     "\n",
     "from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2\n",
     "\n",
@@ -539,7 +552,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/theory_manual/setup_stack.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/setup_stack.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/solver_api.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/solver_api.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/theory_manual/total_derivs_theory.ipynb
+++ b/openmdao/docs/openmdao_book/theory_manual/total_derivs_theory.ipynb
@@ -13,10 +13,9 @@
    "outputs": [],
    "source": [
     "try:\n",
-    "    import openmdao.api as om\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]\n",
-    "    import openmdao.api as om"
+    "    !python -m pip install openmdao[notebooks]"
    ]
   },
   {


### PR DESCRIPTION
### Summary

The getting_started and basic_user_guide docs will now explicitly show the import of the om namespace, which was previously hidden as part of the logic to install it on colab if necessary.

This also changes the header which installs OpenMDAO on colab so that it doesn't import the OM namespace.  Doc examples will fail if om isn't imported in a subsequent code block.

### Related Issues

- Resolves #2163 

### Backwards incompatibilities

None

### New Dependencies

None
