### PR TITLE
fixes for CI

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -204,7 +204,7 @@ jobs:
           cd openmdao/docs
           if [[ "${{ secrets.SNOPT_LOCATION_72 }}" || "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
             echo "============================================================="
-            echo "Build docs with SNOPT examples."
+            echo "Building docs with SNOPT examples."
             echo "============================================================="
           else
             echo "============================================================="
@@ -220,14 +220,17 @@ jobs:
           echo "============================================================="
           echo "Build the docs"
           echo "============================================================="
-          python build_source_docs.py
-          jupyter-book build -W --keep-going openmdao_book
-          python copy_build_artifacts.py
+          ./build_all_docs.sh
 
       - name: Display doc build reports
         if: failure() && matrix.BUILD_DOCS && steps.build_docs.outcome == 'failure'
         run: |
-          cat /home/runner/work/OpenMDAO/OpenMDAO/openmdao/docs/openmdao_book/_build/html/reports/*
+          for f in /home/runner/work/OpenMDAO/OpenMDAO/openmdao/docs/openmdao_book/_build/html/reports/*; do
+            echo "============================================================="
+            echo $f
+            echo "============================================================="
+            cat $f
+          done
 
       - name: Publish docs
         if: ${{ github.event_name == 'push' && matrix.PUBLISH_DOCS }}

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -220,7 +220,9 @@ jobs:
           echo "============================================================="
           echo "Build the docs"
           echo "============================================================="
-          ./build_all_docs.sh
+          python build_source_docs.py
+          jupyter-book build -W --keep-going openmdao_book
+          python copy_build_artifacts.py
 
       - name: Display doc build reports
         if: failure() && matrix.BUILD_DOCS && steps.build_docs.outcome == 'failure'

--- a/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
+++ b/openmdao/docs/openmdao_book/examples/keplers_equation.ipynb
@@ -293,13 +293,6 @@
     "\n",
     "The ImplicitComponent involves only a single system, but writing the `solve_nonlinear` method with some error handling, initial guess generation, and print capability made for more coding on the part of the user."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/differential_evolution.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/differential_evolution.ipynb
@@ -263,6 +263,9 @@
    "pygments_lexer": "ipython3",
    "version": "3.8.1"
   },
+  "nbsphinx": {
+   "timeout": 90
+  },
   "orphan": true
  },
  "nbformat": 4,

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
     },
     python_requires=">=3.6",
     install_requires=[
-        'networkx>=2.0',
+        'networkx>=2.0, <2.6',
         'numpy',
         'pyDOE2',
         'pyparsing',


### PR DESCRIPTION
### Summary

- pin  `networkx<2.6` for now until #2171 is addressed
- increase timeout on the differential evolution driver notebook

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
