### PR TITLE
updated to work with networkx==2.6

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -175,7 +175,7 @@ class Group(System):
         Flag to check if set_order has been called.
     _auto_ivc_warnings : list
         List of Auto IVC warnings to be raised later with simple_warnings.
-    _shapes_graph : nx.OrderedGraph
+    _shapes_graph : nx.Graph
         Dynamic shape dependency graph, or None.
     _shape_knowns : set
         Set of shape dependency graph nodes with known (non-dynamic) shapes.
@@ -1606,8 +1606,6 @@ class Group(System):
         """
         Add shape/size metadata for variables that were created with shape_by_conn or copy_shape.
         """
-        self._shapes_graph = graph = nx.OrderedGraph()  # ordered graph for consistency across procs
-        self._shape_knowns = knowns = set()
         all_abs2meta_out = self._var_allprocs_abs2meta['output']
         all_abs2meta_in = self._var_allprocs_abs2meta['input']
 
@@ -1673,9 +1671,9 @@ class Group(System):
                     rev[src] = [tgt]
             return rev
 
-        graph = nx.OrderedGraph()  # ordered graph for consistency across procs
+        self._shapes_graph = graph = nx.Graph()
+        self._shape_knowns = knowns = set()
         dist_sz = {}  # local distrib sizes
-        knowns = set()  # variable nodes in the graph with known shapes
         my_abs2meta_out = self._var_abs2meta['output']
         my_abs2meta_in = self._var_abs2meta['input']
 

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -185,18 +185,19 @@ def get_nested_calls(class_, method_name, stream=sys.stdout):
 
     graph = OrderedDiGraph()
     seen = set()
+    top = object()
 
     full, klass = _find_owning_class(inspect.getmro(class_), method_name)
     if full is None:
         print("Can't find function '%s' in class '%s'." % (method_name, class_.__name__))
     else:
-        graph.add_edge(None, full)
+        graph.add_edge(top, full)
         parent = full
         _get_nested_calls(class_, klass, method_name, parent, graph, seen)
 
     if graph and stream is not None:
-        seen = set([None])
-        stack = [(0, iter(graph[None]))]
+        seen = set([top])
+        stack = [(0, iter(graph[top]))]
         while stack:
             depth, children = stack[-1]
             try:

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
     },
     python_requires=">=3.6",
     install_requires=[
-        'networkx>=2.0, <2.6',
+        'networkx>=2.0',
         'numpy',
         'pyDOE2',
         'pyparsing',


### PR DESCRIPTION
### Summary

Got rid of references to OrderedGraph and removed None as a node.

### Related Issues

- Resolves #2171

### Backwards incompatibilities

None

### New Dependencies

None
