### PR TITLE
handle deprecated 'value' in `get_io_metadata()` arg

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -122,6 +122,9 @@ class _MatchType(IntEnum):
     PATTERN = 2
 
 
+value_deprecated_msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'."
+
+
 class _MetadataDict(dict):
     """
     A dict wrapper for a dict of metadata, to throw deprecation if a user indexes in using value.
@@ -129,14 +132,14 @@ class _MetadataDict(dict):
 
     def __getitem__(self, key):
         if key == 'value':
-            warn_deprecation("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+            warn_deprecation(value_deprecated_msg)
             key = 'val'
         val = dict.__getitem__(self, key)
         return val
 
     def __setitem__(self, key, val):
         if key == 'value':
-            warn_deprecation("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+            warn_deprecation(value_deprecated_msg)
             key = 'val'
         dict.__setitem__(self, key, val)
 
@@ -3298,7 +3301,7 @@ class System(object):
                 # DEPRECATION: if 'value' in keyset, replace with 'val'
                 keyset.remove('value')
                 keyset.add('val')
-                warn_deprecation("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+                warn_deprecation(value_deprecated_msg)
             except KeyError:
                 pass
             diff = keyset - allowed_meta_names

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3236,7 +3236,7 @@ class System(object):
             Will contain either 'input', 'output', or both.  Defaults to both.
         metadata_keys : iter of str or None
             Names of metadata entries to be retrieved or None, meaning retrieve all
-            available 'allprocs' metadata.  If 'values' or 'src_indices' are required,
+            available 'allprocs' metadata.  If 'val' or 'src_indices' are required,
             their keys must be provided explicitly since they are not found in the 'allprocs'
             metadata and must be retrieved from local metadata located in each process.
         includes : str, iter of str or None
@@ -3294,6 +3294,13 @@ class System(object):
         need_gather = get_remote and self.comm.size > 1
         if metadata_keys is not None:
             keyset = set(metadata_keys)
+            try:
+                # DEPRECATION: if 'value' in keyset, replace with 'val'
+                keyset.remove('value')
+                keyset.add('val')
+                warn_deprecation("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+            except KeyError:
+                pass
             diff = keyset - allowed_meta_names
             if diff:
                 raise RuntimeError(f"{self.msginfo}: {sorted(diff)} are not valid metadata entry "

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -299,7 +299,7 @@ class TestExplicitComponent(unittest.TestCase):
         prob = Problem(comp).setup()
 
         # check optional metadata (desc)
-        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'.")
 
         prob.setup()
         with assert_warning(OMDeprecationWarning, msg):
@@ -310,7 +310,7 @@ class TestExplicitComponent(unittest.TestCase):
         idv = prob.model.add_subsystem('idv', IndepVarComp())
         meta = idv.add_output('x', 1.0)
 
-        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'")
+        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'.")
         with assert_warning(OMDeprecationWarning, msg):
             meta['value']
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -268,7 +268,7 @@ class TestSystem(unittest.TestCase):
             inputs = p.model.list_inputs(values=True, out_stream=None)
         self.assertEqual(inputs, [('comp.a', {'val': 1})])
 
-        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'"
+        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'."
         with assert_warning(OMDeprecationWarning, msg):
             self.assertEqual(inputs[0][1]['value'], 1)
 
@@ -283,7 +283,7 @@ class TestSystem(unittest.TestCase):
             outputs = p.model.list_outputs(values=True, out_stream=None)
         self.assertEqual(outputs, [('comp.b', {'val': 2})])
 
-        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'"
+        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'."
         with assert_warning(OMDeprecationWarning, msg):
             self.assertEqual(outputs[0][1]['value'], 2)
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -291,6 +291,14 @@ class TestSystem(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             self.assertEqual(meta['comp.a']['value'], 1)
 
+        with assert_warning(OMDeprecationWarning, msg):
+            meta = p.model.get_io_metadata(metadata_keys=('value',))
+        self.assertEqual(meta['comp.a']['val'], 1)
+
+        with assert_warning(OMDeprecationWarning, msg):
+            meta = p.model.get_io_metadata(metadata_keys=('value',))
+        with assert_warning(OMDeprecationWarning, msg):
+            self.assertEqual(meta['comp.a']['value'], 1)
 
     def test_recording_options_deprecated(self):
         prob = Problem()


### PR DESCRIPTION
### Summary

- handle deprecated 'value' in `get_io_metadata()` `metadata_keys` arg
- replace deprecated 'value' with 'val' in the docstring for `get_io_metadata()` 

### Related Issues

- Resolves #2189 

### Backwards incompatibilities

None

### New Dependencies

None
