### PR TITLE
Improved error message for global shape errors

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1527,10 +1527,11 @@ class System(object):
                         high_size = np.prod(high_dims)
                         dim1 = global_size // high_size
                         if global_size % high_size != 0:
-                            raise RuntimeError(f"{self.msginfo}: Array dimensions above the "
-                                f"first must match across processes. For output '{abs_name}', "
-                                f"local shape {local_shape} has an upper dimension that "
-                                "differs in another process.")
+                            raise RuntimeError(f"{self.msginfo}: All but the first dimension of "
+                                f"the shape's local parts in a distributed variable must match "
+                                f"across processes. For output '{abs_name}', local shape "
+                                f"{local_shape} in MPI rank {MPI.COMM_WORLD.rank} has a higher "
+                                "dimension that differs in another rank.")
                         mymeta['global_shape'] = tuple([dim1] + list(high_dims))
                     else:
                         mymeta['global_shape'] = (global_size,)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1527,9 +1527,10 @@ class System(object):
                         high_size = np.prod(high_dims)
                         dim1 = global_size // high_size
                         if global_size % high_size != 0:
-                            raise RuntimeError("%s: Global size of output '%s' (%s) does not agree "
-                                               "with local shape %s" % (self.msginfo, abs_name,
-                                                                        global_size, local_shape))
+                            raise RuntimeError(f"{self.msginfo}: Array dimensions above the "
+                                f"first must match across processes. For output '{abs_name}', "
+                                f"local shape {local_shape} has an upper dimension that "
+                                "differs in another process.")
                         mymeta['global_shape'] = tuple([dim1] + list(high_dims))
                     else:
                         mymeta['global_shape'] = (global_size,)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1527,11 +1527,13 @@ class System(object):
                         high_size = np.prod(high_dims)
                         dim1 = global_size // high_size
                         if global_size % high_size != 0:
-                            raise RuntimeError(f"{self.msginfo}: All but the first dimension of "
-                                f"the shape's local parts in a distributed variable must match "
-                                f"across processes. For output '{abs_name}', local shape "
-                                f"{local_shape} in MPI rank {MPI.COMM_WORLD.rank} has a higher "
-                                "dimension that differs in another rank.")
+                            msg = (f"{self.msginfo}: All but the first dimension of the "
+                                   "shape's local parts in a distributed variable must match "
+                                   f"across processes. For output '{abs_name}', local shape "
+                                   f"{local_shape} in MPI rank {MPI.COMM_WORLD.rank} has a "
+                                   "higher dimension that differs in another rank.")
+
+                            raise RuntimeError(msg)
                         mymeta['global_shape'] = tuple([dim1] + list(high_dims))
                     else:
                         mymeta['global_shape'] = (global_size,)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1505,6 +1505,45 @@ class System(object):
         if cfginfo and self.pathname in cfginfo._modified_systems:
             cfginfo._modified_systems.remove(self.pathname)
 
+    def _comm_global_shape_status(self, rank_status_ok):
+        """
+        Communicate the validity of the global_shape dimensions to all ranks.
+
+        Parameters
+        ----------
+        rank_status_ok : bool
+            Whether the global_shape status of the current rank is OK.
+
+        Returns
+        -------
+        bool
+            True if all ranks have valid local shapes, False otherwise.
+        """
+        comm = MPI.COMM_WORLD
+        global_status_ok = True
+
+        # Rank 0 collects the statuses of all other ranks
+        if comm.rank == 0:
+            global_status_ok = rank_status_ok
+
+            for other_rank in range(1, comm.size):
+                other_rank_ok = comm.recv(source=other_rank, tag=100)
+                if other_rank_ok is False:
+                    global_status_ok = False
+        # Ranks higher than 0 send their status to rank 0
+        else:
+            comm.send(rank_status_ok, dest=0, tag=100)
+
+        # Rank 0 sends the global status to higher ranks
+        if comm.rank == 0:
+            for other_rank in range(1, comm.size):
+                comm.send(global_status_ok, dest=other_rank, tag=101)
+        # Higher ranks receive the status from rank 0
+        else:
+            global_status_ok = comm.recv(source=0, tag=101)
+
+        return global_status_ok
+
     def _setup_global_shapes(self):
         """
         Compute the global size and shape of all variables on this system.
@@ -1525,8 +1564,14 @@ class System(object):
                     high_dims = local_shape[1:]
                     if high_dims:
                         high_size = np.prod(high_dims)
-                        dim1 = global_size // high_size
+
+                        dim_size_match = True
                         if global_size % high_size != 0:
+                            dim_size_match = False
+
+                        global_status_ok = self._comm_global_shape_status(dim_size_match)
+
+                        if global_status_ok is False:
                             msg = (f"{self.msginfo}: All but the first dimension of the "
                                    "shape's local parts in a distributed variable must match "
                                    f"across processes. For output '{abs_name}', local shape "
@@ -1534,6 +1579,8 @@ class System(object):
                                    "higher dimension that differs in another rank.")
 
                             raise RuntimeError(msg)
+
+                        dim1 = global_size // high_size
                         mymeta['global_shape'] = tuple([dim1] + list(high_dims))
                     else:
                         mymeta['global_shape'] = (global_size,)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1504,7 +1504,7 @@ class System(object):
         cfginfo = self._problem_meta['config_info']
         if cfginfo and self.pathname in cfginfo._modified_systems:
             cfginfo._modified_systems.remove(self.pathname)
- 
+
     def _setup_global_shapes(self):
         """
         Compute the global size and shape of all variables on this system.
@@ -1531,10 +1531,10 @@ class System(object):
                         with multi_proc_exception_check(comm):
                             if dim_size_match is False:
                                 msg = (f"{self.msginfo}: All but the first dimension of the "
-                                    "shape's local parts in a distributed variable must match "
-                                    f"across processes. For output '{abs_name}', local shape "
-                                    f"{local_shape} in MPI rank {comm.rank} has a "
-                                    "higher dimension that differs in another rank.")
+                                       "shape's local parts in a distributed variable must match "
+                                       f"across processes. For output '{abs_name}', local shape "
+                                       f"{local_shape} in MPI rank {comm.rank} has a "
+                                       "higher dimension that differs in another rank.")
 
                                 raise RuntimeError(msg)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1510,7 +1510,6 @@ class System(object):
         Compute the global size and shape of all variables on this system.
         """
         loc_meta = self._var_abs2meta
-        comm = MPI.COMM_WORLD
 
         for io in ('input', 'output'):
             # now set global sizes and shapes into metadata for distributed variables
@@ -1528,12 +1527,12 @@ class System(object):
                         high_size = np.prod(high_dims)
                         dim_size_match = bool(global_size % high_size == 0)
 
-                        with multi_proc_exception_check(comm):
+                        with multi_proc_exception_check(self.comm):
                             if dim_size_match is False:
                                 msg = (f"{self.msginfo}: All but the first dimension of the "
                                        "shape's local parts in a distributed variable must match "
                                        f"across processes. For output '{abs_name}', local shape "
-                                       f"{local_shape} in MPI rank {comm.rank} has a "
+                                       f"{local_shape} in MPI rank {self.comm.rank} has a "
                                        "higher dimension that differs in another rank.")
 
                                 raise RuntimeError(msg)

--- a/openmdao/core/tests/test_global_shape_err.py
+++ b/openmdao/core/tests/test_global_shape_err.py
@@ -1,0 +1,59 @@
+import unittest
+import numpy as np
+from mpi4py import MPI
+
+import openmdao.api as om
+
+
+class TwoDArrayAdder(om.ExplicitComponent):
+    def initialize(self):
+        self.options.declare('n0')
+        self.options.declare('n1')
+
+    def setup(self):
+        n0 = self.options['n0']
+        n1 = self.options['n1']
+        self.add_input('x', shape=((n0, n1)), distributed=True)
+        self.add_output('x_sum', shape=((n0, n1)), distributed=True)
+
+    def compute(self, inputs, outputs):
+        outputs['x_sum'] = np.sum(inputs['x'], axis=0)
+
+
+class GlobalShapeErr(unittest.TestCase):
+    N_PROCS = 2
+
+    def check_global_shape(self, n1_test_multiple, expect_error):
+        """
+        Run Problem.setup() and test for an error cause by an improperly-sized variable shape.
+
+        Parameters
+        ----------
+        n1_test_multiple : int
+            Multiple the upper array dimension by this value.
+        expect_error: bool
+            Whether this test is intended to produce an error or not.
+        """
+        n0 = 3
+        n1 = 100 if MPI.COMM_WORLD.rank ==0 else 100 * n1_test_multiple
+        prob = om.Problem()
+        ivc = prob.model.add_subsystem('ivc',om.IndepVarComp())
+        ivc.add_output('x', val = np.ones((n0, n1)), distributed=True)
+
+        prob.model.add_subsystem('adder',TwoDArrayAdder(n0=n0, n1=n1))
+        prob.model.connect('ivc.x','adder.x')
+
+        if expect_error:
+            with self.assertRaises(RuntimeError):
+                prob.setup()
+        else:
+            prob.setup()
+
+    def test_global_shape_success(self):
+        self.check_global_shape(1, False)
+    
+    def test_global_shape_failure(self):
+        self.check_global_shape(2, True)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/core/tests/test_global_shape_err.py
+++ b/openmdao/core/tests/test_global_shape_err.py
@@ -20,6 +20,7 @@ class TwoDArrayAdder(om.ExplicitComponent):
         outputs['x_sum'] = np.sum(inputs['x'], axis=0)
 
 
+@unittest.skipUnless(MPI, "MPI is required.")
 class GlobalShapeErr(unittest.TestCase):
     N_PROCS = 2
 

--- a/openmdao/core/tests/test_global_shape_err.py
+++ b/openmdao/core/tests/test_global_shape_err.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from mpi4py import MPI
+from openmdao.utils.mpi import MPI
 
 import openmdao.api as om
 


### PR DESCRIPTION
### Summary

The old error message looked like:
`RuntimeError: <model> <class Group>: Global size of output 'adder.x' (900) does not agree with local shape (3, 200)`

The new message looks like:
`RuntimeError: <model> <class Group>: All but the first dimension of the shape's local parts in a distributed variable must match across processes. For output 'adder.x', local shape (3, 200) in MPI rank 1 has a higher dimension that differs in another rank.`

### Related Issues

- Resolves #2188

### Backwards incompatibilities

None

### New Dependencies

None
