### PR TITLE
Use backward difference for check options on structured mm with slinear.

### DIFF
--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -176,8 +176,8 @@ class MetaModelStructuredComp(ExplicitComponent):
         if self.options['method'].startswith('scipy'):
             self.set_check_partial_options('*', method='fd')
 
-        # Our bracketing album picks the bin behind it if you are interpolating exactly on one of
-        # the grid points, so we needd to set the derivative check to look backwards.
+        # Our bracketing algorithm picks the bin behind it if you are interpolating exactly on one
+        # of the grid points, so we needd to set the derivative check to look backwards.
         elif self.options['method'] == 'slinear':
             self.set_check_partial_options('*', form='backward')
 

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -176,6 +176,11 @@ class MetaModelStructuredComp(ExplicitComponent):
         if self.options['method'].startswith('scipy'):
             self.set_check_partial_options('*', method='fd')
 
+        # Our bracketing album picks the bin behind it if you are interpolating exactly on one of
+        # the grid points, so we needd to set the derivative check to look backwards.
+        elif self.options['method'] == 'slinear':
+            self.set_check_partial_options('*', form='backward')
+
     def compute(self, inputs, outputs):
         """
         Perform the interpolation at run time.

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -177,7 +177,7 @@ class MetaModelStructuredComp(ExplicitComponent):
             self.set_check_partial_options('*', method='fd')
 
         # Our bracketing algorithm picks the bin behind it if you are interpolating exactly on one
-        # of the grid points, so we needd to set the derivative check to look backwards.
+        # of the grid points, so we need to set the derivative check to look backwards.
         elif self.options['method'] == 'slinear':
             self.set_check_partial_options('*', form='backward')
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1154,7 +1154,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         p.run_model()
 
         cpd = p.check_partials(compact_print=False, out_stream=None, method='cs')
-        assert_check_partials(cpd, atol=1.0E-9, rtol=1.0E-9)
+        assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
 
 @use_tempdirs

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1126,9 +1126,35 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         p.set_val('x', 0.75)
 
         msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> " \
-              "Line 205 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
+              "Line 210 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
         with assert_warning(UserWarning, msg):
             p.run_driver()
+
+    def test_slinear_backward_fd(self):
+        # Verify that FD/CS direction for slinear is backward so that direction matches bracketing.
+        machs = np.linspace(4, 10, num=3)
+        grid = np.random.random((3, ))
+
+        class MGroup(om.Group):
+
+            def setup(self):
+                comp=om.MetaModelStructuredComp(method='slinear')
+                comp.add_input('mach', 0.0, machs)
+                comp.add_output('C_L', 0.0, grid)
+
+                self.add_subsystem('comp', comp, promotes=["*"])
+                self.comp._no_check_partials = False  # override skipping of check_partials
+
+        model = om.Group()
+        model.add_subsystem('InterpSubsystem', MGroup())
+        p = om.Problem(model)
+        p.setup(force_alloc_complex=True)
+
+        p.set_val('InterpSubsystem.mach', 7.0)
+        p.run_model()
+
+        cpd = p.check_partials(compact_print=False, out_stream=None, method='cs')
+        assert_check_partials(cpd, atol=1.0E-9, rtol=1.0E-9)
 
 
 @use_tempdirs

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1125,9 +1125,8 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         p.set_val('x', 0.75)
 
-        msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> " \
-              "Line 210 of file {}".format(inspect.getsourcefile(om.MetaModelStructuredComp))
-        with assert_warning(UserWarning, msg):
+        msg = "Analysis Error: 'interp' <class MetaModelStructuredComp> "
+        with assert_warning(UserWarning, msg, contains_msg=True):
             p.run_driver()
 
     def test_slinear_backward_fd(self):

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -18,7 +18,7 @@ from openmdao.utils.om_warnings import warn_deprecation, reset_warning_registry
 
 
 @contextmanager
-def assert_warning(category, msg):
+def assert_warning(category, msg, contains_msg=False):
     """
     Context manager asserting that a warning is issued.
 
@@ -28,6 +28,8 @@ def assert_warning(category, msg):
         The class of the expected warning.
     msg : str
         The text of the expected warning.
+    contains_msg : bool
+        Set to True to check that the warning text contains msg, rather than checking equality.
 
     Raises
     ------
@@ -40,7 +42,12 @@ def assert_warning(category, msg):
             yield
 
     for warn in w:
-        if (issubclass(warn.category, category) and str(warn.message) == msg):
+        if contains_msg:
+            warn_clause = msg in str(warn.message)
+        else:
+            warn_clause = str(warn.message) == msg
+
+        if (issubclass(warn.category, category) and warn_clause):
             break
     else:
         msg = f"Did not see expected {category.__name__}:\n{msg}"


### PR DESCRIPTION
### Summary

Use backward difference for check options on structured mm when the method is slinear.

This is to avoid confusion when checking partials on this component. Since bracketing looks left and forward difference checks look right, check derivatives would report an erroneous derivative if you tried to interpolate on a grid point.

### Related Issues

- Resolves #2194

### Backwards incompatibilities

None

### New Dependencies

None
