### PR TITLE
Fix for list_outputs with includes on case object

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -590,12 +590,12 @@ class Case(object):
             values = True
         else:
             values = val
-        
+
         if isinstance(includes, str):
-            includes = [includes,]
+            includes = [includes, ]
 
         if isinstance(excludes, str):
-            excludes = [excludes,]
+            excludes = [excludes, ]
 
         for var_name in self.outputs.absolute_names():
             if not list_autoivcs and var_name.startswith('_auto_ivc.'):

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -560,10 +560,10 @@ class Case(object):
             User defined tags that can be used to filter what gets listed. Only outputs with the
             given tags will be listed.
             Default is None, which means there will be no filtering based on tags.
-        includes : str, iter of str, or None
+        includes : str, list of strs, or None
             Glob patterns for pathnames to include in the check. Default is None, which
             includes all.
-        excludes : str, iter of str, or None
+        excludes : str, list of strs, or None
             Glob patterns for pathnames to exclude from the check. Default is None, which
             excludes nothing.
         list_autoivcs : bool
@@ -590,12 +590,12 @@ class Case(object):
             values = True
         else:
             values = val
-
+        
         if isinstance(includes, str):
-            includes = iter(includes)
+            includes = [includes,]
 
         if isinstance(excludes, str):
-            excludes = iter(excludes)
+            excludes = [excludes,]
 
         for var_name in self.outputs.absolute_names():
             if not list_autoivcs and var_name.startswith('_auto_ivc.'):

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -560,10 +560,10 @@ class Case(object):
             User defined tags that can be used to filter what gets listed. Only outputs with the
             given tags will be listed.
             Default is None, which means there will be no filtering based on tags.
-        includes : iter of str or None
+        includes : str, iter of str, or None
             Glob patterns for pathnames to include in the check. Default is None, which
             includes all.
-        excludes : iter of str or None
+        excludes : str, iter of str, or None
             Glob patterns for pathnames to exclude from the check. Default is None, which
             excludes nothing.
         list_autoivcs : bool
@@ -590,6 +590,12 @@ class Case(object):
             values = True
         else:
             values = val
+
+        if isinstance(includes, str):
+            includes = iter(includes)
+
+        if isinstance(excludes, str):
+            excludes = iter(excludes)
 
         for var_name in self.outputs.absolute_names():
             if not list_autoivcs and var_name.startswith('_auto_ivc.'):

--- a/openmdao/recorders/tests/test_list_outputs.py
+++ b/openmdao/recorders/tests/test_list_outputs.py
@@ -1,0 +1,43 @@
+import unittest
+import openmdao.api as om
+from openmdao.test_suite.components.paraboloid_problem import ParaboloidProblem
+import io
+
+class ListOutputsTest(unittest.TestCase):
+    def test_list_outputs(self):
+        """
+        Make sure the same includes and excludes has the same output for System.list_outputs() and
+        Case.list_outputs().
+        """
+
+        prob = ParaboloidProblem()
+        rec = om.SqliteRecorder('test_list_outputs.db')
+        prob.model.add_recorder(rec)
+
+        prob.setup()
+        prob.run_model()
+
+        read_p = om.CaseReader('test_list_outputs.db').get_case(-1)
+
+        # Test list_outputs with includes
+        prob_out = io.StringIO()
+        prob.model.list_outputs(val=False, includes="p*", out_stream=prob_out)
+        rec_out = io.StringIO()
+        read_p.list_outputs(val=False, includes="p*", out_stream=rec_out)
+
+        prob_out_str = prob_out.getvalue()
+        rec_out_str = rec_out.getvalue()
+        self.assertEqual(prob_out_str, rec_out_str)
+
+        # Test list_outputs with excludes
+        prob_out.flush()
+        prob.model.list_outputs(val=False, excludes="p*", out_stream=prob_out)
+        rec_out.flush()
+        read_p.list_outputs(val=False, excludes="p*", out_stream=rec_out)
+
+        prob_out_str = prob_out.getvalue()
+        rec_out_str = rec_out.getvalue()
+        self.assertEqual(prob_out_str, rec_out_str)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary

The example problem was using a `str` arg instead of a list of `str`. Since this could be a common problem, case `list_outputs` now converts `str` args used for `include` and `excludes` to lists before continuing. Also added a test to compare the results from system and case `list_outputs`.

### Related Issues

- Resolves #2193

### Backwards incompatibilities

None

### New Dependencies

None
