### PR TITLE
fix input values for hohmann example

### DIFF
--- a/openmdao/docs/openmdao_book/examples/hohmann_transfer/hohmann_transfer.ipynb
+++ b/openmdao/docs/openmdao_book/examples/hohmann_transfer/hohmann_transfer.ipynb
@@ -50,6 +50,7 @@
    "metadata": {},
    "source": [
     "The trajectory optimization problem can thus be stated as:\n",
+    "\n",
     "$$\n",
     "    \\begin{align*}\n",
     "    Minimize J = {\\Delta} V \\\\\n",
@@ -521,8 +522,8 @@
     "model.add_objective('delta_v', scaler=1.0)\n",
     "\n",
     "# set defaults for our promoted variables to remove ambiguities in value and/or units\n",
-    "model.set_input_defaults('r1', val=42164.0)\n",
-    "model.set_input_defaults('r2', val=398600.4418)\n",
+    "model.set_input_defaults('r1', val=6778.0)\n",
+    "model.set_input_defaults('r2', val=42164.0)\n",
     "model.set_input_defaults('mu', val=398600.4418)\n",
     "model.set_input_defaults('dinc1', val=0., units='deg')\n",
     "model.set_input_defaults('dinc2', val=28.5, units='deg')\n",

--- a/openmdao/test_suite/test_examples/test_hohmann_transfer.py
+++ b/openmdao/test_suite/test_examples/test_hohmann_transfer.py
@@ -175,8 +175,8 @@ class TestHohmannTransfer(unittest.TestCase):
         model.add_objective('delta_v', scaler=1.0)
 
         # set defaults for our promoted variables to remove ambiguities in value and/or units
-        model.set_input_defaults('r1', val=42164.0)
-        model.set_input_defaults('r2', val=398600.4418)
+        model.set_input_defaults('r1', val=6778.0)
+        model.set_input_defaults('r2', val=42164.0)
         model.set_input_defaults('mu', val=398600.4418)
         model.set_input_defaults('dinc1', val=0., units='deg')
         model.set_input_defaults('dinc2', val=28.5, units='deg')


### PR DESCRIPTION
### Summary

Fix the erroneous values that were being set as inputs for the Hohmann example in the docs.

### Related Issues

- Resolves #2201

### Backwards incompatibilities

None

### New Dependencies

None
