### PR TITLE
Modifications to relative step sizing in finite difference

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -455,7 +455,8 @@ class ApproximationScheme(object):
                 if fd_count % num_par_fd == system._par_fd_id:
                     # run the finite difference
                     result = self._run_point(system, [(vec, vecidxs)],
-                                             app_data, results_array, total_or_semi)
+                                             app_data, results_array, total_or_semi,
+                                             jcol_idxs[0])
 
                     result = self._transform_result(result)
 

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -456,7 +456,7 @@ class ApproximationScheme(object):
                     # run the finite difference
                     result = self._run_point(system, [(vec, vecidxs)],
                                              app_data, results_array, total_or_semi,
-                                             jcol_idxs[0])
+                                             jcol_idxs)
 
                     result = self._transform_result(result)
 

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -170,7 +170,7 @@ class ComplexStep(ApproximationScheme):
         """
         return array.imag
 
-    def _run_point(self, system, idx_info, delta, result_array, total):
+    def _run_point(self, system, idx_info, delta, result_array, total, idx_start=0):
         """
         Perturb the system inputs with a complex step, run, and return the results.
 
@@ -186,6 +186,8 @@ class ComplexStep(ApproximationScheme):
             An array used to store the results.
         total : bool
             If True total derivatives are being approximated, else partials.
+        idx_start : int
+            Vector index of the first element of this wrt variable.
 
         Returns
         -------

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -83,7 +83,7 @@ class FiniteDifference(ApproximationScheme):
         'order': None,
         'step_calc': 'abs',
         'directional': False,
-        'minimum_step' : 1e-12,
+        'minimum_step': 1e-12,
     }
 
     def __init__(self):
@@ -137,7 +137,6 @@ class FiniteDifference(ApproximationScheme):
                                  " larger vectors, and this behavior is being changed in "
                                  "OpenMDAO 3.12.0. To preserve the older way of doing this "
                                  "calculation, set step_calc to 'rel_legacy'.")
-
 
         options['vector'] = vector
         wrt = abs_key[1]

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -492,13 +492,17 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         step : float
             Step size for approximation. Defaults to None, in which case the approximation
             method provides its default value.
-        form : string
+        form : str
             Form for finite difference, can be 'forward', 'backward', or 'central'. Defaults
             to None, in which case the approximation method provides its default value.
-        step_calc : string
-            Step type for finite difference, can be 'abs' for absolute', or 'rel' for
-            relative. Defaults to None, in which case the approximation method provides
-            its default value.
+        step_calc : str
+            Step type for computing the size of the finite difference step. It can be 'abs' for
+            absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
+            'rel_element' for a size relative to each value in the vector input. In addition, it
+            can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
+            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
+            future will default to 'rel_avg'. Defaults to None, in which case the approximation
+            method provides its default value.
         """
         if method == 'cs':
             raise ValueError('Complex step has not been tested for MetaModelUnStructuredComp')

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1231,7 +1231,7 @@ class Component(System):
             future will default to 'rel_avg'. Defaults to None, in which case the approximation
             method provides its default value.
         minimum_step : float
-            Minimum step size allowed when using 'rel_element' as the step_calc.
+            Minimum fd step size allowed when using 'rel_element' as the step_calc.
         directional : bool
             Set to True to perform a single directional derivative for each vector variable in the
             pattern named in wrt.

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1040,7 +1040,7 @@ class Component(System):
             future will default to 'rel_avg'. Defaults to None, in which case the approximation
             method provides its default value.
         minimum_step : float
-            Minimum step size allowed when using 'rel_element' as the step_calc.
+            Minimum step size allowed when using one of the relative step_calc options.
 
         Returns
         -------
@@ -1231,7 +1231,7 @@ class Component(System):
             future will default to 'rel_avg'. Defaults to None, in which case the approximation
             method provides its default value.
         minimum_step : float
-            Minimum fd step size allowed when using 'rel_element' as the step_calc.
+            Minimum step size allowed when using one of the relative step_calc options.
         directional : bool
             Set to True to perform a single directional derivative for each vector variable in the
             pattern named in wrt.

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1124,7 +1124,7 @@ class Component(System):
             else:
                 raise RuntimeError("{}: d({})/d({}): 'step' is not a valid option for "
                                    "'{}'".format(self.msginfo, of, wrt, method))
-        if minimum_step:
+        if minimum_step is not None:
             if 'minimum_step' in default_opts:
                 meta['minimum_step'] = minimum_step
             else:

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1284,8 +1284,8 @@ class Component(System):
         if matrix_free:
             n_directional = 0
 
-        for wrt_list, method, form, step, step_calc, minimum_step, directional in \
-            self._declared_partial_checks:
+        for data_tup in self._declared_partial_checks:
+            wrt_list, method, form, step, step_calc, minimum_step, directional = data_tup
 
             for pattern in wrt_list:
                 matches = find_matches(pattern, wrt)

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2823,13 +2823,17 @@ class Group(System):
         step : float
             Step size for approximation. Defaults to None, in which case, the approximation
             method provides its default value.
-        form : string
+        form : str
             Form for finite difference, can be 'forward', 'backward', or 'central'. Defaults to
             None, in which case, the approximation method provides its default value.
-        step_calc : string
-            Step type for finite difference, can be 'abs' for absolute', or 'rel' for
-            relative. Defaults to None, in which case, the approximation method
-            provides its default value.
+        step_calc : str
+            Step type for computing the size of the finite difference step. It can be 'abs' for
+            absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
+            'rel_element' for a size relative to each value in the vector input. In addition, it
+            can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
+            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
+            future will default to 'rel_avg'. Defaults to None, in which case the approximation
+            method provides its default value.
         """
         self._has_approx = True
         self._approx_schemes = OrderedDict()

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1020,7 +1020,7 @@ class Problem(object):
     def check_partials(self, out_stream=_DEFAULT_OUT_STREAM, includes=None, excludes=None,
                        compact_print=False, abs_err_tol=1e-6, rel_err_tol=1e-6,
                        method='fd', step=None, form='forward', step_calc='abs',
-                       minimum_step=1e-9, force_dense=True, show_only_incorrect=False):
+                       minimum_step=1e-12, force_dense=True, show_only_incorrect=False):
         """
         Check partial derivatives comprehensively for all components in your model.
 
@@ -1061,7 +1061,7 @@ class Problem(object):
             future will default to 'rel_avg'. Defaults to None, in which case the approximation
             method provides its default value.
         minimum_step : float
-            Minimum fd step size allowed when using 'rel_element' as the step_calc.
+            Minimum step size allowed when using one of the relative step_calc options.
         force_dense : bool
             If True, analytic derivatives will be coerced into arrays. Default is True.
         show_only_incorrect : bool, optional
@@ -1159,7 +1159,8 @@ class Problem(object):
                         # we now have individual vars like 'x'
                         # get the options for checking partials
                         fd_options, _ = _get_fd_options(var, requested_method, local_opts, step,
-                                                        form, step_calc, alloc_complex)
+                                                        form, step_calc, alloc_complex,
+                                                        minimum_step)
                         # compare the compute options to the check options
                         if fd_options['method'] != meta_with_defaults['method']:
                             all_same = False
@@ -1453,7 +1454,8 @@ class Problem(object):
                 local_wrt = rel_key[1]
 
                 fd_options, could_not_cs = _get_fd_options(local_wrt, requested_method, local_opts,
-                                                           step, form, step_calc, alloc_complex)
+                                                           step, form, step_calc, alloc_complex,
+                                                           minimum_step)
 
                 if could_not_cs:
                     comps_could_not_cs.add(c_name)
@@ -2559,7 +2561,7 @@ def _format_error(error, tol):
 
 
 def _get_fd_options(var, global_method, local_opts, global_step, global_form, global_step_calc,
-                    alloc_complex):
+                    alloc_complex, global_minimum_step):
     local_wrt = var
 
     # Determine if fd or cs.
@@ -2584,12 +2586,14 @@ def _get_fd_options(var, global_method, local_opts, global_step, global_form, gl
 
         fd_options['form'] = None
         fd_options['step_calc'] = None
+        fd_options['minimum_step'] = None
 
     elif method == 'fd':
         defaults = FiniteDifference.DEFAULT_OPTIONS
 
         fd_options['form'] = global_form
         fd_options['step_calc'] = global_step_calc
+        fd_options['minimum_step'] = global_minimum_step
 
     if global_step and global_method == method:
         fd_options['step'] = global_step

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2604,7 +2604,7 @@ def _get_fd_options(var, global_method, local_opts, global_step, global_form, gl
 
     # Precedence: component options > global options > defaults
     if local_wrt in local_opts:
-        for name in ['form', 'step', 'step_calc', 'directional']:
+        for name in ['form', 'step', 'step_calc', 'minimum_step', 'directional']:
             value = local_opts[local_wrt][name]
             if value is not None:
                 fd_options[name] = value

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1052,7 +1052,7 @@ class Problem(object):
         form : string
             Form for finite difference, can be 'forward', 'backward', or 'central'. Default
             'forward'.
-        step_calc : string
+        step_calc : str
             Step type for computing the size of the finite difference step. It can be 'abs' for
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
@@ -1561,10 +1561,10 @@ class Problem(object):
         step : float
             Step size for approximation. Default is None, which means 1e-6 for 'fd' and 1e-40 for
             'cs'.
-        form : string
+        form : str
             Form for finite difference, can be 'forward', 'backward', or 'central'. Default
             None, which defaults to 'forward' for FD.
-        step_calc : string
+        step_calc : str
             Step type for computing the size of the finite difference step. It can be 'abs' for
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1020,7 +1020,7 @@ class Problem(object):
     def check_partials(self, out_stream=_DEFAULT_OUT_STREAM, includes=None, excludes=None,
                        compact_print=False, abs_err_tol=1e-6, rel_err_tol=1e-6,
                        method='fd', step=None, form='forward', step_calc='abs',
-                       force_dense=True, show_only_incorrect=False):
+                       minimum_step=1e-9, force_dense=True, show_only_incorrect=False):
         """
         Check partial derivatives comprehensively for all components in your model.
 
@@ -1060,6 +1060,8 @@ class Problem(object):
             compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
             future will default to 'rel_avg'. Defaults to None, in which case the approximation
             method provides its default value.
+        minimum_step : float
+            Minimum fd step size allowed when using 'rel_element' as the step_calc.
         force_dense : bool
             If True, analytic derivatives will be coerced into arrays. Default is True.
         show_only_incorrect : bool, optional
@@ -1164,7 +1166,8 @@ class Problem(object):
                         else:
                             all_same = True
                             if fd_options['method'] == 'fd':
-                                option_names = ['form', 'step', 'step_calc', 'directional']
+                                option_names = ['form', 'step', 'step_calc', 'minimum_step',
+                                                'directional']
                             else:
                                 option_names = ['step', 'directional']
                             for name in option_names:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1053,8 +1053,13 @@ class Problem(object):
             Form for finite difference, can be 'forward', 'backward', or 'central'. Default
             'forward'.
         step_calc : string
-            Step type for finite difference, can be 'abs' for absolute', or 'rel' for relative.
-            Default is 'abs'.
+            Step type for computing the size of the finite difference step. It can be 'abs' for
+            absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
+            'rel_element' for a size relative to each value in the vector input. In addition, it
+            can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
+            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
+            future will default to 'rel_avg'. Defaults to None, in which case the approximation
+            method provides its default value.
         force_dense : bool
             If True, analytic derivatives will be coerced into arrays. Default is True.
         show_only_incorrect : bool, optional
@@ -1552,8 +1557,13 @@ class Problem(object):
             Form for finite difference, can be 'forward', 'backward', or 'central'. Default
             None, which defaults to 'forward' for FD.
         step_calc : string
-            Step type for finite difference, can be 'abs' for absolute', or 'rel' for relative.
-            Default is 'abs'.
+            Step type for computing the size of the finite difference step. It can be 'abs' for
+            absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
+            'rel_element' for a size relative to each value in the vector input. In addition, it
+            can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
+            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
+            future will default to 'rel_avg'. Defaults to None, in which case the approximation
+            method provides its default value.
         show_progress : bool
             True to show progress of check_totals
 

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -1026,7 +1026,7 @@ class TestProblemCheckPartials(unittest.TestCase):
             comp.set_check_partial_options(wrt=['*'], step_calc='foo')
 
         self.assertEqual(str(cm.exception),
-                         "'comp' <class ParaboloidTricky>: The value of 'step_calc' must be one of ('abs', 'rel'), "
+                         "'comp' <class ParaboloidTricky>: The value of 'step_calc' must be one of ('abs', 'rel', 'rel_legacy', 'rel_avg', 'rel_element'), "
                          "but 'foo' was specified.")
 
         # check invalid wrt

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -1336,6 +1336,9 @@ class ZeroLengthInputsOutputs(unittest.TestCase):
         assert_near_equal(J[('C2.outvec', 'indep.x')],
                           np.eye(3)*np.append(2*np.ones(1), -3*np.ones(2)))
 
+        # Make sure that the code for handling element stepsize also works on a distributed model.
+        assert(prob.check_partials(step_calc='rel_element'))
+
 
 class DistribCompDenseJac(om.ExplicitComponent):
 

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
@@ -144,7 +144,16 @@
     "\n",
     "* form='central': Approximates the derivative as $\\frac{\\partial f}{\\partial x} \\approx \\frac{f(x+\\delta, y) - f(x-\\delta,y)}{2||\\delta||}$. Error scales like $||\\delta||^2$, but requires an extra function evaluation.\n",
     "\n",
-    "The step size can be any nonzero number, but should be positive (one can change the form to perform backwards finite difference formulas), small enough to reduce truncation error, but large enough to avoid round-off error. Choosing a step size can be highly problem dependent, but for double precision floating point numbers and reasonably bounded derivatives, 10−6 can be a good place to start. The step_calc can be either ‘abs’ for absolute or ‘rel’ for relative. It determines whether the stepsize ie absolute or a percentage of the input value."
+    "The step size can be any nonzero number, but should be positive (one can change the form to perform backwards finite difference formulas), small enough to reduce truncation error, but large enough to avoid round-off error. Choosing a step size can be highly problem dependent, but for double precision floating point numbers and reasonably bounded derivatives, 10−6 can be a good place to start. \n",
+    "\n",
+    "The step_calc can be either ‘abs’ for absolute or one of ('rel', 'rel_avg', 'rel_legacy', 'rel_element') for different forms of relative stepping. This determines whether the stepsize ie absolute or a percentage of the input value. The following table details how the relative step is calculated:\n",
+    "\n",
+    "| step_calc       | Step size is scaled by |\n",
+    "| :---            |    :----:                                       |\n",
+    "| \"rel_avg\"       | Average absolute value of the vector.           |\n",
+    "| \"rel_element\"   | Absolute value of each vector element.          |\n",
+    "| \"rel_legacy\"    | Norm of the vector.                             |\n",
+    "| \"rel\"           | Same as \"rel_legacy\" currently, but will become \"rel_avg\" in the OpenMDAO 3.12.0.  |"
    ]
   },
   {
@@ -443,7 +452,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.10"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "sufficient-exclusive",
    "metadata": {
     "tags": [
      "remove-input",
@@ -20,6 +21,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "spread-asbestos",
    "metadata": {},
    "source": [
     "# Approximating Semi-Total Derivatives\n",
@@ -41,6 +43,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "emerging-fantasy",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,6 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "mathematical-authorization",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,6 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "worth-italic",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,6 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "prospective-boards",
    "metadata": {
     "tags": [
      "remove-input",
@@ -129,6 +135,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "played-venue",
    "metadata": {},
    "source": [
     "The same arguments are used for both partial and total derivative approximation specifications. Here we set the finite difference step size, the form to central differences, and the step_calc to relative instead of absolute."
@@ -137,6 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "assigned-dinner",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,6 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "linear-measurement",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,6 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "respected-assignment",
    "metadata": {
     "tags": [
      "remove-input",
@@ -212,6 +222,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "photographic-costs",
    "metadata": {},
    "source": [
     "(complex-step-guidelines)=\n",
@@ -237,6 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "enclosed-official",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,6 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "afraid-evolution",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,6 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "forty-experiment",
    "metadata": {
     "tags": [
      "remove-input",
@@ -330,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.10"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
@@ -439,6 +439,8 @@
    "id": "velvet-element",
    "metadata": {},
    "source": [
+    "Here is an example where we check our partials using complex step.\n",
+    "\n",
     "```{Note}\n",
     "You need to set `force_alloc_complex` to True during setup to utilize complex step during a check.\n",
     "```"
@@ -475,7 +477,7 @@
    "id": "otherwise-sheet",
    "metadata": {},
    "source": [
-    "---"
+    "In this example, we check our partials with finite difference, but we use central differencing for more accuracy."
    ]
   },
   {
@@ -511,7 +513,7 @@
    "id": "reduced-richmond",
    "metadata": {},
    "source": [
-    "---"
+    "In this example, we use a relative step-size. This is sometimes needed for casese where an input variable's value can be in a wide range of orders of magnitude, and we don't want the step size to become to small or large for it."
    ]
   },
   {
@@ -534,6 +536,84 @@
     "prob.run_model()\n",
     "\n",
     "prob.check_partials(step_calc='rel', compact_print=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "referenced-diabetes",
+   "metadata": {},
+   "source": [
+    "Finally, in this example, we have a vector input whose elements differ by several orders of magnitude, and whose middle element is sometimes zero.  If you try to scale the step size by a variable that is zero, you end up with a step size equal to zero, which causes division by zero during computation.  To prevent this, OpenMDAO defines a minimum step size of 1e-12. You can change this value by setting the `minimum_step` argument to a new value whenever you set the `step_calc` argument. Here, we also use the 'rel_element' step_calc so that each element computes its own step size relative to the magnitude of that single element."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "nonprofit-dance",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import openmdao.api as om\n",
+    "\n",
+    "\n",
+    "class FDComp(om.ExplicitComponent):\n",
+    "\n",
+    "    def initialize(self):\n",
+    "        self.options.declare('vec_size', types=int, default=1)\n",
+    "\n",
+    "    def setup(self):\n",
+    "        nn = self.options['vec_size']\n",
+    "\n",
+    "        self.add_input('x_element', np.ones((nn, )))\n",
+    "        self.add_output('y', np.ones((nn, )))\n",
+    "\n",
+    "    def setup_partials(self):\n",
+    "        self.declare_partials('*', 'x_element')\n",
+    "\n",
+    "        self.set_check_partial_options('x_element', method='fd', step_calc='rel_element', minimum_step=1e-15)\n",
+    "\n",
+    "    def compute(self, inputs, outputs):\n",
+    "        x = inputs['x_element']\n",
+    "        outputs['y'] = 0.5 * x ** 2\n",
+    "\n",
+    "    def compute_partials(self, inputs, partials):\n",
+    "        x = inputs['x_element']\n",
+    "        partials['y', 'x_element'] = np.diag(x)\n",
+    "\n",
+    "\n",
+    "prob = om.Problem()\n",
+    "model = prob.model\n",
+    "\n",
+    "model.add_subsystem('comp', FDComp(vec_size=3))\n",
+    "\n",
+    "prob.setup(force_alloc_complex=True)\n",
+    "\n",
+    "x = np.array([1e10, 0.0, 1e-10])\n",
+    "prob.set_val('comp.x_element', x)\n",
+    "\n",
+    "prob.run_model()\n",
+    "\n",
+    "totals = prob.check_partials()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "still-outside",
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "assert_near_equal(totals['comp']['y', 'x_element']['J_fd'][0][0], x[0], 1e-5)\n",
+    "assert_near_equal(totals['comp']['y', 'x_element']['J_fd'][1][1], x[1], 1e-5)\n",
+    "assert_near_equal(totals['comp']['y', 'x_element']['J_fd'][2][2], x[2], 1e-5)"
    ]
   }
  ],

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "associate-silicon",
    "metadata": {
     "tags": [
      "remove-input",
@@ -20,6 +21,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "herbal-skating",
    "metadata": {},
    "source": [
     "# Changing Check Settings for FD or CS\n",
@@ -31,6 +33,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "beautiful-ethernet",
    "metadata": {},
    "source": [
     "```{eval-rst}\n",
@@ -41,6 +44,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "received-nightmare",
    "metadata": {},
    "source": [
     "```{Note}\n",
@@ -50,6 +54,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "piano-disease",
    "metadata": {},
    "source": [
     "This allows custom tailoring of the approximation settings on a variable basis."
@@ -57,6 +62,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "unavailable-anaheim",
    "metadata": {},
    "source": [
     "## Usage Examples"
@@ -65,6 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "embedded-traveler",
    "metadata": {
     "tags": [
      "remove-input",
@@ -80,6 +87,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "vocational-capitol",
    "metadata": {},
    "source": [
     ":::{Admonition} `ParaboloidMatVec` class definition \n",
@@ -92,6 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "related-premium",
    "metadata": {
     "tags": [
      "remove-input",
@@ -107,6 +116,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "mighty-companion",
    "metadata": {},
    "source": [
     ":::{Admonition} `ParaboloidTricky` class definition \n",
@@ -119,6 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "angry-drive",
    "metadata": {
     "scrolled": true
    },
@@ -147,6 +158,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "owned-diana",
    "metadata": {},
    "source": [
     "Here, we show how to set the method. In this case, we use complex step on TrickyParaboloid because the finite difference is less accurate."
@@ -154,6 +166,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "bright-despite",
    "metadata": {},
    "source": [
     "---"
@@ -161,6 +174,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "square-disclaimer",
    "metadata": {},
    "source": [
     "```{Note}\n",
@@ -171,6 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "legal-drinking",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,6 +212,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "civilian-silicon",
    "metadata": {},
    "source": [
     "## Directional Derivatives\n",
@@ -206,6 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "superior-document",
    "metadata": {
     "tags": [
      "remove-input",
@@ -221,6 +238,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "educated-stevens",
    "metadata": {},
    "source": [
     ":::{Admonition} `ArrayComp` class definition \n",
@@ -233,6 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "formed-campbell",
    "metadata": {
     "scrolled": true
    },
@@ -253,6 +272,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "facial-container",
    "metadata": {},
    "source": [
     "If your component is matrix-free and you request directional derivatives, then your reverse mode derivatives will be verified using the dot product test described [here](http://www.reproducibility.org/RSF/book/gee/ajt/paper_html/node20.html)."
@@ -261,6 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "rational-stock",
    "metadata": {
     "scrolled": true
    },
@@ -330,6 +351,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "reasonable-honey",
    "metadata": {},
    "source": [
     "## Changing Global Settings For Whole Model"
@@ -337,6 +359,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "academic-charge",
    "metadata": {},
    "source": [
     "You can change the settings globally for all approximations used for all components. This is done by passing in a value for any of the following arguments:"
@@ -344,6 +367,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "noble-triumph",
    "metadata": {},
    "source": [
     "| Name      | Description                                                                                    |\n",
@@ -351,11 +375,22 @@
     "| method    | Method for check: “fd” for finite difference, “cs” for complex step.                           |\n",
     "| form      | Finite difference form for check, can be “forward”, “central”, or backward.                    |\n",
     "| step      | Step size for finite difference check.                                                         |\n",
-    "| step_calc | Type of step calculation for check, can be “abs” for absolute (default) or “rel” for relative. |\n"
+    "| step_calc | When \"abs\", the step is absolute. A relative step can also be chosen with one of the values in table below.                                |\n",
+    "| minimum_step | Minimum allowable step when using one of the relative step_calc options. |\n",
+    "\n",
+    "If you need to scale the finite difference step by the variable's magnitude, the following additional choices for \"step_calc\" are available:\n",
+    "\n",
+    "| step_calc       | Step size is scaled by |\n",
+    "| :---            |    :----:                                       |\n",
+    "| \"rel_avg\"       | Average absolute value of the vector.           |\n",
+    "| \"rel_element\"   | Absolute value of each vector element.          |\n",
+    "| \"rel_legacy\"    | Norm of the vector.                             |\n",
+    "| \"rel\"           | Same as \"rel_legacy\" currently, but will become \"rel_avg\" in the OpenMDAO 3.12.0.  |\n"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "interior-guest",
    "metadata": {},
    "source": [
     "```{Note}\n",
@@ -365,6 +400,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fancy-voltage",
    "metadata": {},
    "source": [
     "## Usage Examples"
@@ -373,6 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "municipal-recruitment",
    "metadata": {
     "scrolled": true
    },
@@ -399,6 +436,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "velvet-element",
    "metadata": {},
    "source": [
     "```{Note}\n",
@@ -409,6 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "affected-seattle",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,6 +472,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "otherwise-sheet",
    "metadata": {},
    "source": [
     "---"
@@ -441,6 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "closed-blood",
    "metadata": {
     "scrolled": true
    },
@@ -467,6 +508,7 @@
   },
   {
    "cell_type": "markdown",
+   "id": "reduced-richmond",
    "metadata": {},
    "source": [
     "---"
@@ -475,6 +517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "multiple-tiffany",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.10"
   },
   "orphan": true
  },


### PR DESCRIPTION
### Summary

This is the implementation for accepted POEM 051.

1. New step_calc modes added for computing the relative finite difference step size.
- 'rel_avg' scale by average absolute value of the vector variable.
- 'rel_element' for each element, scale by its own current value.
- 'rel_legacy' scale by the norm of the vector variable. This is the current behavior for 'rel'
2. The step_calc 'rel' mode will be changed to the behavior of 'rel_avg' in the next release. A deprecation warning has been added.
3. New 'minimum_step' argument has been added to prevent scaling the step size by 0. The default is 1e-12.

### Related Issues

- Resolves #2133

### Backwards incompatibilities

Behavior of the 'rel' step_calc will change, though current behavior is considered a mild bug. A deprecation warning is raised if you use this. The behavior of 'rel' will be fixed in the next release. The 'rel_legacy' choice keeps the old behavior and will continue to be available for those who need it.

### New Dependencies

None
