### PR TITLE
Added support for multidimensional shapes in `EQConstraintComp` and `BalanceComp`

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -159,7 +159,6 @@ class BalanceComp(ImplicitComponent):
         residuals : Vector
             unscaled, dimensional residuals written to via residuals[key]
         """
-
         for name, options in self._state_vars.items():
             lhs = inputs[options['lhs_name']]
             rhs = inputs[options['rhs_name']]

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -170,11 +170,12 @@ class BalanceComp(ImplicitComponent):
 
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero
-                idxs_nz = np.where(cs_safe.abs(rhs) < 2)[0]
-                idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)[0]
+                idxs_nz = np.where(cs_safe.abs(rhs) < 2)
+                idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)
 
                 # Compute scaling factors
                 # scale factor that normalizes by the rhs, except near 0
+                self._scale_factor = np.ones((rhs.shape))
                 self._scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
                 self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
             else:

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -159,14 +159,11 @@ class BalanceComp(ImplicitComponent):
         residuals : Vector
             unscaled, dimensional residuals written to via residuals[key]
         """
-        if inputs._under_complex_step:
-            self._scale_factor = self._scale_factor.astype(complex)
-        else:
-            self._scale_factor = self._scale_factor.real
 
         for name, options in self._state_vars.items():
             lhs = inputs[options['lhs_name']]
             rhs = inputs[options['rhs_name']]
+            _scale_factor = np.ones((rhs.shape))
 
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero
@@ -175,16 +172,13 @@ class BalanceComp(ImplicitComponent):
 
                 # Compute scaling factors
                 # scale factor that normalizes by the rhs, except near 0
-                self._scale_factor = np.ones((rhs.shape))
-                self._scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
-                self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
-            else:
-                self._scale_factor[:] = 1.0
+                _scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
+                _scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
 
             if options['use_mult']:
-                residuals[name] = (inputs[options['mult_name']] * lhs - rhs) * self._scale_factor
+                residuals[name] = (inputs[options['mult_name']] * lhs - rhs) * _scale_factor
             else:
-                residuals[name] = (lhs - rhs) * self._scale_factor
+                residuals[name] = (lhs - rhs) * _scale_factor
 
     def linearize(self, inputs, outputs, jacobian):
         """
@@ -211,37 +205,37 @@ class BalanceComp(ImplicitComponent):
             lhs = inputs[lhs_name]
             rhs = inputs[rhs_name]
 
+            _scale_factor = np.ones((rhs.shape))
+            _dscale_drhs = np.zeros((rhs.shape))
+
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero
                 idxs_nz = np.where(cs_safe.abs(rhs) < 2)[0]
                 idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)[0]
 
                 # scale factor that normalizes by the rhs, except near 0
-                self._scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
-                self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+                _scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
+                _scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
 
-                self._dscale_drhs[idxs_nnz] = -np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
-                self._dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
-            else:
-                self._scale_factor[:] = 1.0
-                self._dscale_drhs[:] = 0.0
+                _dscale_drhs[idxs_nnz] = -np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
+                _dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
 
             if options['use_mult']:
                 mult_name = options['mult_name']
                 mult = inputs[mult_name]
 
                 # Partials of residual wrt mult
-                deriv = lhs * self._scale_factor
+                deriv = lhs * _scale_factor
                 jacobian[name, mult_name] = deriv.flatten()
             else:
                 mult = 1.0
 
             # Partials of residual wrt rhs
-            deriv = (mult * lhs - rhs) * self._dscale_drhs - self._scale_factor
+            deriv = (mult * lhs - rhs) * self._dscale_drhs - _scale_factor
             jacobian[name, rhs_name] = deriv.flatten()
 
             # Partials of residual wrt lhs
-            deriv = mult * self._scale_factor
+            deriv = mult * _scale_factor
             jacobian[name, lhs_name] = deriv.flatten()
 
     def guess_nonlinear(self, inputs, outputs, residuals):
@@ -347,9 +341,6 @@ class BalanceComp(ImplicitComponent):
             self.add_input(options['mult_name'],
                            val=options['mult_val'] * np.ones(shape),
                            units=None)
-
-        self._scale_factor = np.ones(shape)
-        self._dscale_drhs = np.ones(shape)
 
         ar = np.arange(np.prod(shape))
         self.declare_partials(of=name, wrt=options['lhs_name'], rows=ar, cols=ar, val=1.0)

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -193,11 +193,6 @@ class BalanceComp(ImplicitComponent):
         jacobian : Jacobian
             sub-jac components written to jacobian[output_name, input_name]
         """
-        if inputs._under_complex_step:
-            self._dscale_drhs = self._dscale_drhs.astype(complex)
-        else:
-            self._dscale_drhs = self._dscale_drhs.real
-
         for name, options in self._state_vars.items():
             lhs_name = options['lhs_name']
             rhs_name = options['rhs_name']
@@ -231,7 +226,7 @@ class BalanceComp(ImplicitComponent):
                 mult = 1.0
 
             # Partials of residual wrt rhs
-            deriv = (mult * lhs - rhs) * self._dscale_drhs - _scale_factor
+            deriv = (mult * lhs - rhs) * _dscale_drhs - _scale_factor
             jacobian[name, rhs_name] = deriv.flatten()
 
             # Partials of residual wrt lhs

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -117,14 +117,10 @@ class EQConstraintComp(ExplicitComponent):
         outputs : Vector
             unscaled, dimensional output variables read via outputs[key]
         """
-        if inputs._under_complex_step:
-            self._scale_factor = self._scale_factor.astype(complex)
-        else:
-            self._scale_factor = self._scale_factor.real
-
         for name, options in self._output_vars.items():
             lhs = inputs[options['lhs_name']]
             rhs = inputs[options['rhs_name']]
+            _scale_factor = np.ones((rhs.shape))
 
             # Compute scaling factors
             # scale factor that normalizes by the rhs, except near 0
@@ -133,16 +129,13 @@ class EQConstraintComp(ExplicitComponent):
                 idxs_nz = np.where(cs_safe.abs(rhs) < 2)
                 idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)
 
-                self._scale_factor = np.ones((rhs.shape))
-                self._scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
-                self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
-            else:
-                self._scale_factor[:] = 1.0
+                _scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
+                _scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
 
             if options['use_mult']:
-                outputs[name] = (inputs[options['mult_name']] * lhs - rhs) * self._scale_factor
+                outputs[name] = (inputs[options['mult_name']] * lhs - rhs) * _scale_factor
             else:
-                outputs[name] = (lhs - rhs) * self._scale_factor
+                outputs[name] = (lhs - rhs) * _scale_factor
 
     def compute_partials(self, inputs, partials):
         """
@@ -155,11 +148,6 @@ class EQConstraintComp(ExplicitComponent):
         partials : Jacobian
             sub-jac components written to partials[output_name, input_name]
         """
-        if inputs._under_complex_step:
-            self._dscale_drhs = self._dscale_drhs.astype(complex)
-        else:
-            self._dscale_drhs = self._dscale_drhs.real
-
         for name, options in self._output_vars.items():
             lhs_name = options['lhs_name']
             rhs_name = options['rhs_name']
@@ -167,37 +155,36 @@ class EQConstraintComp(ExplicitComponent):
             lhs = inputs[lhs_name]
             rhs = inputs[rhs_name]
 
+            _scale_factor = np.ones((rhs.shape))
+            _dscale_drhs = np.zeros((rhs.shape))
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero
-                idxs_nz = np.where(cs_safe.abs(rhs) < 2)[0]
-                idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)[0]
+                idxs_nz = np.where(cs_safe.abs(rhs) < 2)
+                idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)
 
                 # scale factor that normalizes by the rhs, except near 0
-                self._scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
-                self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
+                _scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
+                _scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
 
-                self._dscale_drhs[idxs_nnz] = -np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
-                self._dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
-            else:
-                self._scale_factor[:] = 1.0
-                self._dscale_drhs[:] = 0.0
+                _dscale_drhs[idxs_nnz] = -np.sign(rhs[idxs_nnz]) / rhs[idxs_nnz]**2
+                _dscale_drhs[idxs_nz] = -.5 * rhs[idxs_nz] / (.25 * rhs[idxs_nz] ** 2 + 1) ** 2
 
             if options['use_mult']:
                 mult_name = options['mult_name']
                 mult = inputs[mult_name]
 
                 # Partials of output wrt mult
-                deriv = lhs * self._scale_factor
+                deriv = lhs * _scale_factor
                 partials[name, mult_name] = deriv.flatten()
             else:
                 mult = 1.0
 
             # Partials of output wrt rhs
-            deriv = (mult * lhs - rhs) * self._dscale_drhs - self._scale_factor
+            deriv = (mult * lhs - rhs) * _dscale_drhs - _scale_factor
             partials[name, rhs_name] = deriv.flatten()
 
             # Partials of output wrt lhs
-            deriv = mult * self._scale_factor
+            deriv = mult * _scale_factor
             partials[name, lhs_name] = deriv.flatten()
 
     def add_eq_output(self, name, eq_units=None, lhs_name=None, rhs_name=None, rhs_val=0.0,
@@ -292,9 +279,6 @@ class EQConstraintComp(ExplicitComponent):
             self.add_input(options['mult_name'],
                            val=options['mult_val'] * np.ones(shape),
                            units=None)
-
-        self._scale_factor = np.ones(shape)
-        self._dscale_drhs = np.ones(shape)
 
         ar = np.arange(np.prod(shape))
         self.declare_partials(of=name, wrt=options['lhs_name'], rows=ar, cols=ar, val=1.0)

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -117,10 +117,10 @@ class EQConstraintComp(ExplicitComponent):
         outputs : Vector
             unscaled, dimensional output variables read via outputs[key]
         """
-        # if inputs._under_complex_step:
-        #     self._scale_factor = self._scale_factor.astype(complex)
-        # else:
-        #     self._scale_factor = self._scale_factor.real
+        if inputs._under_complex_step:
+            self._scale_factor = self._scale_factor.astype(complex)
+        else:
+            self._scale_factor = self._scale_factor.real
 
         for name, options in self._output_vars.items():
             lhs = inputs[options['lhs_name']]
@@ -130,7 +130,6 @@ class EQConstraintComp(ExplicitComponent):
             # scale factor that normalizes by the rhs, except near 0
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero
-                # if len(rhs.shape) > 1:
                 idxs_nz = np.where(cs_safe.abs(rhs) < 2)
                 idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)
 

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -117,10 +117,10 @@ class EQConstraintComp(ExplicitComponent):
         outputs : Vector
             unscaled, dimensional output variables read via outputs[key]
         """
-        if inputs._under_complex_step:
-            self._scale_factor = self._scale_factor.astype(complex)
-        else:
-            self._scale_factor = self._scale_factor.real
+        # if inputs._under_complex_step:
+        #     self._scale_factor = self._scale_factor.astype(complex)
+        # else:
+        #     self._scale_factor = self._scale_factor.real
 
         for name, options in self._output_vars.items():
             lhs = inputs[options['lhs_name']]
@@ -130,9 +130,11 @@ class EQConstraintComp(ExplicitComponent):
             # scale factor that normalizes by the rhs, except near 0
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero
-                idxs_nz = np.where(cs_safe.abs(rhs) < 2)[0]
-                idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)[0]
+                # if len(rhs.shape) > 1:
+                idxs_nz = np.where(cs_safe.abs(rhs) < 2)
+                idxs_nnz = np.where(cs_safe.abs(rhs) >= 2)
 
+                self._scale_factor = np.ones((rhs.shape))
                 self._scale_factor[idxs_nnz] = 1.0 / cs_safe.abs(rhs[idxs_nnz])
                 self._scale_factor[idxs_nz] = 1.0 / (.25 * rhs[idxs_nz] ** 2 + 1)
             else:

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -855,5 +855,12 @@ class TestBalanceComp(unittest.TestCase):
         self.assertTrue(p.get_val('bal.rhs:x').shape == init.shape)
 
 
+    def test_multidimentional_shape_normalize(self):
+        prob = om.Problem()
+
+        bal = om.BalanceComp()
+        bal.add_balance('x', val=1.0, shape=(5,3))
+
+
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -854,8 +854,8 @@ class TestBalanceComp(unittest.TestCase):
         prob = om.Problem()
 
         bal = om.BalanceComp()
-        bal.add_balance('x', use_mult=True, shape=(5,3))
-        bal.add_balance('z', val=4*np.ones(5,), shape=(5,))
+        bal.add_balance('x', use_mult=True, shape=(5,3), normalize=True)
+        bal.add_balance('z', val=4*np.ones(5,), shape=(5,), normalize=True)
 
         exec_comp = om.ExecComp('y=x**2', x={'val': np.ones((5,3)), 'shape': (5,3)}, y={'val': np.ones((5,3)), 'shape': (5,3)})
         exec_comp2 = om.ExecComp('y=x**2', x={'val': np.ones((5,)), 'shape': (5,)}, y={'val': np.ones((5,)), 'shape': (5,)})
@@ -882,9 +882,37 @@ class TestBalanceComp(unittest.TestCase):
 
         prob.run_model()
 
-        cpd = prob.check_partials(out_stream=None)
+    def test_multidimentional_shape(self):
+        prob = om.Problem()
 
-        assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
+        bal = om.BalanceComp()
+        bal.add_balance('x', use_mult=True, shape=(5,3), normalize=False)
+        bal.add_balance('z', val=4*np.ones(5,), shape=(5,), normalize=False)
+
+        exec_comp = om.ExecComp('y=x**2', x={'val': np.ones((5,3)), 'shape': (5,3)}, y={'val': np.ones((5,3)), 'shape': (5,3)})
+        exec_comp2 = om.ExecComp('y=x**2', x={'val': np.ones((5,)), 'shape': (5,)}, y={'val': np.ones((5,)), 'shape': (5,)})
+
+        prob.model.add_subsystem(name='exec', subsys=exec_comp)
+        prob.model.add_subsystem(name='exec2', subsys=exec_comp2)
+        prob.model.add_subsystem(name='balance', subsys=bal)
+
+        prob.model.connect('balance.x', 'exec.x')
+        prob.model.connect('exec.y', 'balance.lhs:x')
+
+        prob.model.connect('balance.z', 'exec2.x')
+        prob.model.connect('exec2.y', 'balance.rhs:z')
+
+        prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
+        prob.model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False, maxiter=100, iprint=0)
+
+        prob.setup()
+
+        prob.set_val('balance.rhs:x', np.ones((5,3)))
+        prob.set_val('balance.mult:x', np.ones((5,3)))
+
+        prob['balance.x'] = 1.0
+
+        prob.run_model()
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -114,9 +114,6 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        # Assert that normalization is happening
-        assert_almost_equal(prob.model.balance._scale_factor, 1.0 / np.abs(2))
-
         cpd = prob.check_partials(out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
@@ -173,8 +170,6 @@ class TestBalanceComp(unittest.TestCase):
         prob.run_model()
 
         assert_almost_equal(prob['balance.x'], np.sqrt(1.5), decimal=7)
-
-        assert_almost_equal(prob.model.balance._scale_factor, 1.0)
 
         cpd = prob.check_partials(out_stream=None)
 

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -549,22 +549,22 @@ class TestEQConstraintComp(unittest.TestCase):
         defect_comp = model.add_subsystem('eq_comp', om.EQConstraintComp())
 
         defect_comp.add_eq_output(name='diff_r',
-                                    shape=(n, 3),
-                                    eq_units='km',
-                                    lhs_name='r1', rhs_name='r2',
-                                    use_mult=False,
-                                    normalize=True,
-                                    add_constraint=True,
-                                    ref=100.0, ref0=None, adder=None, scaler=None)
+                                  shape=(n, 3),
+                                  eq_units='km',
+                                  lhs_name='r1', rhs_name='r2',
+                                  use_mult=False,
+                                  normalize=True,
+                                  add_constraint=True,
+                                  ref=100.0, ref0=None, adder=None, scaler=None)
 
         defect_comp.add_eq_output(name='diff_k',
-                                    shape=(n,),
-                                    eq_units='km',
-                                    lhs_name='k1', rhs_name='k2',
-                                    use_mult=False,
-                                    normalize=True,
-                                    add_constraint=True,
-                                    ref=100.0, ref0=None, adder=None, scaler=None)
+                                  shape=(n,),
+                                  eq_units='km',
+                                  lhs_name='k1', rhs_name='k2',
+                                  use_mult=False,
+                                  normalize=True,
+                                  add_constraint=True,
+                                  ref=100.0, ref0=None, adder=None, scaler=None)
 
 
         prob.setup()

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -540,6 +540,43 @@ class TestEQConstraintComp(unittest.TestCase):
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
+    def test_multidimentional_shape(self):
+        prob = om.Problem()
+        model = prob.model
+
+        n = 15
+
+        defect_comp = model.add_subsystem('eq_comp', om.EQConstraintComp())
+
+        defect_comp.add_eq_output(name='diff_r',
+                                    shape=(n, 3),
+                                    eq_units='km',
+                                    lhs_name='r1', rhs_name='r2',
+                                    use_mult=False,
+                                    normalize=True,
+                                    add_constraint=True,
+                                    ref=100.0, ref0=None, adder=None, scaler=None)
+
+        defect_comp.add_eq_output(name='diff_k',
+                                    shape=(n,),
+                                    eq_units='km',
+                                    lhs_name='k1', rhs_name='k2',
+                                    use_mult=False,
+                                    normalize=True,
+                                    add_constraint=True,
+                                    ref=100.0, ref0=None, adder=None, scaler=None)
+
+
+        prob.setup()
+
+        prob.set_val('eq_comp.r1', np.random.rand(n, 3) * 10)
+        prob.set_val('eq_comp.r2', np.random.rand(n, 3) * 10)
+
+        prob.set_val('eq_comp.k1', np.random.rand(n) * 10)
+        prob.set_val('eq_comp.k2', np.random.rand(n) * 10)
+
+        prob.run_model()
+
 
 if __name__ == '__main__':  # pragma: no cover
     unittest.main()

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -540,7 +540,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
-    def test_multidimentional_shape(self):
+    def test_multidimentional_shape_normalize(self):
         prob = om.Problem()
         model = prob.model
 
@@ -563,6 +563,43 @@ class TestEQConstraintComp(unittest.TestCase):
                                   lhs_name='k1', rhs_name='k2',
                                   use_mult=False,
                                   normalize=True,
+                                  add_constraint=True,
+                                  ref=100.0, ref0=None, adder=None, scaler=None)
+
+
+        prob.setup()
+
+        prob.set_val('eq_comp.r1', np.random.rand(n, 3) * 10)
+        prob.set_val('eq_comp.r2', np.random.rand(n, 3) * 10)
+
+        prob.set_val('eq_comp.k1', np.random.rand(n) * 10)
+        prob.set_val('eq_comp.k2', np.random.rand(n) * 10)
+
+        prob.run_model()
+
+    def test_multidimentional_shape(self):
+        prob = om.Problem()
+        model = prob.model
+
+        n = 15
+
+        defect_comp = model.add_subsystem('eq_comp', om.EQConstraintComp())
+
+        defect_comp.add_eq_output(name='diff_r',
+                                  shape=(n, 3),
+                                  eq_units='km',
+                                  lhs_name='r1', rhs_name='r2',
+                                  use_mult=False,
+                                  normalize=False,
+                                  add_constraint=True,
+                                  ref=100.0, ref0=None, adder=None, scaler=None)
+
+        defect_comp.add_eq_output(name='diff_k',
+                                  shape=(n,),
+                                  eq_units='km',
+                                  lhs_name='k1', rhs_name='k2',
+                                  use_mult=False,
+                                  normalize=False,
                                   add_constraint=True,
                                   ref=100.0, ref0=None, adder=None, scaler=None)
 


### PR DESCRIPTION
### Summary

Added support for multidimensional shapes when using `add_constraint` with `EQConstraintComp` or `add_balance` with `BalanceComp`. This applies when using/not using the `normalize` arg

### Related Issues

- Resolves #2175

### Backwards incompatibilities

None

### New Dependencies

None
