### PR TITLE
fix bug when getting value for input connected with a src_indces slice.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4574,7 +4574,12 @@ class System(object):
             else:
                 if is_slice:
                     val.shape = src_shape
-                    val = val[tuple(src_indices)].ravel()
+                    try:
+                        val = val[tuple(src_indices)].ravel()
+                    except TypeError:
+                        # Single-dimension slices don't convert to tuple, but they don't need to.
+                        val = val[src_indices].ravel()
+
                 elif distrib and (sdistrib or dynshape or not slocal) and not get_remote:
                     var_idx = self._var_allprocs_abs2idx[src]
                     # sizes for src var in each proc

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1028,6 +1028,22 @@ class TestGroup(unittest.TestCase):
         assert_near_equal(p['row134_comp.x'], arr_large_4x4[(0, 2, 3), ...])
         assert_near_equal(p['row134_comp.y'], np.sum(arr_large_4x4[(0, 2, 3), ...])**2)
 
+    def test_om_slice_get_val(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('c1', om.ExecComp('y=x', x=np.ones(2), y=np.ones(2)))
+        model.add_subsystem('c2', om.ExecComp('y=x', x=np.ones(2), y=np.ones(2)))
+
+        model.connect('c1.y', 'c2.x', om.slicer[:])
+
+        prob.setup()
+        prob.set_val('c1.x', 3.5*np.ones(2))
+        prob.run_model()
+
+        val = prob.get_val('c2.x')
+        assert_near_equal(val, np.array([3.5, 3.5]))
+
     def test_promote_not_found1(self):
         p = om.Problem()
         p.model.add_subsystem('indep', om.IndepVarComp('x', np.ones(5)),


### PR DESCRIPTION
### Summary

Fix bug where an exception was raised if you tried to get a value for an input that was connected to a source with a src_indces slice.

### Related Issues

- Resolves #2216 

### Backwards incompatibilities

None

### New Dependencies

None
