### PR TITLE
Use shift-click to close all persistent Node Info windows

### DIFF
--- a/openmdao/visualization/n2_viewer/src/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/src/NodeInfo.js
@@ -641,9 +641,10 @@ class PersistentNodeInfo extends N2WindowDraggable {
     /** Override so that shift-click closes all PersistentNodeInfo windows. */
     close() {
         this.tooltipBox.style("visibility", "hidden");
+        window.getSelection().empty(); // Shift-clicking also selects text, so unselect it
 
         if (d3.event.shiftKey) {
-            const allPNIWin = d3.selectAll('[id^="persistentNodeInfo-"]')
+            const allPNIWin = d3.selectAll('[id^="persistentNodeInfo-"]');
 
             allPNIWin.select('.window-close-button')
                 .on('click', null)

--- a/openmdao/visualization/n2_viewer/src/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/src/NodeInfo.js
@@ -579,6 +579,30 @@ class PersistentNodeInfo extends N2WindowDraggable {
             ._setupCopyButtons()
             .showCloseButton()
             .show();
+
+        this.tooltipBox = d3.select(".tool-tip");
+        this.closeButton
+            .on("mouseover", this.mouseOver.bind(this))
+            .on("mouseleave", this.mouseLeave.bind(this))
+            .on("mousemove", this.mouseMove.bind(this));
+    }
+
+    /** When the mouse enters the element, show the tool tip */
+    mouseOver() {
+        this.tooltipBox
+            .text('Shift-click to close all.')
+            .style("visibility", "visible");
+    }
+
+    /** When the mouse leaves the element, hide the tool tip */
+    mouseLeave() {
+        this.tooltipBox.style("visibility", "hidden");
+    }
+
+    /** Keep the tool-tip near the mouse */
+    mouseMove() {
+        this.tooltipBox.style("top", (d3.event.pageY - 30) + "px")
+            .style("left", (d3.event.pageX + 5) + "px");
     }
 
     /** Set up event handlers for any "Show More" buttons in the panel */
@@ -612,5 +636,28 @@ class PersistentNodeInfo extends N2WindowDraggable {
         }
 
         return this;
+    }
+
+    /** Override so that shift-click closes all PersistentNodeInfo windows. */
+    close() {
+        this.tooltipBox.style("visibility", "hidden");
+
+        if (d3.event.shiftKey) {
+            const allPNIWin = d3.selectAll('[id^="persistentNodeInfo-"]')
+
+            allPNIWin.select('.window-close-button')
+                .on('click', null)
+                .on("mouseover", null)
+                .on("mouseleave", null)
+                .on("mousemove", null);
+            allPNIWin.remove();
+        }
+        else {
+            this.closeButton
+                .on("mouseover", null)
+                .on("mouseleave", null)
+                .on("mousemove", null);
+            super.close();
+        }
     }
 }

--- a/openmdao/visualization/n2_viewer/style/partition_tree.css
+++ b/openmdao/visualization/n2_viewer/style/partition_tree.css
@@ -194,6 +194,8 @@ body {
     padding: 5;
     background-color: #fff;
     border: solid 1px #dfdfdf;
+    transition: visibility 0s ease 0.75s;
+    -webkit-transition: visibility 0s ease 0.75s;
 }
 
 div.offgrid {

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -479,6 +479,82 @@ n2_gui_test_scripts = {
             "selector": '[id^="persistentNodeInfo"] span.window-close-button',
             "button": "left"
         },
+        # Begin multi-window close test
+        {
+            "desc": "Hover to bring up Node Info window for p1.A",
+            "test": "hover",
+            "selector": "#p1_A",
+        },
+        {
+            "desc": "Click p1.A to make Node Info window persistent",
+            "test": "click",
+            "selector": "#p1_A",
+            "button": "left"
+        },
+        {
+            "desc": "Hover to bring up Node Info window for p2.b",
+            "test": "hover",
+            "selector": "#p2_b",
+        },
+        {
+            "desc": "Click p2.b to make Node Info window persistent",
+            "test": "click",
+            "selector": "#p2_b",
+            "button": "left"
+        },
+        {
+            "desc": "Hover to bring up Node Info window for lingrp.lin.A",
+            "test": "hover",
+            "selector": "#lingrp_lin_A",
+        },
+        {
+            "desc": "Click lingrp.lin.A to make Node Info window persistent",
+            "test": "click",
+            "selector": "#lingrp_lin_A",
+            "button": "left"
+        },
+        {
+            "desc": "Hover to bring up Node Info window for lingrp.lin.b",
+            "test": "hover",
+            "selector": "#lingrp_lin_b",
+        },
+        {
+            "desc": "Click lingrp.lin.b to make Node Info window persistent",
+            "test": "click",
+            "selector": "#lingrp_lin_b",
+            "button": "left"
+        },
+        {
+            "desc": "Hover to bring up Node Info window for lingrp.lin.x",
+            "test": "hover",
+            "selector": "#lingrp_lin_x",
+        },
+        {
+            "desc": "Click lingrp.lin.x to make Node Info window persistent",
+            "test": "click",
+            "selector": "#lingrp_lin_x",
+            "button": "left"
+        },
+        {
+            "desc": "Check for 5 open persistent Node Info windows",
+            "test": "count",
+            "selector": "[id^='persistentNodeInfo']",
+            "count": 5
+        },
+        {
+            "desc": "Close All Node Info windows",
+            "test": "click",
+            "selector": '[id^="persistentNodeInfo"] span.window-close-button',
+            "button": "left",
+            "modifiers": ["Shift"]
+        },
+        {
+            "desc": "Check for 0 open persistent Node Info windows",
+            "test": "count",
+            "selector": "[id^='persistentNodeInfo']",
+            "count": 0
+        },
+        # End multi-window close test
         {
             "desc": "Turn off Node Info mode",
             "test": "click",
@@ -692,7 +768,9 @@ class n2_gui_test_case(unittest.TestCase):
                       options['selector'] + "'")
 
         hndl = await self.get_handle(options['selector'])
-        await hndl.click(button=options['button'])
+
+        mod_keys = [] if 'modifiers' not in options else options['modifiers']
+        await hndl.click(button=options['button'], modifiers=mod_keys)
 
     async def drag(self, options):
         """


### PR DESCRIPTION
With multiple Node Info windows open, it's now possible to close them all at once by shift-clicking on any of their close buttons. A tool tip appears with this info when the close button is hovered over. There's also a GUI test that opens 5 windows and closes them with shift-click.

### Related Issues

- Resolves #1881 

### Backwards incompatibilities

None

### New Dependencies

None
