### PR TITLE
I2219 refactor playwright code to enable re-use with other GUI testing

### DIFF
--- a/openmdao/utils/gui_testing_utils.py
+++ b/openmdao/utils/gui_testing_utils.py
@@ -1,10 +1,21 @@
 """Define utils for use in testing GUIs with Playwright."""
 import unittest
 
+
 class gui_test_case(unittest.TestCase):
+    """
+    Class that can be inherited from and used for GUI tests using Playwright.
+    """
 
     def handle_console_err(self, msg):
-        """ Invoked any time that an error or warning appears in the log. """
+        """
+        Invoke any time that an error or warning appears in the log.
+
+        Parameters
+        ----------
+        msg : string
+            message string from console.
+        """
         if msg.type == 'warning':
             self.console_warning = True
             print('    Console Warning: ' + msg.text)
@@ -13,15 +24,34 @@ class gui_test_case(unittest.TestCase):
             print('    Console Error: ' + msg.text)
 
     def handle_page_err(self, msg):
+        """
+        Invoke any time there is a page error.
+
+        Parameters
+        ----------
+        msg : string
+            error message string.
+        """
         self.page_error = True
         print('    Error on page: ', msg)
         print(type(msg))
 
     def handle_request_err(self, msg):
+        """
+        Invoke any time there is a request error.
+
+        Parameters
+        ----------
+        msg : string
+            error message string.
+        """
         self.page_error = True
         print('    Request error: ', msg)
 
     def setup_error_handlers(self):
+        """
+        Set up the error handlers.
+        """
         self.console_warning = False
         self.console_error = False
         self.page_error = False
@@ -31,7 +61,14 @@ class gui_test_case(unittest.TestCase):
         self.page.on('requestfailed', lambda msg: self.handle_request_err(msg))
 
     async def setup_browser(self, playwright):
-        """ Create a browser instance and print user agent info. """
+        """
+        Create a browser instance and print user agent info.
+
+        Parameters
+        ----------
+        playwright : class playwright.async_api._generated.Playwright
+            main playwright class.
+        """
         self.browser = await playwright.chromium.launch(args=['--start-fullscreen'])
         self.page = await self.browser.new_page()
 
@@ -39,10 +76,25 @@ class gui_test_case(unittest.TestCase):
         self.setup_error_handlers()
 
     def log_test(self, msg):
+        """
+        Log a test message.
+
+        Parameters
+        ----------
+        msg : string
+            text to log.
+        """
         print(msg)
 
     async def get_handle(self, selector):
-        """ Get handle for a specific element and assert that it exists. """
+        """
+        Get handle for a specific element and assert that it exists.
+
+        Parameters
+        ----------
+        selector : string
+            selector used to locate the element.
+        """
         handle = await self.page.wait_for_selector(selector, state='attached', timeout=3055)
 
         self.assertIsNotNone(handle,
@@ -50,4 +102,3 @@ class gui_test_case(unittest.TestCase):
                              selector + "' in the N2 diagram.")
 
         return handle
-

--- a/openmdao/utils/gui_testing_utils.py
+++ b/openmdao/utils/gui_testing_utils.py
@@ -1,0 +1,166 @@
+"""Define utils for use in testing GUIs with Playwright."""
+import unittest
+
+import asyncio
+# from playwright.async_api import async_playwright
+
+current_test = 1
+
+
+class gui_test_case(unittest.TestCase):
+
+    def handle_console_err(self, msg):
+        """ Invoked any time that an error or warning appears in the log. """
+        if msg.type == 'warning':
+            self.console_warning = True
+            print('    Console Warning: ' + msg.text)
+        elif msg.type == 'error':
+            self.console_error = True
+            print('    Console Error: ' + msg.text)
+
+    def handle_page_err(self, msg):
+        self.page_error = True
+        print('    Error on page: ', msg)
+        print(type(msg))
+
+    def handle_request_err(self, msg):
+        self.page_error = True
+        print('    Request error: ', msg)
+
+    def setup_error_handlers(self):
+        self.console_warning = False
+        self.console_error = False
+        self.page_error = False
+
+        self.page.on('console', lambda msg: self.handle_console_err(msg))
+        self.page.on('pageerror', lambda msg: self.handle_page_err(msg))
+        self.page.on('requestfailed', lambda msg: self.handle_request_err(msg))
+
+    async def setup_browser(self, playwright):
+        """ Create a browser instance and print user agent info. """
+        self.browser = await playwright.chromium.launch(args=['--start-fullscreen'])
+        self.page = await self.browser.new_page()
+
+        await self.page.bring_to_front()
+        self.setup_error_handlers()
+
+    def log_test(self, msg):
+        global current_test
+
+        """ Print a description and index for the test about to run. """
+        print("  Test {:04}".format(current_test) + ": " + msg)
+        current_test += 1
+
+    async def assert_element_count(self, selector, expected_found):
+        """
+        Count the number of elements located by the selector and make
+        sure it exactly matches the supplied value. Try several times
+        because sometimes transition animations throw things off.
+        """
+        max_tries = 3  # Max number of times to attempt to find a selector
+        max_time = 2000  # The timeout in ms for each search
+
+        if (expected_found > 0):
+            num_tries = 0
+            found = False
+            while (not found and num_tries < max_tries):
+                nth_selector = f':nth-match({selector}, {expected_found})'
+                try:
+                    await self.page.wait_for_selector(nth_selector, state='attached',
+                                                      timeout=max_time)
+                    found = True
+                except:
+                    num_tries += 1
+
+            num_tries = 0
+            found = False
+            while (not found and num_tries < max_tries):
+                nth_selector = f':nth-match({selector}, {expected_found + 1})'
+                try:
+                    await self.page.wait_for_selector(nth_selector, state='detached',
+                                                      timeout=max_time)
+                    found = True
+                except:
+                    num_tries += 1
+
+        else:
+            num_tries = 0
+            found = False
+            while (not found and num_tries < max_tries):
+                nth_selector = f':nth-match({selector}, 1)'
+                try:
+                    await self.page.wait_for_selector(nth_selector, state='detached',
+                                                      timeout=max_time)
+                    found = True
+                except:
+                    num_tries += 1
+
+        hndl_list = await self.page.query_selector_all(selector)
+        if (len(hndl_list) > expected_found):
+            global current_test
+            await self.page.screenshot(path=f'shot_{current_test}.png')
+
+        self.assertEqual(len(hndl_list), expected_found,
+                         'Found ' + str(len(hndl_list)) +
+                         ' elements, expected ' + str(expected_found))
+
+    async def get_handle(self, selector):
+        """ Get handle for a specific element and assert that it exists. """
+        handle = await self.page.wait_for_selector(selector, state='attached', timeout=3055)
+
+        self.assertIsNotNone(handle,
+                             "Could not find element with selector '" +
+                             selector + "' in the N2 diagram.")
+
+        return handle
+
+    async def hover(self, options, log_test=True):
+        """
+        Hover over the specified element.
+        """
+        if log_test:
+            self.log_test(options['desc'] if 'desc' in options else
+                          "Hover over '" + options['selector'] + "'")
+
+        hndl = await self.get_handle(options['selector'])
+
+        await hndl.hover(force=False)
+
+    async def click(self, options):
+        """
+        Perform a click of the type specified by options.button on the
+        element specified by options.selector.
+        """
+        self.log_test(options['desc'] if 'desc' in options else
+                      options['button'] + "-click on '" +
+                      options['selector'] + "'")
+
+        hndl = await self.get_handle(options['selector'])
+        await hndl.click(button=options['button'])
+
+    async def drag(self, options):
+        """
+        Hover over the element, perform a mousedown event, move the mouse to the
+        specified location, and perform a mouseup. Check to make sure the element
+        moved in at least one direction.
+        """
+        self.log_test(options['desc'] if 'desc' in options else
+                      "Dragging '" + options['selector'] + "' to " + options['x'] + "," + options[
+                          'y'])
+
+        hndl = await self.get_handle(options['selector'])
+
+        pre_drag_bbox = await hndl.bounding_box()
+
+        await hndl.hover(force=True)
+        await self.page.mouse.down()
+        await self.page.mouse.move(options['x'], options['y'])
+        await self.page.mouse.up()
+
+        post_drag_bbox = await hndl.bounding_box()
+
+        moved = ((pre_drag_bbox['x'] != post_drag_bbox['x']) or
+                 (pre_drag_bbox['y'] != post_drag_bbox['y']))
+
+        self.assertIsNot(moved, False,
+                         "The '" + options['selector'] + "' element did not move.")

--- a/openmdao/utils/gui_testing_utils.py
+++ b/openmdao/utils/gui_testing_utils.py
@@ -1,8 +1,9 @@
 """Define utils for use in testing GUIs with Playwright."""
+
 import unittest
 
 
-class gui_test_case(unittest.TestCase):
+class _GuiTestCase(unittest.TestCase):
     """
     Class that can be inherited from and used for GUI tests using Playwright.
     """
@@ -51,6 +52,7 @@ class gui_test_case(unittest.TestCase):
     def setup_error_handlers(self):
         """
         Set up the error handlers.
+
         """
         self.console_warning = False
         self.console_error = False

--- a/openmdao/utils/gui_testing_utils.py
+++ b/openmdao/utils/gui_testing_utils.py
@@ -1,12 +1,6 @@
 """Define utils for use in testing GUIs with Playwright."""
 import unittest
 
-import asyncio
-# from playwright.async_api import async_playwright
-
-current_test = 1
-
-
 class gui_test_case(unittest.TestCase):
 
     def handle_console_err(self, msg):
@@ -45,64 +39,7 @@ class gui_test_case(unittest.TestCase):
         self.setup_error_handlers()
 
     def log_test(self, msg):
-        global current_test
-
-        """ Print a description and index for the test about to run. """
-        print("  Test {:04}".format(current_test) + ": " + msg)
-        current_test += 1
-
-    async def assert_element_count(self, selector, expected_found):
-        """
-        Count the number of elements located by the selector and make
-        sure it exactly matches the supplied value. Try several times
-        because sometimes transition animations throw things off.
-        """
-        max_tries = 3  # Max number of times to attempt to find a selector
-        max_time = 2000  # The timeout in ms for each search
-
-        if (expected_found > 0):
-            num_tries = 0
-            found = False
-            while (not found and num_tries < max_tries):
-                nth_selector = f':nth-match({selector}, {expected_found})'
-                try:
-                    await self.page.wait_for_selector(nth_selector, state='attached',
-                                                      timeout=max_time)
-                    found = True
-                except:
-                    num_tries += 1
-
-            num_tries = 0
-            found = False
-            while (not found and num_tries < max_tries):
-                nth_selector = f':nth-match({selector}, {expected_found + 1})'
-                try:
-                    await self.page.wait_for_selector(nth_selector, state='detached',
-                                                      timeout=max_time)
-                    found = True
-                except:
-                    num_tries += 1
-
-        else:
-            num_tries = 0
-            found = False
-            while (not found and num_tries < max_tries):
-                nth_selector = f':nth-match({selector}, 1)'
-                try:
-                    await self.page.wait_for_selector(nth_selector, state='detached',
-                                                      timeout=max_time)
-                    found = True
-                except:
-                    num_tries += 1
-
-        hndl_list = await self.page.query_selector_all(selector)
-        if (len(hndl_list) > expected_found):
-            global current_test
-            await self.page.screenshot(path=f'shot_{current_test}.png')
-
-        self.assertEqual(len(hndl_list), expected_found,
-                         'Found ' + str(len(hndl_list)) +
-                         ' elements, expected ' + str(expected_found))
+        print(msg)
 
     async def get_handle(self, selector):
         """ Get handle for a specific element and assert that it exists. """
@@ -114,53 +51,3 @@ class gui_test_case(unittest.TestCase):
 
         return handle
 
-    async def hover(self, options, log_test=True):
-        """
-        Hover over the specified element.
-        """
-        if log_test:
-            self.log_test(options['desc'] if 'desc' in options else
-                          "Hover over '" + options['selector'] + "'")
-
-        hndl = await self.get_handle(options['selector'])
-
-        await hndl.hover(force=False)
-
-    async def click(self, options):
-        """
-        Perform a click of the type specified by options.button on the
-        element specified by options.selector.
-        """
-        self.log_test(options['desc'] if 'desc' in options else
-                      options['button'] + "-click on '" +
-                      options['selector'] + "'")
-
-        hndl = await self.get_handle(options['selector'])
-        await hndl.click(button=options['button'])
-
-    async def drag(self, options):
-        """
-        Hover over the element, perform a mousedown event, move the mouse to the
-        specified location, and perform a mouseup. Check to make sure the element
-        moved in at least one direction.
-        """
-        self.log_test(options['desc'] if 'desc' in options else
-                      "Dragging '" + options['selector'] + "' to " + options['x'] + "," + options[
-                          'y'])
-
-        hndl = await self.get_handle(options['selector'])
-
-        pre_drag_bbox = await hndl.bounding_box()
-
-        await hndl.hover(force=True)
-        await self.page.mouse.down()
-        await self.page.mouse.move(options['x'], options['y'])
-        await self.page.mouse.up()
-
-        post_drag_bbox = await hndl.bounding_box()
-
-        moved = ((pre_drag_bbox['x'] != post_drag_bbox['x']) or
-                 (pre_drag_bbox['y'] != post_drag_bbox['y']))
-
-        self.assertIsNot(moved, False,
-                         "The '" + options['selector'] + "' element did not move.")

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -2,7 +2,6 @@
 import asyncio
 from playwright.async_api import async_playwright
 import subprocess
-# import unittest
 from aiounittest import async_test
 import os
 import sys
@@ -512,6 +511,13 @@ from openmdao.utils.gui_testing_utils import gui_test_case
 
 class n2_gui_test_case(gui_test_case):
 
+    def log_test(self, msg):
+        global current_test
+
+        """ Print a description and index for the test about to run. """
+        print("  Test {:04}".format(current_test) + ": " + msg)
+        current_test += 1
+
     def generate_n2_file(self):
         """ Generate N2 HTML files from all models in GUI_TEST_SUBDIR. """
         self.parentDir = os.path.dirname(os.path.realpath(__file__))
@@ -550,12 +556,77 @@ class n2_gui_test_case(gui_test_case):
 
         await self.page.reload(wait_until='networkidle')
 
+    async def assert_element_count(self, selector, expected_found):
+        """
+        Count the number of elements located by the selector and make
+        sure it exactly matches the supplied value. Try several times
+        because sometimes transition animations throw things off.
+        """
+        max_tries = 3  # Max number of times to attempt to find a selector
+        max_time = 2000  # The timeout in ms for each search
+
+        if (expected_found > 0):
+            num_tries = 0
+            found = False
+            while (not found and num_tries < max_tries):
+                nth_selector = f':nth-match({selector}, {expected_found})'
+                try:
+                    await self.page.wait_for_selector(nth_selector, state='attached',
+                                                      timeout=max_time)
+                    found = True
+                except:
+                    num_tries += 1
+
+            num_tries = 0
+            found = False
+            while (not found and num_tries < max_tries):
+                nth_selector = f':nth-match({selector}, {expected_found + 1})'
+                try:
+                    await self.page.wait_for_selector(nth_selector, state='detached',
+                                                      timeout=max_time)
+                    found = True
+                except:
+                    num_tries += 1
+
+        else:
+            num_tries = 0
+            found = False
+            while (not found and num_tries < max_tries):
+                nth_selector = f':nth-match({selector}, 1)'
+                try:
+                    await self.page.wait_for_selector(nth_selector, state='detached',
+                                                      timeout=max_time)
+                    found = True
+                except:
+                    num_tries += 1
+
+        hndl_list = await self.page.query_selector_all(selector)
+        if (len(hndl_list) > expected_found):
+            global current_test
+            await self.page.screenshot(path=f'shot_{current_test}.png')
+
+        self.assertEqual(len(hndl_list), expected_found,
+                         'Found ' + str(len(hndl_list)) +
+                         ' elements, expected ' + str(expected_found))
+
     async def assert_arrow_count(self, expected_arrows):
         """
         Count the number of path elements in the n2arrows < div > and make
         sure it matches the specified value.
         """
         await self.assert_element_count('g#n2arrows > g', expected_arrows)
+
+    async def hover(self, options, log_test=True):
+        """
+        Hover over the specified element.
+        """
+        if log_test:
+            self.log_test(options['desc'] if 'desc' in options else
+                          "Hover over '" + options['selector'] + "'")
+
+        hndl = await self.get_handle(options['selector'])
+
+        await hndl.hover(force=False)
 
     async def hover_and_check_arrow_count(self, options):
         """
@@ -568,6 +639,44 @@ class n2_gui_test_case(gui_test_case):
         await self.assert_arrow_count(options['arrowCount'])
         await self.page.mouse.move(0, 0)  # Get the mouse off the element
         await self.assert_arrow_count(0)  # Make sure no arrows left
+
+    async def click(self, options):
+        """
+        Perform a click of the type specified by options.button on the
+        element specified by options.selector.
+        """
+        self.log_test(options['desc'] if 'desc' in options else
+                      options['button'] + "-click on '" +
+                      options['selector'] + "'")
+
+        hndl = await self.get_handle(options['selector'])
+        await hndl.click(button=options['button'])
+
+    async def drag(self, options):
+        """
+        Hover over the element, perform a mousedown event, move the mouse to the
+        specified location, and perform a mouseup. Check to make sure the element
+        moved in at least one direction.
+        """
+        self.log_test(options['desc'] if 'desc' in options else
+                      "Dragging '" + options['selector'] + "' to " + options['x'] + "," + options['y'])
+
+        hndl = await self.get_handle(options['selector'])
+
+        pre_drag_bbox = await hndl.bounding_box()
+
+        await hndl.hover(force=True)
+        await self.page.mouse.down()
+        await self.page.mouse.move(options['x'], options['y'])
+        await self.page.mouse.up()
+
+        post_drag_bbox = await hndl.bounding_box()
+
+        moved = ((pre_drag_bbox['x'] != post_drag_bbox['x']) or
+                 (pre_drag_bbox['y'] != post_drag_bbox['y']))
+
+        self.assertIsNot(moved, False,
+                         "The '" + options['selector'] + "' element did not move.")
 
     async def resize_window(self, options):
         """

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -2,7 +2,7 @@
 import asyncio
 from playwright.async_api import async_playwright
 import subprocess
-import unittest
+# import unittest
 from aiounittest import async_test
 import os
 import sys
@@ -508,50 +508,9 @@ n2_gui_test_scripts = {
 
 n2_gui_test_models = n2_gui_test_scripts.keys()
 
+from openmdao.utils.gui_testing_utils import gui_test_case
 
-class n2_gui_test_case(unittest.TestCase):
-
-    def handle_console_err(self, msg):
-        """ Invoked any time that an error or warning appears in the log. """
-        if msg.type == 'warning':
-            self.console_warning = True
-            print('    Console Warning: ' + msg.text)
-        elif msg.type == 'error':
-            self.console_error = True
-            print('    Console Error: ' + msg.text)
-
-    def handle_page_err(self, msg):
-        self.page_error = True
-        print('    Error on page: ', msg)
-        print(type(msg))
-
-    def handle_request_err(self, msg):
-        self.page_error = True
-        print('    Request error: ', msg)
-
-    def setup_error_handlers(self):
-        self.console_warning = False
-        self.console_error = False
-        self.page_error = False
-
-        self.page.on('console', lambda msg: self.handle_console_err(msg))
-        self.page.on('pageerror', lambda msg: self.handle_page_err(msg))
-        self.page.on('requestfailed', lambda msg: self.handle_request_err(msg))
-
-    async def setup_browser(self, playwright):
-        """ Create a browser instance and print user agent info. """
-        self.browser = await playwright.chromium.launch(args = ['--start-fullscreen'])
-        self.page = await self.browser.new_page()
-    
-        await self.page.bring_to_front()
-        self.setup_error_handlers()
-
-    def log_test(self, msg):
-        global current_test
-
-        """ Print a description and index for the test about to run. """
-        print("  Test {:04}".format(current_test) + ": " + msg)
-        current_test += 1
+class n2_gui_test_case(gui_test_case):
 
     def generate_n2_file(self):
         """ Generate N2 HTML files from all models in GUI_TEST_SUBDIR. """
@@ -591,84 +550,12 @@ class n2_gui_test_case(unittest.TestCase):
 
         await self.page.reload(wait_until='networkidle')
 
-    async def assert_element_count(self, selector, expected_found):
-        """
-        Count the number of elements located by the selector and make
-        sure it exactly matches the supplied value. Try several times
-        because sometimes transition animations throw things off.
-        """
-        max_tries = 3 # Max number of times to attempt to find a selector
-        max_time = 2000 # The timeout in ms for each search
-
-        if (expected_found > 0):
-            num_tries = 0
-            found = False
-            while (not found and num_tries < max_tries):
-                nth_selector = f':nth-match({selector}, {expected_found})'
-                try:
-                    await self.page.wait_for_selector(nth_selector, state='attached', timeout=max_time)
-                    found = True
-                except:
-                    num_tries += 1
-            
-            num_tries = 0
-            found = False
-            while (not found and num_tries < max_tries):
-                    nth_selector = f':nth-match({selector}, {expected_found+1})'
-                    try:          
-                        await self.page.wait_for_selector(nth_selector, state='detached', timeout=max_time)
-                        found = True
-                    except:
-                        num_tries += 1
-
-        else:
-            num_tries = 0
-            found = False
-            while (not found and num_tries < max_tries):
-                nth_selector = f':nth-match({selector}, 1)'
-                try:
-                    await self.page.wait_for_selector(nth_selector, state='detached', timeout=max_time)
-                    found = True
-                except:
-                        num_tries += 1
-    
-        hndl_list = await self.page.query_selector_all(selector)
-        if (len(hndl_list) > expected_found):
-            global current_test
-            await self.page.screenshot(path=f'shot_{current_test}.png')
-
-        self.assertEqual(len(hndl_list), expected_found,
-                         'Found ' + str(len(hndl_list)) +
-                         ' elements, expected ' + str(expected_found))
-
     async def assert_arrow_count(self, expected_arrows):
         """
         Count the number of path elements in the n2arrows < div > and make
         sure it matches the specified value.
         """
         await self.assert_element_count('g#n2arrows > g', expected_arrows)
-
-    async def get_handle(self, selector):
-        """ Get handle for a specific element and assert that it exists. """
-        handle = await self.page.wait_for_selector(selector, state='attached', timeout=3055)
-
-        self.assertIsNotNone(handle,
-                             "Could not find element with selector '" +
-                             selector + "' in the N2 diagram.")
-
-        return handle
-
-    async def hover(self, options, log_test=True):
-        """
-        Hover over the specified element.
-        """
-        if log_test:
-            self.log_test(options['desc'] if 'desc' in options else
-                          "Hover over '" + options['selector'] + "'")
-
-        hndl = await self.get_handle(options['selector'])
-
-        await hndl.hover(force=False)
 
     async def hover_and_check_arrow_count(self, options):
         """
@@ -681,44 +568,6 @@ class n2_gui_test_case(unittest.TestCase):
         await self.assert_arrow_count(options['arrowCount'])
         await self.page.mouse.move(0, 0)  # Get the mouse off the element
         await self.assert_arrow_count(0)  # Make sure no arrows left
-
-    async def click(self, options):
-        """
-        Perform a click of the type specified by options.button on the
-        element specified by options.selector.
-        """
-        self.log_test(options['desc'] if 'desc' in options else
-                      options['button'] + "-click on '" +
-                      options['selector'] + "'")
-
-        hndl = await self.get_handle(options['selector'])
-        await hndl.click(button=options['button'])
-
-    async def drag(self, options):
-        """
-        Hover over the element, perform a mousedown event, move the mouse to the
-        specified location, and perform a mouseup. Check to make sure the element
-        moved in at least one direction.
-        """
-        self.log_test(options['desc'] if 'desc' in options else
-                      "Dragging '" + options['selector'] + "' to " + options['x'] + "," + options['y'])
-
-        hndl = await self.get_handle(options['selector'])
-
-        pre_drag_bbox = await hndl.bounding_box()
-
-        await hndl.hover(force=True)
-        await self.page.mouse.down()
-        await self.page.mouse.move(options['x'], options['y'])
-        await self.page.mouse.up()
-
-        post_drag_bbox = await hndl.bounding_box()
-
-        moved = ((pre_drag_bbox['x'] != post_drag_bbox['x']) or
-                 (pre_drag_bbox['y'] != post_drag_bbox['y']))
-
-        self.assertIsNot(moved, False,
-                         "The '" + options['selector'] + "' element did not move.")
 
     async def resize_window(self, options):
         """

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -6,6 +6,8 @@ from aiounittest import async_test
 import os
 import sys
 
+from openmdao.utils.gui_testing_utils import _GuiTestCase
+
 try:
     from parameterized import parameterized
 except ImportError:
@@ -507,9 +509,8 @@ n2_gui_test_scripts = {
 
 n2_gui_test_models = n2_gui_test_scripts.keys()
 
-from openmdao.utils.gui_testing_utils import gui_test_case
 
-class n2_gui_test_case(gui_test_case):
+class n2_gui_test_case(_GuiTestCase):
 
     def log_test(self, msg):
         global current_test
@@ -543,7 +544,7 @@ class n2_gui_test_case(gui_test_case):
 
         # Without wait_until: 'networkidle', processing will begin before
         # the page is fully rendered
-        await self.page.goto(url, wait_until = 'networkidle')
+        await self.page.goto(url, wait_until='networkidle')
 
     async def generic_toolbar_tests(self):
         """ Click most of the toolbar buttons to see if an error occurs """


### PR DESCRIPTION
### Summary

The existing code in the N2 GUI testing code couldn't be re-used for other GUI testing applications  in OpenMDAO. This PR creates a class that can be inherited and re-used in other GUI testing applications.

Also fixed some PEP errors.

### Related Issues

- Resolves #2219 

### Backwards incompatibilities

None

### New Dependencies

None
