### PR TITLE
Fix a bug in the interpolation bracketing algorithm that caused a hysteresis in the analytic derivative when interpolating on one of the table's gridpoints.

### DIFF
--- a/openmdao/components/interp_util/interp_algorithm.py
+++ b/openmdao/components/interp_util/interp_algorithm.py
@@ -125,7 +125,7 @@ class InterpAlgorithm(object):
         highbound = len(grid) - 1
         inc = 1
 
-        while x < grid[last_index]:
+        while x <= grid[last_index]:
             high = last_index
             last_index -= inc
             if last_index < 0:

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -805,6 +805,30 @@ class TestInterpNDPython(unittest.TestCase):
         msg = "Either 'values' or 'x_interp' must be specified."
         self.assertTrue(str(cm.exception).startswith(msg))
 
+    def test_derivative_hysteresis_bug(self):
+        alt = np.array([-1000, 0, 1000], dtype=float)
+        rho = np.array([0.00244752, 0.00237717, 0.00230839])
+
+        rho_interp = InterpND(method='slinear', points=alt, values=rho, extrapolate=True)
+
+        x = 0.0
+        _, dval1 = rho_interp.interpolate([x], compute_derivative=True)
+
+        x = 0.5
+        _, dval2 = rho_interp.interpolate([x], compute_derivative=True)
+
+        x = 0.0
+        _, dval3 = rho_interp.interpolate([x], compute_derivative=True)
+
+        x = -0.5
+        _, dval4 = rho_interp.interpolate([x], compute_derivative=True)
+
+        x = 0.0
+        _, dval5 = rho_interp.interpolate([x], compute_derivative=True)
+
+        assert_near_equal(dval3 - dval1, np.array([[0.0]]))
+        assert_near_equal(dval5 - dval1, np.array([[0.0]]))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -261,9 +261,6 @@ class _CheckingJacobian(DictionaryJacobian):
                     arr[:] = column[start:end]
                     arr[row_inds] = 0.
                     nzs = np.nonzero(arr)
-                    print(key, arr, start, end)
-                    print(column)
-                    print(row_inds, arr[row_inds])
                     if nzs[0].size > 0:
                         self._errors.append(f"{system.msginfo}: User specified sparsity (rows/cols)"
                                             f" for subjac '{of}' wrt '{wrt}' is incorrect. There "

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -261,6 +261,9 @@ class _CheckingJacobian(DictionaryJacobian):
                     arr[:] = column[start:end]
                     arr[row_inds] = 0.
                     nzs = np.nonzero(arr)
+                    print(key, arr, start, end)
+                    print(column)
+                    print(row_inds, arr[row_inds])
                     if nzs[0].size > 0:
                         self._errors.append(f"{system.msginfo}: User specified sparsity (rows/cols)"
                                             f" for subjac '{of}' wrt '{wrt}' is incorrect. There "


### PR DESCRIPTION
### Summary

Fix a bug in the interpolation bracketing algorithm that caused a hysteresis in the analytic derivative when interpolating on one of the table's gridpoints.

### Related Issues

- Resolves #2224

### Backwards incompatibilities

None

### New Dependencies

None
