### PR TITLE
fixed issue with directional derivs and distributed vars

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -264,6 +264,8 @@ class ApproximationScheme(object):
                             vec_idx = range(abs2meta['output'][wrt]['global_size'])
                     else:
                         vec_idx = LocalRangeIterable(system, wrt)
+                        if directional:
+                            vec_idx = [v for v in vec_idx if v is not None]
 
                     # Directional derivatives for quick partial checking.
                     # Place the indices in a list so that they are all stepped at the same time.


### PR DESCRIPTION
### Summary

When computing directional derivatives wrt distributed variables, an invalid index array that contained None's was being created.

### Related Issues

- Resolves #2232

### Backwards incompatibilities

None

### New Dependencies

None
