### PR TITLE
Fix for IndexError raised in the lagrange3 semi-structured interpolation.

### DIFF
--- a/openmdao/components/interp_util/interp_lagrange3.py
+++ b/openmdao/components/interp_util/interp_lagrange3.py
@@ -253,7 +253,7 @@ class InterpLagrange3Semi(InterpAlgorithmSemi):
                     val2, dx2, dvalue2 = val1, dx1, dvalue1
                     val1, dx1, dvalue1 = val0, dx0, dvalue0
                     val0, dx0, dvalue0 = val_a, dx_a, dvalue_a
-            elif flags == (True, False, False, False) and idx < ngrid-3:
+            elif flags == (True, False, False, False) and idx < ngrid - 3:
                 # We are near the left edge of our sub-region, so slide to the right.
                 idx += 1
                 val_a, dx_a, dvalue_a, flag_a = subtables[idx + 2].interpolate(x[1:])

--- a/openmdao/components/interp_util/interp_lagrange3.py
+++ b/openmdao/components/interp_util/interp_lagrange3.py
@@ -180,7 +180,7 @@ class InterpLagrange3Semi(InterpAlgorithmSemi):
         super().__init__(grid, values, interp, extrapolate=extrapolate,
                          compute_d_dvalues=compute_d_dvalues, idx=idx, idim=idim, **kwargs)
         self.k = 4
-        self._name = 'lagrange2'
+        self._name = 'lagrange3'
 
     def interpolate(self, x):
         """
@@ -253,7 +253,7 @@ class InterpLagrange3Semi(InterpAlgorithmSemi):
                     val2, dx2, dvalue2 = val1, dx1, dvalue1
                     val1, dx1, dvalue1 = val0, dx0, dvalue0
                     val0, dx0, dvalue0 = val_a, dx_a, dvalue_a
-            elif flags == (True, False, False, False) and idx > 0:
+            elif flags == (True, False, False, False) and idx < ngrid-3:
                 # We are near the left edge of our sub-region, so slide to the right.
                 idx += 1
                 val_a, dx_a, dvalue_a, flag_a = subtables[idx + 2].interpolate(x[1:])

--- a/openmdao/components/tests/test_meta_model_semi_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_semi_structured_comp.py
@@ -500,6 +500,63 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
             assert_near_equal(prob.get_val('interp.f'), expected, 1e-3)
 
+    def test_lagrange3_edge_extrapolation_detection_bug(self):
+        import itertools
+
+        import numpy as np
+        import openmdao.api as om
+
+        grid = np.array(
+            [[0, 0],
+             [0, 1],
+             [0, 2],
+             [0, 3],
+             [0, 4],
+             [1, 0],
+             [1, 1],
+             [1, 2],
+             [1, 3],
+             [1, 4],
+             [2, 0],
+             [2, 1],
+             [2, 2],
+             [2, 3],
+             [2, 4],
+             [2, 5],
+             [3, 0],
+             [3, 1],
+             [3, 2],
+             [3, 3],
+             [3, 4],
+             [3, 5],
+             [4, 0],
+             [4, 1],
+             [4, 2],
+             [4, 3],
+             [4, 4],
+             [4, 5]])
+
+
+        values = 15.0 + 2 * np.random.random(grid.shape[0])
+
+        prob = om.Problem()
+        model = prob.model
+
+        interp = om.MetaModelSemiStructuredComp(method='lagrange3')
+        interp.add_input('x', training_data=grid[:, 0])
+        interp.add_input('y', training_data=grid[:, 1])
+        interp.add_output('f', training_data=values)
+
+        model.add_subsystem('interp', interp)
+
+        prob.setup()
+
+        prob.set_val('interp.x', 2.5)
+        prob.set_val('interp.y', 4.5)
+
+        # Should run without an Indexerror.
+        prob.run_model()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Fixed a bug in the lagrange3 semi-structured interpolation in the algorithm that detects if you are interpolating near an "edge" due to extrapolation at lower dimensions, and accommodates by choosing 1 point on one side and 3 on the other, instead of 2 and 2.   The algorithm was not detecting that it was too close to an "edge" on the other side as well.

### Related Issues

- Resolves #2242

### Backwards incompatibilities

None

### New Dependencies

None
