### PR TITLE
pin ipyparallel because of some problems in v 7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ optional_dependencies = {
         'jupyter',
         'nbconvert',
         'testflo',
-        'ipyparallel',
+        'ipyparallel<7',
         'numpydoc>=1.1',
         'tabulate',
         'jupyter-book',


### PR DESCRIPTION
### Summary

Recent updates to the ipyparallel package's config file API caused our CI to fail. Pinning to 7 fixes this and any future changes they make. We can revisit in the future whether we need any new features they add.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
