### PR TITLE
Fix test that was failing due to varying precision in warning message.

### DIFF
--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -15,6 +15,7 @@ from openmdao.test_suite.components.implicit_newton_linesearch \
     import ImplCompTwoStates, ImplCompTwoStatesArrays
 from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2withDerivatives
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.general_utils import printoptions
 
 
 class TestArmejoGoldsteinBounds(unittest.TestCase):
@@ -426,8 +427,6 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         self.top = top
         self.ub = np.array([2.6, 2.5, 2.65])
 
-    @unittest.skipIf((os.environ.get("GITHUB_ACTION") and sys.platform == 'win32'), \
-        'Lower bounds check fails on Windows.')
     def test_linesearch_vector_bound_enforcement(self):
         top = self.top
 
@@ -445,9 +444,10 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         for ind in range(3):
             assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
-        msg = (f"'comp.z' exceeds lower bounds\n  Val: [1.33333333 1.33333333 1.33333333]\n  Lower: [1.5 1.5 1.5]\n")
-        with assert_warning(om.SolverWarning, msg):
-            top.run_model()
+        with printoptions(precision=3):
+            msg = (f"'comp.z' exceeds lower bounds\n  Val: [1.333 1.333 1.333]\n  Lower: [1.5 1.5 1.5]\n")
+            with assert_warning(om.SolverWarning, msg):
+                top.run_model()
 
         top.setup()
         # Test upper bounds: should go to the minimum upper bound and stall
@@ -455,9 +455,10 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top['comp.y'] = 0.
         top['comp.z'] = 2.4
 
-        msg = (f"'comp.z' exceeds upper bounds\n  Val: [2.66666667 2.66666667 2.66666667]\n  Upper: [2.6  2.5  2.65]\n")
-        with assert_warning(om.SolverWarning, msg):
-            top.run_model()
+        with printoptions(precision=3):
+            msg = (f"'comp.z' exceeds upper bounds\n  Val: [2.667 2.667 2.667]\n  Upper: [2.6  2.5  2.65]\n")
+            with assert_warning(om.SolverWarning, msg):
+                top.run_model()
 
         for ind in range(3):
             assert_near_equal(top['comp.z'][ind], [2.5], 1e-8)


### PR DESCRIPTION
### Summary

Fixed test that was failing due to varying precision in warning message.

### Related Issues

- Resolves #2282

### Backwards incompatibilities

None

### New Dependencies

None
