### PR TITLE
Change GitHub actions to use Python <3.9

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -33,7 +33,7 @@ jobs:
 
           # latest versions
           - NAME: Latest
-            PY: 3
+            PY: <3.9
             NUMPY: 1
             SCIPY: 1
             PETSc: 3
@@ -43,7 +43,7 @@ jobs:
 
           # minimal install
           - NAME: Minimal
-            PY: 3
+            PY: <3.9
             NUMPY: 1
             SCIPY: 1
             PYOPTSPARSE: 'conda-forge'


### PR DESCRIPTION
### Summary

There is currently something in the stack for the Python 3.9 environments on GitHub Actions that is causing tests to fail inappropriately.  This change will get CI functioning again until the issue is resolved.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
