### PR TITLE
fix documentation upload

### DIFF
--- a/openmdao/docs/upload_doc_version.py
+++ b/openmdao/docs/upload_doc_version.py
@@ -102,7 +102,7 @@ def upload_doc_version(source_dir, destination, *args):
             cmd += f" {arg}"
 
     try:
-        subprocess.run(cmd.split(), check=True)  # nosec: trusted input
+        subprocess.run(cmd, shell=True, check=True)  # nosec: trusted input
     except:
         raise Exception('Doc transfer failed.')
     else:


### PR DESCRIPTION
### Summary

PR #2317 introduced a change that was incompatible with the format of the production  value of DOCS_LOCATION and thus prevented the uploading of documentation after a merge.  This fixes that issue.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
