### PR TITLE
Handle recording of constraints that use input names

### DIFF
--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -349,8 +349,8 @@ class SqliteRecorder(CaseRecorder):
             if driver is None:
                 desvars = system.get_design_vars(True, get_sizes=False, use_prom_ivc=False)
                 responses = system.get_responses(True, get_sizes=False)
-                objectives = OrderedDict()
                 constraints = OrderedDict()
+                objectives = OrderedDict()
                 for name, data in responses.items():
                     if data['type'] == 'con':
                         constraints[name] = data
@@ -358,9 +358,9 @@ class SqliteRecorder(CaseRecorder):
                         objectives[name] = data
             else:
                 desvars = driver._designvars.copy()
+                responses = driver._responses.copy()
                 constraints = driver._cons.copy()
                 objectives = driver._objs.copy()
-                responses = driver._responses.copy()
 
             inputs = list(system.abs_name_iter('input', local=False, discrete=True))
             outputs = list(system.abs_name_iter('output', local=False, discrete=True))
@@ -395,8 +395,8 @@ class SqliteRecorder(CaseRecorder):
             for var_set, var_type in full_var_set:
                 for name in var_set:
 
-                    # Design variables can be requested by input name.
-                    if var_type == 'desvar':
+                    # Design variables, constraints and objectives can be requested by input name.
+                    if var_type != 'output':
                         name = var_set[name]['ivc_source']
 
                     if name not in self._abs2meta:


### PR DESCRIPTION
### Summary

Handle recording of constraints that use input names, which is how bounds are implemented when using COBYLA.

### Related Issues

- Resolves #2304

### Backwards incompatibilities

None

### New Dependencies

None
