### PR TITLE
Additional speed improvements for interpolation.

### DIFF
--- a/openmdao/components/interp_util/interp_algorithm.py
+++ b/openmdao/components/interp_util/interp_algorithm.py
@@ -533,6 +533,32 @@ class InterpAlgorithmFixed(object):
         """
         raise NotImplementedError()
 
+    def interpolate_vectorized(self, x_vec, idx):
+        """
+        Compute the interpolated value for multiple points.
+
+        This method must be defined by child classes.
+
+        Parameters
+        ----------
+        x_vec : ndarray
+            The coordinates to interpolate on this grid.
+        idx : int
+            List of interval indices for x.
+
+        Returns
+        -------
+        ndarray
+            Interpolated values.
+        ndarray
+            Derivative of interpolated values with respect to independents.
+        ndarray
+            Derivative of interpolated values with respect to values.
+        ndarray
+            Derivative of interpolated values with respect to grid.
+        """
+        raise NotImplementedError()
+
 
 class InterpAlgorithmSemi(object):
     """

--- a/openmdao/components/interp_util/interp_lagrange3.py
+++ b/openmdao/components/interp_util/interp_lagrange3.py
@@ -701,7 +701,7 @@ class InterpLagrange3D(InterpAlgorithmFixed):
         if self.vec_coeff is None:
             self.coeffs = set()
             grid = self.grid
-            self.vec_coeff = np.empty((len(grid[0]), len(grid[1]), len(grid[2]), 4, 4, 4))
+            self.vec_coeff = np.empty((nx, ny, nz, 4, 4, 4))
 
         needed = set(zip(i_x, i_y, i_z))
         uncached = needed.difference(self.coeffs)

--- a/openmdao/components/interp_util/interp_lagrange3.py
+++ b/openmdao/components/interp_util/interp_lagrange3.py
@@ -666,31 +666,15 @@ class InterpLagrange3D(InterpAlgorithmFixed):
         i_x, i_y, i_z = idx
 
         # extrapolate low
-        extrap_idx = np.where(i_x < 1)[0]
-        if len(extrap_idx):
-            i_x[extrap_idx] = 1
-
-        extrap_idx = np.where(i_y < 1)[0]
-        if len(extrap_idx):
-            i_y[extrap_idx] = 1
-
-        extrap_idx = np.where(i_z < 1)[0]
-        if len(extrap_idx):
-            i_z[extrap_idx] = 1
+        i_x[i_x < 1] = 1
+        i_y[i_y < 1] = 1
+        i_z[i_z < 1] = 1
 
         # extrapolate high
         nx, ny, nz = self.values.shape
-        extrap_idx = np.where(i_x > nx - 3)[0]
-        if len(extrap_idx):
-            i_x[extrap_idx] = nx - 3
-
-        extrap_idx = np.where(i_y > ny - 3)[0]
-        if len(extrap_idx):
-            i_y[extrap_idx] = ny - 3
-
-        extrap_idx = np.where(i_z > nz - 3)[0]
-        if len(extrap_idx):
-            i_z[extrap_idx] = nz - 3
+        i_x[i_x > nx - 3] = nx - 3
+        i_y[i_y > ny - 3] = ny - 3
+        i_z[i_z > nz - 3] = nz - 3
 
         if self.vec_coeff is None:
             self.coeffs = set()

--- a/openmdao/components/interp_util/interp_trilinear.py
+++ b/openmdao/components/interp_util/interp_trilinear.py
@@ -270,31 +270,15 @@ class InterpTrilinear(InterpAlgorithmFixed):
             dtype = x.dtype
 
         # extrapolate low
-        extrap_idx = np.where(i_x == -1)[0]
-        if len(extrap_idx) > 0:
-            i_x[extrap_idx] = 0
-
-        extrap_idx = np.where(i_y == -1)[0]
-        if len(extrap_idx) > 0:
-            i_y[extrap_idx] = 0
-
-        extrap_idx = np.where(i_z == -1)[0]
-        if len(extrap_idx) > 0:
-            i_z[extrap_idx] = 0
+        i_x[i_x == -1] = 0
+        i_y[i_y == -1] = 0
+        i_z[i_z == -1] = 0
 
         # extrapolate high
         nx, ny, nz = self.values.shape
-        extrap_idx = np.where(i_x == nx - 1)[0]
-        if len(extrap_idx) > 0:
-            i_x[extrap_idx] = nx - 2
-
-        extrap_idx = np.where(i_y == ny - 1)[0]
-        if len(extrap_idx) > 0:
-            i_y[extrap_idx] = ny - 2
-
-        extrap_idx = np.where(i_z == nz - 1)[0]
-        if len(extrap_idx) > 0:
-            i_z[extrap_idx] = nz - 2
+        i_x[i_x == nx - 1] = nx - 2
+        i_y[i_y == ny - 1] = ny - 2
+        i_z[i_z == nz - 1] = nz - 2
 
         if self.vec_coeff is None:
             self.coeffs = set()


### PR DESCRIPTION
### Summary

1. Implemented a much faster way to compute the partials in the new 3d lagrange3 interpolation method.
2. Other speedups are minor, but they include removing an "in" check before computing np.where, because that check was actually slower than np.where.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
