### PR TITLE
Add deprecated method names to the TABLE_METHODS list.

### DIFF
--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -37,6 +37,7 @@ INTERP_METHODS = {
 
 TABLE_METHODS = ['slinear', 'lagrange2', 'lagrange3', 'cubic', 'akima',
                  'scipy_cubic', 'scipy_slinear', 'scipy_quintic',
+                 'trilinear', 'akima1D',  # all Deprecated
                  '3D-slinear', '1D-akima', '3D-lagrange3']
 SPLINE_METHODS = ['slinear', 'lagrange2', 'lagrange3', 'cubic', 'akima', 'bsplines',
                   'scipy_cubic', 'scipy_slinear', 'scipy_quintic']

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -160,7 +160,7 @@ class InterpNDStandaloneFeatureTestcase(unittest.TestCase):
             if method.startswith('scipy'):
                 continue
 
-            if method in ['1D-akima']:
+            if method in ['1D-akima', 'akima1D']:
                 # These methods are for fixed grids other than 3d.
                 continue
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1236,6 +1236,10 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         actual_msg = str(cm.exception)
         self.assertTrue(actual_msg.endswith(msg))
 
+    def test_deprecated(self):
+        # Make sure deprecated methods are still in the table_methods list.
+        om.MetaModelStructuredComp(method='trilinear')
+        om.MetaModelStructuredComp(method='akima1D')
 
 @use_tempdirs
 @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")


### PR DESCRIPTION
### Summary

In last PR, I forgot to add the deprecated method names to the list that metamodel uses to check for method names.  Added a test to verify they are there.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
