### PR TITLE
Allow arguments to be passed to show_options_table

### DIFF
--- a/openmdao/utils/notebook_utils.py
+++ b/openmdao/utils/notebook_utils.py
@@ -94,27 +94,31 @@ def display_source(reference, hide_doc_string=False):
         display(get_code(reference, hide_doc_string))
 
 
-def show_options_table(reference, recording_options=False):
+def show_options_table(reference, recording_options=False, init_args=None, init_kwargs=None):
     """
     Return the options table of the given reference path.
 
     Parameters
     ----------
-    reference : str or object
-        Dot path of desired class or function or an instance.
+    reference : str
+        Dot path of desired class or function.
 
     recording_options : bool
         If True, display recording options instead of options.
+    init_args : list or None
+        Arguments to be passed to the initialization of the referenced object.
+    init_kwargs : dict or None
+        Keyword arguments to be passed to the initialization of the referenced object.
 
     Returns
     -------
     IPython.display
         Options table of the given class or function.
     """
-    if isinstance(reference, str):
-        obj = _get_object_from_reference(reference)()
-    else:
-        obj = reference
+    _init_args = init_args if init_args is not None else []
+    _init_kwargs = init_kwargs if init_kwargs is not None else {}
+
+    obj = _get_object_from_reference(reference)(*_init_args, **_init_kwargs)
 
     if ipy:
         if not hasattr(obj, "options"):

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -29,6 +29,25 @@ class StateOptionsDictionary(om.OptionsDictionary):
         self.declare(name='name', types=str,
                      desc='name of ODE state variable')
 
+
+class _TestComp(om.ExplicitComponent):
+    """
+    A simple test component to test show_options_table.
+    """
+
+    def __init__(self, required_arg, **kwargs):
+        super().__init__(**kwargs)
+
+        assert(required_arg == 1)
+
+    def initialize(self):
+        self.options.declare('required_kwarg', types=(int,))
+
+    def setup(self):
+        foo = self.options['required_kwarg']
+        assert(foo == 2)
+
+
 @unittest.skipUnless(tabulate and IPython, "Tabulate and IPython are required")
 class TestNotebookUtils(unittest.TestCase):
 
@@ -45,6 +64,15 @@ class TestNotebookUtils(unittest.TestCase):
         notebook_utils.ipy = True
 
         options = om.show_options_table("openmdao.components.balance_comp.BalanceComp")
+
+        self.assertEqual(options, None)
+
+    def test_show_options_with_kwargs(self):
+        from openmdao.utils import notebook_utils
+        notebook_utils.ipy = True
+
+        options = om.show_options_table('openmdao.utils.tests.test_notebook_utils._TestComp',
+                                        init_args=(1,), init_kwargs={'required_kwarg': 2})
 
         self.assertEqual(options, None)
 


### PR DESCRIPTION
### Summary

Documentation build would fail in some use-cases of `show_options_table`.
The method instantiates an object and then queries its options, but provides no arguments to the instantiation.
During instantiation, some objects with options (transcriptions in Dymos) will raise an exception if a required option is not provided.  This change allows args and kwargs to be passed to the instantiation of the object.

### Related Issues

- Resolves #2333

### Backwards incompatibilities

None

### New Dependencies

None
