### PR TITLE
Added warning when user calls list_inputs before final_setup

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -18,7 +18,8 @@ import numpy as np
 import networkx as nx
 
 from openmdao.core.configinfo import _ConfigInfo
-from openmdao.core.constants import _DEFAULT_OUT_STREAM, _UNDEFINED, INT_DTYPE, INF_BOUND
+from openmdao.core.constants import _DEFAULT_OUT_STREAM, _UNDEFINED, INT_DTYPE, INF_BOUND, \
+    _SetupStatus
 from openmdao.jacobians.assembled_jacobian import DenseJacobian, CSCJacobian
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.vectors.vector import _full_slice
@@ -3489,7 +3490,7 @@ class System(object):
         else:
             values = val
 
-        if self._problem_meta['setup_status'] == 2:
+        if self._problem_meta['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
             issue_warning("Calling `list_inputs` before `final_setup` will only "
                           "display the default values of variables and will not show the result of "
                           "any `set_val` calls.")

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3490,8 +3490,8 @@ class System(object):
             values = val
 
         if self._problem_meta['setup_status'] == 2:
-            issue_warning("Calling `list_inputs` before `final_setup` or `run_model` will only "
-                          "display the default values variables and will not show the result of "
+            issue_warning("Calling `list_inputs` before `final_setup` will only "
+                          "display the default values of variables and will not show the result of "
                           "any `set_val` calls.")
 
         metavalues = values and self._inputs is None

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3489,6 +3489,11 @@ class System(object):
         else:
             values = val
 
+        if self._problem_meta['setup_status'] == 2:
+            issue_warning("Calling `list_inputs` before `final_setup` or `run_model` will only "
+                          "display the default values variables and will not show the result of "
+                          "any `set_val` calls.")
+
         metavalues = values and self._inputs is None
 
         keynames = ['val', 'units', 'shape', 'global_shape', 'desc', 'tags']

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -380,8 +380,8 @@ class TestSystem(unittest.TestCase):
 
         prob.set_val('distance', 1.0, units='m')
 
-        msg = ("Calling `list_inputs` before `final_setup` or `run_model` will only "
-              "display the default values variables and will not show the result of "
+        msg = ("Calling `list_inputs` before `final_setup` will only "
+              "display the default values of variables and will not show the result of "
               "any `set_val` calls.")
 
         with assert_warning(UserWarning, msg):

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -378,8 +378,6 @@ class TestSystem(unittest.TestCase):
 
         prob.setup()
 
-        prob.set_val('distance', 1.0, units='m')
-
         msg = ("Calling `list_inputs` before `final_setup` will only "
               "display the default values of variables and will not show the result of "
               "any `set_val` calls.")


### PR DESCRIPTION
### Summary

Added check inside of system's `list_inputs` func to see if user called it before final_setup/run_model

### Related Issues

- Resolves #2324 

### Backwards incompatibilities

None

### New Dependencies

None
