### PR TITLE
Added a RuntimeError When User Connects Design Variable to Output

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -464,7 +464,8 @@ class Driver(object):
 
         myoutputs = set(myoutputs)
         if recording_options['record_desvars']:
-            myoutputs.update(model.get_source(n) for n in self._designvars)
+            myoutputs.update(model.get_source(n) for n in self._designvars if model.get_source(n)
+                             is not None)
         if recording_options['record_objectives'] or recording_options['record_responses']:
             myoutputs.update(self._objs)
         if recording_options['record_constraints'] or recording_options['record_responses']:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -707,7 +707,7 @@ class Group(System):
             myrank = self.comm.rank
             vars_to_gather = self._vars_to_gather
 
-            for s in self.system_iter(recurse=True):
+            for s in self.system_iter(recurse=True, include_self=True):
                 prefix = s.pathname + '.' if s.pathname else ''
                 for typ in iotypes:
                     # use abs2prom to determine locality since prom2abs is for allprocs
@@ -737,7 +737,7 @@ class Group(System):
                 prom2abs = self.comm.bcast(None, root=0)
         else:  # serial
             prom2abs = {'input': defaultdict(list), 'output': defaultdict(list)}
-            for s in self.system_iter(recurse=True):
+            for s in self.system_iter(recurse=True, include_self=True):
                 prefix = s.pathname + '.' if s.pathname else ''
                 for typ in iotypes:
                     t_prom2abs = prom2abs[typ]

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -937,6 +937,14 @@ class Problem(object):
         }
         model._setup(model_comm, mode, self._metadata)
 
+        des_vars = self.model.get_design_vars()
+        prom2abs = self._metadata['prom2abs']
+        if des_vars:
+            for key in des_vars.keys():
+                if key in prom2abs['output'] and key in prom2abs['input']:
+                    raise RuntimeError(f"Cannot connect the design variable '{key}' to output "
+                                       f"'{prom2abs['output'][key][0]}'.")
+
         # set static mode back to True in all systems in this Problem
         self._metadata['static_mode'] = True
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -799,7 +799,7 @@ class System(object):
         if name in model._conn_global_abs_in2out:
             return model._conn_global_abs_in2out[name]
 
-        return name
+        issue_warning(f"'{name}' not found.")
 
     def _setup(self, comm, mode, prob_meta):
         """

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2071,6 +2071,27 @@ class TestProblem(unittest.TestCase):
             prob.set_val('x', 0.)
         self.assertEqual(str(cm.exception), "Problem: 'x' Cannot call set_val before setup.")
 
+    def test_design_var_connected_to_output(self):
+        prob = om.Problem()
+        root = prob.model
+
+        prob.driver = om.ScipyOptimizeDriver()
+
+        root.add_subsystem('initial_comp', om.ExecComp(['x = 10']), promotes_outputs=['x'])
+
+        outer_group = root.add_subsystem('outer_group', om.Group(), promotes_inputs=['x'])
+        inner_group = outer_group.add_subsystem('inner_group', om.Group(), promotes_inputs=['x'])
+
+        c1 = inner_group.add_subsystem('c1', om.ExecComp(['y = x * 2.0',  'z = x ** 2']),
+                                       promotes_inputs=['x'])
+
+        c1.add_design_var('x', lower=0, upper=5)
+
+        msg = "Cannot connect the design variable 'x' to output 'initial_comp.x'."
+        with self.assertRaises(RuntimeError) as cm:
+            prob.setup()
+        self.assertEqual(str(cm.exception), msg)
+
 
 class NestedProblemTestCase(unittest.TestCase):
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -361,6 +361,17 @@ class TestSystem(unittest.TestCase):
 
         self.assertEqual(str(cm.exception), "'comp' <class BadComp>: You forget to call super() in setup()")
 
+    def test_missing_source(self):
+        prob = Problem()
+        root = prob.model
+
+        root.add_subsystem('initial_comp', ExecComp(['x = 10']), promotes_outputs=['x'])
+
+        prob.setup()
+
+        msg = "'f' not found."
+        with assert_warning(UserWarning, msg):
+            root.get_source('f')
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -374,6 +374,7 @@ class TestSystem(unittest.TestCase):
             root.get_source('f')
 
     def test_list_inputs_before_final_setup(self):
+
         class SpeedComp(ExplicitComponent):
 
             def setup(self):


### PR DESCRIPTION
### Summary

Added a RuntimeError when user connects design variable to output.

- Substory: Found a bug in `get_source` where it was returning the name of the input even if it was found. Since all inputs now have a source, a warning is issued if it cannot find the variable input in `prom2abs`. Also added `include_self=True` to two instances of `system_iter` because it was not including the top level system in `prom2abs`.

### Related Issues

- Resolves #2295 

### Backwards incompatibilities

None

### New Dependencies

None
