### PR TITLE
Fix for deriv calc on vectorized 1D-akima

### DIFF
--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -238,8 +238,12 @@ class MetaModelStructuredComp(ExplicitComponent):
         """
         for out_name, interp in self.interps.items():
             dval = interp._gradient()
-            for i, p in enumerate(self.pnames):
-                partials[out_name, p] = dval[:, i]
+
+            if len(dval.shape) < 2:
+                partials[out_name, self.pnames[0]] = dval
+            else:
+                for i, p in enumerate(self.pnames):
+                    partials[out_name, p] = dval[:, i]
 
             if self.options['training_data_gradients']:
 


### PR DESCRIPTION
### Summary

A previous commit had accidentally broken the derivative calculation on a vectorized model when using `1D-akima`.

1. Fixed the bug that caused the exception.
2. Added tests to cover the hole.
3. Several tests weren't actually doing anything because of a flag that disables computing the derivatives on Structured `MetaModelStructuredComp`.  Re-enabled that flag for those tests.

### Related Issues

- Resolves #2351 

### Backwards incompatibilities

None

### New Dependencies

None
