### PR TITLE
Added clarity to error msg for shape mismatch during setup

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3272,7 +3272,11 @@ class Group(System):
                 if val is None:
                     val = value
                 else:
-                    val[:] = value
+                    try:
+                        val[:] = value
+                    except ValueError:
+                        raise ValueError(f"Could not broadcast input array '{tgt}' from shape "
+                                         f"{value.shape} into shape {val.shape}.")
 
                 if tgt not in vars_to_gather:
                     found_dup = True

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3274,9 +3274,8 @@ class Group(System):
                 else:
                     try:
                         val[:] = value
-                    except ValueError:
-                        raise ValueError(f"Could not broadcast input array '{tgt}' from shape "
-                                         f"{value.shape} into shape {val.shape}.")
+                    except ValueError as err:
+                        raise ValueError(f"Input '{tgt}': {str(err)}")
 
                 if tgt not in vars_to_gather:
                     found_dup = True

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1435,7 +1435,7 @@ class TestGroup(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             p.setup()
 
-        msg = "Could not broadcast input array 'G.foo.test_param' from shape (5,) into shape (1,)."
+        msg = "Input 'G.foo.test_param': could not broadcast input array from shape (5) into shape (1)"
         self.assertEqual(str(cm.exception), msg)
 
 @unittest.skipUnless(MPI, "MPI is required.")

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1432,11 +1432,9 @@ class TestGroup(unittest.TestCase):
 
         p.model.set_input_defaults('G.test_param', val=7.0)
 
-        with self.assertRaises(ValueError) as cm:
+        msg = "Input 'G.foo.test_param': could not broadcast input array from shape \(5.*\) into shape \(1.*\)"
+        with self.assertRaisesRegex(ValueError, msg) as cm:
             p.setup()
-
-        msg = "Input 'G.foo.test_param': could not broadcast input array from shape (5) into shape (1)"
-        self.assertEqual(str(cm.exception), msg)
 
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestGroupMPISlice(unittest.TestCase):


### PR DESCRIPTION
### Summary

Added the target name to the error msg in `_get_auto_ivc_out_val` which showed up during setup.

### Related Issues

- Resolves #2316 

### Backwards incompatibilities

None

### New Dependencies

None
