### PR TITLE
Provide a better error message when setting an invalid value to an auto_ivc output

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -555,7 +555,7 @@ class Problem(object):
                                 src_indices = inds
 
                             if src_indices is None:
-                                model._outputs.set_var(src, value, _full_slice, flat, 
+                                model._outputs.set_var(src, value, _full_slice, flat,
                                                        var_name=var_name)
                             else:
                                 if tmeta['distributed']:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -540,7 +540,7 @@ class Problem(object):
                 src_is_auto_ivc = src.rsplit('.', 1)[0] == '_auto_ivc'
                 # when setting auto_ivc output, error messages should refer
                 # to the promoted name used in the set_val call
-                var_name = name if src_is_auto_ivc else abs_name
+                var_name = name if src_is_auto_ivc else src
                 if model._outputs._contains_abs(src):  # src is local
                     if (model._outputs._abs_get_val(src).size == 0 and
                             src_is_auto_ivc and

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -537,9 +537,13 @@ class Problem(object):
             if model._outputs._contains_abs(abs_name):
                 model._outputs.set_var(abs_name, value, indices)
             elif abs_name in conns:  # input name given. Set value into output
+                src_is_auto_ivc = src.rsplit('.', 1)[0] == '_auto_ivc'
+                # when setting auto_ivc output, error messages should refer
+                # to the promoted name used in the set_val call
+                var_name = name if src_is_auto_ivc else abs_name
                 if model._outputs._contains_abs(src):  # src is local
                     if (model._outputs._abs_get_val(src).size == 0 and
-                            src.rsplit('.', 1)[0] == '_auto_ivc' and
+                            src_is_auto_ivc and
                             all_meta['output'][src]['distributed']):
                         pass  # special case, auto_ivc dist var with 0 local size
                     elif tmeta['has_src_indices']:
@@ -551,7 +555,8 @@ class Problem(object):
                                 src_indices = inds
 
                             if src_indices is None:
-                                model._outputs.set_var(src, value, _full_slice, flat)
+                                model._outputs.set_var(src, value, _full_slice, flat, 
+                                                       var_name=var_name)
                             else:
                                 if tmeta['distributed']:
                                     src_indices = src_indices.shaped_array()
@@ -568,10 +573,11 @@ class Problem(object):
                                         src_indices = src_indices - start
                                     src_indices = indexer(src_indices)
                                 if indices is _full_slice:
-                                    model._outputs.set_var(src, value, src_indices, flat)
+                                    model._outputs.set_var(src, value, src_indices, flat,
+                                                           var_name=var_name)
                                 else:
                                     model._outputs.set_var(src, value, src_indices.apply(indices),
-                                                           True)
+                                                           True, var_name=var_name)
                         else:
                             raise RuntimeError(f"{model.msginfo}: Can't set {abs_name}: remote"
                                                " connected inputs with src_indices currently not"
@@ -580,7 +586,7 @@ class Problem(object):
                         value = np.asarray(value)
                         if indices is not _full_slice:
                             indices = indexer(indices)
-                        model._outputs.set_var(src, value, indices)
+                        model._outputs.set_var(src, value, indices, var_name=var_name)
                 elif src in model._discrete_outputs:
                     model._discrete_outputs[src] = value
                 # also set the input

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -261,9 +261,9 @@ class SerialTests(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             p.final_setup()
 
-        self.assertEqual(str(cm.exception), 
-                         "<model> <class Group>: Failed to set value of 'exec.b': "
-                         "could not broadcast input array from shape (15,) into shape (100,).")
+        # can not broadcast input array from shape (15,) into shape (100,) for exec.b
+        self.assertTrue(str(cm.exception).startswith(
+                        "<model> <class Group>: Failed to set value of 'exec.b': "))
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -243,6 +243,23 @@ class SerialTests(unittest.TestCase):
         for key, meta in totals.items():
             np.testing.assert_allclose(meta['abs error'][0], 0.)
 
+    def test_set_val_auto_ivc(self):
+        p = om.Problem()
+        p.model.add_subsystem('exec',
+                              om.ExecComp('z = a + b**2 + c**3',
+                                          z={'shape': (100,)},
+                                          a={'shape': (100,)},
+                                          b={'shape': (100,)},
+                                          c={'shape': (100,)}))
+
+        p.setup()
+
+        p.set_val('exec.a', np.linspace(5, 10, 100))
+        p.set_val('exec.b', np.linspace(10, 20, 15))
+        p.set_val('exec.c', np.linspace(1, 3, 23))
+
+        p.final_setup()
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class MPITests(SerialTests):

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -258,7 +258,12 @@ class SerialTests(unittest.TestCase):
         p.set_val('exec.b', np.linspace(10, 20, 15))
         p.set_val('exec.c', np.linspace(1, 3, 23))
 
-        p.final_setup()
+        with self.assertRaises(ValueError) as cm:
+            p.final_setup()
+
+        self.assertEqual(str(cm.exception), 
+                         "<model> <class Group>: Failed to set value of 'exec.b': "
+                         "could not broadcast input array from shape (15,) into shape (100,).")
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -580,17 +580,16 @@ class Vector(object):
             If True, set into flattened variable.
         var_name : str or None
             If specified, the variable name to use when reporting errors. This is useful
-            when setting an IVC value that the user only knows by a connected input name.
+            when setting an AutoIVC value that the user only knows by a connected input name.
         """
-        if not var_name:
-            var_name = name
-
         abs_name = self._name2abs_name(name)
         if abs_name is None:
-            raise KeyError(f"{self._system().msginfo}: Variable name '{var_name}' not found.")
+            raise KeyError(f"{self._system().msginfo}: Variable name "
+                           f"'{var_name if var_name else name}' not found.")
 
         if self.read_only:
-            raise ValueError(f"{self._system().msginfo}: Attempt to set value of '{var_name}' in "
+            raise ValueError(f"{self._system().msginfo}: Attempt to set value of "
+                             f"'{var_name if var_name else name}' in "
                              f"{self._kind} vector when it is read only.")
 
         if idxs is _full_slice:
@@ -623,7 +622,7 @@ class Vector(object):
                     value = value.reshape(view[idxs()].shape)
                 except Exception:
                     raise ValueError(f"{self._system().msginfo}: Failed to set value of "
-                                     f"'{var_name}': {str(err)}.")
+                                     f"'{var_name if var_name else name}': {str(err)}.")
                 view[idxs()] = value
 
     def dot(self, vec):

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -564,7 +564,7 @@ class Vector(object):
                     arr[start:end] = v.ravel()
                 start = end
 
-    def set_var(self, name, val, idxs=_full_slice, flat=False):
+    def set_var(self, name, val, idxs=_full_slice, flat=False, var_name=None):
         """
         Set the array view corresponding to the named variable, with optional indexing.
 
@@ -578,13 +578,19 @@ class Vector(object):
             The locations where the data array should be updated.
         flat : bool
             If True, set into flattened variable.
+        var_name : str or None
+            If specified, the variable name to use when reporting errors. This is useful
+            when setting an IVC value that the user only knows by a connected input name.
         """
+        if not var_name:
+            var_name = name
+
         abs_name = self._name2abs_name(name)
         if abs_name is None:
-            raise KeyError(f"{self._system().msginfo}: Variable name '{name}' not found.")
+            raise KeyError(f"{self._system().msginfo}: Variable name '{var_name}' not found.")
 
         if self.read_only:
-            raise ValueError(f"{self._system().msginfo}: Attempt to set value of '{name}' in "
+            raise ValueError(f"{self._system().msginfo}: Attempt to set value of '{var_name}' in "
                              f"{self._kind} vector when it is read only.")
 
         if idxs is _full_slice:
@@ -617,7 +623,7 @@ class Vector(object):
                     value = value.reshape(view[idxs()].shape)
                 except Exception:
                     raise ValueError(f"{self._system().msginfo}: Failed to set value of "
-                                     f"'{name}': {str(err)}.")
+                                     f"'{var_name}': {str(err)}.")
                 view[idxs()] = value
 
     def dot(self, vec):


### PR DESCRIPTION
### Summary

Add an optional `var_name` argument the to `Vector.set_val()` method to override the variable name used in error messages.  When setting an Auto-IVC output value via `Problem.set_val()`, error messages will refer to the matching promoted input name, which is known to the user. 

### Related Issues

- Resolves #2336 

### Backwards incompatibilities

None

### New Dependencies

None
