### PR TITLE
Fix bug where subjacs declared with scipy.sparse cause check_partials to fail.

### DIFF
--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -168,10 +168,13 @@ class _CheckingJacobian(DictionaryJacobian):
         super().__init__(system)
         self._subjacs_info = self._subjacs_info.copy()
 
-        # Convert any scipy.sparse subjacs to dense.
+        # Convert any scipy.sparse subjacs to OpenMDAO's interal COO specification.
         for key, subjac in self._subjacs_info.items():
             if sp.issparse(subjac['val']):
-                self._subjacs_info[key]['val'] = subjac['val'].toarray()
+                coo_val = subjac['val'].tocoo()
+                self._subjacs_info[key]['rows'] = coo_val.row
+                self._subjacs_info[key]['cols'] = coo_val.col
+                self._subjacs_info[key]['val'] = coo_val.data
 
         self._errors = []
 

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -1,5 +1,6 @@
 """Define the DictionaryJacobian class."""
 import numpy as np
+import scipy.sparse as sp
 
 from openmdao.jacobians.jacobian import Jacobian
 from openmdao.core.constants import INT_DTYPE
@@ -166,6 +167,12 @@ class _CheckingJacobian(DictionaryJacobian):
     def __init__(self, system):
         super().__init__(system)
         self._subjacs_info = self._subjacs_info.copy()
+
+        # Convert any scipy.sparse subjacs to dense.
+        for key, subjac in self._subjacs_info.items():
+            if sp.issparse(subjac['val']):
+                self._subjacs_info[key]['val'] = subjac['val'].toarray()
+
         self._errors = []
 
     def __iter__(self):

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -11,7 +11,7 @@ from openmdao.api import IndepVarComp, Group, Problem, \
                          ExplicitComponent, ImplicitComponent, ExecComp, \
                          NewtonSolver, ScipyKrylov, \
                          LinearBlockGS, DirectSolver
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.array_utils import rand_sparsity
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.api import ScipyOptimizeDriver
@@ -254,6 +254,11 @@ class TestJacobian(unittest.TestCase):
             self.prob.model.run_linearize()
         self._check_fwd(self.prob, fwd_check)
         self._check_rev(self.prob, rev_check)
+
+        # Make sure that checking jacobian works for sparse subjacs.
+        if comp_jac_class in [coo_matrix, csr_matrix, inverted_coo, inverted_csr]:
+            partials = self.prob.check_partials(out_stream=None)
+            assert_check_partials(partials, atol=1e-5, rtol=1e-5)
 
     def _setup_model(self, assembled_jac, comp_jac_class, nested, lincalls):
         self.prob = prob = Problem()


### PR DESCRIPTION
### Summary

Fix bug where subjacs declared with scipy.sparse cause check_partials to fail.

This bug arose when we moved over to using a `_CheckingJacobian` to perform the fd/cs checking. Subjacs are copied from the model when it is created, so we can just convert them to a regular dense array. 

### Related Issues

- Resolves #2354

### Backwards incompatibilities

None

### New Dependencies

None
