### PR TITLE
fix doc test

### DIFF
--- a/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
@@ -158,7 +158,7 @@ class LintJupyterOutputsTestCase(unittest.TestCase):
         """
         files = set()
 
-        for file in FILES:
+        for file in _get_files():
             with open(file) as f:
                 json_data = json.load(f)
                 blocks = json_data['cells']


### PR DESCRIPTION
### Summary

Fix  a jupyter linting test that was not using the proper function to make sure the FILES list was initialized.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
