### PR TITLE
Added a search box to the N2 variable selection dialog

### DIFF
--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -272,7 +272,10 @@
                 <tbody></tbody>
             </table>
         </div>
-        <div class="search-container"><span>Search </span><input class='variable-selection-search' type='text'></div>
+        <div class="search-container">
+            <span class='search-label'>Search</span><input class='variable-selection-search' type='text'>
+            <span class='search-clear'>&#x2715;</span><span class='search-perform'>&#x27a4;</span>
+        </div>
         <div class="button-container">
             <button class="select-all-variables">Select All</button>
             <button class="select-no-variables">Select None</button>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -271,7 +271,7 @@
                 <tbody></tbody>
             </table>
         </div>
-        <div class="search-container"></div>
+        <div class="search-container"><span>Search </span><input class='variable-selection-search' type='text'></div>
         <div class="button-container">
             <button class="select-all-variables">Select All</button>
             <button class="select-no-variables">Select None</button>

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -264,6 +264,7 @@
             <tr>
                 <th class="varname"><span class="sort-up">&#9650;</span><span>Variable Name</span><span class="sort-down">&#9660;</span></th>
                 <th class="varvis">Visible</th>
+                <th class="scrollbar-spacer"></th>
             </tr>
         </table>
         <div class="table-container">

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -102,8 +102,6 @@
             </div>
         </div>
 
-
-
         <div id="d3_content_div">
             <!-- 2D Matrix Showing All Inputs/Outputs and Functions -->
             <div id="svgDiv">
@@ -258,6 +256,26 @@
             <img id="toolbar-snapshot" alt="Snapshot of toolbar buttons"
                 src="data:image/png;base64,{{n2toolbar_png}}" />
             <svg id='help-graphic-svg'></svg>
+        </div>
+    </div>
+
+    <div id="variable-selection-body">
+        <table class="header">
+            <tr>
+                <th class="varname"><span class="sort-up">&#9650;</span><span>Variable Name</span><span class="sort-down">&#9660;</span></th>
+                <th class="varvis">Visible</th>
+            </tr>
+        </table>
+        <div class="table-container">
+            <table class="variables">
+                <tbody></tbody>
+            </table>
+        </div>
+        <div class="search-container"></div>
+        <div class="button-container">
+            <button class="select-all-variables">Select All</button>
+            <button class="select-no-variables">Select None</button>
+            <button class="apply-variable-selection">Apply</button>
         </div>
     </div>
 

--- a/openmdao/visualization/n2_viewer/src/N2Legend.js
+++ b/openmdao/visualization/n2_viewer/src/N2Legend.js
@@ -250,15 +250,7 @@ class N2Help extends N2Window {
             .title('Instructions')
             .footerText(`OpenMDAO Version ${version} Model Hierarchy and N2 diagram`);
 
-        // Take ownership of the help div contents defined in index.html
-        const newParent = this.body.node();
-        const oldParent = d3.select('#toolbar-help-container').node();
-
-        while (oldParent.childNodes.length > 0) {
-            newParent.appendChild(oldParent.childNodes[0]);
-        }
-
-        oldParent.remove();
+        this.absorbBody('#toolbar-help-container');
 
         this.helpDiv = this.body.select('div.help-graphic');
         this.helpSvg = this.helpDiv.select('#help-graphic-svg');

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -977,7 +977,17 @@ class ChildSelectDialog extends N2WindowDraggable {
         this.searchContainer = this.body.select('div.search-container');
         this.searchBox = this.searchContainer.select('input');
         if (this.searchTerm) { this.searchBox.property('value', this.searchTerm); }
-        this.searchBox.on('change', self.updateSearch.bind(self));
+        this.searchBox.on('keyup', self.updateSearch.bind(self));
+
+        this.searchContainer.select('.search-clear').on('click', e => {
+            self.searchTerm = '';
+            self.searchBox.property('value', '');
+            self.updateSearch(true);
+        });
+
+        this.searchContainer.select('.search-perform').on('click', e => {
+            self.updateSearch(true);
+        });
 
         this.buttonContainer = this.body.select('div.button-container');
 
@@ -1173,10 +1183,12 @@ class ChildSelectDialog extends N2WindowDraggable {
         return this;
     }
 
-    updateSearch() {
-        this.searchTerm = this.searchBox.property('value');
-        this.repopulate();
-        this.resize();
+    updateSearch(clicked = false) {
+        if (d3.event.keyCode == 13 || clicked) {
+                this.searchTerm = this.searchBox.property('value');
+                this.repopulate();
+                this.resize();
+        }
 
         return this;
     }

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -981,6 +981,9 @@ class ChildSelectDialog extends N2WindowDraggable {
         this.tbody = this.table.select('tbody');
 
         this.searchContainer = this.body.select('div.search-container');
+
+
+
         this.buttonContainer = this.body.select('div.button-container');
 
         // The Select All button makes all variables visible.
@@ -1042,7 +1045,7 @@ class ChildSelectDialog extends N2WindowDraggable {
         // Add an empty cell to account for scrollbar width
         if (this.scrollbarIsVisible()) { topRow.append('th').text(' '); }
 
-        this.sizeToContent(3,30)
+        this.sizeToContent(3,57)
             .modal(true)
             .moveNearMouse(d3.event)
             .show();

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -900,6 +900,8 @@ class ChildSelectDialog extends N2WindowDraggable {
         this.node = node;
         this.nodeColor = color;
         this.scrollbarWidth = 14;
+
+        this.ribbonColor(this.nodeColor);
         
         // Don't do anything else if the node has no variables
         if ( ! this._fetchVarNames() ) { this.close(); }
@@ -948,55 +950,49 @@ class ChildSelectDialog extends N2WindowDraggable {
         this.minWidth = 300;
         this.minHeight = 100;
         this.theme('child-select');
-        
         this.title(this.node.name);
+        this.copyBody('#variable-selection-body');
 
-        this.headerTable = this.body.append('table').attr('class', 'header');
+        this.headerTable = this.body.select('table.header');
+        const topRow = this.headerTable.select('tr');
+        const childName = topRow.select('th:first-child');
 
-        const topRow = this.headerTable.append('tr');
-        const childName = topRow.append('th');
-        childName.append('span')
-            .attr('class', 'sort-up')
-            .html('&#9650;') // Up-arrow
+        childName.select('span.sort-up') // Up arrow
             .on('click', e => {
                 self.varNameArr.sort();
                 self.repopulate();
-            })
-        childName.append('span').text('Variable Name');
-        childName.append('span')
-            .attr('class', 'sort-down')
-            .html('&#9660;') // Down-arrow
+            });
+
+        childName.select('span.sort-down') // Down arrow
             .on('click', e => {
                 self.varNameArr.sort();
                 self.varNameArr.reverse();
                 self.repopulate();
-            })
-        topRow.append('th').attr('class','varvis').text('Visible');
+            });
 
-        this.tableContainer = this.body.append('div').attr('class', 'table-container');
-        this.table = this.tableContainer.append('table').attr('class', 'variables');
+        this.tableContainer = this.body.select('div.table-container');
+        this.table = this.tableContainer.select('table.variables');
         const UA = navigator.userAgent;
         if (! /Chrom/.test(UA)) {
             // Chrome puts the scrollbar outside the element, other browsers inside
             this.table.style('margin-right', `${this.scrollbarWidth}px`);
         }
 
-        this.tbody = this.table.append('tbody');
-        this.buttonContainer = this.body.append('div').attr('class', 'button-container');
+        this.tbody = this.table.select('tbody');
 
-        this.ribbonColor(this.nodeColor);
+        this.searchContainer = this.body.select('div.search-container');
+        this.buttonContainer = this.body.select('div.button-container');
 
         // The Select All button makes all variables visible.
-        this.buttonContainer.append('button')
+        this.buttonContainer.select('button.select-all-variables')
             .on('click', e => {
                 d3.selectAll('.window-theme-child-select input[type="checkbox"]')
                     .property('checked', true);
                 this.hiddenVars = [];
-            })
-            .text('Select All');
+            });
 
         // The Select None button hides all variables.
-        this.buttonContainer.append('button')
+        this.buttonContainer.select('button.select-no-variables')
             .on('click', e => {
                 d3.selectAll('.window-theme-child-select input[type="checkbox"]')
                     .property('checked', false);
@@ -1004,11 +1000,10 @@ class ChildSelectDialog extends N2WindowDraggable {
                 for (const child of self.node.children) {
                     this.hiddenVars.push(child);
                 }
-            })
-            .text('Select None');
+            });
 
         // Hitting Apply closes the dialog and updates the diagram.
-        this.buttonContainer.append('button')
+        this.buttonContainer.select('button.apply-variable-selection')
             .on('click', e => {
                 if (self.hiddenVars.length == self.node.children.length ) {
                     // If every variable was hidden, just collapse the node if it's expanded
@@ -1032,22 +1027,20 @@ class ChildSelectDialog extends N2WindowDraggable {
                     n2Diag.update();
                 }
                 self.close();
-            })
-            .text('Apply');
+            });
         
         this.repopulate();
 
         this.tableContainer.style('width', `${this.table.node().scrollWidth +
                 this.scrollbarWidth}px`);
         this.headerTable.style('width', this.tableContainer.style('width'));
-        this.headerTable.select('th:first-child')
+        this.headerTable.select('th.varname')
             .style('width', this.table.select('td:first-child').style('width'));
         this.headerTable.select('th.varvis')
             .style('width', this.table.select('td.varvis').style('width'));
 
-            if (this.scrollbarIsVisible()) {
-                topRow.append('th').text(' ');
-            }
+        // Add an empty cell to account for scrollbar width
+        if (this.scrollbarIsVisible()) { topRow.append('th').text(' '); }
 
         this.sizeToContent(3,30)
             .modal(true)

--- a/openmdao/visualization/n2_viewer/src/N2UserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/N2UserInterface.js
@@ -979,12 +979,14 @@ class ChildSelectDialog extends N2WindowDraggable {
         if (this.searchTerm) { this.searchBox.property('value', this.searchTerm); }
         this.searchBox.on('keyup', self.updateSearch.bind(self));
 
+        // Clear the search box and repopulate the variable list by clicking on the X button
         this.searchContainer.select('.search-clear').on('click', e => {
             self.searchTerm = '';
             self.searchBox.property('value', '');
             self.updateSearch(true);
         });
 
+        // Execute the search by clicking on the arrow button
         this.searchContainer.select('.search-perform').on('click', e => {
             self.updateSearch(true);
         });
@@ -1011,6 +1013,7 @@ class ChildSelectDialog extends N2WindowDraggable {
             .show();
     }
 
+    /** Reset the array of hidden vars from the node's array if it exists. */
     _initHiddenVars() {
         if ('hiddenVars' in this.node) {
             this.hiddenVars = this.node.hiddenVars;
@@ -1022,9 +1025,7 @@ class ChildSelectDialog extends N2WindowDraggable {
         }
     }
 
-    /**
-     * Add all the variables, their display status, and the control buttons.
-     */
+    /** Add all the variables, their display status, and the control buttons. */
     repopulate() {
         const self = this;
         this.tbody.html('');
@@ -1089,6 +1090,10 @@ class ChildSelectDialog extends N2WindowDraggable {
         return this;
     }
 
+    /**
+     * If the container scroll height is larger than the visible height the scrollbar is there.
+     * @returns {Boolean} True if the scrollbar is visible, false otherwise.
+     */
     scrollbarIsVisible() {
         return (this.tableContainer.node().scrollHeight > this.tableContainer.node().clientHeight);
     }
@@ -1152,6 +1157,7 @@ class ChildSelectDialog extends N2WindowDraggable {
 
     }
 
+    /** Adjust the size of the window body object based on the size of their contents. */
     resize() {
         const headerTableNode = this.headerTable.node(),
             searchConNode = this.searchContainer.node(),
@@ -1183,6 +1189,7 @@ class ChildSelectDialog extends N2WindowDraggable {
         return this;
     }
 
+    /** Update the variable list based on the provided search term. */
     updateSearch(clicked = false) {
         if (d3.event.keyCode == 13 || clicked) {
                 this.searchTerm = this.searchBox.property('value');

--- a/openmdao/visualization/n2_viewer/src/N2Window.js
+++ b/openmdao/visualization/n2_viewer/src/N2Window.js
@@ -392,6 +392,38 @@ class N2Window {
         this._enabledModal = enable;
         return this;
     }
+
+    /**
+     * Take ownership of a predefined DOM object, usually a div, by appending
+     * its children to the window body. This allows the definition of more
+     * complex window contents to be located in index.html for example.
+     * @param {String} id HTML id of the object to copy.
+     */
+    absorbBody(id) {
+      const newParent = this.body.node();
+      const oldParent = d3.select(id).node();
+
+        while (oldParent.childNodes.length > 0) {
+            newParent.appendChild(oldParent.childNodes[0]);
+        }
+
+        oldParent.remove();
+    }
+
+    /**
+     * Copy the structure of a predefined DOM object, usually a div, by cloning
+     * its children to the window body. This allows the definition of more
+     * complex window contents to be located in index.html for example.
+     * @param {String} id HTML id of the object to copy.
+     */
+     copyBody(id) {
+        const dstParent = this.body.node();
+        const srcParent = d3.select(id).node();
+  
+          for (const child of srcParent.childNodes) {
+              dstParent.appendChild(child.cloneNode(true));
+          }
+      }
 }
 
 

--- a/openmdao/visualization/n2_viewer/style/window.css
+++ b/openmdao/visualization/n2_viewer/style/window.css
@@ -1008,8 +1008,9 @@ i.help-text-icon {
     color: #202020;
 }
 
-.window-theme-child-select .search-container span {
+.window-theme-child-select .search-label {
     padding-left: 10px;
+    padding-right: 3px;
     font-style: italic;
 }
 
@@ -1018,7 +1019,31 @@ i.help-text-icon {
     border-radius: 5px;
     border: 1px solid #a0a0a0;
     background-color: #e0e0e0;
-    width: 75%;
+    width: 65%;
+}
+
+.window-theme-child-select .search-clear,
+.window-theme-child-select .search-perform
+ {
+    height: 17px;
+    width: 17px;
+    border: 1px solid #808080;
+    border-radius: 7px;
+    text-align: center;
+    padding: 0 2px 0 2px;
+    margin: 0 0 0 3px;
+    font-size: 8pt;
+    color: #c0c0c0;
+    background-color: #909090;
+}
+
+.window-theme-child-select .search-clear:hover,
+.window-theme-child-select .search-perform:hover,
+.window-theme-child-select .search-clear:focus,
+.window-theme-child-select .search-perform:focus {
+    color:black;
+    text-decoration: none;
+    cursor: pointer;
 }
 
 .window-theme-child-select .button-container {

--- a/openmdao/visualization/n2_viewer/style/window.css
+++ b/openmdao/visualization/n2_viewer/style/window.css
@@ -993,6 +993,33 @@ i.help-text-icon {
     background-color: #d8ffff;
 }
 
+.window-theme-child-select .search-container {
+    height: 21px;
+    width: 100%;
+    bottom: 23px;
+    text-align: left;
+    font-size: 8pt;
+    border-top: 1px solid #a0a0a0;
+    border-bottom: 1px solid #a0a0a0;
+    padding: 2px 0 2px 0;
+    background-color: #c0c0c0;
+    white-space: nowrap;
+    color: #202020;
+}
+
+.window-theme-child-select .search-container span {
+    padding-left: 10px;
+    font-style: italic;
+}
+
+.window-theme-child-select .search-container input {
+    padding-left: 10px;
+    border-radius: 5px;
+    border: 1px solid #a0a0a0;
+    background-color: #e0e0e0;
+    width: 75%;
+}
+
 .window-theme-child-select .button-container {
     height: 21px;
     width: 100%;

--- a/openmdao/visualization/n2_viewer/style/window.css
+++ b/openmdao/visualization/n2_viewer/style/window.css
@@ -889,7 +889,7 @@ i.help-text-icon {
     overflow: hidden;
     visibility: visible;
     border: 1px solid gray;
-
+    min-width: 300px;
 }
 
 .window-theme-child-select .window-footer {
@@ -903,53 +903,69 @@ i.help-text-icon {
     right: 0;
 }
 
-/* Child select window table */
-.window-theme-child-select .window-body .table-container {
-    max-height: 280px;
-    overflow-x: hidden;
-    overflow-y: auto;
-}
-
-.window-theme-child-select .table-container table {
+.window-theme-child-select table.header {
 	overflow: hidden;
-	background-color: white;
-    min-width: 300px;
+    width: 100%;
     border-collapse: separate;
     border-spacing: 0;
-    margin: 0 14px 0 0;
+    margin: 0;
     padding: 0;
     border: 0;
+    top: 0px;
 }
 
-.window-theme-child-select thead th {
+.window-theme-child-select table.header th {
     text-align: center;
     font-size: 8pt;
     margin: 0;
+
     border-top: 0;
     border-bottom: 1px solid #a0a0a0;
     border-right: 1px solid #a0a0a0;
     background-color: #c0c0c0;
-    padding: 3px;
+
+    padding: 2px 3px 2px 3px;
     white-space: nowrap;
-    position: sticky; /* Only seems to work on Firefox */
-    top: 0px;
 
     color: #202020;
-    min-width: 30px;
     font-weight: 300;
 }
 
-.window-theme-child-select tbody tr th:last-child,
-.window-theme-child-select tbody tr td:last-child {
+.window-theme-child-select table.header th.varvis {
+    min-width: 40px;
+}
+
+/* Child select window table */
+.window-theme-child-select .window-body .table-container {
+    max-height: 280px;
+    width: 100%;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+.window-theme-child-select .table-container table.variables {
+	overflow: hidden;
+	background-color: white;
+    width: 100%;
+    border-collapse: separate;
+    border-spacing: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
+
+
+.window-theme-child-select table.variables tr th:last-child,
+.window-theme-child-select table.variables tr td:last-child {
     border-right: 0;
 }
 
-.window-theme-child-select tbody tr:last-child th,
-.window-theme-child-select tbody tr:last-child td {
+.window-theme-child-select table.variables tr:last-child th,
+.window-theme-child-select table.variables tr:last-child td {
     border-bottom: 0;
 }
 
-.window-theme-child-select tbody td {
+.window-theme-child-select table.variables td {
     font-size: 9pt;
     margin: 0;    
     border-top: 0;
@@ -960,19 +976,20 @@ i.help-text-icon {
     white-space: nowrap;
 }
 
-.window-theme-child-select tbody tr td:first-child {
+.window-theme-child-select table.variables td.varname {
     text-align: left;
 }
 
-.window-theme-child-select tbody tr td:not(first-child) {
+.window-theme-child-select table.variables td.varvis {
     text-align: center;
+    min-width: 40px;
 }
 
-.window-theme-child-select tbody tr.even td {
+.window-theme-child-select table.variables tr.even td {
     background-color:white;
 }
 
-.window-theme-child-select tbody tr.odd td {
+.window-theme-child-select table.variables tr.odd td {
     background-color: #d8ffff;
 }
 

--- a/openmdao/visualization/n2_viewer/style/window.css
+++ b/openmdao/visualization/n2_viewer/style/window.css
@@ -952,6 +952,7 @@ i.help-text-icon {
     margin: 0;
     padding: 0;
     border: 0;
+    max-height: 280px;
 }
 
 
@@ -1051,5 +1052,12 @@ i.help-text-icon {
     text-decoration: none;
     cursor: pointer;
 }
+
+.window-theme-child-select .scrollbar-spacer {
+    margin: 0;
+    padding: 0;
+    min-width: 0;
+}
+
 
 /* ^^^^^^^^^^ End Child Select Window theme ^^^^^^^^^^ */

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -259,7 +259,38 @@ n2_gui_test_scripts = {
             "test": "count",
             "selector": "rect#circuit_n1_V",
             "count": 0
-        }
+        },
+        {
+            "desc": "Alt-right-click the n1 component",
+            "test": "click",
+            "selector": "rect#circuit_n1",
+            "button": "right",
+            "modifiers": [ "Alt" ]
+        },
+        {
+            "desc": "Click the Clear Search button",
+            "test": "click",
+            "selector": ".search-clear",
+            "button": "left"
+        },
+        {
+            "desc": "Perform a search on out in the variable selection dialog",
+            "test": "var_select_search",
+            "searchString": "out",
+            "foundVariableCount": 2
+        },
+        {
+            "desc": "Click the Apply button",
+            "test": "click",
+            "selector": ".button-container button:last-child",
+            "button": "left"
+        },
+        {
+            "desc": "Check the number of cells in the N2 Matrix",
+            "test": "count",
+            "selector": "g#n2elements > g.n2cell",
+            "count": 32
+        },
     ],
     "bug_arrow": [
         {
@@ -850,6 +881,21 @@ class n2_gui_test_case(_GuiTestCase):
 
         await self.assert_element_count("g.n2cell", options['n2ElementCount'])
 
+    async def var_select_search_and_check_result(self, options):
+        """
+        Enter a string in the variable selection search textbox and check the result.
+        """
+        searchString = options['searchString']
+        self.log_test(options['desc'] if 'desc' in options else
+                      "Searching for '" + options['searchString'] +
+                      "' and checking for " +
+                      str(options['foundVariableCount']) + " table rows after.")
+
+        searchbar = await self.page.wait_for_selector('.search-container input', state='visible')
+        await searchbar.type(searchString + "\n", delay=50)
+
+        await self.assert_element_count("td.varname", options['foundVariableCount'])
+
     async def run_model_script(self, script):
         """
         Iterate through the supplied script array and perform each
@@ -877,6 +923,8 @@ class n2_gui_test_case(_GuiTestCase):
                 await self.return_to_root()
             elif test_type == 'search':
                 await self.search_and_check_result(script_item)
+            elif test_type == 'var_select_search':
+                await self.var_select_search_and_check_result(script_item)
             elif test_type == 'toolbar':
                 await self.generic_toolbar_tests()
             elif test_type == 'count':


### PR DESCRIPTION
### Summary

There is now a search box available with the N2 variable selection dialog. It treats the user-provided string as a regular expression, so it's possible to search using a simple variable name or a complex selector. Hitting Enter or clicking the small arrow button executes the search, and clicking the X button clears the search. Variable names matching the search regexp are automatically selected, and all others are deselected. The results are not applied to the diagram until the Apply button is clicked (same behavior as previous). Previous search strings on a particular are remembered while navigating the diagram.

![image](https://user-images.githubusercontent.com/12797795/143315396-4cc3ff4b-db6d-47ee-9f1e-64adbf82b2a6.png)
![image](https://user-images.githubusercontent.com/12797795/143315412-4f083dd7-9146-487e-85ea-0fca60319cf8.png)


### Related Issues

- Resolves #2344

### Backwards incompatibilities

None

### New Dependencies

None
