### PR TITLE
Removed Deprecation Warning For Serial to Distributed IO Connections  

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -876,8 +876,7 @@ class Group(System):
                 elif in_dist and not out_dist:
                     issue_warning(f"Connecting a serial output '{abs_out}' and distributed input "
                                   f"'{abs_in}' is not common. While legal in OM, verify "
-                                  f"connections are as expected.",
-                                  category=DistributedComponentWarning)
+                                  "connections are as expected.", category=DistributedComponentWarning)
 
     def _get_group_input_meta(self, prom_in, meta_name):
         if prom_in in self._group_inputs:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -31,7 +31,7 @@ from openmdao.utils.mpi import MPI, check_mpi_exceptions, multi_proc_exception_c
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.indexer import indexer, Indexer
 from openmdao.utils.om_warnings import issue_warning, UnitsWarning, UnusedOptionWarning, \
-    SetupWarning, PromotionWarning, MPIWarning, DistributedComponentWarning
+    SetupWarning, PromotionWarning, MPIWarning
 from openmdao.core.constants import _SetupStatus
 from openmdao.utils.om_warnings import warn_deprecation
 
@@ -873,11 +873,6 @@ class Group(System):
                         raise RuntimeError(f"{self.msginfo}: Can't connect distributed output "
                                            f"'{abs_out}' to serial input '{abs_in}' without "
                                            "specifying src_indices.")
-                elif in_dist and not out_dist:
-                    issue_warning(f"Connecting a serial output '{abs_out}' and distributed input "
-                                  f"'{abs_in}' is not common. While legal in OM, verify "
-                                  "connections are as expected.",
-                                  category=DistributedComponentWarning)
 
     def _get_group_input_meta(self, prom_in, meta_name):
         if prom_in in self._group_inputs:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -31,7 +31,7 @@ from openmdao.utils.mpi import MPI, check_mpi_exceptions, multi_proc_exception_c
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.indexer import indexer, Indexer
 from openmdao.utils.om_warnings import issue_warning, UnitsWarning, UnusedOptionWarning, \
-    SetupWarning, PromotionWarning, MPIWarning
+    SetupWarning, PromotionWarning, MPIWarning, DistributedComponentWarning
 from openmdao.core.constants import _SetupStatus
 from openmdao.utils.om_warnings import warn_deprecation
 
@@ -876,7 +876,8 @@ class Group(System):
                 elif in_dist and not out_dist:
                     issue_warning(f"Connecting a serial output '{abs_out}' and distributed input "
                                   f"'{abs_in}' is not common. While legal in OM, verify "
-                                  f"connections are as expected.")
+                                  f"connections are as expected.",
+                                  category=DistributedComponentWarning)
 
     def _get_group_input_meta(self, prom_in, meta_name):
         if prom_in in self._group_inputs:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -874,9 +874,9 @@ class Group(System):
                                            f"'{abs_out}' to serial input '{abs_in}' without "
                                            "specifying src_indices.")
                 elif in_dist and not out_dist:
-                    warn_deprecation(f"Connection between serial output '{abs_out}' and distributed"
-                                     f" input '{abs_in}' is deprecated and will become an error "
-                                     "in a future release.")
+                    issue_warning(f"Connecting a serial output '{abs_out}' and distributed input "
+                                  f"'{abs_in}' is not common. While legal in OM, verify "
+                                  f"connections are as expected.")
 
     def _get_group_input_meta(self, prom_in, meta_name):
         if prom_in in self._group_inputs:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -876,7 +876,8 @@ class Group(System):
                 elif in_dist and not out_dist:
                     issue_warning(f"Connecting a serial output '{abs_out}' and distributed input "
                                   f"'{abs_in}' is not common. While legal in OM, verify "
-                                  "connections are as expected.", category=DistributedComponentWarning)
+                                  "connections are as expected.",
+                                  category=DistributedComponentWarning)
 
     def _get_group_input_meta(self, prom_in, meta_name):
         if prom_in in self._group_inputs:

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -748,19 +748,6 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.run_model()
         np.testing.assert_allclose(p.get_val('indeps.x'), p.get_val('comp.x'))
 
-    def test_ser_known_dist_unknown(self):
-        p = om.Problem()
-        indeps = p.model.add_subsystem('indeps', om.IndepVarComp())
-
-        indeps.add_output('x', val=np.random.random(2))
-        p.model.add_subsystem('comp', DistCompUnknownInput())
-        p.model.connect('indeps.x', 'comp.x')
-        msg = "Connection between serial output 'indeps.x' and distributed input 'comp.x' is deprecated and will become an error in a future release."
-        with assert_warning(OMDeprecationWarning, msg):
-            p.setup()
-        p.run_model()
-        np.testing.assert_allclose(p.get_val('indeps.x'), p.get_val('comp.x'))
-
     def test_ser_unknown_dist_known_err(self):
         p = om.Problem()
         indeps = p.model.add_subsystem('indeps', om.IndepVarComp())
@@ -771,18 +758,6 @@ class TestDistribDynShapeCombos(unittest.TestCase):
             p.setup()
         self.assertEquals(cm.exception.args[0],
                           "<model> <class Group>: dynamic sizing of serial output 'indeps.x' from distributed input 'comp.x' is not supported because not all comp.x ranks are the same size (sizes=[3 6 9]).")
-
-    def test_ser_unknown_dist_known(self):
-        p = om.Problem()
-        indeps = p.model.add_subsystem('indeps', om.IndepVarComp())
-        indeps.add_output('x', shape_by_conn=True)
-        p.model.add_subsystem('comp', DistCompKnownInput())
-        p.model.connect('indeps.x', 'comp.x')
-        msg = "Connection between serial output 'indeps.x' and distributed input 'comp.x' is deprecated and will become an error in a future release."
-        with assert_warning(OMDeprecationWarning, msg):
-            p.setup()
-        p.run_model()
-        np.testing.assert_allclose(p.get_val('indeps.x'), p.get_val('comp.x'))
 
     def test_dist_known_ser_unknown(self):
         p = om.Problem()

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -17,8 +17,7 @@ from openmdao.test_suite.components.sellar import SellarDis2
 from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning
 from openmdao.utils.logger_utils import TestLogger
-from openmdao.utils.om_warnings import PromotionWarning, OMDeprecationWarning, \
-    DistributedComponentWarning
+from openmdao.utils.om_warnings import PromotionWarning, OMDeprecationWarning
 from openmdao.utils.name_maps import name2abs_names
 
 try:

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1442,7 +1442,7 @@ class TestGroupMPISlice(unittest.TestCase):
         p.model = SimpleGroup()
 
         msg = ("Connecting a serial output 'serial_ivc.global_a' and distributed input "
-              "'parallel_sum.local_a' is not common. While legal in OM, verify connections are as expected")
+               "'parallel_sum.local_a' is not common. While legal in OM, verify connections are as expected.")
         with assert_warning(DistributedComponentWarning, msg):
             p.setup()
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1413,39 +1413,6 @@ class TestGroup(unittest.TestCase):
 class TestGroupMPISlice(unittest.TestCase):
     N_PROCS = 2
 
-    def test_distrib_input_to_serial_output(self):
-        class ParallelSum(om.ExplicitComponent):
-            """Simple parallel summation."""
-
-            def setup(self):
-                self.add_input('local_a', shape=1, distributed=True, desc='local slice of parallel a vector.')
-                self.add_output('sum')
-
-            def compute(self, inputs, outputs):
-                outputs['sum'] = self.comm.allreduce(inputs['local_a'])
-
-        class SerialIVC(om.IndepVarComp):
-            """Simple serial vector independent variable component"""
-            def setup(self):
-                size = self.comm.size
-                self.add_output('global_a', val=np.arange(size), shape=size, desc='global a vector.')
-
-        class SimpleGroup(om.Group):
-            def setup(self):
-                indx = self.comm.rank
-                self.add_subsystem('serial_ivc', SerialIVC())
-                self.add_subsystem('parallel_sum', ParallelSum())
-                # Split serial vector across each processor
-                self.connect('serial_ivc.global_a', 'parallel_sum.local_a', src_indices=[indx])
-
-        p = om.Problem()
-        p.model = SimpleGroup()
-
-        msg = ("Connecting a serial output 'serial_ivc.global_a' and distributed input "
-               "'parallel_sum.local_a' is not common. While legal in OM, verify connections are as expected.")
-        with assert_warning(DistributedComponentWarning, msg):
-            p.setup()
-
     def test_om_slice_2d_mpi(self):
         class MyComp1(om.ExplicitComponent):
             def setup(self):

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1413,7 +1413,7 @@ class TestGroup(unittest.TestCase):
 class TestGroupMPISlice(unittest.TestCase):
     N_PROCS = 2
 
-    def test_serial_input_to_distrib_output(self):
+    def test_distrib_input_to_serial_output(self):
         class ParallelSum(om.ExplicitComponent):
             """Simple parallel summation."""
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -17,7 +17,8 @@ from openmdao.test_suite.components.sellar import SellarDis2
 from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning
 from openmdao.utils.logger_utils import TestLogger
-from openmdao.utils.om_warnings import PromotionWarning, OMDeprecationWarning
+from openmdao.utils.om_warnings import PromotionWarning, OMDeprecationWarning, \
+    DistributedComponentWarning
 from openmdao.utils.name_maps import name2abs_names
 
 try:
@@ -1442,7 +1443,7 @@ class TestGroupMPISlice(unittest.TestCase):
 
         msg = ("Connecting a serial output 'serial_ivc.global_a' and distributed input "
               "'parallel_sum.local_a' is not common. While legal in OM, verify connections are as expected")
-        with assert_warning(UserWarning, msg):
+        with assert_warning(DistributedComponentWarning, msg):
             p.setup()
 
     def test_om_slice_2d_mpi(self):


### PR DESCRIPTION
### Summary

Removed the deprecation warning as we have decided to keep the functionality.

### Related Issues

- Resolves #2346

### Backwards incompatibilities

None

### New Dependencies

None
