### PR TITLE
I2338 if no explicit name given to a Problem, assign one automatically

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -59,7 +59,6 @@ _contains_all = ContainsAll()
 # Used for naming Problems when no explicit name is given
 # Also handles sub problems
 _problem_names = []
-_problem_counter = 0
 
 CITATION = """@article{openmdao_2019,
     Author={Justin S. Gray and John T. Hwang and Joaquim R. R. A.
@@ -144,24 +143,24 @@ class Problem(object):
         """
         Initialize attributes.
         """
-        global _problem_counter
+        global _problem_names
 
         self.cite = CITATION
 
         # Code to give non-empty names to Problems so that they can be
         # referenced from command line tools (e.g. check) that accept a Problem argument
-        _problem_counter += 1
         if name:  # if name hasn't been used yet, use it. Otherwise, error
             if name not in _problem_names:
                 self._name = name
             else:
                 raise ValueError(f"The problem name '{name}' already exists")
-        else:  # No name given: look for a name, of the form, 'problemN', that hasn't been used yet
-            _name = f"problem{_problem_counter}"
+        else:  # No name given: look for a name, of the form, 'problemN', that hasn't been used
+            problem_counter = len(_problem_names) + 1
+            _name = f"problem{problem_counter}"
             if _name in _problem_names:  # need to make it unique so append string of form '.N'
                 i = 1
                 while True:
-                    _name = f"problem{_problem_counter}.{i}"
+                    _name = f"problem{problem_counter}.{i}"
                     if _name not in _problem_names:
                         break
                     i += 1

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -1986,17 +1986,17 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
             prob.setup(force_alloc_complex=force_alloc_complex)
             return prob, parab
 
-        expected_check_partials_error = f"Problem: Checking partials with respect " \
+        expected_check_partials_error = f"Problem .*: Checking partials with respect " \
               "to variable '{var}' in component " \
               "'{comp.pathname}' using the same " \
               "method and options as are used to compute the " \
               "component's derivatives " \
               "will not provide any relevant information on the " \
-              "accuracy.\n" \
+              "accuracy\.\n" \
               "To correct this, change the options to do the \n" \
               "check_partials using either:\n" \
-              "     - arguments to Problem.check_partials. \n" \
-              "     - arguments to Component.set_check_partial_options"
+              "     - arguments to Problem\.check_partials. \n" \
+              "     - arguments to Component\.set_check_partial_options"
 
         # Scenario 1:
         #    Compute partials: exact
@@ -2011,10 +2011,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         #    Expected result: Error
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as err:
-            prob.check_partials(method='fd')
         expected_error_msg = expected_check_partials_error.format(var='x', comp=self.parab)
-        self.assertEqual(expected_error_msg, str(err.exception))
+        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+            prob.check_partials(method='fd')
 
         # Scenario 3:
         #    Compute partials: fd, with default options
@@ -2056,10 +2055,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         #    Expected result: Error since using fd to check fd. All options the same
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as err:
-            prob.check_partials(method='cs')
         expected_error_msg = expected_check_partials_error.format(var='x', comp=parab)
-        self.assertEqual(expected_error_msg, str(err.exception)[:len(expected_error_msg)])
+        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+            prob.check_partials(method='cs')
 
         # Scenario 7:
         #    Compute partials: fd, with default options
@@ -2079,10 +2077,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
         parab.set_check_partial_options('*')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as err:
-            prob.check_partials()
         expected_error_msg = expected_check_partials_error.format(var='x', comp=parab)
-        self.assertEqual(expected_error_msg, str(err.exception)[:len(expected_error_msg)])
+        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+            prob.check_partials()
 
         # Scenario 9:
         #    Compute partials: fd, with default options
@@ -2138,10 +2135,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob, parab = create_problem(force_alloc_complex=True)
         parab.declare_partials(of='*', wrt='*', method='cs')
         parab.set_check_partial_options('*', method='cs')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as err:
-            prob.check_partials()
         expected_error_msg = expected_check_partials_error.format(var='x', comp=parab)
-        self.assertEqual(expected_error_msg, str(err.exception)[:len(expected_error_msg)])
+        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+            prob.check_partials()
 
         # Scenario 15:
         #    Compute partials: cs, with default options
@@ -2155,12 +2151,12 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.check_partials()
 
         # Now do similar checks for check_totals when approximations are used
-        expected_check_totals_error_msg = "Problem: Checking totals using the same " \
+        expected_check_totals_error_msg = "Problem .*: Checking totals using the same " \
               "method and options as are used to compute the " \
               "totals will not provide any relevant information on the " \
-              "accuracy.\n" \
+              "accuracy\.\n" \
               "To correct this, change the options to do the " \
-              "check_totals or on the call to approx_totals for the model."
+              "check_totals or on the call to approx_totals for the model\."
 
         # Scenario 16:
         #    Compute totals: no approx on totals
@@ -2179,9 +2175,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.model.approx_totals()
         prob.setup()
         prob.run_model()
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as err:
+        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning,
+                                        expected_check_totals_error_msg) :
             prob.check_totals()
-        self.assertEqual(expected_check_totals_error_msg, str(err.exception))
 
         # Scenario 18:
         #    Compute totals: approx on totals using defaults
@@ -2222,9 +2218,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.model.approx_totals(method='cs')
         prob.setup()
         prob.run_model()
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as err:
+        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning,
+                               expected_check_totals_error_msg):
             prob.check_totals(method='cs')
-        self.assertEqual(expected_check_totals_error_msg, str(err.exception))
 
         # Scenario 22:
         #    Compute totals: fd, the default
@@ -3484,12 +3480,10 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        with self.assertRaises(RuntimeError) as cm:
+        msg = "\nProblem .*: To enable complex step, specify 'force_alloc_complex=True' when calling " + \
+                "setup on the problem, e\.g\. 'problem\.setup\(force_alloc_complex=True\)'"
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.check_totals(method='cs')
-
-        msg = "\nProblem: To enable complex step, specify 'force_alloc_complex=True' when calling " + \
-                "setup on the problem, e.g. 'problem.setup(force_alloc_complex=True)'"
-        self.assertEqual(str(cm.exception), msg)
 
     def test_fd_zero_check(self):
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1343,10 +1343,9 @@ class TestGroup(unittest.TestCase):
         prob.setup()
         prob.model.set_order(['C2', 'C1'])
 
-        msg = "Problem: Cannot call set_order without calling setup after"
-        with self.assertRaises(RuntimeError) as cm:
+        msg = "Problem .*: Cannot call set_order without calling setup after"
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.run_model()
-        self.assertEqual(str(cm.exception), msg)
 
     def test_set_order_normal(self):
 

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -308,13 +308,11 @@ class TestParallelGroups(unittest.TestCase):
 
         # check that error is thrown if not using PETScVector
         if MPI:
-            msg = ("Problem: The `distributed_vector_class` argument must be a distributed vector "
+            msg = ("Problem .*: The `distributed_vector_class` argument must be a distributed vector "
                    "class like `PETScVector` when running in parallel under MPI but 'DefaultVector' "
-                   "was specified which is not distributed.")
-            with self.assertRaises(ValueError) as cm:
+                   "was specified which is not distributed\.")
+            with self.assertRaisesRegex(ValueError, msg):
                 prob.setup(check=False, mode='fwd', distributed_vector_class=om.DefaultVector)
-
-            self.assertEqual(str(cm.exception), msg)
         else:
             prob.setup(check=False, mode='fwd')
 

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -81,21 +81,21 @@ class ProbRemoteTestCase(unittest.TestCase):
         par.add_subsystem('C2', om.ExecComp('y=3*x'))
         p.model.connect('indep.x', ['par.C1.x', 'par.C2.x'])
 
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError,
+            "Problem .*: is_local\('indep\.x'\) was called before setup\(\) completed\."):
             loc = p.is_local('indep.x')
-        self.assertEqual(str(cm.exception), "Problem: is_local('indep.x') was called before setup() completed.")
 
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError,
+            "Problem .*: is_local\('par\.C1'\) was called before setup\(\) completed\."):
             loc = p.is_local('par.C1')
-        self.assertEqual(str(cm.exception), "Problem: is_local('par.C1') was called before setup() completed.")
 
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError,
+            "Problem .*: is_local\('par\.C1\.y'\) was called before setup\(\) completed\."):
             loc = p.is_local('par.C1.y')
-        self.assertEqual(str(cm.exception), "Problem: is_local('par.C1.y') was called before setup() completed.")
 
-        with self.assertRaises(RuntimeError) as cm:
+        with self.assertRaisesRegex(RuntimeError,
+            "Problem .*: is_local\('par\.C1\.x'\) was called before setup\(\) completed\."):
             loc = p.is_local('par.C1.x')
-        self.assertEqual(str(cm.exception), "Problem: is_local('par.C1.x') was called before setup() completed.")
 
         p.setup()
         p.final_setup()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2159,8 +2159,7 @@ class NestedProblemTestCase(unittest.TestCase):
                 return super().solve()
 
         # Initially use the default names
-        openmdao.core.problem._problem_counter = 0  # need to reset these to simulate separate runs
-        openmdao.core.problem._problem_names = []
+        openmdao.core.problem._problem_names = []  # need to reset these to simulate separate runs
         p = om.Problem()
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
         G = p.model.add_subsystem('G', om.Group())
@@ -2174,8 +2173,7 @@ class NestedProblemTestCase(unittest.TestCase):
         self.assertEqual(G.nonlinear_solver._problem._get_inst_id(), 'problem2')
 
         # If the second Problem uses the default name of the first
-        openmdao.core.problem._problem_counter = 0  # need to reset these to simulate separate runs
-        openmdao.core.problem._problem_names = []
+        openmdao.core.problem._problem_names = []  # need to reset these to simulate separate runs
         p = om.Problem()
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
         G = p.model.add_subsystem('G', om.Group())
@@ -2189,8 +2187,7 @@ class NestedProblemTestCase(unittest.TestCase):
         self.assertEqual(str(context.exception), "The problem name 'problem1' already exists")
 
         # If the first Problem uses the default name of 'problem2'
-        openmdao.core.problem._problem_counter = 0  # need to reset these to simulate separate runs
-        openmdao.core.problem._problem_names = []
+        openmdao.core.problem._problem_names = []  # need to reset these to simulate separate runs
         p = om.Problem(name='problem2')
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
         G = p.model.add_subsystem('G', om.Group())

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2159,7 +2159,7 @@ class NestedProblemTestCase(unittest.TestCase):
                 return super().solve()
 
         # Initially use the default names
-        openmdao.core.problem._problem_counter = 0
+        openmdao.core.problem._problem_counter = 0  # need to reset these to simulate separate runs
         openmdao.core.problem._problem_names = []
         p = om.Problem()
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
@@ -2174,7 +2174,7 @@ class NestedProblemTestCase(unittest.TestCase):
         self.assertEqual(G.nonlinear_solver._problem._get_inst_id(), 'problem2')
 
         # If the second Problem uses the default name of the first
-        openmdao.core.problem._problem_counter = 0
+        openmdao.core.problem._problem_counter = 0  # need to reset these to simulate separate runs
         openmdao.core.problem._problem_names = []
         p = om.Problem()
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
@@ -2189,7 +2189,7 @@ class NestedProblemTestCase(unittest.TestCase):
         self.assertEqual(str(context.exception), "The problem name 'problem1' already exists")
 
         # If the first Problem uses the default name of 'problem2'
-        openmdao.core.problem._problem_counter = 0
+        openmdao.core.problem._problem_counter = 0  # need to reset these to simulate separate runs
         openmdao.core.problem._problem_names = []
         p = om.Problem(name='problem2')
         p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -827,20 +827,17 @@ class TestProblem(unittest.TestCase):
         prob.model.add_subsystem('comp', Paraboloid())
         prob.setup()
         prob.run_model()
-        with self.assertRaises(RuntimeError) as cm:
+        msg = "Problem .*: To enable complex step, specify 'force_alloc_complex=True' when calling " + \
+            "setup on the problem, e\.g\. 'problem\.setup\(force_alloc_complex=True\)'"
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.set_complex_step_mode(True)
-
-        msg = "Problem: To enable complex step, specify 'force_alloc_complex=True' when calling " + \
-            "setup on the problem, e.g. 'problem.setup(force_alloc_complex=True)'"
-        self.assertEqual(cm.exception.args[0], msg)
 
         prob = om.Problem()
         prob.model.add_subsystem('comp', Paraboloid())
-        with self.assertRaises(RuntimeError) as cm:
+        msg = "Problem .*: set_complex_step_mode cannot be called before `Problem\.run_model\(\)`, " + \
+            "`Problem\.run_driver\(\)`, or `Problem\.final_setup\(\)`."
+        with self.assertRaisesRegex(RuntimeError, msg) :
             prob.set_complex_step_mode(True)
-        msg = "Problem: set_complex_step_mode cannot be called before `Problem.run_model()`, " + \
-            "`Problem.run_driver()`, or `Problem.final_setup()`."
-        self.assertEqual(cm.exception.args[0], msg)
 
     def test_feature_run_driver(self):
 
@@ -1385,44 +1382,26 @@ class TestProblem(unittest.TestCase):
 
         prob = om.Problem()
 
-        try:
+        msg = "Problem .*: The `setup` method must be called before `run_model`."
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.run_model()
-        except RuntimeError as err:
-            msg = "Problem: The `setup` method must be called before `run_model`."
-            self.assertEqual(str(err), msg)
-        else:
-            self.fail('Expecting RuntimeError')
 
-        try:
+        msg = "Problem .*: The `setup` method must be called before `run_driver`."
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.run_driver()
-        except RuntimeError as err:
-            msg = "Problem: The `setup` method must be called before `run_driver`."
-            self.assertEqual(str(err), msg)
-        else:
-            self.fail('Expecting RuntimeError')
 
     def test_run_with_invalid_prefix(self):
         # Test error message when running with invalid prefix.
 
-        msg = "Problem: The 'case_prefix' argument should be a string."
-
         prob = om.Problem()
 
-        try:
+        msg = "Problem .*: The 'case_prefix' argument should be a string."
+        with self.assertRaisesRegex(TypeError, msg):
             prob.setup()
             prob.run_model(case_prefix=1234)
-        except TypeError as err:
-            self.assertEqual(str(err), msg)
-        else:
-            self.fail('Expecting TypeError')
-
-        try:
+        with self.assertRaisesRegex(TypeError, msg):
             prob.setup()
             prob.run_driver(case_prefix=12.34)
-        except TypeError as err:
-            self.assertEqual(str(err), msg)
-        else:
-            self.fail('Expecting TypeError')
 
     def test_args(self):
         # defaults
@@ -1446,18 +1425,14 @@ class TestProblem(unittest.TestCase):
         self.assertTrue(isinstance(prob.driver, om.ScipyOptimizeDriver))
 
         # invalid model
-        with self.assertRaises(TypeError) as cm:
+        msg = "Problem .*: The value provided for 'model' is not a valid System."
+        with self.assertRaisesRegex(TypeError, msg) :
             prob = om.Problem(om.ScipyOptimizeDriver())
 
-        self.assertEqual(str(cm.exception),
-                         "Problem: The value provided for 'model' is not a valid System.")
-
         # invalid driver
-        with self.assertRaises(TypeError) as cm:
+        msg = "Problem .*: The value provided for 'driver' is not a valid Driver."
+        with self.assertRaisesRegex(TypeError, msg) :
             prob = om.Problem(driver=SellarDerivatives())
-
-        self.assertEqual(str(cm.exception),
-                         "Problem: The value provided for 'driver' is not a valid Driver.")
 
     def test_relevance(self):
         p = om.Problem()
@@ -2067,9 +2042,9 @@ class TestProblem(unittest.TestCase):
         model = prob.model
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
-        with self.assertRaises(RuntimeError) as cm:
+        msg = "Problem .*: 'x' Cannot call set_val before setup."
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.set_val('x', 0.)
-        self.assertEqual(str(cm.exception), "Problem: 'x' Cannot call set_val before setup.")
 
 
 class NestedProblemTestCase(unittest.TestCase):
@@ -2159,6 +2134,74 @@ class NestedProblemTestCase(unittest.TestCase):
         totals = prob.check_totals(of='f_xy', wrt=['x', 'y'], method='cs', out_stream=None)
         for key, val in totals.items():
             assert_near_equal(val['rel error'][0], 0.0, 1e-12)
+
+    def test_nested_prob_default_naming(self):
+        import openmdao.core.problem
+        class _ProblemSolver(om.NonlinearRunOnce):
+
+            def __init__(self, prob_name=None):
+                super(_ProblemSolver, self).__init__()
+                self.prob_name = prob_name
+                self._problem = None
+
+            def solve(self):
+                # create a simple subproblem and run it to test for global solver_info bug
+                p = om.Problem(name=self.prob_name)
+                self._problem = p
+                p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
+                p.model.add_subsystem('comp', om.ExecComp('y=2*x'))
+                p.model.connect('indep.x', 'comp.x')
+                p.setup()
+                p.run_model()
+
+                print(p.msginfo)
+
+                return super().solve()
+
+        # Initially use the default names
+        openmdao.core.problem._problem_counter = 0
+        openmdao.core.problem._problem_names = []
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
+        G = p.model.add_subsystem('G', om.Group())
+        G.add_subsystem('comp', om.ExecComp('y=2*x'))
+        G.nonlinear_solver = _ProblemSolver()
+        p.model.connect('indep.x', 'G.comp.x')
+        p.setup()
+        p.run_model()  # need to do run_model in this test so sub problem is created
+
+        self.assertEqual(p._get_inst_id(), 'problem1')
+        self.assertEqual(G.nonlinear_solver._problem._get_inst_id(), 'problem2')
+
+        # If the second Problem uses the default name of the first
+        openmdao.core.problem._problem_counter = 0
+        openmdao.core.problem._problem_names = []
+        p = om.Problem()
+        p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
+        G = p.model.add_subsystem('G', om.Group())
+        G.add_subsystem('comp', om.ExecComp('y=2*x'))
+        G.nonlinear_solver = _ProblemSolver(prob_name='problem1')
+        p.model.connect('indep.x', 'G.comp.x')
+        p.setup()
+
+        with self.assertRaises(Exception) as context:
+            p.run_model()
+        self.assertEqual(str(context.exception), "The problem name 'problem1' already exists")
+
+        # If the first Problem uses the default name of 'problem2'
+        openmdao.core.problem._problem_counter = 0
+        openmdao.core.problem._problem_names = []
+        p = om.Problem(name='problem2')
+        p.model.add_subsystem('indep', om.IndepVarComp('x', 1.0))
+        G = p.model.add_subsystem('G', om.Group())
+        G.add_subsystem('comp', om.ExecComp('y=2*x'))
+        G.nonlinear_solver = _ProblemSolver()
+        p.model.connect('indep.x', 'G.comp.x')
+        p.setup()
+        p.run_model()
+
+        self.assertEqual(p._get_inst_id(), 'problem2')
+        self.assertEqual(G.nonlinear_solver._problem._get_inst_id(), 'problem2.1')
 
 
 class SystemInTwoProblemsTestCase(unittest.TestCase):

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1537,12 +1537,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        with self.assertRaises(RuntimeError) as cm:
+        expected_msg = \
+            "Problem .*: run_model must be called before total derivatives can be checked\."
+        with self.assertRaisesRegex(RuntimeError, expected_msg):
             totals = prob.check_totals(method='fd', out_stream=False)
-
-        expected_msg = "Problem: run_model must be called before total derivatives can be checked."
-
-        self.assertEqual(expected_msg, str(cm.exception))
 
     def test_cobyla_linear_constraint(self):
         # Bug where ScipyOptimizeDriver tried to compute and cache the constraint derivatives for the

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2611,13 +2611,11 @@ class TestSqliteRecorder(unittest.TestCase):
         prob.add_recorder(self.recorder)
         prob.setup()
 
-        with self.assertRaises(RuntimeError) as cm:
+        msg = "Problem .*: Problem.record\(\) cannot be called before " \
+                         "`Problem\.run_model\(\)`, `Problem\.run_driver\(\)`, or " \
+                         "`Problem\.final_setup\(\)`\."
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.record('initial')
-
-        self.assertEqual(str(cm.exception),
-                         "Problem: Problem.record() cannot be called before "
-                         "`Problem.run_model()`, `Problem.run_driver()`, or "
-                         "`Problem.final_setup()`.")
 
         prob.cleanup()
 


### PR DESCRIPTION
### Summary

Currently, if the user doesn't provide an explicit name for a Problem, the name is the empty string. If a model has sub problems, and the user wants to use one of the command line tools that take problem name as an argument, there is no way to indicate which Problem to apply the command to.

This PR assigns default values to Problems that are explicitly given a name.

### Related Issues

- Resolves #2338 

### Backwards incompatibilities

None

### New Dependencies

None
