### PR TITLE
Replace np.bool with bool

### DIFF
--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -246,7 +246,7 @@ class COOMatrix(Matrix):
             for key, val in self._key_ranges.items():
                 if key[1] in input_names:
                     if mask is None:
-                        mask = np.ones(self._matrix.data.size, dtype=np.bool)
+                        mask = np.ones(self._matrix.data.size, dtype=bool)
                     ind1, ind2, _, _ = val
                     mask[ind1:ind2] = False
 

--- a/openmdao/matrices/dense_matrix.py
+++ b/openmdao/matrices/dense_matrix.py
@@ -75,7 +75,7 @@ class DenseMatrix(COOMatrix):
                 # Mask need to be applied to ext_mtx so that we can ignore multiplication
                 # by certain columns.
                 mat_T = mat.T
-                arrmask = np.zeros(mat_T.shape, dtype=np.bool)
+                arrmask = np.zeros(mat_T.shape, dtype=bool)
                 arrmask[mask, :] = True
                 masked_mtx = np.ma.array(mat_T, mask=arrmask, fill_value=0.0)
 
@@ -101,7 +101,7 @@ class DenseMatrix(COOMatrix):
         """
         if d_inputs._in_matvec_context():
             sub = d_inputs._names
-            mask = np.ones(len(d_inputs), dtype=np.bool)
+            mask = np.ones(len(d_inputs), dtype=bool)
             for key, val in self._metadata.items():
                 if key[1] in sub:
                     mask[val[1]] = False

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -148,7 +148,7 @@ def format_nan_error(system, matrix):
     # need to associate each index with a variable.
     varsizes = np.sum(system._owned_sizes, axis=0)
 
-    nanrows = np.zeros(matrix.shape[0], dtype=np.bool)
+    nanrows = np.zeros(matrix.shape[0], dtype=bool)
     nanrows[np.where(np.isnan(matrix))[0]] = True
 
     varnames = []


### PR DESCRIPTION
### Summary

This fixes the np.bool deprecation warning (from numpy 1.20.0).
"DeprecationWarning: `np.bool` is a deprecated alias for the builtin
`bool`. To silence this warning, use `bool` by itself. Doing this will not
modify any behavior and is safe."

### Related Issues

- Resolves #2374 

### Backwards incompatibilities

None known. From https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated it says np.bool and others existed for 'historical reasons'.

### New Dependencies

None
