### PR TITLE
Fix 'Ken' (kelvin-as-energy-unit) definition

### DIFF
--- a/openmdao/utils/unit_library.ini
+++ b/openmdao/utils/unit_library.ini
@@ -215,7 +215,7 @@ planck: 2*pi*hbar, Planck constant
 mp: 1.672614e-27*kg, proton rest mass
 mn: 1.674920e-27*kg, neutron rest mass
 sigma: 5.66961e-8*W/(m**2*K**-4), Stefan-Boltzmann constant
-Ken: sigma*K, kelvin as energy unit
+Ken: 1.380649e-23*J, kelvin as energy unit
 Rinfinity: 1.09737312e7/m, Rydberg constant
 re: 2.817939e-15*m, classic electron radius
 lambdac: 2.4263096e-12*m, Compton wavelength of electron


### PR DESCRIPTION
The new value is from the 2018 redefinition of the SI system, where
Boltzmann's constant is defined as 1.380649e-23 J/K.

See for example https://www.nist.gov/si-redefinition/kelvin-boltzmann-constant

### Summary

Fix definition of the Kelvin-as-energy unit

### Related Issues

- Resolves #2385

### Backwards incompatibilities

This would change the results of anyone previously using the `Ken` unit who *also* converted it to/from other units.

### New Dependencies

None
