### PR TITLE
Changed minimum Python version to 3.7 since 3.6 has reached end-of-life.

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -53,7 +53,7 @@ jobs:
 
           # oldest supported versions
           - NAME: Oldest
-            PY: 3.6
+            PY: 3.7
             NUMPY: 1.17
             SCIPY: 1.2
             PETSc: 3.10.2

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -1,12 +1,9 @@
 """Test Jupyter doc GUI mods specific to OpenMDAO using Playwright."""
 import unittest
 import os
-import sys
 
-# Playwright requires Python 3.7 or higher
-if sys.version_info >= (3, 7):
-    os.system("playwright install")
-    from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs
+os.system("playwright install")
+from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs
 
-    if __name__ == "__main__":
-        unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -1,12 +1,9 @@
 """Test N2 GUI with multiple models using Playwright."""
 import unittest
 import os
-import sys
 
-# Playwright requires Python 3.7 or higher
-if sys.version_info >= (3, 7):
-    os.system("playwright install")
-    from n2_gui_test import n2_gui_test_case
+os.system("playwright install")
+from n2_gui_test import n2_gui_test_case
 
-    if __name__ == "__main__":
-        unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -37,12 +37,10 @@ optional_dependencies = {
         'pydocstyle==2.0.0',
         'testflo>=1.3.6'
         'websockets>8',
-        'aiounittest'
+        'aiounittest',
+        'playwright<1.15'
     ]
 }
-
-if sys.version_info >= (3, 7):
-    optional_dependencies['test'].append('playwright<1.15')
 
 # Add an optional dependency that concatenates all others
 optional_dependencies['all'] = sorted([
@@ -70,7 +68,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Topic :: Scientific/Engineering',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
@@ -164,7 +161,7 @@ setup(
         ],
         'openmdao': ['*/tests/*.py', '*/*/tests/*.py', '*/*/*/tests/*.py']
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=[
         'networkx>=2.0',
         'numpy',


### PR DESCRIPTION
### Summary

Set minimum required version of Python to 3.7, since Python 3.6 has reached end of life:
https://www.python.org/dev/peps/pep-0494/#lifespan

### Related Issues

- Resolves #2391

### Backwards incompatibilities

None

### New Dependencies

None
