### PR TITLE
Removed 'remove-output' tag on metamodel notebooks with options tables

### DIFF
--- a/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelsemistructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelsemistructured_comp.ipynb
@@ -62,8 +62,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "remove-input",
-     "remove-output"
+     "remove-input"
     ]
    },
    "outputs": [],
@@ -483,7 +482,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.1"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelstructured_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/metamodelstructured_comp.ipynb
@@ -107,8 +107,7 @@
    "execution_count": null,
    "metadata": {
     "tags": [
-     "remove-input",
-     "remove-output"
+     "remove-input"
     ]
    },
    "outputs": [],
@@ -510,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.1"
   },
   "orphan": true
  },


### PR DESCRIPTION
### Summary

Removed 'remove-output' tag on structured metamodel and metamodel semistructured options table cell

### Related Issues

- Resolves #2380

### Backwards incompatibilities

None

### New Dependencies

None
