### PR TITLE
updates to hooks system

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -198,10 +198,7 @@ class Driver(object):
     def _get_inst_id(self):
         if self._problem is None:
             return None
-        probid = self._problem()._get_inst_id()
-        if probid is None:
-            return "driver"
-        return f"{probid}.driver"
+        return f"{self._problem()._get_inst_id()}.driver"
 
     @property
     def msginfo(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -945,6 +945,7 @@ class Problem(object):
 
         # this metadata will be shared by all Systems/Solvers in the system tree
         self._metadata = {
+            'name': self._name,  # the name of this Problem
             'coloring_dir': self.options['coloring_dir'],  # directory for coloring files
             'recording_iter': _RecIteration(),  # manager of recorder iterations
             'local_vector_class': local_vector_class,

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -711,10 +711,9 @@ def _check_config_cmd(options, user_args):
 
             prob.check_config(logger, options.checks)
 
-        exit()
-
     # register the hook
-    _register_hook('final_setup', class_name='Problem', inst_id=options.problem, post=_check_config)
+    _register_hook('final_setup', class_name='Problem', inst_id=options.problem, post=_check_config,
+                   exit=True)
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -2050,9 +2050,8 @@ def _total_coloring_cmd(options, user_args):
                 coloring.summary()
         else:
             print("Derivatives are turned off.  Cannot compute simul coloring.")
-        exit()
 
-    hooks._register_hook('final_setup', 'Problem', post=_total_coloring)
+    hooks._register_hook('final_setup', 'Problem', post=_total_coloring, exit=True)
 
     _load_and_exec(options.file[0], user_args)
 
@@ -2222,9 +2221,8 @@ def _partial_coloring_cmd(options, user_args):
                                 _show(s, options, c)
         else:
             print("Derivatives are turned off.  Cannot compute simul coloring.")
-        exit()
 
-    hooks._register_hook('final_setup', 'Problem', post=_partial_coloring)
+    hooks._register_hook('final_setup', 'Problem', post=_partial_coloring, exit=True)
 
     _load_and_exec(options.file[0], user_args)
 

--- a/openmdao/utils/hooks.py
+++ b/openmdao/utils/hooks.py
@@ -8,32 +8,26 @@ import inspect
 import warnings
 
 
-def _reset_all_hooks():
-    global _hooks, _hook_skip_classes
-    _hooks = defaultdict(
-        lambda: defaultdict(lambda: defaultdict(lambda: defaultdict(lambda: None)))
-    )
-    _hook_skip_classes = set()
-
-
 # global dict of hooks
-# {class_name: { inst_id: {fname: <hook_meta_dict>}}}
+# {class_name: { inst_id: {fname: [pre_hooks, post_hooks]}}}
 # At class_name level, there might be a 'None' entry, which means that all instances of
 # that class will have have the hooks specified in the 'None' dict.  Otherwise, entries
 # there will be specific instance names.
-# The <hook_meta_dict> contains the following:
-# {
-#    'pre': funct or None,   # hook function for pre-execution
-#    'post': funct or None,  # hook function for post-execution
-# }
-_hooks = None
-_reset_all_hooks()
+# pre_hooks and post_hooks are lists of functions to call before or after the function named
+# 'fname'.
+_hooks = {}
 
 # classes found here are known to contain no hooks within themselves or their ancestors
 _hook_skip_classes = set()
 
 # global switch that turns hook machinery on/off
 use_hooks = False
+
+
+def _reset_all_hooks():
+    global _hooks, _hook_skip_classes
+    _hooks = {}
+    _hook_skip_classes = set()
 
 
 def _setup_hooks(obj):
@@ -45,6 +39,8 @@ def _setup_hooks(obj):
     obj : object
         The object whose methods may be wrapped.
     """
+    global _hooks, _hook_skip_classes
+
     # _setup_hooks should be called after 'obj' can return a valid name from _get_inst_id().
     # For example, in Problem, it can happen in __init__, but in Component and Group it shouldn't
     # happen until _setup_procs because that's the earliest point where the component/group has a
@@ -54,7 +50,7 @@ def _setup_hooks(obj):
         classes = inspect.getmro(obj.__class__)
         for c in classes:
             if c.__name__ in _hooks:
-                hk = _hooks[c.__name__]
+                classmeta = _hooks[c.__name__]
                 break
         else:
             # didn't find any matching hooks for this class or any base class, so skip in future
@@ -64,20 +60,19 @@ def _setup_hooks(obj):
         # any object where we register hooks must define the '_get_inst_id' method.
         ident = obj._get_inst_id()
 
-        if ident in hk:
-            hk = hk[ident]
-        elif None in hk:
-            hk = hk[None]
+        if ident in classmeta:
+            instmeta = classmeta[ident]
+        elif None in classmeta:  # ident of None applies to all instances of a class
+            instmeta = classmeta[None]
         else:
             return
 
-        for name, hook in hk.items():
-            method = getattr(obj, name, None)
+        for funcname in instmeta:
+            method = getattr(obj, funcname, None)
             if method is not None:
                 # if _hook_ attr is present, we've already wrapped this method
-                if hasattr(method, '_hook_'):
-                    method = method.f  # unwrap the method prior to re-wrapping
-                setattr(obj, name, _hook_decorator(method, obj, hook))
+                if not hasattr(method, '_hook_'):
+                    setattr(obj, funcname, _hook_decorator(method, obj, instmeta[funcname]))
 
 
 def _hook_decorator(f, inst, hookmeta):
@@ -93,20 +88,49 @@ def _hook_decorator(f, inst, hookmeta):
     hookmeta : dict
         A dict with information about the hooks.
     """
-    def check_hooks(*args, **kwargs):
-        pre = hookmeta['pre']
-        if pre:
-            pre(inst)
+    def execute_hooks(*args, **kwargs):
+        pre_hooks, post_hooks = hookmeta
+        for hook in pre_hooks:
+            hook(inst)
 
-        f(*args, **kwargs)
+        ret = f(*args, **kwargs)
 
-        post = hookmeta['post']
-        if post:
-            post(inst)
+        for hook in post_hooks:
+            hook(inst)
 
-    check_hooks._hook_ = True  # to prevent multiple decoration of same function
+        return ret
 
-    return wraps(f)(check_hooks)
+    execute_hooks._hook_ = True  # to prevent multiple decoration of same function
+
+    return wraps(f)(execute_hooks)
+
+
+def _get_hook_lists(class_name, inst_id, fname):
+    """
+    Retrieve the pre and post hook lists for the given class, instance, and function name.
+
+    Parameters
+    ----------
+    class_name : str
+        The name of the class owning the method where the hook will be applied.
+    inst_id : str, optional
+        The name of the instance owning the method where the hook will be applied.
+    fname : str
+        The name of the function where the pre and/or post hook will be applied.
+    """
+    global _hooks
+    if class_name in _hooks:
+        cmeta = _hooks[class_name]
+    else:
+        _hooks[class_name] = cmeta = {}
+    if inst_id in cmeta:
+        imeta = cmeta[inst_id]
+    else:
+        cmeta[inst_id] = imeta = {}
+    if fname in imeta:
+        return imeta[fname]
+    imeta[fname] = [[], []]
+    return imeta[fname]
 
 
 def _register_hook(fname, class_name, inst_id=None, pre=None, post=None):
@@ -131,11 +155,11 @@ def _register_hook(fname, class_name, inst_id=None, pre=None, post=None):
     if pre is None and post is None:
         raise RuntimeError("In _register_hook you must specify pre or post.")
 
-    hook = _hooks[class_name][inst_id][fname]
+    pre_hooks, post_hooks = _get_hook_lists(class_name, inst_id, fname)
     if pre is not None:
-        hook['pre'] = pre
+        pre_hooks.append(pre)
     if post is not None:
-        hook['post'] = post
+        post_hooks.append(post)
 
 
 def _unregister_hook(fname, class_name, inst_id=None, pre=True, post=True):
@@ -153,26 +177,52 @@ def _unregister_hook(fname, class_name, inst_id=None, pre=True, post=True):
         The name of the class owning the method where the hook will be removed.
     inst_id : str, optional
         The name of the instance owning the method where the hook will be removed.
-    pre : bool (True)
-        If True, the hook that runs before the named function runs will be removed.
-    post : bool, (True)
-        If True, the hook that runs after the named function runs will be removed.
+    pre : bool or function, (True)
+        If True, hooks that run before the named function runs will be removed. If a
+        function then that function, if found, will be removed from the pre list, else
+        an exception will be raised.
+    post : bool or function, (True)
+        If True, hooks that run after the named function runs will be removed. If a
+        function then that function, if found, will be removed from the post list, else
+        an exception will be raised.
     """
-    hookdict = _hooks[class_name][inst_id]
-    if fname in hookdict:
-        hook = hookdict[fname]
-        if pre and hook['pre']:
-            hook['pre'] = None
-        if post and hook['post']:
-            hook['post'] = None
+    try:
+        hookdict = _hooks[class_name][inst_id]
+    except KeyError:
+        warnings.warn(f"No hooks found for class '{class_name}' and instance '{inst_id}'.")
+        return
 
-        if not (hook['pre'] or hook['post']):
+    if fname in hookdict:
+        pre_hooks, post_hooks = hookdict[fname]
+        if pre and pre_hooks:
+            if pre is True:
+                pre_hooks[:] = []
+            else:
+                for p in pre_hooks:
+                    if p is pre:
+                        pre_hooks.remove(pre)
+                        break
+                else:
+                    raise RuntimeError("Couldn't find the given 'pre' function in the pre hooks "
+                                       f"for {class_name}.{fname}.")
+        if post and post_hooks:
+            if post is True:
+                post_hooks[:] = []
+            else:
+                for p in post_hooks:
+                    if p is post:
+                        post_hooks.remove(post)
+                        break
+                else:
+                    raise RuntimeError("Couldn't find the given 'post' function in the post hooks "
+                                       f"for {class_name}.{fname}.")
+
+        if not (pre_hooks or post_hooks):
             del hookdict[fname]
             if not hookdict:  # we just removed the last hook entry for this inst
                 del _hooks[class_name][inst_id]
                 if not _hooks[class_name]:  # removed last entry for this class
                     del _hooks[class_name]
     else:
-        warnings.warn("No hook found for method '{}' for class '{}' and instance '{}'.".format(
-            fname, class_name, inst_id
-        ))
+        warnings.warn(f"No hook found for method '{fname}' for class '{class_name}' and instance "
+                      f"'{inst_id}'.")

--- a/openmdao/utils/hooks.py
+++ b/openmdao/utils/hooks.py
@@ -111,6 +111,7 @@ def _hook_decorator(f, inst, hookmeta):
         A dict with information about the hooks.
     """
     pre_hooks, post_hooks = hookmeta
+
     def execute_hooks(*args, **kwargs):
         _run_hooks(pre_hooks, inst)
         ret = f(*args, **kwargs)

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -114,10 +114,9 @@ def _n2_cmd(options, user_args):
         def _viewmod(prob):
             n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
                 title=options.title, embeddable=options.embeddable)
-            exit()  # could make this command line selectable later
 
-        hooks._register_hook('setup', 'Problem', pre=_noraise)
-        hooks._register_hook('final_setup', 'Problem', post=_viewmod)
+        hooks._register_hook('setup', 'Problem', pre=_noraise, ncalls=1)
+        hooks._register_hook('final_setup', 'Problem', post=_viewmod, exit=True)
 
         ignore_errors(True)
         _load_and_exec(options.file[0], user_args)
@@ -166,14 +165,14 @@ def _view_connections_cmd(options, user_args):
             title = "Connections for %s" % os.path.basename(options.file[0])
         view_connections(prob, outfile=options.outfile, show_browser=not options.no_browser,
                          show_values=options.show_values, title=title)
-        exit()
 
     # register the hook
     if options.show_values:
         funcname = 'final_setup'
     else:
         funcname = 'setup'
-    hooks._register_hook(funcname, class_name='Problem', inst_id=options.problem, post=_viewconns)
+    hooks._register_hook(funcname, class_name='Problem', inst_id=options.problem, post=_viewconns,
+                         exit=True)
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)
@@ -271,9 +270,8 @@ def _meta_model_cmd(options, user_args):
                 else:
                     print("\n'{}' is not a Metamodel. Try the following:\n".format(pathname))
                 _mm_list(mm_names, options)
-        exit()
 
-    hooks._register_hook('final_setup', 'Problem', post=_view_metamodel)
+    hooks._register_hook('final_setup', 'Problem', post=_view_metamodel, exit=True)
 
     _load_and_exec(options.file[0], user_args)
 
@@ -301,11 +299,7 @@ def _config_summary_cmd(options, user_args):
     user_args : list of str
         Args to be passed to the user script.
     """
-    def summary(prob):
-        config_summary(prob)
-        sys.exit(0)
-
-    hooks._register_hook('final_setup', 'Problem', post=summary)
+    hooks._register_hook('final_setup', 'Problem', post=config_summary, exit=True)
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)
@@ -409,14 +403,14 @@ def _tree_cmd(options, user_args):
         tree(prob, show_colors=options.show_colors, show_sizes=options.show_sizes,
              show_approx=options.show_approx, filter=filt, max_depth=options.depth,
              rank=options.rank, stream=out)
-        exit()
 
     # register the hook
     if options.vecvars or options.show_sizes or options.show_approx:
         funcname = 'final_setup'
     else:
         funcname = 'setup'
-    hooks._register_hook(funcname, class_name='Problem', inst_id=options.problem, post=_tree)
+    hooks._register_hook(funcname, class_name='Problem', inst_id=options.problem, post=_tree,
+                         exit=True)
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)
@@ -460,9 +454,8 @@ def _cite_cmd(options, user_args):
     def _cite(prob):
         if not MPI or MPI.COMM_WORLD.rank == 0:
             print_citations(prob, classes=options.classes, out_stream=out)
-        exit()
 
-    hooks._register_hook('setup', 'Problem', post=_cite)
+    hooks._register_hook('setup', 'Problem', post=_cite, exit=True)
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)

--- a/openmdao/utils/tests/test_hooks.py
+++ b/openmdao/utils/tests/test_hooks.py
@@ -12,7 +12,7 @@ def make_hook(name):
     return hook_func
 
 
-def hook_tester(f):
+def hooks_active(f):
     def _wrapper(*args, **kwargs):
         hooks.use_hooks = True
         try:
@@ -24,7 +24,7 @@ def hook_tester(f):
 
 
 class HooksTestCase(unittest.TestCase):
-    @hook_tester
+    @hooks_active
     def test_multiwrap(self):
         pre_final = make_hook('pre_final')
         post_final = make_hook('post_final')
@@ -64,7 +64,7 @@ class HooksTestCase(unittest.TestCase):
                                       'pre_final2', 'post_final', 'post_final2',
                                      ])
 
-    @hook_tester
+    @hooks_active
     def test_problem_hooks(self):
         hooks._register_hook('setup', 'Problem', pre=make_hook('pre_setup'), post=make_hook('post_setup'))
         hooks._register_hook('final_setup', 'Problem', pre=make_hook('pre_final'), post=make_hook('post_final'))

--- a/openmdao/utils/tests/test_hooks.py
+++ b/openmdao/utils/tests/test_hooks.py
@@ -6,79 +6,123 @@ import openmdao.utils.hooks as hooks
 from openmdao.utils.assert_utils import assert_warning
 
 
-class HooksTestCase(unittest.TestCase):
-    def test_rewrap(self):
-        # can't test this until we have hooks in Systems or Solvers
-        pass
+def make_hook(name):
+    def hook_func(prob):
+        prob.calls.append(name)
+    return hook_func
 
-    def test_problem_hooks(self):
-        def make_hook(name):
-            def hook_func(prob):
-                prob.calls.append(name)
-            return hook_func
 
+def hook_tester(f):
+    def _wrapper(*args, **kwargs):
         hooks.use_hooks = True
-        hooks._register_hook('setup', 'Problem', pre=make_hook('pre_setup'), post=make_hook('post_setup'))
-        hooks._register_hook('final_setup', 'Problem', pre=make_hook('pre_final'), post=make_hook('post_final'))
-        hooks._register_hook('run_model', 'Problem', pre=make_hook('pre_run_model'), post=make_hook('post_run_model'))
         try:
-            prob = om.Problem()
-            prob.calls = []
-            model = prob.model
-
-            model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
-            model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
-            model.add_subsystem('comp', om.ExecComp("f_xy=2.0*x+3.0*y"))
-
-            model.connect('p1.x', 'comp.x')
-            model.connect('p2.y', 'comp.y')
-
-            prob.setup()
-            prob.run_model()
-            prob.run_model()
-            prob.run_model()
-
-            self.assertEqual(prob.calls, ['pre_setup', 'post_setup',
-                                          'pre_run_model', 'pre_final', 'post_final', 'post_run_model',
-                                          'pre_run_model', 'pre_final', 'post_final', 'post_run_model',
-                                          'pre_run_model', 'pre_final', 'post_final', 'post_run_model',
-                                          ])
-
-            np.testing.assert_allclose(prob['comp.f_xy'], -6.0)
-
-            hooks._unregister_hook('setup', 'Problem', pre=False)
-            hooks._unregister_hook('final_setup', 'Problem')
-            hooks._unregister_hook('run_model', 'Problem', post=False)
-            prob.calls = []
-
-            prob.setup()
-            prob.run_model()
-            prob.run_model()
-            prob.run_model()
-
-            self.assertEqual(prob.calls, ['pre_setup', 'post_run_model', 'post_run_model', 'post_run_model'])
-
-            hooks._unregister_hook('setup', 'Problem')
-
-            msg = "No hook found for method 'final_setup' for class 'Problem' and instance 'None'."
-
-            # already removed final_setup hooks earlier, so expect a warning here
-            with assert_warning(UserWarning, msg):
-                hooks._unregister_hook('final_setup', 'Problem')
-
-            hooks._unregister_hook('run_model', 'Problem')
-            prob.calls = []
-
-            prob.setup()
-            prob.run_model()
-            prob.run_model()
-
-            self.assertEqual(prob.calls, [])
-            self.assertEqual(len(hooks._hooks), 0)  # should be no hooks left
-
+            f(*args, **kwargs)
         finally:
             hooks.use_hooks = False
             hooks._reset_all_hooks()
+    return _wrapper
+
+
+class HooksTestCase(unittest.TestCase):
+    @hook_tester
+    def test_multiwrap(self):
+        pre_final = make_hook('pre_final')
+        post_final = make_hook('post_final')
+        hooks._register_hook('final_setup', 'Problem', pre=pre_final, post=post_final)
+        hooks._register_hook('final_setup', 'Problem', pre=make_hook('pre_final2'), post=make_hook('post_final2'))
+
+        prob = om.Problem()
+        prob.calls = []
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
+        model.add_subsystem('comp', om.ExecComp("f_xy=2.0*x+3.0*y"))
+
+        model.connect('p1.x', 'comp.x')
+        model.connect('p2.y', 'comp.y')
+
+        prob.setup()
+        prob.run_model()
+        prob.run_model()
+        prob.run_model()
+
+        self.assertEqual(prob.calls, ['pre_final', 'pre_final2', 'post_final', 'post_final2',
+                                      'pre_final', 'pre_final2', 'post_final', 'post_final2',
+                                      'pre_final', 'pre_final2', 'post_final', 'post_final2',
+                                     ])
+
+        hooks._unregister_hook('final_setup', 'Problem', pre=pre_final, post=False)
+        prob.calls = []
+
+        prob.run_model()
+        prob.run_model()
+        prob.run_model()
+
+        self.assertEqual(prob.calls, ['pre_final2', 'post_final', 'post_final2',
+                                      'pre_final2', 'post_final', 'post_final2',
+                                      'pre_final2', 'post_final', 'post_final2',
+                                     ])
+
+    @hook_tester
+    def test_problem_hooks(self):
+        hooks._register_hook('setup', 'Problem', pre=make_hook('pre_setup'), post=make_hook('post_setup'))
+        hooks._register_hook('final_setup', 'Problem', pre=make_hook('pre_final'), post=make_hook('post_final'))
+        hooks._register_hook('run_model', 'Problem', pre=make_hook('pre_run_model'), post=make_hook('post_run_model'))
+
+        prob = om.Problem()
+        prob.calls = []
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 3.0))
+        model.add_subsystem('p2', om.IndepVarComp('y', -4.0))
+        model.add_subsystem('comp', om.ExecComp("f_xy=2.0*x+3.0*y"))
+
+        model.connect('p1.x', 'comp.x')
+        model.connect('p2.y', 'comp.y')
+
+        prob.setup()
+        prob.run_model()
+        prob.run_model()
+        prob.run_model()
+
+        self.assertEqual(prob.calls, ['pre_setup', 'post_setup',
+                                        'pre_run_model', 'pre_final', 'post_final', 'post_run_model',
+                                        'pre_run_model', 'pre_final', 'post_final', 'post_run_model',
+                                        'pre_run_model', 'pre_final', 'post_final', 'post_run_model',
+                                        ])
+
+        np.testing.assert_allclose(prob['comp.f_xy'], -6.0)
+
+        hooks._unregister_hook('setup', 'Problem', pre=False)
+        hooks._unregister_hook('final_setup', 'Problem')
+        hooks._unregister_hook('run_model', 'Problem', post=False)
+        prob.calls = []
+
+        prob.setup()
+        prob.run_model()
+        prob.run_model()
+        prob.run_model()
+
+        self.assertEqual(prob.calls, ['pre_setup', 'post_run_model', 'post_run_model', 'post_run_model'])
+
+        hooks._unregister_hook('setup', 'Problem')
+
+        msg = "No hook found for method 'final_setup' for class 'Problem' and instance 'None'."
+
+        # already removed final_setup hooks earlier, so expect a warning here
+        with assert_warning(UserWarning, msg):
+            hooks._unregister_hook('final_setup', 'Problem')
+
+        hooks._unregister_hook('run_model', 'Problem')
+        prob.calls = []
+
+        prob.setup()
+        prob.run_model()
+        prob.run_model()
+
+        self.assertEqual(prob.calls, [])
+        self.assertEqual(len(hooks._hooks), 0)  # should be no hooks left
 
 
 if __name__ == '__main__':

--- a/openmdao/visualization/dyn_shape_plot.py
+++ b/openmdao/visualization/dyn_shape_plot.py
@@ -44,7 +44,6 @@ def _view_dyn_shapes_cmd(options, user_args):
     def _view_shape_graph(model):
         view_dyn_shapes(model, outfile=options.outfile, show=not options.no_display,
                         title=options.title)
-        exit()
 
     def _set_dyn_hook(prob):
         # we can't wait until the end of Problem.setup because we'll die in _setup_sizes
@@ -52,11 +51,11 @@ def _view_dyn_shapes_cmd(options, user_args):
         # _setup_dynamic_shapes.  inst_id is None here because no system's pathname will
         # have been set at the time this hook is triggered.
         hooks._register_hook('_setup_dynamic_shapes', class_name='Group', inst_id=None,
-                             post=_view_shape_graph)
+                             post=_view_shape_graph, exit=True)
         hooks._setup_hooks(prob.model)
 
     # register the hooks
-    hooks._register_hook('setup', 'Problem', pre=_set_dyn_hook)
+    hooks._register_hook('setup', 'Problem', pre=_set_dyn_hook, ncalls=1)
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -520,9 +520,6 @@ def _scaling_cmd(options, user_args):
                 _scaling(problem)
 
     def _scaling(problem):
-        hooks._unregister_hook('final_setup', 'Problem')  # avoid recursive loop
-        hooks._unregister_hook('run_driver', 'Problem')
-        hooks._unregister_hook('run_model', 'Problem')
         driver = problem.driver
         if options.title:
             title = options.title
@@ -537,10 +534,10 @@ def _scaling_cmd(options, user_args):
                          post=_scaling_check)
 
     hooks._register_hook('run_model', class_name='Problem', inst_id=options.problem,
-                         pre=_set_run_model_start, post=_set_run_model_done)
+                         pre=_set_run_model_start, post=_set_run_model_done, ncalls=1)
 
     hooks._register_hook('run_driver', class_name='Problem', inst_id=options.problem,
-                         pre=_set_run_driver_flag)
+                         pre=_set_run_driver_flag, ncalls=1)
 
     # register an atexit function to check if scaling report was triggered during the script
     import atexit

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -1,10 +1,8 @@
 
 """Define a function to view driver scaling."""
 import os
-import sys
 import json
-from itertools import chain
-from collections import defaultdict
+import functools
 
 import numpy as np
 
@@ -15,18 +13,8 @@ import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.mpi import MPI
 from openmdao.utils.webview import webview
-from openmdao.utils.general_utils import printoptions, ignore_errors, default_noraise
-from openmdao.utils.file_utils import _load_and_exec, _to_filename
-
-
-def _val2str(val):
-    if isinstance(val, np.ndarray):
-        if val.size > 5:
-            return 'array %s' % str(val.shape)
-        else:
-            return np.array2string(val)
-
-    return str(val)
+from openmdao.utils.general_utils import ignore_errors, default_noraise
+from openmdao.utils.file_utils import _load_and_exec
 
 
 def _unscale(val, scaler, adder, default=''):
@@ -36,16 +24,6 @@ def _unscale(val, scaler, adder, default=''):
         val = val * (1.0 / scaler)
     if adder is not None:
         val = val - adder
-    return val
-
-
-def _scale(val, scaler, adder, unset=''):
-    if val is None:
-        return unset
-    if adder is not None:
-        val = val + adder
-    if scaler is not None:
-        val = val * scaler
     return val
 
 
@@ -477,15 +455,22 @@ def _scaling_setup_parser(parser):
                         help="Don't show jacobian info")
 
 
-_run_driver_called = False
-_run_model_start = False
-_run_model_done = False
+_run_driver_called = set()
+_run_model_start = set()
+_run_model_done = set()
 
 
-def _exitfunc():
-    if not _run_driver_called:
-        print("\n\nNo driver scaling report was generated because run_driver() was not called "
-              "on the required Problem.\n")
+def _exitfunc(probname):
+    global _run_driver_called
+    from openmdao.core.problem import _problem_names
+    if probname is None:
+        probnames = _problem_names
+    else:
+        probnames = [probname]
+    missing = [p for p in probnames if p not in _run_driver_called]
+    if missing:
+        print(f"\n\nMissing call(s) to run_driver() for Problem(s) {sorted(missing)} "
+              "so couldn't generate corresponding driver scaling report.\n")
 
 
 def _scaling_cmd(options, user_args):
@@ -501,22 +486,22 @@ def _scaling_cmd(options, user_args):
     """
     def _set_run_driver_flag(problem):
         global _run_driver_called
-        _run_driver_called = True
+        _run_driver_called.add(problem._name)
 
     def _set_run_model_start(problem):
         global _run_model_start
-        _run_model_start = True
+        _run_model_start.add(problem._name)
 
     def _set_run_model_done(problem):
         global _run_model_done
-        _run_model_done = True
+        _run_model_done.add(problem._name)
 
     def _scaling_check(problem):
-        if _run_driver_called:
+        if problem._name in _run_driver_called:
             # If run_driver has been called, we know no more user changes are coming.
-            if not _run_model_start:
+            if problem._name not in _run_model_start:
                 problem.run_model()
-            if _run_model_done:
+            if problem._name in _run_model_done:
                 _scaling(problem)
 
     def _scaling(problem):
@@ -541,7 +526,7 @@ def _scaling_cmd(options, user_args):
 
     # register an atexit function to check if scaling report was triggered during the script
     import atexit
-    atexit.register(_exitfunc)
+    atexit.register(functools.partial(_exitfunc, options.problem))
 
     ignore_errors(True)
     _load_and_exec(options.file[0], user_args)


### PR DESCRIPTION
### Summary

This work was originally done to support POEM 60, but now POEM 60 is using an alternative implementation that doesn't use hooks.  Since these changes were mostly done before POEM 60 changed direction, I decided to go ahead and issue this PR because I think the changes are useful.

Changes are:
- multiple hooks can be added at the same location
- hook can be registered to auto-remove itself after n calls
- hook can be registered to call sys.exit() after calling hook function
- hooks for scaling report were fixed so they will now work properly if applied to multiple Problems

### Related Issues

- Resolves #2397

### Backwards incompatibilities

None

### New Dependencies

None
