### PR TITLE
Added leading underscore to valid options names

### DIFF
--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -7,7 +7,7 @@ from openmdao.core.constants import _UNDEFINED
 
 
 # regex to check for valid names.
-namecheck_rgx = re.compile('[a-zA-Z][_a-zA-Z0-9]*')
+namecheck_rgx = re.compile('[a-zA-Z_][_a-zA-Z0-9]*')
 
 
 #


### PR DESCRIPTION
### Summary

In options dictionaries, my application distinguished between "private" and "public" variables in the standard python convention using a leading underscore. Public options the users are free to set, private options are typically set under the hood and shouldn't be touched by users, but are kept as options for case recording, etc.

The issue is that openmdao 3.16 doesn't seem to like leading underscores, and complains that they are not valid python names, even though they are.

### Related Issues

- Resolves #2409

### Backwards incompatibilities

None

### New Dependencies

None
