### PR TITLE
Removed exception when get_io_metadata called on dyn shaped variable before shape is known

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3341,7 +3341,6 @@ class System(object):
         loc2meta = self._var_abs2meta
         all2meta = self._var_allprocs_abs2meta
 
-        dynset = set(('shape', 'size', 'val'))
         gather_keys = {'val', 'src_indices'}
         need_gather = get_remote and self.comm.size > 1
         if metadata_keys is not None:
@@ -3358,7 +3357,6 @@ class System(object):
                 raise RuntimeError(f"{self.msginfo}: {sorted(diff)} are not valid metadata entry "
                                    "names.")
         need_local_meta = metadata_keys is not None and len(gather_keys.intersection(keyset)) > 0
-        nodyn = metadata_keys is None or keyset.intersection(dynset)
 
         if need_local_meta:
             metadict = loc2meta
@@ -3388,12 +3386,6 @@ class System(object):
                 if abs_name in all2meta[iotype]:  # continuous
                     meta = cont2meta[abs_name] if abs_name in cont2meta else None
                     distrib = all2meta[iotype][abs_name]['distributed']
-                    if nodyn:
-                        a2m = all2meta[iotype][abs_name]
-                        if a2m['shape'] is None and (a2m['shape_by_conn'] or a2m['copy_shape']):
-                            raise RuntimeError(f"{self.msginfo}: Can't retrieve shape, size, or "
-                                               f"value for dynamically sized variable '{prom}' "
-                                               "because they aren't known yet.")
                 else:  # discrete
                     if need_local_meta:  # use relative name for discretes
                         meta = disc2meta[rel_name] if rel_name in disc2meta else None

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -302,11 +302,12 @@ class DistribDynShapeComp(om.ExplicitComponent):
 class DynShapeGroupSeries(om.Group):
     # strings together some number of components in series.
     # component type is determined by comp_class
-    def __init__(self, n_comps, n_inputs, comp_class):
+    def __init__(self, n_comps, n_inputs, comp_class, call_get_io_meta=False):
         super().__init__()
         self.n_comps = n_comps
         self.n_inputs = n_inputs
         self.comp_class = comp_class
+        self.call_get_io_meta = call_get_io_meta
 
         for icmp in range(1, self.n_comps + 1):
             self.add_subsystem(f"C{icmp}", self.comp_class(n_inputs=self.n_inputs))
@@ -314,6 +315,12 @@ class DynShapeGroupSeries(om.Group):
         for icmp in range(1, self.n_comps):
             for i in range(1, self.n_inputs + 1):
                 self.connect(f"C{icmp}.y{i}", f"C{icmp+1}.x{i}")
+
+    def configure(self):
+        if self.call_get_io_meta:
+            for icmp in range(1, self.n_comps + 1):
+                sub = self._get_subsystem(f"C{icmp}")
+                sub_meta = sub.get_io_metadata(iotypes=('input', 'output'))
 
 
 class DynShapeGroupConnectedInputs(om.Group):
@@ -337,6 +344,26 @@ class TestDynShapes(unittest.TestCase):
         indep = p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
         indep.add_output('x2', val=np.ones((4,2)))
         p.model.add_subsystem('Gdyn', DynShapeGroupSeries(3, 2, DynShapeComp))
+        p.model.add_subsystem('sink', om.ExecComp('y1, y2 = x1*2, x2*2',
+                                                  x1={'shape_by_conn': True, 'copy_shape': 'y1'},
+                                                  x2={'shape_by_conn': True, 'copy_shape': 'y2'},
+                                                  y1={'shape_by_conn': True, 'copy_shape': 'x1'},
+                                                  y2={'shape_by_conn': True, 'copy_shape': 'x2'}))
+        p.model.connect('Gdyn.C3.y1', 'sink.x1')
+        p.model.connect('Gdyn.C3.y2', 'sink.x2')
+        p.model.connect('indep.x1', 'Gdyn.C1.x1')
+        p.model.connect('indep.x2', 'Gdyn.C1.x2')
+        p.setup()
+        p.run_model()
+        np.testing.assert_allclose(p['sink.y1'], np.ones((2,3))*16)
+        np.testing.assert_allclose(p['sink.y2'], np.ones((4,2))*16)
+
+    def test_series_config_get_io_metadata(self):
+        # this test used to raise an exception when the DynShapeGroupSeries called get_io_metadata from config
+        p = om.Problem()
+        indep = p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
+        indep.add_output('x2', val=np.ones((4,2)))
+        p.model.add_subsystem('Gdyn', DynShapeGroupSeries(3, 2, DynShapeComp, call_get_io_meta=True))
         p.model.add_subsystem('sink', om.ExecComp('y1, y2 = x1*2, x2*2',
                                                   x1={'shape_by_conn': True, 'copy_shape': 'y1'},
                                                   x2={'shape_by_conn': True, 'copy_shape': 'y2'},

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -3819,33 +3819,6 @@ class TestFeatureConfigure(unittest.TestCase):
         assert_near_equal(p.get_val('totalforcecomp.total_force', units='kN'),
                          np.array([[100, 200, 300], [0, -1, -2]]).T)
 
-    def test_configure_dyn_shape_err(self):
-
-        class MyComp(om.ExplicitComponent):
-            def setup(self):
-                self.add_input('x', shape_by_conn=True, copy_shape='y')
-                self.add_output('y', shape_by_conn=True, copy_shape='x')
-
-            def compute(self, inputs, outputs):
-                outputs['y'] = 3*inputs['x']
-
-        class MyGroup(om.Group):
-            def setup(self):
-                self.add_subsystem('comp', MyComp())
-
-            def configure(self):
-                meta = self.comp.get_io_metadata('output', includes='y')
-
-        p = om.Problem()
-        p.model.add_subsystem("G", MyGroup())
-        p.model.add_subsystem("sink", om.ExecComp('y=5*x'))
-        p.model.connect('G.comp.y', 'sink.x')
-        with self.assertRaises(RuntimeError) as cm:
-            p.setup()
-
-        msg="'G.comp' <class MyComp>: Can't retrieve shape, size, or value for dynamically sized variable 'y' because they aren't known yet."
-        self.assertEqual(str(cm.exception), msg)
-
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestConfigureMPI(unittest.TestCase):


### PR DESCRIPTION
### Summary

The exception was causing issues with dymos model introspection so it was removed.  It is now the responsibility of the caller of get_io_metadata to deal with possibly unknown shapes of dynamically shaped variables.

### Related Issues

- Resolves #2423

### Backwards incompatibilities

None

### New Dependencies

None
