### PR TITLE
Fix Iterable deprecation and a couple tests for Python 3.10

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -35,7 +35,7 @@ jobs:
 
           # latest versions
           - NAME: Latest
-            PY: <3.9
+            PY: 3
             NUMPY: 1
             SCIPY: 1
             PETSc: 3
@@ -45,7 +45,7 @@ jobs:
 
           # minimal install
           - NAME: Minimal
-            PY: <3.9
+            PY: 3
             NUMPY: 1
             SCIPY: 1
             PYOPTSPARSE: 'conda-forge'

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -4,7 +4,7 @@ import os.path
 import importlib
 import inspect
 import textwrap
-import collections
+from collections.abc import Iterable
 import re
 
 try:
@@ -109,7 +109,7 @@ class ReturnFinder(ast.NodeVisitor):
             if node.value is not None:
                 self.has_return = True
 
-        if hasattr(node, 'body') and isinstance(node.body, collections.Iterable):
+        if hasattr(node, 'body') and isinstance(node.body, Iterable):
             # If the top level function does nothing but pass, note it.
             if is_func_def and self._depth == 2 and len(node.body) <= 2 \
                      and isinstance(node.body[-1], ast.Pass):

--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -1,7 +1,7 @@
 """
 Definition of the Add/Subtract Component.
 """
-import collections
+from collections.abc import Iterable
 
 import numpy as np
 from scipy import sparse as sp
@@ -81,7 +81,7 @@ class AddSubtractComp(ExplicitComponent):
         if isinstance(output_name, str):
             self.add_equation(output_name, input_names, vec_size, length, val,
                               scaling_factors=scaling_factors, **kwargs)
-        elif isinstance(output_name, collections.Iterable):
+        elif isinstance(output_name, Iterable):
             raise NotImplementedError(self.msginfo + ': Declaring multiple addition systems '
                                       'on initiation is not implemented.'
                                       'Use a string to name a single addition relationship or use '

--- a/openmdao/core/tests/test_deriv_transfers.py
+++ b/openmdao/core/tests/test_deriv_transfers.py
@@ -2,11 +2,7 @@
 import unittest
 import itertools
 
-# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 
@@ -377,4 +373,3 @@ class TestParallelGroups(unittest.TestCase):
         np.testing.assert_allclose(J['C6.y', 'ivc.x'][0][0], 141.2)
         np.testing.assert_allclose(prob.get_val('C6.y', get_remote=True),
                                    141.2)
-

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -789,8 +789,8 @@ class TestObjectiveOnModel(unittest.TestCase):
             prob.model.add_objective('con1', lower=-100, upper=100, ref=1.0,
                                       scaler=0.5)
 
-        self.assertEqual(str(context.exception),
-                         "add_objective() got an unexpected keyword argument 'lower'")
+        self.assertTrue(str(context.exception).endswith(
+                        "add_objective() got an unexpected keyword argument 'lower'"))
 
         with self.assertRaises(ValueError) as context:
             prob.model.add_objective('con1', ref=0.0, scaler=0.5)
@@ -846,7 +846,7 @@ class TestObjectiveOnModel(unittest.TestCase):
         self.assertAlmostEqual( obj_scaler*(obj_ref + obj_adder), 1.0,
                                 places=12)
 
-    @parameterized.expand(['lower', 'upper', 'adder', 'scaler', 'ref', 'ref0'], 
+    @parameterized.expand(['lower', 'upper', 'adder', 'scaler', 'ref', 'ref0'],
                           name_func=lambda f, n, p: 'test_desvar_size_err_' + '_'.join(a for a in p.args))
     def test_desvar_size_err(self, name):
 
@@ -864,7 +864,7 @@ class TestObjectiveOnModel(unittest.TestCase):
         self.assertEqual(str(context.exception),
                          f"<model> <class SellarDerivatives>: When adding design var 'z', {name} should have size 1 but instead has size 2.")
 
-    @parameterized.expand(['lower', 'upper', 'equals', 'adder', 'scaler', 'ref', 'ref0'], 
+    @parameterized.expand(['lower', 'upper', 'equals', 'adder', 'scaler', 'ref', 'ref0'],
                           name_func=lambda f, n, p: 'test_constraint_size_err_' + '_'.join(a for a in p.args))
     def test_constraint_size_err(self, name):
 
@@ -882,7 +882,7 @@ class TestObjectiveOnModel(unittest.TestCase):
         self.assertEqual(str(context.exception),
                          f"<model> <class SellarDerivatives>: When adding constraint 'z', {name} should have size 1 but instead has size 2.")
 
-    @parameterized.expand(['adder', 'scaler', 'ref', 'ref0'], 
+    @parameterized.expand(['adder', 'scaler', 'ref', 'ref0'],
                           name_func=lambda f, n, p: 'test_objective_size_err_' + '_'.join(a for a in p.args))
     def test_objective_size_err(self, name):
 

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -672,9 +672,9 @@ class DiscreteTestCase(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             p.run_model()
 
-        msg = ("'g0.g1.broken' <class BrokenComp>: Error calling compute(), "
-               "compute() takes 3 positional arguments but 5 were given")
-        self.assertEqual(str(cm.exception), msg)
+        msg = str(cm.exception)
+        self.assertTrue(msg.startswith("'g0.g1.broken' <class BrokenComp>: Error calling compute()"))
+        self.assertTrue(msg.endswith("compute() takes 3 positional arguments but 5 were given"))
 
     def test_discrete_input_dataframe(self):
         class OMDataFrame:

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -3,11 +3,7 @@
 import unittest
 import itertools
 
-# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 

--- a/openmdao/test_suite/parametric_suite.py
+++ b/openmdao/test_suite/parametric_suite.py
@@ -1,5 +1,5 @@
 import itertools
-import collections
+from collections.abc import Iterable
 
 try:
     from parameterized import parameterized
@@ -63,7 +63,7 @@ def _test_suite(*args, **kwargs):
                     if arg_value == '*':
                         opts[arg] = default_val
                     elif isinstance(arg_value, str) \
-                            or not isinstance(arg_value, collections.Iterable):
+                            or not isinstance(arg_value, Iterable):
                         # itertools.product expects iterables, so make 1-item tuple
                         opts[arg] = (arg_value,)
                     else:

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -9,11 +9,7 @@ from fnmatch import fnmatchcase
 from io import StringIO
 from numbers import Number
 
-# note: this is a Python 3.3 change, clean this up for OpenMDAO 3.x
-try:
-    from collections.abc import Iterable
-except ImportError:
-    from collections import Iterable
+from collections.abc import Iterable
 
 import numbers
 


### PR DESCRIPTION
### Summary

Fix Iterable deprecation and a couple tests for Python 3.10

### Related Issues

- Resolves #2425

### Backwards incompatibilities

None

### New Dependencies

None
