### PR TITLE
DOE driver no longer generates redundant recordings when not running in parallel

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -102,6 +102,8 @@ jobs:
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
+          pip install --upgrade pip
+
           echo "============================================================="
           echo "Install OpenMDAO"
           echo "============================================================="
@@ -336,6 +338,8 @@ jobs:
         shell: pwsh
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+
+          pip install --upgrade pip
 
           echo "============================================================="
           echo "Install OpenMDAO"


### PR DESCRIPTION
### Summary

DOE driver no longer generates redundant recordings when not running in parallel

When a DOE is run in parallel, i.e. different instances of the model are run across available processors, a separate recording file is written for each parallel set of cases.

If a DOE is run under MPI but the `run_parallel` option is set to `False`, then excess processors will be tasked with redundant copies of the model.  Previously, multiple recording files would still be generated as if it were running in parallel but the files would contain the same/redundant data.  With this change, a single recording is generated under these circumstances, since any parallel instances will only generate duplicate data.

### Related Issues

- Resolves #2416

### Backwards incompatibilities

DOE driver no longer generates redundant recordings when not running in parallel

### New Dependencies

None
