### PR TITLE
Fixed a bug when a flat slice is specified as the src_indices for a non-flat source, and added usage of slicer to connection documentation.

### DIFF
--- a/openmdao/core/tests/test_src_indices.py
+++ b/openmdao/core/tests/test_src_indices.py
@@ -371,23 +371,6 @@ class SrcIndicesTestCase(unittest.TestCase):
         assert_near_equal(p.get_val('exec.B').ravel(), p.get_val('ivc.M')[:1].ravel())
         assert_near_equal(p.get_val('exec.A').ravel(), p.get_val('ivc.M')[:1].ravel())
 
-        print('M')
-        print(p.get_val('ivc.M'))
-
-        print()
-        print('p.get_val("exec.A")')
-        print(p.get_val('exec.A'))
-        print('p.get_val("exec.B")')
-        print(p.get_val('exec.B'))
-        print('p.model.exec.get_val("B")')
-        print(p.model.exec.get_val('B'))
-        print()
-        print('numpy M[:1]')
-        print(p.get_val('ivc.M')[:1])
-
-        p.model.list_inputs(print_arrays=True)
-
-
     def test_promote_slice_src_indices_not_full_size(self):
         p = om.Problem()
 
@@ -408,22 +391,6 @@ class SrcIndicesTestCase(unittest.TestCase):
 
         assert_near_equal(p.get_val('exec.B').ravel(), p.get_val('ivc.M')[:1].ravel())
         assert_near_equal(p.get_val('exec.A').ravel(), p.get_val('ivc.M')[:1].ravel())
-
-        print('M')
-        print(p.get_val('ivc.M'))
-
-        print()
-        print('p.get_val("exec.A")')
-        print(p.get_val('exec.A'))
-        print('p.get_val("exec.B")')
-        print(p.get_val('exec.B'))
-        print('p.model.exec.get_val("B")')
-        print(p.model.exec.get_val('B'))
-        print()
-        print('numpy M[:1]')
-        print(p.get_val('ivc.M')[:1])
-
-        p.model.list_inputs(print_arrays=True)
 
 class SrcIndicesFeatureTestCase(unittest.TestCase):
     def test_multi_promotes(self):

--- a/openmdao/core/tests/test_src_indices.py
+++ b/openmdao/core/tests/test_src_indices.py
@@ -351,6 +351,79 @@ class SrcIndicesTestCase(unittest.TestCase):
                          "'C1' <class MyComp>: When promoting 'C1.x' with src_indices [4 5 7 9] and "
                          "source shape (3, 3): index 9 is out of bounds for source dimension of size 9.")
 
+    def test_connect_slice_src_indices_not_full_size(self):
+        p = om.Problem()
+
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp())
+        M_np = np.arange(9)[::-1].reshape((3, 3))
+        ivc.add_output('M', val=M_np)
+
+        exec = p.model.add_subsystem('exec', om.ExecComp())
+
+        exec.add_expr('A = B', A={'shape': (3,)}, B={'shape': (3,)})
+
+        p.model.connect('ivc.M', 'exec.B', src_indices=om.slicer[:1])
+
+        p.setup()
+
+        p.run_model()
+
+        assert_near_equal(p.get_val('exec.B').ravel(), p.get_val('ivc.M')[:1].ravel())
+        assert_near_equal(p.get_val('exec.A').ravel(), p.get_val('ivc.M')[:1].ravel())
+
+        print('M')
+        print(p.get_val('ivc.M'))
+
+        print()
+        print('p.get_val("exec.A")')
+        print(p.get_val('exec.A'))
+        print('p.get_val("exec.B")')
+        print(p.get_val('exec.B'))
+        print('p.model.exec.get_val("B")')
+        print(p.model.exec.get_val('B'))
+        print()
+        print('numpy M[:1]')
+        print(p.get_val('ivc.M')[:1])
+
+        p.model.list_inputs(print_arrays=True)
+
+
+    def test_promote_slice_src_indices_not_full_size(self):
+        p = om.Problem()
+
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp())
+        M_np = np.arange(9)[::-1].reshape((3, 3))
+        ivc.add_output('M', val=M_np)
+
+        exec = p.model.add_subsystem('exec', om.ExecComp())
+
+        exec.add_expr('A = B', A={'shape': (3,)}, B={'shape': (3,)})
+
+        p.model.promotes('ivc', outputs=['M'])
+        p.model.promotes('exec', inputs=[('B', 'M')], src_indices=om.slicer[:1], src_shape=(3, 3))
+
+        p.setup()
+
+        p.run_model()
+
+        assert_near_equal(p.get_val('exec.B').ravel(), p.get_val('ivc.M')[:1].ravel())
+        assert_near_equal(p.get_val('exec.A').ravel(), p.get_val('ivc.M')[:1].ravel())
+
+        print('M')
+        print(p.get_val('ivc.M'))
+
+        print()
+        print('p.get_val("exec.A")')
+        print(p.get_val('exec.A'))
+        print('p.get_val("exec.B")')
+        print(p.get_val('exec.B'))
+        print('p.model.exec.get_val("B")')
+        print(p.model.exec.get_val('B'))
+        print()
+        print('numpy M[:1]')
+        print(p.get_val('ivc.M')[:1])
+
+        p.model.list_inputs(print_arrays=True)
 
 class SrcIndicesFeatureTestCase(unittest.TestCase):
     def test_multi_promotes(self):

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
@@ -45,9 +45,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1. 1. 1. 1. 1.]\n",
+      "[12. 12. 12. 12. 12.]\n",
+      "[60.]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
@@ -72,14 +82,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.1842378929335003e-16"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -97,9 +118,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10.]\n",
+      "[20.]\n",
+      "[30.]\n"
+     ]
+    }
+   ],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -118,14 +149,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(p.get_val('C1.y'), 10.)\n",
     "assert_near_equal(p.get_val('C2.y'), 20.)\n",
@@ -142,9 +184,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1. 1. 1.]\n",
+      "[6.]\n",
+      "[1. 1.]\n",
+      "[8.]\n"
+     ]
+    }
+   ],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -170,14 +223,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(p['C1.x'], np.ones(3))\n",
     "assert_near_equal(p['C1.y'], 6.)\n",
@@ -194,9 +258,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[ 0.  1.  2.]\n",
+      " [ 3.  4.  5.]\n",
+      " [ 6.  7.  8.]\n",
+      " [ 9. 10. 11.]]\n",
+      "[[ 0. 10.]\n",
+      " [ 7.  4.]]\n",
+      "[42.]\n"
+     ]
+    }
+   ],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -220,14 +298,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(p.get_val('indep.x'), np.array([[0., 1., 2.],\n",
     "                                                  [3., 4., 5.],\n",
@@ -246,18 +335,33 @@
     "\n",
     "The `om.slicer` object was introduced to OpenMDAO to make connecting non-scalar variables easier by allowing the `src_indices` to be specified as slices.\n",
     "This way of thinking about `src_indices` is probably more intuitive for users who are experienced with numpy.\n",
-    "Note when `src_indices` is provided as a slicer object, `flat_src_indices` has no effect.\n",
     "    \n",
     "The following example connects a 2x2 portion of a 5x5 matrix, starting from indices [2, 3]:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "M\n",
+      "[[ 0.  1.  2.  3.  4.]\n",
+      " [ 5.  6.  7.  8.  9.]\n",
+      " [10. 11. 12. 13. 14.]\n",
+      " [15. 16. 17. 18. 19.]\n",
+      " [20. 21. 22. 23. 24.]]\n",
+      "A\n",
+      "[[13. 14.]\n",
+      " [18. 19.]]\n"
+     ]
+    }
+   ],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -283,13 +387,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -307,9 +422,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "M\n",
+      "[[ 0.  1.  2.  3.  4.]\n",
+      " [ 5.  6.  7.  8.  9.]\n",
+      " [10. 11. 12. 13. 14.]\n",
+      " [15. 16. 17. 18. 19.]\n",
+      " [20. 21. 22. 23. 24.]]\n",
+      "A\n",
+      "[[ 0.  1.  2.]\n",
+      " [10. 11. 12.]\n",
+      " [15. 16. 17.]]\n"
+     ]
+    }
+   ],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -335,20 +467,153 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
-    "expected = np.array([[0, 1, 2], [10, 11, 12], [20, 21, 22]])\n",
+    "expected = np.array([[0, 1, 2], [10, 11, 12], [15, 16, 17]])\n",
     "\n",
     "assert_near_equal(p.get_val('exec.A'), expected)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## The meaning of `flat_src_indices` when using `om.slicer`\n",
+    "\n",
+    "When `src_indices` are provided as a slicer and `flat_src_indices = True`, OpenMDAO first flattens (in row-major order), the source variable and then applies the slicer.\n",
+    "Consider connecting the 3x3 matrix `M` below to a target 3-vector.\n",
+    "In this first case, we don't flatten the matrix before indexing it (`flat_src_indices=False`), so in this case `om.slicer[:1]` refers to the first element in the first dimension (the first row)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "M\n",
+      "[[8. 7. 6.]\n",
+      " [5. 4. 3.]\n",
+      " [2. 1. 0.]]\n",
+      "\n",
+      "A\n",
+      "[[8. 8. 8.]]\n",
+      "\n",
+      "numpy M[:1]\n",
+      "[[8 7 6]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = om.Problem()\n",
+    "\n",
+    "ivc = p.model.add_subsystem('ivc', om.IndepVarComp())\n",
+    "M_np = np.arange(9)[::-1].reshape((3, 3))\n",
+    "ivc.add_output('M', val=M_np)\n",
+    "\n",
+    "exec = p.model.add_subsystem('exec', om.ExecComp())\n",
+    "\n",
+    "exec.add_expr('A = B', A={'shape': (1, 3)}, B={'shape': (3,)})\n",
+    "\n",
+    "p.model.connect('ivc.M', 'exec.B', src_indices=om.slicer[:1])\n",
+    "\n",
+    "p.setup()\n",
+    "\n",
+    "p.run_model()\n",
+    "\n",
+    "print('M')\n",
+    "print(p.get_val('ivc.M'))\n",
+    "print()\n",
+    "print('A')\n",
+    "print(p.get_val('exec.A'))\n",
+    "print()\n",
+    "print('numpy M[:1]')\n",
+    "print(M_np[:1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "M\n",
+      "[[8. 7. 6.]\n",
+      " [5. 4. 3.]\n",
+      " [2. 1. 0.]]\n",
+      "A\n",
+      "[8.]\n"
+     ]
+    }
+   ],
+   "source": [
+    "p = om.Problem()\n",
+    "\n",
+    "ivc = p.model.add_subsystem('ivc', om.IndepVarComp())\n",
+    "ivc.add_output('M', val=np.arange(9)[::-1].reshape((3, 3)))\n",
+    "\n",
+    "exec = p.model.add_subsystem('exec', om.ExecComp())\n",
+    "\n",
+    "exec.add_expr('A = B', A={'shape': (1,)}, B={'shape': (1,)})\n",
+    "\n",
+    "p.model.connect('ivc.M', 'exec.B', src_indices=om.slicer[:1], flat_src_indices=True)\n",
+    "\n",
+    "p.setup()\n",
+    "\n",
+    "p.run_model()\n",
+    "\n",
+    "print('M')\n",
+    "print(p.get_val('ivc.M'))\n",
+    "\n",
+    "print('A')\n",
+    "print(p.get_val('exec.A'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
@@ -45,19 +45,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1. 1. 1. 1. 1.]\n",
-      "[12. 12. 12. 12. 12.]\n",
-      "[60.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
@@ -82,25 +72,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "1.1842378929335003e-16"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -118,19 +97,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[10.]\n",
-      "[20.]\n",
-      "[30.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -149,25 +118,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(p.get_val('C1.y'), 10.)\n",
     "assert_near_equal(p.get_val('C2.y'), 20.)\n",
@@ -184,20 +142,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[1. 1. 1.]\n",
-      "[6.]\n",
-      "[1. 1.]\n",
-      "[8.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -223,25 +170,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(p['C1.x'], np.ones(3))\n",
     "assert_near_equal(p['C1.y'], 6.)\n",
@@ -258,23 +194,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[[ 0.  1.  2.]\n",
-      " [ 3.  4.  5.]\n",
-      " [ 6.  7.  8.]\n",
-      " [ 9. 10. 11.]]\n",
-      "[[ 0. 10.]\n",
-      " [ 7.  4.]]\n",
-      "[42.]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -298,25 +220,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "assert_near_equal(p.get_val('indep.x'), np.array([[0., 1., 2.],\n",
     "                                                  [3., 4., 5.],\n",
@@ -341,27 +252,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "M\n",
-      "[[ 0.  1.  2.  3.  4.]\n",
-      " [ 5.  6.  7.  8.  9.]\n",
-      " [10. 11. 12. 13. 14.]\n",
-      " [15. 16. 17. 18. 19.]\n",
-      " [20. 21. 22. 23. 24.]]\n",
-      "A\n",
-      "[[13. 14.]\n",
-      " [18. 19.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -387,24 +282,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -422,26 +306,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "M\n",
-      "[[ 0.  1.  2.  3.  4.]\n",
-      " [ 5.  6.  7.  8.  9.]\n",
-      " [10. 11. 12. 13. 14.]\n",
-      " [15. 16. 17. 18. 19.]\n",
-      " [20. 21. 22. 23. 24.]]\n",
-      "A\n",
-      "[[ 0.  1.  2.]\n",
-      " [10. 11. 12.]\n",
-      " [15. 16. 17.]]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -467,24 +334,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-cell"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "0.0"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -506,26 +362,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "M\n",
-      "[[8. 7. 6.]\n",
-      " [5. 4. 3.]\n",
-      " [2. 1. 0.]]\n",
-      "\n",
-      "A\n",
-      "[[8. 8. 8.]]\n",
-      "\n",
-      "numpy M[:1]\n",
-      "[[8 7 6]]\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -547,30 +388,34 @@
     "print(p.get_val('ivc.M'))\n",
     "print()\n",
     "print('A')\n",
-    "print(p.get_val('exec.A'))\n",
-    "print()\n",
-    "print('numpy M[:1]')\n",
-    "print(M_np[:1])"
+    "print(p.get_val('exec.A'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(p.get_val('exec.A'), p.get_val('ivc.M')[:1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "M\n",
-      "[[8. 7. 6.]\n",
-      " [5. 4. 3.]\n",
-      " [2. 1. 0.]]\n",
-      "A\n",
-      "[8.]\n"
-     ]
-    }
-   ],
+   "source": [
+    "If, on the other hand, we specify `flat_src_indices=True` in the connection, then we will first flatten M, and pass the first element of the flattened array to `exec.B`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -597,23 +442,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "assert_near_equal(p.get_val('exec.A'), p.get_val('ivc.M')[0, 0])"
+   ]
   }
  ],
  "metadata": {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/connect.ipynb
@@ -3,23 +3,24 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "try:\n",
-    "    from openmdao.utils.notebook_utils import notebook_mode\n",
-    "except ImportError:\n",
-    "    !python -m pip install openmdao[notebooks]"
-   ],
-   "outputs": [],
    "metadata": {
     "tags": [
      "remove-input",
      "active-ipynb",
      "remove-output"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
+    "except ImportError:\n",
+    "    !python -m pip install openmdao[notebooks]"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Connecting Variables\n",
     "\n",
@@ -40,12 +41,13 @@
     "## Usage\n",
     "\n",
     "1: Connect an output variable to an input variable, with an automatic unit conversion.  "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
@@ -66,38 +68,38 @@
     "print(p.get_val('x', units='ft'))\n",
     "print(p.get_val('comp1.x'))\n",
     "print(p.get_val('comp1.y'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
     "assert_near_equal(p.get_val('x', units='ft'), np.ones(5))\n",
     "assert_near_equal(p.get_val('comp1.x'), np.ones(5)*12.)\n",
     "assert_near_equal(p.get_val('comp1.y'), 60.)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": [
-     "remove-input",
-     "remove-output"
-    ]
-   }
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "2: Connect one output to many inputs.  "
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -112,37 +114,37 @@
     "print(p.get_val('C1.y'))\n",
     "print(p.get_val('C2.y'))\n",
     "print(p.get_val('C3.y'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "assert_near_equal(p.get_val('C1.y'), 10.)\n",
-    "assert_near_equal(p.get_val('C2.y'), 20.)\n",
-    "assert_near_equal(p.get_val('C3.y'), 30.)"
-   ],
-   "outputs": [],
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(p.get_val('C1.y'), 10.)\n",
+    "assert_near_equal(p.get_val('C2.y'), 20.)\n",
+    "assert_near_equal(p.get_val('C3.y'), 30.)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "(connect-with-src-indices)=\n",
     "3: Connect only part of an array output to an input of a smaller size."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -164,37 +166,37 @@
     "print(p['C1.y'])\n",
     "print(p['C2.x'])\n",
     "print(p['C2.y'])"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "assert_near_equal(p['C1.x'], np.ones(3))\n",
-    "assert_near_equal(p['C1.y'], 6.)\n",
-    "assert_near_equal(p['C2.x'], np.ones(2))\n",
-    "assert_near_equal(p['C2.y'], 8.)"
-   ],
-   "outputs": [],
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(p['C1.x'], np.ones(3))\n",
+    "assert_near_equal(p['C1.y'], 6.)\n",
+    "assert_near_equal(p['C2.x'], np.ones(2))\n",
+    "assert_near_equal(p['C2.y'], 8.)"
+   ]
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "4: Connect only part of a non-flat array output to a non-flat array input."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "p = om.Problem()\n",
     "\n",
@@ -214,13 +216,18 @@
     "print(p.get_val('indep.x'))\n",
     "print(p.get_val('C1.x'))\n",
     "print(p.get_val('C1.y'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
    "source": [
     "assert_near_equal(p.get_val('indep.x'), np.array([[0., 1., 2.],\n",
     "                                                  [3., 4., 5.],\n",
@@ -229,21 +236,130 @@
     "assert_near_equal(p.get_val('C1.x'), np.array([[0., 10.],\n",
     "                                               [7., 4.]]))\n",
     "assert_near_equal(p.get_val('C1.y'), 42.)"
-   ],
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `om.slicer` to connect non-scalar variables\n",
+    "\n",
+    "The `om.slicer` object was introduced to OpenMDAO to make connecting non-scalar variables easier by allowing the `src_indices` to be specified as slices.\n",
+    "This way of thinking about `src_indices` is probably more intuitive for users who are experienced with numpy.\n",
+    "Note when `src_indices` is provided as a slicer object, `flat_src_indices` has no effect.\n",
+    "    \n",
+    "The following example connects a 2x2 portion of a 5x5 matrix, starting from indices [2, 3]:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
+   "source": [
+    "p = om.Problem()\n",
+    "\n",
+    "ivc = p.model.add_subsystem('ivc', om.IndepVarComp())\n",
+    "ivc.add_output('M', val=np.arange(25).reshape((5, 5)))\n",
+    "\n",
+    "exec = p.model.add_subsystem('exec', om.ExecComp())\n",
+    "\n",
+    "exec.add_expr('A = B', A={'shape': (2, 2)}, B={'shape': (2, 2)})\n",
+    "\n",
+    "p.model.connect('ivc.M', 'exec.B', src_indices=om.slicer[2:4, 3:5])\n",
+    "\n",
+    "p.setup()\n",
+    "\n",
+    "p.run_model()\n",
+    "\n",
+    "print('M')\n",
+    "print(p.get_val('ivc.M'))\n",
+    "\n",
+    "print('A')\n",
+    "print(p.get_val('exec.A'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": [
-     "remove-input",
-     "remove-output"
+     "remove-cell"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "\n",
+    "expected = np.array([[13, 14], [18, 19]])\n",
+    "\n",
+    "assert_near_equal(p.get_val('exec.A'), expected)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following example connects the first 3 columns of rows 0, 2, and 3 of `M` to `B`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p = om.Problem()\n",
+    "\n",
+    "ivc = p.model.add_subsystem('ivc', om.IndepVarComp())\n",
+    "ivc.add_output('M', val=np.arange(25).reshape((5, 5)))\n",
+    "\n",
+    "exec = p.model.add_subsystem('exec', om.ExecComp())\n",
+    "\n",
+    "exec.add_expr('A = B', A={'shape': (3, 3)}, B={'shape': (3, 3)})\n",
+    "\n",
+    "p.model.connect('ivc.M', 'exec.B', src_indices=om.slicer[[0, 2 ,3], :3])\n",
+    "\n",
+    "p.setup()\n",
+    "\n",
+    "p.run_model()\n",
+    "\n",
+    "print('M')\n",
+    "print(p.get_val('ivc.M'))\n",
+    "\n",
+    "print('A')\n",
+    "print(p.get_val('exec.A'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-cell"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "\n",
+    "expected = np.array([[0, 1, 2], [10, 11, 12], [20, 21, 22]])\n",
+    "\n",
+    "assert_near_equal(p.get_val('exec.A'), expected)"
+   ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
+  "interpreter": {
+   "hash": "49f71f8b029ccfc892068b15e7b6668703dcc2d714d079581384c7016c112935"
+  },
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.8.10 64-bit ('py38mpich_new2': conda)"
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -255,12 +371,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.9.7"
   },
-  "orphan": true,
-  "interpreter": {
-   "hash": "49f71f8b029ccfc892068b15e7b6668703dcc2d714d079581384c7016c112935"
-  }
+  "orphan": true
  },
  "nbformat": 4,
  "nbformat_minor": 4

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_output_linting.py
@@ -141,7 +141,7 @@ class LintJupyterOutputsTestCase(unittest.TestCase):
                     if tags:
 
                         # Don't check hidden cells
-                        if 'remove-input' in tags and 'remove-output' in tags:
+                        if ('remove-input' in tags and 'remove-output' in tags) or 'remove-cell' in tags:
                             continue
 
                         # We allow an assert in a cell if you tag it.

--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -550,15 +550,16 @@ class ShapedSliceIndexer(Indexer):
             # use maxsize here since a shaped slice always has positive int start and stop
             return np.arange(*self._slice.indices(sys.maxsize), dtype=int)
         else:
+            src_size = np.prod(self._src_shape, dtype=int)
+            arr = np.arange(src_size, dtype=int).reshape(self._src_shape)[self._slice]
             if flat:
                 # Case 2: Requested flattened indices of multidimensional array
                 # Return indices into a flattened src.
-                src_size = np.prod(self._src_shape, dtype=int)
-                return np.arange(src_size, dtype=int).reshape(self._src_shape)[self._slice].ravel()
+                return arr.ravel()
             else:
                 # Case 3: Requested non-flat indices of multidimensional array
-                grid = np.mgrid[{tuple: self._slice, slice: (self._slice,)}[type(self._slice)]]
-                return tuple(grid[i].ravel() for i in range(grid.shape[0]))
+                # This is never called within OpenMDAO
+                raise NotImplementedError('ShapedSliceIndexer.as_array only returns flat arrays.')
 
     def flat(self, copy=False):
         """

--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -551,15 +551,15 @@ class ShapedSliceIndexer(Indexer):
             return np.arange(*self._slice.indices(sys.maxsize), dtype=int)
         else:
             src_size = np.prod(self._src_shape, dtype=int)
-            arr = np.arange(src_size, dtype=int).reshape(self._src_shape)[self._slice]
+            arr = np.arange(src_size, dtype=int).reshape(self._src_shape)[self._slice].ravel()
             if flat:
                 # Case 2: Requested flattened indices of multidimensional array
                 # Return indices into a flattened src.
-                return arr.ravel()
+                return arr
             else:
                 # Case 3: Requested non-flat indices of multidimensional array
                 # This is never called within OpenMDAO
-                raise NotImplementedError('ShapedSliceIndexer.as_array only returns flat arrays.')
+                return np.unravel_index(arr, shape=self._src_shape)
 
     def flat(self, copy=False):
         """

--- a/openmdao/utils/tests/test_indexer.py
+++ b/openmdao/utils/tests/test_indexer.py
@@ -318,6 +318,28 @@ class IndexerMultiDimTestCase(unittest.TestCase):
         assert_equal(ind.indexed_src_shape, (3,3,3))
         assert_equal(ind.min_src_dim, 3)
 
+    def test_flat_slice_into_nd_source(self):
+        ind = indexer[1:]
+        src = np.arange(27).reshape((3,3,3))
+        ind.set_src_shape(src.shape)
+
+        assert_equal(ind(), slice(1, None, None))
+
+        expected = np.stack([np.arange(9, 18).reshape((3, 3)), np.arange(18, 27).reshape((3, 3))])
+
+        assert_equal(expected, src[1:])
+        assert_equal(src[ind()], expected)
+
+        shaped_ind = ind.shaped_instance()
+
+        assert_equal(shaped_ind.as_array(flat=True), expected.ravel())
+
+        expected_nonflat = (np.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2]),
+                            np.array([0, 0, 0, 1, 1, 1, 2, 2, 2, 0, 0, 0, 1, 1, 1, 2, 2, 2]),
+                            np.array([0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]))
+
+        assert_equal(shaped_ind.as_array(flat=False), expected_nonflat)
+
     def test_slice_neg(self):
         ind = indexer[:-1,:,:2]
         src = np.arange(27).reshape((3,3,3))

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -98,6 +98,7 @@ class DefaultTransfer(Transfer):
                 src_indices = meta_in['src_indices']
                 if src_indices is not None:
                     src_indices = src_indices.shaped_array()
+                    # src_indices = src_indices.shaped_array(flat=meta_in['flat_src_indices'])
 
                 # 1. Compute the output indices
                 offset = offsets_out[idx_out]

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -98,7 +98,6 @@ class DefaultTransfer(Transfer):
                 src_indices = meta_in['src_indices']
                 if src_indices is not None:
                     src_indices = src_indices.shaped_array()
-                    # src_indices = src_indices.shaped_array(flat=meta_in['flat_src_indices'])
 
                 # 1. Compute the output indices
                 offset = offsets_out[idx_out]


### PR DESCRIPTION
### Summary

The core features documentation on connections did not demonstrate the use of `om.slicer` for `src_indices`.
This adds two examples of its use.
It also fixes a big that occurs when a flat slice is applied as non-flat_src_indices.

If `M` is a 3 x 3 matrix, then in numpy's convention, `M[:1]` retrieves the first _row_ of M.
In OpenMDAO, applying this slice to a connection would just give the first element.
This has been fixed.

There may be some setup performance hits due to this PR, but the fact that this bug was not encountered previously means that is probably unlikely that the slightly slower way of sorting out the src_indices from the indexer is commonly used.

### Related Issues

- Resolves #2437 
- Resolves #2446 

### Backwards incompatibilities

None

### New Dependencies

None
