### PR TITLE
Bug fix and some changes to recording under MPI

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -482,17 +482,12 @@ class Driver(object):
 
         return vars2record
 
-    def _setup_recording(self, comm):
+    def _setup_recording(self):
         """
         Set up case recording.
-
-        Parameters
-        ----------
-        comm : MPI.Comm or <FakeComm> or None
-            The communicator for recorders (should be the comm for the Problem).
         """
         self._filtered_vars_to_record = self._get_vars_to_record(self.recording_options)
-        self._rec_mgr.startup(self, comm)
+        self._rec_mgr.startup(self, self._problem().comm)
 
     def _get_voi_val(self, name, meta, remote_vois, driver_scaling=True,
                      get_remote=True, rank=None):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -482,13 +482,17 @@ class Driver(object):
 
         return vars2record
 
-    def _setup_recording(self):
+    def _setup_recording(self, comm):
         """
         Set up case recording.
+
+        Parameters
+        ----------
+        comm : MPI.Comm or <FakeComm> or None
+            The communicator for recorders (should be the comm for the Problem).
         """
         self._filtered_vars_to_record = self._get_vars_to_record(self.recording_options)
-
-        self._rec_mgr.startup(self)
+        self._rec_mgr.startup(self, comm)
 
     def _get_voi_val(self, name, meta, remote_vois, driver_scaling=True,
                      get_remote=True, rank=None):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -17,7 +17,7 @@ from openmdao.utils.general_utils import _prom2ivc_src_dict, \
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 import openmdao.utils.coloring as coloring_mod
-from openmdao.utils.array_utils import sizes2offsets, convert_neg
+from openmdao.utils.array_utils import sizes2offsets
 from openmdao.vectors.vector import _full_slice
 from openmdao.utils.indexer import indexer
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -680,7 +680,7 @@ class Group(System):
         list
             List of all states.
         """
-        if MPI:
+        if MPI and self.comm.size > 1:
             all_states = set()
             byproc = self.comm.allgather(self._list_states())
             for proc_states in byproc:
@@ -3180,7 +3180,7 @@ class Group(System):
         else:
             systems = [s.name for s in self._subsystems_myproc]
 
-        if MPI:
+        if MPI and self.comm.size > 1:
             sysbyproc = self.comm.allgather(systems)
 
             systems = set()
@@ -3540,7 +3540,7 @@ class Group(System):
         gprom = None
 
         # get promoted name relative to g
-        if MPI is not None and self.comm.size > 1:
+        if MPI and self.comm.size > 1:
             if g is not None and not g._is_local:
                 g = None
             if self.comm.allreduce(int(g is not None)) < self.comm.size:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -793,17 +793,12 @@ class Problem(object):
             # may need to convert some lnames to auto_ivc names
             return {n: lvec[conns[n] if n in conns else n].copy() for n in lnames}
 
-    def _setup_recording(self, comm):
+    def _setup_recording(self):
         """
         Set up case recording.
-
-        Parameters
-        ----------
-        comm : MPI.Comm or <FakeComm> or None
-            The communicator for recorders (should be the comm for the Problem).
         """
         self._filtered_vars_to_record = self.driver._get_vars_to_record(self.recording_options)
-        self._rec_mgr.startup(self, comm)
+        self._rec_mgr.startup(self, self.comm)
 
     def add_recorder(self, recorder):
         """
@@ -951,6 +946,7 @@ class Problem(object):
         # this metadata will be shared by all Systems/Solvers in the system tree
         self._metadata = {
             'name': self._name,  # the name of this Problem
+            'comm': comm,
             'coloring_dir': self.options['coloring_dir'],  # directory for coloring files
             'recording_iter': _RecIteration(comm),  # manager of recorder iterations
             'local_vector_class': local_vector_class,
@@ -1043,8 +1039,8 @@ class Problem(object):
 
         # set up recording, including any new recorders since last setup
         if self._metadata['setup_status'] >= _SetupStatus.POST_SETUP:
-            driver._setup_recording(comm)
-            self._setup_recording(comm)
+            driver._setup_recording()
+            self._setup_recording()
             record_viewer_data(self)
 
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -948,7 +948,7 @@ class Problem(object):
             'name': self._name,  # the name of this Problem
             'comm': comm,
             'coloring_dir': self.options['coloring_dir'],  # directory for coloring files
-            'recording_iter': _RecIteration(comm),  # manager of recorder iterations
+            'recording_iter': _RecIteration(comm.rank),  # manager of recorder iterations
             'local_vector_class': local_vector_class,
             'distributed_vector_class': distributed_vector_class,
             'solver_info': SolverInfo(),
@@ -994,7 +994,6 @@ class Problem(object):
         started, and the rest of the framework is prepared for execution.
         """
         driver = self.driver
-        comm = self.comm
 
         response_size, desvar_size = driver._update_voi_meta(self.model)
 
@@ -1006,7 +1005,7 @@ class Problem(object):
             mode = self._orig_mode
 
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
-            self.model._final_setup(comm)
+            self.model._final_setup(self.comm)
 
         driver._setup_driver(self)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -929,8 +929,7 @@ class System(object):
         if self._use_derivatives:
             self._setup_jacobians()
 
-        # recorders will use the problem comm
-        self._setup_recording(comm)
+        self._setup_recording()
 
         self.set_initial_values()
 
@@ -1451,14 +1450,9 @@ class System(object):
 
         return comm
 
-    def _setup_recording(self, comm):
+    def _setup_recording(self):
         """
         Set up case recording.
-
-        Parameters
-        ----------
-        comm : MPI.Comm or <FakeComm> or None
-            The communicator for recorders (should be the comm for the Problem).
         """
         if self._rec_mgr._recorders:
             myinputs = myoutputs = myresiduals = []
@@ -1498,10 +1492,10 @@ class System(object):
                 'residual': myresiduals
             }
 
-            self._rec_mgr.startup(self, comm)
+            self._rec_mgr.startup(self, self._problem_meta['comm'])
 
         for subsys in self._subsystems_myproc:
-            subsys._setup_recording(comm)
+            subsys._setup_recording()
 
     def _setup_procs(self, pathname, comm, mode, prob_meta):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -929,7 +929,8 @@ class System(object):
         if self._use_derivatives:
             self._setup_jacobians()
 
-        self._setup_recording()
+        # recorders will use the problem comm
+        self._setup_recording(comm)
 
         self.set_initial_values()
 
@@ -1450,7 +1451,15 @@ class System(object):
 
         return comm
 
-    def _setup_recording(self):
+    def _setup_recording(self, comm):
+        """
+        Set up case recording.
+
+        Parameters
+        ----------
+        comm : MPI.Comm or <FakeComm> or None
+            The communicator for recorders (should be the comm for the Problem).
+        """
         if self._rec_mgr._recorders:
             myinputs = myoutputs = myresiduals = []
 
@@ -1489,10 +1498,10 @@ class System(object):
                 'residual': myresiduals
             }
 
-            self._rec_mgr.startup(self)
+            self._rec_mgr.startup(self, comm)
 
         for subsys in self._subsystems_myproc:
-            subsys._setup_recording()
+            subsys._setup_recording(comm)
 
     def _setup_procs(self, pathname, comm, mode, prob_meta):
         """

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -192,17 +192,15 @@ class DifferentialEvolutionDriver(Driver):
                     # write cases only on procs up to the number of parallel DOEs
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:
-                        recorder.record_on_proc = True
+                        recorder.record_on_process = True
                     else:
                         size = self._problem_comm.size // procs_per_model
                         if self._problem_comm.rank < size:
-                            recorder.record_on_proc = True
-                        else:
-                            recorder.record_on_proc = False
+                            recorder.record_on_process = True
 
-                elif self._problem_comm.rank > 0:
+                elif self._problem_comm.rank == 0:
                     # if not running cases in parallel, then just record on proc 0
-                    recorder.record_on_proc = False
+                    recorder.record_on_process = True
 
         super()._setup_recording()
 

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -189,7 +189,7 @@ class DifferentialEvolutionDriver(Driver):
 
             for recorder in self._rec_mgr:
                 if run_parallel:
-                    # write cases only on procs up to the number of parallel DOEs
+                    # write cases only on procs up to the number of parallel models
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:
                         recorder.record_on_process = True

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -38,6 +38,8 @@ class DifferentialEvolutionDriver(Driver):
 
     Attributes
     ----------
+    _problem_comm : MPI.Comm or None
+        The MPI communicator for the Problem.
     _concurrent_pop_size : int
         Number of points to run concurrently when model is a parallel one.
     _concurrent_color : int
@@ -151,6 +153,8 @@ class DifferentialEvolutionDriver(Driver):
         MPI.Comm or <FakeComm> or None
             The communicator for the Problem model.
         """
+        self._problem_comm = comm
+
         procs_per_model = self.options['procs_per_model']
         if MPI and self.options['run_parallel']:
 
@@ -174,6 +178,33 @@ class DifferentialEvolutionDriver(Driver):
         self._concurrent_pop_size = 0
         self._concurrent_color = 0
         return comm
+
+    def _setup_recording(self):
+        """
+        Set up case recording.
+        """
+        if MPI:
+            run_parallel = self.options['run_parallel']
+            procs_per_model = self.options['procs_per_model']
+
+            for recorder in self._rec_mgr:
+                if run_parallel:
+                    # write cases only on procs up to the number of parallel DOEs
+                    # (i.e. on the root procs for the cases)
+                    if procs_per_model == 1:
+                        recorder.record_on_proc = True
+                    else:
+                        size = self._problem_comm.size // procs_per_model
+                        if self._problem_comm.rank < size:
+                            recorder.record_on_proc = True
+                        else:
+                            recorder.record_on_proc = False
+
+                elif self._problem_comm.rank > 0:
+                    # if not running cases in parallel, then just record on proc 0
+                    recorder.record_on_proc = False
+
+        super()._setup_recording()
 
     def _get_name(self):
         """

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -245,7 +245,7 @@ class DOEDriver(Driver):
 
             for recorder in self._rec_mgr:
                 if run_parallel:
-                    # write cases only on procs up to the number of parallel DOEs
+                    # write cases only on procs up to the number of parallel models
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:
                         recorder.record_on_process = True

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -248,17 +248,15 @@ class DOEDriver(Driver):
                     # write cases only on procs up to the number of parallel DOEs
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:
-                        recorder.record_on_proc = True
+                        recorder.record_on_process = True
                     else:
                         size = self._problem_comm.size // procs_per_model
                         if self._problem_comm.rank < size:
-                            recorder.record_on_proc = True
-                        else:
-                            recorder.record_on_proc = False
+                            recorder.record_on_process = True
 
-                elif self._problem_comm.rank > 0:
+                elif self._problem_comm.rank == 0:
                     # if not running cases in parallel, then just record on proc 0
-                    recorder.record_on_proc = False
+                    recorder.record_on_process = True
 
         super()._setup_recording()
 

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -256,17 +256,17 @@ class DOEDriver(Driver):
                     # of parallel DOEs (i.e. on the root procs for the cases)
                     if isinstance(recorder, SqliteRecorder):
                         if procs_per_model == 1:
-                            recorder._record_on_proc = True
+                            recorder.record_on_proc = True
                         else:
                             size = self._problem_comm.size // procs_per_model
                             if self._problem_comm.rank < size:
-                                recorder._record_on_proc = True
+                                recorder.record_on_proc = True
                             else:
-                                recorder._record_on_proc = False
+                                recorder.record_on_proc = False
 
                 elif comm.rank > 0:
                     # if not running cases in parallel, then just record on proc 0
-                    recorder._record_on_proc = False
+                    recorder.record_on_proc = False
 
         super()._setup_recording(comm)
 

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -245,8 +245,6 @@ class DOEDriver(Driver):
 
             for recorder in self._rec_mgr:
                 if run_parallel:
-                    recorder.parallel = True
-
                     # write cases only on procs up to the number of parallel DOEs
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -245,19 +245,18 @@ class DOEDriver(Driver):
 
             for recorder in self._rec_mgr:
                 if run_parallel:
-                    recorder._parallel = True
+                    recorder.parallel = True
 
-                    # if SqliteRecorder, write cases only on procs up to the number
-                    # of parallel DOEs (i.e. on the root procs for the cases)
-                    if isinstance(recorder, SqliteRecorder):
-                        if procs_per_model == 1:
+                    # write cases only on procs up to the number of parallel DOEs
+                    # (i.e. on the root procs for the cases)
+                    if procs_per_model == 1:
+                        recorder.record_on_proc = True
+                    else:
+                        size = self._problem_comm.size // procs_per_model
+                        if self._problem_comm.rank < size:
                             recorder.record_on_proc = True
                         else:
-                            size = self._problem_comm.size // procs_per_model
-                            if self._problem_comm.rank < size:
-                                recorder.record_on_proc = True
-                            else:
-                                recorder.record_on_proc = False
+                            recorder.record_on_proc = False
 
                 elif self._problem_comm.rank > 0:
                     # if not running cases in parallel, then just record on proc 0

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -235,14 +235,9 @@ class DOEDriver(Driver):
             if i % size == color:
                 yield case
 
-    def _setup_recording(self, comm):
+    def _setup_recording(self):
         """
         Set up case recording.
-
-        Parameters
-        ----------
-        comm : MPI.Comm or <FakeComm> or None
-            The communicator for recorders (should be the comm for the Problem).
         """
         if MPI:
             run_parallel = self.options['run_parallel']
@@ -264,11 +259,11 @@ class DOEDriver(Driver):
                             else:
                                 recorder.record_on_proc = False
 
-                elif comm.rank > 0:
+                elif self._problem_comm.rank > 0:
                     # if not running cases in parallel, then just record on proc 0
                     recorder.record_on_proc = False
 
-        super()._setup_recording(comm)
+        super()._setup_recording()
 
     def _get_recorder_metadata(self, case_name):
         """

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -235,9 +235,14 @@ class DOEDriver(Driver):
             if i % size == color:
                 yield case
 
-    def _setup_recording(self):
+    def _setup_recording(self, comm):
         """
         Set up case recording.
+
+        Parameters
+        ----------
+        comm : MPI.Comm or <FakeComm> or None
+            The communicator for recorders (should be the comm for the Problem).
         """
         if MPI:
             run_parallel = self.options['run_parallel']
@@ -259,11 +264,11 @@ class DOEDriver(Driver):
                             else:
                                 recorder._record_on_proc = False
 
-                elif self._problem_comm.rank > 0:
+                elif comm.rank > 0:
                     # if not running cases in parallel, then just record on proc 0
                     recorder._record_on_proc = False
 
-        super()._setup_recording()
+        super()._setup_recording(comm)
 
     def _get_recorder_metadata(self, case_name):
         """

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -214,7 +214,7 @@ class SimpleGADriver(Driver):
 
             for recorder in self._rec_mgr:
                 if run_parallel:
-                    # write cases only on procs up to the number of parallel DOEs
+                    # write cases only on procs up to the number of parallel models
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:
                         recorder.record_on_process = True

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -44,6 +44,8 @@ class SimpleGADriver(Driver):
 
     Attributes
     ----------
+    _problem_comm : MPI.Comm or None
+        The MPI communicator for the Problem.
     _concurrent_pop_size : int
         Number of points to run concurrently when model is a parallel one.
     _concurrent_color : int
@@ -176,6 +178,8 @@ class SimpleGADriver(Driver):
         MPI.Comm or <FakeComm> or None
             The communicator for the Problem model.
         """
+        self._problem_comm = comm
+
         procs_per_model = self.options['procs_per_model']
         if MPI and self.options['run_parallel']:
 
@@ -199,6 +203,33 @@ class SimpleGADriver(Driver):
         self._concurrent_pop_size = 0
         self._concurrent_color = 0
         return comm
+
+    def _setup_recording(self):
+        """
+        Set up case recording.
+        """
+        if MPI:
+            run_parallel = self.options['run_parallel']
+            procs_per_model = self.options['procs_per_model']
+
+            for recorder in self._rec_mgr:
+                if run_parallel:
+                    # write cases only on procs up to the number of parallel DOEs
+                    # (i.e. on the root procs for the cases)
+                    if procs_per_model == 1:
+                        recorder.record_on_proc = True
+                    else:
+                        size = self._problem_comm.size // procs_per_model
+                        if self._problem_comm.rank < size:
+                            recorder.record_on_proc = True
+                        else:
+                            recorder.record_on_proc = False
+
+                elif self._problem_comm.rank > 0:
+                    # if not running cases in parallel, then just record on proc 0
+                    recorder.record_on_proc = False
+
+        super()._setup_recording()
 
     def _get_name(self):
         """

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -217,17 +217,15 @@ class SimpleGADriver(Driver):
                     # write cases only on procs up to the number of parallel DOEs
                     # (i.e. on the root procs for the cases)
                     if procs_per_model == 1:
-                        recorder.record_on_proc = True
+                        recorder.record_on_process = True
                     else:
                         size = self._problem_comm.size // procs_per_model
                         if self._problem_comm.rank < size:
-                            recorder.record_on_proc = True
-                        else:
-                            recorder.record_on_proc = False
+                            recorder.record_on_process = True
 
-                elif self._problem_comm.rank > 0:
+                elif self._problem_comm.rank == 0:
                     # if not running cases in parallel, then just record on proc 0
-                    recorder.record_on_proc = False
+                    recorder.record_on_process = True
 
         super()._setup_recording()
 

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -10,8 +10,9 @@ from openmdao.test_suite.components.branin import Branin
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar_feature import SellarMDA
-from openmdao.test_suite.components.three_bar_truss import ThreeBarTruss
 
+from openmdao.utils.general_utils import run_driver
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
@@ -706,6 +707,7 @@ class Summer(om.ExplicitComponent):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+@use_tempdirs
 class MPITestDifferentialEvolution4Procs(unittest.TestCase):
     N_PROCS = 4
 
@@ -780,15 +782,43 @@ class MPITestDifferentialEvolution4Procs(unittest.TestCase):
         model.add_objective('obj')
 
         driver = prob.driver = om.DifferentialEvolutionDriver()
-        prob.driver.options['pop_size'] = 4
-        prob.driver.options['max_gen'] = 3
-        prob.driver.options['run_parallel'] = True
-        prob.driver.options['procs_per_model'] = 2
+        driver.options['pop_size'] = 4
+        driver.options['max_gen'] = 3
+        driver.options['run_parallel'] = True
+        driver.options['procs_per_model'] = 2
+
+        # also check that parallel recording works
+        driver.add_recorder(om.SqliteRecorder("cases.sql"))
 
         prob.setup()
         prob.set_solver_print(level=0)
 
-        prob.run_driver()
+        failed, output = run_driver(prob)
+
+        self.assertFalse(failed)
+
+        # we will have run 2 models in parallel on our 4 procs
+        num_models = prob.comm.size // driver.options['procs_per_model']
+        self.assertEqual(num_models, 2)
+
+        # a separate case file should have been written by rank 0 of each parallel model
+        # (the top two global ranks)
+        rank = prob.comm.rank
+        filename = "cases.sql_%d" % rank
+
+        if rank < num_models:
+            expect_msg = "Cases from rank %d are being written to %s." % (rank, filename)
+            self.assertTrue(expect_msg in output)
+
+            cr = om.CaseReader(filename)
+            cases = cr.list_cases('driver')
+
+            # check that cases were recorded on this proc
+            num_cases = len(cases)
+            self.assertTrue(num_cases > 0)
+        else:
+            self.assertFalse("Cases from rank %d are being written" % rank in output)
+            self.assertFalse(os.path.exists(filename))
 
     def test_distributed_obj(self):
         size = 3

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -13,6 +13,8 @@ from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar_feature import SellarMDA
 from openmdao.test_suite.components.three_bar_truss import ThreeBarTruss
 
+from openmdao.utils.general_utils import run_driver
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 
@@ -1072,6 +1074,7 @@ class Summer(om.ExplicitComponent):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+@use_tempdirs
 class MPITestSimpleGA4Procs(unittest.TestCase):
 
     N_PROCS = 4
@@ -1199,10 +1202,38 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         prob.driver.options['run_parallel'] = True
         prob.driver.options['procs_per_model'] = 2
 
+        # also check that parallel recording works
+        driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
         prob.setup()
         prob.set_solver_print(level=0)
 
-        prob.run_driver()
+        failed, output = run_driver(prob)
+
+        self.assertFalse(failed)
+
+        # we will have run 2 models in parallel on our 4 procs
+        num_models = prob.comm.size // driver.options['procs_per_model']
+        self.assertEqual(num_models, 2)
+
+        # a separate case file should have been written by rank 0 of each parallel model
+        # (the top two global ranks)
+        rank = prob.comm.rank
+        filename = "cases.sql_%d" % rank
+
+        if rank < num_models:
+            expect_msg = "Cases from rank %d are being written to %s." % (rank, filename)
+            self.assertTrue(expect_msg in output)
+
+            cr = om.CaseReader(filename)
+            cases = cr.list_cases('driver')
+
+            # check that cases were recorded on this proc
+            num_cases = len(cases)
+            self.assertTrue(num_cases > 0)
+        else:
+            self.assertFalse("Cases from rank %d are being written" % rank in output)
+            self.assertFalse(os.path.exists(filename))
 
     def test_distributed_obj(self):
         size = 3

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -1197,10 +1197,10 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         model.add_objective('obj')
 
         driver = prob.driver = om.SimpleGADriver()
-        prob.driver.options['pop_size'] = 4
-        prob.driver.options['max_gen'] = 3
-        prob.driver.options['run_parallel'] = True
-        prob.driver.options['procs_per_model'] = 2
+        driver.options['pop_size'] = 4
+        driver.options['max_gen'] = 3
+        driver.options['run_parallel'] = True
+        driver.options['procs_per_model'] = 2
 
         # also check that parallel recording works
         driver.add_recorder(om.SqliteRecorder("cases.sql"))

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -46,8 +46,6 @@ class CaseRecorder(object):
         Flag indicating if this recorder will record on multiple processes.
     _record_on_proc : bool or None
         Flag indicating if this recorder will record on the current process (None if unspecified).
-    _record_on_ranks : list
-        list of _record_on_proc flags for all ranks (gathered at startup)
     """
 
     def __init__(self, record_viewer_data=True):
@@ -86,9 +84,6 @@ class CaseRecorder(object):
         # will be set and recording will occur on all processes for which the
         # value is True.
         self._record_on_proc = None
-
-        # list of _record_on_proc flags for all ranks (gathered at startup)
-        self._record_on_ranks = None
 
     @property
     def record_on_process(self):

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -180,7 +180,7 @@ class CaseRecorder(object):
         **kwargs : keyword args
             Some implementations of record_iteration need additional args.
         """
-        if self._record_on_proc:
+        if self.record_on_proc:
             self._counter += 1
 
             self._iteration_coordinate = \
@@ -272,10 +272,6 @@ class CaseRecorder(object):
         **kwargs : keyword args
             Some implementations of record_derivatives need additional args.
         """
-        if not self.parallel:
-            if MPI and MPI.COMM_WORLD.rank > 0:
-                raise RuntimeError("Non-parallel recorders should not be recording on ranks > 0")
-
         self._iteration_coordinate = \
             recording_requester._recording_iter.get_formatted_iteration_coordinate()
 

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -46,6 +46,8 @@ class CaseRecorder(object):
         Flag indicating if this recorder will record on multiple processes.
     _record_on_proc : bool or None
         Flag indicating if this recorder will record on the current process (None if unspecified).
+    _recording_ranks : list
+        List of ranks on which this recorder will record if running under MPI.
     """
 
     def __init__(self, record_viewer_data=True):
@@ -84,6 +86,10 @@ class CaseRecorder(object):
         # will be set and recording will occur on all processes for which the
         # value is True.
         self._record_on_proc = None
+
+        # List of ranks on which this recorder will record if running under MPI.
+        # Only used when running under MPI with communicator size greater than one.
+        self._recording_ranks = None
 
     @property
     def record_on_process(self):

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -93,7 +93,7 @@ class CaseRecorder(object):
         recording_requester : object
             Object to which this recorder is attached.
         comm : MPI.Comm or <FakeComm> or None
-            The communicator for the recorder (should be the comm for the Problem).
+            The MPI communicator for the recorder (should be the comm for the Problem).
         """
         self._counter = 0
 

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -43,8 +43,8 @@ class CaseRecorder(object):
         Solver abs_error value, to be used by a derived recorder.
     _iteration_coordinate : str
         The unique iteration coordinate of where an iteration originates.
-    parallel : bool
-        Designates if the current recorder is parallel-recording-capable.
+    _parallel : bool
+        Flag indicating if this recorder will record on multiple processes.
     record_on_proc : bool or _UNDEFINED
         Flag indicating if this recorder will record on the current process.
     """
@@ -77,7 +77,7 @@ class CaseRecorder(object):
         # By default, this is False, but it should be set to True
         # if the recorder will record data on multiple processes to avoid
         # unnecessary gathering.
-        self.parallel = False
+        self._parallel = False
 
         # Flag indicating if recording will be performed on the current process
         # Defaults to undefined indicating the default behavior, which is normally
@@ -96,6 +96,13 @@ class CaseRecorder(object):
             The MPI communicator for the recorder (should be the comm for the Problem).
         """
         self._counter = 0
+
+    @property
+    def parallel(self):
+        """
+        Return True if this recorder is recording on multiple processes.
+        """
+        return self._parallel
 
     def record_metadata(self, recording_requester):
         """

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -5,6 +5,7 @@ from openmdao.core.system import System
 from openmdao.core.driver import Driver
 from openmdao.solvers.solver import Solver
 from openmdao.core.problem import Problem
+from openmdao.core.constants import _UNDEFINED
 from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import check_path
@@ -44,6 +45,8 @@ class CaseRecorder(object):
         The unique iteration coordinate of where an iteration originates.
     _parallel : bool
         Designates if the current recorder is parallel-recording-capable.
+    record_on_proc : bool or _UNDEFINED
+        Flag indicating if this recorder will record on the current process.
     """
 
     def __init__(self, record_viewer_data=True):
@@ -72,11 +75,16 @@ class CaseRecorder(object):
         self._iteration_coordinate = None
 
         # By default, this is False, but it should be set to True
-        # if the recorder will record data on each process to avoid
+        # if the recorder will record data on multiple processes to avoid
         # unnecessary gathering.
         self._parallel = False
 
-    def startup(self, recording_requester, comm=None):
+        # Flag indicating if recording will be performed on the current process
+        # Defaults to undefined indicating the default behavior, which is normally
+        # that recording should only be performed on rank 0.
+        self.record_on_proc = _UNDEFINED
+
+    def startup(self, recording_requester, comm):
         """
         Prepare for a new run and calculate inclusion lists.
 

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -43,7 +43,7 @@ class CaseRecorder(object):
         Solver abs_error value, to be used by a derived recorder.
     _iteration_coordinate : str
         The unique iteration coordinate of where an iteration originates.
-    _parallel : bool
+    parallel : bool
         Designates if the current recorder is parallel-recording-capable.
     record_on_proc : bool or _UNDEFINED
         Flag indicating if this recorder will record on the current process.
@@ -77,7 +77,7 @@ class CaseRecorder(object):
         # By default, this is False, but it should be set to True
         # if the recorder will record data on multiple processes to avoid
         # unnecessary gathering.
-        self._parallel = False
+        self.parallel = False
 
         # Flag indicating if recording will be performed on the current process
         # Defaults to undefined indicating the default behavior, which is normally
@@ -272,7 +272,7 @@ class CaseRecorder(object):
         **kwargs : keyword args
             Some implementations of record_derivatives need additional args.
         """
-        if not self._parallel:
+        if not self.parallel:
             if MPI and MPI.COMM_WORLD.rank > 0:
                 raise RuntimeError("Non-parallel recorders should not be recording on ranks > 0")
 

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -84,7 +84,7 @@ class CaseRecorder(object):
         # that recording should only be performed on rank 0.
         self.record_on_proc = _UNDEFINED
 
-    def startup(self, recording_requester, comm):
+    def startup(self, recording_requester, comm=None):
         """
         Prepare for a new run and calculate inclusion lists.
 

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -30,7 +30,7 @@ class _RecIteration(object):
         Parameters
         ----------
         rank : int
-            The MPI rank to use when constructing iteration coordinates.
+            The rank to use when constructing iteration coordinates.
         """
         self.stack = []
         self.prefix = None

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -19,14 +19,22 @@ class _RecIteration(object):
         A list that holds the stack of iteration coordinates.
     prefix : str or None
         Prefix to prepend to iteration coordinates.
+    comm : MPI.Comm or <FakeComm> or None
+        The communicator to use when generating iteration coordinates.
     """
 
-    def __init__(self):
+    def __init__(self, comm=None):
         """
         Initialize.
+
+        Parameters
+        ----------
+        comm : MPI.Comm or <FakeComm> or None
+            The communicator to use when generating iteration coordinates.
         """
         self.stack = []
         self.prefix = None
+        self.comm = comm
         self._norec_refcount = 0
 
     def print_recording_iteration_stack(self):
@@ -59,8 +67,8 @@ class _RecIteration(object):
         else:
             prefix = ''
 
-        if MPI:
-            prefix += 'rank%d:' % MPI.COMM_WORLD.rank
+        if self.comm:
+            prefix += f'rank{self.comm.rank}:'
         else:
             prefix += 'rank0:'
 

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -19,22 +19,22 @@ class _RecIteration(object):
         A list that holds the stack of iteration coordinates.
     prefix : str or None
         Prefix to prepend to iteration coordinates.
-    comm : MPI.Comm or <FakeComm> or None
-        The communicator to use when generating iteration coordinates.
+    rank : int
+        The MPI rank to use when constructing iteration coordinates.
     """
 
-    def __init__(self, comm=None):
+    def __init__(self, rank=0):
         """
         Initialize.
 
         Parameters
         ----------
-        comm : MPI.Comm or <FakeComm> or None
-            The communicator to use when generating iteration coordinates.
+        rank : int
+            The MPI rank to use when constructing iteration coordinates.
         """
         self.stack = []
         self.prefix = None
-        self.comm = comm
+        self.rank = 0
         self._norec_refcount = 0
 
     def print_recording_iteration_stack(self):
@@ -67,10 +67,7 @@ class _RecIteration(object):
         else:
             prefix = ''
 
-        if self.comm:
-            prefix += f'rank{self.comm.rank}:'
-        else:
-            prefix += 'rank0:'
+        prefix += f'rank{self.rank}:'
 
         # iteration hierarchy
         coord_list = []

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -107,7 +107,7 @@ class RecordingManager(object):
             # Each of the recorders determines its self._filtered_* list of vars to record
             recorder.startup(recording_requester, comm)
 
-            if not recorder._parallel:
+            if not recorder.parallel:
                 self._has_serial_recorders = True
 
     def shutdown(self):
@@ -172,7 +172,7 @@ class RecordingManager(object):
             metadata['timestamp'] = time.time()
 
         for recorder in self._recorders:
-            if recorder._parallel or MPI is None or self.rank == 0:
+            if recorder.parallel or MPI is None or self.rank == 0:
                 recorder.record_derivatives(recording_requester, data, metadata)
 
     def has_recorders(self):
@@ -187,7 +187,7 @@ class RecordingManager(object):
         return True if self._recorders else False
 
     def _check_parallel(self):
-        pset = {bool(r._parallel) for r in self._recorders}
+        pset = {bool(r.parallel) for r in self._recorders}
 
         # check to make sure we don't have mixed parallel/non-parallel, because that
         # currently won't work properly.

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -3,13 +3,7 @@ RecordingManager class definition.
 """
 import time
 
-from openmdao.utils.general_utils import simple_warning
 from openmdao.utils.om_warnings import warn_deprecation
-
-try:
-    from openmdao.utils.mpi import MPI
-except ImportError:
-    MPI = None
 
 
 class RecordingManager(object):
@@ -20,10 +14,6 @@ class RecordingManager(object):
     ----------
     _recorders : list of CaseRecorder
         All of the recorders attached to the current object.
-    rank : int
-        Rank of the iteration coordinate.
-    _has_serial_recorders : bool
-        True if any of the recorders managed by this object are serial recorders.
     """
 
     def __init__(self):
@@ -31,12 +21,6 @@ class RecordingManager(object):
         init.
         """
         self._recorders = []
-        self._has_serial_recorders = False
-
-        if MPI:
-            self.rank = MPI.COMM_WORLD.rank
-        else:
-            self.rank = 0
 
     def __getitem__(self, index):
         """
@@ -87,28 +71,9 @@ class RecordingManager(object):
         comm : MPI.Comm or <FakeComm> or None
             The communicator for recorders (should be the comm for the Problem).
         """
-        # Will only add parallel code for Drivers. Use the old method for System and Solver
-        from openmdao.core.driver import Driver
-        if not isinstance(recording_requester, Driver):
-            for recorder in self._recorders:
-                recorder.startup(recording_requester, comm)
-            return
-
-        # The remaining code only works for recording of Drivers
-        model = recording_requester._problem().model
-        if MPI:
-            # TODO Eventually, we think we can get rid of this next check. But to be safe,
-            #       we are leaving it in there.
-            if not model.is_active():
-                raise RuntimeError("RecordingManager.startup should never be called when "
-                                   "running in parallel on an inactive System")
-
+        # Each of the recorders determines its self._filtered_* list of vars to record
         for recorder in self._recorders:
-            # Each of the recorders determines its self._filtered_* list of vars to record
             recorder.startup(recording_requester, comm)
-
-            if not recorder.parallel:
-                self._has_serial_recorders = True
 
     def shutdown(self):
         """
@@ -172,8 +137,7 @@ class RecordingManager(object):
             metadata['timestamp'] = time.time()
 
         for recorder in self._recorders:
-            if recorder.parallel or MPI is None or self.rank == 0:
-                recorder.record_derivatives(recording_requester, data, metadata)
+            recorder.record_derivatives(recording_requester, data, metadata)
 
     def has_recorders(self):
         """

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -71,7 +71,6 @@ class RecordingManager(object):
         comm : MPI.Comm or <FakeComm> or None
             The communicator for recorders (should be the comm for the Problem).
         """
-        # Each of the recorders determines its self._filtered_* list of vars to record
         for recorder in self._recorders:
             recorder.startup(recording_requester, comm)
 

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -790,7 +790,8 @@ class SqliteCaseReader(BaseCaseReader):
                         current_cases = {table: [case_coord]}
 
         if out_stream:
-            source_cases.append(current_cases)
+            if current_cases:
+                source_cases.append(current_cases)
             write_source_table(source_cases, out_stream)
 
         return cases

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -157,8 +157,6 @@ class SqliteRecorder(CaseRecorder):
         Flag indicating whether or not the database has been initialized.
     _started : set
         set of recording requesters for which this recorder has been started.
-    _record_on_proc : bool
-        Flag indicating whether to record on this processor when running in parallel.
     """
 
     def __init__(self, filepath, append=False, pickle_version=PICKLE_VER, record_viewer_data=True):
@@ -181,9 +179,6 @@ class SqliteRecorder(CaseRecorder):
         self._database_initialized = False
         self._started = set()
 
-        # default to record on all procs when running in parallel
-        self._record_on_proc = True
-
         super().__init__(record_viewer_data)
 
     def _initialize_database(self, comm):
@@ -203,7 +198,8 @@ class SqliteRecorder(CaseRecorder):
             if True in record_on_ranks:
                 # recording ranks have been specified
                 recording_ranks = [rnk for rnk, rec in enumerate(record_on_ranks) if rec is True]
-                if len(recording_ranks) > 1 and rank in recording_ranks:
+                parallel = self._parallel = len(recording_ranks) > 1
+                if parallel and rank in recording_ranks:
                     filepath = f"{self._filepath}_{rank}"
                     print("Note: SqliteRecorder is running on multiple processors. "
                           f"Cases from rank {rank} are being written to {filepath}.")

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -207,7 +207,6 @@ class SqliteRecorder(CaseRecorder):
                     filepath = f"{self._filepath}_{rank}"
                     print("Note: SqliteRecorder is running on multiple processors. "
                           f"Cases from rank {rank} are being written to {filepath}.")
-                    print(f"{rank=} {recording_ranks=}")
                     if rank == min(recording_ranks):
                         metadata_filepath = f'{self._filepath}_meta'
                         print("Note: Metadata is being recorded separately as "

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -275,7 +275,7 @@ class SqliteRecorder(CaseRecorder):
                               "solver_options BLOB, solver_class TEXT)")
 
         self._database_initialized = True
-        if MPI is not None:
+        if MPI and self._parallel:
             MPI.COMM_WORLD.barrier()
 
     def _cleanup_abs2meta(self):

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -285,7 +285,7 @@ class SqliteRecorder(CaseRecorder):
                               "solver_options BLOB, solver_class TEXT)")
 
         self._database_initialized = True
-        if MPI and self._parallel:
+        if MPI and self.parallel:
             comm.barrier()
 
     def _cleanup_abs2meta(self):

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -326,7 +326,7 @@ class SqliteRecorder(CaseRecorder):
         recording_requester : object
             Object to which this recorder is attached.
         comm : MPI.Comm or <FakeComm> or None
-            The communicator for the recorder (should be the comm for the Problem).
+            The MPI communicator for the recorder (should be the comm for the Problem).
         """
         # we only want to set up recording once for each recording_requester
         if recording_requester in self._started:

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -313,7 +313,7 @@ class SqliteRecorder(CaseRecorder):
                 var_settings[name][prop] = make_serializable(var_settings[name][prop])
         return var_settings
 
-    def startup(self, recording_requester, comm):
+    def startup(self, recording_requester, comm=None):
         """
         Prepare for a new run and create/update the abs2prom and prom2abs variables.
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -197,7 +197,7 @@ class SqliteRecorder(CaseRecorder):
         """
         filepath = None
 
-        if MPI and comm:
+        if MPI and comm and comm.size > 1:
             rank = comm.rank
             record_on_ranks = comm.allgather(self.record_on_proc)
             if True in record_on_ranks:
@@ -285,7 +285,7 @@ class SqliteRecorder(CaseRecorder):
                               "solver_options BLOB, solver_class TEXT)")
 
         self._database_initialized = True
-        if MPI and self.parallel:
+        if MPI and comm and comm.size > 1:
             comm.barrier()
 
     def _cleanup_abs2meta(self):

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -364,7 +364,7 @@ class DistributedRecorderTest(unittest.TestCase):
         my_comm = MPI.COMM_WORLD.Split(rank)
 
         def run_sequential():
-            # problem will run in the single proc comm
+            # problem will run in the single proc comm for this rank
             prob = om.Problem(comm=my_comm)
 
             prob.model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -404,11 +404,11 @@ class DistributedRecorderTest(unittest.TestCase):
             ])
 
             my_responses = [cr.get_case(case_id)['f_xy'] for case_id in my_cases]
-            self.assertEqual(my_responses, [22., 17., 23.75, 31., 27] if rank == 0 else
+            self.assertEqual(my_responses, [22., 17., 23.75, 31., 27.] if rank == 0 else
                                            [19.25, 26.25, 21.75, 28.75])
 
-        # Run only by proc 0
-        if rank == 0:
+        # Run model on a single processor
+        if rank == 1:
             run_sequential()
 
         # Synchronize as generated doe will be used by all procs

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -300,7 +300,9 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.run_model()
         prob.record('final')
 
-    def test_regression_bug_fix_issue_2062_sql_meta_file_running_parallel(self):
+    def test_sql_meta_file_exists(self):
+        # Check that an existing sql_meta file will be deleted/overwritten
+        # if it already exists before a run. (see Issue #2062)
         prob = om.Problem()
 
         prob.model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
@@ -318,8 +320,7 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
-        # Run this again. Because of the bug fix for issue 2062, this code should NOT
-        #   throw an exception
+        # Run this again. It should NOT throw an exception.
         prob = om.Problem()
 
         prob.model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -10,6 +10,7 @@ import numpy as np
 from openmdao.utils.mpi import MPI
 
 import openmdao.api as om
+
 from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.recorders.tests.sqlite_recorder_test_utils import \
     assertDriverIterDataRecorded, assertProblemDataRecorded
@@ -20,6 +21,8 @@ if MPI:
     from openmdao.api import PETScVector
 else:
     PETScVector = None
+
+from openmdao.test_suite.components.paraboloid import Paraboloid
 
 
 class DistributedAdder(om.ExplicitComponent):
@@ -298,9 +301,6 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.record('final')
 
     def test_regression_bug_fix_issue_2062_sql_meta_file_running_parallel(self):
-
-        from openmdao.test_suite.components.paraboloid import Paraboloid
-
         prob = om.Problem()
 
         prob.model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
@@ -337,23 +337,85 @@ class DistributedRecorderTest(unittest.TestCase):
 
         if prob.comm.rank == 0:
             expected_warnings = [
-                                 (UserWarning,
-                                  'The existing case recorder metadata file, cases.sql_meta, '
-                                  'is being overwritten.'),
-                                 (UserWarning,
-                                  'The existing case recorder file, cases.sql_0, is being '
-                                  'overwritten.'),
-                                 ]
+                (UserWarning,
+                'The existing case recorder metadata file, cases.sql_meta, '
+                'is being overwritten.'),
+                (UserWarning,
+                'The existing case recorder file, cases.sql_0, is being '
+                'overwritten.'),
+            ]
         else:
             expected_warnings = [
-                                (UserWarning,
-                                  'The existing case recorder file, cases.sql_1, is being '
-                                  'overwritten.'),
-                                 ]
+                (UserWarning,
+                    'The existing case recorder file, cases.sql_1, is being '
+                    'overwritten.'),
+            ]
         with assert_warnings(expected_warnings):
             prob.run_driver()
 
         prob.cleanup()
+
+    def test_record_on_one_proc(self):
+        # This test verifies that cases can be recorded on a single process in an MPI environment
+        # with more than one process, and the recorded cases can then be processed in parallel
+
+        size = MPI.COMM_WORLD.size
+        rank = MPI.COMM_WORLD.rank
+        my_comm = MPI.COMM_WORLD.Split(rank)
+
+        def run_sequential():
+            # problem will run in the single proc comm
+            prob = om.Problem(comm=my_comm)
+
+            prob.model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+            prob.model.add_design_var('x', lower=0.0, upper=1.0)
+            prob.model.add_design_var('y', lower=0.0, upper=1.0)
+            prob.model.add_objective('f_xy')
+
+            prob.driver = om.DOEDriver(om.FullFactorialGenerator(levels=3))
+            prob.driver.options['run_parallel'] = False
+            prob.driver.options['procs_per_model'] = 1
+            prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+            prob.setup()
+            prob.run_driver()
+            prob.cleanup()
+
+        def run_parallel():
+            # process cases.sql in parallel
+            cr = om.CaseReader("cases.sql")
+
+            cases = cr.list_cases()
+            self.assertEqual(len(cases), 9)
+
+            my_idxs = list(range(len(cases)))[rank::size]
+            my_cases = [cases[i] for i in my_idxs]
+            self.assertEqual(my_cases, [
+                'rank0:DOEDriver_FullFactorial|0',
+                'rank0:DOEDriver_FullFactorial|2',
+                'rank0:DOEDriver_FullFactorial|4',
+                'rank0:DOEDriver_FullFactorial|6',
+                'rank0:DOEDriver_FullFactorial|8'
+            ] if rank == 0 else [
+                'rank0:DOEDriver_FullFactorial|1',
+                'rank0:DOEDriver_FullFactorial|3',
+                'rank0:DOEDriver_FullFactorial|5',
+                'rank0:DOEDriver_FullFactorial|7'
+            ])
+
+            my_responses = [cr.get_case(case_id)['f_xy'] for case_id in my_cases]
+            self.assertEqual(my_responses, [22., 17., 23.75, 31., 27] if rank == 0 else
+                                           [19.25, 26.25, 21.75, 28.75])
+
+        # Run only by proc 0
+        if rank == 0:
+            run_sequential()
+
+        # Synchronize as generated doe will be used by all procs
+        MPI.COMM_WORLD.barrier()
+
+        # Run by all procs
+        run_parallel()
 
 
 if __name__ == "__main__":

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -297,7 +297,8 @@ class Solver(object):
         if isinstance(self, LinearSolver) and not system._use_derivatives:
             return
 
-        self._rec_mgr.startup(self)
+        # NOTE: can't currently add a recorder to a solver under MPI, so comm=None
+        self._rec_mgr.startup(self, comm=None)
 
         myoutputs = myresiduals = myinputs = []
         incl = self.recording_options['includes']

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -297,8 +297,7 @@ class Solver(object):
         if isinstance(self, LinearSolver) and not system._use_derivatives:
             return
 
-        # NOTE: can't currently add a recorder to a solver under MPI, so comm=None
-        self._rec_mgr.startup(self, comm=None)
+        self._rec_mgr.startup(self, self._problem_meta['comm'])
 
         myoutputs = myresiduals = myinputs = []
         incl = self.recording_options['includes']

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -111,28 +111,6 @@ def take_nth(rank, size, seq):
                     return
 
 
-def convert_neg(arr, size):
-    """
-    Convert any negative indices into their positive equivalent.
-
-    This only works for a 1D array.
-
-    Parameters
-    ----------
-    arr : ndarray
-        Array having negative indices converted.
-    size : int
-        Dimension of the array.
-
-    Returns
-    -------
-    ndarray
-        The converted array.
-    """
-    arr[arr < 0] += size
-    return arr
-
-
 def array_viz(arr, prob=None, of=None, wrt=None, stream=sys.stdout):
     """
     Display the structure of a boolean array in a compact form.

--- a/openmdao/utils/scaffolding_templates/CaseRecorder_template
+++ b/openmdao/utils/scaffolding_templates/CaseRecorder_template
@@ -21,7 +21,7 @@ class {class_name}(CaseRecorder):
 
         # initialize attributes here...
 
-    def startup(self, recording_requester, comm):
+    def startup(self, recording_requester, comm=None):
         """
         Prepare for a new run and calculate inclusion lists.
 

--- a/openmdao/utils/scaffolding_templates/CaseRecorder_template
+++ b/openmdao/utils/scaffolding_templates/CaseRecorder_template
@@ -23,7 +23,7 @@ class {class_name}(CaseRecorder):
 
     def startup(self, recording_requester, comm=None):
         """
-        Prepare for a new run and calculate inclusion lists.
+        Prepare for a new run.
 
         Parameters
         ----------

--- a/openmdao/utils/scaffolding_templates/CaseRecorder_template
+++ b/openmdao/utils/scaffolding_templates/CaseRecorder_template
@@ -21,7 +21,7 @@ class {class_name}(CaseRecorder):
 
         # initialize attributes here...
 
-    def startup(self, recording_requester, comm=None):
+    def startup(self, recording_requester, comm):
         """
         Prepare for a new run and calculate inclusion lists.
 

--- a/openmdao/utils/scaffolding_templates/CaseRecorder_template
+++ b/openmdao/utils/scaffolding_templates/CaseRecorder_template
@@ -21,16 +21,18 @@ class {class_name}(CaseRecorder):
 
         # initialize attributes here...
 
-    def startup(self, recording_requester):
+    def startup(self, recording_requester, comm=None):
         """
-        Prepare for a new run.
+        Prepare for a new run and calculate inclusion lists.
 
         Parameters
         ----------
         recording_requester : object
             Object to which this recorder is attached.
+        comm : MPI.Comm or <FakeComm> or None
+            The communicator for the recorder (should be the comm for the Problem).
         """
-        super().startup(recording_requester)
+        super().startup(recording_requester, comm)
 
         # put any necessary startup code here...
 

--- a/openmdao/utils/variable_table.py
+++ b/openmdao/utils/variable_table.py
@@ -214,6 +214,10 @@ def write_source_table(source_dicts, out_stream):
     elif not isinstance(out_stream, TextIOBase):
         raise TypeError("Invalid output stream specified for 'out_stream'.")
 
+    if not source_dicts:
+        out_stream.write('No data found.\n')
+        return
+
     if not isinstance(source_dicts, list):
         source_dicts = [source_dicts]
 

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from openmdao.core.constants import INT_DTYPE
 from openmdao.vectors.transfer import Transfer
-from openmdao.utils.array_utils import convert_neg, _global2local_offsets
+from openmdao.utils.array_utils import _global2local_offsets
 from openmdao.utils.mpi import MPI
 
 _empty_idx_array = np.array([], dtype=INT_DTYPE)


### PR DESCRIPTION
### Summary

Fixes a bug in `SqliteRecorder`, where it was blocking with a `Barrier` regardless of whether recording was in parallel or not, and adds a test for this condition, where the model is run and recorded on a single process in a multi-process MPI context.

Also:
- The Problem `comm` is now passed to all recorders at startup
- The `parallel` property of CaseRecorder is now computed based on the `record_on_process` property (parallel recording under MPI is activated by specifying `record_on_process = True` on the ranks which are to record)
- Added parallel recording logic/tests for GA and Differential Evolution drivers
- Got rid of some references to `MPI.COMM_WORLD`, some of which actually wanted the Problem `comm`.
- Fixed a bug in the `variable_table` logic where it didn't handle an empty list of variables
- Cleaned up some unused code

### Related Issues

- Resolves #2434

### Backwards incompatibilities

Some small changes to the `CaseRecorder` and `RecordingManager`  APIs, which should not be visible to users but may effect any developers that have implemented parallel recording on top of those APIs.

### New Dependencies

None
