### PR TITLE
Fix CaseReader bug

### DIFF
--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3332,18 +3332,18 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         reader = om.CaseReader(self.filename)
 
-        self.assertEqual(set(reader.list_sources(out_stream=None)), {
-            'root.cycle1.nonlinear_solver',
-            'root.cycle1.cycle1_1.nonlinear_solver',
-            'root.cycle1.cycle1_2.nonlinear_solver',
-            'root.cycle2.nonlinear_solver'
-        })
         self.assertEqual(reader.list_cases(out_stream=None), [
             'rank0:root._solve_nonlinear|0|NLRunOnce|0|cycle1._solve_nonlinear|0|NLRunOnce|0|cycle1.cycle1_1._solve_nonlinear|0|NLRunOnce|0',
             'rank0:root._solve_nonlinear|0|NLRunOnce|0|cycle1._solve_nonlinear|0|NLRunOnce|0|cycle1.cycle1_2._solve_nonlinear|0|NLRunOnce|0',
             'rank0:root._solve_nonlinear|0|NLRunOnce|0|cycle1._solve_nonlinear|0|NLRunOnce|0',
             'rank0:root._solve_nonlinear|0|NLRunOnce|0|cycle2._solve_nonlinear|0|NLRunOnce|0'
         ])
+        self.assertEqual(set(reader.list_sources(out_stream=None)), {
+            'root.cycle1.nonlinear_solver',
+            'root.cycle1.cycle1_1.nonlinear_solver',
+            'root.cycle1.cycle1_2.nonlinear_solver',
+            'root.cycle2.nonlinear_solver'
+        })
 
 
 @use_tempdirs

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -68,11 +68,11 @@ def format_iteration_coordinate(coord, prefix=None):
     return ':'.join([prefix, separator.join(iteration_coordinate)])
 
 
-# regular expression used to determine if a node in an iteration coordinate represents a system
-_coord_system_re = re.compile('(_solve_nonlinear|_apply_nonlinear)$')
-
 # Regular expression used for splitting iteration coordinates, removes separator and iter counts
 _coord_split_re = re.compile('\\|\\d+\\|*')
+
+# regular expression used to determine if a node in an iteration coordinate represents a system
+_coord_system_re = re.compile('(\\._solve_nonlinear|\\._apply_nonlinear)$')
 
 
 def get_source_system(iteration_coordinate):
@@ -94,8 +94,8 @@ def get_source_system(iteration_coordinate):
     for part in parts:
         match = _coord_system_re.search(part)
         if (match):
-            # take the part up to the beginning of the match
-            part = part[:match.span()[0] - 1]
+            # take the part up to "._solve_nonlinear" or "._apply_nonlinear"
+            part = part[:match.span()[0]]
             # get rid of 'rank#:'
             if ':' in part:
                 part = part.split(':')[1]

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -92,11 +92,14 @@ def get_source_system(iteration_coordinate):
     path = []
     parts = _coord_split_re.split(iteration_coordinate)
     for part in parts:
-        if (_coord_system_re.search(part) is not None):
+        match = _coord_system_re.search(part)
+        if (match):
+            # take the part up to the beginning of the match
+            part = part[:match.span()[0]-1]
+            # get rid of 'rank#:'
             if ':' in part:
-                # get rid of 'rank#:'
                 part = part.split(':')[1]
-            path.append(part.split('.')[0])
+            path.append(part)
 
     # return pathname of the system
     return '.'.join(path)

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -95,7 +95,7 @@ def get_source_system(iteration_coordinate):
         match = _coord_system_re.search(part)
         if (match):
             # take the part up to the beginning of the match
-            part = part[:match.span()[0]-1]
+            part = part[:match.span()[0] - 1]
             # get rid of 'rank#:'
             if ':' in part:
                 part = part.split(':')[1]


### PR DESCRIPTION
### Summary

The code that parses an iteration coordinate for its source system did not properly handle coordinates with nested systems. 

### Related Issues

- Resolves #2453

### Backwards incompatibilities

None

### New Dependencies

None
