### PR TITLE
I2435 nonlinear solver recording initial data

### DIFF
--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -44,12 +44,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
-    "!openmdao -h "
+    "!openmdao -h"
    ]
   },
   {
@@ -60,9 +73,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao n2 -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao n2 -h"
@@ -104,9 +130,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao check -c cycles circuit.py\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao check -c cycles circuit.py"
@@ -120,9 +159,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao check -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao check -h"
@@ -315,9 +367,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao tree --sizes --approx circuit.py\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao tree --sizes --approx circuit.py"
@@ -333,9 +398,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao summary circle_opt.py\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao summary circle_opt.py"
@@ -354,9 +432,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao cite circuit.py\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao cite circuit.py"
@@ -436,9 +527,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao call_tree openmdao.api.LinearBlockGS.solve\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao call_tree openmdao.api.LinearBlockGS.solve"
@@ -457,9 +561,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao scaffold -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao scaffold -h"
@@ -484,9 +601,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao list_installed -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao list_installed -h"
@@ -505,9 +635,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao list_installed lin_solver nl_solver -i openmdao\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao list_installed lin_solver nl_solver -i openmdao"
@@ -531,9 +674,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao find_plugins -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao find_plugins -h"
@@ -548,9 +704,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao find_plugins command\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao find_plugins command"
@@ -569,9 +738,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "openmdao compute_entry_points -h\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!openmdao compute_entry_points -h"
@@ -598,9 +780,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    "mpirun -n 2 openmdao summary multipoint_beam_opt.py\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
    "outputs": [],
    "source": [
     "!mpirun -n 2 openmdao summary multipoint_beam_opt.py"
@@ -657,7 +852,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -21,7 +21,7 @@ from openmdao.solvers.linesearch.tests.test_backtracking import ImplCompTwoState
 from openmdao.recorders.tests.sqlite_recorder_test_utils import assertMetadataRecorded, \
     assertDriverIterDataRecorded, assertSystemIterDataRecorded, assertSolverIterDataRecorded, \
     assertViewerDataRecorded, assertSystemMetadataIdsRecorded, assertSystemIterCoordsRecorded, \
-    assertDriverDerivDataRecorded, assertProblemDerivDataRecorded
+    assertDriverDerivDataRecorded, assertProblemDerivDataRecorded, database_cursor
 
 from openmdao.recorders.tests.recorder_test_utils import run_driver
 from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, \
@@ -1475,8 +1475,10 @@ class TestSqliteRecorder(unittest.TestCase):
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_nonlinear_newton(self):
-        prob = SellarProblem(linear_solver=om.LinearBlockGS,
-                             nonlinear_solver=om.NewtonSolver(solve_subsystems=False))
+
+        prob = SellarProblem(
+            linear_solver=om.LinearBlockGS,
+            nonlinear_solver=om.NewtonSolver(solve_subsystems=False))
         prob.setup()
 
         prob.model.nonlinear_solver.add_recorder(self.recorder)
@@ -1505,6 +1507,16 @@ class TestSqliteRecorder(unittest.TestCase):
         expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
                           expected_solver_output, expected_solver_residuals),)
         assertSolverIterDataRecorded(self, expected_data, self.eps)
+
+        # Also check to make sure the first iteration has correct abs and rel errors
+        # as a regression test for
+        #   https://github.com/OpenMDAO/OpenMDAO/issues/2435
+        cr = om.CaseReader(self.filename)
+
+        solver_cases = cr.get_cases("root.nonlinear_solver")
+        self.assertAlmostEqual(solver_cases[0].abs_err, 36.331584, delta=1e-6)
+        self.assertEqual(solver_cases[0].rel_err, 1.0)
+
 
     def test_record_solver_nonlinear_nonlinear_run_once(self):
         prob = SellarProblem(nonlinear_solver=om.NonlinearRunOnce)

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -21,7 +21,7 @@ from openmdao.solvers.linesearch.tests.test_backtracking import ImplCompTwoState
 from openmdao.recorders.tests.sqlite_recorder_test_utils import assertMetadataRecorded, \
     assertDriverIterDataRecorded, assertSystemIterDataRecorded, assertSolverIterDataRecorded, \
     assertViewerDataRecorded, assertSystemMetadataIdsRecorded, assertSystemIterCoordsRecorded, \
-    assertDriverDerivDataRecorded, assertProblemDerivDataRecorded, database_cursor
+    assertDriverDerivDataRecorded, assertProblemDerivDataRecorded
 
 from openmdao.recorders.tests.recorder_test_utils import run_driver
 from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, \
@@ -1475,7 +1475,6 @@ class TestSqliteRecorder(unittest.TestCase):
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
     def test_record_solver_nonlinear_newton(self):
-
         prob = SellarProblem(
             linear_solver=om.LinearBlockGS,
             nonlinear_solver=om.NewtonSolver(solve_subsystems=False))

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -64,7 +64,7 @@ class BroydenSolver(NonlinearSolver):
         Flag that becomes True when Broyden detects it needs to recompute the inverse Jacobian.
     """
 
-    SOLVER = 'NL: BROYDEN'
+    SOLVER = 'BROYDEN'
 
     def __init__(self, **kwargs):
         """

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -335,7 +335,6 @@ class BroydenSolver(NonlinearSolver):
             norm0 = norm if norm != 0.0 else 1.0
             rec.rel = norm / norm0
 
-        norm0 = norm if norm != 0.0 else 1.0
         return norm0, norm
 
     def _iter_get_norm(self):

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -64,7 +64,7 @@ class BroydenSolver(NonlinearSolver):
         Flag that becomes True when Broyden detects it needs to recompute the inverse Jacobian.
     """
 
-    SOLVER = 'BROYDEN'
+    SOLVER = 'NL: BROYDEN'
 
     def __init__(self, **kwargs):
         """
@@ -320,7 +320,7 @@ class BroydenSolver(NonlinearSolver):
         # Start with initial states.
         self.xm = self.get_vector(system._outputs)
 
-        with Recording('Broyden', 0, self):
+        with Recording('Broyden', 0, self) as rec:
             self._solver_info.append_solver()
 
             # should call the subsystems solve before computing the first residual
@@ -328,8 +328,12 @@ class BroydenSolver(NonlinearSolver):
 
             self._solver_info.pop()
 
-        self._run_apply()
-        norm = self._iter_get_norm()
+            self._run_apply()
+            norm = self._iter_get_norm()
+
+            rec.abs = norm
+            norm0 = norm if norm != 0.0 else 1.0
+            rec.rel = norm / norm0
 
         norm0 = norm if norm != 0.0 else 1.0
         return norm0, norm

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -208,7 +208,6 @@ class NewtonSolver(NonlinearSolver):
             norm0 = norm if norm != 0.0 else 1.0
             rec.rel = norm / norm0
 
-        norm0 = norm if norm != 0.0 else 1.0
         return norm0, norm
 
     def _single_iteration(self):

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -189,7 +189,8 @@ class NewtonSolver(NonlinearSolver):
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()
 
-        with Recording('Newton_subsolve', 0, self):
+        with Recording('Newton_subsolve', 0, self) as rec:
+
             if self.options['solve_subsystems'] and \
                (self._iter_count <= self.options['max_sub_solves']):
 
@@ -200,8 +201,12 @@ class NewtonSolver(NonlinearSolver):
 
                 self._solver_info.pop()
 
-        self._run_apply()
-        norm = self._iter_get_norm()
+            self._run_apply()
+            norm = self._iter_get_norm()
+
+            rec.abs = norm
+            norm0 = norm if norm != 0.0 else 1.0
+            rec.rel = norm / norm0
 
         norm0 = norm if norm != 0.0 else 1.0
         return norm0, norm


### PR DESCRIPTION
### Summary

Updated Newton code so that initial iteration records values for abs and rel errors. Added regression test for that fix.

Made similar change to Broyden which had the same issue.

Unrelated, but included a small fix for the cmd line docs. 

### Related Issues

- Resolves #2435 

### Backwards incompatibilities

None

### New Dependencies

None
