### PR TITLE
I2461 Added a test for solver recording when Broyden is the solver and also eliminate double recording of Broyden

### DIFF
--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1506,6 +1506,49 @@ class TestSqliteRecorder(unittest.TestCase):
                           expected_solver_output, expected_solver_residuals),)
         assertSolverIterDataRecorded(self, expected_data, self.eps)
 
+    def test_record_solver_nonlinear_broyden(self):
+        prob = SellarProblem(
+                             linear_solver=om.DirectSolver,
+                             nonlinear_solver=om.BroydenSolver()
+        )
+        prob.setup()
+
+        prob.model.nonlinear_solver.add_recorder(self.recorder)
+
+        prob.set_solver_print(-1)
+        t0, t1 = run_driver(prob)
+        prob.cleanup()
+
+        coordinate = [0, 'Driver', (0,), 'root._solve_nonlinear', (0,), 'BroydenSolver', (2,)]
+
+        expected_abs_error = 0.0009547575844806033
+        expected_rel_error = 0.00042348707505980126
+
+        expected_solver_output = {
+            '_auto_ivc.v1': [1.],
+            '_auto_ivc.v0': [5., 2.],
+            'd1.y1': [25.58830237],
+            'd2.y2': [12.05848815],
+            'obj_cmp.obj': [28.58830817],
+            'con_cmp1.con1': [-22.42830237],
+            'con_cmp2.con2': [-11.94151185]
+        }
+
+        expected_solver_residuals = None
+
+        expected_data = ((coordinate, (t0, t1), expected_abs_error, expected_rel_error,
+                          expected_solver_output, expected_solver_residuals),)
+        assertSolverIterDataRecorded(self, expected_data, self.eps)
+
+        # Also check to make sure the first iteration has correct abs and rel errors
+        # as a regression test for
+        #   https://github.com/OpenMDAO/OpenMDAO/issues/2435
+        cr = om.CaseReader(self.filename)
+
+        solver_cases = cr.get_cases("root.nonlinear_solver")
+        self.assertAlmostEqual(solver_cases[0].abs_err, 2.254514106, delta=1e-6)
+        self.assertEqual(solver_cases[0].rel_err, 1.0)
+
     def test_record_solver_nonlinear_nonlinear_run_once(self):
         prob = SellarProblem(nonlinear_solver=om.NonlinearRunOnce)
         prob.setup()

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -64,7 +64,7 @@ class BroydenSolver(NonlinearSolver):
         Flag that becomes True when Broyden detects it needs to recompute the inverse Jacobian.
     """
 
-    SOLVER = 'BROYDEN'
+    SOLVER = 'NL: BROYDEN'
 
     def __init__(self, **kwargs):
         """
@@ -320,7 +320,7 @@ class BroydenSolver(NonlinearSolver):
         # Start with initial states.
         self.xm = self.get_vector(system._outputs)
 
-        with Recording('Broyden', 0, self):
+        with Recording('Broyden', 0, self) as rec:
             self._solver_info.append_solver()
 
             # should call the subsystems solve before computing the first residual
@@ -328,10 +328,13 @@ class BroydenSolver(NonlinearSolver):
 
             self._solver_info.pop()
 
-        self._run_apply()
-        norm = self._iter_get_norm()
+            self._run_apply()
+            norm = self._iter_get_norm()
 
-        norm0 = norm if norm != 0.0 else 1.0
+            rec.abs = norm
+            norm0 = norm if norm != 0.0 else 1.0
+            rec.rel = norm / norm0
+
         return norm0, norm
 
     def _iter_get_norm(self):
@@ -396,10 +399,9 @@ class BroydenSolver(NonlinearSolver):
             self.set_states(xm)
 
         # Run the model.
-        with Recording('Broyden', 0, self):
-            self._solver_info.append_solver()
-            self._gs_iter()
-            self._solver_info.pop()
+        self._solver_info.append_solver()
+        self._gs_iter()
+        self._solver_info.pop()
 
         self._run_apply()
 

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -159,7 +159,7 @@ class TestBryoden(unittest.TestCase):
         with self.assertRaises(om.AnalysisError) as context:
             prob.run_model()
 
-        msg = "Solver 'BROYDEN' on system 'g1' failed to converge in 1 iterations."
+        msg = "Solver 'NL: BROYDEN' on system 'g1' failed to converge in 1 iterations."
         self.assertEqual(str(context.exception), msg)
 
     def test_error_badname(self):


### PR DESCRIPTION
### Summary

Added a test for recording of the Broyden solver.

Eliminated duplicate recording of Broyden solver. Iterations were being recorded both by NonlinearSolver and inside of BroydenSolver.

Also, the SOLVER value for Broyden should include the NL prefix

SOLVER = 'NL: BROYDEN'

### Related Issues

- Resolves #2461

### Backwards incompatibilities

None

### New Dependencies

None
