### PR TITLE
Fixed some issues with indexing values for plots in the CaseViewer

### DIFF
--- a/openmdao/visualization/case_viewer/case_viewer.py
+++ b/openmdao/visualization/case_viewer/case_viewer.py
@@ -49,8 +49,7 @@ def _apply_transform(data, transform):
         The name of the transform to be applied.  This will be looked up in _func_map.
     """
     if transform in _func_map:
-        out = _func_map[transform](data)
-        return out
+        return _func_map[transform](data)
     return data
 
 

--- a/openmdao/visualization/case_viewer/case_viewer.py
+++ b/openmdao/visualization/case_viewer/case_viewer.py
@@ -50,7 +50,7 @@ def _apply_transform(data, transform):
     """
     if transform in _func_map:
         out = _func_map[transform](data)
-        return np.atleast_2d(np.asarray(out))
+        return out
     return data
 
 
@@ -865,7 +865,7 @@ class CaseViewer(object):
                     else:
                         x_val = self._case_reader.get_case(case_name).get_val(x_var)
                 else:
-                    x_val = i * np.ones_like(y_val)
+                    x_val = i * np.ones(y_val.size)
 
                 try:
                     x_val = _apply_slice(x_val, x_slice)
@@ -878,9 +878,9 @@ class CaseViewer(object):
                 if x_val is None or y_val is None:
                     continue
 
-                if x_val.ravel().shape[0] != y_val.T.shape[0]:
-                    print(f'Incompatible shapes: x.shape = {x_val.ravel().shape[0]} '
-                          f' y.shape = {y_val.T.shape[0]}.')
+                if x_val.shape[0] != y_val.shape[0]:
+                    print(f'Incompatible shapes: x.shape = {x_val.shape} '
+                          f' y.shape = {y_val.shape}.')
                     print('Size along first axis must agree.')
                     return
 
@@ -896,7 +896,7 @@ class CaseViewer(object):
                                          cmap=self._cmap, alpha=alpha)
                     self._scatters.append(s)
                 else:
-                    line = self._ax.plot(x_val.ravel(), y_val.T,
+                    line = self._ax.plot(x_val, y_val,
                                          c=self._cmap(float(i) / len(cases)),
                                          mfc=self._cmap(float(i) / len(cases)),
                                          mec='k',

--- a/openmdao/visualization/case_viewer/tests/test_case_viewer.py
+++ b/openmdao/visualization/case_viewer/tests/test_case_viewer.py
@@ -120,22 +120,22 @@ class TestOtherFuncs(unittest.TestCase):
     def test_apply_transform(self):
         x = np.random.random((20, 3)) - 0.5
 
-        max = np.atleast_2d(np.max(x))
+        max = np.max(x)
         assert_near_equal(_apply_transform(x, 'max'), max)
 
-        min = np.atleast_2d(np.min(x))
+        min = np.min(x)
         assert_near_equal(_apply_transform(x, 'min'), min)
 
-        maxabs = np.atleast_2d(np.max(np.abs(x)))
+        maxabs = np.max(np.abs(x))
         assert_near_equal(_apply_transform(x, 'maxabs'), maxabs)
 
-        minabs = np.atleast_2d(np.min(np.abs(x)))
+        minabs = np.min(np.abs(x))
         assert_near_equal(_apply_transform(x, 'minabs'), minabs)
 
-        norm = np.atleast_2d(np.linalg.norm(x))
+        norm = np.linalg.norm(x)
         assert_near_equal(_apply_transform(x, 'norm'), norm)
 
-        ravel = np.atleast_2d(np.ravel(x))
+        ravel = np.ravel(x)
         assert_near_equal(_apply_transform(x, 'ravel'), ravel)
 
         assert_near_equal(_apply_transform(x, 'None'), x)


### PR DESCRIPTION
### Summary

A test of the CaseViewer on a more complex problem revealed some weaknesses with our assumptions that everything should be cast to a 2D array.  Now when using scatter plots when plotting against Case Index, the X-axis values are flat and no automatic reshaping is performed otherwise.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
