### PR TITLE
Fix bug in ExecComp where value was not saved as a numpy array

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -313,7 +313,7 @@ class ExecComp(ExplicitComponent):
         self._requires_fd = {}
 
         # find all of the variables and which ones are outputs
-        for i, (onames, names) in enumerate(exprs_info):
+        for onames, names in exprs_info:
             outs.update(onames)
             allvars.update(names[0])
             if _not_complex_safe.intersection(names[1]):
@@ -433,7 +433,9 @@ class ExecComp(ExplicitComponent):
 
                 new_val = kwargs[var].get('val')
                 if new_val is not None:
-                    current_meta['val'] = new_val
+                    # val is normally ensured to be a numpy array in add_input/add_output,
+                    # do the same here...
+                    current_meta['val'] = np.atleast_1d(new_val)
             else:
                 # new input and/or output.
                 if var in outs:

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -481,27 +481,6 @@ class TestViewModelData(unittest.TestCase):
         self.assertTrue('OpenMDAO Model Hierarchy and N2 diagram: Bad Connection'
                         in open(self.conn_html_filename, 'r', encoding='utf-8').read())
 
-    def test_execcomp_config(self):
-        class ConfigGroup(om.Group):
-            def setup(self):
-                excomp = om.ExecComp('y=x',
-                                     x={'val': 3.0, 'units': 'mm'},
-                                     y={'shape': (1,), 'units': 'cm'})
-
-                self.add_subsystem('excomp', excomp, promotes=['*'])
-
-            def configure(self):
-                self.excomp.add_expr('z = 2.9*x',
-                                     z={'shape': (1,), 'units': 's'})
-
-        p = om.Problem()
-        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
-        p.setup()
-        p.run_model()
-
-        # check for bug fix (issue #2415), value for 'x' was not a numpy array
-        _get_viewer_data(p)
-
 
 @use_tempdirs
 class TestUnderMPI(unittest.TestCase):

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -481,6 +481,27 @@ class TestViewModelData(unittest.TestCase):
         self.assertTrue('OpenMDAO Model Hierarchy and N2 diagram: Bad Connection'
                         in open(self.conn_html_filename, 'r', encoding='utf-8').read())
 
+    def test_execcomp_config(self):
+        class ConfigGroup(om.Group):
+            def setup(self):
+                excomp = om.ExecComp('y=x',
+                                     x={'val': 3.0, 'units': 'mm'},
+                                     y={'shape': (1,), 'units': 'cm'})
+
+                self.add_subsystem('excomp', excomp, promotes=['*'])
+
+            def configure(self):
+                self.excomp.add_expr('z = 2.9*x',
+                                     z={'shape': (1,), 'units': 's'})
+
+        p = om.Problem()
+        p.model.add_subsystem('sub', ConfigGroup(), promotes=['*'])
+        p.setup()
+        p.run_model()
+
+        # check for bug fix (issue #2415), value for 'x' was not a numpy array
+        _get_viewer_data(p)
+
 
 @use_tempdirs
 class TestUnderMPI(unittest.TestCase):


### PR DESCRIPTION
### Summary

Fix bug in ExecComp where value was not saved as a numpy array

### Related Issues

- Resolves #2415

### Backwards incompatibilities

None

### New Dependencies

None
