### PR TITLE
Fixed indexer.py such that shapes and sizes created using np.product are always integers.

### DIFF
--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -990,7 +990,8 @@ class ShapedMultiIndexer(Indexer):
         if self._src_shape is None:
             raise ValueError(f"Can't determine extent of array because source shape is not known.")
 
-        idxs = np.arange(np.product(self._src_shape, dtype=int), dtype=np.int32).reshape(self._src_shape)
+        idxs = np.arange(np.product(self._src_shape, dtype=int),
+                         dtype=np.int32).reshape(self._src_shape)
 
         if flat:
             return idxs[self()].ravel()

--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -158,7 +158,7 @@ class Indexer(object):
             raise RuntimeError(f"Can't get indexed_src_shape of {self} because source shape "
                                "is unknown.")
         if self._flat_src:
-            return resolve_shape(np.product(self._src_shape))[self.flat()]
+            return resolve_shape(np.product(self._src_shape, dtype=int))[self.flat()]
         else:
             return resolve_shape(self._src_shape)[self()]
 
@@ -284,14 +284,14 @@ class Indexer(object):
 
         shape = shape2tuple(shape)
         if self._flat_src:
-            shape = (np.product(shape),)
+            shape = (np.product(shape, dtype=int),)
 
         if dist_shape is None:
             return shape, shape
 
         dist_shape = shape2tuple(dist_shape)
         if self._flat_src:
-            dist_shape = (np.product(dist_shape),)
+            dist_shape = (np.product(dist_shape, dtype=int),)
 
         return shape, dist_shape
 
@@ -600,7 +600,7 @@ class ShapedSliceIndexer(Indexer):
         if self._src_shape is not None:
             start = self._slice.start
             stop = self._slice.stop
-            sz = np.product(self._dist_shape)
+            sz = np.product(self._dist_shape, dtype=int)
             if (start is not None and (start >= sz or start < -sz)
                     or (stop is not None and (stop > sz or stop < -sz))):
                 raise IndexError(f"{self._slice} is out of bounds of the source shape "
@@ -813,7 +813,7 @@ class ShapedArrayIndexer(Indexer):
         Check that indices are within the bounds of the source shape.
         """
         if self._src_shape is not None and self._arr.size > 0:
-            src_size = np.product(self._dist_shape)
+            src_size = np.product(self._dist_shape, dtype=int)
             amax = np.max(self._arr)
             ob = None
             if amax >= src_size or -amax < -src_size:
@@ -990,7 +990,7 @@ class ShapedMultiIndexer(Indexer):
         if self._src_shape is None:
             raise ValueError(f"Can't determine extent of array because source shape is not known.")
 
-        idxs = np.arange(np.product(self._src_shape), dtype=np.int32).reshape(self._src_shape)
+        idxs = np.arange(np.product(self._src_shape, dtype=int), dtype=np.int32).reshape(self._src_shape)
 
         if flat:
             return idxs[self()].ravel()
@@ -1329,7 +1329,7 @@ class IndexMaker(object):
 
         if src_shape is not None:
             if flat_src:
-                src_shape = (np.product(src_shape),)
+                src_shape = (np.product(src_shape, dtype=int),)
             idxer.set_src_shape(src_shape)
 
         return idxer


### PR DESCRIPTION

### Summary

There were some corner cases where the use of np.product in index.py without `dtype=int` was causing errors.
This pull request makes dtype=int in those np.product calls.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
