### PR TITLE
move MPI scaling report test to it's own file

### DIFF
--- a/openmdao/core/tests/test_scaling_report.py
+++ b/openmdao/core/tests/test_scaling_report.py
@@ -286,9 +286,5 @@ class TestDiscreteScalingReport(unittest.TestCase):
         prob.driver.scaling_report(show_browser=False)
 
 
-class TestDriverScalingReportMPI(TestDriverScalingReport):
-    N_PROCS=2
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/core/tests/test_scaling_report_mpi.py
+++ b/openmdao/core/tests/test_scaling_report_mpi.py
@@ -1,0 +1,14 @@
+"""Define the units/scaling tests."""
+import unittest
+
+from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.core.tests.test_scaling_report import TestDriverScalingReport
+
+
+class TestDriverScalingReportMPI(TestDriverScalingReport):
+    N_PROCS = 2
+    ISOLATED = True
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Summary

This test has a history of timing out and failing when run as part of the test suite via testflo, so move it to it's own file and set it to run in ISOLATED mode.

### Related Issues

- Resolves # N/A

### Backwards incompatibilities

None

### New Dependencies

None
