### PR TITLE
Print pyOptSparse opt_prob before the optimization

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -29,6 +29,7 @@ from openmdao.utils.class_util import WeakMethodWrapper
 from openmdao.utils.mpi import FakeComm
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 from openmdao.utils.general_utils import _src_or_alias_name
+from openmdao.utils.mpi import MPI
 
 
 # names of optimizers that use gradients
@@ -211,6 +212,8 @@ class pyOptSparseDriver(Driver):
                              desc='Name of optimizers to use')
         self.options.declare('title', default='Optimization using pyOpt_sparse',
                              desc='Title of this optimization run')
+        self.options.declare('print_opt_prob', types=bool, default=True,
+                             desc='Print the opt problem summary before running the optimization')
         self.options.declare('print_results', types=bool, default=True,
                              desc='Print pyOpt results if True')
         self.options.declare('gradient method', default='openmdao',
@@ -453,6 +456,12 @@ class pyOptSparseDriver(Driver):
         for option, value in self.opt_settings.items():
             opt.setOption(option, value)
 
+        # Print the pyoptsparse optimization problem summary before running the optimization.
+        # This allows users to confirm their optization setup.
+        if self.options['print_opt_prob']:
+            if not MPI or model.comm.rank == 0:
+                print(opt_prob)
+
         self._exc_info = None
         try:
 
@@ -496,7 +505,8 @@ class pyOptSparseDriver(Driver):
 
         # Print results
         if self.options['print_results']:
-            print(sol)
+            if not MPI or model.comm.rank == 0:
+                print(sol)
 
         # Pull optimal parameters back into framework and re-run, so that
         # framework is left in the right final state


### PR DESCRIPTION
### Summary

Added a feature to print the opt_prob in the pyOptSparse driver before the optimization runs. This allows users to confirm their optimization configurations (e.g., design variable bounds). The print can be controlled by the driver's `print_opt_prob` option (default True). Also fixed a problem for the pyOptSparse driver's `print_result` behavior in parallel. Before, each processor will print an identical optimization summary to the screen when the optimization finishes. This becomes annoying when running with a lot of CPU cores because users will see a long list of duplicated opt summaries at the end of the log file. Now only the root processor 0 will print the info.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
