### PR TITLE
fix  a couple bugs related to discrete variables

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -348,8 +348,6 @@ class Problem(object):
 
         # Vector not setup, so we need to pull values from saved metadata request.
         else:
-            proms = self.model._var_allprocs_prom2abs_list
-            meta = self.model._var_abs2meta
             try:
                 conns = self.model._conn_abs_in2out
             except AttributeError:
@@ -362,12 +360,22 @@ class Problem(object):
             abs_name = abs_names[0]
             vars_to_gather = self._metadata['vars_to_gather']
 
+            meta = self.model._var_abs2meta
             io = 'output' if abs_name in meta['output'] else 'input'
             if abs_name in meta[io]:
                 if abs_name in conns:
                     val = meta['output'][conns[abs_name]]['val']
                 else:
                     val = meta[io][abs_name]['val']
+            else:
+                # not found in real outputs or inputs, try discretes
+                meta = self.model._var_discrete
+                io = 'output' if abs_name in meta['output'] else 'input'
+                if abs_name in meta[io]:
+                    if abs_name in conns:
+                        val = meta['output'][conns[abs_name]]['val']
+                    else:
+                        val = meta[io][abs_name]['val']
 
             if get_remote and abs_name in vars_to_gather:
                 owner = vars_to_gather[abs_name]

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -705,6 +705,15 @@ class DiscreteTestCase(unittest.TestCase):
         with assert_no_warning(OMDeprecationWarning, msg):
             prob.run_model()
 
+    def test_discrete_get_cached_val(self):
+        # make sure _get_cached_val() works for discretes
+        prob = om.Problem()
+        prob.model.add_subsystem('comp', ModCompEx(3), promotes=['*'])
+        prob.setup()
+
+        self.assertEqual(prob['x'], 10)
+
+
 class SolverDiscreteTestCase(unittest.TestCase):
     def _setup_model(self, solver_class):
         prob = om.Problem()

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -204,7 +204,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
 
     model = driver._problem().model
 
-    mod_meta = model._var_allprocs_abs2meta['output']
+    mod_meta = model._var_allprocs_abs2meta['output'].copy()  # shallow copy
     mod_meta.update(model._var_allprocs_discrete['output'])
 
     discretes = {'dvs': [], 'con': [], 'obj': []}


### PR DESCRIPTION
### Summary

- Fix bug in scaling report that caused side effects in the model, preventing access to discrete variable value
- Fix bug where you could not access a discrete variable value before final_setup

### Related Issues

- Resolves #2494

### Backwards incompatibilities

None

### New Dependencies

None
