### PR TITLE
Changed a few test tolerances to avoid sporadic failures on Python 3.7 test environment.

### DIFF
--- a/openmdao/surrogate_models/tests/test_kriging.py
+++ b/openmdao/surrogate_models/tests/test_kriging.py
@@ -147,7 +147,7 @@ class TestKrigingSurrogate(unittest.TestCase):
 
         surrogate.train(x, y)
         jac = surrogate.linearize(np.array([[0.5, 0.5]]))
-        assert_near_equal(jac, np.array([[1, 1], [1, -1], [1, 2]]), 6e-4)
+        assert_near_equal(jac, np.array([[1, 1], [1, -1], [1, 2]]), 1e-3)
 
     def test_cache(self):
         x = np.array([[-2., 0.], [-0.5, 1.5], [1., 3.], [8.5, 4.5],

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -542,7 +542,7 @@ class TestUnderMPI(unittest.TestCase):
                               0.03538417,  0.03029845,  0.02575245,  0.02186027,  0.01872173,  0.01641869,
                               0.0150119,   0.01453876])
 
-        assert np.linalg.norm(h - expected) < 1e-6
+        assert np.linalg.norm(h - expected) < 1e-4
 
         def check_initial_value(subsys, parallel=False):
             """


### PR DESCRIPTION
### Summary

Reduced unnecessarily tight tolerances on a few tests that have becom…e problematic in the python3.7 Oldest CI environment. A Kriging test was testing derivatives to 6e-4 and has been changed to 1e-3.  Similarly, an n2 viewer test was testing completion of the model to a tolerance of 1E-6, while elsewhere the same model was only being tested to 1e-4.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
