### PR TITLE
fix for reverse slice issue

### DIFF
--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -3,6 +3,7 @@ Classes that handle array indexing.
 """
 
 import sys
+from math import prod
 import numpy as np
 from numbers import Integral
 from itertools import zip_longest
@@ -493,6 +494,8 @@ class ShapedSliceIndexer(Indexer):
         """
         super().__init__(flat_src)
         self._check_ind_type(slc, slice)
+        if slc.step is None:
+            slc = slice(slc.start, slc.stop, 1)
         self._slice = slc
 
     def __call__(self):
@@ -544,13 +547,17 @@ class ShapedSliceIndexer(Indexer):
         ndarray
             The index array.
         """
-        if self._src_shape is None or len(self._src_shape) == 1:
+        if len(self._src_shape) == 1:
             # Case 1: Requested flat or nonflat indices but src_shape is None or flat
             # return a flattened arange
-            # use maxsize here since a shaped slice always has positive int start and stop
-            return np.arange(*self._slice.indices(sys.maxsize), dtype=int)
+            slc = self._slice
+            if slc.stop is None and slc.step < 0:  # special case - neg step down to -1
+                return np.arange(self._src_shape[0], dtype=int)[slc]
+            else:
+                # use maxsize here since a shaped slice always has positive int start and stop
+                return np.arange(*slc.indices(sys.maxsize), dtype=int)
         else:
-            src_size = np.prod(self._src_shape, dtype=int)
+            src_size = prod(self._src_shape)
             arr = np.arange(src_size, dtype=int).reshape(self._src_shape)[self._slice].ravel()
             if flat:
                 # Case 2: Requested flattened indices of multidimensional array
@@ -646,7 +653,10 @@ class SliceIndexer(ShapedSliceIndexer):
             return None
 
         slc = self._slice
-        if (slc.start is not None and slc.start < 0) or slc.stop is None or slc.stop < 0:
+        if slc.stop is None and slc.step < 0:  # special backwards indexing case
+            self._shaped_inst = \
+                ShapedSliceIndexer(slc)
+        elif (slc.start is not None and slc.start < 0) or slc.stop is None or slc.stop < 0:
             self._shaped_inst = \
                 ShapedSliceIndexer(slice(*self._slice.indices(self._src_shape[0])))
         else:
@@ -684,8 +694,7 @@ class SliceIndexer(ShapedSliceIndexer):
         """
         slc = self._slice
         if self._flat_src and slc.start is not None and slc.stop is not None:
-            step = 1 if slc.step is None else slc.step
-            return (len(range(slc.start, slc.stop, step)),)
+            return (len(range(slc.start, slc.stop, slc.step)),)
         return super().indexed_src_shape
 
 

--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -3,7 +3,10 @@ Classes that handle array indexing.
 """
 
 import sys
-from math import prod
+if sys.version_info >= (3, 8):
+    from math import prod
+else:
+    from numpy import prod
 import numpy as np
 from numbers import Integral
 from itertools import zip_longest
@@ -557,7 +560,8 @@ class ShapedSliceIndexer(Indexer):
                 # use maxsize here since a shaped slice always has positive int start and stop
                 return np.arange(*slc.indices(sys.maxsize), dtype=int)
         else:
-            src_size = prod(self._src_shape)
+            # TODO: get rid of int() after we drop python 3.7 support
+            src_size = int(prod(self._src_shape))
             arr = np.arange(src_size, dtype=int).reshape(self._src_shape)[self._slice].ravel()
             if flat:
                 # Case 2: Requested flattened indices of multidimensional array

--- a/openmdao/utils/tests/test_indexer.py
+++ b/openmdao/utils/tests/test_indexer.py
@@ -183,8 +183,8 @@ class IndexerTestCase(unittest.TestCase):
         ind = indexer[:]
         src = np.arange(10)
 
-        assert_equal(ind(), slice(None))
-        assert_equal(ind.flat(), slice(None))
+        assert_equal(ind(), slice(None, None, 1))
+        assert_equal(ind.flat(), slice(None, None, 1))
 
         assert_equal(src[ind()], np.arange(10, dtype=int))
         assert_equal(src[ind.flat()], np.arange(10, dtype=int))
@@ -193,10 +193,10 @@ class IndexerTestCase(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             ind.indexed_src_shape
-        self.assertEqual(cm.exception.args[0], "Can't get indexed_src_shape of slice(None, None, None) because source shape is unknown.")
+        self.assertEqual(cm.exception.args[0], "Can't get indexed_src_shape of slice(None, None, 1) because source shape is unknown.")
         with self.assertRaises(ValueError) as cm:
             ind.as_array()
-        self.assertEqual(cm.exception.args[0], "Can't get shaped array of slice(None, None, None) because it has no source shape.")
+        self.assertEqual(cm.exception.args[0], "Can't get shaped array of slice(None, None, 1) because it has no source shape.")
 
         ind.set_src_shape(src.shape)
 
@@ -228,8 +228,8 @@ class IndexerTestCase(unittest.TestCase):
         ind = indexer[:5]
         src = np.arange(10)
 
-        assert_equal(ind(), slice(None, 5, None))
-        assert_equal(ind.flat(), slice(None, 5, None))
+        assert_equal(ind(), slice(None, 5, 1))
+        assert_equal(ind.flat(), slice(None, 5, 1))
 
         assert_equal(src[ind()], np.array([0, 1, 2, 3, 4]))
         assert_equal(src[ind.flat()], np.array([0, 1, 2, 3, 4]))
@@ -240,7 +240,7 @@ class IndexerTestCase(unittest.TestCase):
         assert_equal(ind.as_array(), np.array([0, 1, 2, 3, 4]))
         assert_equal(src[ind.as_array()], np.array([0, 1, 2, 3, 4]))
 
-        assert_equal(ind.shaped_instance()(), slice(None, 5, None))
+        assert_equal(ind.shaped_instance()(), slice(None, 5, 1))
         assert_equal(ind.indexed_src_shape, (5,))
         assert_equal(ind.min_src_dim, 1)
 
@@ -248,8 +248,8 @@ class IndexerTestCase(unittest.TestCase):
         ind = indexer[3:]
         src = np.arange(10)
 
-        assert_equal(ind(), slice(3, None))
-        assert_equal(ind.flat(), slice(3, None))
+        assert_equal(ind(), slice(3, None, 1))
+        assert_equal(ind.flat(), slice(3, None, 1))
 
         assert_equal(src[ind()], np.array([3, 4, 5, 6, 7, 8, 9]))
         assert_equal(src[ind.flat()], np.array([3, 4, 5, 6, 7, 8, 9]))
@@ -258,7 +258,7 @@ class IndexerTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError) as cm:
             ind.as_array()
-        self.assertEqual(cm.exception.args[0], "Can't get shaped array of slice(3, None, None) because it has no source shape.")
+        self.assertEqual(cm.exception.args[0], "Can't get shaped array of slice(3, None, 1) because it has no source shape.")
 
         ind.set_src_shape(src.shape)
 
@@ -288,13 +288,55 @@ class IndexerTestCase(unittest.TestCase):
         assert_equal(ind.indexed_src_shape, (4,))
         assert_equal(ind.min_src_dim, 1)
 
+    def test_rev_slice(self):
+        ind = indexer[::-1]
+        src = np.arange(10)
+
+        assert_equal(ind(), slice(None, None, -1))
+        assert_equal(ind.flat(), slice(None, None, -1))
+
+        assert_equal(src[ind()], np.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))
+        assert_equal(src[ind.flat()], np.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))
+
+        assert_equal(ind.min_src_dim, 1)
+
+        ind.set_src_shape(src.shape)
+
+        assert_equal(ind.as_array(), np.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))
+        assert_equal(src[ind.as_array()], np.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))
+        assert_equal(src[ind.shaped_array()], np.array([9, 8, 7, 6, 5, 4, 3, 2, 1, 0]))
+        assert_equal(ind.shaped_instance()(), slice(None, None, -1))
+        assert_equal(ind.indexed_src_shape, (10,))
+        assert_equal(ind.min_src_dim, 1)
+
+    def test_rev_slice2D(self):
+        ind = indexer[::-1]
+        src = np.arange(4).reshape((2,2))
+
+        assert_equal(ind(), slice(None, None, -1))
+        assert_equal(ind.flat(), slice(None, None, -1))
+
+        expected = src[::-1]
+
+        assert_equal(src[ind()], expected)
+        assert_equal(src[ind.flat()], expected)
+
+        assert_equal(ind.min_src_dim, 1)
+
+        ind.set_src_shape(src.shape)
+
+        assert_equal(ind.as_array(), expected.flatten())
+        assert_equal(src[ind()], expected)
+        assert_equal(ind.shaped_instance()(), slice(None, None, -1))
+        assert_equal(ind.indexed_src_shape, (2,2))
+        assert_equal(ind.min_src_dim, 1)
 
 class IndexerMultiDimTestCase(unittest.TestCase):
     def test_multi_slice(self):
         ind = indexer[:,:,:]
         src = np.arange(27).reshape((3,3,3))
 
-        assert_equal(ind(), (slice(None), slice(None), slice(None)))
+        assert_equal(ind(), (slice(None, None, 1), slice(None, None, 1), slice(None, None, 1)))
         assert_equal(src[ind()], src)
 
         with self.assertRaises(Exception) as cm:
@@ -323,7 +365,7 @@ class IndexerMultiDimTestCase(unittest.TestCase):
         src = np.arange(27).reshape((3,3,3))
         ind.set_src_shape(src.shape)
 
-        assert_equal(ind(), slice(1, None, None))
+        assert_equal(ind(), slice(1, None, 1))
 
         expected = np.stack([np.arange(9, 18).reshape((3, 3)), np.arange(18, 27).reshape((3, 3))])
 
@@ -344,7 +386,7 @@ class IndexerMultiDimTestCase(unittest.TestCase):
         ind = indexer[:-1,:,:2]
         src = np.arange(27).reshape((3,3,3))
 
-        assert_equal(ind(), (slice(None, -1), slice(None), slice(None, 2)))
+        assert_equal(ind(), (slice(None, -1, 1), slice(None, None, 1), slice(None, 2, 1)))
         assert_equal(src[ind()], src[:-1,:,:2])
 
         with self.assertRaises(RuntimeError) as cm:
@@ -356,7 +398,7 @@ class IndexerMultiDimTestCase(unittest.TestCase):
 
         ind.set_src_shape(src.shape)
 
-        assert_equal(ind.shaped_instance()(), (slice(0, 2, 1), slice(0, 3, 1), slice(None, 2, None)))
+        assert_equal(ind.shaped_instance()(), (slice(0, 2, 1), slice(0, 3, 1), slice(None, 2, 1)))
         assert_equal(ind.as_array(), np.arange(27, dtype=np.int32).reshape((3,3,3))[:-1,:,:2].ravel())
         assert_equal(ind.as_array(flat=False), np.arange(27, dtype=np.int32).reshape((3,3,3))[:-1,:,:2])
         assert_equal(ind.indexed_src_shape, (2,3,2))
@@ -366,7 +408,7 @@ class IndexerMultiDimTestCase(unittest.TestCase):
         src = np.arange(27).reshape((3,3,3))
         ind = indexer[[0,2], :, [1,2]]
 
-        assert_equal(ind(), ([0,2], slice(None, None, None), [1,2]))
+        assert_equal(ind(), ([0,2], slice(None, None, 1), [1,2]))
         with self.assertRaises(RuntimeError) as cm:
             ind.indexed_src_shape
         self.assertEqual(cm.exception.args[0], "Can't get indexed_src_shape of ([0, 2], slice(None, None, None), [1, 2]) because source shape is unknown.")


### PR DESCRIPTION
### Summary
`om.slicer[::-1]` was resulting in a 'shaped' slice of `[size-1:-1:-1]` which produced an empty array when `as_array` was called on the indexer.

Summary of PR.

### Related Issues

- Resolves #2504

### Backwards incompatibilities

None

### New Dependencies

None
