### PR TITLE
handle more than just ImportError in pyOptSparse driver

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -17,7 +17,7 @@ from scipy.sparse import coo_matrix
 try:
     import pyoptsparse
     Optimization = pyoptsparse.Optimization
-except ImportError:
+except Exception:
     Optimization = None
     pyoptsparse = None
 


### PR DESCRIPTION
### Summary

This change makes pyoptsparse_driver more robust in cases where pyoptsparse is not available.

In particular, there seems to be an issue with the current version of testflo which results in 'pyoptsparse' being added to sys.modules as a namespace, even though it is not available.  In this situation the import will succeed but will be followed by an AttributeError when trying to access pyoptsparse.Optimization. 

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
