### PR TITLE
fix: Added missing comma to test dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ optional_dependencies = {
         'numpydoc>=1.1',
         'pycodestyle>=2.4.0',
         'pydocstyle==2.0.0',
-        'testflo>=1.3.6'
+        'testflo>=1.3.6',
         'websockets>8',
         'aiounittest',
         'playwright>=1.20'


### PR DESCRIPTION
### Summary

Added missing comma in setup.py where test dependencies are specified. 

This is causing the following error when installing `OpenMDAO `with `poetry`:
`Invalid PEP 440 version: '1.3.6websockets'`

### Related Issues


### Backwards incompatibilities

None

### New Dependencies

None
