### PR TITLE
Fix for a bug where complex step around an implicit component containing a newton solver would discard the imaginary part.

### DIFF
--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -747,9 +747,9 @@ def check_allocate_complex_ln(group, under_cs):
     for sub, _ in group._subsystems_allprocs.values():
         if isinstance(sub, Group) and check_allocate_complex_ln(sub, under_cs):
             return True
-        elif sub.nonlinear_solver is not None and \
-            sub.nonlinear_solver.supports['gradients']:
+
+        elif sub.nonlinear_solver is not None and sub.nonlinear_solver.supports['gradients']:
             # Special case, gradient-supporting solver in an ImplicitComponent.
-            return False
+            return True
 
     return False

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -748,8 +748,9 @@ def check_allocate_complex_ln(group, under_cs):
         if isinstance(sub, Group) and check_allocate_complex_ln(sub, under_cs):
             return True
 
-        elif sub.nonlinear_solver is not None and sub.nonlinear_solver.supports['gradients']:
-            # Special case, gradient-supporting solver in an ImplicitComponent.
-            return True
+        elif isinstance(sub, ImplicitComponent):
+            if sub.nonlinear_solver is not None and sub.nonlinear_solver.supports['gradients']:
+                # Special case, gradient-supporting solver in an ImplicitComponent.
+                return True
 
     return False

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -747,5 +747,9 @@ def check_allocate_complex_ln(group, under_cs):
     for sub, _ in group._subsystems_allprocs.values():
         if isinstance(sub, Group) and check_allocate_complex_ln(sub, under_cs):
             return True
+        elif sub.nonlinear_solver is not None and \
+            sub.nonlinear_solver.supports['gradients']:
+            # Special case, gradient-supporting solver in an ImplicitComponent.
+            return False
 
     return False


### PR DESCRIPTION
### Summary

Fixed a bug where complex step around an implicit component containing a newton solver would discard the imaginary part.

The linear vector was not being allocated as complex.

### Related Issues

- Resolves #2516

### Backwards incompatibilities

None

### New Dependencies

None
