### PR TITLE
changed text in notebook describing parallel groups from raw to markdown

### DIFF
--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
@@ -97,7 +97,7 @@
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
     "In this example, components *c1* through *c4* will be executed in parallel, provided that the `ParallelGroup` is given four MPI processes.  If the name of the python file containing our example were `my_par_model.py`, we could run it under MPI and give it two processes using the following command:\n",
@@ -106,9 +106,11 @@
     "    mpirun -n 4 python my_par_model.py\n",
     "```\n",
     "\n",
+    "\n",
     "```{Note}\n",
     "This will only work if you've installed the mpi4py and petsc4py python packages, which are not installed by default in OpenMDAO.\n",
     "```\n",
+    "\n",
     "\n",
     "In the previous example, all four components in the `ParallelGroup` required just a single MPI process, but\n",
     "what happens if we want to add subsystems to a `ParallelGroup` that has other processor requirements?\n",


### PR DESCRIPTION
### Summary

The cell in 'raw' format was not showing up in the docs.

### Related Issues

- Resolves #2514

### Backwards incompatibilities

None

### New Dependencies

None
