### PR TITLE
added restoration of recorder prefix

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -692,7 +692,8 @@ class Problem(object):
         Parameters
         ----------
         case_prefix : str or None
-            Prefix to prepend to coordinates when recording.
+            Prefix to prepend to coordinates when recording.  None means keep the preexisting
+            prefix.
 
         reset_iter_counts : bool
             If True and model has been run previously, reset all iteration counters.
@@ -701,24 +702,27 @@ class Problem(object):
             raise RuntimeError(self.msginfo +
                                ": The `setup` method must be called before `run_model`.")
 
-        if case_prefix:
+        old_prefix = self._recording_iter.prefix
+
+        if case_prefix is not None:
             if not isinstance(case_prefix, str):
                 raise TypeError(self.msginfo + ": The 'case_prefix' argument should be a string.")
             self._recording_iter.prefix = case_prefix
-        else:
-            self._recording_iter.prefix = None
 
-        if self.model.iter_count > 0 and reset_iter_counts:
-            self.driver.iter_count = 0
-            self.model._reset_iter_counts()
+        try:
+            if self.model.iter_count > 0 and reset_iter_counts:
+                self.driver.iter_count = 0
+                self.model._reset_iter_counts()
 
-        self.final_setup()
+            self.final_setup()
 
-        self._run_counter += 1
-        record_model_options(self, self._run_counter)
+            self._run_counter += 1
+            record_model_options(self, self._run_counter)
 
-        self.model._clear_iprint()
-        self.model.run_solve_nonlinear()
+            self.model._clear_iprint()
+            self.model.run_solve_nonlinear()
+        finally:
+            self._recording_iter.prefix = old_prefix
 
     def run_driver(self, case_prefix=None, reset_iter_counts=True):
         """
@@ -727,7 +731,8 @@ class Problem(object):
         Parameters
         ----------
         case_prefix : str or None
-            Prefix to prepend to coordinates when recording.
+            Prefix to prepend to coordinates when recording.  None means keep the preexisting
+            prefix.
 
         reset_iter_counts : bool
             If True and model has been run previously, reset all iteration counters.
@@ -741,24 +746,27 @@ class Problem(object):
             raise RuntimeError(self.msginfo +
                                ": The `setup` method must be called before `run_driver`.")
 
-        if case_prefix:
+        old_prefix = self._recording_iter.prefix
+
+        if case_prefix is not None:
             if not isinstance(case_prefix, str):
                 raise TypeError(self.msginfo + ": The 'case_prefix' argument should be a string.")
             self._recording_iter.prefix = case_prefix
-        else:
-            self._recording_iter.prefix = None
 
-        if self.model.iter_count > 0 and reset_iter_counts:
-            self.driver.iter_count = 0
-            self.model._reset_iter_counts()
+        try:
+            if self.model.iter_count > 0 and reset_iter_counts:
+                self.driver.iter_count = 0
+                self.model._reset_iter_counts()
 
-        self.final_setup()
+            self.final_setup()
 
-        self._run_counter += 1
-        record_model_options(self, self._run_counter)
+            self._run_counter += 1
+            record_model_options(self, self._run_counter)
 
-        self.model._clear_iprint()
-        return self.driver.run()
+            self.model._clear_iprint()
+            return self.driver.run()
+        finally:
+            self._recording_iter.prefix = old_prefix
 
     def compute_jacvec_product(self, of, wrt, mode, seed):
         """

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -1,5 +1,4 @@
 """ Unit test for the SqliteRecorder. """
-import errno
 import os
 import unittest
 from io import StringIO
@@ -27,7 +26,7 @@ from openmdao.recorders.tests.recorder_test_utils import run_driver
 from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, \
     assert_warning, assert_no_warning
 from openmdao.utils.general_utils import determine_adder_scaler
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.om_warnings import OMDeprecationWarning
 
 # check that pyoptsparse is installed. if it is, try to use SLSQP.
@@ -2709,6 +2708,89 @@ class TestSqliteRecorder(unittest.TestCase):
         assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8)
         assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8)
         assert_near_equal(obj, {'f_xy': -27.33333333}, tolerance=1e-8)
+
+    @require_pyoptsparse('IPOPT')
+    def test_total_coloring_record_case_prefix(self):
+
+        SIZE = 10
+
+        p = om.Problem()
+
+        p.model.add_subsystem('arctan_yox', om.ExecComp('g=arctan(y/x)', has_diag_partials=True,
+                                                        g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)),
+                              promotes_inputs=['x', 'y'])
+
+        p.model.add_subsystem('circle', om.ExecComp('area=pi*r**2'), promotes_inputs=['r'])
+
+        p.model.add_subsystem('r_con', om.ExecComp('g=x**2 + y**2 - r', has_diag_partials=True,
+                                                   g=np.ones(SIZE), x=np.ones(SIZE), y=np.ones(SIZE)),
+                              promotes_inputs=['r', 'x', 'y'])
+
+        thetas = np.linspace(0, np.pi/4, SIZE)
+        p.model.add_subsystem('theta_con', om.ExecComp('g = x - theta', has_diag_partials=True,
+                                                       g=np.ones(SIZE), x=np.ones(SIZE),
+                                                       theta=thetas))
+        p.model.add_subsystem('delta_theta_con', om.ExecComp('g = even - odd', has_diag_partials=True,
+                                                             g=np.ones(SIZE//2), even=np.ones(SIZE//2),
+                                                             odd=np.ones(SIZE//2)))
+
+        p.model.add_subsystem('l_conx', om.ExecComp('g=x-1', has_diag_partials=True, g=np.ones(SIZE), x=np.ones(SIZE)),
+                              promotes_inputs=['x'])
+
+        IND = np.arange(SIZE, dtype=int)
+        ODD_IND = IND[1::2]  # all odd indices
+        EVEN_IND = IND[0::2]  # all even indices
+
+        p.model.connect('arctan_yox.g', 'theta_con.x')
+        p.model.connect('arctan_yox.g', 'delta_theta_con.even', src_indices=EVEN_IND)
+        p.model.connect('arctan_yox.g', 'delta_theta_con.odd', src_indices=ODD_IND)
+
+        p.driver = om.pyOptSparseDriver()
+        p.driver.options['optimizer'] = 'IPOPT'
+        p.driver.opt_settings['print_level'] = 5
+
+        p.driver.add_recorder(om.SqliteRecorder('driver_iterations.sql'))
+
+        # set up dynamic total coloring here
+        p.driver.declare_coloring()
+
+        p.model.add_design_var('x')
+        p.model.add_design_var('y')
+        p.model.add_design_var('r', lower=.5, upper=10)
+
+        # nonlinear constraints
+        p.model.add_constraint('r_con.g', equals=0)
+
+        p.model.add_constraint('theta_con.g', lower=-1e-5, upper=1e-5, indices=EVEN_IND)
+        p.model.add_constraint('delta_theta_con.g', lower=-1e-5, upper=1e-5)
+
+        # this constrains x[0] to be 1 (see definition of l_conx)
+        p.model.add_constraint('l_conx.g', equals=0, linear=False, indices=[0,])
+
+        # linear constraint
+        p.model.add_constraint('y', equals=0, indices=[0,], linear=False)
+
+        p.model.add_objective('circle.area', ref=-1)
+
+        p.setup(mode='fwd')
+
+        # the following were randomly generated using np.random.random(10)*2-1 to randomly
+        # disperse them within a unit circle centered at the origin.
+        p.set_val('x', np.array([ 0.55994437, -0.95923447,  0.21798656, -0.02158783,  0.62183717,
+                                  0.04007379,  0.46044942, -0.10129622,  0.27720413, -0.37107886]))
+        p.set_val('y', np.array([ 0.52577864,  0.30894559,  0.8420792 ,  0.35039912, -0.67290778,
+                                 -0.86236787, -0.97500023,  0.47739414,  0.51174103,  0.10052582]))
+        p.set_val('r', .7)
+
+        p.run_driver(case_prefix='foo')
+
+        assert_near_equal(p['circle.area'], np.pi, tolerance=1e-7)
+
+        cr = om.CaseReader('driver_iterations.sql')
+        driver_cases = cr.list_cases(source='driver', out_stream=None)
+
+        self.assertTrue(all([case.startswith('foo_') for case in driver_cases]),
+                        msg='One or more cases do not start with the expected prefix.')
 
 @use_tempdirs
 class TestFeatureSqliteRecorder(unittest.TestCase):


### PR DESCRIPTION
### Summary

When recorder prefix is set in problem run_driver or run_model, old prefix is now restored at the end, and a passed in prefix of None does not change the existing prefix.

### Related Issues

- Resolves #2511

### Backwards incompatibilities

None

### New Dependencies

None
