### PR TITLE
clean up imports in test_scaling_report_mpi.py

### DIFF
--- a/openmdao/core/tests/test_scaling_report.py
+++ b/openmdao/core/tests/test_scaling_report.py
@@ -2,10 +2,9 @@
 import unittest
 
 import numpy as np
-
 import openmdao.api as om
-from openmdao.utils.testing_utils import use_tempdirs
 
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 
 
@@ -145,6 +144,10 @@ class TestDriverScalingReport(unittest.TestCase):
         p.final_setup()
         data = p.driver.scaling_report(show_browser=False)
         self._check_data(data, expected)
+
+
+@use_tempdirs
+class TestDriverScalingReport2(unittest.TestCase):
 
     def test_unconstrained(self):
         from openmdao.test_suite.components.paraboloid import Paraboloid

--- a/openmdao/core/tests/test_scaling_report.py
+++ b/openmdao/core/tests/test_scaling_report.py
@@ -164,8 +164,7 @@ class TestDriverScalingReport2(unittest.TestCase):
         prob.model.connect('indeps.y', 'paraboloid.y')
 
         # setup the optimization
-        prob.driver = om.ScipyOptimizeDriver()
-        prob.driver.options['optimizer'] = 'COBYLA'
+        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYLA')
 
         prob.model.add_design_var('indeps.x', lower=-50, upper=50)
         prob.model.add_design_var('indeps.y', lower=-50, upper=50)
@@ -184,6 +183,9 @@ class TestDriverScalingReport2(unittest.TestCase):
         # just make sure this doesn't raise an exception
         prob.driver.scaling_report(show_browser=False)
 
+
+@use_tempdirs
+class TestDriverScalingReport3(unittest.TestCase):
     def test_setup_message(self):
         x_train = np.arange(0., 10.)
         y_train = np.arange(10., 20.)
@@ -230,6 +232,7 @@ class TestDriverScalingReport2(unittest.TestCase):
         p.driver.scaling_report(show_browser=False)
 
 
+@use_tempdirs
 class TestDiscreteScalingReport(unittest.TestCase):
 
     def test_scaling_report(self):

--- a/openmdao/core/tests/test_scaling_report.py
+++ b/openmdao/core/tests/test_scaling_report.py
@@ -1,15 +1,11 @@
-"""Define the units/scaling tests."""
+"""Define the scaling report tests."""
 import unittest
-from copy import deepcopy
 
 import numpy as np
 
 import openmdao.api as om
-from openmdao.core.driver import Driver
 from openmdao.utils.testing_utils import use_tempdirs
 
-from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
-from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayDense
 from openmdao.utils.assert_utils import assert_near_equal
 
 

--- a/openmdao/core/tests/test_scaling_report_mpi.py
+++ b/openmdao/core/tests/test_scaling_report_mpi.py
@@ -8,5 +8,9 @@ class TestDriverScalingReportMPI(NonMPI.TestDriverScalingReport):
     N_PROCS = 2
 
 
+class TestDriverScalingReportMPI2(NonMPI.TestDriverScalingReport2):
+    N_PROCS = 2
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/core/tests/test_scaling_report_mpi.py
+++ b/openmdao/core/tests/test_scaling_report_mpi.py
@@ -1,11 +1,10 @@
 """Define the units/scaling tests."""
 import unittest
 
-from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.core.tests.test_scaling_report import TestDriverScalingReport
+import  openmdao.core.tests.test_scaling_report as NonMPI
 
 
-class TestDriverScalingReportMPI(TestDriverScalingReport):
+class TestDriverScalingReportMPI(NonMPI.TestDriverScalingReport):
     N_PROCS = 2
 
 

--- a/openmdao/core/tests/test_scaling_report_mpi.py
+++ b/openmdao/core/tests/test_scaling_report_mpi.py
@@ -1,4 +1,4 @@
-"""Define the units/scaling tests."""
+"""Define MPI version of the scaling report tests."""
 import unittest
 
 import  openmdao.core.tests.test_scaling_report as NonMPI

--- a/openmdao/core/tests/test_scaling_report_mpi.py
+++ b/openmdao/core/tests/test_scaling_report_mpi.py
@@ -8,7 +8,15 @@ class TestDriverScalingReportMPI(NonMPI.TestDriverScalingReport):
     N_PROCS = 2
 
 
-class TestDriverScalingReportMPI2(NonMPI.TestDriverScalingReport2):
+class TestDriverScalingReport2MPI(NonMPI.TestDriverScalingReport2):
+    N_PROCS = 2
+
+
+class TestDriverScalingReport3MPI(NonMPI.TestDriverScalingReport3):
+    N_PROCS = 2
+
+
+class TestDiscreteScalingReportMPI(NonMPI.TestDiscreteScalingReport):
     N_PROCS = 2
 
 


### PR DESCRIPTION
### Summary

clean up imports in `test_scaling_report_mpi.py`

Importing `TestScalingReport` causes `testflo` to run both the non-mpi and the MPI versions of the TestCase when processing this file.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
