### PR TITLE
Fixed a bug in which reverse-mode derivatives were not computed correctly for models that contained both unit conversion and solver scaling.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -448,6 +448,7 @@ class Group(System):
                     a0 = ref0
                     a1 = ref - ref0
 
+                    # No unit conversion, only scaling. Just send the scale factors.
                     scale_factors[abs_in] = {
                         'input': (a0, a1),
                     }
@@ -457,27 +458,14 @@ class Group(System):
                     a0 = ref0
                     a1 = ref - ref0
 
-                    if a1 == 1.0:
-                        # No solver scaling, just unit conversion.
-                        # Note: a case like ref=3, ref0=2 is safe to treat as unscaled for the
-                        # linear vectors because the "scaler" is 1.0.
-                        a0 = (ref0 + offset) * factor
-                        a1 = (ref - ref0) * factor
+                    # Send both unit scaling and solver scaling. Linear input vectors need to
+                    # treat them differently in reverse mode.
+                    scale_factors[abs_in] = {
+                        'input': (a0, a1, factor, offset),
+                    }
 
-                        scale_factors[abs_in] = {
-                            'input': (a0, a1),
-                        }
-
-                    else:
-                        # When we have unit conversion and solver scaling, we need to track them
-                        # independently during reverse mode linear solves, so save the unit
-                        # conversion factors too, and let the root vector sort it out.
-                        scale_factors[abs_in] = {
-                            'input': (a0, a1, factor, offset),
-                        }
-
-                        # For adder allocation check.
-                        a0 = (ref0 + offset) * factor
+                    # For adder allocation check.
+                    a0 = (ref0 + offset) * factor
 
                 # Check whether we need to allocate an adder for the input vector.
                 if np.any(np.asarray(a0)):

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -161,18 +161,22 @@ class DefaultVector(Vector):
                 factor_tuple = factors[abs_name][kind]
 
                 if len(factor_tuple) == 4:
-                    # Input vector unit conversion.
+                    # Only input vectors can have 4 factors. Linear input vectors need to be able
+                    # to handle the unit and solver scaling in opposite directions in reverse mode.
                     a0, a1, factor, offset = factor_tuple
 
                     if self._name == 'linear':
                         scale0 = None
-                        scale1 = a1 / factor
-
+                        scale1 = factor / a1
                     else:
                         scale0 = (a0 + offset) * factor
                         scale1 = a1 * factor
                 else:
-                    scale0, scale1 = factor_tuple
+                    if self._name == 'linear' and self._typ == 'input':
+                        scale0 = None
+                        scale1 = 1.0 / factor_tuple[1]
+                    else:
+                        scale0, scale1 = factor_tuple
 
                 if scaling[0] is not None:
                     scaling[0][start:end] = scale0
@@ -312,7 +316,7 @@ class DefaultVector(Vector):
         else:
             adder, scaler = self._scaling
 
-        if mode == 'rev' and not self._has_solver_ref:
+        if mode == 'rev':
             self._scale_reverse(scaler, adder)
         else:
             self._scale_forward(scaler, adder)
@@ -332,7 +336,7 @@ class DefaultVector(Vector):
         else:
             adder, scaler = self._scaling
 
-        if mode == 'rev' and not self._has_solver_ref:
+        if mode == 'rev':
             self._scale_forward(scaler, adder)
         else:
             self._scale_reverse(scaler, adder)


### PR DESCRIPTION
### Summary

Fixed a bug in which reverse-mode derivatives were not computed correctly for models that contained both unit conversion and solver scaling. The problem is that scaling and unit-conversion in the linear input vector need to be handled differently in the reverse-mode case. This had been partially fixed on #2131, but the logic allowed a lot of cases to slip through. This new implementation addresses this and is cleaner.

### Related Issues

- Resolves #2522

### Backwards incompatibilities

None

### New Dependencies

None
