### PR TITLE
Replace distutils.LooseVersion with packaging Version

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -901,8 +901,8 @@ except ImportError:
 else:
     _import_functs(scipy.special, _expr_dict, names=['erf', 'erfc'])
 
-    from distutils.version import LooseVersion
-    if LooseVersion(scipy.__version__) >= LooseVersion("1.5.0"):
+    from packaging import version
+    if version.parse(scipy.__version__) >= version.parse("1.5.0"):
         def factorial(*args):
             """
             Raise a RuntimeError stating that the factorial function is not supported.

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -901,8 +901,8 @@ except ImportError:
 else:
     _import_functs(scipy.special, _expr_dict, names=['erf', 'erfc'])
 
-    from packaging import version
-    if version.parse(scipy.__version__) >= version.parse("1.5.0"):
+    from packaging.version import Version
+    if Version(scipy.__version__) >= Version("1.5.0"):
         def factorial(*args):
             """
             Raise a RuntimeError stating that the factorial function is not supported.

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_almost_equal
 import scipy
 from io import StringIO
 
-from distutils.version import LooseVersion
+from packaging import version
 
 try:
     from parameterized import parameterized
@@ -278,7 +278,7 @@ _ufunc_test_data = {
 
 
 # 'factorial' will raise a RuntimeError or a deprecation warning depending on scipy version
-if LooseVersion(scipy.__version__) >= LooseVersion("1.5.0"):
+if version.parse(scipy.__version__) >= version.parse("1.5.0"):
     _ufunc_test_data['factorial'] = {
         'str': 'f=factorial(x)',
         'args': {'f': {'val': np.zeros(6)},

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -10,7 +10,7 @@ from numpy.testing import assert_almost_equal
 import scipy
 from io import StringIO
 
-from packaging import version
+from packaging.version import Version
 
 try:
     from parameterized import parameterized
@@ -278,7 +278,7 @@ _ufunc_test_data = {
 
 
 # 'factorial' will raise a RuntimeError or a deprecation warning depending on scipy version
-if version.parse(scipy.__version__) >= version.parse("1.5.0"):
+if Version(scipy.__version__) >= Version("1.5.0"):
     _ufunc_test_data['factorial'] = {
         'str': 'f=factorial(x)',
         'args': {'f': {'val': np.zeros(6)},

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from io import StringIO
 
-from packaging import version
+from packaging.version import Version
 
 import openmdao.api as om
 
@@ -257,7 +257,7 @@ class DistributedListVarsTest(unittest.TestCase):
     def test_parallel_list_vars(self):
         print_opts = {'linewidth': 1024, 'precision': 1}
 
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        if Version(np.__version__) >= Version("1.14"):
             print_opts['legacy'] = '1.13'
 
         prob = om.Problem(FanOutGrouped())
@@ -411,7 +411,7 @@ class DistributedListVarsTest(unittest.TestCase):
     def test_distribcomp_list_vars(self):
         print_opts = {'linewidth': 1024}
 
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        if Version(np.__version__) >= Version("1.14"):
             print_opts['legacy'] = '1.13'
 
         size = 15

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 from io import StringIO
 
-from distutils.version import LooseVersion
+from packaging import version
 
 import openmdao.api as om
 
@@ -257,7 +257,7 @@ class DistributedListVarsTest(unittest.TestCase):
     def test_parallel_list_vars(self):
         print_opts = {'linewidth': 1024, 'precision': 1}
 
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        if version.parse(np.__version__) >= version.parse("1.14"):
             print_opts['legacy'] = '1.13'
 
         prob = om.Problem(FanOutGrouped())
@@ -411,7 +411,7 @@ class DistributedListVarsTest(unittest.TestCase):
     def test_distribcomp_list_vars(self):
         print_opts = {'linewidth': 1024}
 
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        if version.parse(np.__version__) >= version.parse("1.14"):
             print_opts['legacy'] = '1.13'
 
         size = 15

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -1,7 +1,7 @@
 """ Unit tests for the Driver base class."""
 
 
-from distutils.version import LooseVersion
+from packaging import version
 from io import StringIO
 import sys
 import unittest
@@ -364,7 +364,7 @@ class TestDriver(unittest.TestCase):
 
         try:
             # formatting has changed in numpy 1.14 and beyond.
-            if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+            if version.parse(np.__version__) >= version.parse("1.14"):
                 with printoptions(precision=2, legacy="1.13"):
                     prob.run_driver()
             else:
@@ -416,7 +416,7 @@ class TestDriver(unittest.TestCase):
 
         try:
             # formatting has changed in numpy 1.14 and beyond.
-            if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+            if version.parse(np.__version__) >= version.parse("1.14"):
                 with printoptions(precision=2, legacy="1.13"):
                     prob.run_driver()
             else:
@@ -448,7 +448,7 @@ class TestDriver(unittest.TestCase):
 
         try:
             # formatting has changed in numpy 1.14 and beyond.
-            if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+            if version.parse(np.__version__) >= version.parse("1.14"):
                 with printoptions(precision=2, legacy="1.13"):
                     prob.run_driver()
             else:

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -1,7 +1,7 @@
 """ Unit tests for the Driver base class."""
 
 
-from packaging import version
+from packaging.version import Version
 from io import StringIO
 import sys
 import unittest
@@ -364,7 +364,7 @@ class TestDriver(unittest.TestCase):
 
         try:
             # formatting has changed in numpy 1.14 and beyond.
-            if version.parse(np.__version__) >= version.parse("1.14"):
+            if Version(np.__version__) >= Version("1.14"):
                 with printoptions(precision=2, legacy="1.13"):
                     prob.run_driver()
             else:
@@ -416,7 +416,7 @@ class TestDriver(unittest.TestCase):
 
         try:
             # formatting has changed in numpy 1.14 and beyond.
-            if version.parse(np.__version__) >= version.parse("1.14"):
+            if Version(np.__version__) >= Version("1.14"):
                 with printoptions(precision=2, legacy="1.13"):
                     prob.run_driver()
             else:
@@ -448,7 +448,7 @@ class TestDriver(unittest.TestCase):
 
         try:
             # formatting has changed in numpy 1.14 and beyond.
-            if version.parse(np.__version__) >= version.parse("1.14"):
+            if Version(np.__version__) >= Version("1.14"):
                 with printoptions(precision=2, legacy="1.13"):
                     prob.run_driver()
             else:

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -657,8 +657,8 @@ class ExplCompTestCase(unittest.TestCase):
             'threshold': 1000,
         }
 
-        from distutils.version import LooseVersion
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        from packaging import version
+        if version.parse(np.__version__) >= version.parse("1.14"):
             opts['legacy'] = '1.13'
 
         with printoptions(**opts):

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -657,8 +657,8 @@ class ExplCompTestCase(unittest.TestCase):
             'threshold': 1000,
         }
 
-        from packaging import version
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        from packaging.version import Version
+        if Version(np.__version__) >= Version("1.14"):
             opts['legacy'] = '1.13'
 
         with printoptions(**opts):

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -5,7 +5,7 @@ from io import StringIO
 import sys
 import unittest
 import time
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 
@@ -499,7 +499,7 @@ class PartialDependGroup(om.Group):
 
 # This one hangs on Travis for numpy 1.12 and we can't reproduce the error anywhere where we can
 # debug it, so we're skipping it for numpy 1.12.
-@unittest.skipUnless(MPI and PETScVector and LooseVersion(np.__version__) >= LooseVersion("1.13"),
+@unittest.skipUnless(MPI and PETScVector and parse(np.__version__) >= version.parse("1.13"),
                      "MPI, PETSc, and numpy >= 1.13 are required.")
 class ParDerivColorFeatureTestCase(unittest.TestCase):
     N_PROCS = 2
@@ -527,7 +527,7 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
 
         of = ['ParallelGroup1.Con1.y', 'ParallelGroup1.Con2.y']
         wrt = ['Comp1.x']
-        
+
         p = om.Problem(model=PartialDependGroup())
         p.setup(mode='fwd')
         p.run_model()

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -5,7 +5,7 @@ from io import StringIO
 import sys
 import unittest
 import time
-from packaging import version
+from packaging.version import Version
 
 import numpy as np
 
@@ -499,7 +499,7 @@ class PartialDependGroup(om.Group):
 
 # This one hangs on Travis for numpy 1.12 and we can't reproduce the error anywhere where we can
 # debug it, so we're skipping it for numpy 1.12.
-@unittest.skipUnless(MPI and PETScVector and parse(np.__version__) >= version.parse("1.13"),
+@unittest.skipUnless(MPI and PETScVector and Version(np.__version__) >= Version("1.13"),
                      "MPI, PETSc, and numpy >= 1.13 are required.")
 class ParDerivColorFeatureTestCase(unittest.TestCase):
     N_PROCS = 2

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/linear_restart.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/linear_restart.ipynb
@@ -48,7 +48,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from distutils.version import LooseVersion\n",
     "import numpy as np\n",
     "import scipy\n",
     "from scipy.sparse.linalg import gmres\n",

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from packaging import version\n",
+    "from packaging.version import Version\n",
     "import numpy as np\n",
     "\n",
     "import openmdao.api as om\n",
@@ -114,7 +114,7 @@
     "\n",
     "opts = {}\n",
     "# formatting has changed in numpy 1.14 and beyond.\n",
-    "if version.parse(np.__version__) >= version.parse(\"1.14\"):\n",
+    "if Version(np.__version__) >= Version(\"1.14\"):\n",
     "    opts[\"legacy\"] = '1.13'\n",
     "\n",
     "with printoptions(**opts):\n",

--- a/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/debugging_solvers.ipynb
@@ -86,7 +86,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from distutils.version import LooseVersion\n",
+    "from packaging import version\n",
     "import numpy as np\n",
     "\n",
     "import openmdao.api as om\n",
@@ -114,7 +114,7 @@
     "\n",
     "opts = {}\n",
     "# formatting has changed in numpy 1.14 and beyond.\n",
-    "if LooseVersion(np.__version__) >= LooseVersion(\"1.14\"):\n",
+    "if version.parse(np.__version__) >= version.parse(\"1.14\"):\n",
     "    opts[\"legacy\"] = '1.13'\n",
     "\n",
     "with printoptions(**opts):\n",

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -9,7 +9,7 @@ additional MPI capability.
 import sys
 import json
 import signal
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 from scipy.sparse import coo_matrix
@@ -346,7 +346,7 @@ class pyOptSparseDriver(Driver):
                                  lower=meta['lower'], upper=meta['upper'])
 
         if not hasattr(pyoptsparse, '__version__') or \
-           LooseVersion(pyoptsparse.__version__) < LooseVersion('2.5.1'):
+           version.parse(pyoptsparse.__version__) < version.parse('2.5.1'):
             opt_prob.finalizeDesignVariables()
         else:
             opt_prob.finalize()

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -9,7 +9,7 @@ additional MPI capability.
 import sys
 import json
 import signal
-from packaging import version
+from packaging.version import Version
 
 import numpy as np
 from scipy.sparse import coo_matrix
@@ -346,7 +346,7 @@ class pyOptSparseDriver(Driver):
                                  lower=meta['lower'], upper=meta['upper'])
 
         if not hasattr(pyoptsparse, '__version__') or \
-           version.parse(pyoptsparse.__version__) < version.parse('2.5.1'):
+           Version(pyoptsparse.__version__) < Version('2.5.1'):
             opt_prob.finalizeDesignVariables()
         else:
             opt_prob.finalize()

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -3,7 +3,7 @@ OpenMDAO Wrapper for the scipy.optimize.minimize family of local optimizers.
 """
 
 import sys
-from packaging import version
+from packaging.version import Version
 
 import numpy as np
 from scipy import __version__ as scipy_version
@@ -19,7 +19,7 @@ from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 # Optimizers in scipy.minimize
 _optimizers = {'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',
                'TNC', 'COBYLA', 'SLSQP'}
-if version.parse(scipy_version) >= version.parse("1.1"):  # Only available in newer versions
+if Version(scipy_version) >= Version("1.1"):  # Only available in newer versions
     _optimizers.add('trust-constr')
 
 # For 'basinhopping' and 'shgo' gradients are used only in the local minimization
@@ -32,7 +32,7 @@ _constraint_optimizers = {'COBYLA', 'SLSQP', 'trust-constr', 'shgo'}
 _constraint_grad_optimizers = _gradient_optimizers & _constraint_optimizers
 _eq_constraint_optimizers = {'SLSQP', 'trust-constr'}
 _global_optimizers = {'differential_evolution', 'basinhopping'}
-if version.parse(scipy_version) >= version.parse("1.2"):  # Only available in newer versions
+if Version(scipy_version) >= Version("1.2"):  # Only available in newer versions
     _global_optimizers |= {'shgo', 'dual_annealing'}
 
 # Global optimizers and optimizers in minimize

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -3,7 +3,7 @@ OpenMDAO Wrapper for the scipy.optimize.minimize family of local optimizers.
 """
 
 import sys
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 from scipy import __version__ as scipy_version
@@ -19,7 +19,7 @@ from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 # Optimizers in scipy.minimize
 _optimizers = {'Nelder-Mead', 'Powell', 'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B',
                'TNC', 'COBYLA', 'SLSQP'}
-if LooseVersion(scipy_version) >= LooseVersion("1.1"):  # Only available in newer versions
+if version.parse(scipy_version) >= version.parse("1.1"):  # Only available in newer versions
     _optimizers.add('trust-constr')
 
 # For 'basinhopping' and 'shgo' gradients are used only in the local minimization
@@ -32,7 +32,7 @@ _constraint_optimizers = {'COBYLA', 'SLSQP', 'trust-constr', 'shgo'}
 _constraint_grad_optimizers = _gradient_optimizers & _constraint_optimizers
 _eq_constraint_optimizers = {'SLSQP', 'trust-constr'}
 _global_optimizers = {'differential_evolution', 'basinhopping'}
-if LooseVersion(scipy_version) >= LooseVersion("1.2"):  # Only available in newer versions
+if version.parse(scipy_version) >= version.parse("1.2"):  # Only available in newer versions
     _global_optimizers |= {'shgo', 'dual_annealing'}
 
 # Global optimizers and optimizers in minimize

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -438,8 +438,8 @@ class TestDOEDriver(unittest.TestCase):
             for case in cases:
                 writer.writerow([np.ones((2, 2)) * val for _, val in case])
 
-        from packaging import version
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        from packaging.version import Version
+        if Version(np.__version__) >= Version("1.14"):
             opts = {'legacy': '1.13'}
         else:
             opts = {}

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -438,8 +438,8 @@ class TestDOEDriver(unittest.TestCase):
             for case in cases:
                 writer.writerow([np.ones((2, 2)) * val for _, val in case])
 
-        from distutils.version import LooseVersion
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        from packaging import version
+        if version.parse(np.__version__) >= version.parse("1.14"):
             opts = {'legacy': '1.13'}
         else:
             opts = {}

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -3,7 +3,7 @@
 import copy
 import unittest
 
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 
@@ -1751,7 +1751,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     # Travis testing core dumps on many of the machines. Probabaly a build problem with the NSGA source.
     # Limiting this to the single travis 1.14 machine for now.
-    @unittest.skipUnless(LooseVersion(np.__version__) >= LooseVersion("1.13"), "numpy >= 1.13 is required.")
+    @unittest.skipUnless(version.parse(np.__version__) >= version.parse("1.13"), "numpy >= 1.13 is required.")
     def test_initial_run_NSGA2(self):
         _, local_opt = set_pyoptsparse_opt('NSGA2')
         if local_opt != 'NSGA2':
@@ -1833,7 +1833,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertNotEqual(comp.visited_points[1], 1.0)
 
     # Seems to be a bug in numpy 1.12, fixed in later versions.
-    @unittest.skipUnless(LooseVersion(np.__version__) >= LooseVersion("1.13"), "numpy >= 1.13 is required.")
+    @unittest.skipUnless(version.parse(np.__version__) >= version.parse("1.13"), "numpy >= 1.13 is required.")
     def test_initial_run_ALPSO(self):
         _, local_opt = set_pyoptsparse_opt('ALPSO')
         if local_opt != 'ALPSO':
@@ -1945,7 +1945,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         import pyoptsparse
         if not hasattr(pyoptsparse, '__version__') or \
-           LooseVersion(pyoptsparse.__version__) < LooseVersion('1.1.0'):
+           version.parse(pyoptsparse.__version__) < version.parse('1.1.0'):
             raise unittest.SkipTest("pyoptsparse needs to be updated to 1.1.0")
 
         class ParaboloidSIG(om.ExplicitComponent):

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -3,7 +3,7 @@
 import copy
 import unittest
 
-from packaging import version
+from packaging.version import Version
 
 import numpy as np
 
@@ -1751,7 +1751,7 @@ class TestPyoptSparse(unittest.TestCase):
 
     # Travis testing core dumps on many of the machines. Probabaly a build problem with the NSGA source.
     # Limiting this to the single travis 1.14 machine for now.
-    @unittest.skipUnless(version.parse(np.__version__) >= version.parse("1.13"), "numpy >= 1.13 is required.")
+    @unittest.skipUnless(Version(np.__version__) >= Version("1.13"), "numpy >= 1.13 is required.")
     def test_initial_run_NSGA2(self):
         _, local_opt = set_pyoptsparse_opt('NSGA2')
         if local_opt != 'NSGA2':
@@ -1833,7 +1833,7 @@ class TestPyoptSparse(unittest.TestCase):
         self.assertNotEqual(comp.visited_points[1], 1.0)
 
     # Seems to be a bug in numpy 1.12, fixed in later versions.
-    @unittest.skipUnless(version.parse(np.__version__) >= version.parse("1.13"), "numpy >= 1.13 is required.")
+    @unittest.skipUnless(Version(np.__version__) >= Version("1.13"), "numpy >= 1.13 is required.")
     def test_initial_run_ALPSO(self):
         _, local_opt = set_pyoptsparse_opt('ALPSO')
         if local_opt != 'ALPSO':
@@ -1945,7 +1945,7 @@ class TestPyoptSparse(unittest.TestCase):
 
         import pyoptsparse
         if not hasattr(pyoptsparse, '__version__') or \
-           version.parse(pyoptsparse.__version__) < version.parse('1.1.0'):
+           Version(pyoptsparse.__version__) < Version('1.1.0'):
             raise unittest.SkipTest("pyoptsparse needs to be updated to 1.1.0")
 
         class ParaboloidSIG(om.ExplicitComponent):

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 from io import StringIO
 
-from packaging import version
+from packaging.version import Version
 
 import numpy as np
 from scipy import __version__ as scipy_version
@@ -1119,7 +1119,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_near_equal(prob['z'][1], 0.0, 1e-3)
         assert_near_equal(prob['x'], 0.0, 1e-3)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.1"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.1"),
                          "scipy >= 1.1 is required.")
     def test_trust_constr(self):
 
@@ -1161,7 +1161,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.1"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.1"),
                          "scipy >= 1.1 is required.")
     def test_trust_constr_hess_option(self):
 
@@ -1204,7 +1204,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.1"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.1"),
                          "scipy >= 1.1 is required.")
     def test_trust_constr_equality_con(self):
 
@@ -1245,7 +1245,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_near_equal(prob['con.c'], 1., 1e-3)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.2"),
                          "scipy >= 1.2 is required.")
     def test_trust_constr_inequality_con(self):
 
@@ -1283,7 +1283,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_near_equal(prob['c'], 1.0, 1e-2)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.2"),
                          "scipy >= 1.2 is required.")
     def test_trust_constr_bounds(self):
         class Rosenbrock(om.ExplicitComponent):
@@ -1678,7 +1678,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_near_equal(prob['x'], np.array([0.234171, -0.1000]), 1e-3)
         assert_near_equal(prob['f'], -0.907267, 1e-3)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.2"),
                          "scipy >= 1.2 is required.")
     def test_dual_annealing_rastrigin(self):
         # Example from the Scipy documentation
@@ -1786,7 +1786,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_near_equal(prob['x'], -np.ones(size), 1e-2)
         assert_near_equal(prob['f'], 3.0, 1e-2)
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.2"),
                          "scipy >= 1.2 is required.")
     def test_shgo_rosenbrock(self):
         # Source of example:
@@ -2007,7 +2007,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertEqual(str(msg.exception),
                          "Constraints or objectives [('parab.f_z', inds=[(1, 1, 0)])] cannot be impacted by the design variables of the problem.")
 
-    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
+    @unittest.skipUnless(Version(scipy_version) >= Version("1.2"),
                          "scipy >= 1.2 is required.")
     def test_feature_shgo_rastrigin(self):
         # Source of example: https://stefan-endres.github.io/shgo/

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -4,7 +4,7 @@ import unittest
 import sys
 from io import StringIO
 
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 from scipy import __version__ as scipy_version
@@ -1119,7 +1119,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_near_equal(prob['z'][1], 0.0, 1e-3)
         assert_near_equal(prob['x'], 0.0, 1e-3)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.1"),
                          "scipy >= 1.1 is required.")
     def test_trust_constr(self):
 
@@ -1161,7 +1161,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.1"),
                          "scipy >= 1.1 is required.")
     def test_trust_constr_hess_option(self):
 
@@ -1204,7 +1204,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertTrue(prob['c'] < 10)
         self.assertTrue(prob['c'] > 0)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.1"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.1"),
                          "scipy >= 1.1 is required.")
     def test_trust_constr_equality_con(self):
 
@@ -1245,7 +1245,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_near_equal(prob['con.c'], 1., 1e-3)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
                          "scipy >= 1.2 is required.")
     def test_trust_constr_inequality_con(self):
 
@@ -1283,7 +1283,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         assert_near_equal(prob['c'], 1.0, 1e-2)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
                          "scipy >= 1.2 is required.")
     def test_trust_constr_bounds(self):
         class Rosenbrock(om.ExplicitComponent):
@@ -1678,7 +1678,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_near_equal(prob['x'], np.array([0.234171, -0.1000]), 1e-3)
         assert_near_equal(prob['f'], -0.907267, 1e-3)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
                          "scipy >= 1.2 is required.")
     def test_dual_annealing_rastrigin(self):
         # Example from the Scipy documentation
@@ -1786,7 +1786,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         assert_near_equal(prob['x'], -np.ones(size), 1e-2)
         assert_near_equal(prob['f'], 3.0, 1e-2)
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
                          "scipy >= 1.2 is required.")
     def test_shgo_rosenbrock(self):
         # Source of example:
@@ -2007,7 +2007,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         self.assertEqual(str(msg.exception),
                          "Constraints or objectives [('parab.f_z', inds=[(1, 1, 0)])] cannot be impacted by the design variables of the problem.")
 
-    @unittest.skipUnless(LooseVersion(scipy_version) >= LooseVersion("1.2"),
+    @unittest.skipUnless(version.parse(scipy_version) >= version.parse("1.2"),
                          "scipy >= 1.2 is required.")
     def test_feature_shgo_rastrigin(self):
         # Source of example: https://stefan-endres.github.io/shgo/

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -1,7 +1,7 @@
 """A module containing various configuration checks for an OpenMDAO Problem."""
 
 from collections import defaultdict
-from distutils.version import LooseVersion
+from packaging import version
 
 import numpy as np
 import pickle
@@ -24,7 +24,7 @@ from openmdao.utils.om_warnings import issue_warning, SetupWarning
 _UNSET = object()
 
 # numpy default print options changed in 1.14
-if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+if version.parse(np.__version__) >= version.parse("1.14"):
     _npy_print_opts = {'legacy': '1.13'}
 else:
     _npy_print_opts = {}

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -1,7 +1,7 @@
 """A module containing various configuration checks for an OpenMDAO Problem."""
 
 from collections import defaultdict
-from packaging import version
+from packaging.version import Version
 
 import numpy as np
 import pickle
@@ -24,7 +24,7 @@ from openmdao.utils.om_warnings import issue_warning, SetupWarning
 _UNSET = object()
 
 # numpy default print options changed in 1.14
-if version.parse(np.__version__) >= version.parse("1.14"):
+if Version(np.__version__) >= Version("1.14"):
     _npy_print_opts = {'legacy': '1.13'}
 else:
     _npy_print_opts = {}

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2985,8 +2985,8 @@ class TestSqliteCaseReader(unittest.TestCase):
             'threshold': 1000,
         }
 
-        from distutils.version import LooseVersion
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        from packaging import version
+        if version.parse(np.__version__) >= version.parse("1.14"):
             opts['legacy'] = '1.13'
 
         with printoptions(**opts):

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2985,8 +2985,8 @@ class TestSqliteCaseReader(unittest.TestCase):
             'threshold': 1000,
         }
 
-        from packaging import version
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        from packaging.version import Version
+        if Version(np.__version__) >= Version("1.14"):
             opts['legacy'] = '1.13'
 
         with printoptions(**opts):

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -1,6 +1,6 @@
 """Define the scipy iterative solver class."""
 
-from distutils.version import LooseVersion
+from packaging import version
 import numpy as np
 import scipy
 from scipy.sparse.linalg import LinearOperator, gmres
@@ -219,7 +219,7 @@ class ScipyKrylov(LinearSolver):
 
         self._iter_count = 0
         if solver is gmres:
-            if LooseVersion(scipy.__version__) < LooseVersion("1.1"):
+            if version.parse(scipy.__version__) < version.parse("1.1"):
                 x, info = solver(linop, b_vec.asarray(True), M=M, restart=restart,
                                  x0=x_vec_combined, maxiter=maxiter, tol=atol,
                                  callback=self._monitor)

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -1,6 +1,6 @@
 """Define the scipy iterative solver class."""
 
-from packaging import version
+from packaging.version import Version
 import numpy as np
 import scipy
 from scipy.sparse.linalg import LinearOperator, gmres
@@ -219,7 +219,7 @@ class ScipyKrylov(LinearSolver):
 
         self._iter_count = 0
         if solver is gmres:
-            if version.parse(scipy.__version__) < version.parse("1.1"):
+            if Version(scipy.__version__) < Version("1.1"):
                 x, info = solver(linop, b_vec.asarray(True), M=M, restart=restart,
                                  x0=x_vec_combined, maxiter=maxiter, tol=atol,
                                  callback=self._monitor)

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 
 import unittest
-from distutils.version import LooseVersion
+from packaging import version
 from io import StringIO
 
 import numpy as np
@@ -124,7 +124,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         opts = {}
         # formatting has changed in numpy 1.14 and beyond.
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        if version.parse(np.__version__) >= version.parse("1.14"):
             opts["legacy"] = '1.13'
 
         with printoptions(**opts):
@@ -170,7 +170,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         opts = {}
         # formatting has changed in numpy 1.14 and beyond.
-        if LooseVersion(np.__version__) >= LooseVersion("1.14"):
+        if version.parse(np.__version__) >= version.parse("1.14"):
             opts["legacy"] = '1.13'
 
         with printoptions(**opts):

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -7,7 +7,7 @@ import shutil
 import tempfile
 
 import unittest
-from packaging import version
+from packaging.version import Version
 from io import StringIO
 
 import numpy as np
@@ -124,7 +124,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         opts = {}
         # formatting has changed in numpy 1.14 and beyond.
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        if Version(np.__version__) >= Version("1.14"):
             opts["legacy"] = '1.13'
 
         with printoptions(**opts):
@@ -170,7 +170,7 @@ class TestNonlinearSolvers(unittest.TestCase):
 
         opts = {}
         # formatting has changed in numpy 1.14 and beyond.
-        if version.parse(np.__version__) >= version.parse("1.14"):
+        if Version(np.__version__) >= Version("1.14"):
             opts["legacy"] = '1.13'
 
         with printoptions(**opts):

--- a/openmdao/surrogate_models/tests/test_nearest_neighbor.py
+++ b/openmdao/surrogate_models/tests/test_nearest_neighbor.py
@@ -311,8 +311,8 @@ class TestRBFInterpolator1D(unittest.TestCase):
         assert_near_equal(mu, expected_y, 1e-8)
 
     def test_jacobian(self):
-        from distutils.version import LooseVersion
-        if LooseVersion(np.__version__) == LooseVersion("1.14"):
+        from packaging import version
+        if version.parse(np.__version__) == version.parse("1.14"):
             raise unittest.SkipTest("This test doesn't work in numpy 1.14.")
 
         test_x = np.array([[0.5], [2.5], [1.0]])
@@ -402,8 +402,8 @@ class TestRBFInterpolatorND(unittest.TestCase):
         assert_near_equal(mu, expected_y, 1e-6)
 
     def test_jacobian(self):
-        from distutils.version import LooseVersion
-        if LooseVersion(np.__version__) == LooseVersion("1.14"):
+        from packaging import version
+        if version.parse(np.__version__) == version.parse("1.14"):
             raise unittest.SkipTest("This test doesn't work in numpy 1.14.")
 
         test_x = np.array([[0.5, 0.5],

--- a/openmdao/surrogate_models/tests/test_nearest_neighbor.py
+++ b/openmdao/surrogate_models/tests/test_nearest_neighbor.py
@@ -311,8 +311,8 @@ class TestRBFInterpolator1D(unittest.TestCase):
         assert_near_equal(mu, expected_y, 1e-8)
 
     def test_jacobian(self):
-        from packaging import version
-        if version.parse(np.__version__) == version.parse("1.14"):
+        from packaging.version import Version
+        if Version(np.__version__) == Version("1.14"):
             raise unittest.SkipTest("This test doesn't work in numpy 1.14.")
 
         test_x = np.array([[0.5], [2.5], [1.0]])
@@ -402,8 +402,8 @@ class TestRBFInterpolatorND(unittest.TestCase):
         assert_near_equal(mu, expected_y, 1e-6)
 
     def test_jacobian(self):
-        from packaging import version
-        if version.parse(np.__version__) == version.parse("1.14"):
+        from packaging.version import Version
+        if Version(np.__version__) == Version("1.14"):
             raise unittest.SkipTest("This test doesn't work in numpy 1.14.")
 
         test_x = np.array([[0.5, 0.5],

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging import version
 import unittest
 
 import scipy
@@ -209,7 +209,7 @@ class TestBetzLimit(unittest.TestCase):
         assert_near_equal(prob['a'], 0.33333, 1e-4)
 
         # There is a bug in scipy version < 1.0 that causes this value to be wrong.
-        if LooseVersion(scipy.__version__) >= LooseVersion("1.0"):
+        if version.parse(scipy.__version__) >= version.parse("1.0"):
             assert_near_equal(prob['Area'], 1.0, 1e-4)
 
     def test_betz_with_var_tags(self):

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -1,4 +1,4 @@
-from packaging import version
+from packaging.version import Version
 import unittest
 
 import scipy
@@ -209,7 +209,7 @@ class TestBetzLimit(unittest.TestCase):
         assert_near_equal(prob['a'], 0.33333, 1e-4)
 
         # There is a bug in scipy version < 1.0 that causes this value to be wrong.
-        if version.parse(scipy.__version__) >= version.parse("1.0"):
+        if Version(scipy.__version__) >= Version("1.0"):
             assert_near_equal(prob['Area'], 1.0, 1e-4)
 
     def test_betz_with_var_tags(self):

--- a/setup.py
+++ b/setup.py
@@ -179,7 +179,8 @@ setup(
         'pyDOE2',
         'pyparsing',
         'scipy',
-        'requests'
+        'requests',
+        'packaging'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
### Summary

Replace uses of `distutils.LooseVersion` with `Version` from the Python Packaging Authority's `packaging` package.

### Related Issues

- Resolves #2491

### Backwards incompatibilities

None

### New Dependencies

[packaging](https://pypi.org/project/packaging/)
