### PR TITLE
Update GA & DE drivers to handle INF_BOUND on constraints

### DIFF
--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -428,6 +428,8 @@ class DifferentialEvolutionDriver(Driver):
                     elif (con['equals'] is not None) and np.any(np.abs(con['equals']) < almost_inf):
                         diff = val - con['equals']
                         violation = np.absolute(diff)
+                    else:
+                        violation = np.zeros(val.shape)
                     constraint_violations = np.hstack((constraint_violations, violation))
                 fun = obj + penalty * sum(np.power(constraint_violations, exponent))
             # Record after getting obj to assure they have

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -451,8 +451,6 @@ class DifferentialEvolutionDriver(Driver):
                     elif (con['equals'] is not None) and np.any(np.abs(con['equals']) < almost_inf):
                         diff = val - con['equals']
                         violation = np.absolute(diff)
-                    else:
-                        violation = np.zeros(val.shape)
                     constraint_violations = np.hstack((constraint_violations, violation))
                 fun = obj + penalty * sum(np.power(constraint_violations, exponent))
             # Record after getting obj to assure they have

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -511,6 +511,8 @@ class SimpleGADriver(Driver):
                     elif (con['equals'] is not None) and np.any(np.abs(con['equals']) < almost_inf):
                         diff = val - con['equals']
                         violation = np.absolute(diff)
+                    else:
+                        violation = np.zeros(val.shape)
                     constraint_violations = np.hstack((constraint_violations, violation))
                 fun = obj + penalty * sum(np.power(constraint_violations, exponent))
             # Record after getting obj to assure they have

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -153,6 +153,29 @@ class SimpleGADriver(Driver):
         """
         super()._setup_driver(problem)
 
+        # check design vars and constraints for invalid bounds
+        for name, meta in self._designvars.items():
+            lower, upper = meta['lower'], meta['upper']
+            for param in (lower, upper):
+                if param is None or np.all(np.abs(param) >= INF_BOUND):
+                    msg = (f"Invalid bounds for design variable '{name}'. When using "
+                           f"{self.__class__.__name__}, values for both 'lower' and 'upper' "
+                           f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
+                           f"but they are: lower={lower}, upper={upper}.")
+                    raise ValueError(msg)
+
+        for name, meta in self._cons.items():
+            equals, lower, upper = meta['equals'], meta['lower'], meta['upper']
+            if ((equals is None or np.all(np.abs(equals) >= INF_BOUND)) and
+               (lower is None or np.all(np.abs(lower) >= INF_BOUND)) and
+               (upper is None or np.all(np.abs(upper) >= INF_BOUND))):
+                msg = (f"Invalid bounds for constraint '{name}'. "
+                       f"When using {self.__class__.__name__}, the value for 'equals', "
+                       f"'lower' or 'upper' must be specified between +/-INF_BOUND "
+                       f"({INF_BOUND}), but they are: "
+                       f"equals={equals}, lower={lower}, upper={upper}.")
+                raise ValueError(msg)
+
         model_mpi = None
         comm = problem.comm
         if self._concurrent_pop_size > 0:
@@ -511,8 +534,6 @@ class SimpleGADriver(Driver):
                     elif (con['equals'] is not None) and np.any(np.abs(con['equals']) < almost_inf):
                         diff = val - con['equals']
                         violation = np.absolute(diff)
-                    else:
-                        violation = np.zeros(val.shape)
                     constraint_violations = np.hstack((constraint_violations, violation))
                 fun = obj + penalty * sum(np.power(constraint_violations, exponent))
             # Record after getting obj to assure they have

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -667,6 +667,35 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
         assert_near_equal(p.get_val('exec.z')[0], -900)
         assert_near_equal(p.get_val('exec.z')[50], -1000)
 
+    def test_inf_constraints(self):
+        from openmdao.core.constants import INF_BOUND
+
+        prob = om.Problem()
+        prob.model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])
+
+        # define the component whose output will be constrained
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
+
+        # Design variables 'x' and 'y' span components, so we need to provide a common initial
+        # value for them.
+        prob.model.set_input_defaults('x', 3.0)
+        prob.model.set_input_defaults('y', -4.0)
+
+        # setup the optimization
+        prob.driver = om.DifferentialEvolutionDriver()
+
+        prob.model.add_design_var('x', lower=-INF_BOUND, upper=INF_BOUND)
+        prob.model.add_design_var('y', lower=-INF_BOUND, upper=INF_BOUND)
+        prob.model.add_objective('parab.f_xy')
+
+        # to add the constraint to the model
+        prob.model.add_constraint('const.g', lower=-INF_BOUND, upper=INF_BOUND)
+
+        prob.setup()
+
+        # just check that it doesn't fail due to INF_BOUNDs
+        prob.run_driver()
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class MPITestDifferentialEvolution(unittest.TestCase):

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -6,6 +6,9 @@ import os
 import numpy as np
 
 import openmdao.api as om
+
+from openmdao.core.constants import INF_BOUND
+
 from openmdao.test_suite.components.branin import Branin
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
@@ -15,6 +18,10 @@ from openmdao.utils.general_utils import run_driver
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
+try:
+    from parameterized import parameterized
+except ImportError:
+    from openmdao.utils.assert_utils import SkipParameterized as parameterized
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -22,6 +29,18 @@ except ImportError:
     PETScVector = None
 
 extra_prints = False  # enable printing results
+
+
+def _test_func_name(func, num, param):
+    args = []
+    for p in param.args:
+        if p and p == INF_BOUND:
+            args.append('INF_BOUND')
+        elif p and p == -INF_BOUND:
+            args.append('-INF_BOUND')
+        else:
+            args.append(str(p))
+    return func.__name__ + '_' + '_'.join(args)
 
 
 class TestDifferentialEvolution(unittest.TestCase):
@@ -237,16 +256,16 @@ class TestDifferentialEvolution(unittest.TestCase):
         np.testing.assert_array_almost_equal(prob['indeps.x'], -5)
         np.testing.assert_array_almost_equal(prob['indeps.y'], [3, 1])
 
-    def test_DifferentialEvolutionDriver_missing_objective(self):
+    def test_missing_objective(self):
         prob = om.Problem()
+        model = prob.model
 
-        prob.model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
-        prob.model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
+        model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
+        model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
+
+        model.add_design_var('x', lower=-50, upper=50)
 
         prob.driver = om.DifferentialEvolutionDriver()
-
-        prob.model.add_design_var('x', lower=0)
-        prob.model.add_constraint('x', lower=0)
 
         prob.setup()
 
@@ -258,6 +277,46 @@ class TestDifferentialEvolution(unittest.TestCase):
         msg = "Driver requires objective to be declared"
 
         self.assertEqual(exception.args[0], msg)
+
+    @parameterized.expand([
+        (None, None),
+        (INF_BOUND, INF_BOUND),
+        (None, INF_BOUND),
+        (None, -INF_BOUND),
+        (INF_BOUND, None),
+        (-INF_BOUND, None),
+    ],
+    name_func=_test_func_name)
+    def test_inf_desvar(self, lower, upper):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
+        model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
+
+        model.add_objective('f_xy')
+        model.add_design_var('x', lower=lower, upper=upper)
+
+        prob.driver = om.DifferentialEvolutionDriver()
+
+        prob.setup()
+
+        with self.assertRaises(ValueError) as err:
+            prob.final_setup()
+
+        # A value of None for lower and upper is changed to +/- INF_BOUND in add_design_var()
+        if lower == None:
+            lower = -INF_BOUND
+        if upper == None:
+            upper = INF_BOUND
+
+        msg = ("Invalid bounds for design variable 'x.x'. When using "
+               "DifferentialEvolutionDriver, values for both 'lower' and 'upper' "
+               f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
+               f"but they are: lower={lower}, upper={upper}.")
+
+        self.maxDiff = None
+        self.assertEqual(err.exception.args[0], msg)
 
     def test_vectorized_constraints(self):
         prob = om.Problem()
@@ -667,34 +726,48 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
         assert_near_equal(p.get_val('exec.z')[0], -900)
         assert_near_equal(p.get_val('exec.z')[50], -1000)
 
-    def test_inf_constraints(self):
-        from openmdao.core.constants import INF_BOUND
-
+    @parameterized.expand([
+        (None, -INF_BOUND, INF_BOUND),
+        (INF_BOUND, None, None),
+        (-INF_BOUND, None, None),
+    ],
+    name_func=_test_func_name)
+    def test_inf_constraints(self, equals, lower, upper):
+        # define paraboloid problem with constraint
         prob = om.Problem()
-        prob.model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])
+        model = prob.model
 
-        # define the component whose output will be constrained
-        prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
-
-        # Design variables 'x' and 'y' span components, so we need to provide a common initial
-        # value for them.
-        prob.model.set_input_defaults('x', 3.0)
-        prob.model.set_input_defaults('y', -4.0)
+        model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])
+        model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
+        model.set_input_defaults('x', 3.0)
+        model.set_input_defaults('y', -4.0)
 
         # setup the optimization
         prob.driver = om.DifferentialEvolutionDriver()
-
-        prob.model.add_design_var('x', lower=-INF_BOUND, upper=INF_BOUND)
-        prob.model.add_design_var('y', lower=-INF_BOUND, upper=INF_BOUND)
-        prob.model.add_objective('parab.f_xy')
-
-        # to add the constraint to the model
-        prob.model.add_constraint('const.g', lower=-INF_BOUND, upper=INF_BOUND)
+        model.add_objective('parab.f_xy')
+        model.add_design_var('x', lower=-50, upper=50)
+        model.add_design_var('y', lower=-50, upper=50)
+        model.add_constraint('const.g', equals=equals, lower=lower, upper=upper)
 
         prob.setup()
 
-        # just check that it doesn't fail due to INF_BOUNDs
-        prob.run_driver()
+        with self.assertRaises(ValueError) as err:
+            prob.final_setup()
+
+        # A value of None for lower and upper is changed to +/- INF_BOUND in add_constraint()
+        if lower == None:
+            lower = -INF_BOUND
+        if upper == None:
+            upper = INF_BOUND
+
+        msg = ("Invalid bounds for constraint 'const.g'. "
+               "When using DifferentialEvolutionDriver, the value for "
+               "'equals', 'lower' or 'upper' must be specified between "
+               f"+/-INF_BOUND ({INF_BOUND}), but they are: "
+               f"equals={equals}, lower={lower}, upper={upper}.")
+
+        self.maxDiff = None
+        self.assertEqual(err.exception.args[0], msg)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -6,7 +6,11 @@ import os
 import numpy as np
 
 import openmdao.api as om
+
+from openmdao.core.constants import INF_BOUND
+
 from openmdao.drivers.genetic_algorithm_driver import GeneticAlgorithm
+
 from openmdao.test_suite.components.branin import Branin, BraninDiscrete
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
@@ -16,6 +20,11 @@ from openmdao.test_suite.components.three_bar_truss import ThreeBarTruss
 from openmdao.utils.general_utils import run_driver
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal
+try:
+    from parameterized import parameterized
+except ImportError:
+    from openmdao.utils.assert_utils import SkipParameterized as parameterized
+
 from openmdao.utils.mpi import MPI
 
 try:
@@ -24,6 +33,19 @@ except ImportError:
     PETScVector = None
 
 extra_prints = False  # enable printing results
+
+
+def _test_func_name(func, num, param):
+    args = []
+    for p in param.args:
+        if p and p == INF_BOUND:
+            args.append('INF_BOUND')
+        elif p and p == -INF_BOUND:
+            args.append('-INF_BOUND')
+        else:
+            args.append(str(p))
+    return func.__name__ + '_' + '_'.join(args)
+
 
 class TestSimpleGA(unittest.TestCase):
 
@@ -393,17 +415,15 @@ class TestSimpleGA(unittest.TestCase):
         np.testing.assert_array_almost_equal(prob['indeps.x'], -5)
         np.testing.assert_array_almost_equal(prob['indeps.y'], [3, 1])
 
-    def test_SimpleGADriver_missing_objective(self):
+    def test_missing_objective(self):
         prob = om.Problem()
         model = prob.model
 
         model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
         model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
+        model.add_design_var('x', lower=-50, upper=50)
 
         prob.driver = om.SimpleGADriver()
-
-        prob.model.add_design_var('x', lower=0)
-        prob.model.add_constraint('x', lower=0)
 
         prob.setup()
 
@@ -415,6 +435,46 @@ class TestSimpleGA(unittest.TestCase):
         msg = "Driver requires objective to be declared"
 
         self.assertEqual(exception.args[0], msg)
+
+    @parameterized.expand([
+        (None, None),
+        (INF_BOUND, INF_BOUND),
+        (None, INF_BOUND),
+        (None, -INF_BOUND),
+        (INF_BOUND, None),
+        (-INF_BOUND, None),
+    ],
+    name_func=_test_func_name)
+    def test_inf_desvar(self, lower, upper):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('x', om.IndepVarComp('x', 2.0), promotes=['*'])
+        model.add_subsystem('f_x', Paraboloid(), promotes=['*'])
+
+        model.add_objective('f_xy')
+        model.add_design_var('x', lower=lower, upper=upper)
+
+        prob.driver = om.SimpleGADriver()
+
+        prob.setup()
+
+        with self.assertRaises(ValueError) as err:
+            prob.final_setup()
+
+        # A value of None for lower and upper is changed to +/- INF_BOUND in add_design_var()
+        if lower == None:
+            lower = -INF_BOUND
+        if upper == None:
+            upper = INF_BOUND
+
+        msg = ("Invalid bounds for design variable 'x.x'. When using "
+               "SimpleGADriver, values for both 'lower' and 'upper' "
+               f"must be specified between +/-INF_BOUND ({INF_BOUND}), "
+               f"but they are: lower={lower}, upper={upper}.")
+
+        self.maxDiff = None
+        self.assertEqual(err.exception.args[0], msg)
 
     def test_vectorized_constraints(self):
         prob = om.Problem()
@@ -868,34 +928,48 @@ class TestConstrainedSimpleGA(unittest.TestCase):
         assert_near_equal(p.get_val('exec.z')[0], -300)
         assert_near_equal(p.get_val('exec.z')[50], -400)
 
-    def test_inf_constraints(self):
-        from openmdao.core.constants import INF_BOUND
-
+    @parameterized.expand([
+        (None, -INF_BOUND, INF_BOUND),
+        (INF_BOUND, None, None),
+        (-INF_BOUND, None, None),
+    ],
+    name_func=_test_func_name)
+    def test_inf_constraints(self, equals, lower, upper):
+        # define paraboloid problem with constraint
         prob = om.Problem()
-        prob.model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])
+        model = prob.model
 
-        # define the component whose output will be constrained
-        prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
-
-        # Design variables 'x' and 'y' span components, so we need to provide a common initial
-        # value for them.
-        prob.model.set_input_defaults('x', 3.0)
-        prob.model.set_input_defaults('y', -4.0)
+        model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])
+        model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
+        model.set_input_defaults('x', 3.0)
+        model.set_input_defaults('y', -4.0)
 
         # setup the optimization
         prob.driver = om.SimpleGADriver()
-
-        prob.model.add_design_var('x', lower=-INF_BOUND, upper=INF_BOUND)
-        prob.model.add_design_var('y', lower=-INF_BOUND, upper=INF_BOUND)
-        prob.model.add_objective('parab.f_xy')
-
-        # to add the constraint to the model
-        prob.model.add_constraint('const.g', lower=-INF_BOUND, upper=INF_BOUND)
+        model.add_objective('parab.f_xy')
+        model.add_design_var('x', lower=-50, upper=50)
+        model.add_design_var('y', lower=-50, upper=50)
+        model.add_constraint('const.g', equals=equals, lower=lower, upper=upper)
 
         prob.setup()
 
-        # just check that it doesn't fail due to INF_BOUNDs
-        prob.run_driver()
+        with self.assertRaises(ValueError) as err:
+            prob.final_setup()
+
+        # A value of None for lower and upper is changed to +/- INF_BOUND in add_constraint()
+        if lower == None:
+            lower = -INF_BOUND
+        if upper == None:
+            upper = INF_BOUND
+
+        msg = ("Invalid bounds for constraint 'const.g'. "
+               "When using SimpleGADriver, the value for 'equals', "
+               "'lower' or 'upper' must be specified between "
+               f"+/-INF_BOUND ({INF_BOUND}), but they are: "
+               f"equals={equals}, lower={lower}, upper={upper}.")
+
+        self.maxDiff = None
+        self.assertEqual(err.exception.args[0], msg)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")


### PR DESCRIPTION
### Summary

Fixed an edge case where the SimpleGADriver and DifferentialEvolutionDriver would fail if bounds where set to +/- `INF_BOUND`
### Related Issues

- Resolves #2509

### Backwards incompatibilities

None

### New Dependencies

None
