### PR TITLE
Minor fixes to generic model diagram code

### DIFF
--- a/openmdao/visualization/htmlpp.py
+++ b/openmdao/visualization/htmlpp.py
@@ -34,6 +34,8 @@ class HtmlPreprocessor():
 
     Attributes
     ----------
+    _start_path : Path
+        A Path object to help with testing functions for the provided start_filename.
     _start_filename : str
         The path to the file to begin processing from, normally an HTML file.
     _search_path : Path
@@ -129,7 +131,7 @@ class HtmlPreprocessor():
 
         self.msg("HtmlProcessor object created.")
 
-    def find_file(self, filename:str) -> str:
+    def find_file(self, filename: str) -> str:
         """
         Check specified locations for the provided filename.
 
@@ -152,7 +154,7 @@ class HtmlPreprocessor():
                 test_path = Path(path / filename)
                 if test_path.is_file():
                     return test_path
-        
+
         raise FileNotFoundError(f"Error: {filename} not found")
 
     def load_file(self, filename: str, rlvl=0, binary=False, allow_dup=False) -> str:

--- a/openmdao/visualization/htmlpp.py
+++ b/openmdao/visualization/htmlpp.py
@@ -20,9 +20,8 @@ class HtmlPreprocessor():
         The file to begin processing from.
     output_filename : str
         The path to the newly merged HTML file.
-    start_path : str
-        Directory path that all other paths are relative to. Defaults to the path
-        that the start_filename is found in.
+    search_path : str[]
+        List of directory names to search for files.
     allow_overwrite : bool
         If true, overwrite the output file if it exists.
     var_dict : dict
@@ -37,10 +36,8 @@ class HtmlPreprocessor():
     ----------
     _start_filename : str
         The path to the file to begin processing from, normally an HTML file.
-    _start_path : Path
-        Path object used to determine relative paths for subsequent directives.
-    _start_dirname : str
-        The absolute path of the directory containing the start_file.
+    _search_path : Path
+        List of Path objects to search for included files.
     _output_filename : str
         The path to the newly merged HTML file.
     _var_dict : dict
@@ -94,7 +91,7 @@ class HtmlPreprocessor():
     Nothing is written until every directive has been successfully processed.
     """
 
-    def __init__(self, start_filename: str, output_filename: str, start_path: str = None,
+    def __init__(self, start_filename: str, output_filename: str, search_path=[],
                  allow_overwrite=False, var_dict: dict = None, json_dumps_default=None,
                  verbose=False):
         """
@@ -105,13 +102,21 @@ class HtmlPreprocessor():
         if self._start_path.is_file() is False:
             raise FileNotFoundError(f"Error: {self._start_path} not found")
 
+        self._search_path = []
+        for path_name in search_path:
+            self._search_path.append(Path(path_name))
+
+        # Put location of start file after manually-specified paths:
+        self._search_path.append(self._start_path.resolve().parent)
+
+        # Current folder:
+        self._search_path.append(Path('.'))
+
         output_path = Path(output_filename)
         if output_path.is_file() and not allow_overwrite:
             raise FileExistsError(f"Error: {output_filename} already exists")
 
         self._start_filename = start_filename
-        self._start_dirname = \
-            self._start_path.resolve().parent if start_path is None else Path(start_path)
         self._output_filename = output_filename
         self._allow_overwrite = allow_overwrite
         self._var_dict = var_dict
@@ -123,6 +128,32 @@ class HtmlPreprocessor():
         self._loaded_filenames = []
 
         self.msg("HtmlProcessor object created.")
+
+    def find_file(self, filename:str) -> str:
+        """
+        Check specified locations for the provided filename.
+
+        Parameters
+        ----------
+        filename : str
+            The path to the text file to locate.
+
+        Returns
+        -------
+        str
+            The full path to the existing file if found.
+        """
+        file_path = Path(filename)
+        if file_path.is_absolute():
+            if file_path.is_file():
+                return filename
+        else:
+            for path in self._search_path:
+                test_path = Path(path / filename)
+                if test_path.is_file():
+                    return test_path
+        
+        raise FileNotFoundError(f"Error: {filename} not found")
 
     def load_file(self, filename: str, rlvl=0, binary=False, allow_dup=False) -> str:
         """
@@ -144,8 +175,7 @@ class HtmlPreprocessor():
         str
             The complete contents of the file.
         """
-        path = Path(filename)
-        pathname = filename if path.is_absolute() else self._start_dirname / filename
+        pathname = self.find_file(filename)
 
         if pathname in self._loaded_filenames and not allow_dup:
             self.msg(f"Ignoring previously-loaded file {filename}.", rlvl)

--- a/openmdao/visualization/n2_viewer/gen/CellRenderer.js
+++ b/openmdao/visualization/n2_viewer/gen/CellRenderer.js
@@ -13,12 +13,13 @@ class CellRenderer {
         this.id = 'cellShape_' + id; // To ensure it doesn't start with a number
     }
 
-    static updateDims(baseWidth, baseHeight) {
+    static updateDims(baseWidth, baseHeight, pcntSize = 0.6) {
         if (!CellRenderer.dims) {
             CellRenderer.prevDims = {
                 "size": {
                     "width": 0,
-                    "height": 0
+                    "height": 0,
+                    "percent": pcntSize
                 },
                 "bottomRight": {
                     "x": 0,
@@ -40,7 +41,8 @@ class CellRenderer {
         CellRenderer.dims = {
             "size": {
                 "width": baseWidth,
-                "height": baseHeight
+                "height": baseHeight,
+                "percent": pcntSize
             },
             "bottomRight": {
                 "x": baseWidth * .5,
@@ -119,8 +121,8 @@ class ScalarBase extends CellRenderer {
             .transition(sharedTransition);
             
         return d3Elem
-            .attr("rx", dims.bottomRight.x * .6)
-            .attr("ry", dims.bottomRight.y * .6);
+            .attr("rx", dims.bottomRight.x * dims.size.percent)
+            .attr("ry", dims.bottomRight.y * dims.size.percent);
     }
 
     /** 
@@ -164,10 +166,10 @@ class VectorBase extends CellRenderer {
             .transition(sharedTransition);
 
         const ret = d3Elem
-            .attr("x", dims.topLeft.x * .6)
-            .attr("y", dims.topLeft.y * .6)
-            .attr("width", dims.bottomRight.x * 1.2)
-            .attr("height", dims.bottomRight.y * 1.2);
+            .attr("x", dims.topLeft.x * dims.size.percent)
+            .attr("y", dims.topLeft.y * dims.size.percent)
+            .attr("width", dims.bottomRight.x * dims.size.percent * 2)
+            .attr("height", dims.bottomRight.y * dims.size.percent * 2);
 
 
         return ret;
@@ -313,10 +315,10 @@ class GroupBase extends CellRenderer {
         this._updateBorder(dims, d3Group, border);
 
         return d3Elem
-            .attr("x", dims.topLeft.x * .6)
-            .attr("y", dims.topLeft.y * .6)
-            .attr("width", dims.size.width * .6)
-            .attr("height", dims.size.height * .6);
+            .attr("x", dims.topLeft.x * dims.size.percent)
+            .attr("y", dims.topLeft.y * dims.size.percent)
+            .attr("width", dims.size.width * dims.size.percent)
+            .attr("height", dims.size.height * dims.size.percent);
     }
 
     /** 

--- a/openmdao/visualization/n2_viewer/gen/ChildSelectDialog.js
+++ b/openmdao/visualization/n2_viewer/gen/ChildSelectDialog.js
@@ -137,9 +137,9 @@ class ChildSelectDialog extends WindowDraggable {
         this.hiddenVars = [];
         this.existingHiddenVars = false;
 
-        for (const iotype of ['inputs', 'outputs']) {
-            if (this.node.filter[iotype].count > 0) {
-                for (const child of this.node.filter[iotype].children) {
+        for (const filter of this.node.getFilterList()) {
+            if (filter.count > 0) {
+                for (const child of filter.children) {
                     this.hiddenVars.push(child);
                 };
                 this.existingHiddenVars = true;
@@ -231,12 +231,10 @@ class ChildSelectDialog extends WindowDraggable {
             this.diag.ui.addBackButtonHistory();
 
             this.node.searchTerm = this.searchTerm;
-            this.node.filter.inputs.wipe();
-            this.node.filter.outputs.wipe();
+            this.node.wipeFilters();
 
             for (const child of this.hiddenVars) {
-                if (child.isInput()) { this.node.filter.inputs.add(child); }
-                else { this.node.filter.outputs.add(child); }
+                this.node.addToFilter(child);
             }
             
             if (this.node.draw.minimized) {

--- a/openmdao/visualization/n2_viewer/gen/ChildSelectDialog.js
+++ b/openmdao/visualization/n2_viewer/gen/ChildSelectDialog.js
@@ -43,8 +43,8 @@ class ChildSelectDialog extends WindowDraggable {
             if (!child.isInputOrOutput()) { continue; }
             foundVariables = true;
 
-            // Use Layout.getText() because Auto-IVC variable names are not usually descriptive.
-            const varName = this.diag.layout.getText(child);
+            // Use getTextName() because Auto-IVC variable names are not usually descriptive.
+            const varName = child.getTextName();
             this.varNames[varName] = child;
             this.varNameArr.push(varName)
 

--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -264,6 +264,8 @@ class Diagram {
         const enterSelection = enter
             .append("g")
             .attr("class", d => `model_tree_grp ${self.style.getNodeClass(d)}`)
+            .attr("transform", d =>
+                `translate(${scale.prev.x(d.draw.dims.prev.x)},${scale.prev.y(d.draw.dims.prev.y)})`)
             .on("click", (e,d) => self.leftClickSelector(e, d))
             .on("contextmenu", function(e,d) {
                 if (e.altKey) {

--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -39,7 +39,7 @@ class Diagram {
         this.manuallyResized = false; // If the diagram has been sized by the user
 
         // Assign this way because defaultDims is read-only.
-        this.dims = structuredClone(defaultDims);
+        this.dims = {...defaultDims};
 
         this._referenceD3Elements();
         this.transitionStartDelay = transitionDefaults.startDelay;

--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -297,7 +297,7 @@ class Diagram {
         // Add a label
         enterSelection
             .append("text")
-            .text(self.layout.getText.bind(self.layout))
+            .text(d => d.getTextName())
             .style('visibility', 'hidden')
             .attr("dy", ".35em")
             .attr("transform", d => {

--- a/openmdao/visualization/n2_viewer/gen/Dimensions.js
+++ b/openmdao/visualization/n2_viewer/gen/Dimensions.js
@@ -6,7 +6,8 @@
  */
  class Dimensions {
     static allowedProps = ['x', 'x1', 'x2', 'y', 'y1', 'y2', 'z', 'count',
-        'size', 'height', 'width', 'margin', 'top', 'right', 'bottom', 'left'];
+        'size', 'height', 'width', 'margin', 'top', 'right', 'bottom', 'left',
+        'start', 'stop'];
 
     /**
      * Load the values into the object.
@@ -21,6 +22,19 @@
     /** Return the property value as a string with the unit appended. */
     valAsStyleStr(propName) {
         return `${this[propName]}${this.unit}`;
+    }
+
+    /**
+     * Find managed properties in object and copy their values.
+     * @param {Object} obj Object to search for properties.
+     * @returns Reference to this.
+     */
+    set(obj) {
+        for (const prop of this._managedProps) {
+            if (prop in obj) this[prop] = obj[prop];
+        }
+
+        return this;
     }
 
     /**

--- a/openmdao/visualization/n2_viewer/gen/Dimensions.js
+++ b/openmdao/visualization/n2_viewer/gen/Dimensions.js
@@ -5,7 +5,8 @@
  * @property {Object} prev Previous set of coordinates.
  */
  class Dimensions {
-    static allowedProps = ['x', 'y', 'z', 'height', 'width', 'margin', 'top', 'right', 'bottom', 'left'];
+    static allowedProps = ['x', 'x1', 'x2', 'y', 'y1', 'y2', 'z', 'count',
+        'size', 'height', 'width', 'margin', 'top', 'right', 'bottom', 'left'];
 
     /**
      * Load the values into the object.
@@ -46,7 +47,9 @@
                     get: function() { return self.valAsStyleStr(prop); }
                 });
             }
-        } 
+        }
+
+        return this;
     }
 
     /**
@@ -60,6 +63,8 @@
         for (const prop of other.prev) {
             this.prev[prop] = other.prev[prop];
         }
+
+        return this;
     }
 
     /** Backup the current values for future reference. */
@@ -68,5 +73,7 @@
         for (const prop of this._managedProps) {
             this.prev[prop] = this[prop];
         }
+
+        return this;
     }
 }

--- a/openmdao/visualization/n2_viewer/gen/Layout.js
+++ b/openmdao/visualization/n2_viewer/gen/Layout.js
@@ -144,28 +144,6 @@ class Layout {
         return width;
     }
 
-    /** Determine the text associated with the node. Normally its name,
-     * but can be changed if promoted.
-     * @param {TreeNode} node The item to operate on.
-     * @return {String} The selected text.
-     */
-    getText(node) {
-        let retVal = node.name;
-
-        if (node.name == '_auto_ivc') {
-            retVal = 'Auto-IVC';
-        }
-        else if (node.isFilter()) {
-            if (node.name.match(/.*_FILTER_inputs$/)) retVal = 'Filtered Inputs';
-            else retVal = 'Filtered Outputs';
-        }
-        else if (node.path.match(/^_auto_ivc.*/) && node.promotedName !== undefined) {
-            retVal = node.promotedName;
-        }
-
-        return retVal;
-    }
-
     /**
      * Determine text widths for all descendents of the specified node.
      * @param {TreeNode} [node = this.zoomedElement] Item to begin looking from.
@@ -173,7 +151,7 @@ class Layout {
     _updateTextWidths(node = this.zoomedElement) {
         if (node.draw.hidden) return;
 
-        node.draw.nameWidthPx = this._getTextWidth(this.getText(node)) + 2 *
+        node.draw.nameWidthPx = this._getTextWidth(node.getTextName()) + 2 *
             this.size.rightTextMargin;
 
         if (node.hasChildren() && !node.draw.minimized) {

--- a/openmdao/visualization/n2_viewer/gen/Legend.js
+++ b/openmdao/visualization/n2_viewer/gen/Legend.js
@@ -123,13 +123,13 @@ class Legend extends WindowDraggable {
      * @param {Object} item Contains the name and color of the item
      * @param {Object} container The div to append into
      */
-    _addItem(item, container) {
+    _addItem(item, container, cssClass = '') {
         const newDiv = container
             .append('div')
             .attr('class', 'legend-box-container');
 
         newDiv.append('div')
-            .attr('class', 'legend-box')
+            .attr('class', `legend-box ${cssClass}`)
             .style('background-color', item.color);
 
         newDiv.append('p')

--- a/openmdao/visualization/n2_viewer/gen/Matrix.js
+++ b/openmdao/visualization/n2_viewer/gen/Matrix.js
@@ -327,7 +327,7 @@ class Matrix {
             if (box.startI == box.stopI) continue;
 
             const curNode = this.diagNodes[box.startI];
-            if (!curNode.boxAncestor()) { throw "Ancestor not found in box."; }
+            if (!curNode.boxAncestor()) { continue; throw "Ancestor not found in box."; }
 
             box.obj = curNode.boxAncestor();
             if (box.obj.draw.varBoxDims) {

--- a/openmdao/visualization/n2_viewer/gen/Matrix.js
+++ b/openmdao/visualization/n2_viewer/gen/Matrix.js
@@ -51,11 +51,16 @@ class Matrix {
         d3.select("#arrow").attr("markerWidth", markerSize).attr("markerHeight", markerSize);
         d3.select("#offgridArrow").attr("markerWidth", markerSize * 2).attr("markerHeight", markerSize);
 
-        CellRenderer.updateDims(this.nodeSize.width, this.nodeSize.height);
+        this._init();
+        
         this.updateLevelOfDetailThreshold(layout.size.matrix.height);
 
         this._buildGrid();
         this._setupVariableBoxesAndGridLines();
+    }
+
+    _init() {
+        CellRenderer.updateDims(this.nodeSize.width, this.nodeSize.height);
     }
 
     get cellDims() { return CellRenderer.dims; }
@@ -311,9 +316,13 @@ class Matrix {
             if (box.startI == box.stopI) continue;
 
             const curNode = this.diagNodes[box.startI];
-            if (!curNode.parent) { throw "Parent not found in box."; }
+            if (!curNode.boxAncestor()) { throw "Ancestor not found in box."; }
 
-            box.obj = curNode.parent;
+            box.obj = curNode.boxAncestor();
+            if (box.obj.draw.varBoxDims) {
+                box.obj.draw.varBoxDims.preserve().count = 1 + box.stopI - box.startI;
+            }
+
             i = box.stopI;
             this._variableBoxInfo.push(box);
         }

--- a/openmdao/visualization/n2_viewer/gen/Matrix.js
+++ b/openmdao/visualization/n2_viewer/gen/Matrix.js
@@ -291,8 +291,7 @@ class Matrix {
             const curNode = this.diagNodes[ri];
             const startINode = this.diagNodes[currentBox.startI];
 
-            if (startINode.parent && startINode.parent.draw.boxChildren && 
-                curNode.parent && startINode.parent === curNode.parent) {
+            if (startINode.boxAncestor() === curNode.boxAncestor()) {
                 ++currentBox.stopI;
             }
             else {

--- a/openmdao/visualization/n2_viewer/gen/ModelData.js
+++ b/openmdao/visualization/n2_viewer/gen/ModelData.js
@@ -37,7 +37,7 @@ class ModelData {
         this._init(modelJSON);
 
         this.root = this.tree = modelJSON.tree = this._adoptNodes(modelJSON.tree);
-        this._setParentsAndDepth(this.root, null, 1);
+        this._setDepth(this.root, 1);
 
         for (const conn of this.conns) {
             this.connObjs.push(this._newConnectionObj(conn));
@@ -107,14 +107,12 @@ class ModelData {
     }
 
    /**
-     * Sets parents and depth of all nodes, and determine max depth.
+     * Sets depth of all nodes and determines max depth.
      * @param {TreeNode} node Item to process.
-     * @param {TreeNode} parent Parent of node, null for root node.
      * @param {number} depth Numerical level of ancestry.
      */
-    _setParentsAndDepth(node, parent, depth) {
+    _setDepth(node, depth) {
         node.depth = depth;
-        node.parent = parent;
         node.id = this.nodeIds.length;
         this.nodeIds.push(node);
 
@@ -133,7 +131,7 @@ class ModelData {
         if (node.hasChildren()) {
             node.numDescendants = node.children.length;
             for (const child of node.children) {
-                this._setParentsAndDepth(child, node, depth + 1);
+                this._setDepth(child, depth + 1);
                 node.numDescendants += child.numDescendants;
 
                 // Add absolute pathnames of children to a set for quick searching

--- a/openmdao/visualization/n2_viewer/gen/Style.js
+++ b/openmdao/visualization/n2_viewer/gen/Style.js
@@ -85,11 +85,11 @@ class Style {
             '#tree > g.minimized > text': {
                 'fill': Style.color.collapsedText,
             },
-            'text': {
+            /* 'text': {
                 //'dominant-baseline: middle',
                 //'dy: .35em',
-            },
-            '#svgId g.model_tree_grp > text': {
+            }, */
+            'g.model_tree_grp > text': {
                 'text-anchor': 'end',
                 'pointer-events': 'none',
                 'font-family': 'helvetica, sans-serif',

--- a/openmdao/visualization/n2_viewer/gen/Style.js
+++ b/openmdao/visualization/n2_viewer/gen/Style.js
@@ -113,10 +113,7 @@ class Style {
             '.horiz_line, .vert_line': {
                 'stroke': Style.color.gridline,
             },
-            "g.model_tree_grp > rect[id$='_FILTER_inputs'] + text": {
-                'font-style': 'italic'
-            },
-            "g.model_tree_grp > rect[id$='_FILTER_outputs'] + text": {
+            "g.model_tree_grp > rect[id*='_FILTER_'] + text": {
                 'font-style': 'italic'
             },
             'g.variable_box > rect': {

--- a/openmdao/visualization/n2_viewer/gen/TreeNode.js
+++ b/openmdao/visualization/n2_viewer/gen/TreeNode.js
@@ -315,7 +315,7 @@ class FilterNode extends TreeNode {
     }
 
     getTextName() {
-        return `Filtered ${this.suffix[0].toUpperCase() + this.suffix[0].slice(1)}`;
+        return `Filtered ${this.suffix[0].toUpperCase() + this.suffix.slice(1)}`;
     }
 
     /**
@@ -477,10 +477,9 @@ class FilterCapableNode extends TreeNode {
     }
 
     addToFilter(node) {
-        if (node.isInput()) { this.filter.inputs.add(child); }
-        else { this.filter.outputs.add(child); }
+        if (node.isInput()) { this.filter.inputs.add(node); }
+        else { this.filter.outputs.add(node); }
     }
-
 
     /**
      * Filter ourselves based on the supplied filter state.

--- a/openmdao/visualization/n2_viewer/gen/TreeNode.js
+++ b/openmdao/visualization/n2_viewer/gen/TreeNode.js
@@ -284,6 +284,8 @@ class TreeNode {
         this.draw.hidden = state.hidden;
         this.filterSelf(state.filtered);
     }
+
+    getTextName() { return this.name; }
 }
 
 /**
@@ -310,6 +312,10 @@ class FilterNode extends TreeNode {
         this.hide();
         this.minimize();
         this.suffix = suffix;
+    }
+
+    getTextName() {
+        return `Filtered ${this.suffix[0].toUpperCase() + this.suffix[0].slice(1)}`;
     }
 
     /**

--- a/openmdao/visualization/n2_viewer/gen/TreeNode.js
+++ b/openmdao/visualization/n2_viewer/gen/TreeNode.js
@@ -13,7 +13,6 @@ class NodeDisplayData {
         this.filtered = false; // Node is a child to be shown w/partially collapsed parent
         this.filterParent = null; // When filtered, reference to FilterNode container
         this.manuallyExpanded = false; // Node was pre-collapsed but expanded by user
-        this.boxChildren = false; // Surround children with a box in the matrix grid
 
         this.dims = new Dimensions({ x: 1e-6, y: 1e-6, width: 1, height: 1 });
         this.dims.preserve();
@@ -59,8 +58,12 @@ class TreeNode {
     }
 
     _newDisplayData() {
-        if (this.isInputOrOutput()) { this.parent.draw.boxChildren = true; }
         return new NodeDisplayData();
+    }
+
+    /** In the matrix grid, draw a box around variables that share the same boxAncestor() */
+    boxAncestor() {
+        return this.isInputOrOutput()? this.parent : null;
     }
 
     // Accessor functions for this.draw.minimized - whether or not to draw children
@@ -423,8 +426,8 @@ class FilterNode extends TreeNode {
  * @property {FilterNode} filter.outputs Children that are outputs to be viewed as collapsed.
  */
 class FilterCapableNode extends TreeNode {
-    constructor(origNode, attribNames) {
-        super(origNode, attribNames);
+    constructor(origNode, attribNames, parent) {
+        super(origNode, attribNames, parent);
     }
 
     // Accessor functions for this.draw.filtered - whether a variable is shown in collapsed form

--- a/openmdao/visualization/n2_viewer/gen/TreeNode.js
+++ b/openmdao/visualization/n2_viewer/gen/TreeNode.js
@@ -451,17 +451,30 @@ class FilterCapableNode extends TreeNode {
         }
     }
 
-    /** Add ourselves to the corrent parental filter */
+    /** Add ourselves to the correct parental filter */
     addSelfToFilter() {
         if (this.isInput()) { this.parent.filter.inputs.add(this); }
         else if (this.isOutput()) { this.parent.filter.outputs.add(this); }
     }
 
-    /** Remove ourselves from the corrent parental filter */
+    /** Remove ourselves from the correct parental filter */
     removeSelfFromFilter() {
         if (this.isInput()) { this.parent.filter.inputs.del(this); }
         else if (this.isOutput()) { this.parent.filter.outputs.del(this); }
     }
+
+    getFilterList() { return [ this.filter.inputs, this.filter.outputs]; }
+
+    wipeFilters() {
+        this.filter.inputs.wipe();
+        this.filter.outputs.wipe();
+    }
+
+    addToFilter(node) {
+        if (node.isInput()) { this.filter.inputs.add(child); }
+        else { this.filter.outputs.add(child); }
+    }
+
 
     /**
      * Filter ourselves based on the supplied filter state.

--- a/openmdao/visualization/n2_viewer/src/OmDiagram.js
+++ b/openmdao/visualization/n2_viewer/src/OmDiagram.js
@@ -19,7 +19,7 @@ class OmDiagram extends Diagram {
         super(modelJSON, false);
 
         // Solver tree initial dimensions are the same as the model tree
-        this.dims.size.solverTree = structuredClone(this.dims.size.partitionTree);
+        this.dims.size.solverTree = {...this.dims.size.partitionTree};
 
         this._init();
     }

--- a/openmdao/visualization/n2_viewer/src/OmModelData.js
+++ b/openmdao/visualization/n2_viewer/src/OmModelData.js
@@ -62,14 +62,13 @@ class OmModelData extends ModelData {
     }
 
     /**
-     * Sets parents and depth of all nodes, and determine max depth. Flags the
+     * Sets depth of all nodes determine max depth. Flags the
      * parent node as implicit if the node itself is implicit.
      * @param {OmTreeNode} node Item to process.
-     * @param {OmTreeNode} parent Parent of node, null for root node.
      * @param {number} depth Numerical level of ancestry.
      */
-     _setParentsAndDepth(node, parent, depth) {
-        super._setParentsAndDepth(node, parent, depth);
+     _setDepth(node, depth) {
+        super._setDepth(node, depth);
 
         if (this.abs2prom.input[node.path] !== undefined) {
             node.promotedName = this.abs2prom.input[node.path];
@@ -94,7 +93,7 @@ class OmModelData extends ModelData {
             this.maxSystemDepth = Math.max(depth, this.maxSystemDepth);
         }
 
-        if (parent && node.implicit) { parent.implicit = true; }
+        if (node.parent && node.implicit) { parent.implicit = true; }
     }
 
     /**

--- a/openmdao/visualization/n2_viewer/src/OmTreeNode.js
+++ b/openmdao/visualization/n2_viewer/src/OmTreeNode.js
@@ -30,6 +30,21 @@ class OmTreeNode extends FilterCapableNode {
     get absPathName() { return this.path; }
     set absPathName(newName) { this.path = newName; return newName; }
 
+    getTextName() {
+        let retVal = this.name;
+
+        if (this.name == '_auto_ivc') {
+            retVal = 'Auto-IVC';
+        }
+        else if (this.isFilter()) {
+            retVal = super.getTextName();
+        }
+        else if (this.path.match(/^_auto_ivc.*/) && this.promotedName !== undefined) {
+            retVal = this.promotedName;
+        }
+        return retVal;
+    }
+
     _newDisplayData() { return new OmNodeDisplayData(); }
 
     addFilterChild(attribNames) {

--- a/openmdao/visualization/n2_viewer/src/OmTreeNode.js
+++ b/openmdao/visualization/n2_viewer/src/OmTreeNode.js
@@ -24,7 +24,6 @@ class OmTreeNode extends FilterCapableNode {
         // Solver names may be empty, so set them to "None" instead.
         if (this.linear_solver == "") this.linear_solver = "None";
         if (this.nonlinear_solver == "") this.nonlinear_solver = "None";
-        if (this.isComponent()) this.draw.boxChildren = true;
         if (exists(this.parentComponent)) this.parentComponent = parent;
     }
 

--- a/openmdao/visualization/n2_viewer/tests/create_generic_model.py
+++ b/openmdao/visualization/n2_viewer/tests/create_generic_model.py
@@ -77,5 +77,5 @@ openmdao_dir = os.path.dirname(inspect.getfile(openmdao))
 vis_dir = os.path.join(openmdao_dir, "visualization/n2_viewer")
 
 HtmlPreprocessor(os.path.join(vis_dir, "tests/gen_test.html"), default_output_filename,
-                    start_path=vis_dir, allow_overwrite=True, var_dict=html_vars,
+                    search_path=[vis_dir], allow_overwrite=True, var_dict=html_vars,
                     verbose=False).run()


### PR DESCRIPTION
### Summary

Multiple fairly minor fixes to the generic model diagram code to accommodate the new Dymos linkage report. The more significant ones include:
- Moving `Layout.getText()` to `TreeNode.getTextName()` to avoid having to derive another Layout class
- Having `HtmlPreprocessor` search a list of paths for included files rather than only look at one path derived from the starting file's location
- Handling TreeNode filters in a more generic way

These changes need to be merged before the new Dymos diagram can be pull requested.

### Backwards incompatibilities

None

### New Dependencies

None
