### PR TITLE
Bug when pyoptsparse used with coloring and scaling report

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -78,7 +78,8 @@ class Driver(object):
     _total_jac_sparsity : dict, str, or None
         Specifies sparsity of sub-jacobians of the total jacobian. Only used by pyOptSparseDriver.
     _total_jac_format : str
-        Specifies the format of the total jacobian.
+        Specifies the format of the total jacobian. Allowed values are 'flat_dict', 'dict', and
+        'array'.
     _res_subjacs : dict
         Dict of sparse subjacobians for use with certain optimizers, e.g. pyOptSparseDriver.
         Keyed by sources and aliases.

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -77,6 +77,8 @@ class Driver(object):
         Metadata pertaining to total coloring.
     _total_jac_sparsity : dict, str, or None
         Specifies sparsity of sub-jacobians of the total jacobian. Only used by pyOptSparseDriver.
+    _total_jac_format : str
+        Specifies the format of the total jacobian.
     _res_subjacs : dict
         Dict of sparse subjacobians for use with certain optimizers, e.g. pyOptSparseDriver.
         Keyed by sources and aliases.
@@ -160,6 +162,7 @@ class Driver(object):
         self._coloring_info = coloring_mod._get_coloring_meta()
 
         self._total_jac_sparsity = None
+        self._total_jac_format = 'flat_dict'
         self._res_subjacs = {}
         self._total_jac = None
         self._total_jac_linear = None

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -21,7 +21,7 @@ from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.array_utils import array_viz
 from openmdao.utils.coloring import _compute_coloring, compute_total_coloring, Coloring
 from openmdao.utils.mpi import MPI
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 from openmdao.test_suite.tot_jac_builder import TotJacBuilder
 from openmdao.utils.general_utils import run_driver
 
@@ -264,6 +264,9 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         # make sure no default reports run because they'll mess up run counts
         om.clear_reports()
 
+    # turn off TESTFLO_RUNNING so that reports will be active, in order to detect a bug
+    # when scaling report and coloring are both active.
+    @set_env_vars(TESTFLO_RUNNING='0')
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_total_coloring_snopt_auto(self):
         # first, run w/o coloring

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -266,7 +266,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
 
     # turn off TESTFLO_RUNNING so that reports will be active, in order to detect a bug
     # when scaling report and coloring are both active.
-    @set_env_vars(TESTFLO_RUNNING='0')
+    @set_env_vars(TESTFLO_RUNNING='0', OPENMDAO_REPORTS='scaling')
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_total_coloring_snopt_auto(self):
         # first, run w/o coloring

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -201,6 +201,7 @@ class pyOptSparseDriver(Driver):
         self._in_user_function = False
         self._check_jac = False
         self._exc_info = None
+        self._total_jac_format = 'dict'
 
         self.cite = CITATIONS
 
@@ -327,7 +328,8 @@ class pyOptSparseDriver(Driver):
         # Calculate and save derivatives for any linear constraints.
         lcons = [key for (key, con) in con_meta.items() if con['linear']]
         if len(lcons) > 0:
-            _lin_jacs = self._compute_totals(of=lcons, wrt=indep_list, return_format='dict')
+            _lin_jacs = self._compute_totals(of=lcons, wrt=indep_list,
+                                             return_format=self._total_jac_format)
             # convert all of our linear constraint jacs to COO format. Otherwise pyoptsparse will
             # do it for us and we'll end up with a fully dense COO matrix and very slow evaluation
             # of linear constraints!
@@ -635,7 +637,7 @@ class pyOptSparseDriver(Driver):
                 self._in_user_function = True
                 sens_dict = self._compute_totals(of=self._quantities,
                                                  wrt=self._indep_list,
-                                                 return_format='dict')
+                                                 return_format=self._total_jac_format)
 
                 # First time through, check for zero row/col.
                 if self._check_jac:

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -149,6 +149,7 @@ class ScipyOptimizeDriver(Driver):
         self.iter_count = 0
         self._check_jac = False
         self._exc_info = None
+        self._total_jac_format = 'array'
 
         self.cite = CITATIONS
 
@@ -400,7 +401,7 @@ class ScipyOptimizeDriver(Driver):
             # precalculate gradients of linear constraints
             if lincons:
                 self._lincongrad_cache = self._compute_totals(of=lincons, wrt=self._dvlist,
-                                                              return_format='array')
+                                                              return_format=self._total_jac_format)
             else:
                 self._lincongrad_cache = None
 
@@ -685,7 +686,7 @@ class ScipyOptimizeDriver(Driver):
         """
         try:
             grad = self._compute_totals(of=self._obj_and_nlcons, wrt=self._dvlist,
-                                        return_format='array')
+                                        return_format=self._total_jac_format)
             self._grad_cache = grad
 
             # First time through, check for zero row/col.

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -46,7 +46,7 @@ def reports_active():
     bool
         Return True if reports are active.
     """
-    return 'TESTFLO_RUNNING' not in os.environ
+    return os.environ.get('TESTFLO_RUNNING', '').lower() not in ('1', 'true')
 
 
 def register_report(name, func, desc, class_name, method, pre_or_post, filename=None, inst_id=None):

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -2,6 +2,7 @@
 import json
 import functools
 import builtins
+import os
 
 import numpy as np
 
@@ -128,6 +129,51 @@ def require_pyoptsparse(optimizer=None):
 
         return obj
     return decorator
+
+
+class set_env_vars(object):
+    """
+    Decorate a function to temporarily set some environment variables.
+
+    Parameters
+    ----------
+    **envs : dict
+        Keyword args corresponding to environment variables to set.
+
+    Attributes
+    ----------
+    envs : dict
+        Saved mapping of environment var name to value.
+    """
+    def __init__(self, **envs):
+        """
+        Initialize attributes.
+        """
+        self.envs = envs
+
+    def __call__(self, fnc):
+
+        def wrap(*args, **kwargs):
+            saved = {}
+            news = set()
+            try:
+                for k, v in self.envs.items():
+                    os.environ[k] = v  # will raise exception if v is not a string
+                    if k in os.environ:
+                        saved[k] = os.environ[k]
+                    else:
+                        news.add(k)
+
+                return fnc(*args, **kwargs)
+            finally:
+                # put environment back as it was
+                for name in news:
+                    if name in os.environ:
+                        del os.environ[name]
+                for k, v in saved.items():
+                    os.environ[k] = v
+
+        return wrap
 
 
 class _ModelViewerDataTreeEncoder(json.JSONEncoder):

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -166,11 +166,12 @@ class set_env_vars(object):
             news = set()
             try:
                 for k, v in self.envs.items():
-                    os.environ[k] = v  # will raise exception if v is not a string
                     if k in os.environ:
                         saved[k] = os.environ[k]
                     else:
                         news.add(k)
+
+                    os.environ[k] = v  # will raise exception if v is not a string
 
                 return fnc(*args, **kwargs)
             finally:

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -145,6 +145,7 @@ class set_env_vars(object):
     envs : dict
         Saved mapping of environment var name to value.
     """
+
     def __init__(self, **envs):
         """
         Initialize attributes.
@@ -152,7 +153,14 @@ class set_env_vars(object):
         self.envs = envs
 
     def __call__(self, fnc):
+        """
+        Apply the decorator.
 
+        Parameters
+        ----------
+        fnc : function
+            The function being wrapped.
+        """
         def wrap(*args, **kwargs):
             saved = {}
             news = set()

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -396,9 +396,8 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
         if driver._total_jac is None:
             # this call updates driver._total_jac
             totals = driver._compute_totals(of=data['oflabels'], wrt=data['wrtlabels'],
-                                            return_format='array')
-        else:
-            totals = driver._total_jac.J
+                                            return_format='dict')
+        totals = driver._total_jac.J
 
         data['linear'] = lindata = {}
         lindata['oflabels'] = [n for n, meta in driver._cons.items() if meta['linear']]

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -396,7 +396,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
         if driver._total_jac is None:
             # this call updates driver._total_jac
             totals = driver._compute_totals(of=data['oflabels'], wrt=data['wrtlabels'],
-                                            return_format='dict')
+                                            return_format=driver._total_jac_format)
         totals = driver._total_jac.J
 
         data['linear'] = lindata = {}

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -395,8 +395,8 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
 
         if driver._total_jac is None:
             # this call updates driver._total_jac
-            totals = driver._compute_totals(of=data['oflabels'], wrt=data['wrtlabels'],
-                                            return_format=driver._total_jac_format)
+            driver._compute_totals(of=data['oflabels'], wrt=data['wrtlabels'],
+                                   return_format=driver._total_jac_format)
         totals = driver._total_jac.J
 
         data['linear'] = lindata = {}

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -397,7 +397,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
             # this call updates driver._total_jac
             driver._compute_totals(of=data['oflabels'], wrt=data['wrtlabels'],
                                    return_format=driver._total_jac_format)
-        totals = driver._total_jac.J
+        totals = driver._total_jac.J  # .J is always an array even if return format != 'array'
 
         data['linear'] = lindata = {}
         lindata['oflabels'] = [n for n, meta in driver._cons.items() if meta['linear']]


### PR DESCRIPTION
### Summary

When used with coloring, the scaling report was setting the return format to 'array' when computing totals, which is incompatible with pyoptsparse, so the scaling report was updated to set the format to the preferred format for the driver.

Also added a decorator to allow temporary setting of environment variables, and tweaked the report system's use of the TESTFLO_RUNNING environment var to make it easier to turn reports on selectively during testing.

### Related Issues

- Resolves #2552

### Backwards incompatibilities

Added a new attribute to Driver called `_total_jac_format` that defaults to 'flat_dict'.  All drivers that support derivatives should set this to the appropriate value or it may cause errors when using the scaling report and coloring.

### New Dependencies

None
