### PR TITLE
remove use of deprecated 'asscalar' in unit test

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -216,6 +216,18 @@ jobs:
           conda info
           conda list
 
+          echo "============================================================="
+          echo "Check installed versions of Python, Numpy and Scipy"
+          echo "============================================================="
+          python -c "import sys; assert str(sys.version).startswith(str(${{ matrix.PY }})), \
+                    f'Python version {sys.version} is not the requested version (${{ matrix.PY }})'"
+
+          python -c "import numpy; assert str(numpy.__version__).startswith(str(${{ matrix.NUMPY }})), \
+                    f'Numpy version {numpy.__version__} is not the requested version (${{ matrix.NUMPY }})'"
+
+          python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
+                    f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
+
       - name: Audit dependencies
         shell: bash -l {0}
         run: |

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -3532,7 +3532,7 @@ class TestFeatureAdvancedExample(unittest.TestCase):
         case = cr.get_case(system_cases[0])
         self.assertEqual(list(case.inputs.keys()), ['x', 'y1', 'y2', 'z'])
 
-        assert_near_equal([np.asscalar(case['y1']) for case in cr.get_cases('root.obj_cmp')],
+        assert_near_equal([case['y1'].item() for case in cr.get_cases('root.obj_cmp')],
                           [25.6, 25.6, 8.33, 4.17, 3.30, 3.18, 3.16,
                            3.16, 3.16, 3.16, 3.16, 3.16, 3.16, 3.16],
                           tolerance=1e-1)


### PR DESCRIPTION
### Summary

Modify test that used deprecated  Numpy function.

`asscalar` has been removed from Numpy with the 1.23 release (June 22, 2022)
(It has been deprecated since Numpy 1.16)

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
