### PR TITLE
Require python>=3.8, use readme.md for long_description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,21 @@
 
 # [OpenMDAO][0]
 
+OpenMDAO is an open-source high-performance computing platform for
+systems analysis and multidisciplinary optimization, written in Python.
+It enables you to decompose your models, making them easier to build and
+maintain, while still solving them in a tightly coupled manner with
+efficient parallel numerical methods.
+
+The OpenMDAO project is primarily focused on supporting gradient-based
+optimization with analytic derivatives to allow you to explore large
+design spaces with hundreds or thousands of design variables, but the
+framework also has a number of parallel computing features that can
+work with gradient-free optimization, mixed-integer nonlinear
+programming, and traditional design space exploration.
+
+If you are using OpenMDAO, please [cite](other/citing.ipynb) us!
+
 ## Documentation
 
 Documentation for the latest version can be found [here][2].
@@ -21,8 +36,8 @@ update periodically.
 ### OpenMDAO Versions
 
 **OpenMDAO 3.x.y** represents the current version and is no longer
-considered **[BETA][15]**.  It requires Python 3.6 or later and is
-maintained [here][4]. 
+considered **[BETA][15]**.  It requires Python 3.7 or later and is
+maintained [here][4].
 To install the latest release, run `pip install --upgrade openmdao`.
 
 **OpenMDAO 2.10.x** is the last version to support Python2.x and will
@@ -30,7 +45,7 @@ only receive critical bug fixes going forward.
 To install this older release, run `pip install "openmdao<3"`
 (the quotes around `openmdao<3` are required).
 
-> **PLEASE NOTE**: This repository was previously named **OpenMDAO/blue**. 
+> **PLEASE NOTE**: This repository was previously named **OpenMDAO/blue**.
 If you had cloned that repository, please update your repository name and
 remotes to reflect these changes. You can find instructions [here][8].
 
@@ -38,7 +53,7 @@ The **OpenMDAO 1.7.4** code repository is now named **OpenMDAO1**, and has moved
 [here][5]. To install it, run: `pip install "openmdao<2"`
 (the quotes around `openmdao<2` are required).
 
-The legacy **OpenMDAO v0.x** (versions 0.13.0 and older) of the 
+The legacy **OpenMDAO v0.x** (versions 0.13.0 and older) of the
 **OpenMDAO-Framework** are [here][6].
 
 ## Install OpenMDAO
@@ -46,10 +61,10 @@ The legacy **OpenMDAO v0.x** (versions 0.13.0 and older) of the
 You have two options for installing **OpenMDAO**, (1) from the
 [Python Package Index (PyPI)][1], and (2) from the [GitHub repository][4].
 
-**OpenMDAO** includes several optional sets of dependencies: 
-`test` for installing the developer tools (e.g., testing, coverage), 
+**OpenMDAO** includes several optional sets of dependencies:
+`test` for installing the developer tools (e.g., testing, coverage),
 `docs` for building the documentation and
-`visualization` for some extra visualization tools.  
+`visualization` for some extra visualization tools.
 Specifying `all` will include all of the optional dependencies.
 
 ### Install from [PyPI][1]
@@ -98,7 +113,7 @@ correctly.  In order to do so, you must install the testing dependencies.
 
     `testflo openmdao -n 1`
 
-3. If everything works correctly, you should see a message stating that there 
+3. If everything works correctly, you should see a message stating that there
 were zero failures.  If the tests produce failures, you are encouraged to report
 them as an [issue][7].  If so, please make sure you include your system spec,
 and include the error message.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ update periodically.
 ### OpenMDAO Versions
 
 **OpenMDAO 3.x.y** represents the current version and is no longer
-considered **[BETA][15]**.  It requires Python 3.7 or later and is
+considered **[BETA][15]**.  It requires Python 3.8 or later and is
 maintained [here][4].
 To install the latest release, run `pip install --upgrade openmdao`.
 

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,18 @@
-import re
-import sys
-
 from setuptools import setup
+
+from pathlib import Path
+from io import open
+
+import re
 
 __version__ = re.findall(
     r"""__version__ = ["']+([0-9\.\-dev]*)["']+""",
     open('openmdao/__init__.py').read(),
 )[0]
+
+with open(Path(__file__).parent / "README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
 
 optional_dependencies = {
     'docs': [
@@ -57,11 +63,7 @@ setup(
     name='openmdao',
     version=__version__,
     description="OpenMDAO framework infrastructure",
-    long_description="""OpenMDAO is an open-source high-performance computing platform
-    for systems analysis and multidisciplinary optimization, written in Python. It
-    enables you to decompose your models, making them easier to build and maintain,
-    while still solving them in a tightly coupled manner with efficient parallel numerical methods.
-    """,
+    long_description=long_description,
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',
@@ -72,7 +74,6 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Topic :: Scientific/Engineering',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
@@ -172,7 +173,7 @@ setup(
         ],
         'openmdao': ['*/tests/*.py', '*/*/tests/*.py', '*/*/*/tests/*.py']
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'networkx>=2.0',
         'numpy',


### PR DESCRIPTION
### Summary

- update `setup.py` with  `python_requires>=3.8` to conform with Numpy  support
- update `long_description` in `setup.py` to use the contents of `readme.md`, which will be displayed on [PyPi](https://pypi.org/project/openmdao/)
- added the introductory text from the docs to `readme.md`
 
### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
