### PR TITLE
specified utf-8 encoding when reading certain files

### DIFF
--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -196,7 +196,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
 
     jsontxt = json.dumps(data)
 
-    with open(outfile, 'w') as f:
+    with open(outfile, 'w', encoding='utf-8') as f:
         s = template.replace("<connection_data>", jsontxt)
         s = s.replace("<tabulator_src>", tabulator_src)
         s = s.replace("<tabulator_style>", tabulator_style)

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -185,13 +185,13 @@ def view_connections(root, outfile='connections.html', show_browser=True,
     libs_dir = os.path.join(os.path.dirname(code_dir), 'common', 'libs')
     style_dir = os.path.join(os.path.dirname(code_dir), 'common', 'style')
 
-    with open(os.path.join(code_dir, viewer), "r") as f:
+    with open(os.path.join(code_dir, viewer), "r", encoding='utf-8') as f:
         template = f.read()
 
-    with open(os.path.join(libs_dir, 'tabulator.min.js'), "r") as f:
+    with open(os.path.join(libs_dir, 'tabulator.min.js'), "r", encoding='utf-8') as f:
         tabulator_src = f.read()
 
-    with open(os.path.join(style_dir, 'tabulator.min.css'), "r") as f:
+    with open(os.path.join(style_dir, 'tabulator.min.css'), "r", encoding='utf-8') as f:
         tabulator_style = f.read()
 
     jsontxt = json.dumps(data)

--- a/openmdao/visualization/html_utils.py
+++ b/openmdao/visualization/html_utils.py
@@ -325,7 +325,7 @@ def add_help(txt, diagram_filepath, header='Instructions', footer=''):
     body = write_div(content=write_paragraph(txt), cls_attr="modal-body")
     toolbar_help_header = write_div(content='Toolbar Help', cls_attr="modal-section-header")
 
-    with open(diagram_filepath, "r") as f:
+    with open(diagram_filepath, "r", encoding='utf-8') as f:
         help_diagram = f.read()
     help_diagram = write_div(content=help_diagram, cls_attr="toolbar-help")
 

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -443,16 +443,16 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
         libs_dir = os.path.join(os.path.dirname(code_dir), 'common', 'libs')
         style_dir = os.path.join(os.path.dirname(code_dir), 'common', 'style')
 
-        with open(os.path.join(code_dir, viewer), "r") as f:
+        with open(os.path.join(code_dir, viewer), "r", encoding='utf-8') as f:
             template = f.read()
 
-        with open(os.path.join(libs_dir, 'tabulator.min.js'), "r") as f:
+        with open(os.path.join(libs_dir, 'tabulator.min.js'), "r", encoding='utf-8') as f:
             tabulator_src = f.read()
 
-        with open(os.path.join(style_dir, 'tabulator.min.css'), "r") as f:
+        with open(os.path.join(style_dir, 'tabulator.min.css'), "r", encoding='utf-8') as f:
             tabulator_style = f.read()
 
-        with open(os.path.join(libs_dir, 'd3.v6.min.js'), "r") as f:
+        with open(os.path.join(libs_dir, 'd3.v6.min.js'), "r", encoding='utf-8') as f:
             d3_src = f.read()
 
         jsontxt = json.dumps(data, default=default_noraise)

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -457,7 +457,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
 
         jsontxt = json.dumps(data, default=default_noraise)
 
-        with open(outfile, 'w') as f:
+        with open(outfile, 'w', encoding='utf-8') as f:
             s = template.replace("<tabulator_src>", tabulator_src)
             s = s.replace("<tabulator_style>", tabulator_style)
             s = s.replace("<d3_src>", d3_src)

--- a/openmdao/visualization/timing_viewer/timing_viewer.py
+++ b/openmdao/visualization/timing_viewer/timing_viewer.py
@@ -174,16 +174,16 @@ def view_timing(timing_file, outfile='timing_report.html', show_browser=True):
         libs_dir = os.path.join(os.path.dirname(code_dir), 'common', 'libs')
         style_dir = os.path.join(os.path.dirname(code_dir), 'common', 'style')
 
-        with open(os.path.join(code_dir, viewer), "r") as f:
+        with open(os.path.join(code_dir, viewer), "r", encoding='utf-8') as f:
             template = f.read()
 
-        with open(os.path.join(libs_dir, 'tabulator.min.js'), "r") as f:
+        with open(os.path.join(libs_dir, 'tabulator.min.js'), "r", encoding='utf-8') as f:
             tabulator_src = f.read()
 
-        with open(os.path.join(style_dir, 'tabulator.min.css'), "r") as f:
+        with open(os.path.join(style_dir, 'tabulator.min.css'), "r", encoding='utf-8') as f:
             tabulator_style = f.read()
 
-        with open(os.path.join(libs_dir, 'd3.v6.min.js'), "r") as f:
+        with open(os.path.join(libs_dir, 'd3.v6.min.js'), "r", encoding='utf-8') as f:
             d3_src = f.read()
 
         jsontxt = json.dumps(data, default=default_noraise)

--- a/openmdao/visualization/timing_viewer/timing_viewer.py
+++ b/openmdao/visualization/timing_viewer/timing_viewer.py
@@ -188,7 +188,7 @@ def view_timing(timing_file, outfile='timing_report.html', show_browser=True):
 
         jsontxt = json.dumps(data, default=default_noraise)
 
-        with open(outfile, 'w') as f:
+        with open(outfile, 'w', encoding='utf-8') as f:
             s = template.replace("<tabulator_src>", tabulator_src)
             s = s.replace("<tabulator_style>", tabulator_style)
             s = s.replace("<d3_src>", d3_src)


### PR DESCRIPTION
### Summary

A user was getting encoding errors when running the scaling viewer because we weren't specifying the encoding when reading some of our html files.

### Related Issues

- Resolves #2562

### Backwards incompatibilities

None

### New Dependencies

None
