### PR TITLE
Use mamba instead of conda in CI workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -136,6 +136,8 @@ jobs:
           else
             mamba install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
           fi
+
+          export OMPI_MCA_rmaps_base_oversubscribe=1
           echo "-----------------------"
           echo "Quick test of mpi4py:"
           mpirun -n 2 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
@@ -143,6 +145,7 @@ jobs:
           echo "Quick test of petsc4py:"
           mpirun -n 2 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; import petsc4py; petsc4py.init(); x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  print(x.getArray())"
           echo "-----------------------"
+
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
 
       - name: Install pyOptSparse

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -56,8 +56,9 @@ jobs:
             PY: 3.8
             NUMPY: 1.22
             SCIPY: 1.7
+            OPENMPI: '4.0'
             MPI4PY: '3.0'
-            PETSc: 3.12
+            PETSc: 3.13
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             OPTIONAL: '[all]'
@@ -92,16 +93,18 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Setup miniconda
+      - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.PY }}
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
 
       - name: Install OpenMDAO
         shell: bash -l {0}
         run: |
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip
 
@@ -119,15 +122,6 @@ jobs:
           echo "============================================================="
           python -m pip install jax jaxlib
 
-      - name: Install dependencies for Oldest
-        if: matrix.name == 'Oldest'
-        shell: bash -l {0}
-        run: |
-          echo "============================================================="
-          echo "Install dependencies for Oldest"
-          echo "============================================================="
-          conda install -c conda-forge openmpi=4.0
-
       - name: Install PETSc
         if: matrix.PETSc
         shell: bash -l {0}
@@ -135,10 +129,12 @@ jobs:
           echo "============================================================="
           echo "Install PETSc"
           echo "============================================================="
-          if [[ "${{ matrix.MPI4PY }}" ]]; then
-            conda install -c conda-forge mpi4py=${{ matrix.MPI4PY }} petsc=${{ matrix.PETSc }} petsc4py -q -y
+          if [[ "${{ matrix.OPENMPI }}" && "${{ matrix.MPI4PY }}" ]]; then
+            mamba install openmpi=${{ matrix.OPENMPI }} mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
+          elif [[ "${{ matrix.MPI4PY }}" ]]; then
+            mamba install mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
           else
-            conda install -c conda-forge mpi4py petsc=${{ matrix.PETSc }} petsc4py -q -y
+            mamba install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
           fi
           echo "-----------------------"
           echo "Quick test of mpi4py:"
@@ -158,7 +154,7 @@ jobs:
           echo "============================================================="
 
           if [[ "${{ matrix.PYOPTSPARSE }}" == "conda-forge" ]]; then
-            conda install -c conda-forge pyoptsparse
+            mamba install pyoptsparse
             if [[ "${{ matrix.SNOPT }}" ]]; then
               echo "SNOPT ${{ matrix.SNOPT }} was requested but is not available on conda-forge"
             fi
@@ -210,11 +206,11 @@ jobs:
           echo "============================================================="
           python -m pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
 
-      - name: Display conda info
+      - name: Display environmant info
         shell: bash -l {0}
         run: |
-          conda info
-          conda list
+          mamba info
+          mamba list
 
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"
@@ -348,7 +344,7 @@ jobs:
         include:
           # baseline versions
           - NAME: Baseline
-            PY: 3
+            PY: 3.9
             NUMPY: 1.22
             SCIPY: 1.6
 
@@ -372,16 +368,18 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Setup miniconda
+      - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-conda: true
           python-version: ${{ matrix.PY }}
+          mamba-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
 
       - name: Install OpenDMAO
         shell: pwsh
         run: |
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip
 
@@ -398,11 +396,23 @@ jobs:
           echo "============================================================="
           python -m pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
 
-      - name: Display conda info
+      - name: Display environment info
         shell: pwsh
         run: |
-          conda info
-          conda list
+          mamba info
+          mamba list
+
+          echo "============================================================="
+          echo "Check installed versions of Python, Numpy and Scipy"
+          echo "============================================================="
+          python -c "import sys; assert str(sys.version).startswith(str(${{ matrix.PY }})), \
+                    f'Python version {sys.version} is not the requested version (${{ matrix.PY }})'"
+
+          python -c "import numpy; assert str(numpy.__version__).startswith(str(${{ matrix.NUMPY }})), \
+                    f'Numpy version {numpy.__version__} is not the requested version (${{ matrix.NUMPY }})'"
+
+          python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
+                    f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Audit dependencies
         shell: bash -l {0}

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -277,13 +277,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_total_coloring_snopt_auto_autoivc(self):
@@ -296,13 +298,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_total_coloring_snopt_auto_dyn_partials(self):
@@ -314,13 +318,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
         partial_coloring = p_color.model._get_subsystem('arctan_yox')._coloring_info['coloring']
         expected = [
@@ -345,16 +351,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
 
-        # This has been changed to greater or equal to 28 iterations. This change arose when updating
-        # to pyOptSparse v2.1.0 and SNOPT 7.7
-        self.assertGreaterEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_total_coloring_snopt_auto_assembled(self):
@@ -366,13 +371,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_fwd_simul_coloring_snopt_approx_cs(self):
@@ -385,12 +392,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - fwd coloring saves 16 nonlinear solves per driver iter  (6 vs 22).
-        # - dynamic coloring takes 66 nonlinear solves (22 each for 3 full jacs)
-        # - (total_solves - 2) / (solves_per_iter) should be equal to
-        #       (total_color_solves - 2 - dyn_solves) / color_solves_per_iter
-        self.assertEqual((p.model._solve_nl_count - 2) / 22,
-                         (p_color.model._solve_nl_count - 2 - 66) / 6)
+        p.model._solve_nl_count = 0
+        p_color.model._solve_nl_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_nl_count, 21)
+        self.assertEqual(p_color.model._solve_nl_count, 5)
 
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_dynamic_fwd_simul_coloring_snopt_approx_fd(self):
@@ -403,13 +413,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
+        p.model._solve_nl_count = 0
+        p_color.model._solve_nl_count = 0
 
-        # - fwd coloring saves 16 nonlinear solves per driver iter  (6 vs 22).
-        # - dynamic coloring takes 66 nonlinear solves (22 each for 3 full jacs)
-        # - (total_solves - 2) / (solves_per_iter) should be equal to
-        #       (total_color_solves - 2 - dyn_solves) / color_solves_per_iter
-        self.assertEqual((p.model._solve_nl_count - 2) / 22,
-                         (p_color.model._solve_nl_count - 2 - 66) / 6)
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_nl_count, 21)
+        self.assertEqual(p_color.model._solve_nl_count, 5)
 
     def test_size_zero_array_in_component(self):
         class DynamicPartialsComp(om.ExplicitComponent):
@@ -512,13 +524,15 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         p = run_opt(pyOptSparseDriver, 'auto', optimizer='SLSQP', print_results=False)
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
         # test __repr__
         rep = repr(p_color.driver._coloring_info['coloring'])
@@ -591,13 +605,15 @@ class SimulColoringPyoptSparseRevTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - rev coloring saves 11 solves per driver iter  (11 vs 22)
-        # - initial solve for linear constraints takes 1 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 22 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 1 for the uncolored case and 22 * 3 + 1 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 1) / 22,
-                         (p_color.model._solve_count - 1 - 22 * 3) / 11)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 11 solves per driver iter  (11 vs 22)
+        self.assertEqual(p.model._solve_count, 22)
+        self.assertEqual(p_color.model._solve_count, 11)
 
         # improve coverage of coloring.py
         coloring = p_color.driver._coloring_info['coloring']
@@ -628,13 +644,15 @@ class SimulColoringPyoptSparseRevTestCase(unittest.TestCase):
         p = run_opt(pyOptSparseDriver, 'rev', optimizer='SLSQP', print_results=False)
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
 
-        # - coloring saves 11 solves per driver iter  (11 vs 22)
-        # - initial solve for linear constraints takes 1 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 22 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 1 for the uncolored case and 22 * 3 + 1 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 1) / 22,
-                         (p_color.model._solve_count - 1 - 22 * 3) / 11)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 11 solves per driver iter  (11 vs 22)
+        self.assertEqual(p.model._solve_count, 22)
+        self.assertEqual(p_color.model._solve_count, 11)
 
 
 @use_tempdirs
@@ -662,13 +680,15 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - bidirectional coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
     def test_dynamic_total_coloring_auto_con_alias(self):
         # This test makes sure that coloring works with aliased constraints.
@@ -680,13 +700,15 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - bidirectional coloring saves 16 solves per driver iter  (5 vs 21)
-        # - initial solve for linear constraints takes 21 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 21 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 21 for the uncolored case and 21 * 4 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 21) / 21,
-                         (p_color.model._solve_count - 21 * 4) / 5)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (5 vs 21)
+        self.assertEqual(p.model._solve_count, 21)
+        self.assertEqual(p_color.model._solve_count, 5)
 
     def test_problem_total_coloring_auto(self):
 
@@ -963,13 +985,15 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
         assert_almost_equal(p['circle.area'], np.pi, decimal=7)
         assert_almost_equal(p_color['circle.area'], np.pi, decimal=7)
 
-        # - rev coloring saves 11 solves per driver iter  (11 vs 22)
-        # - initial solve for linear constraints takes 1 in both cases (only done once)
-        # - dynamic case does 3 full compute_totals to compute coloring, which adds 22 * 3 solves
-        # - (total_solves - N) / (solves_per_iter) should be equal between the two cases,
-        # - where N is 1 for the uncolored case and 22 * 3 + 1 for the dynamic colored case.
-        self.assertEqual((p.model._solve_count - 1) / 22,
-                         (p_color.model._solve_count - 1 - 22 * 3) / 11)
+        p.model._solve_count = 0
+        p_color.model._solve_count = 0
+
+        J = p.driver._compute_totals()
+        J_color = p_color.driver._compute_totals()
+
+        # coloring saves 16 solves per driver iter  (11 vs 22)
+        self.assertEqual(p.model._solve_count, 22)
+        self.assertEqual(p_color.model._solve_count, 11)
 
     def test_dynamic_total_coloring_no_derivs(self):
         with self.assertRaises(Exception) as context:


### PR DESCRIPTION
### Summary

Conda is having difficulty installing petsc/petsc4py due to some internal issues, but these seem to be resolved by using mamba instead. Switch the actions script to use mamba for setting up the CI system.

Also, update coloring tests to make them more robust.

### Related Issues

- Resolves #2564 

### Backwards incompatibilities

None

### New Dependencies

None
