### PR TITLE
Fixed N2 diagram NL-solver toolbar button

### DIFF
--- a/openmdao/visualization/n2_viewer/src/OmDiagram.js
+++ b/openmdao/visualization/n2_viewer/src/OmDiagram.js
@@ -30,14 +30,11 @@ class OmDiagram extends Diagram {
 
     /** Override Diagram._newLayout() to create an OmLayout object. */
     _newLayout() {
-        if (this.showLinearSolverNames === undefined)
-            this.showLinearSolverNames = true;
 
         if (this.showSolvers === undefined)
             this.showSolvers = true;
 
-        return new OmLayout(this.model, this.zoomedElement, this.dims,
-            this.showLinearSolverNames, this.showSolvers);
+        return new OmLayout(this.model, this.zoomedElement, this.dims, this.showSolvers);
     }
 
     /** Create a new OmMatrix object. Overrides superclass method. */
@@ -55,13 +52,6 @@ class OmDiagram extends Diagram {
         this.layout = this._newLayout();
         this.ui = new OmUserInterface(this);
         this.matrix = this._newMatrix(true);
-    }
-
-    /**
-     * Switch back and forth between showing the linear or non-linear solver names.
-     */
-    toggleSolverNameType() {
-        this.showLinearSolverNames = !this.showLinearSolverNames;
     }
 
     /**
@@ -115,8 +105,8 @@ class OmDiagram extends Diagram {
         const enterSelection = enter
             .append("g")
             .attr("class", d => {
-                const solver_class = self.style.getSolverClass(self.showLinearSolverNames,
-                    { 'linear': d.linear_solver, 'nonLinear': d.nonlinear_solver });
+                const solver_class = self.style.getSolverClass({ 'linear': d.linear_solver,
+                    'nonLinear': d.nonlinear_solver });
                 return `${solver_class} solver_group ${self.style.getNodeClass(d)}`;
             })
             .on("click", (e,d) => self.leftClickSelector(e, d))
@@ -172,7 +162,7 @@ class OmDiagram extends Diagram {
 
         enterSelection // Add a label
             .append("text")
-            .text(self.layout.getSolverText.bind(self.layout))
+            .text( d => d.getSolverText())
             .style('visibility', 'hidden')
             .attr("dy", ".35em")
             .attr("transform", d => {
@@ -203,8 +193,8 @@ class OmDiagram extends Diagram {
         // New location for each group
         const mergedSelection = update
             .attr("class", d => {
-                const solver_class = self.style.getSolverClass(self.showLinearSolverNames,
-                    { 'linear': d.linear_solver, 'nonLinear': d.nonlinear_solver });
+                const solver_class = self.style.getSolverClass({ 'linear': d.linear_solver,
+                    'nonLinear': d.nonlinear_solver });
                 return `${solver_class} solver_group ${self.style.getNodeClass(d)}`;
             })
             .transition(sharedTransition)
@@ -224,6 +214,7 @@ class OmDiagram extends Diagram {
          // Move the text label
         mergedSelection
             .select("text")
+            .text( d => d.getSolverText())
             .attr("transform", d => {
                 const anchorX = d.draw.solverDims.width * treeSize.width -
                     self.layout.size.rightTextMargin;
@@ -315,7 +306,7 @@ class OmDiagram extends Diagram {
      */
      restoreSavedState(oldState) {
         // Solver toggle state.
-        this.showLinearSolverNames = oldState.showLinearSolverNames;
+        OmTreeNode.showLinearSolverNames = oldState.showLinearSolverNames;
         this.ui.setSolvers(oldState.showLinearSolverNames);
         this.showSolvers = oldState.showSolvers;
         

--- a/openmdao/visualization/n2_viewer/src/OmLayout.js
+++ b/openmdao/visualization/n2_viewer/src/OmLayout.js
@@ -55,7 +55,7 @@ class OmLayout extends Layout {
         if (node.draw.hidden) return;
         super._updateTextWidths(node);
 
-        if (!node.isInputOrOutput()) {
+        if (!node.isInputOrOutput() && !node.isFilter()) {
             node.draw.nameSolverWidthPx = this._getTextWidth(node.getSolverText()) + 2 *
                 this.size.rightTextMargin;
         }

--- a/openmdao/visualization/n2_viewer/src/OmLayout.js
+++ b/openmdao/visualization/n2_viewer/src/OmLayout.js
@@ -17,15 +17,13 @@ class OmLayout extends Layout {
      * @param {ModelData} model The pre-processed model object.
      * @param {Object} newZoomedElement The element the new layout is based around.
      * @param {Object} dims The initial sizes for multiple tree elements.
-     * @param {Boolean} showLinearSolverNames Whether to show linear or non-linear solver names.
      * @param {Boolean} showSolvers Whether to display the solver tree.
      */
-    constructor(model, zoomedElement, dims, showLinearSolverNames, showSolvers) {
+    constructor(model, zoomedElement, dims, showSolvers) {
         super(model, zoomedElement, dims, false);
 
         this.zoomedSolverNodes = [];
         this.visibleSolverNodes = [];
-        this.showLinearSolverNames = showLinearSolverNames;
         this.showSolvers = showSolvers;
         this._init();
     }
@@ -50,22 +48,6 @@ class OmLayout extends Layout {
     }
 
     /**
-     * Return the name of the linear or non-linear solver depending
-     * on the current setting.
-     * @param {OmTreeNode} node The item to get the solver text from.
-     */
-     getSolverText(node) {
-        let solver_name = this.showLinearSolverNames ? node.linear_solver : node.nonlinear_solver;
-
-        if (!this.showLinearSolverNames && node.hasOwnProperty("solve_subsystems") && node.solve_subsystems) {
-            return solver_name + " (sub_solve)";
-        }
-        else {
-            return solver_name;
-        }
-    }
-
-    /**
      * Determine text widths for all descendents of the specified node.
      * @param {OmTreeNode} [node = this.zoomedElement] Item to begin looking from.
      */
@@ -74,7 +56,7 @@ class OmLayout extends Layout {
         super._updateTextWidths(node);
 
         if (!node.isInputOrOutput()) {
-            node.draw.nameSolverWidthPx = this._getTextWidth(this.getSolverText(node)) + 2 *
+            node.draw.nameSolverWidthPx = this._getTextWidth(node.getSolverText()) + 2 *
                 this.size.rightTextMargin;
         }
     }

--- a/openmdao/visualization/n2_viewer/src/OmLegend.js
+++ b/openmdao/visualization/n2_viewer/src/OmLegend.js
@@ -170,7 +170,6 @@ class OmLegend extends Legend {
         }
     }
 
-
     /** Add symbols for all of the items that were discovered */
     _setupContents() {
         super._setupContents();
@@ -183,18 +182,18 @@ class OmLegend extends Legend {
     }
 
     /**
-     * Wipe the current solvers legend area and populate with the other type.
-     * @param {Boolean} linear True to use linear solvers, false for non-linear.
+     * Wipe the current solvers legend area and populate with the current setting.
      */
-    toggleSolvers(linear) {
+    updateSolvers() {
         const solversLegendTitle = d3.select('#solvers-legend-title');
-        solversLegendTitle.text(linear ? "Linear Solvers" : "Non-Linear Solvers");
+        solversLegendTitle.text(OmTreeNode.showLinearSolverNames?
+            "Linear Solvers" : "Non-Linear Solvers");
 
         const solversLegend = d3.select('#solvers-legend');
         solversLegend.html('');
 
-        const solvers = linear ? this.linearSolvers : this.nonLinearSolvers;
-        for (let item of solvers) this._addItem(item, solversLegend);
+        const solvers = OmTreeNode.showLinearSolverNames? this.linearSolvers : this.nonLinearSolvers;
+        for (const item of solvers) this._addItem(item, solversLegend);
 
         solversLegend.style('width', solversLegend.node().scrollWidth + 'px');
     }

--- a/openmdao/visualization/n2_viewer/src/OmStyle.js
+++ b/openmdao/visualization/n2_viewer/src/OmStyle.js
@@ -145,14 +145,13 @@ class OmStyle extends Style {
 
     /**
      * Determine the name of the CSS class based on the name of the solver.
-     * @param {boolean} showLinearSolverNames Whether to use the linear or non-linear solver name.
      * @param {Object} solverNames
      * @param {string} solverNames.linear The linear solver name.
      * @param {string} solverNames.nonLinear The non-linear solver name.
      * @return {string} The CSS class of the solver, or for "other" if not found.
      */
-    getSolverClass(showLinearSolverNames, solverNames) {
-        const solverName = showLinearSolverNames? solverNames.linear : solverNames.nonLinear;
+    getSolverClass(solverNames) {
+        const solverName = OmTreeNode.showLinearSolverNames? solverNames.linear : solverNames.nonLinear;
         return this.solvers[solverName]? this.solvers[solverName].class : this.solvers.other.class;
     }
 

--- a/openmdao/visualization/n2_viewer/src/OmTreeNode.js
+++ b/openmdao/visualization/n2_viewer/src/OmTreeNode.js
@@ -18,6 +18,15 @@ class OmNodeDisplayData extends NodeDisplayData {
  * @typedef OmTreeNode
  */
 class OmTreeNode extends FilterCapableNode {
+    static showLinearSolverNames = true;
+
+    /**
+     * Switch back and forth between showing the linear or non-linear solver names.
+     */
+    static toggleSolverNameType() {
+        this.showLinearSolverNames = !this.showLinearSolverNames;
+    }
+
     constructor(origNode, attribNames, parent) {
         super(origNode, attribNames, parent);
 
@@ -30,6 +39,11 @@ class OmTreeNode extends FilterCapableNode {
     get absPathName() { return this.path; }
     set absPathName(newName) { this.path = newName; return newName; }
 
+    /**
+     * Perform special checking for filter and auto-IVC nodes when determining
+     * the node's name.
+     * @returns {String} The label for the node.
+     */
     getTextName() {
         let retVal = this.name;
 
@@ -45,6 +59,23 @@ class OmTreeNode extends FilterCapableNode {
         return retVal;
     }
 
+    /**
+     * Return the name of the linear or non-linear solver depending
+     * on the value of OmTreeNode.showLinearSolverNames.
+     * @returns {String} The label for the solver node.
+     */
+    getSolverText() {
+        const solverName = OmTreeNode.showLinearSolverNames? this.linear_solver : this.nonlinear_solver;
+        let suffix = '';
+
+        if (!OmTreeNode.showLinearSolverNames && 'solve_subsystems' in this && this.solve_subsystems) {
+            suffix = ' (sub_solve)';
+        }
+
+        return `${solverName}${suffix}`;
+    }
+
+    /** Create and return a new  OmNodeDisplayData object. */
     _newDisplayData() { return new OmNodeDisplayData(); }
 
     addFilterChild(attribNames) {

--- a/openmdao/visualization/n2_viewer/src/OmUserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/OmUserInterface.js
@@ -50,16 +50,13 @@ class OmUserInterface extends UserInterface {
      */
     setSolvers(linear) {
         // Update the diagram
-        this.diag.showLinearSolverNames = linear;
+        OmTreeNode.showLinearSolverNames = linear;
 
         // update the legend
-        this.legend.toggleSolvers(this.diag.showLinearSolverNames);
+        this.legend.updateSolvers();
 
         if (this.legend.shown)
-            this.legend.show(
-                this.diag.showLinearSolverNames,
-                this.diag.style.solvers
-            );
+            this.legend.show();
         this.diag.update();
     }
 
@@ -110,7 +107,7 @@ class OmUserInterface extends UserInterface {
     saveState() {
         // Solver toggle state.
         const extraData = {
-            'showLinearSolverNames': this.diag.showLinearSolverNames,
+            'showLinearSolverNames': OmTreeNode.showLinearSolverNames,
             'showSolvers': this.diag.showSolvers,            
         }
 

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -449,6 +449,23 @@ n2_gui_test_scripts = {
             "selector": "g#n2elements rect#cellShape_node_23.vMid",
             "arrowCount": 2
         },
+        {"test": "root"},
+        {
+            "desc": "Expand solver selector toolbar group",
+            "test": "hover",
+            "selector": "div.group-3 > div.expandable:nth-child(2)"
+        },
+        {
+            "desc": "Click on non-linear solver toolbar button",
+            "test": "click",
+            "button": "left",
+            "selector": "#non-linear-solver-button"
+        },
+        {
+            "desc": "Check that solver names have been updated",
+            "test": "hover",
+            "selector": 'g.solver_nl_nlbgs:has-text("NL: NLBGS") > rect'
+        }
     ],
     "parabaloid": [
         {


### PR DESCRIPTION
### Summary
Fixed the action of toolbar button for switching between displaying linear and non-linear solvers, and added a test. Moved the functions that return solver node names into `OmTreeNode` so that `OmDiagram` and `OmLayout` don't have to store the display state themselves. Also performed other minor cleanups.

### Related Issues

- Resolves #2570 

### Backwards incompatibilities

None

### New Dependencies

None
