### PR TITLE
Allowed total derivatives to be approximated when there is discrete coupling

### DIFF
--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -213,10 +213,15 @@ class _TotalJacInfo(object):
                 inter = discrete_outs.intersection(model._relevant[inp]['@all'][0]['output'])
                 if inter:
                     kind = 'of' if self.mode == 'rev' else 'with respect to'
-                    raise RuntimeError("Total derivative %s '%s' depends upon "
-                                       "discrete output variables %s." %
-                                       (kind, inp, sorted(inter)))
-
+                    msg = "Total derivative %s '%s' depends upon " \
+                          "discrete output variables %s." % (kind, inp, sorted(inter))
+                    if not approx:
+                        raise RuntimeError(msg)
+                    else:
+                        msg += " Since this total derivative is approximated this might " \
+                               "not be a problem."
+                        issue_warning(msg, category=DerivativesWarning)
+                        
         self.of = of
         self.wrt = wrt
         self.prom_of = prom_of


### PR DESCRIPTION
### Summary

It is often possible to approximate total derivatives even there there is discrete coupling in a system. However, without the changes proposed in this pull request OpenMDAO would not attempt to approximate the total derivatives. These small changes make it possible to use OpenMDAO to investigate a large set of problems where it is unavoidable to pass discrete inputs and outputs between components.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None

### Example

```
import numpy as np
from openmdao.test_suite.components.sellar_feature import SellarDis2

import openmdao.api as om


class SellarDis1Modified(om.ExplicitComponent):

    def setup(self):
        self.add_input('z', val=np.zeros(2))
        self.add_input('x', val=0.)
        self.add_input('y2', val=1.0)
        self.add_discrete_output('y1_discrete', val='1.0')

    def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
        z1 = inputs['z'][0]
        z2 = inputs['z'][1]
        x1 = inputs['x']
        y2 = inputs['y2']
        y1 = z1 ** 2 + z2 + x1 - 0.2 * y2
        discrete_outputs['y1_discrete'] = str(y1[0])


class StrToFloat(om.ExplicitComponent):
    """
    Component containing Discipline 1 -- no derivatives version.
    """

    def setup(self):
        self.add_discrete_input('y1_discrete', val='1.0')
        self.add_output('y1', val=1.0)

    def compute(self, inputs, outputs, discrete_inputs, discrete_outputs):
        outputs['y1'] = complex(discrete_inputs['y1_discrete'])


class SellarMDA(om.Group):
    """
    Group containing the Sellar MDA.
    """

    def setup(self):
        cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
        cycle.add_subsystem('d1', SellarDis1Modified(), promotes=['x', 'z', 'y2', 'y1_discrete'])
        cycle.add_subsystem('dx', StrToFloat(), promotes=['y1_discrete', 'y1'])
        cycle.add_subsystem('d2', SellarDis2(), promotes=['z', 'y1', 'y2'])

        cycle.set_input_defaults('x', 1.0)
        cycle.set_input_defaults('z', np.array([5.0, 2.0]))

        # Nonlinear Block Gauss Seidel is a gradient free solver
        cycle.nonlinear_solver = om.NonlinearBlockGS()

        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                  z=np.array([0.0, 0.0]), x=0.0),
                           promotes=['x', 'z', 'y1', 'y2', 'obj'])

        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])
        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])


prob = om.Problem()
prob.model = SellarMDA()

prob.driver = om.ScipyOptimizeDriver()
prob.driver.options['optimizer'] = 'SLSQP'
prob.driver.options['tol'] = 1e-8

prob.model.add_design_var('x', lower=0, upper=10)
prob.model.add_design_var('z', lower=0, upper=10)
prob.model.add_objective('obj')
prob.model.add_constraint('con1', upper=0)
prob.model.add_constraint('con2', upper=0)

prob.model.approx_totals()

prob.setup()
prob.set_solver_print(level=0)

prob.run_driver()

print('minimum found at')
print(prob.get_val('x')[0])
print(prob.get_val('z'))

print('minumum objective')
print(prob.get_val('obj')[0])
```