### PR TITLE
update GitHub workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -19,39 +19,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # baseline versions
+          # test baseline versions
           - NAME: Baseline
             PY: '3.10'
             NUMPY: 1.22
             SCIPY: 1.7
             PETSc: 3.16
             PYOPTSPARSE: 'v2.8.3'
+            PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: True
-            BANDIT: True
-            BUILD_DOCS: True
-            PUBLISH_DOCS: True
+            JAX: true
+            BANDIT: true
+            TESTS: true
 
-          # latest versions
+          # test latest versions
           - NAME: Latest
             PY: 3
             NUMPY: 1
             SCIPY: 1
             PETSc: 3
-            PYOPTSPARSE: 'main'
+            PYOPTSPARSE: 'latest'
+            PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
+            TESTS: true
 
-          # minimal install
+          # test minimal install
           - NAME: Minimal
             PY: 3
             NUMPY: 1
             SCIPY: 1
             PYOPTSPARSE: 'conda-forge'
             OPTIONAL: '[test]'
+            TESTS: true
 
-          # oldest supported versions
+          # test oldest supported versions
           - NAME: Oldest
             PY: 3.8
             NUMPY: 1.22
@@ -62,6 +65,19 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: 7.2
             OPTIONAL: '[all]'
+            TESTS: true
+
+          # build docs (baseline versions)
+          - NAME: BuildDocs
+            PY: '3.10'
+            NUMPY: 1.22
+            SCIPY: 1.7
+            PETSc: 3.16
+            PYOPTSPARSE: 'v2.8.3'
+            SNOPT: 7.7
+            OPTIONAL: '[all]'
+            JAX: true
+            BUILD_DOCS: true
 
     name: Ubuntu ${{ matrix.NAME }}
 
@@ -93,18 +109,18 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Setup mamba
+      - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
-          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
+          auto-update-conda: true
 
       - name: Install OpenMDAO
         shell: bash -l {0}
         run: |
-          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip
 
@@ -129,21 +145,30 @@ jobs:
           echo "============================================================="
           echo "Install PETSc"
           echo "============================================================="
-          if [[ "${{ matrix.OPENMPI }}" && "${{ matrix.MPI4PY }}" ]]; then
-            mamba install openmpi=${{ matrix.OPENMPI }} mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
-          elif [[ "${{ matrix.MPI4PY }}" ]]; then
-            mamba install mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
+          if [[ "${{ matrix.OPENMPI }}" ]]; then
+            COMPILERS="cython compilers openmpi-mpicc=${{ matrix.OPENMPI }}"
           else
-            mamba install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
+            COMPILERS="cython compilers openmpi-mpicc"
           fi
+
+          if [[  "${{ matrix.MPI4PY }}" ]]; then
+            MPI4PY="mpi4py=${{ matrix.MPI4PY }}"
+          else
+            MPI4PY="mpi4py"
+          fi
+
+          conda install $COMPILERS $MPI4PY petsc4py=${{ matrix.PETSc }} -q -y
 
           export OMPI_MCA_rmaps_base_oversubscribe=1
           echo "-----------------------"
           echo "Quick test of mpi4py:"
-          mpirun -n 2 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
+          mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
           echo "-----------------------"
           echo "Quick test of petsc4py:"
-          mpirun -n 2 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; import petsc4py; petsc4py.init(); x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  print(x.getArray())"
+          mpirun -n 3 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; \
+                                 import petsc4py; petsc4py.init(); \
+                                 x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  \
+                                 print(x.getArray())"
           echo "-----------------------"
 
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
@@ -157,47 +182,41 @@ jobs:
           echo "============================================================="
 
           if [[ "${{ matrix.PYOPTSPARSE }}" == "conda-forge" ]]; then
-            mamba install pyoptsparse
             if [[ "${{ matrix.SNOPT }}" ]]; then
               echo "SNOPT ${{ matrix.SNOPT }} was requested but is not available on conda-forge"
             fi
+
+            conda install -c conda-forge pyoptsparse
           else
-            git clone -q https://github.com/OpenMDAO/build_pyoptsparse
+            pip install git+https://github.com/OpenMDAO/build_pyoptsparse
 
-            cd build_pyoptsparse
-            chmod 755 ./build_pyoptsparse.sh
+            if [[ "${{ matrix.PYOPTSPARSE }}" == "latest" ]]; then
+              LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/mdolab/pyoptsparse/releases/latest`
+              LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,"/tag/"); print a[2]}'`
+              BRANCH="-b $LATEST_VER"
+            else
+              BRANCH="-b ${{ matrix.PYOPTSPARSE }}"
+            fi
 
-            if [[ "${{ matrix.PETSc }}" && "${{ matrix.PYOPTSPARSE }}" == "v1.2" ]]; then
-              PAROPT=-a
+            if [[ "${{ matrix.PAROPT }}" ]]; then
+              PAROPT="-a"
             fi
 
             if [[ "${{ matrix.SNOPT }}" == "7.7" && "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
               echo "  > Secure copying SNOPT 7.7 over SSH"
               mkdir SNOPT
               scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT
-              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -s SNOPT/src -d
-
+              SNOPT="-s SNOPT/src"
             elif [[ "${{ matrix.SNOPT }}" == "7.2" && "${{ secrets.SNOPT_LOCATION_72 }}" ]]; then
               echo "  > Secure copying SNOPT 7.2 over SSH"
               mkdir SNOPT
               scp -qr ${{ secrets.SNOPT_LOCATION_72 }} SNOPT
-              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -s SNOPT/source -d
-
-            else
-              if [[ "${{ matrix.SNOPT }}" ]]; then
-                echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
-              fi
-              ./build_pyoptsparse.sh $PAROPT -b "${{ matrix.PYOPTSPARSE }}" -d
+              SNOPT="-s SNOPT/source"
+            elif [[ "${{ matrix.SNOPT }}" ]]; then
+              echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
             fi
 
-            echo "--------------------------"
-            echo "Quick test of pyoptsparse:"
-            testflo -v build*/pyoptsparse/ --show_skipped
-            echo "--------------------------"
-
-            cd ..
-
-            echo "LD_LIBRARY_PATH=$HOME/ipopt/lib" >> $GITHUB_ENV
+            build_pyoptsparse $BRANCH $PAROPT $SNOPT
           fi
 
       - name: Install optional dependencies
@@ -209,11 +228,11 @@ jobs:
           echo "============================================================="
           python -m pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
 
-      - name: Display environmant info
+      - name: Display environment info
         shell: bash -l {0}
         run: |
-          mamba info
-          mamba list
+          conda info
+          conda list
 
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"
@@ -233,10 +252,12 @@ jobs:
           python -m pip install pip-audit
           echo "============================================================="
           echo "Scan environment for packages with known vulnerabilities"
+          echo "(Temporarily ignoring PYSEC-2022-237, required by nbconvert)"
           echo "============================================================="
-          python -m pip_audit
+          python -m pip_audit --ignore-vuln PYSEC-2022-237
 
       - name: Run tests
+        if: matrix.TESTS
         shell: bash -l {0}
         run: |
           echo "============================================================="
@@ -244,14 +265,15 @@ jobs:
           echo "============================================================="
           cp .coveragerc $HOME
           cd $HOME
-          testflo -n 1 openmdao --timeout=120 --show_skipped --coverage --coverpkg openmdao
+          testflo -n 2 openmdao --timeout=120 --show_skipped --coverage --coverpkg openmdao --durations=20
 
       - name: Submit coverage
+        if: matrix.TESTS
         shell: bash -l {0}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
-          COVERALLS_PARALLEL: True
+          COVERALLS_PARALLEL: true
         run: |
           echo "============================================================="
           echo "Submit coverage"
@@ -302,7 +324,7 @@ jobs:
           done
 
       - name: Publish docs
-        if: ${{ github.event_name == 'push' && matrix.PUBLISH_DOCS }}
+        if: ${{ github.event_name == 'push' && matrix.BUILD_DOCS }}
         shell: bash -l {0}
         env:
           DOCS_LOCATION: ${{ secrets.DOCS_LOCATION }}
@@ -372,18 +394,18 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Setup mamba
+      - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
-          mamba-version: "*"
+          conda-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
 
       - name: Install OpenDMAO
         shell: pwsh
         run: |
-          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip
 
@@ -403,8 +425,8 @@ jobs:
       - name: Display environment info
         shell: pwsh
         run: |
-          mamba info
-          mamba list
+          conda info
+          conda list
 
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"
@@ -424,8 +446,9 @@ jobs:
           python -m pip install pip-audit
           echo "============================================================="
           echo "Scan environment for packages with known vulnerabilities"
+          echo "(Temporarily ignoring PYSEC-2022-237, required by nbconvert)"
           echo "============================================================="
-          python -m pip_audit
+          python -m pip_audit --ignore-vuln PYSEC-2022-237
 
       - name: Run tests
         shell: pwsh
@@ -435,13 +458,13 @@ jobs:
           echo "============================================================="
           copy .coveragerc $HOME
           cd $HOME
-          testflo -n 1 openmdao --timeout=120 --show_skipped --coverage  --coverpkg openmdao
+          testflo -n 2 openmdao --timeout=120 --show_skipped --coverage  --coverpkg openmdao --durations=20
 
       - name: Submit coverage
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
-          COVERALLS_PARALLEL: True
+          COVERALLS_PARALLEL: true
         shell: pwsh
         run: |
           echo "============================================================="

--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -14,7 +14,7 @@ execute:
   execute_notebooks: force
   stderr_output: show
   allow_errors: false
-  timeout: 120
+  timeout: 300
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -247,7 +247,8 @@ class TestMPIScatter(unittest.TestCase):
         model.add_subsystem('sum', om.ExecComp('f_sum = sum(f_xy)',
                                                f_sum=np.ones((size, )),
                                                f_xy=np.ones((size, ))),
-                            promotes=['*'])
+                            promotes_outputs=['*'])
+        model.promotes('sum', inputs=['f_xy'], src_indices=om.slicer[:])
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
         model.add_design_var('y', lower=-50.0, upper=50.0)


### PR DESCRIPTION
### Summary

Some updates to the GitHub workflow:
- separate doc build into a separate job so it runs concurrently with tests
- use the new pip-installable version of the `build_pyoptsparse` script
- temporarily ignore `jupyter` `nbconvert` related vulnerability
- switch back to using `conda` instead of `mamba`
- run tests with 2 processors for slight speedup
- add `durations` argument to `testflo` to show 20 longest running tests
- fix a `pyoptsparse_driver` test for `ParOpt` that needed updated to use `src_indices`
- increased notebook timeout on doc build

### Related Issues

- Resolves #2581 

### Backwards incompatibilities

None

### New Dependencies

None
