### PR TITLE
Changed to wipeFilters() in Diagram and ModelData classes

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -179,10 +179,7 @@ class Diagram {
 
         // Get rid of any existing filters before processing children, as they'll
         // be populated while processing the state of each child node.
-        if (node.hasFilters()) {
-            node.filter.inputs.wipe();
-            node.filter.outputs.wipe();
-        }
+        if (node.hasFilters()) { node.wipeFilters(); }
 
         if (node.hasChildren()) {
             for (const child of node.children) {

--- a/openmdao/visualization/n2_viewer/gen/ModelData.js
+++ b/openmdao/visualization/n2_viewer/gen/ModelData.js
@@ -263,7 +263,7 @@ class ModelData {
 
         // If variables were selectively hidden, force the variable selection
         // dialog to rebuild the hiddenVars array.
-        if (node.hasFilters()) { node.filter.inputs.wipe(); node.filter.outputs.wipe(); }
+        if (node.hasFilters()) { node.wipeFilters(); }
 
         if (!foundEntry) { // Not found, reset values to default
             node.expand();


### PR DESCRIPTION
### Summary

This fixes the generic Diagram and ModelData problem with referencing `input` and `output` filters. It was breaking the  Dymos linkage report `Home` button and possibly other areas because the DmLinkageTreeNode class does not have `input` and `output` filters.

### Related Issues

- Resolves #2583

### Backwards incompatibilities

None

### New Dependencies

None
