### PR TITLE
Fixed docs for NonlinearBlockJac

### DIFF
--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_jac.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/nonlinear_block_jac.ipynb
@@ -37,7 +37,9 @@
     "executed.\n",
     "\n",
     "Here, we choose NonlinearBlockJac to solve the Sellar problem, which has two components with a\n",
-    "cyclic dependency, has no implicit states, and works very well with Jacobi."
+    "cyclic dependency, has no implicit states, and works with Jacobi, although it fails to converge before\n",
+    "hitting the default iteration limit of 10.  In the next section we'll show how to increase the number\n",
+    "of allowed iterations so that it will converge."
    ]
   },
   {
@@ -192,9 +194,8 @@
     "\n",
     "**maxiter**\n",
     "\n",
-    "  This lets you specify the maximum number of Jacobi iterations to apply. In this example, we\n",
-    "  cut it back from the default, ten, down to two, so that it terminates a few iterations earlier and doesn't\n",
-    "  reach the specified absolute or relative tolerance."
+    "  This lets you specify the maximum number of allowed Jacobi iterations during a solve. In this example, we\n",
+    "  increase it from the default, 10, up to 20, so that it successfully converges."
    ]
   },
   {
@@ -221,7 +222,7 @@
     "model.linear_solver = om.LinearBlockGS()\n",
     "\n",
     "nlbgs = model.nonlinear_solver = om.NonlinearBlockJac()\n",
-    "nlbgs.options['maxiter'] = 4\n",
+    "nlbgs.options['maxiter'] = 20\n",
     "\n",
     "prob.setup()\n",
     "\n",
@@ -245,8 +246,8 @@
    },
    "outputs": [],
    "source": [
-    "assert_near_equal(prob['y1'], 25.5723813937, .00001)\n",
-    "assert_near_equal(prob['y2'], 12.0542542372, .00001)"
+    "assert_near_equal(prob['y1'], 25.58830237, .00001)\n",
+    "assert_near_equal(prob['y2'], 12.05848815, .00001)"
    ]
   },
   {


### PR DESCRIPTION
### Summary

In the docs, the initial example for NonlinearBlockJac was failing to converge in the default 10 iterations.  I left this behavior but added an explanation of the issue, because in the next example the `maxiter` option was explained, so I modified that example to increase the `maxiter` to 20 so the case would converge.  In the old version, `maxiter` had been lowered to 4 which was just giving a redundant example of failing to converge.

### Related Issues

- Resolves #2573

### Backwards incompatibilities

None

### New Dependencies

None
