### PR TITLE
Clean up some documentation

### DIFF
--- a/openmdao/docs/ipcluster_start.sh
+++ b/openmdao/docs/ipcluster_start.sh
@@ -15,4 +15,4 @@ else
   ipython profile create --parallel --profile=mpi
 fi
 
-ipcluster start -n 4 --profile=mpi --engines='ipyparallel.cluster.launcher.MPIEngineSetLauncher' &
+ipcluster start -n 4 --profile=mpi --log-level=DEBUG  --engines='ipyparallel.cluster.launcher.MPIEngineSetLauncher' &

--- a/openmdao/docs/ipcluster_start.sh
+++ b/openmdao/docs/ipcluster_start.sh
@@ -15,4 +15,4 @@ else
   ipython profile create --parallel --profile=mpi
 fi
 
-ipcluster start -n 4 --profile=mpi --log-level=DEBUG  --engines='ipyparallel.cluster.launcher.MPIEngineSetLauncher' &
+ipcluster start -n 4 --profile=mpi --engines='ipyparallel.cluster.launcher.MPIEngineSetLauncher' &

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -219,20 +219,8 @@
     "prob.driver.add_recorder(om.SqliteRecorder(\"cases.sql\"))\n",
     "\n",
     "prob.setup()\n",
-    "prob.run_driver()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "\n",
-    "prob.cleanup()\n",
-    "\n",
-    "print(MPI.COMM_WORLD.size)"
+    "prob.run_driver()\n",
+    "prob.cleanup()"
    ]
   },
   {
@@ -244,6 +232,7 @@
     "%%px\n",
     "\n",
     "# check recorded cases from each case file\n",
+    "from mpi4py import MPI\n",
     "rank = MPI.COMM_WORLD.rank\n",
     "filename = \"cases.sql_%d\" % rank\n",
     "print(filename)"

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -138,16 +138,7 @@
     "prob.cleanup()\n",
     "\n",
     "cr = om.CaseReader(\"cases.sql\")\n",
-    "cases = cr.list_cases('driver')\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(len(cases))"
+    "cases = cr.list_cases('driver')"
    ]
   },
   {
@@ -234,35 +225,12 @@
     "# check recorded cases from each case file\n",
     "from mpi4py import MPI\n",
     "rank = MPI.COMM_WORLD.rank\n",
+    "\n",
     "filename = \"cases.sql_%d\" % rank\n",
-    "print(filename)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
     "\n",
-    "\n",
-    "# SqliteCaseReader will automatically look for cases.sql_meta if\n",
-    "# metadata_filename is not specified, but test by explicitly\n",
-    "# using it here.\n",
-    "cr = om.CaseReader(filename, metadata_filename = 'cases.sql_meta')\n",
-    "cases = cr.list_cases('driver')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "\n",
-    "print(len(cases))"
+    "cr = om.CaseReader(filename)\n",
+    "cases = cr.list_cases('driver', out_stream=None)\n",
+    "print(cases)"
    ]
   },
   {
@@ -279,26 +247,6 @@
     "    values.append((outputs['x'], outputs['y'], outputs['f_xy']))\n",
     "\n",
     "print(\"\\n\"+\"\\n\".join([\"x: %5.2f, y: %5.2f, f_xy: %6.2f\" % xyf for xyf in values]))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "\n",
-    "del cr\n",
-    "\n",
-    "# Test for missing metadata db file error\n",
-    "try:\n",
-    "    cr_test = om.CaseReader(filename, metadata_filename = 'nonexistant_filename')\n",
-    "    found_metadata = True\n",
-    "except IOError:\n",
-    "    found_metadata = False\n",
-    "\n",
-    "print(found_metadata, \"No error from SqliteCaseReader for missing metadata file.\")\n"
    ]
   },
   {
@@ -384,6 +332,7 @@
     "\n",
     "        self.sub = self.add_subsystem('sub', om.ParallelGroup(),\n",
     "                                      promotes_inputs=['x1', 'x2'])\n",
+    "        \n",
     "        self.sub.add_subsystem('c1', om.ExecComp(['y=-2.0*x']),\n",
     "                               promotes_inputs=[('x', 'x1')])\n",
     "        self.sub.add_subsystem('c2', om.ExecComp(['y=5.0*x']),\n",
@@ -442,7 +391,7 @@
     "    filename = \"cases.sql_%d\" % rank\n",
     "\n",
     "    cr = om.CaseReader(filename)\n",
-    "    cases = cr.list_cases('driver')\n",
+    "    cases = cr.list_cases('driver', out_stream=None)\n",
     "\n",
     "    values = []\n",
     "    for case in cases:\n",
@@ -607,15 +556,8 @@
     "prob.cleanup()\n",
     "\n",
     "cr = om.CaseReader(\"cases.sql\")\n",
-    "cases = cr.list_cases('driver')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "cases = cr.list_cases('driver', out_stream=None)\n",
+    "\n",
     "values = []\n",
     "for case in cases:\n",
     "    outputs = cr.get_case(case).outputs\n",
@@ -652,25 +594,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import openmdao.api as om\n",
-    "from openmdao.test_suite.components.paraboloid import Paraboloid\n",
-    "\n",
-    "import json\n",
-    "\n",
-    "prob = om.Problem()\n",
-    "model = prob.model\n",
-    "\n",
-    "model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])\n",
-    "\n",
-    "model.add_design_var('x', lower=0.0, upper=1.0)\n",
-    "model.add_design_var('y', lower=0.0, upper=1.0)\n",
-    "model.add_objective('f_xy')\n",
-    "\n",
-    "prob.setup()\n",
-    "\n",
-    "prob.set_val('x', 0.0)\n",
-    "prob.set_val('y', 0.0)\n",
-    "\n",
     "# load design variable inputs from JSON file and decode into list\n",
     "with open('cases.json', 'r') as f:\n",
     "    json_data = f.read()\n",
@@ -684,45 +607,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "case_list = json.loads(json_data)\n",
-    "\n",
-    "print(case_list)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# create DOEDriver using provided list of cases\n",
+    "case_list = json.loads(json_data)\n",
     "prob.driver = om.DOEDriver(case_list)\n",
     "\n",
-    "# a ListGenerator was created\n",
-    "print(type(prob.driver.options['generator']))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "prob.driver.add_recorder(om.SqliteRecorder(\"cases.sql\"))\n",
     "\n",
     "prob.run_driver()\n",
     "prob.cleanup()\n",
     "\n",
+    "# check the recorded cases\n",
     "cr = om.CaseReader(\"cases.sql\")\n",
-    "cases = cr.list_cases('driver')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "cases = cr.list_cases('driver', out_stream=None)\n",
+    "\n",
     "values = []\n",
     "for case in cases:\n",
     "    outputs = cr.get_case(case).outputs\n",
@@ -762,7 +659,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -776,7 +673,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.10.5"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
@@ -76,9 +76,48 @@
     "\n",
     "This genetic algorithm optimizer supports integer and continuous variables. It uses a binary encoding scheme to encode any continuous variables into a user-definable number of bits. The number of bits you choose should be equal to the base-2 logarithm of the number of discrete values you want between the min and max value. A higher value means more accuracy for this variable, but it also increases the number of generations (and hence total evaluations) that will be required to find the minimum. If you do not specify a value for bits for a continuous variable, then the variable is assumed to be integer, and encoded as such. Note that if the range between the upper and lower bounds is not a power of two, then the variable is discretized beyond the upper bound, but those points that the GA generates which exceed the declared upper bound are discarded before evaluation.\n",
     "\n",
-    "The SimpleGADriver supports both constrained and unconstrained optimization.\n",
+    "The SimpleGADriver supports both constrained and unconstrained optimization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SimpleGADriver Options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true,
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "import openmdao.api as om\n",
+    "om.show_options_table(\"openmdao.drivers.genetic_algorithm_driver.SimpleGADriver\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## SimpleGADriver Constructor\n",
     "\n",
-    "The examples below show a mixed-integer problem to illustrate usage of this driver with both integer and discrete design variables."
+    "The call signature for the `SimpleGADriver` constructor is:\n",
+    "\n",
+    "\n",
+    "```{eval-rst}\n",
+    "    .. automethod:: openmdao.drivers.genetic_algorithm_driver.SimpleGADriver.__init__\n",
+    "       :noindex:\n",
+    "```  \n",
+    "\n",
+    "## Using SimpleGADriver\n",
+    "\n",
+    "The examples below show a mixed-integer problem to illustrate usage of this driver with both integer and discrete design variables.  The driver `iter_count` attribute reflects the number of times the model is evaluated in the course of the run."
    ]
   },
   {
@@ -135,45 +174,14 @@
     "prob.set_val('xC', 7.5)\n",
     "prob.set_val('xI', 0.0)\n",
     "\n",
-    "prob.run_driver()"
+    "prob.run_driver()\n",
+    "print(prob.driver.iter_count)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## SimpleGADriver Options"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-input"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "om.show_options_table(\"openmdao.drivers.genetic_algorithm_driver.SimpleGADriver\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## SimpleGADriver Constructor\n",
-    "\n",
-    "The call signature for the `SimpleGADriver` constructor is:\n",
-    "\n",
-    "\n",
-    "```{eval-rst}\n",
-    "    .. automethod:: openmdao.drivers.pyoptsparse_driver.pyOptSparseDriver.__init__\n",
-    "       :noindex:\n",
-    "```  \n",
-    "\n",
-    "## Using SimpleGADriver\n",
-    "\n",
     "You can change the number of generations to run the genetic algorithm by setting the “max_gen” option."
    ]
   },
@@ -205,7 +213,8 @@
     "prob.set_val('xC', 7.5)\n",
     "prob.set_val('xI', 0.0)\n",
     "\n",
-    "prob.run_driver()"
+    "prob.run_driver()\n",
+    "print(prob.driver.iter_count)"
    ]
   },
   {
@@ -243,7 +252,8 @@
     "prob.set_val('xC', 7.5)\n",
     "prob.set_val('xI', 0.0)\n",
     "\n",
-    "prob.run_driver()"
+    "prob.run_driver()\n",
+    "print(prob.driver.iter_count)"
    ]
   },
   {
@@ -555,30 +565,11 @@
     "\n",
     "prob.run_driver()\n",
     "\n",
-    "# Optimal solution\n",
-    "print(prob.get_val('comp.f'))\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "\n",
-    "print(prob.get_val('xI'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "\n",
-    "print(prob.get_val('xC'))"
+    "if prob.comm.rank == 0:\n",
+    "    print(\"\\nOptimal Solution:\")\n",
+    "    print(f\"{prob.get_val('comp.f')=}\")\n",
+    "    print(f\"{prob.get_val('xI')=}\")\n",
+    "    print(f\"{prob.get_val('xC')=}\")"
    ]
   },
   {
@@ -655,28 +646,11 @@
     "\n",
     "prob.run_driver()\n",
     "\n",
-    "# Optimal solution\n",
-    "print(prob.get_val('comp.f'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "print(prob.get_val('xI'))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "print(prob.get_val('xC'))"
+    "if prob.comm.rank == 0:\n",
+    "    print(\"\\nOptimal Solution:\")\n",
+    "    print(f\"{prob.get_val('comp.f')=}\")\n",
+    "    print(f\"{prob.get_val('xI')=}\")\n",
+    "    print(f\"{prob.get_val('xC')=}\")"
    ]
   },
   {
@@ -700,7 +674,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -714,7 +688,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.10.5"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_inputs()"
+    "prob.model.list_inputs();"
    ]
   },
   {
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_outputs()"
+    "prob.model.list_outputs();"
    ]
   },
   {
@@ -175,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_outputs(implicit=False)"
+    "prob.model.list_outputs(implicit=False);"
    ]
   },
   {
@@ -184,7 +184,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_outputs(explicit=False)"
+    "prob.model.list_outputs(explicit=False);"
    ]
   },
   {
@@ -204,15 +204,15 @@
    "source": [
     "# list inputs\n",
     "inputs = prob.model.list_inputs(out_stream=None)\n",
-    "print(sorted(inputs))"
+    "\n",
+    "from pprint import pprint\n",
+    "pprint(sorted(inputs))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `System.get_io_metadata` method, which is used internally by `list_inputs` and `list_outputs`, returns the specified variable information as a dict.\n",
-    "\n",
     "### *List Names Only*\n",
     "\n",
     "If you just need the names of the variables, you can disable the display of the values by setting the optional argument, `val`, to *False*."
@@ -226,16 +226,6 @@
    "source": [
     "# list inputs\n",
     "inputs = prob.model.list_inputs(val=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# list only explicit outputs\n",
-    "outputs = prob.model.list_outputs(implicit=False, val=False)"
    ]
   },
   {
@@ -253,7 +243,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_outputs(prom_name=True)"
+    "prob.model.list_outputs(prom_name=True);"
    ]
   },
   {
@@ -282,17 +272,6 @@
    "outputs": [],
    "source": [
     "inputs = prob.model.list_inputs(val=False, excludes=['*comp2*',])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# list only explicit outputs\n",
-    "outputs = prob.model.list_outputs(implicit=False, val=False, includes=['*b',])\n",
-    "outputs = prob.model.list_outputs(implicit=False, val=False, excludes=['*b',])"
    ]
   },
   {
@@ -418,7 +397,7 @@
     "prob.model.add_objective('a_disk.Cp', scaler=-1)\n",
     "\n",
     "prob.setup()\n",
-    "prob.run_driver()"
+    "prob.run_driver();"
    ]
   },
   {
@@ -427,7 +406,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_inputs(tags='basic', units=True, shape=True)"
+    "prob.model.list_inputs(tags='basic', units=True, shape=True);"
    ]
   },
   {
@@ -436,7 +415,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_inputs(tags=['basic','advanced'], units=True, shape=True)"
+    "prob.model.list_inputs(tags=['basic','advanced'], units=True, shape=True);"
    ]
   },
   {
@@ -445,7 +424,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_outputs(tags='basic', units=False, shape=False)"
+    "prob.model.list_outputs(tags='basic', units=False, shape=False);"
    ]
   },
   {
@@ -454,7 +433,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "prob.model.list_outputs(tags=['basic','advanced'], units=False, shape=False)"
+    "prob.model.list_outputs(tags=['basic','advanced'], units=False, shape=False);"
    ]
   },
   {
@@ -472,7 +451,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "comp = om.IndepVarComp('indep_var', tags='tag1')\n"
+    "comp = om.IndepVarComp('indep_var', tags='tag1')"
    ]
   },
   {
@@ -482,18 +461,24 @@
    "outputs": [],
    "source": [
     "ec = om.ExecComp('y=x+z+1.',\n",
-    "                  x={'val': 1.0, 'units': 'm', 'tags': 'tagx'},\n",
-    "                  y={'units': 'm', 'tags': ['tagy','tagm']},\n",
-    "                  z={'val': 2.0, 'tags': 'tagz'},\n",
-    "                  )\n"
+    "                 x={'val': 1.0, 'units': 'm', 'tags': 'tagx'},\n",
+    "                 y={'units': 'm', 'tags': ['tagy','tagm']},\n",
+    "                 z={'val': 2.0, 'tags': 'tagz'})"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "```{note}\n",
     "Note that outputs of `IndepVarComp` are always tagged with `indep_var_comp`.\n",
-    "\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### *List Residuals Above a Tolerance*\n",
     "\n",
     "In some cases, it might be convenient to only list variables whose residuals are above a given tolerance. The `System.list_outputs` method provides an optional argument, `residuals_tol` for this purpose."
@@ -598,7 +583,7 @@
    "source": [
     "### *List Additional Variable Metadata*\n",
     "\n",
-    "The `list_outputs()` method has many options to also display units, shape, bounds (lower and upper), and scaling (res, res0, and res_ref) for the variables."
+    "The `list_inputs()` and `list_outputs()` methods have many options to also display units, shape, bounds (lower and upper), and scaling (res, res0, and res_ref) for the variables."
    ]
   },
   {
@@ -668,7 +653,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(sorted(outputs))"
+    "from pprint import pprint\n",
+    "pprint(sorted(outputs))"
    ]
   },
   {
@@ -738,7 +724,7 @@
     "prob.model.list_inputs(val=True,\n",
     "                       units=True,\n",
     "                       hierarchical=True,\n",
-    "                       print_arrays=True)"
+    "                       print_arrays=True);"
    ]
   },
   {
@@ -776,7 +762,7 @@
     "                        residuals=True,\n",
     "                        scaling=True,\n",
     "                        hierarchical=True,\n",
-    "                        print_arrays=True)"
+    "                        print_arrays=True);"
    ]
   },
   {
@@ -798,7 +784,7 @@
     "                       units=True,\n",
     "                       hierarchical=True,\n",
     "                       print_min=True,\n",
-    "                       print_max=True)"
+    "                       print_max=True);"
    ]
   },
   {
@@ -816,20 +802,19 @@
     "                        scaling=True,\n",
     "                        hierarchical=True,\n",
     "                        print_min=True,\n",
-    "                        print_max=True)"
+    "                        print_max=True);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
-    "It is normally required to run the model before `list_inputs()` and `list_outputs()` can be used. This is because the final setup that occurs just before execution determines the hierarchy and builds the data structures and connections. In some cases however, it can be useful to call these functions on a system prior to execution to assist in configuring your model. At `configure` time, basic metadata about a system’s inputs and outputs is available. See the documentation for the [configure() method (../core_features/working_with_groups/configure_method.ipynb) for one such use case.\n",
-    "```\n",
+    "Note that it is normally required to run the model before `list_inputs()` and `list_outputs()` can be used. This is because the final setup that occurs just before execution determines the hierarchy and builds the data structures and connections. In some cases however, it can be useful to call these functions on a system prior to execution to assist in configuring your model. At `configure` time, basic metadata about a system’s inputs and outputs is available. \n",
+    "See the documentation for the [configure](../core_features/working_with_groups/configure_method.ipynb) method for one such use case.\n",
     "\n",
     "### *List Global Shape*\n",
     "\n",
-    "When working with [Distributed Variables](../core_features/working_with_components/distributed_components.ipynb), it may also be useful to display the global shape of a variable as well as the shape on the current processor. Note that this information is not available until after the model has been completely set up and run."
+    "When working with [Distributed Variables](../core_features/working_with_components/distributed_components.ipynb), it may also be useful to display the global shape of a variable as well as the shape on the current processor. Note that this information is not available until after the model has been completely set up."
    ]
   },
   {
@@ -914,7 +899,7 @@
     "model = prob.model\n",
     "\n",
     "indep = model.add_subsystem(\"indep\", om.IndepVarComp())\n",
-    "indep.add_output('x', np.zeros(get_evenly_distributed_size(prob.comm, size)), distributed=True)\n",
+    "indep.add_output('x', np.ones(get_evenly_distributed_size(prob.comm, size)), distributed=True)\n",
     "model.add_subsystem(\"C2\", DistribComp(size=size))\n",
     "model.add_subsystem(\"C3\", Summer(size=size))\n",
     "\n",
@@ -922,10 +907,10 @@
     "model.connect('C2.outvec', 'C3.invec', src_indices=om.slicer[:])\n",
     "\n",
     "prob.setup()\n",
+    "prob.final_setup()\n",
     "\n",
-    "# prior to model execution, the global shape of a distributed variable is not available\n",
-    "# and only the local portion of the value is available\n",
-    "model.C2.list_inputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True)\n"
+    "model.C2.list_inputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True);\n",
+    "model.C2.list_outputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True);"
    ]
   },
   {
@@ -936,14 +921,7 @@
    "source": [
     "%%px\n",
     "\n",
-    "model.C2.list_outputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True)\n",
-    "\n",
-    "prob['indep.x'] = np.ones(size)\n",
-    "prob.run_model()\n",
-    "\n",
-    "# after model execution, the global shape of a distributed variable is available\n",
-    "# and the complete global value is available\n",
-    "model.C2.list_inputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True)"
+    "prob.run_model()"
    ]
   },
   {
@@ -954,22 +932,9 @@
    "source": [
     "%%px\n",
     "\n",
-    "model.C2.list_outputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True)\n",
-    "\n",
-    "# note that the shape of the input variable for the non-distributed Summer component\n",
-    "# is different on each processor, use the all_procs argument to display on all processors\n",
-    "model.C3.list_inputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True, all_procs=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%px\n",
-    "\n",
-    "print(prob['C3.sum'])"
+    "# note that the shape of the `invec` and `outvec` variables for the distributed C2 component\n",
+    "# can be different on each processor, use the all_procs argument to display on all processors\n",
+    "model.C2.list_outputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True, all_procs=True);"
    ]
   },
   {
@@ -1057,7 +1022,7 @@
     "model.add_constraint('con2', upper=0.0)\n",
     "\n",
     "prob.setup()\n",
-    "prob.run_driver()"
+    "prob.run_driver();"
    ]
   },
   {
@@ -1085,7 +1050,7 @@
    "hash": "e6c7471802ed76737b16357fb02af5587f3a4cbee5ea7658f3f9a6981469039b"
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1099,7 +1064,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.5"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -130,7 +130,7 @@
     "(list-inputs)=\n",
     "### *List Inputs*\n",
     "\n",
-    "The `list_inputs()` method on a System will display all the inputs in execution order with their values. By default, the variable name and variable value are displayed. Also by default, the variables are displayed as part of the System hierarchy. Finally, the default is to display this information to 'stdout'."
+    "The `list_inputs()` method on a System will display all the inputs in execution order with their values. By default, the variable name and variable value are displayed. Also by default, the variables are displayed as part of the System hierarchy."
    ]
   },
   {
@@ -215,7 +215,7 @@
    "source": [
     "### *List Names Only*\n",
     "\n",
-    "If you just need the names of the variables, you can disable the display of the values by setting the optional argument, `val`, to *False*."
+    "If you just want to see the names of the variables, you can disable the display of the values by setting the optional argument `val` to *False*."
    ]
   },
   {
@@ -224,8 +224,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# list inputs\n",
-    "inputs = prob.model.list_inputs(val=False)"
+    "prob.model.list_inputs(val=False);"
    ]
   },
   {
@@ -234,7 +233,7 @@
    "source": [
     "### *List Names and Promoted Name*\n",
     "\n",
-    "If you want the names of the variables and their promoted name within the model, you can enable the display of promoted names by setting the optional argument, `prom_name`, to *True*."
+    "If you want the names of the variables and their promoted name within the model, you can enable the display of promoted names by setting the optional argument `prom_name` to *True*."
    ]
   },
   {
@@ -261,8 +260,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# list inputs\n",
-    "inputs = prob.model.list_inputs(val=False, includes=['*comp2*',])"
+    "prob.model.list_inputs(val=False, includes=['*comp2*',]);"
    ]
   },
   {
@@ -271,7 +269,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inputs = prob.model.list_inputs(val=False, excludes=['*comp2*',])"
+    "prob.model.list_outputs(val=False, excludes=['*comp2*',]);"
    ]
   },
   {
@@ -282,7 +280,7 @@
     "\n",
     "When you add inputs and outputs to components, you can optionally set tags on the variables. These tags can then be used to filter what variables are printed and returned by the `System.list_inputs` and `System.list_outputs` methods. Each of those methods has an optional argument `tags` for that purpose.\n",
     "\n",
-    "Here is a simple example to show you how this works. Imagine that a model-builder builds a model with some set of variables they expect other non-model-builder users to vary. They want to classify the inputs into two sets: “beginner” and “advanced”. The model-builder would like to write some functions that query the model for the set of *beginner* and *advanced* inputs and do some stuff with those lists (like make fancy formatted outputs or something)."
+    "Here is a simple example to show you how this works. Imagine that a model-builder builds a model with some set of variables they expect other non-model-builder users to vary. They want to classify the inputs into two sets: “beginner” and “advanced”. The model-builder would like to write some functions that query the model for the set of *basic* and *advanced* inputs and do some stuff with those lists (like make fancy formatted outputs or something)."
    ]
   },
   {
@@ -393,8 +391,7 @@
     "prob.driver.options['optimizer'] = 'SLSQP'\n",
     "\n",
     "prob.model.add_design_var('a', lower=0., upper=1.)\n",
-    "# negative one so we maximize the objective\n",
-    "prob.model.add_objective('a_disk.Cp', scaler=-1)\n",
+    "prob.model.add_objective('a_disk.Cp', scaler=-1)  # negated to maximize the objective\n",
     "\n",
     "prob.setup()\n",
     "prob.run_driver();"
@@ -481,7 +478,7 @@
    "source": [
     "### *List Residuals Above a Tolerance*\n",
     "\n",
-    "In some cases, it might be convenient to only list variables whose residuals are above a given tolerance. The `System.list_outputs` method provides an optional argument, `residuals_tol` for this purpose."
+    "In some cases, it might be convenient to only list variables whose residuals are above a given tolerance. The `list_outputs` method provides the optional argument `residuals_tol` for this purpose."
    ]
   },
   {
@@ -663,15 +660,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "outputs = prob.model.list_outputs(implicit=False,\n",
-    "                                  val=True,\n",
-    "                                  units=True,\n",
-    "                                  shape=True,\n",
-    "                                  bounds=True,\n",
-    "                                  residuals=True,\n",
-    "                                  scaling=True,\n",
-    "                                  hierarchical=True,\n",
-    "                                  print_arrays=False)"
+    "prob.model.list_outputs(implicit=False,\n",
+    "                        val=True,\n",
+    "                        units=True,\n",
+    "                        shape=True,\n",
+    "                        bounds=True,\n",
+    "                        residuals=True,\n",
+    "                        scaling=True,\n",
+    "                        hierarchical=True,\n",
+    "                        print_arrays=False);"
    ]
   },
   {
@@ -680,7 +677,7 @@
    "source": [
     "### *Print Array Values*\n",
     "\n",
-    "The `list_inputs()` and `list_outputs()` methods both have a `print_arrays` option. By default, this option is set to False and only the norm of the array will appear in the tabular display. The norm value is surrounded by vertical bars to indicate that it is a norm. When the option is set to True, the complete value of the array will also be a displayed below the row. The format is affected by the values set with `numpy.set_printoptions`."
+    "The `list_inputs()` and `list_outputs()` methods both have a `print_arrays` option. By default, this option is set to False and only the norm of the array will appear in the tabular display. The norm value is surrounded by vertical bars to indicate that it is a norm. When the option is set to True, the complete value of the array will also be a displayed below the row."
    ]
   },
   {
@@ -692,7 +689,6 @@
     "import numpy as np\n",
     "\n",
     "import openmdao.api as om\n",
-    "from openmdao.utils.general_utils import printoptions\n",
     "\n",
     "class ArrayAdder(om.ExplicitComponent):\n",
     "    \"\"\"\n",
@@ -733,6 +729,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "prob.model.list_outputs(val=True,\n",
+    "                        implicit=False,\n",
+    "                        units=True,\n",
+    "                        shape=True,\n",
+    "                        bounds=True,\n",
+    "                        residuals=True,\n",
+    "                        scaling=True,\n",
+    "                        hierarchical=True,\n",
+    "                        print_arrays=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can control the format of the array values via `numpy.set_printoptions`. OpenMDAO provides the `printoptions` context manager to assist with this."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.general_utils import printoptions\n",
+    "\n",
     "with printoptions(edgeitems=3, infstr='inf',\n",
     "                  linewidth=75, nanstr='nan', precision=8,\n",
     "                  suppress=False, threshold=1000, formatter=None):\n",
@@ -746,23 +768,6 @@
     "                            scaling=True,\n",
     "                            hierarchical=False,\n",
     "                            print_arrays=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "prob.model.list_outputs(val=True,\n",
-    "                        implicit=False,\n",
-    "                        units=True,\n",
-    "                        shape=True,\n",
-    "                        bounds=True,\n",
-    "                        residuals=True,\n",
-    "                        scaling=True,\n",
-    "                        hierarchical=True,\n",
-    "                        print_arrays=True);"
    ]
   },
   {
@@ -914,14 +919,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "%%px\n",
-    "\n",
-    "prob.run_model()"
+    "Note that the shape of the `invec` and `outvec` variables for the distributed C2 component can be different on each processor. Use the `all_procs` argument to display on all processors"
    ]
   },
   {
@@ -932,8 +933,8 @@
    "source": [
     "%%px\n",
     "\n",
-    "# note that the shape of the `invec` and `outvec` variables for the distributed C2 component\n",
-    "# can be different on each processor, use the all_procs argument to display on all processors\n",
+    "prob.run_model()\n",
+    "\n",
     "model.C2.list_outputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True, all_procs=True);"
    ]
   },
@@ -960,14 +961,14 @@
    "source": [
     "### *Listing Problem Variables*\n",
     "\n",
-    "Problem has a method `list_problem_vars` which prints out the values and metadata for design, constraint, and objective variables.\n",
+    "The `Problem` class has a method `list_problem_vars` which prints out the values and metadata for design, constraint, and objective variables.\n",
     "\n",
     "```{eval-rst}\n",
     "    .. automethod:: openmdao.core.problem.Problem.list_problem_vars\n",
     "        :noindex:\n",
     "```\n",
     "\n",
-    "You can optionally print out a variety of metadata. In this example, all the metadata is printed. The `print_arrays` option is also set to true so that full array values are printed, and `min` and `max` are used so that the array's lowest and highest values are shown."
+    "You can optionally print out a variety of metadata. In this example, all the metadata is printed. The `print_arrays` option is also set to true so that full array values are printed and `min` and `max` are used so that the array's lowest and highest values are shown."
    ]
   },
   {


### PR DESCRIPTION
### Summary

Reviewed the notebooks that have been having intermittent `ipyparallel` failures in the doc build on CI.

Changes that may improve robustness:
- added missing MPI import to DOE notebook
- updated a couple of cells in the GA notebook to only display on rank 0
- consolidated some code cells

Editorial changes:
- reorganized GA doc to move boilerplate API cells to the top
- removed inaccurate statement about global_shape in the listing_variables notebook
- added semicolons to get rid of some output that was cluttering the doc
- edited/reformatted some cells for readability

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
