### PR TITLE
Fixed several minor N2 bugs

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/UserInterface.js
+++ b/openmdao/visualization/n2_viewer/gen/UserInterface.js
@@ -185,7 +185,7 @@ class UserInterface {
 
             body.style('cursor', 'nwse-resize')
                 .on('mouseup', () => {
-                    diag.manuallyResized = true;
+                    self.diag.manuallyResized = true;
 
                     // Update the slider value and display
                     const defaultHeight = window.innerHeight * .95;
@@ -247,7 +247,7 @@ class UserInterface {
                 return;
             }
 
-            if (!diag.manuallyResized) {
+            if (!self.diag.manuallyResized) {
                 clearTimeout(self.resizeTimeout);
                 self.resizeTimeout =
                     setTimeout(function () {

--- a/openmdao/visualization/n2_viewer/src/OmDiagram.js
+++ b/openmdao/visualization/n2_viewer/src/OmDiagram.js
@@ -263,7 +263,7 @@ class OmDiagram extends Diagram {
     /** Add the opt-vars class to design variable elements to set the fill color */
     showDesignVars() {
         [Object.keys(modelData.design_vars), Object.keys(modelData.responses)].flat().forEach(
-            item => d3.select("#" + item.replaceAll(".", "_")).classed('opt-vars', true)
+            path => d3.select(`#${TreeNode.pathToId(path)}`).classed('opt-vars', true)
             );
         d3.select('.model_tree_grp #_auto_ivc').classed('opt-vars', true)
     }
@@ -271,7 +271,7 @@ class OmDiagram extends Diagram {
     /** Remove the opt-vars class from design variable elements to use the default fill color */
     hideDesignVars() {
         [Object.keys(modelData.design_vars), Object.keys(modelData.responses)].flat().forEach(
-            item => d3.select("#" + item.replaceAll(".", "_")).classed('opt-vars', false)
+            path => d3.select(`#${TreeNode.pathToId(path)}`).classed('opt-vars', false)
             );
         d3.select("#_auto_ivc").classed('opt-vars', false)
     }

--- a/openmdao/visualization/n2_viewer/src/OmUserInterface.js
+++ b/openmdao/visualization/n2_viewer/src/OmUserInterface.js
@@ -40,7 +40,7 @@ class OmUserInterface extends UserInterface {
 
     /** Determine the style of the inactive handle (overriding superclass) */
     _inactiveResizerHandlerStyle() {
-        return self.diag.showSolvers?
+        return this.diag.showSolvers?
             'inactive-resizer-handle' : 'inactive-resizer-handle-without-solvers'
     }
 

--- a/openmdao/visualization/n2_viewer/style/model_tree.css
+++ b/openmdao/visualization/n2_viewer/style/model_tree.css
@@ -285,9 +285,9 @@ rect.outputHighlight {
 #show-error-button-container {
     visibility: hidden;
     position: absolute;
-    bottom: 17px;
+    bottom: 250px;
     right: 115px;
-    z-index:5;
+    z-index: 5;
 }
 
 #show-error-button{


### PR DESCRIPTION
### Summary

This fixes the `Show Errors` button not appearing when there's a Javascript error (it was off-screen). It also fixes the `Show Optimization Variables` toolbar button, which was not properly renaming paths to ids for path names containing punctuation. A drag-to-resize bug was also discovered and fixed.

### Related Issues

- Resolves #2427,#2428

### Backwards incompatibilities

None

### New Dependencies

None
