### PR TITLE
prevent hang in opt_report when using MPI

### DIFF
--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -7,7 +7,7 @@ from io import StringIO
 
 import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
-from openmdao.test_suite.components.sellar_feature import SellarMDA
+from openmdao.test_suite.groups.parallel_groups import Diamond
 from openmdao.core.problem import _default_prob_name
 import openmdao.core.problem as probmod
 from openmdao.core.constants import _UNDEFINED
@@ -527,16 +527,14 @@ class TestReportsSystemMPI(unittest.TestCase):
             os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
     @hooks_active
-    def test_reports_system_mpi_basic(self):  # example taken from TestScipyOptimizeDriverMPI
+    def test_reports_system_mpi_basic(self):
         prob = om.Problem()
-        prob.model = SellarMDA()
+        prob.model = Diamond()
         prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-8)
 
-        prob.model.add_design_var('x', lower=0, upper=10)
-        prob.model.add_design_var('z', lower=0, upper=10)
-        prob.model.add_objective('obj')
-        prob.model.add_constraint('con1', upper=0)
-        prob.model.add_constraint('con2', upper=0)
+        prob.model.add_design_var('iv.x', lower=0, upper=10)
+        prob.model.add_objective('sub.c2.y1')
+        prob.model.add_constraint('sub.c3.y1', upper=0)
 
         prob.setup()
         prob.set_solver_print(level=0)

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -125,8 +125,7 @@ def opt_report(prob, outfile=None):
         return
 
     # only create report on rank 0
-    if MPI and MPI.COMM_WORLD.rank != 0:
-        return
+    create = MPI is None or MPI.COMM_WORLD.rank == 0
 
     if not outfile:
         outfile = _default_optimizer_report_filename
@@ -154,8 +153,9 @@ pip install tabulate
 </body>
 </html>
         '''
-        with open(outfilepath, 'w') as f:
-            f.write(s)
+        if create:
+            with open(outfilepath, 'w') as f:
+                f.write(s)
 
         return
 
@@ -223,14 +223,15 @@ pip install tabulate
 
     this_dir = os.path.dirname(os.path.abspath(__file__))
 
-    with open(os.path.join(this_dir, _optimizer_report_template), 'r', encoding='utf-8') as f:
-        template = f.read()
+    if create:
+        with open(os.path.join(this_dir, _optimizer_report_template), 'r', encoding='utf-8') as f:
+            template = f.read()
 
-    with open(outfilepath, 'w') as f:
-        s = template.format(title=prob._name, header=header_html, objs=objs_html,
-                            desvars=desvars_html, cons=cons_html, driver=driver_info_html,
-                            driver_class=type(driver).__name__)
-        f.write(s)
+        with open(outfilepath, 'w') as f:
+            s = template.format(title=prob._name, header=header_html, objs=objs_html,
+                                desvars=desvars_html, cons=cons_html, driver=driver_info_html,
+                                driver_class=type(driver).__name__)
+            f.write(s)
 
 
 def _make_header_table(prob):


### PR DESCRIPTION
### Summary

The opt_report was returning if MPI.WORLD_COMM != 0 but making collective calls after that, which was causing it to hang.

### Related Issues

- This fixes issue 777 in dymos.

### Backwards incompatibilities

None

### New Dependencies

None
