### PR TITLE
add `long_description_content_type` to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,7 @@ setup(
     version=__version__,
     description="OpenMDAO framework infrastructure",
     long_description=long_description,
+    long_description_content_type='text/markdown',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
### Summary

add [long_description_content_type](https://packaging.python.org/en/latest/specifications/core-metadata/#description-content-type) to metadata in `setup.py`  per [PEP-566](https://peps.python.org/pep-0566/#description-content-type-optional) so that the description will render properly on [pypi](https://pypi.org/project/openmdao/)


### Related Issues

- Resolves #2608 

### Backwards incompatibilities

None

### New Dependencies

None
