### PR TITLE
Pin `setuptools<65.0.0` in test workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -124,6 +124,8 @@ jobs:
 
           python -m pip install --upgrade pip
 
+          python -m pip install 'setuptools<65.0.0'
+
           echo "============================================================="
           echo "Install OpenMDAO"
           echo "============================================================="

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -124,6 +124,8 @@ jobs:
 
           python -m pip install --upgrade pip
 
+          # setuptools v65.0.0 breaks pyoptsparse install with:
+          # ModuleNotFoundError: No module named 'distutils.msvccompiler'
           python -m pip install 'setuptools<65.0.0'
 
           echo "============================================================="
@@ -218,8 +220,7 @@ jobs:
               echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
             fi
 
-            conda list
-            build_pyoptsparse --verbose $BRANCH $PAROPT $SNOPT
+            build_pyoptsparse $BRANCH $PAROPT $SNOPT
           fi
 
       - name: Install optional dependencies

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -216,7 +216,8 @@ jobs:
               echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
             fi
 
-            build_pyoptsparse $BRANCH $PAROPT $SNOPT
+            conda list
+            build_pyoptsparse --verbose $BRANCH $PAROPT $SNOPT
           fi
 
       - name: Install optional dependencies


### PR DESCRIPTION
### Summary

Pin `setuptools<65.0.0` in `openmdao_test_workflow.yml` due to [breaking change](https://github.com/pypa/setuptools/blob/main/CHANGES.rst#v6500) that causes `pyoptsparse` installation to fail.

### Related Issues

- Resolves #2611

### Backwards incompatibilities

None

### New Dependencies

None
