### PR TITLE
N2: Sort cycle arrow-related structures & fix cycle arrow display

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -53,7 +53,6 @@ class Diagram {
 
     _newModelData() {
         this.model = new ModelData(this.modelData);
-        console.log(this.model)
     }
 
     /** Create a Layout object. Can be overridden to create different types of Layouts */

--- a/openmdao/visualization/n2_viewer/gen/Matrix.js
+++ b/openmdao/visualization/n2_viewer/gen/Matrix.js
@@ -295,7 +295,7 @@ class Matrix {
 
         // Find which variable box each of the variables belong in,
         // while finding the bounds of that box. Top and bottom
-        // rows recorded for each node in this._boxInfo[].
+        // rows recorded for each node.
         for (let ri = 1; ri < this.diagNodes.length; ++ri) {
             const curNode = this.diagNodes[ri];
             const startINode = this.diagNodes[currentBox.startI];

--- a/openmdao/visualization/n2_viewer/gen/NodeConnection.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeConnection.js
@@ -25,8 +25,8 @@ class NodeConnection {
         else {
             // Collect all parents of the source node.
             srcObjParents.push(this.srcObj);
-            for (let obj = this.srcObj.parent; obj != null; obj = obj.parent) {
-                srcObjParents.push(obj);
+            for (let parentObj = this.srcObj.parent; parentObj != null; parentObj = parentObj.parent) {
+                srcObjParents.push(parentObj);
             }
         }
 

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -502,7 +502,7 @@ def _get_viewer_data(data_source, case_id=None):
             if nz.size > 1:
                 nz -= 1  # convert back to correct edge index
                 edges_list = [edge_ids[i] for i in nz]
-                edges_list = sorted(edges_list, key=itemgetter(0,1))
+                edges_list = sorted(edges_list, key=itemgetter(0, 1))
 
                 for vsrc, vtgtlist in G.get_edge_data(src, tgt)['conns'].items():
                     for vtgt in vtgtlist:
@@ -514,7 +514,7 @@ def _get_viewer_data(data_source, case_id=None):
             for vtgt in vtgtlist:
                 connections_list.append({'src': vsrc, 'tgt': vtgt})
 
-    connections_list = sorted(connections_list, key=itemgetter('src','tgt'))
+    connections_list = sorted(connections_list, key=itemgetter('src', 'tgt'))
 
     data_dict['sys_pathnames_list'] = list(sys_idx)
     data_dict['connections_list'] = connections_list

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -2,6 +2,7 @@
 import inspect
 import os
 import pathlib
+from operator import itemgetter
 
 import networkx as nx
 import numpy as np
@@ -447,13 +448,12 @@ def _get_viewer_data(data_source, case_id=None):
 
     connections_list = []
 
-    sys_idx = {}  # map of pathnames to index of pathname in list (systems in cycles only)
-
     G = root_group.compute_sys_graph(comps_only=True)
 
     scc = nx.strongly_connected_components(G)
 
     strongdict = {}
+    sys_idx_names = []
 
     for i, strong_comp in enumerate(scc):
         for c in strong_comp:
@@ -462,9 +462,13 @@ def _get_viewer_data(data_source, case_id=None):
         if len(strong_comp) > 1:
             # these IDs are only used when back edges are present
             for name in strong_comp:
-                sys_idx[name] = len(sys_idx)
+                sys_idx_names.append(name)
+
+    sys_idx = {}  # map of pathnames to index of pathname in list (systems in cycles only)
 
     comp_orders = {name: i for i, name in enumerate(root_group._ordered_comp_name_iter())}
+    for name in sorted(sys_idx_names):
+        sys_idx[name] = len(sys_idx)
 
     # 1 is added to the indices of all edges in the matrix so that we can use 0 entries to
     # indicate that there is no connection.
@@ -498,6 +502,8 @@ def _get_viewer_data(data_source, case_id=None):
             if nz.size > 1:
                 nz -= 1  # convert back to correct edge index
                 edges_list = [edge_ids[i] for i in nz]
+                edges_list = sorted(edges_list, key=itemgetter(0,1))
+
                 for vsrc, vtgtlist in G.get_edge_data(src, tgt)['conns'].items():
                     for vtgt in vtgtlist:
                         connections_list.append({'src': vsrc, 'tgt': vtgt,
@@ -508,14 +514,10 @@ def _get_viewer_data(data_source, case_id=None):
             for vtgt in vtgtlist:
                 connections_list.append({'src': vsrc, 'tgt': vtgt})
 
-    # connections_list2 = []
-    # conns2 = root_group._problem_meta['model_ref']()._conn_global_abs_in2out
-    # for c in conns2:
-    #    connections_list2.append({'src': conns2[c], 'tgt': c})
+    connections_list = sorted(connections_list, key=itemgetter('src','tgt'))
 
     data_dict['sys_pathnames_list'] = list(sys_idx)
     data_dict['connections_list'] = connections_list
-    # data_dict['connections_list'] = connections_list2
     data_dict['abs2prom'] = root_group._var_abs2prom
 
     data_dict['driver'] = {

--- a/openmdao/visualization/n2_viewer/src/OmMatrix.js
+++ b/openmdao/visualization/n2_viewer/src/OmMatrix.js
@@ -198,11 +198,10 @@ class OmMatrix extends Matrix {
     drawOffDiagonalArrows(cell) {
         super.drawOffDiagonalArrows(cell);
 
-        /* Cycle arrows are only drawn in the bottom triangle of the diagram */
+        /* Cycle arrows are only drawn for cells in the bottom triangle of the diagram */
         if (cell.row > cell.col) {
             const src = this.diagNodes[cell.row],
                 tgt = this.diagNodes[cell.col];
-
             // Get an array of all the parents and children of the target with cycle arrows
             const relativesWithCycleArrows = tgt.getNodesWithCycleArrows();
 

--- a/openmdao/visualization/n2_viewer/src/OmMatrix.js
+++ b/openmdao/visualization/n2_viewer/src/OmMatrix.js
@@ -139,8 +139,9 @@ class OmMatrix extends Matrix {
      * @param {Number} endIndex The index of the last diagonal node.
      */
     _drawArrowsInputView(cell, startIndex, endIndex) {
-        const boxStart = this._boxInfo[startIndex],
-            boxEnd = this._boxInfo[endIndex];
+        const boxInfo = this._boxInfo()
+        const boxStart = boxInfo[startIndex],
+            boxEnd = boxInfo[endIndex];
 
         // Draw multiple horizontal lines, but no more than one vertical line
         // for box-to-box connections
@@ -175,6 +176,22 @@ class OmMatrix extends Matrix {
     }
 
     /**
+     * Find the index of the first node in this.diagNodes that "has" the supplied node.
+     * For some reason Array.findIndex() did not work correctly for this.
+     * @param {OmTreeNode} node Reference to the node to search for.
+     * @returns {Number} The index of the node if found, otherwise -1.
+     */
+    _findDiagNodeIndex(node) {
+        for (const idx in this.diagNodes) {
+            if (this.diagNodes[idx].hasNode(node)) {
+                return idx;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
      * Look for and draw cycle arrows of the specified cell.
      * @param {OmMatrixCell} cell The off-diagonal cell to draw arrows for.
      */
@@ -193,13 +210,11 @@ class OmMatrix extends Matrix {
                 for (const ai of relative.cycleArrows) {
                     if (src.hasNode(ai.src)) {
                         for (const arrow of ai.arrows) {
-                            const firstBeginIndex =
-                                this.diagNodes.findIndex(diagNode => diagNode.hasNode(arrow.begin));
+                            const firstBeginIndex = this._findDiagNodeIndex(arrow.begin);
                             if (firstBeginIndex == -1)
                                 throw ("OmMatrix.drawOffDiagonalArrows() error: first begin index not found");
 
-                            const firstEndIndex =
-                                this.diagNodes.findIndex(diagNode => diagNode.hasNode(arrow.end));
+                            const firstEndIndex = this._findDiagNodeIndex(arrow.end);
                             if (firstEndIndex == -1)
                                 throw ("OmMatrix.drawOffDiagonalArrows() error: first end index not found");
 

--- a/openmdao/visualization/n2_viewer/src/OmTreeNode.js
+++ b/openmdao/visualization/n2_viewer/src/OmTreeNode.js
@@ -125,8 +125,9 @@ class OmTreeNode extends FilterCapableNode {
 
         if (this.hasChildren()) {
             for (const child of this.children) {
-                if (child instanceof OmTreeNode)
+                if (child instanceof OmTreeNode) {
                     child._getNodesInChildrenWithCycleArrows(arr);
+                }
             }
         }
     }

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -113,6 +113,11 @@ n2_gui_test_scripts = {
             "arrowCount": 4
         },
         {
+            "desc": "Hover on an N2 cell with cycle arrows and count",
+            "test": "hoverArrow",
+            
+        },
+        {
             "desc": "Left-click on partition tree element to zoom",
             "test": "click",
             "selector": "g#tree rect#circuit_R2",

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -115,7 +115,8 @@ n2_gui_test_scripts = {
         {
             "desc": "Hover on an N2 cell with cycle arrows and count",
             "test": "hoverArrow",
-            
+            "selector": "#cellShape_conn_33_to_13",
+            "arrowCount": 6
         },
         {
             "desc": "Left-click on partition tree element to zoom",


### PR DESCRIPTION
### Summary

The first issue relates to the fact that generating multiple N2 diagrams from the same model would produce slightly different N2 data structures. This was due to `sys_pathnames_list` and the `cycle_arrows` arrays not being sorted. Pre-sorting them in `n2_viewer.py` resolved the problem.

The second issue that was discovered while testing the first is that hovering over a connection cell that contained cycle arrows would cause an error. This was fixed by pointing to an existing object in `OmMatrix._drawArrowsInputView()`. However, yet another issue came up, which was that not all of the arrows were the right color. The problem was that `Array.findIndex()` in `OmMatrix.drawOffDiagonalArrows()` was not working as expected, and after a lot of trial-and-error still didn't succeed. The workaround was to write function `OmMatrix._findDiagNodeIndex()`, which worked fine.

### Related Issues

- Resolves #1909

### Backwards incompatibilities

None

### New Dependencies

None
