### PR TITLE
update GitHub workflow to use mamba and pre-install jupyter dependencies

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -414,6 +414,11 @@ jobs:
         run: |
           mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
+          echo "============================================================="
+          echo "Install jupyter dependencies with mamba"
+          echo "============================================================="
+          mamba install jupyter jupyter-book 'lxml>=4.9.1'
+
           python -m pip install --upgrade pip
 
           echo "============================================================="

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -109,18 +109,25 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Setup conda
+      - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
+          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
-          auto-update-conda: true
 
       - name: Install OpenMDAO
         shell: bash -l {0}
         run: |
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+
+          if [[ "${{ matrix.OPTIONAL }}" == "[all]" ]]; then
+            echo "============================================================="
+            echo "Install jupyter dependencies with mamba"
+            echo "============================================================="
+            mamba install jupyter jupyter-book 'lxml>=4.9.1'
+          fi
 
           python -m pip install --upgrade pip
 
@@ -151,13 +158,13 @@ jobs:
             COMPILERS="cython compilers openmpi-mpicc"
           fi
 
-          if [[  "${{ matrix.MPI4PY }}" ]]; then
+          if [[ "${{ matrix.MPI4PY }}" ]]; then
             MPI4PY="mpi4py=${{ matrix.MPI4PY }}"
           else
             MPI4PY="mpi4py"
           fi
 
-          conda install $COMPILERS $MPI4PY petsc4py=${{ matrix.PETSc }} -q -y
+          mamba install $COMPILERS $MPI4PY petsc4py=${{ matrix.PETSc }} -q -y
 
           export OMPI_MCA_rmaps_base_oversubscribe=1
           echo "-----------------------"
@@ -186,7 +193,7 @@ jobs:
               echo "SNOPT ${{ matrix.SNOPT }} was requested but is not available on conda-forge"
             fi
 
-            conda install -c conda-forge pyoptsparse
+            mamba install -c conda-forge pyoptsparse
           else
             pip install git+https://github.com/OpenMDAO/build_pyoptsparse
 
@@ -231,8 +238,8 @@ jobs:
       - name: Display environment info
         shell: bash -l {0}
         run: |
-          conda info
-          conda list
+          mamba info
+          mamba list
 
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"
@@ -394,18 +401,18 @@ jobs:
         run: |
           git fetch --prune --unshallow --tags
 
-      - name: Setup conda
+      - name: Setup mamba
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
-          conda-version: "*"
+          mamba-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
 
       - name: Install OpenDMAO
         shell: pwsh
         run: |
-          conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
+          mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip
 
@@ -425,8 +432,8 @@ jobs:
       - name: Display environment info
         shell: pwsh
         run: |
-          conda info
-          conda list
+          mamba info
+          mamba list
 
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"


### PR DESCRIPTION
### Summary

Changes to GitHub workflow:
- switch back to using  *mamba* instead of *conda* (it's faster)
- install `jupyter` and `jupyter-book` with *mamba* prior to installing `OpenMDAO` (*pip* is broken)
- make sure we have the latest `lxml` since the version we get by default does not pass audit

### Related Issues

- Resolves #2617

### Backwards incompatibilities

None

### New Dependencies

None
