### PR TITLE
Fix up N2 file save dialogs

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -142,8 +142,13 @@ class Diagram {
         const svgUrl = URL.createObjectURL(svgBlob);
         const downloadLink = document.createElement("a");
         downloadLink.href = svgUrl;
-        const svgFileName = prompt("Filename to save SVG as", 'partition_tree_n2.svg');
+        
+        // To suggest a filename to save as, get the basename of the current HTML file,
+        // remove the .html/.htm extension, and add .svg.
+        const svgFileName = String(window.location.pathname)
+            .replace(/^.*\/(.+)\.html?$/i, "$1") + ".svg";
         downloadLink.download = svgFileName;
+        
         document.body.appendChild(downloadLink);
         downloadLink.click();
         document.body.removeChild(downloadLink);

--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -142,11 +142,10 @@ class Diagram {
         const svgUrl = URL.createObjectURL(svgBlob);
         const downloadLink = document.createElement("a");
         downloadLink.href = svgUrl;
-        
+
         // To suggest a filename to save as, get the basename of the current HTML file,
-        // remove the .html/.htm extension, and add .svg.
-        const svgFileName = String(window.location.pathname)
-            .replace(/^.*\/(.+)\.html?$/i, "$1") + ".svg";
+        // remove the .html/.htm extension, and add ".svg".
+        const svgFileName = basename() + ".svg";
         downloadLink.download = svgFileName;
         
         document.body.appendChild(downloadLink);

--- a/openmdao/visualization/n2_viewer/gen/UserInterface.js
+++ b/openmdao/visualization/n2_viewer/gen/UserInterface.js
@@ -750,7 +750,7 @@ class UserInterface {
      * @param {Object} [extraData={}] Additional items to save.
      */
     saveState(extraData = {}) {
-        const stateFileName = prompt("Filename to save view state as", 'saved.n2view');
+        const stateFileName = basename() + '.n2view';
 
         // Zoomed node
         const zoomedElement = this.diag.zoomedElement.id;

--- a/openmdao/visualization/n2_viewer/gen/utils.js
+++ b/openmdao/visualization/n2_viewer/gen/utils.js
@@ -127,3 +127,12 @@ function wipeObj(obj) {
 function visible(elem) {
     return !!( elem.offsetWidth || elem.offsetHeight || elem.getClientRects().length );
 }
+
+/**
+ * An adaptation of the common "basename()" function.
+ * @param {String} filepath The path to get the basename from.
+ * @returns {String} The basename of the current URL, minus the .html/.htm extension.
+ */
+function basename(filepath = window.location.pathname) {
+    return String(filepath).replace(/^.*[\/\\](.+)\.html?$/i, "$1");
+}


### PR DESCRIPTION
### Summary

The dialogs for the Save SVG function and the Save View function in the N2 were prompting for a filename, then putting up a second dialog to save the file. This update bases the suggested filename on the name of the N2 html file, and only presents the normal file save dialog. The user is still able to change the filename if desired.

### Related Issues

- Resolves #1908 

### Backwards incompatibilities

None

### New Dependencies

None
