### PR TITLE
Fix for bug in check_totals when an aliased constraint is defined in a child system.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2972,6 +2972,7 @@ class Group(System):
         abs2idx = self._var_allprocs_abs2idx
         sizes = self._var_sizes['output']
         approx_of_idx = self._owns_approx_of_idx
+        responses = self.get_responses(recurse=True)
 
         if self._owns_approx_of:
             szname = 'global_size' if total else 'size'
@@ -2980,8 +2981,8 @@ class Group(System):
             for of in self._owns_approx_of:
 
                 # Support for constraint aliases.
-                if of in self._responses and self._responses[of]['alias'] is not None:
-                    path = self._responses[of]['source']
+                if of in responses and responses[of]['alias'] is not None:
+                    path = responses[of]['source']
                 else:
                     path = of
 
@@ -3121,6 +3122,7 @@ class Group(System):
 
         abs2meta = self._var_allprocs_abs2meta
         info = self._coloring_info
+        responses = self.get_responses(recurse=True)
 
         if info['coloring'] is not None and (self._owns_approx_of is None or
                                              self._owns_approx_wrt is None):
@@ -3138,10 +3140,10 @@ class Group(System):
         approx_keys = self._get_approx_subjac_keys()
         for key in approx_keys:
             left, right = key
-            if left in self._responses and self._responses[left]['alias'] is not None:
-                left = self._responses[left]['source']
-            if right in self._responses and self._responses[right]['alias'] is not None:
-                right = self._responses[right]['source']
+            if left in responses and responses[left]['alias'] is not None:
+                left = responses[left]['source']
+            if right in responses and responses[right]['alias'] is not None:
+                right = responses[right]['source']
 
             if key in self._subjacs_info:
                 meta = self._subjacs_info[key]

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -20,7 +20,8 @@ from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1w
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.components.array_comp import ArrayComp
 from openmdao.test_suite.groups.parallel_groups import FanInSubbedIDVC, Diamond
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_partials, \
+     assert_check_totals
 from openmdao.utils.om_warnings import OMInvalidCheckDerivativesOptionsWarning
 
 from openmdao.utils.mpi import MPI
@@ -3719,6 +3720,36 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(totals['a2', 'p1.widths']['abs error'][0], 0.0, 1e-6)
         assert_near_equal(totals['a3', 'p1.widths']['abs error'][0], 0.0, 1e-6)
         assert_near_equal(totals['a4', 'p1.widths']['abs error'][0], 0.0, 1e-6)
+
+    def test_alias_constraints_nested(self):
+        # Tests a bug where we need to lookup the constraint alias on a response that is from
+        # a child system.
+        prob = om.Problem()
+        model = prob.model
+
+        sub = model.add_subsystem('sub', om.Group())
+
+        sub.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        sub.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        sub.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        sub.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = om.pyOptSparseDriver(optimizer='SLSQP', print_results=False)
+        prob.driver.opt_settings['ACC'] = 1e-9
+
+        sub.add_design_var('x', lower=-50.0, upper=50.0)
+        sub.add_design_var('y', lower=-50.0, upper=50.0)
+        sub.add_objective('f_xy')
+        sub.add_constraint('c', upper=-15.0, alias="Stuff")
+
+        prob.setup()
+
+        prob.run_model()
+
+        totals = prob.check_totals()
+        assert_check_totals(totals)
 
     def test_exceed_tol_show_only_incorrect(self):
 

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -3736,9 +3736,6 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.driver = om.pyOptSparseDriver(optimizer='SLSQP', print_results=False)
-        prob.driver.opt_settings['ACC'] = 1e-9
-
         sub.add_design_var('x', lower=-50.0, upper=50.0)
         sub.add_design_var('y', lower=-50.0, upper=50.0)
         sub.add_objective('f_xy')
@@ -3748,7 +3745,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.run_model()
 
-        totals = prob.check_totals()
+        totals = prob.check_totals(out_stream=None)
         assert_check_totals(totals)
 
     def test_exceed_tol_show_only_incorrect(self):


### PR DESCRIPTION
### Summary

Fix for bug in check_totals when an aliased constraint is defined in a child system.

During setup of the approximation at the top of the model, it needs to query into the _responses dictionary to find if it is an alias and what the source is... but the responses dictionary is local, with only the cons added at that group level.
So, just need to call the function to recurse and return all the responses.

### Related Issues

- Resolves #2620

### Backwards incompatibilities

None

### New Dependencies

None
