### PR TITLE
Add a MacOS build to CI

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -10,8 +10,7 @@ on:
 
 jobs:
 
-  ubuntu_tests:
-    runs-on: ubuntu-latest
+  tests:
 
     timeout-minutes: 120
 
@@ -19,8 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # test baseline versions
-          - NAME: Baseline
+          # test baseline versions on Ubuntu
+          - NAME: Ubuntu Baseline
+            OS: ubuntu-latest
             PY: '3.10'
             NUMPY: 1.22
             SCIPY: 1.7
@@ -33,8 +33,23 @@ jobs:
             BANDIT: true
             TESTS: true
 
+          # test baseline versions on MacOS
+          - NAME: MacOS Baseline
+            OS: macos-latest
+            PY: '3.10'
+            NUMPY: 1.22
+            SCIPY: 1.7
+            PETSc: 3.16
+            # PYOPTSPARSE: 'v2.8.3'
+            # PAROPT: true
+            # SNOPT: 7.7
+            OPTIONAL: '[all]'
+            JAX: true
+            TESTS: true
+
           # test latest versions
-          - NAME: Latest
+          - NAME: Ubuntu Latest
+            OS: ubuntu-latest
             PY: 3
             NUMPY: 1
             SCIPY: 1
@@ -43,10 +58,12 @@ jobs:
             PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
+            JAX: true
             TESTS: true
 
           # test minimal install
-          - NAME: Minimal
+          - NAME: Ubuntu Minimal
+            OS: ubuntu-latest
             PY: 3
             NUMPY: 1
             SCIPY: 1
@@ -55,7 +72,8 @@ jobs:
             TESTS: true
 
           # test oldest supported versions
-          - NAME: Oldest
+          - NAME: Ubuntu Oldest
+            OS: ubuntu-latest
             PY: 3.8
             NUMPY: 1.22
             SCIPY: 1.7
@@ -68,7 +86,8 @@ jobs:
             TESTS: true
 
           # build docs (baseline versions)
-          - NAME: BuildDocs
+          - NAME: Build Docs
+            OS: ubuntu-latest
             PY: '3.10'
             NUMPY: 1.22
             SCIPY: 1.7
@@ -79,7 +98,13 @@ jobs:
             JAX: true
             BUILD_DOCS: true
 
-    name: Ubuntu ${{ matrix.NAME }}
+    runs-on: ${{ matrix.OS }}
+
+    name: ${{ matrix.NAME }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - name: Display run details
@@ -93,6 +118,7 @@ jobs:
           echo "============================================================="
 
       - name: Create SSH key
+        if: (matrix.SNOPT || matrix.BUILD_DOCS)
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
@@ -118,7 +144,6 @@ jobs:
           channel-priority: true
 
       - name: Install OpenMDAO
-        shell: bash -l {0}
         run: |
           mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
@@ -138,7 +163,6 @@ jobs:
 
       - name: Install jax
         if: matrix.JAX
-        shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Install jax"
@@ -147,7 +171,6 @@ jobs:
 
       - name: Install PETSc
         if: matrix.PETSc
-        shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Install PETSc"
@@ -180,9 +203,11 @@ jobs:
 
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
 
+          echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+
       - name: Install pyOptSparse
         if: matrix.PYOPTSPARSE
-        shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Install pyoptsparse"
@@ -228,7 +253,6 @@ jobs:
 
       - name: Install optional dependencies
         if: matrix.OPTIONAL == '[all]'
-        shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Install additional packages for testing/coverage"
@@ -236,7 +260,6 @@ jobs:
           python -m pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
 
       - name: Display environment info
-        shell: bash -l {0}
         run: |
           mamba info
           mamba list
@@ -254,7 +277,6 @@ jobs:
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Audit dependencies
-        shell: bash -l {0}
         run: |
           python -m pip install pip-audit
           echo "============================================================="
@@ -265,7 +287,6 @@ jobs:
 
       - name: Run tests
         if: matrix.TESTS
-        shell: bash -l {0}
         run: |
           echo "============================================================="
           echo "Run tests with coverage (from directory other than repo root)"
@@ -276,7 +297,6 @@ jobs:
 
       - name: Submit coverage
         if: matrix.TESTS
-        shell: bash -l {0}
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
@@ -293,7 +313,6 @@ jobs:
       - name: Build docs
         if: matrix.BUILD_DOCS
         id: build_docs
-        shell: bash -l {0}
         run: |
           export OPENMDAO_REPORTS=0
 
@@ -332,7 +351,6 @@ jobs:
 
       - name: Publish docs
         if: ${{ github.event_name == 'push' && matrix.BUILD_DOCS }}
-        shell: bash -l {0}
         env:
           DOCS_LOCATION: ${{ secrets.DOCS_LOCATION }}
         run: |
@@ -349,7 +367,6 @@ jobs:
       - name: Scan for security issues
         if: matrix.BANDIT
         id: bandit
-        shell: bash -l {0}
         run: |
           python -m pip install bandit
           echo "============================================================="
@@ -376,12 +393,16 @@ jobs:
       matrix:
         include:
           # baseline versions
-          - NAME: Baseline
+          - NAME: Windows Baseline
             PY: 3.9
             NUMPY: 1.22
             SCIPY: 1.6
 
-    name: Windows ${{ matrix.NAME }}
+    name: ${{ matrix.NAME }}
+
+    defaults:
+      run:
+        shell: pwsh
 
     steps:
       - name: Display run details
@@ -410,7 +431,6 @@ jobs:
           channel-priority: true
 
       - name: Install OpenDMAO
-        shell: pwsh
         run: |
           mamba install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
@@ -427,7 +447,6 @@ jobs:
           python -m pip install .[all]
 
       - name: Install optional dependencies
-        shell: pwsh
         run: |
           echo "============================================================="
           echo "Install additional packages for testing/coverage"
@@ -435,7 +454,6 @@ jobs:
           python -m pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
 
       - name: Display environment info
-        shell: pwsh
         run: |
           mamba info
           mamba list
@@ -453,7 +471,6 @@ jobs:
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Audit dependencies
-        shell: bash -l {0}
         run: |
           python -m pip install pip-audit
           echo "============================================================="
@@ -463,7 +480,6 @@ jobs:
           python -m pip_audit --ignore-vuln PYSEC-2022-237
 
       - name: Run tests
-        shell: pwsh
         run: |
           echo "============================================================="
           echo "Run tests with coverage (from directory other than repo root)"
@@ -477,7 +493,6 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
           COVERALLS_PARALLEL: true
-        shell: pwsh
         run: |
           echo "============================================================="
           echo "Submit coverage"
@@ -497,7 +512,7 @@ jobs:
 
   coveralls:
     name: Finish coverage
-    needs: [ubuntu_tests, windows_tests]
+    needs: [tests, windows_tests]
     runs-on: ubuntu-latest
     steps:
     - uses: coverallsapp/github-action@master
@@ -507,7 +522,7 @@ jobs:
 
   dymos_tests:
     name: Run Dymos Tests
-    needs: [ubuntu_tests, windows_tests]
+    needs: [tests, windows_tests]
     runs-on: ubuntu-latest
     steps:
     - uses: benc-uk/workflow-dispatch@v1


### PR DESCRIPTION
### Summary

Add a MacOS build to the GitHub Actions test workflow.

I have so far been unable to get the `build_pyoptsparse` script working on the `macos` image, so it is left for future work.

### Related Issues

- Resolves #2622

### Backwards incompatibilities

None

### New Dependencies

None
