### PR TITLE
I2275 show more helpful error message when user calls Problem.list_problem_vars before final_setup

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2020,7 +2020,6 @@ class Problem(object):
             ['ref', 'ref0', 'indices', 'adder', 'scaler', 'units',
             'parallel_deriv_color', 'cache_linear_solution'].
         """
-
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
             raise RuntimeError(
                 "list_problem_vars can only be called after final_setup is called, either "

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2020,6 +2020,12 @@ class Problem(object):
             ['ref', 'ref0', 'indices', 'adder', 'scaler', 'units',
             'parallel_deriv_color', 'cache_linear_solution'].
         """
+
+        if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
+            raise RuntimeError(
+                "list_problem_vars can only be called after final_setup is called, either "
+                "explicitly, or by running run_driver")
+
         default_col_names = ['name', 'val', 'size']
 
         # Design vars

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1961,6 +1961,26 @@ class TestProblem(unittest.TestCase):
         self.assertRegex(output[12], r'^\s+upper:')
         self.assertRegex(output[13], r'^\s+array+\(+\[[0-9., e+-]+\]+\)')
 
+    def test_list_problem_vars_before_final_setup(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])
+        prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
+        prob.model.set_input_defaults('x', 3.0)
+        prob.model.set_input_defaults('y', -4.0)
+        prob.driver = om.ScipyOptimizeDriver()
+        prob.driver.options['optimizer'] = 'COBYLA'
+        prob.model.add_design_var('x', lower=-50, upper=50)
+        prob.model.add_design_var('y', lower=-50, upper=50)
+        prob.model.add_objective('parab.f_xy')
+        prob.model.add_constraint('const.g', lower=0, upper=10.)
+        prob.setup()
+
+        with self.assertRaises(RuntimeError) as err:
+            prob.list_problem_vars()
+        expected_error_msg = "list_problem_vars can only be called after final_setup is called, " \
+                             "either explicitly, or by running run_driver"
+        self.assertEqual(str(err.exception), expected_error_msg)
+
     def test_list_problem_w_multi_constraints(self):
         p = om.Problem()
 


### PR DESCRIPTION
### Summary

Instead of failing with an unhelpful error message, let the user know what went wrong if they call `Problem.list_problem_vars` before `final_setup` is called.

### Related Issues

- Resolves #2275 

### Backwards incompatibilities

None

### New Dependencies

None
