### PR TITLE
This should get rid of the deprecation warnings under python 3.10 when entry points are used.

### DIFF
--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -256,6 +256,13 @@ def _run_test_func(mod, funcpath):
 if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 
+    if sys.version_info >= (3, 10):
+        def _eps_get(eps, group):
+            return eps.select(group=group)
+    else:
+        def _eps_get(eps, group):
+            return eps[group]
+
     def _iter_entry_points(group):
         eps = entry_points()
         # there seems to be a bug currently where entry points can show up more than
@@ -263,7 +270,7 @@ if sys.version_info >= (3, 8):
         # TODO: revisit later to see if we can remove the check
         seen = set()
         if group in eps:
-            for ep in eps[group]:
+            for ep in _eps_get(eps, group):
                 if ep.name not in seen:
                     seen.add(ep.name)
                     yield ep

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -257,23 +257,25 @@ if sys.version_info >= (3, 8):
     from importlib.metadata import entry_points
 
     if sys.version_info >= (3, 10):
-        def _eps_get(eps, group):
-            return eps.select(group=group)
+        def _eps_get(group):
+            eps = entry_points().select(group=group)
+            for name in eps.names:
+                yield eps[name]
     else:
-        def _eps_get(eps, group):
-            return eps[group]
+        def _eps_get(group):
+            eps = entry_points()
+            if group in eps:
+                yield from eps[group]
 
     def _iter_entry_points(group):
-        eps = entry_points()
         # there seems to be a bug currently where entry points can show up more than
         # once in the iterator, so keep track of the ones we've already seen.
         # TODO: revisit later to see if we can remove the check
         seen = set()
-        if group in eps:
-            for ep in _eps_get(eps, group):
-                if ep.name not in seen:
-                    seen.add(ep.name)
-                    yield ep
+        for ep in _eps_get(group):
+            if ep.name not in seen:
+                seen.add(ep.name)
+                yield ep
 else:
     try:
         import pkg_resources

--- a/openmdao/utils/tests/test_entry_points.py
+++ b/openmdao/utils/tests/test_entry_points.py
@@ -1,13 +1,10 @@
 import unittest
-import os
 import importlib
-import inspect
 import types
-from os.path import dirname, abspath, splitext
 
 from openmdao.utils.entry_points import list_installed, _filtered_ep_iter, _allowed_types, \
     compute_entry_points, _epgroup_bases, split_ep
-from openmdao.utils.file_utils import files_iter
+from openmdao.utils.assert_utils import assert_no_warning
 
 from openmdao.api import Group, SurrogateModel
 from openmdao.core.component import Component
@@ -90,6 +87,14 @@ class TestEntryPoints(unittest.TestCase):
         if badep:
             self.fail("For entry point group 'openmdao_report', the following EPs either couldn't "
                       f"be found or are not functions: {sorted(badep)}.")
+
+
+class TestEntryPointsWarning(unittest.TestCase):
+    ISOLATED = True
+
+    def test_ep_warn(self):
+        with assert_no_warning(Warning):
+            list_installed()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Backwards incompatibilities

None

### New Dependencies

None
