### PR TITLE
Fixed failure in load_case when variable is distributed.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2219,7 +2219,7 @@ class Problem(object):
                                    "case is not found in the model")
                 varmeta = meta[name]
                 if varmeta['distributed'] and self.model.comm.size > 1:
-                    sizes = self.model._var_sizes['input'][:, abs2idx[name]]
+                    sizes = self.model._var_sizes['output'][:, abs2idx[name]]
                     self[name] = scatter_dist_to_local(outputs[name], self.model.comm, sizes)
                 else:
                     self[name] = outputs[name]

--- a/openmdao/core/tests/test_global_shape_err.py
+++ b/openmdao/core/tests/test_global_shape_err.py
@@ -36,7 +36,7 @@ class GlobalShapeErr(unittest.TestCase):
             Whether this test is intended to produce an error or not.
         """
         n0 = 3
-        n1 = 100 if MPI.COMM_WORLD.rank ==0 else 100 * n1_test_multiple
+        n1 = 100 if MPI.COMM_WORLD.rank == 0 else 100 * n1_test_multiple
         prob = om.Problem()
         ivc = prob.model.add_subsystem('ivc',om.IndepVarComp())
         ivc.add_output('x', val = np.ones((n0, n1)), distributed=True)

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -72,7 +72,7 @@ META_KEY_SEP = '!'
 
 def array_to_blob(array):
     """
-    Make numpy array in to BLOB type.
+    Make numpy array into a BLOB.
 
     Convert a numpy array to something that can be written
     to a BLOB field in sqlite.

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -4888,10 +4888,9 @@ class Adder(om.ExplicitComponent):
 class SqliteCaseReaderMPI(unittest.TestCase):
     N_PROCS = 2
     def test_distrib_var_load(self):
-        size = 100 if MPI.COMM_WORLD.rank ==0 else 10
         prob = om.Problem()
         ivc = prob.model.add_subsystem('ivc',om.IndepVarComp(), promotes=['*'])
-        ivc.add_output('x', val = np.ones(size), distributed=True)
+        ivc.add_output('x', val = np.ones(100 if prob.comm.rank == 0 else 10), distributed=True)
         ivc.add_output('y', val = 1.0)
 
         prob.model.add_subsystem('adder', Adder(), promotes=['*'])

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -35,6 +35,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.general_utils import set_pyoptsparse_opt, determine_adder_scaler, printoptions
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.mpi import MPI, multi_proc_exception_check
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import OMDeprecationWarning
 
@@ -42,6 +43,11 @@ from openmdao.utils.om_warnings import OMDeprecationWarning
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 if OPTIMIZER:
     from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
 
 
 def count_keys(d):
@@ -4864,6 +4870,61 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
 
         _assert_model_matches_case(seventh_slsqp_iteration_case, prob.model)
 
+
+class Adder(om.ExplicitComponent):
+    def setup(self):
+        self.add_input('x', shape_by_conn=True, distributed=True)
+        self.add_input('y')
+        self.add_output('x_sum', shape=1)
+        self.add_output('out_dist', copy_shape='x', distributed=True)
+
+    def compute(self, inputs, outputs):
+        outputs['x_sum'] = np.sum(inputs['x']) + inputs['y']**2.0
+        outputs['out_dist'] = inputs['x'] + 1.
+
+
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+@use_tempdirs
+class SqliteCaseReaderMPI(unittest.TestCase):
+    N_PROCS = 2
+    def test_distrib_var_load(self):
+        size = 100 if MPI.COMM_WORLD.rank ==0 else 10
+        prob = om.Problem()
+        ivc = prob.model.add_subsystem('ivc',om.IndepVarComp(), promotes=['*'])
+        ivc.add_output('x', val = np.ones(size), distributed=True)
+        ivc.add_output('y', val = 1.0)
+
+        prob.model.add_subsystem('adder', Adder(), promotes=['*'])
+        prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9)
+        prob.model.add_design_var('y', lower=-1, upper=1)
+        prob.model.add_objective('x_sum')
+
+        recorder_file = 'distributed.sql'
+        prob.driver.add_recorder(om.SqliteRecorder(recorder_file))
+        prob.driver.recording_options['includes'] = ['*']
+        prob.driver.recording_options['record_objectives'] = True
+        prob.driver.recording_options['record_constraints'] = True
+        prob.driver.recording_options['record_desvars'] = True
+
+        prob.setup()
+        prob.run_driver()
+
+        reader = om.CaseReader(recorder_file)
+        # print(reader.list_cases())
+        prob.load_case(reader.get_case(-1))
+
+        with multi_proc_exception_check(prob.comm):
+            val = prob.get_val('adder.x', get_remote=False)
+            if prob.comm.rank == 0:
+                assert_near_equal(val, np.ones(100, dtype=float))
+            else:
+                assert_near_equal(val, np.ones(10, dtype=float))
+
+            val = prob.get_val('adder.out_dist', get_remote=False)
+            if prob.comm.rank == 0:
+                assert_near_equal(val, np.ones(100, dtype=float) + 1.)
+            else:
+                assert_near_equal(val, np.ones(10, dtype=float) + 1.)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -93,6 +93,32 @@ def evenly_distrib_idxs(num_divisions, arr_size):
     return sizes, offsets
 
 
+def scatter_dist_to_local(dist_val, comm, sizes):
+    """
+    Scatter a full distributed value to local values in each MPI process.
+
+    Parameters
+    ----------
+    dist_val : ndarray
+        The full distributed value.
+    comm : MPI communicator
+        The MPI communicator.
+    sizes : ndarray
+        The array of sizes for each process.
+
+    Returns
+    -------
+    ndarray
+        The local value on this process.
+    """
+    from openmdao.utils.mpi import MPI
+    offsets = np.zeros(sizes.shape, dtype=INT_DTYPE)
+    offsets[1:] = np.cumsum(sizes)[:-1]
+    local = np.zeros(sizes[comm.rank])
+    comm.Scatterv([dist_val, sizes, offsets, MPI.DOUBLE], local, root=0)
+    return local
+
+
 def get_evenly_distributed_size(comm, full_size):
     """
     Return the size of the current rank's part of an array of the given size.

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -7,6 +7,8 @@ import re
 import json
 import numpy as np
 
+from openmdao.utils.mpi import MPI
+
 
 def create_local_meta(name):
     """

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -7,8 +7,6 @@ import re
 import json
 import numpy as np
 
-from openmdao.utils.mpi import MPI
-
 
 def create_local_meta(name):
     """


### PR DESCRIPTION
### Summary

Distributed variables were not being scattered out into their local parts properly. 
A scatter for distributed variables was added to the `load_case` method.

### Related Issues

- Resolves #2626

### Backwards incompatibilities

None

### New Dependencies

None
