### PR TITLE
updated check for when coloring doesn't meet min improvement percentage

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1292,13 +1292,15 @@ class Driver(object):
 
             if coloring is not None:
                 # if the improvement wasn't large enough, don't use coloring
-                pct = coloring._solves_info()[1]
+                pct = coloring._solves_info()[-1]
                 info = self._coloring_info
                 if info['min_improve_pct'] > pct:
                     info['coloring'] = info['static'] = None
                     msg = f"Coloring was deactivated.  Improvement of {pct:.1f}% was less " \
                           f"than min allowed ({info['min_improve_pct']:.1f}%)."
                     issue_warning(msg, prefix=self.msginfo, category=DerivativesWarning)
+                    coloring = None
+                    self._coloring_info['coloring'] = self._coloring_info['coloring'] = None
 
             return coloring
 

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1299,8 +1299,7 @@ class Driver(object):
                     msg = f"Coloring was deactivated.  Improvement of {pct:.1f}% was less " \
                           f"than min allowed ({info['min_improve_pct']:.1f}%)."
                     issue_warning(msg, prefix=self.msginfo, category=DerivativesWarning)
-                    coloring = None
-                    self._coloring_info['coloring'] = self._coloring_info['coloring'] = None
+                    self._coloring_info['coloring'] = coloring = None
 
             return coloring
 

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -132,7 +132,7 @@ def _compute_jac_view_info(totals, data, dv_vals, response_vals, coloring):
             # use max of abs value here instead of norm to keep coloring consistent between
             # top level jac and subjacs
             var_matrix[i, j] = np.max(matrix[ofstart:ofend, wrtstart:wrtend])
-            if var_matrix[i, j] > 0. or (coloring and
+            if var_matrix[i, j] > 0. or (coloring is not None and
                                          np.any(mask[ofstart:ofend, wrtstart:wrtend])):
                 nonempty_submats.add((of, wrt))
 
@@ -141,7 +141,7 @@ def _compute_jac_view_info(totals, data, dv_vals, response_vals, coloring):
     for i in range(matrix.shape[0]):
         for j in range(matrix.shape[1]):
             val = matrix[i, j]
-            if coloring and not mask[i, j]:
+            if coloring is not None and not mask[i, j]:
                 val = None
             else:
                 if val == 0.:


### PR DESCRIPTION
### Summary

When computing total coloring, we were accessing the wrong member of the tuple returned from Coloring._solves_info() so we were comparing the min improvement percentage to the wrong thing.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
