### PR TITLE
Fixed  to allow a shape mismatch in AutoIVC if all promoted inputs have a size of 1.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3371,12 +3371,13 @@ class Group(System):
                     if val.size > 1:
                         raise ValueError(f"Shape of input '{tgt}', (), doesn't match shape "
                                          f"{val.shape}.")
-                elif val.shape != value.shape and val.size > 1 and value.size > 1:
+                elif np.squeeze(val).shape != np.squeeze(value).shape:
                     raise ValueError(f"Shape of input '{tgt}', {value.shape}, doesn't match shape "
                                      f"{val.shape}.")
+
                 if val is not value:
                     if val.shape:
-                        val[:] = value
+                        val = np.reshape(value, newshape=val.shape)
                     else:
                         val = value
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3371,7 +3371,7 @@ class Group(System):
                     if val.size > 1:
                         raise ValueError(f"Shape of input '{tgt}', (), doesn't match shape "
                                          f"{val.shape}.")
-                elif val.shape != value.shape:
+                elif val.shape != value.shape and val.size > 1 and value.size > 1:
                     raise ValueError(f"Shape of input '{tgt}', {value.shape}, doesn't match shape "
                                      f"{val.shape}.")
                 if val is not value:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1990,6 +1990,8 @@ class System(object):
 
             Parameters
             ----------
+            io : str
+                One of 'input' or 'output'.
             matches : dict {'input': ..., 'output': ...}
                 Dict of promoted names and associated info.
             match_type : intEnum

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -547,6 +547,34 @@ class TestMultiConns(unittest.TestCase):
         self.assertEqual(err_msg, msg)
 
 
+class TestAutoIVCAllowableShapeMismatch(unittest.TestCase):
+
+    def test_allowable_shape_mismatch(self):
+
+        p = om.Problem()
+
+        c1 = p.model.add_subsystem('c1', om.ExecComp())
+        c2 = p.model.add_subsystem('c2', om.ExecComp())
+
+        c1.add_expr('a = 5.0 * x1', a=dict(shape=(1,)), x1=dict(shape=(1,)))
+        c2.add_expr('b = 5.0 * x2', b=dict(shape=(1,)), x2=dict(shape=(1, 1)))
+
+        p.model.promotes('c1', inputs=[('x1', 'x')])
+        p.model.promotes('c2', inputs=[('x2', 'x')])
+
+        p.setup()
+
+        p.set_val('x', 4.0)
+
+        p.run_model()
+
+        a = p.get_val('c1.a')
+        b = p.get_val('c2.b')
+
+        assert_near_equal(a, 20.0)
+        assert_near_equal(b, 20.0)
+
+
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestConnectionsDistrib(unittest.TestCase):
     N_PROCS = 2

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -574,6 +574,31 @@ class TestAutoIVCAllowableShapeMismatch(unittest.TestCase):
         assert_near_equal(a, 20.0)
         assert_near_equal(b, 20.0)
 
+    def test_allowable_shape_mismatch_1x3x1(self):
+
+        p = om.Problem()
+
+        c1 = p.model.add_subsystem('c1', om.ExecComp())
+        c2 = p.model.add_subsystem('c2', om.ExecComp())
+
+        c1.add_expr('a = 5.0 * x1', a=dict(shape=(3,)), x1=dict(shape=(3,)))
+        c2.add_expr('b = 5.0 * x2', b=dict(shape=(3,)), x2=dict(shape=(1, 3, 1)))
+
+        p.model.promotes('c1', inputs=[('x1', 'x')])
+        p.model.promotes('c2', inputs=[('x2', 'x')])
+
+        p.setup()
+
+        p.set_val('x', np.array([1., 2., 3.]))
+
+        p.run_model()
+
+        a = p.get_val('c1.a')
+        b = p.get_val('c2.b')
+
+        assert_near_equal(a, np.array([5., 10., 15.]))
+        assert_near_equal(b, np.array([5., 10., 15.]))
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestConnectionsDistrib(unittest.TestCase):


### PR DESCRIPTION
### Summary

If multiple inputs have different shapes, are promoted to the same name, and are connected to AutoIVC, OpenMDAO will now allow this if they all have a size of 1.

### Related Issues

- Resolves #2631 

### Backwards incompatibilities

None

### New Dependencies

None
