### PR TITLE
Fix to AddSubtractComp for derivatives that weren't declared when an equation reused an input from a previous equation.

### DIFF
--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -187,11 +187,6 @@ class AddSubtractComp(ExplicitComponent):
             if input_name not in self._input_names:
                 self.add_input(input_name, shape=shape, units=units,
                                desc=desc + '_inp_' + input_name)
-                sf = scaling_factors[i]
-                self.declare_partials([output_name], [input_name],
-                                      val=sf * sp.eye(vec_size * length, format='csc'))
-                self._input_names[input_name] = {'vec_size': vec_size, 'length': length,
-                                                 'units': units}
             else:
                 # Verify that the input is consistent with that added for a previous equation
                 prev_vec_size = self._input_names[input_name]['vec_size']
@@ -209,6 +204,12 @@ class AddSubtractComp(ExplicitComponent):
                     raise ValueError(self.msginfo + f': Input {input_name} was added in a previous '
                                                     f'equation but had different units '
                                                     f'({prev_units} vs. {units}.')
+
+            sf = scaling_factors[i]
+            self.declare_partials([output_name], [input_name],
+                                  val=sf * sp.eye(vec_size * length, format='csc'))
+            self._input_names[input_name] = {'vec_size': vec_size, 'length': length,
+                                             'units': units}
 
     def add_output(self):
         """

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -190,6 +190,10 @@ def set_env_vars_context(**kwargs):
     ----------
     **kwargs : dict
         Keyword args corresponding to environment variables to set.
+
+    Yields
+    ------
+    None
     """
     saved = {}
     try:


### PR DESCRIPTION
### Summary

Fix to AddSubtractComp for derivatives that weren't declared when an equation reused an input from a previous equation.

Note: the tests are formatted differently than other tests in OpenMDAO. I preserved this style for consistency. 

### Related Issues

- Resolves #2635

### Backwards incompatibilities

None

### New Dependencies

None
