### PR TITLE
Replaced all occurrances of time.time() with time.perf_counter()

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -442,7 +442,7 @@ class ApproximationScheme(object):
         for group_i, tup in enumerate(approx_groups):
             wrt, data, jcol_idxs, vec, vec_idxs, directional, direction = tup
             if self._progress_out:
-                start_time = time.time()
+                start_time = time.perf_counter()
 
             if direction is not None:
                 app_data = self.apply_directional(data, direction)
@@ -474,7 +474,7 @@ class ApproximationScheme(object):
                         tosend = (group_i, next(jidx_iter), result)  # use local jac row var index
 
                     if self._progress_out:
-                        end_time = time.time()
+                        end_time = time.perf_counter()
                         prom_name = _convert_auto_ivc_to_conn_name(
                             system._conn_global_abs_in2out, wrt)
                         self._progress_out.write(f"{fd_count+1}/{len(result)}: Checking "

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1192,7 +1192,7 @@ class System(object):
 
         save_first_call = self._first_call_to_linearize
         self._first_call_to_linearize = False
-        sparsity_start_time = time.time()
+        sparsity_start_time = time.perf_counter()
 
         # for groups, this does some setup of approximations
         self._setup_approx_coloring()
@@ -1243,7 +1243,7 @@ class System(object):
             for scheme in self._approx_schemes.values():
                 scheme._reset()
 
-        sparsity_time = time.time() - sparsity_start_time
+        sparsity_time = time.perf_counter() - sparsity_start_time
 
         ordered_wrt_info = list(self._jac_wrt_iter(info['wrt_matches']))
         ordered_of_info = list(self._jac_of_iter())

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -550,17 +550,17 @@ class ParDerivColorFeatureTestCase(unittest.TestCase):
 
         p.run_model()
 
-        elapsed_rev = time.time()
+        elapsed_rev = time.perf_counter()
         Jrev = p.compute_totals(of, wrt, return_format='dict')
-        elapsed_rev = time.time() - elapsed_rev
+        elapsed_rev = time.perf_counter() - elapsed_rev
 
         # run in fwd mode and compare times for deriv calculation
         p.setup(mode='fwd')
         p.run_model()
 
-        elapsed_fwd = time.time()
+        elapsed_fwd = time.perf_counter()
         Jfwd = p.compute_totals(of, wrt, return_format='dict')
-        elapsed_fwd = time.time() - elapsed_fwd
+        elapsed_fwd = time.perf_counter() - elapsed_fwd
 
         assert_near_equal(Jfwd['ParallelGroup1.Con1.y']['Comp1.x'][0], np.ones(size)*2., 1e-6)
         assert_near_equal(Jfwd['ParallelGroup1.Con2.y']['Comp1.x'][0], np.ones(size)*-3., 1e-6)

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1367,7 +1367,7 @@ class _TotalJacInfo(object):
                                 print(f"In mode: {mode}.\n('{self.ivc_print_names.get(key, key)}'"
                                       f", [{inds}])", flush=True)
 
-                        t0 = time.time()
+                        t0 = time.perf_counter()
 
                     # restore old linear solution if cache_linear_solution was set by the user for
                     # any input variables involved in this linear solution.
@@ -1380,7 +1380,7 @@ class _TotalJacInfo(object):
                             model._solve_linear(mode, rel_systems)
 
                     if debug_print:
-                        print(f'Elapsed Time: {time.time() - t0} secs\n', flush=True)
+                        print(f'Elapsed Time: {time.perf_counter() - t0} secs\n', flush=True)
 
                     jac_setter(inds, mode, imeta)
 
@@ -1433,7 +1433,7 @@ class _TotalJacInfo(object):
         # Solve for derivs with the approximation_scheme.
         # This cuts out the middleman by grabbing the Jacobian directly after linearization.
 
-        t0 = time.time()
+        t0 = time.perf_counter()
 
         model._tot_jac = self
         try:
@@ -1470,7 +1470,7 @@ class _TotalJacInfo(object):
 
         totals = self.J_dict
         if debug_print:
-            print(f'Elapsed time to approx totals: {time.time() - t0} secs\n', flush=True)
+            print(f'Elapsed time to approx totals: {time.perf_counter() - t0} secs\n', flush=True)
 
         # Driver scaling.
         if self.has_scaling:

--- a/openmdao/devtools/iprof_mem.py
+++ b/openmdao/devtools/iprof_mem.py
@@ -33,13 +33,13 @@ def _create_profile_callback(depth, fileset, stream):
                 else:
                     klass = '?'
                 print('c', fpath, frame.f_code.co_firstlineno,
-                      frame.f_code.co_name, mem_usage(), time.time(), klass, sep='|', file=stream)
+                      frame.f_code.co_name, mem_usage(), time.perf_counter(), klass, sep='|', file=stream)
         elif event == 'return' and depth[0] > 0:
             fpath = abspath(frame.f_code.co_filename)
             depth[0] -= 1
             if fpath in fileset:
                 print('r', fpath, frame.f_code.co_firstlineno,
-                      frame.f_code.co_name, mem_usage(), time.time(), '-', sep='|', file=stream)
+                      frame.f_code.co_name, mem_usage(), time.perf_counter(), '-', sep='|', file=stream)
 
     return _wrapped
 

--- a/openmdao/devtools/itrace.py
+++ b/openmdao/devtools/itrace.py
@@ -90,7 +90,7 @@ def _trace_call(frame, arg, stack, context):
     """
     global time0
     if time0 is None:
-        time0 = time.time()
+        time0 = time.perf_counter()
 
     (qual_cache, method_counts, class_counts, id2count,
      verbose, memory, leaks, stream, show_ptrs) = context
@@ -163,7 +163,7 @@ def _trace_return(frame, arg, stack, context):
         if current_mem != last_mem:
             delta = current_mem - last_mem
             _printer("%s<-- %s (time: %8.5f) (total: %6.3f MB) (diff: %+.0f KB)" %
-                     (indent, '.'.join((sname, funcname)), time.time() - time0, current_mem,
+                     (indent, '.'.join((sname, funcname)), time.perf_counter() - time0, current_mem,
                      delta * 1024.))
 
             # add this delta to all callers so when they calculate their own delta, this
@@ -172,7 +172,7 @@ def _trace_return(frame, arg, stack, context):
                 memory[i] += delta
         else:
             _printer("%s<-- %s (time: %8.5f) (total: %6.3f MB)" %
-                     (indent, '.'.join((sname, funcname)), time.time() - time0, current_mem))
+                     (indent, '.'.join((sname, funcname)), time.perf_counter() - time0, current_mem))
     else:
         _printer("%s<-- %s" % (indent, '.'.join((sname, funcname))))
 

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -97,7 +97,7 @@ class RecordingManager(object):
             return
 
         if metadata is not None:
-            metadata['timestamp'] = time.time()
+            metadata['timestamp'] = time.perf_counter()
 
         for recorder in self._recorders:
             recorder.record_iteration(recording_requester, data, metadata)
@@ -119,7 +119,7 @@ class RecordingManager(object):
             return
 
         if metadata is not None:
-            metadata['timestamp'] = time.time()
+            metadata['timestamp'] = time.perf_counter()
 
         for recorder in self._recorders:
             recorder.record_derivatives(recording_requester, data, metadata)

--- a/openmdao/recorders/tests/recorder_test_utils.py
+++ b/openmdao/recorders/tests/recorder_test_utils.py
@@ -1,8 +1,8 @@
 import time
 
 def run_driver(problem, **kwargs):
-    t0 = time.time()
+    t0 = time.perf_counter()
     problem.run_driver(**kwargs)
-    t1 = time.time()
+    t1 = time.perf_counter()
     return t0, t1
 

--- a/openmdao/test_suite/components/matmultcomp.py
+++ b/openmdao/test_suite/components/matmultcomp.py
@@ -64,9 +64,9 @@ if __name__ == '__main__':
     p.setup(mode='fwd', force_alloc_complex=True)
     p.run_model()
 
-    start = time.time()
+    start = time.perf_counter()
     J = p.compute_totals(of=['comp.y'], wrt=['indep.x'])
 
     print("norm J - mat:", np.linalg.norm(J['comp.y','indep.x'] - comp.mat))
-    print("Elapsed time:", time.time() - start)
+    print("Elapsed time:", time.perf_counter() - start)
 

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -1662,7 +1662,7 @@ def _get_bool_total_jac(prob, num_full_jacs=_DEF_COMP_SPARSITY_ARGS['num_full_ja
         use_driver = False
 
     with _compute_total_coloring_context(prob.model):
-        start_time = time.time()
+        start_time = time.perf_counter()
         fullJ = None
         for i in range(num_full_jacs):
             if use_driver:
@@ -1677,7 +1677,7 @@ def _get_bool_total_jac(prob, num_full_jacs=_DEF_COMP_SPARSITY_ARGS['num_full_ja
                 fullJ += np.abs(Jabs)
 
         Jabs = None
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
 
     fullJ *= (1.0 / np.max(fullJ))
 
@@ -1769,7 +1769,7 @@ def _compute_coloring(J, mode):
     Coloring
         See Coloring class docstring.
     """
-    start_time = time.time()
+    start_time = time.perf_counter()
     try:
         start_mem = mem_usage()
     except RuntimeError:
@@ -1792,7 +1792,7 @@ def _compute_coloring(J, mode):
         fallback = None
 
         # record the total time and memory usage for bidir, fwd, and rev
-        coloring._meta['coloring_time'] = time.time() - start_time
+        coloring._meta['coloring_time'] = time.perf_counter() - start_time
         if start_mem is not None:
             coloring._meta['coloring_memory'] = mem_usage() - start_mem
 
@@ -1831,7 +1831,7 @@ def _compute_coloring(J, mode):
     else:  # fwd
         coloring._fwd = (col_groups, col2rows)
 
-    coloring._meta['coloring_time'] = time.time() - start_time
+    coloring._meta['coloring_time'] = time.perf_counter() - start_time
     if start_mem is not None:
         coloring._meta['coloring_memory'] = mem_usage() - start_mem
 


### PR DESCRIPTION
### Summary

Replace all calls to `time.time()` with `time.perf_counter()`.

### Related Issues

- Resolves #2577

### Backwards incompatibilities

None

### New Dependencies

None
