### PR TITLE
Updated AnalysisError handling in pyoptsparse_driver

### DIFF
--- a/openmdao/docs/openmdao_book/_toc.yml
+++ b/openmdao/docs/openmdao_book/_toc.yml
@@ -28,6 +28,8 @@ parts:
     - file: advanced_user_guide/analytic_derivatives/partial_derivs_explicit
     - file: advanced_user_guide/recording/advanced_case_recording
     - file: advanced_user_guide/example/euler_integration_example
+    - file: advanced_user_guide/complex_step
+    - file: advanced_user_guide/analysis_errors/analysis_error
 - caption: Reference Guide
   chapters:
   - file: theory_manual/theory_manual

--- a/openmdao/docs/openmdao_book/advanced_user_guide/advanced_user_guide.md
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/advanced_user_guide.md
@@ -23,3 +23,6 @@ These tutorials cover more advanced topics. This guide assumes that you have rea
 
 ## Details about Complex Step
 - [Using Complex Step to Compute Derivatives](complex_step.ipynb)
+
+## Using AnalysisError
+- [Using AnalysisError to avoid a region in the solution space](analysis_errors/analysis_error.ipynb)

--- a/openmdao/docs/openmdao_book/advanced_user_guide/analysis_errors/analysis_error.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analysis_errors/analysis_error.ipynb
@@ -100,7 +100,7 @@
     "    # pyOptSparseDriver with selected optimizer\n",
     "    driver = om.pyOptSparseDriver(optimizer=optimizer)\n",
     "    if optimizer == 'IPOPT':\n",
-    "        driver.opt_settings['file_print_level'] = 12\n",
+    "        driver.opt_settings['file_print_level'] = 5\n",
     "    driver.options['print_results'] = False\n",
     "\n",
     "    # setup problem & initialize values\n",
@@ -238,8 +238,8 @@
    "source": [
     "with open(\"IPOPT.out\", encoding=\"utf-8\") as f:\n",
     "    IPOPT_history = f.read()\n",
-    "beg = IPOPT_history.find(\"--> Starting line search in iteration 1 <--\")\n",
-    "end = IPOPT_history.find(\"**************************************\", beg)\n",
+    "beg = IPOPT_history.find(\"iter    objective\")\n",
+    "end = IPOPT_history.find(\"(scaled)\", beg)\n",
     "print(IPOPT_history[beg:end])"
    ]
   },

--- a/openmdao/docs/openmdao_book/advanced_user_guide/analysis_errors/analysis_error.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analysis_errors/analysis_error.ipynb
@@ -1,0 +1,432 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "active-ipynb",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode\n",
+    "except ImportError:\n",
+    "    !python -m pip install openmdao[notebooks]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Raising an AnalysisError\n",
+    "\n",
+    "This example demonstrates the effect of raising an `AnalysisError` in your Component's `compute` function.  The result depends on which driver and optimizer is used.  The `SNOPT` and `IPOPT` optimizers, used in conjunction with [pyOptSparseDriver](../../features/building_blocks/drivers/pyoptsparse_driver.ipynb), are good options if your model has invalid regions.\n",
+    "\n",
+    "\n",
+    "## Model\n",
+    "\n",
+    "\n",
+    "For this somewhat contrived case, we will assume some range of input values to our Component is invalid and raise an `AnalysisError` if those inputs are encountered.  We will use the [Paraboloid](../../basic_user_guide/single_disciplinary_optimization/first_analysis) as the basis for our example, modifying it so that it will raise an AnalysisError if the x or y inputs are within a specified range."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.notebook_utils import get_code\n",
+    "from myst_nb import glue\n",
+    "glue(\"code_paraboloid_invalid_region\", get_code(\"openmdao.test_suite.components.paraboloid_invalid_region.Paraboloid\"), display=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{Admonition} `Paraboloid` class definition \n",
+    ":class: dropdown\n",
+    "\n",
+    "{glue:}`code_paraboloid_invalid_region`\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, we will define a function to create a Problem instance while allowing us to specify the optimizer and the invalid region:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import openmdao.api as om\n",
+    "\n",
+    "from openmdao.test_suite.components.paraboloid_invalid_region import Paraboloid\n",
+    "\n",
+    "\n",
+    "def setup_problem(optimizer, invalid_x=None, invalid_y=None):\n",
+    "    # Paraboloid model with optional AnalysisErrors\n",
+    "    model = om.Group()\n",
+    "\n",
+    "    model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])\n",
+    "    model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])\n",
+    "\n",
+    "    comp = model.add_subsystem('comp',\n",
+    "                               Paraboloid(invalid_x, invalid_y),\n",
+    "                               promotes=['*'])\n",
+    "\n",
+    "    model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])\n",
+    "\n",
+    "    model.add_design_var('x', lower=-50.0, upper=50.0)\n",
+    "    model.add_design_var('y', lower=-50.0, upper=50.0)\n",
+    "\n",
+    "    model.add_objective('f_xy')\n",
+    "    model.add_constraint('c', upper=-15.)\n",
+    "\n",
+    "    # pyOptSparseDriver with selected optimizer\n",
+    "    driver = om.pyOptSparseDriver(optimizer=optimizer)\n",
+    "    if optimizer == 'IPOPT':\n",
+    "        driver.opt_settings['file_print_level'] = 12\n",
+    "    driver.options['print_results'] = False\n",
+    "\n",
+    "    # setup problem & initialize values\n",
+    "    prob = om.Problem(model, driver)\n",
+    "    prob.setup()\n",
+    "\n",
+    "    prob.set_val('x', 50)\n",
+    "    prob.set_val('y', 50)\n",
+    "\n",
+    "    return prob, comp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example using IPOPT\n",
+    "\n",
+    "First we will run the Paraboloid optimization as normal, without raising any errors. In doing this, we can see the nominal path that the optimizer follows throught solution space to arrive at the optimum.  For this initial case, we will use the `IPOPT` optimizer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prob, comp = setup_problem('IPOPT')\n",
+    "prob.run_driver()\n",
+    "\n",
+    "for (x, y, f_xy) in comp.eval_history:\n",
+    "    print(f\"x: {x:9.5f}  y: {y:9.5f}  f_xy: {f_xy:10.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "assert_near_equal(prob['x'], 7.166667, 1e-6)\n",
+    "assert_near_equal(prob['y'], -7.833334, 1e-6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, we will define our invalid region as `x` between 7.2 and 10.2 and `y` between -50 and -10.  This region was chosen as it is crossed in the course of the nominal optimization from our chosen starting point at `x=50`, `y=50`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "invalid_x = (7.2, 10.2)\n",
+    "invalid_y = (-50., -40.)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will recreate the problem using this invalid region and see that the optimizer's path to the optimum now must reroute around the invalid values. It will take many more iterations to get to the solution, but IPOPT still gets there in the end:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "prob, comp = setup_problem('IPOPT', invalid_x, invalid_y)\n",
+    "prob.run_driver()\n",
+    "\n",
+    "for i, (x, y, f_xy) in enumerate(comp.eval_history):\n",
+    "    print(f\"{i:2d}  x: {x:9.5f}  y: {y:9.5f}  f_xy: {f_xy:10.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "assert_near_equal(prob['x'], 7.166667, 1e-6)\n",
+    "assert_near_equal(prob['y'], -7.833334, 1e-6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see how many times our Component raised an AnalysisError and at which iteration they occurred:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Number of errors: {len(comp.raised_eval_errors)}\")\n",
+    "print(f\"Iterations:{comp.raised_eval_errors}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Looking at the IPOPT output file (`IPOPT.out`) will reveal what happened when the optimizer encountered these bad points. Here we just show a relevant subsection of the file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"IPOPT.out\", encoding=\"utf-8\") as f:\n",
+    "    IPOPT_history = f.read()\n",
+    "beg = IPOPT_history.find(\"--> Starting line search in iteration 1 <--\")\n",
+    "end = IPOPT_history.find(\"**************************************\", beg)\n",
+    "print(IPOPT_history[beg:end])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specifically, we can see the following message when IPOPT changes its search in response to the bad point:\n",
+    "\n",
+    "    Warning: Cutting back alpha due to evaluation error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count = 0\n",
+    "\n",
+    "for line in IPOPT_history.split('\\n'):\n",
+    "    if 'Cutting back alpha' in line:\n",
+    "        print(line)\n",
+    "        count = count + 1\n",
+    "\n",
+    "print(\"\\nNumber of times IPOPT encountered an evaluation error:\", count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example using SNOPT\n",
+    "\n",
+    "We can exercise the same model using `SNOPT` as our optimizer, with similar results. First we will run the nominal case, and then again with the invalid region:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "prob, comp = setup_problem('SNOPT')\n",
+    "prob.run_driver()\n",
+    "\n",
+    "for i, (x, y, f_xy) in enumerate(comp.eval_history):\n",
+    "    print(f\"{i:2d}  x: {x:9.5f}  y: {y:9.5f}  f_xy: {f_xy:10.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "assert_near_equal(prob['x'], 7.166667, 1e-6)\n",
+    "assert_near_equal(prob['y'], -7.833334, 1e-6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "prob, comp = setup_problem('SNOPT', invalid_x, invalid_y)\n",
+    "prob.run_driver()\n",
+    "\n",
+    "for i, (x, y, f_xy) in enumerate(comp.eval_history):\n",
+    "    print(f\"{i:2d}  x: {x:9.5f}  y: {y:9.5f}  f_xy: {f_xy:10.5f}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "assert_near_equal(prob['x'], 7.166667, 1e-6)\n",
+    "assert_near_equal(prob['y'], -7.833334, 1e-6)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"Number of errors: {len(comp.raised_eval_errors)}\")\n",
+    "print(f\"Iterations:{comp.raised_eval_errors}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert(len(comp.raised_eval_errors) == 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case we can see that we raised a single AnalysisError.  We can again find evidence of SNOPT encountering this evaluation error in the `SNOPT_print.out` file, but still finding the solution. For SNOPT, we are looking for the `D` code at the end of an iteration. Here again we just show a relevant subsection of the file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(\"SNOPT_print.out\", encoding=\"utf-8\", errors='ignore') as f:\n",
+    "    SNOPT_history = f.read()\n",
+    "beg = SNOPT_history.find(\"   Itns Major Minor\")\n",
+    "end = SNOPT_history.find(\"Problem name\", beg)\n",
+    "print(SNOPT_history[beg:end])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "count = 0\n",
+    "\n",
+    "for line in SNOPT_history.split('\\n'):\n",
+    "    if line.endswith(' D'):\n",
+    "        print(line)\n",
+    "        count = count + 1\n",
+    "\n",
+    "print(\"\\nNumber of times SNOPT encountered an evaluation error:\", count)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{Note}\n",
+    "Not all optimizers will respond as nicely to an AnalysisError as the two demonstrated here (`IPOPT` and `SNOPT`).  Some optimizers may fail to navigate around the bad region and find a solution at all.  Other may find an incorrect solution.  It is important to understand the capabilities of your chosen optimizer when working with a model that may raise an AnlysisError.\n",
+    "```\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/openmdao/docs/openmdao_book/other/disable_snopt_cells.py
+++ b/openmdao/docs/openmdao_book/other/disable_snopt_cells.py
@@ -37,8 +37,10 @@ def disable_snopt_cells(fname):
 
 if __name__ == '__main__':
 
-    notebooks = ['features/building_blocks/drivers/pyoptsparse_driver.ipynb']
+    notebooks = [
+        'features/building_blocks/drivers/pyoptsparse_driver.ipynb',
+        'advanced_user_guide/analysis_errors/analysis_error.ipynb'
+    ]
 
     for notebook in notebooks:
         disable_snopt_cells(notebook)
-

--- a/openmdao/drivers/tests/test_analysis_errors.py
+++ b/openmdao/drivers/tests/test_analysis_errors.py
@@ -1,0 +1,343 @@
+""" Unit tests for AnalysisError with Pyoptsparse Driver."""
+
+import unittest
+
+from collections import defaultdict
+from packaging.version import Version
+
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs, parameterized_name, require_pyoptsparse
+from openmdao.test_suite.components.paraboloid_invalid_region import Paraboloid
+
+from openmdao.utils.mpi import MPI
+
+try:
+    from parameterized import parameterized
+except ImportError:
+    from openmdao.utils.assert_utils import SkipParameterized as parameterized
+
+from openmdao.drivers.pyoptsparse_driver import optlist, grad_drivers, pyoptsparse_version
+
+
+do_not_test = {
+    'NLPY_AUGLAG',  # requires nlpy to be built (raises pyOpt_error.Error)
+    'NSGA2',        # PETSc segfault with Analysis Errors, NANs or not
+    'PSQP',         # fails nominal with: (4) Maximum constraint value is less than or equal to tolerance
+}
+
+@use_tempdirs
+@require_pyoptsparse()
+class TestPyoptSparseAnalysisErrors(unittest.TestCase):
+
+    # optimizer specific settings
+    opt_settings = {
+        'ALPSO': {
+            'seed': 1.0 if pyoptsparse_version == Version('1.2') else 1
+        },
+        'IPOPT': {
+            'file_print_level': 5
+        },
+        'SLSQP': {
+            'ACC': 1e-9
+        },
+    }
+
+    # some optimizers may not be able to find the solution within 1e-6
+    tolerances = defaultdict(lambda: 1e-6)
+    tolerances.update({
+        'ALPSO': 1e-3,    # ALPSO gets a pretty bad answer, especially in v1.2
+        'CONMIN': 1e-3,   # CONMIN gets a pretty bad answer
+        'NSGA2': 1e-1,    # NSGA2 gets a really bad answer
+    })
+
+    # invalid range chosen to be on the nominal path of the optimizer
+    invalid_range = defaultdict(lambda: {'x': (7.2, 10.2), 'y': (-50., -40.)})
+    invalid_range.update({
+        'ParOpt': {'x': (4., 6.), 'y': (-4., -6.)},
+    })
+
+    expected_result_eval_errors = defaultdict(lambda: 0)
+    expected_result_eval_errors.update({
+        'CONMIN': None,  # CONMIN does not provide a return code and will just give a bad answer
+        'ParOpt': None,  # ParOpt does not provide a return code and will just give a bad answer
+    })
+
+    expected_result_grad_errors = defaultdict(lambda: 0)
+    expected_result_grad_errors.update({
+        'CONMIN': None,  # CONMIN does not provide a return code and will just give a bad answer
+        'IPOPT': -13,    # Invalid Number Detected (i.e. NaN)
+        'SLSQP': 9,      # Iteration limit exceeded (will just keep trying?)
+        'ParOpt': None,  # ParOpt does not provide a return code and will just give a bad answer
+    })
+
+    if pyoptsparse_version == Version('1.2'):
+        # behavior is different on v1.2 (currently oldest supported version) for these optimizers
+        expected_result_eval_errors.update({
+            'SLSQP': None,  # SLSQP does not provide a return code and will return NaNs
+        })
+        expected_result_grad_errors.update({
+            'IPOPT': None,  # IPOPT does not provide a return code and will just give a bad answer
+            'SLSQP': None,  # SLSQP does not provide a return code and will return NaNs
+        })
+
+    def setup_problem(self, optimizer, func=None):
+        # Paraboloid model with optional AnalysisErrors
+        model = om.Group()
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+
+        if func:
+            invalid_range = self.invalid_range[optimizer]
+            invalid_x = invalid_range['x']
+            invalid_y = invalid_range['y']
+
+            comp = model.add_subsystem('comp', Paraboloid(invalid_x, invalid_y, func),
+                                       promotes=['*'])
+        else:
+            comp = model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15.)
+
+        # pyOptSparseDriver with selected optimizer
+        driver = om.pyOptSparseDriver(optimizer=optimizer)
+        if optimizer in self.opt_settings:
+            driver.opt_settings = self.opt_settings[optimizer]
+        driver.options['print_results'] = False
+
+        # setup problem & initialize values
+        prob = om.Problem(model, driver)
+        prob.setup()
+
+        prob.set_val('x', 50)
+        prob.set_val('y', 50)
+
+        return prob, comp
+
+    def check_history(self, optimizer, err_count=None, func='eval'):
+        """
+        Check the optimizer output file for evaluation errors and successful optimization.
+        """
+        # make sure there was at least one AnalysisError raised
+        if err_count is not None:
+            self.assertGreater(err_count, 0, "There was no AnalysisError raised.")
+
+        if optimizer == 'CONMIN':
+            # check for NaN in CONMIN.out
+            with open("CONMIN.out", encoding="utf-8") as f:
+                CONMIN_history = f.readlines()
+
+            if func == 'eval':
+                nan_text = "OBJ =            NaN"
+            else:
+                nan_text = "GRADIENT OF OBJ\n  1)            NaN          NaN"
+            errs = CONMIN_history.count(nan_text)
+
+            if err_count is None:
+                self.assertEqual(errs, 0,
+                                f"Found {errs} unexpected {func} errors in CONMIN.out")
+            else:
+                self.assertGreater(errs, 0,
+                                   f"Found {errs} {func} errors in CONMIN.out, expected {err_count}")
+
+        elif optimizer == 'IPOPT':
+            with open("IPOPT.out", encoding="utf-8") as f:
+                IPOPT_history = f.read()
+
+            if func == 'eval':
+                # check for evaluation error messages in the IPOPT history file
+                eval_msg = "Warning: Cutting back alpha due to evaluation error"
+                errs = IPOPT_history.count(eval_msg)
+
+                if err_count is None:
+                    self.assertEqual(errs, 0,
+                                     f"Found {errs} unexpected evaluation errors in IPOPT.out")
+                else:
+                    self.assertGreater(errs, 0,
+                                       f"Found {errs} evaluation errors in IPOPT.out, expected {err_count}")
+
+                # confirm that the optimization completed successfully
+                self.assertTrue("EXIT: Optimal Solution Found."
+                                in IPOPT_history)
+            else:
+                # confirm that the optimization failed due to invalid derivatives
+                self.assertTrue("EXIT: Invalid number in NLP function or derivative detected."
+                                in IPOPT_history)
+
+        elif optimizer == 'SLSQP':
+            # there is no information about evaluation/gradient errors in SLSQP.out
+            pass
+
+        elif optimizer == 'SNOPT':
+            # check for evaluation error flags in the SNOPT history file
+            with open("SNOPT_print.out", encoding="utf-8", errors='ignore') as f:
+                SNOPT_history = f.readlines()
+
+            itns = False
+            errs = 0
+            success = False
+            for line in SNOPT_history:
+                line = line.strip()
+                # find the beginning of the Iterations section
+                if line.startswith('Itns'):
+                    itns = True
+                    continue
+                # count the number of iterations that encountered an evaluation error
+                elif itns and line.endswith(' D'):
+                    errs = errs + 1
+                # confirm that the optimization completed successfully
+                elif line.startswith('SNOPTC EXIT'):
+                    success = line.endswith('finished successfully')
+                    break
+
+            self.assertTrue(success)
+
+            if err_count is None:
+                self.assertEqual(errs, 0,
+                                 f"Found {errs} unexpected evaluation errors in SNOPT_print.out")
+            else:
+                self.assertEqual(errs, err_count,
+                                 f"Found {errs} evaluation errors in SNOPT_print.out, expected {err_count}")
+
+    @parameterized.expand(optlist - do_not_test, name_func=parameterized_name)
+    def test_analysis_errors_eval(self, optimizer):
+        #
+        # first optimize without Analysis Errors
+        #
+        try:
+            prob, comp = self.setup_problem(optimizer)
+            failed = prob.run_driver()
+        except ImportError as err:
+            raise unittest.SkipTest(str(err))
+
+        self.assertFalse(failed, "Nominal Optimization failed, info = " +
+                                 str(prob.driver.pyopt_solution.optInform))
+
+        tolerance = self.tolerances[optimizer]
+
+        # make sure we got the right answer
+        assert_near_equal(prob['x'], 7.166667, tolerance)
+        assert_near_equal(prob['y'], -7.833334, tolerance)
+
+        # check that there are no AnalysisError related messages in the history
+        self.check_history(optimizer, err_count=None)
+
+        # save the optimizer's path to the solution
+        nominal_history = comp.eval_history
+
+        #
+        # Now try raising Analysis Errors in compute()
+        #
+        prob, comp = self.setup_problem(optimizer, func='compute')
+        failed = prob.run_driver()
+
+        expected_result = self.expected_result_eval_errors[optimizer]
+        opt_inform = prob.driver.pyopt_solution.optInform
+
+        if expected_result == 0:
+            # we still expect the right answer
+            self.assertFalse(failed,
+                             "Optimization with AnalysisErrors failed, info = " +
+                             str(prob.driver.pyopt_solution.optInform))
+
+            assert_near_equal(prob['x'], 7.166667, tolerance)
+            assert_near_equal(prob['y'], -7.833334, tolerance)
+
+            # but it should take more iterations
+            self.assertTrue(len(comp.eval_history) > len(nominal_history),
+                            f"Iterations with analysis errors ({len(comp.eval_history)}) is "
+                            f"not greater than nominal iterations ({len(nominal_history)})")
+
+            # check that the optimizer output shows the optimizer handling the errors
+            self.check_history(optimizer, err_count=len(comp.raised_eval_errors))
+
+        elif expected_result is not None:
+            # we expect the optimizer to return an error code
+            self.assertEqual(opt_inform['value'], expected_result,
+                             f"Optimization was expected to fail with code '{expected_result}'\n" +
+                             str(prob.driver.pyopt_solution.optInform))
+            self.assertTrue(failed,
+                            f"Optimization was expected to fail with code '{expected_result}'\n" +
+                            str(prob.driver.pyopt_solution.optInform))
+
+            # check that the optimizer output shows the optimizer was unable to handle the errors
+            self.check_history(optimizer, err_count=len(comp.raised_eval_errors), func='eval')
+
+    @parameterized.expand(grad_drivers - do_not_test, name_func=parameterized_name)
+    def test_analysis_errors_grad(self, optimizer):
+        #
+        # first optimize without Analysis Errors
+        #
+        try:
+            prob, comp = self.setup_problem(optimizer)
+            failed = prob.run_driver()
+        except ImportError as err:
+            raise unittest.SkipTest(str(err))
+
+        self.assertFalse(failed, "Nominal Optimization failed, info = " +
+                                 str(prob.driver.pyopt_solution.optInform))
+
+        tolerance = self.tolerances[optimizer]
+
+        # make sure we got the right answer
+        assert_near_equal(prob['x'], 7.166667, tolerance)
+        assert_near_equal(prob['y'], -7.833334, tolerance)
+
+        # check that there are no AnalysisError related messages in the history
+        self.check_history(optimizer, err_count=None)
+
+        # save the optimizer's path to the solution
+        nominal_history = comp.eval_history
+
+        #
+        # Now try raising Analysis Errors in compute_partials()
+        #
+        try:
+            prob, comp = self.setup_problem(optimizer, func='compute_partials')
+            failed = prob.run_driver()
+        except ImportError as err:
+            raise unittest.SkipTest(str(err))
+
+        expected_result = self.expected_result_grad_errors[optimizer]
+        opt_inform = prob.driver.pyopt_solution.optInform
+
+        if expected_result == 0:
+            # we still expect the right answer
+            self.assertFalse(failed,
+                             "Optimization with AnalysisErrors failed, info = " +
+                             str(opt_inform))
+
+            tolerance = self.tolerances[optimizer]
+            assert_near_equal(prob['x'], 7.166667, tolerance)
+            assert_near_equal(prob['y'], -7.833334, tolerance)
+
+            # but it should take more iterations
+            self.assertTrue(len(comp.eval_history) > len(nominal_history),
+                            f"Iterations with analysis errors ({len(comp.eval_history)}) is "
+                            f"not greater than nominal iterations ({len(nominal_history)})")
+
+            # check that the optimizer output shows the optimizer handling the errors
+            self.check_history(optimizer, err_count=len(comp.raised_grad_errors))
+
+        elif expected_result is not None:
+            # we expect the optimizer to return an error code
+            self.assertEqual(opt_inform['value'], expected_result,
+                             f"Optimization was expected to fail with code '{expected_result}'\n" +
+                             str(opt_inform))
+            self.assertTrue(failed,
+                            f"Optimization was expected to fail with code '{expected_result}'\n" +
+                            str(opt_inform))
+
+            # check that the optimizer output shows the optimizer was unable to handle the errors
+            self.check_history(optimizer, err_count=len(comp.raised_grad_errors), func='grad')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/test_suite/components/paraboloid_invalid_region.py
+++ b/openmdao/test_suite/components/paraboloid_invalid_region.py
@@ -1,0 +1,106 @@
+
+import openmdao.api as om
+
+
+class Paraboloid(om.ExplicitComponent):
+    """
+    Evaluates the equation f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+
+    This version of Paraboloid optionally raises an analysis error when the
+    design variables x and y are in an invalid region defined by the specified
+    "invalid_x" and "invalid_y" ranges.
+
+    The path of evaluated points to the optmized solution is recorded as
+    well as the number of analysis errors raised.
+
+    Parameters
+    ----------
+    invalid_x : tuple of float or None
+        The range of values for x which will trigger an AnalysisError
+    invalid_y : tuple of float or None
+        The range of values for y which will trigger an AnalysisError
+    func : str, 'compute' or 'compute_partials'
+        The function that will raise the AnalysisError (compute or compute_partials).
+
+    Attributes
+    ----------
+    invalid_x : tuple of float or None
+        The range of values for x which will trigger an AnalysisError
+    invalid_y : tuple of float or None
+        The range of values for y which will trigger an AnalysisError
+    func : str, 'compute' or 'compute_partials'
+        The function that will raise the AnalysisError (compute or compute_partials).
+    """
+
+    def __init__(self, invalid_x=None, invalid_y=None, func='compute'):
+        super().__init__()
+        self.invalid_x = invalid_x
+        self.invalid_y = invalid_y
+        self.func = func
+
+        self.eval_count = -1
+        self.eval_history = []
+        self.raised_eval_errors = []
+
+        self.grad_count = -1
+        self.grad_history = []
+        self.raised_grad_errors = []
+
+    def setup(self):
+        self.add_input('x', val=0.0)
+        self.add_input('y', val=0.0)
+
+        self.add_output('f_xy', val=0.0)
+
+        self.declare_partials('*', '*')
+
+    def compute(self, inputs, outputs):
+        """
+        f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+        """
+        self.eval_count += 1
+
+        x = inputs['x']
+        y = inputs['y']
+
+        f_xy = outputs['f_xy'] = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0
+
+        self.eval_history.append((x.item(), y.item(), f_xy.item()))
+
+        if self.invalid_x and self.func == 'compute':
+            beg, end =  self.invalid_x
+            if x > beg and x < end:
+                self.raised_eval_errors.append(self.eval_count)
+                raise om.AnalysisError(f'Invalid x: {beg} < {float(x):8.4f} < {end}).')
+
+        if self.invalid_y and self.func == 'compute':
+            beg, end =  self.invalid_y
+            if y > beg and y < end:
+                self.raised_eval_errors.append(self.eval_count)
+                raise om.AnalysisError(f'Invalid y: {beg} < {float(y):8.4f} < {end}).')
+
+    def compute_partials(self, inputs, partials):
+        """
+        Partial derivatives.
+        """
+        self.grad_count += 1
+
+        x = inputs['x']
+        y = inputs['y']
+
+        partials['f_xy', 'x'] = 2.0*x - 6.0 + y
+        partials['f_xy', 'y'] = 2.0*y + 8.0 + x
+
+        self.grad_history.append((x.item(), y.item()))
+
+        if self.invalid_x and self.func == 'compute_partials':
+            beg, end =  self.invalid_x
+            if x > beg and x < end:
+                self.raised_grad_errors.append(self.grad_count)
+                raise om.AnalysisError(f'Invalid x: {beg} < {float(x):8.4f} < {end}).')
+
+        if self.invalid_y and self.func == 'compute_partials':
+            beg, end =  self.invalid_y
+            if y > beg and y < end:
+                self.raised_grad_errors.append(self.grad_count)
+                raise om.AnalysisError(f'Invalid y: {beg} < {float(y):8.4f} < {end}).')

--- a/openmdao/utils/hooks.py
+++ b/openmdao/utils/hooks.py
@@ -7,6 +7,8 @@ import inspect
 import warnings
 import sys
 
+from openmdao.utils.om_warnings import issue_warning
+
 
 # global dict of hooks
 # {class_name: { inst_id: {fname: [pre_hooks, post_hooks]}}}
@@ -262,8 +264,8 @@ def _remove_hook(to_remove, hooks, class_name, fname, hook_loc, inst_id):
                     hooks.remove(hook)
                     break
             else:
-                raise RuntimeError(f"Couldn't find the given '{hook_loc}' function in the "
-                                   f"{hook_loc} hooks for {class_name}.{fname}.")
+                issue_warning(f"Couldn't find the given '{hook_loc}' function in the "
+                              f"{hook_loc} hooks for {class_name}.{fname}.")
 
 
 def _unregister_hook(fname, class_name, inst_id=None, pre=True, post=True):


### PR DESCRIPTION
### Summary

- `pyOptSparseDriver` has been modified to return `NaN` values when an `AnalysisError` is raised and the optimizer does not observe the `fail` flag in the return value of the objective and gradient functions.  `IPOPT` will respond appropriately by modifying it's search.  Other optimizers respond in different ways (e.g. by erroring or returning `NaN` values), but no longer continue as if nothing is wrong.

- a page has been added to the documentation demonstrating the handling of `AnalysisError` by `SNOPT` and `IPOPT`

- enabling the ability for a user to terminate an `IPOPT` optimization gracefully, as we can with `SNOPT`, will require a supporting change to `pyoptsparse` and is not part of this PR.

### Related Issues

- Resolves #2598

### Backwards incompatibilities

None

### New Dependencies

None
