### PR TITLE
POEM 073 draft implementation

### DIFF
--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -237,8 +237,8 @@ class DOEDriver(Driver):
         opts = self.recording_options
         if opts['record_derivatives']:
             self._compute_totals(of=self._quantities,
-                                wrt=self._indep_list,
-                                return_format=self._total_jac_format)
+                                 wrt=self._indep_list,
+                                 return_format=self._total_jac_format)
 
     def _parallel_generator(self, design_vars, model=None):
         """


### PR DESCRIPTION
### Summary

Add implementation to `DOEDriver` that will compute and record total derivatives if the recording option `record_derivaties` is set to `True`.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
