### PR TITLE
Added a command line test for the scaling report

### DIFF
--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -55,6 +55,7 @@ cmd_tests = [
     ('openmdao scaffold -b ExplicitComponent -c Foo', {}),
     ('openmdao scaffold -b ImplicitComponent -c Foo', {}),
     ('openmdao scaffold -p blahpkg --cmd=hello', {}),
+    ('openmdao scaling --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao timing -v no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao total_coloring {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),


### PR DESCRIPTION
### Summary

Added the scaling report to the command line tests performed in `test_cmdline.py`, using `circle_opt.py` as the model.

### Related Issues

- Resolves #2488 

### Backwards incompatibilities

None

### New Dependencies

None
