### PR TITLE
change map test to use weighted interpolant

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -397,9 +397,9 @@ jobs:
         include:
           # baseline versions
           - NAME: Windows Baseline
-            PY: 3.9
-            NUMPY: 1.22
-            SCIPY: 1.6
+            PY: 3
+            NUMPY: 1
+            SCIPY: 1
 
     name: ${{ matrix.NAME }}
 

--- a/openmdao/surrogate_models/nn_interpolators/nn_base.py
+++ b/openmdao/surrogate_models/nn_interpolators/nn_base.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from math import ceil
-from scipy.spatial import cKDTree
+from scipy.spatial import KDTree
 
 
 class NNBase(object):
@@ -78,7 +78,7 @@ class NNBase(object):
 
         # Make training data into a Tree
         leavesz = ceil(self._ntpts / float(num_leaves))
-        self._KData = cKDTree(self._tp, leafsize=leavesz)
+        self._KData = KDTree(self._tp, leafsize=leavesz)
 
         # Cache for gradients
         self._pt_cache = None

--- a/openmdao/surrogate_models/tests/test_map.py
+++ b/openmdao/surrogate_models/tests/test_map.py
@@ -14,9 +14,9 @@ class CompressorMap(MetaModelUnStructuredComp):
         self.add_input('Rline', val=2.0)
         self.add_input('alpha', val=0.0)
 
-        self.add_output('PR', val=1.0, surrogate=NearestNeighbor(interpolant_type='linear'))
-        self.add_output('eff', val=1.0, surrogate=NearestNeighbor(interpolant_type='linear'))
-        self.add_output('Wc', val=1.0, surrogate=NearestNeighbor(interpolant_type='linear'))
+        self.add_output('PR', val=1.0, surrogate=NearestNeighbor(interpolant_type='weighted'))
+        self.add_output('eff', val=1.0, surrogate=NearestNeighbor(interpolant_type='weighted'))
+        self.add_output('Wc', val=1.0, surrogate=NearestNeighbor(interpolant_type='weighted'))
 
 
 class TestMap(unittest.TestCase):


### PR DESCRIPTION
### Summary

- change NearestNeighbor surrogate test to use `weighted` interpolant. which gives a better value
- update Windows test in GitHuib workflow to use latest versions of Python, NumPy & SciPy
- change cKDTree import to KDTree per this [note](https://docs.scipy.org/doc/scipy/reference/generated/scipy.spatial.cKDTree.html#scipy.spatial.cKDTree):

> cKDTree is functionally identical to KDTree. Prior to SciPy v1.6.0, cKDTree had better performance 
and slightly different functionality but now the two names exist only for backward-compatibility 
reasons. If compatibility with SciPy < 1.6 is not a concern, prefer KDTree.


### Related Issues

- Resolves #2471

### Backwards incompatibilities

None

### New Dependencies

None
