### PR TITLE
Drop required Python version back to 3.7

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1051,7 +1051,8 @@ class Problem(object):
             msg = f'OpenMDAO support for Python version {sv.major}.{sv.minor} will end soon.'
             try:
                 from IPython import get_ipython
-                if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
+                ip = get_ipython()
+                if ip is None or ip.config is None or 'IPKernelApp' not in ip.config:
                     warn_deprecation(msg)
             except ImportError:
                 warn_deprecation(msg)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1046,6 +1046,19 @@ class Problem(object):
         model = self.model
         comm = self.comm
 
+        if sys.version_info.minor < 8:
+            sv = sys.version_info
+            msg = f'Python version {sv.major}.{sv.minor} detected. Only version 3.8 and ' \
+                   'higher are tested and supported for OpenMDAO.'
+            try:
+                from IPython import get_ipython
+                if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover
+                    warn_deprecation(msg)
+            except ImportError:
+                warn_deprecation(msg)
+            except AttributeError:
+                warn_deprecation(msg)
+
         # A distributed vector type is required for MPI
         if comm.size > 1:
             if distributed_vector_class is PETScVector and PETScVector is None:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1048,8 +1048,7 @@ class Problem(object):
 
         if sys.version_info.minor < 8:
             sv = sys.version_info
-            msg = f'Python version {sv.major}.{sv.minor} detected. Only version 3.8 and ' \
-                  'higher are tested and supported for OpenMDAO.'
+            msg = f'OpenMDAO support for Python version {sv.major}.{sv.minor} will end soon.'
             try:
                 from IPython import get_ipython
                 if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1049,7 +1049,7 @@ class Problem(object):
         if sys.version_info.minor < 8:
             sv = sys.version_info
             msg = f'Python version {sv.major}.{sv.minor} detected. Only version 3.8 and ' \
-                   'higher are tested and supported for OpenMDAO.'
+                  'higher are tested and supported for OpenMDAO.'
             try:
                 from IPython import get_ipython
                 if 'IPKernelApp' not in get_ipython().config:  # pragma: no cover

--- a/openmdao/test_suite/tests/test_warnings.py
+++ b/openmdao/test_suite/tests/test_warnings.py
@@ -144,7 +144,9 @@ class TestWarnings(unittest.TestCase):
         warnings.filterwarnings('error', category=om.OpenMDAOWarning)
 
         with self.assertRaises(om.UnitsWarning) as e:
-            p.setup()
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
+                p.setup()
 
         expected = "<model> <class Group>: Output 'a_comp.y' with units of 'm' is connected to " \
                    "input 'exec_comp.y' which has no units."

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -5,7 +5,11 @@ A console script wrapper for multiple openmdao functions.
 import sys
 import os
 import argparse
-import importlib.metadata as ilmd
+if sys.version_info.minor > 7:
+    import importlib.metadata as ilmd
+else:
+    ilmd = None
+
 import re
 from openmdao import __version__ as version
 
@@ -613,7 +617,7 @@ def openmdao_cmd():
 
         if hasattr(options, 'executor'):
             options.executor(options, user_args)
-        elif options.dependency_versions is True:
+        elif options.dependency_versions is True and ilmd is not None:
             dep_versions = {}
             _get_deps(dep_versions, 'openmdao')
 

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -338,6 +338,7 @@ class TestModuleFunctions(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
+            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
             p.setup()
 
         p.run_model()
@@ -354,6 +355,7 @@ class TestModuleFunctions(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
+            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
             p.setup()
 
         p.run_model()
@@ -371,6 +373,7 @@ class TestModuleFunctions(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
+            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
             p.setup()
 
         p.run_model()

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Topic :: Scientific/Engineering',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     keywords='optimization multidisciplinary multi-disciplinary analysis',
@@ -179,7 +179,7 @@ setup(
         ],
         'openmdao': ['*/tests/*.py', '*/*/tests/*.py', '*/*/*/tests/*.py']
     },
-    python_requires=">=3.8",
+    python_requires=">=3.7",
     install_requires=[
         'networkx>=2.0',
         'numpy',


### PR DESCRIPTION
### Summary

As long as Binder and Google Colab still run Python 3.7.x, we need to define that as the minimum version in `setup.py`. However, when used outside of a notebook, a deprecation warning is printed that states that Python 3.7 is no longer tested or supported by OpenMDAO.

### Related Issues

- Resolves #2297

### Backwards incompatibilities

None

### New Dependencies

None
