### PR TITLE
Changed ImplicitComponent.apply_nonlinear() to raise NotImplementedError

### DIFF
--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -337,7 +337,8 @@ class ImplicitComponent(Component):
         discrete_outputs : dict or None
             If not None, dict containing discrete output values.
         """
-        pass
+        raise NotImplementedError('ImplicitComponent.apply_nonlinear() must overridden '
+                                  'by the child class.')
 
     def solve_nonlinear(self, inputs, outputs):
         """

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -337,7 +337,7 @@ class ImplicitComponent(Component):
         discrete_outputs : dict or None
             If not None, dict containing discrete output values.
         """
-        raise NotImplementedError('ImplicitComponent.apply_nonlinear() must overridden '
+        raise NotImplementedError('ImplicitComponent.apply_nonlinear() must be overridden '
                                   'by the child class.')
 
     def solve_nonlinear(self, inputs, outputs):

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -892,6 +892,10 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
                 # inputs is read_only, should not be allowed
                 inputs['x'] = 0.
 
+            def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs=None,
+                                discrete_outputs=None):
+                pass
+
         group = om.Group()
 
         group.add_subsystem('px', om.IndepVarComp('x', 77.0))
@@ -923,6 +927,10 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
 
             def guess_nonlinear(self, inputs, outputs, resids):
                 raise om.AnalysisError("It's just a scratch.")
+
+            def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs=None,
+                discrete_outputs=None):
+                pass
 
         group = om.Group()
 

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -964,6 +964,10 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
                 # inputs is read_only, should not be allowed
                 resids['y'] = 0.
 
+            def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs=None,
+                discrete_outputs=None):
+                pass
+            
         group = om.Group()
 
         group.add_subsystem('px', om.IndepVarComp('x', 77.0))

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -990,6 +990,39 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
                          "'comp1' <class ImpWithInitial>: Attempt to set value of 'y' in residual vector "
                          "when it is read only.")
 
+    def test_apply_nonlinear_missing_override(self):
+        class ImpWithInitial(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('x', 3.0)
+                self.add_output('y', 4.0)
+
+            def guess_nonlinear(self, inputs, outputs, resids):
+                # inputs is read_only, should not be allowed
+                inputs['x'] = 0.
+
+        group = om.Group()
+
+        group.add_subsystem('px', om.IndepVarComp('x', 77.0))
+        group.add_subsystem('comp1', ImpWithInitial())
+        group.add_subsystem('comp2', ImpWithInitial())
+        group.connect('px.x', 'comp1.x')
+        group.connect('comp1.y', 'comp2.x')
+
+        group.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        group.nonlinear_solver.options['maxiter'] = 1
+
+        prob = om.Problem(model=group)
+        prob.set_solver_print(level=0)
+        prob.setup()
+
+        with self.assertRaises(NotImplementedError) as cm:
+            prob.run_model()
+
+        self.assertEqual(str(cm.exception),
+                         "'comp1' <class ImpWithInitial>: Error calling apply_nonlinear(), "
+                         "ImplicitComponent.apply_nonlinear() must be overridden by the "
+                         "child class.")
 
 class ImplicitCompReadOnlyTestCase(unittest.TestCase):
 


### PR DESCRIPTION
### Summary

Instead of just calling `pass`, `apply_nonlinear()` now raises NotImplementedError.

### Related Issues

- Resolves #2660

### Backwards incompatibilities

None

### New Dependencies

None
