### PR TITLE
fixed issue with hang in guess_nonlinear in ParallelGroup

### DIFF
--- a/openmdao/core/parallel_group.py
+++ b/openmdao/core/parallel_group.py
@@ -28,5 +28,4 @@ class ParallelGroup(Group):
         """
         super()._configure()
         if self.comm.size > 1:
-            all_results = self.comm.allgather(self._has_guess)
-            self._has_guess = any(all_results)
+            self._has_guess = any(self.comm.allgather(self._has_guess))

--- a/openmdao/core/parallel_group.py
+++ b/openmdao/core/parallel_group.py
@@ -19,3 +19,14 @@ class ParallelGroup(Group):
         """
         super().__init__(**kwargs)
         self._mpi_proc_allocator.parallel = True
+
+    def _configure(self):
+        """
+        Configure our model recursively to assign any children settings.
+
+        Highest system's settings take precedence.
+        """
+        super()._configure()
+        if self.comm.size > 1:
+            all_results = self.comm.allgather(self._has_guess)
+            self._has_guess = any(all_results)

--- a/openmdao/core/tests/test_impl_comp_mpi.py
+++ b/openmdao/core/tests/test_impl_comp_mpi.py
@@ -1,0 +1,53 @@
+
+import unittest
+
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_near_equal
+
+
+class IC(om.ImplicitComponent):
+
+    def setup(self):
+        self.add_input('x')
+        self.add_output('y')
+
+    def guess_nonlinear(self, inputs, outputs, residuals):
+        outputs['y'] = 0.
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        residuals['y'] = inputs['x'] + outputs['y']
+
+    def solve_nonlinear(self, inputs, outputs):
+        outputs['y'] = -inputs['x']
+
+
+class EC(om.ExplicitComponent):
+
+    def setup(self):
+        self.add_input('y')
+        self.add_output('z')
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        outputs['z'] = inputs['y']
+
+
+
+class ImplicitCompMPITestCase(unittest.TestCase):
+
+    N_PROCS = 2
+
+    def test_compute_and_derivs(self):
+        prob = om.Problem()
+        pg = om.ParallelGroup()
+        pg.add_subsystem('ic', IC(), promotes=['*'])
+        pg.add_subsystem('ec', EC(), promotes=['*'])
+        prob.model.add_subsystem('pg', pg, promotes=['*'])
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
+
+        prob.setup()
+        prob.set_val('x', 1.)
+        prob.run_model()
+
+        assert_near_equal(prob.get_val('y', get_remote=True), [-1.])
+        assert_near_equal(prob.get_val('z', get_remote=True), [-1.])
+


### PR DESCRIPTION
### Summary

When there were transfers between children of a ParallelGroup and some but not all of the children of that group had a `guess_nonlinear` method, the model would hang when running under MPI.

### Related Issues

- Resolves #2668

### Backwards incompatibilities

None

### New Dependencies

None
