### PR TITLE
move filterwarnings into catch_warnings context

### DIFF
--- a/openmdao/test_suite/tests/test_warnings.py
+++ b/openmdao/test_suite/tests/test_warnings.py
@@ -95,9 +95,9 @@ class TestWarnings(unittest.TestCase):
         p.model.connect('a_comp.z', 'exec_comp.z')
         p.driver.declare_coloring()
 
-        warnings.filterwarnings('ignore', category=om.UnitsWarning)
-
         with warnings.catch_warnings(record=True) as w:
+            warnings.filterwarnings('ignore', category=om.UnitsWarning)
+
             p.setup()
             unit_warnings = [wm for wm in w if wm.category is om.UnitsWarning]
             assert (len(unit_warnings) == 0)
@@ -141,11 +141,11 @@ class TestWarnings(unittest.TestCase):
         p.model.connect('a_comp.z', 'exec_comp.z')
         p.driver.declare_coloring()
 
-        warnings.filterwarnings('error', category=om.OpenMDAOWarning)
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', category=om.OpenMDAOWarning)
+            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
 
-        with self.assertRaises(om.UnitsWarning) as e:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
+            with self.assertRaises(om.UnitsWarning) as e:
                 p.setup()
 
         expected = "<model> <class Group>: Output 'a_comp.y' with units of 'm' is connected to " \

--- a/openmdao/utils/om_warnings.py
+++ b/openmdao/utils/om_warnings.py
@@ -278,6 +278,7 @@ class reset_warning_registry(object):
     Context manager which archives & clears warning registry for duration of context.
 
     From https://bugs.python.org/file40031/reset_warning_registry.py
+    (https://bugs.python.org/issue21724, https://github.com/python/cpython/issues/65923)
 
     Parameters
     ----------

--- a/openmdao/utils/tests/test_om_warnings.py
+++ b/openmdao/utils/tests/test_om_warnings.py
@@ -1,15 +1,16 @@
 import unittest
 import warnings
 import io
-from contextlib import redirect_stdout, redirect_stderr
-
-from openmdao.utils.om_warnings import reset_warnings, OMDeprecationWarning
+from contextlib import redirect_stderr
 
 
 class TestOMWarnings(unittest.TestCase):
+
     def test_warnings_filters(self):
-        # OMDeprecationWarning should only generate one warning because it has the 'once'
-        #   filter
+        # OMDeprecationWarning should only generate one warning
+        # because it has the 'once' filter
+
+        from openmdao.utils.om_warnings import OMDeprecationWarning
 
         # first call should generate a warning
         f = io.StringIO()
@@ -26,3 +27,7 @@ class TestOMWarnings(unittest.TestCase):
             warnings.warn('msg', OMDeprecationWarning)
         err = f.getvalue()
         self.assertEqual(len(err), 0 )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Move `filterwarnings` call into `catch_warnings` context so it doesn't persist outside of test.

### Related Issues

- Resolves #2676

### Backwards incompatibilities

None

### New Dependencies

None
