### PR TITLE
Fixed an issue with embedded newlines in tables and added some '*grid' formats.

### DIFF
--- a/openmdao/code_review/test_lint_attributes.py
+++ b/openmdao/code_review/test_lint_attributes.py
@@ -117,7 +117,16 @@ class LintAttributesTestCase(unittest.TestCase):
                         # There is a valid __init__ section in the class
                         if('__init__' in class_.__dict__ and '__init__' in dir(class_) and (inspect.ismethod(getattr(class_, '__init__')) or inspect.isfunction(getattr(class_, '__init__'))) ):
                             method = getattr(class_, '__init__')
-                            mysrc = inspect.getsource(method)
+                            # don't die if inspect can't get the source.  This can happen with
+                            # dataclasses
+                            try:
+                                mysrc = inspect.getsource(method)
+                            except Exception:
+                                if new_failures:
+                                    key = '{0}/{1}:{2}'.format(dir_name, file_name, class_name)
+                                    failures[key] = new_failures
+                                continue
+
                             valid_lines = ''.join(valid_line_with_self_re.findall(mysrc))
                             all_member_vars = set(member_var_re.findall(valid_lines))
 

--- a/openmdao/docs/openmdao_book/features/model_visualization/generate_table.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/generate_table.ipynb
@@ -29,8 +29,17 @@
     "* `text`, a simple text based table\n",
     "* `rst`, a table in restructured text format\n",
     "* `github`, a table in github's markdown format\n",
+    "* `grid`, is like the `grid` format in the Tabulate package, which mimics Emacs' table.el package\n",
+    "* `simple_grid` draws a grid using single-line box drawing characters\n",
+    "* `heavy_grid` draws a grid using thick single-line box drawing characters\n",
+    "* `double_grid` draws a grid using double-line box drawing characters\n",
+    "* `box_grid` mixes double-line and single-line dashed drawing characters\n",
     "* `html`, a basic html table, viewable in a browser\n",
     "* `tabulator`, a table with sortable, filterable columns that's viewable in a browser, built using the tabulator.js library.\n",
+    "\n",
+    "All of the `*grid` formats have a corresponding `*outline` format that is identical but\n",
+    "doesn't draw lines between data rows.\n",
+    "\n",
     "\n",
     "```{eval-rst}\n",
     "    .. autofunction:: openmdao.visualization.tables.table_builder.generate_table\n",
@@ -72,6 +81,9 @@
     "a column, you'll need to set the column metadata yourself, either by passing a list of column\n",
     "metadata dicts via the `column_meta` argument, or by calling `update_column_meta` on the table \n",
     "builder object returned from `generate_table`.\n",
+    "The `headers` argument also has two special values, `keys` for specifying that the keys\n",
+    "of a dictionary should be used as headers, and `firstrow` for specifying that the first row\n",
+    "of the given row data will be used as the headers.\n",
     "\n",
     "\n",
     "```{eval-rst}\n",
@@ -193,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's try the other table formats."
+    "Now let's try the other table formats.  First, the text based formats."
    ]
   },
   {
@@ -202,18 +214,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "table = om.generate_table(rows, tablefmt='rst', headers=headers)\n",
-    "table.display()"
+    "formats = ['rst', 'grid', 'simple_grid', 'heavy_grid', 'double_grid', 'box_grid',\n",
+    "           'outline', 'simple_outline', 'heavy_outline', 'double_outline', 'box_outline']\n",
+    "\n",
+    "for fmt in formats:\n",
+    "    print(f\"\\n{fmt} table format:\\n\")\n",
+    "    table = om.generate_table(rows, tablefmt=fmt, headers=headers)\n",
+    "    table.display()"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "table = om.generate_table(rows, tablefmt='github', headers=headers)\n",
-    "table.display()"
+    "And now for the web based table formats."
    ]
   },
   {

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -130,7 +130,8 @@ class OptionsDictionary(object):
         ----------
         fmt : str
             The formatting of the requested table.  Options are
-            ['github', 'rst', 'html', 'text', 'tabulator'].
+            ['github', 'rst', 'text', 'html', 'tabulator'] and several '*grid' and '*outline'
+            formats that mimic those found in the python 'tabulate' library.
             Default value of 'github' produces a table in GitHub-flavored markdown.
             'html' and 'tabulator' produce output viewable in a browser.
         missingval : str

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -123,7 +123,7 @@ class OptionsDictionary(object):
         return self.to_table(fmt='rst', display=False)
 
     def to_table(self, fmt='github', missingval='N/A', max_width=None, display=True):
-        """
+        r"""
         Get a table representation of this OptionsDictionary as a table in the requested format.
 
         Parameters

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -123,14 +123,14 @@ class OptionsDictionary(object):
         return self.to_table(fmt='rst', display=False)
 
     def to_table(self, fmt='github', missingval='N/A', max_width=None, display=True):
-        r"""
+        """
         Get a table representation of this OptionsDictionary as a table in the requested format.
 
         Parameters
         ----------
         fmt : str
             The formatting of the requested table.  Options are
-            ['github', 'rst', 'text', 'html', 'tabulator'] and several '*grid' and '*outline'
+            ['github', 'rst', 'text', 'html', 'tabulator'] and several 'grid' and 'outline'
             formats that mimic those found in the python 'tabulate' library.
             Default value of 'github' produces a table in GitHub-flavored markdown.
             'html' and 'tabulator' produce output viewable in a browser.

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -37,8 +37,8 @@ class TestOptionsDict(unittest.TestCase):
 =========  ============  =================  =====================  ======================
 Option     Default       Acceptable Values  Acceptable Types       Description           
 =========  ============  =================  =====================  ======================
-comp       MyComp        N/A                ['ExplicitComponent']  
-flag       False         [True, False]      ['bool']               
+comp       MyComp        N/A                ['ExplicitComponent']                        
+flag       False         [True, False]      ['bool']                                     
 long_desc  **Required**  N/A                ['str']                This description is   
                                                                    long and verbose, so  
                                                                    it takes up multiple  

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -6,6 +6,7 @@ import sys
 import os
 import json
 import textwrap
+from collections import namedtuple
 from itertools import zip_longest, chain
 from html import escape
 from numbers import Number, Integral
@@ -513,6 +514,11 @@ class TableBuilder(object):
                 f.write(str(self))
 
 
+# these are taken straight from Tabulate to make it easier to define lots of different formats
+Line = namedtuple("Line", ["begin", "hline", "sep", "end"])
+DataRow = namedtuple("DataRow", ["begin", "sep", "end"])
+
+
 class TextTableBuilder(TableBuilder):
     r"""
     Base class for all text-based table builders.
@@ -700,14 +706,13 @@ class TextTableBuilder(TableBuilder):
 
             if True:  # needs_wrap:
                 cell_lists = []
-                for meta, cell, colwid in zip(sorted_cols, row_cells, self._data_widths):
+                for meta, cell, wid in zip(sorted_cols, row_cells, widths):
                     maxwid = meta['max_width']
                     if maxwid is not None and maxwid < len(cell):
                         lines = textwrap.wrap(cell, maxwid)
                         wid = maxwid
                     elif '\n' in cell:
                         lines = cell.split('\n')
-                        wid = colwid
                     else:
                         cell_lists.append([cell])
                         continue

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -344,9 +344,6 @@ class TableBuilder(object):
 
         meta = self._column_meta[col_idx]
         for name, val in options.items():
-            # if name not in self.allowed_col_meta:
-            #     raise KeyError(f"'{name}' is not a valid column metadata key. Allowed keys are "
-            #                    f"{sorted(self.allowed_col_meta)}.")
             meta[name] = val
 
     def _set_widths(self, force_set_max=False):
@@ -1648,6 +1645,12 @@ def generate_table(rows, tablefmt='text', **options):
             'data_row_line': Line("║ ", " ┊ ", " ║"),
         },
     }
+
+    for fmt in list(_text_formats):
+        if 'grid' in fmt:
+            dct = _text_formats[fmt].copy()
+            dct['row_separator'] = None
+            _text_formats[fmt.replace('grid', 'outline')] = dct
 
     _table_types = {
         'text': TextTableBuilder,

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -1551,12 +1551,20 @@ def generate_table(rows, tablefmt='text', **options):
         },
         'grid': {
             'top_border': Line('+-', '-+-', '-+', '-'),
-            'header_bottom_border': Line('+-', '-+-', '-+', '-'),
+            'header_bottom_border': Line('+=', '=+=', '=+', '='),
             'bottom_border': Line('+-', '-+-', '-+', '-'),
             'header_line': Line('| ', ' | ', ' |'),
             'data_row_line':Line('| ', ' | ', ' |'),
             'row_separator': Line('+-', '-+-', '-+', '-')
         },
+        'simple_grid': {
+            'top_border': Line("┌─", "─┬─", "─┐", "─"),
+            'header_bottom_border': Line("├─", "─┼─", "─┤", "─"),
+            'row_separator': Line("├─", "─┼─", "─┤", "─"),
+            'bottom_border': Line("└─", "─┴─", "─┘", "─"),
+            'header_line': Line("│ ", " │ ", " │"),
+            'data_row_line': Line("│ ", " │ ", " │"),
+        }
     }
 
     _table_types = {

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -522,13 +522,9 @@ class Line:
     right: str = ''
     hline: str = ''
 
-    def get_border_line(self, widths, line_info=None):
-        if line_info is None:
-            line = self.sep.join([(self.hline * w)[:w] for w in widths])
-            return ''.join((self.left, line, self.right))
-
-        total_width = sum(widths) + len(line_info.sep) * (len(widths) - 1)
-        return ''.join((self.left, (self.hline * total_width)[:total_width], self.right))
+    def get_border_line(self, widths):
+        line = self.sep.join([(self.hline * w)[:w] for w in widths])
+        return ''.join((self.left, line, self.right))
 
     def get_data_line(self, cells):
         return ''.join((self.left, self.sep.join(cells), self.right))
@@ -574,9 +570,9 @@ class TextTableBuilder(TableBuilder):
     """
 
     def __init__(self, rows,
-                 top_border=Line('| ', ' | ', ' |', '-'),
+                 top_border=Line('| ', '---', ' |', '-'),
                  header_bottom_border=Line('| ', ' | ', ' |', '-'),
-                 bottom_border=Line('| ', ' | ', ' |', '-'),
+                 bottom_border=Line('| ', '---', ' |', '-'),
                  header_line=Line('| ', ' | ', ' |'),
                  data_row_line=Line('| ', ' | ', ' |'),
                  row_separator=None,
@@ -756,7 +752,7 @@ class TextTableBuilder(TableBuilder):
             else:
                 yield row_cells
 
-    def get_top_border(self, widths, line_info=None):
+    def get_top_border(self, widths):
         """
         Return the top border string for this table.
 
@@ -770,7 +766,7 @@ class TextTableBuilder(TableBuilder):
         str
             The top border string.
         """
-        return self.top_border.get_border_line(widths, line_info=line_info)
+        return self.top_border.get_border_line(widths)
 
     def get_header_bottom_border(self, widths):
         """
@@ -788,7 +784,7 @@ class TextTableBuilder(TableBuilder):
         """
         return self.header_bottom_border.get_border_line(widths)
 
-    def get_bottom_border(self, widths, line_info=None):
+    def get_bottom_border(self, widths):
         """
         Return the bottom border string for this table.
 
@@ -802,7 +798,7 @@ class TextTableBuilder(TableBuilder):
         str
             The bottom border string.
         """
-        return self.bottom_border.get_border_line(widths, line_info=line_info)
+        return self.bottom_border.get_border_line(widths)
 
     def __str__(self):
         """
@@ -829,10 +825,10 @@ class TextTableBuilder(TableBuilder):
                 data_lines.append(self.row_separator.get_border_line(widths))
 
         if self.bottom_border:
-            data_lines.append(self.get_bottom_border(widths, line_info=self.data_row_line))
+            data_lines.append(self.get_bottom_border(widths))
 
         if row_cells is not None and self.top_border:
-            header_lines.append(self.get_top_border(widths, line_info=self.data_row_line))
+            header_lines.append(self.get_top_border(widths))
 
         if sum(self._header_widths) > 0:
             for header_cells in self._stringified_header_iter():
@@ -883,38 +879,6 @@ class RSTTableBuilder(TextTableBuilder):
                          bottom_border=Line('', '  ', '', '='),
                          header_line=Line('', '  ', ''),
                          data_row_line=Line('', '  ', ''), **kwargs)
-
-    def get_top_border(self, widths, line_info=None):
-        """
-        Return the top border string.
-
-        Parameters
-        ----------
-        widths : list of int
-           Column widths.
-
-        Returns
-        -------
-        str
-            The top border string.
-        """
-        return self.top_border.get_border_line(widths, line_info=None)
-
-    def get_bottom_border(self, widths, line_info=None):
-        """
-        Return the top border string.
-
-        Parameters
-        ----------
-        widths : list of int
-           Column widths.
-
-        Returns
-        -------
-        str
-            The top border string.
-        """
-        return self.bottom_border.get_border_line(widths, line_info=None)
 
 
 class GithubTableBuilder(TextTableBuilder):

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -517,16 +517,68 @@ class TableBuilder(object):
 
 @dataclass(frozen=True)
 class Line:
+    """
+    Information about a line in the table.
+
+    Parameters
+    ----------
+    left : str
+        Left border string.
+    sep : str
+        Column separator.
+    right : str
+        Right border string.
+    hline : str
+        Horizontal line string.
+
+    Attributes
+    ----------
+    left : str
+        Left border string.
+    sep : str
+        Column separator.
+    right : str
+        Right border string.
+    hline : str
+        Horizontal line string.
+    """
+
     left: str = ''
     sep: str = ''
     right: str = ''
     hline: str = ''
 
     def get_border_line(self, widths):
+        """
+        Return a border line given the column widths.
+
+        Parameters
+        ----------
+        widths : list of int
+            Column widths.
+
+        Returns
+        -------
+        str
+            The border line.
+        """
         line = self.sep.join([(self.hline * w)[:w] for w in widths])
         return ''.join((self.left, line, self.right))
 
     def get_data_line(self, cells):
+        """
+        Return a table line containing the given cells.
+
+        Parameters
+        ----------
+        cells : list of str
+            Contents of table columns for the current row.
+
+        Returns
+        -------
+        str
+            The table line containing the cells, with separators and left and right borders.
+        """
         return ''.join((self.left, self.sep.join(cells), self.right))
 
 
@@ -538,35 +590,35 @@ class TextTableBuilder(TableBuilder):
     ----------
     rows : iter of iters
         Data used to fill table cells.
-    column_sep : str
-        Column separator string.
-    top_border : str
-        Top border character(s).
-    bottom_border : str
-        Bottom border character(s).
-    header_bottom_border : str
-        Header bottom border character(s).
-    left_border : str
-        Left border character(s).
-    right_border : str
-        Right border character(s).
+    top_border : Line
+        Top border info.
+    header_bottom_border : Line
+        Header bottom border info.
+    bottom_border : Line
+        Bottom border info.
+    header_line : Line
+        Header line info.
+    data_row_line : Line
+        Data row line info.
+    row_separator : Line or None
+        If not None, info for lines between data rows.
     **kwargs : dict
         Keyword args for the base class.
 
     Attributes
     ----------
-    column_sep : str
-        Column separator string.
-    top_border : str
-        Top border character(s).
-    bottom_border : str
-        Bottom border character(s).
-    header_bottom_border : str
-        Header bottom border character(s).
-    left_border : str
-        Left border character(s).
-    right_border : str
-        Right border character(s).
+    top_border : Line
+        Top border info.
+    header_bottom_border : Line
+        Header bottom border info.
+    bottom_border : Line
+        Bottom border info.
+    header_line : Line
+        Header line info.
+    data_row_line : Line
+        Data row line info.
+    row_separator : Line or None
+        If not None, info for lines between data rows.
     """
 
     def __init__(self, rows,
@@ -724,6 +776,8 @@ class TextTableBuilder(TableBuilder):
                 maxwid = meta['max_width']
                 if maxwid is not None and maxwid < len(cell):
                     lines = textwrap.wrap(cell, maxwid)
+                    if not lines:  # empty cell or whitespace
+                        lines = ['']
                     wid = maxwid
                 elif '\n' in cell:
                     lines = cell.split('\n')
@@ -1554,7 +1608,7 @@ def generate_table(rows, tablefmt='text', **options):
             'header_bottom_border': Line('+=', '=+=', '=+', '='),
             'bottom_border': Line('+-', '-+-', '-+', '-'),
             'header_line': Line('| ', ' | ', ' |'),
-            'data_row_line':Line('| ', ' | ', ' |'),
+            'data_row_line': Line('| ', ' | ', ' |'),
             'row_separator': Line('+-', '-+-', '-+', '-')
         },
         'simple_grid': {

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -677,10 +677,7 @@ class TextTableBuilder(TableBuilder):
                 header_cells[i] = self._get_fixed_width_cell(meta, header, widths[i],
                                                              'header_align')
 
-        if self.needs_wrap():
-            yield from self.get_lengthened_columns(sorted_cols, header_cells, widths)
-        else:
-            yield header_cells
+        yield from self.get_lengthened_columns(sorted_cols, header_cells, widths)
 
     def _stringified_row_iter(self):
         """

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -101,6 +101,8 @@ class TableBuilder(object):
         """
         if headers in ('keys', 'firstrow'):
             rows, headers = self._to_rows(rows, headers)
+        elif isinstance(headers, str):
+            raise RuntimeError(f"If 'headers' is a string, it must be one of ['keys', 'firstrow'].")
 
         self._raw_rows = []
         for row in rows:
@@ -132,6 +134,8 @@ class TableBuilder(object):
                                    f"{hlen} != {self._ncols}.")
 
             for i, h in enumerate(headers):
+                if not isinstance(h, str):
+                    h = str(h)
                 self.update_column_meta(i, header=h)
 
         if column_meta is not None:
@@ -1598,27 +1602,51 @@ def generate_table(rows, tablefmt='text', **options):
     _text_formats = {
         'rst': {
             'top_border': Line('', '  ', '', '='),
+            'header_line': Line('', '  ', ''),
             'header_bottom_border': Line('', '  ', '', '='),
             'bottom_border': Line('', '  ', '', '='),
-            'header_line': Line('', '  ', ''),
             'data_row_line': Line('', '  ', '')
         },
         'grid': {
             'top_border': Line('+-', '-+-', '-+', '-'),
+            'header_line': Line('| ', ' | ', ' |'),
             'header_bottom_border': Line('+=', '=+=', '=+', '='),
             'bottom_border': Line('+-', '-+-', '-+', '-'),
-            'header_line': Line('| ', ' | ', ' |'),
             'data_row_line': Line('| ', ' | ', ' |'),
             'row_separator': Line('+-', '-+-', '-+', '-')
         },
         'simple_grid': {
             'top_border': Line("┌─", "─┬─", "─┐", "─"),
+            'header_line': Line("│ ", " │ ", " │"),
             'header_bottom_border': Line("├─", "─┼─", "─┤", "─"),
             'row_separator': Line("├─", "─┼─", "─┤", "─"),
             'bottom_border': Line("└─", "─┴─", "─┘", "─"),
-            'header_line': Line("│ ", " │ ", " │"),
             'data_row_line': Line("│ ", " │ ", " │"),
-        }
+        },
+        'heavy_grid': {
+            'top_border': Line("┏━", "━┳━", "━┓", "━"),
+            'header_line': Line("┃ ", " ┃ ", " ┃"),
+            'header_bottom_border': Line("┣━", "━╋━", "━┫", "━"),
+            'row_separator': Line("┣━", "━╋━", "━┫", "━"),
+            'bottom_border': Line("┗━", "━┻━", "━┛", "━"),
+            'data_row_line': Line("┃ ", " ┃ ", " ┃"),
+        },
+        'double_grid': {
+            'top_border': Line("╔═", "═╦═", "═╗", "═"),
+            'header_line': Line("║ ", " ║ ", " ║"),
+            'header_bottom_border': Line("╠═", "═╬═", "═╣", "═"),
+            'row_separator': Line("╠═", "═╬═", "═╣", "═"),
+            'bottom_border': Line("╚═", "═╩═", "═╝", "═"),
+            'data_row_line': Line("║ ", " ║ ", " ║"),
+        },
+        'box_grid': {
+            'top_border': Line("╔═", "═╤═", "═╗", "═"),
+            'header_line': Line("║ ", " ┊ ", " ║"),
+            'header_bottom_border': Line("╠═", "═╪═", "═╣", "═"),
+            'row_separator': Line("╟┈", "┈┿┈", "┈╢", "┈"),
+            'bottom_border': Line("╚═", "═╧═", "═╝", "═"),
+            'data_row_line': Line("║ ", " ┊ ", " ║"),
+        },
     }
 
     _table_types = {

--- a/openmdao/visualization/tables/tests/test_tables.py
+++ b/openmdao/visualization/tables/tests/test_tables.py
@@ -114,7 +114,7 @@ class TableTestCase(unittest.TestCase):
 | 0 | 1 | 2 |
 | 3 | 4 | 5 |
 | 6 | 7 | 8 |
-| - | - | - |"""
+| --------- |"""
         self.check_text('text', np.arange(9).reshape((3,3)), None, expected)
         self.check_text('text', [[0,1,2],[3,4,5],[6,7,8]], None, expected)
         self.check_text('text', iter(np.arange(9).reshape((3,3))), None, expected)
@@ -146,7 +146,7 @@ class TableTestCase(unittest.TestCase):
 |    0 |    1 |    2 |
 |    3 |    4 |    5 |
 |    6 |    7 |    8 |
-| ---- | ---- | ---- |"""
+| ------------------ |"""
         self.check_text('text', np.arange(9).reshape((3,3)), headers, expected)
         self.check_text('text', [[0,1,2],[3,4,5],[6,7,8]], headers, expected)
 
@@ -210,7 +210,7 @@ Col0  Col1  Col2
 | foobar blah           |    1.0 | N/A            |
 | asdfas dffff          |  3.142 | N/A            |
 | hello world blah blah |   9.87 | N/A            |
-| --------------------- | ------ | -------------- |
+| ----------------------------------------------- |
 """
         self.check_text('text', self.table_row_iter('str', 'float', None), headers, expected, missing_val='N/A')
 
@@ -226,7 +226,7 @@ Col0  Col1  Col2
 | dffff       |        |             |
 | hello world |   9.87 | N/A         |
 | blah blah   |        |             |
-| ----------- | ------ | ----------- |
+| ---------------------------------- |
 """
         self.check_text('text', self.table_row_iter('str', 'float', None), headers, expected, missing_val='N/A', max_width=38)
 
@@ -243,7 +243,7 @@ Col0  Col1  Col2
 | dffff       |        |             |
 | hello world |   9.87 |     N/A     |
 | blah blah   |        |             |
-| ----------- | ------ | ----------- |
+| ---------------------------------- |
 """
         self.check_text('text', self.table_row_iter('str', 'float', None), headers, expected,
                         column_meta=column_meta, missing_val='N/A', max_width=38)


### PR DESCRIPTION
### Summary

Embedded newlines were not being handled properly.  We were also missing the 'grid' table format which is needed by one of our users.  The newline bug was fixed and a number of '*grid' and '*outline' formats were added that mimic the correspondingly named formats in the tabulate package.

### Related Issues

- Resolves #2673
- Also partially resolves issue 2678 (OptionsDictionary.to_table stopped supporting 'grid' format). This PR will allow the 'grid' format to be used with the `to_table` method.

### Backwards incompatibilities

The args passed to the TextTableBuilder.__init__ method have changed, but users typically do not use this class directly so it shouldn't effect existing models.

### New Dependencies

None
