### PR TITLE
Allow `indep_var` tag to work with inputs report for backward compatibility.

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -282,8 +282,9 @@ jobs:
           echo "============================================================="
           echo "Scan environment for packages with known vulnerabilities"
           echo "(Temporarily ignoring PYSEC-2022-237, required by nbconvert)"
+          echo "(Temporarily ignoring OSV-2022-715, in Pillow, required by matplotlib)"
           echo "============================================================="
-          python -m pip_audit --ignore-vuln PYSEC-2022-237 --ignore-vuln GHSA-fpfv-jqm9-f5jm
+          python -m pip_audit --ignore-vuln OSV-2022-715 --ignore-vuln PYSEC-2022-237 --ignore-vuln GHSA-fpfv-jqm9-f5jm
 
       - name: Run tests
         if: matrix.TESTS

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -480,8 +480,9 @@ jobs:
           echo "============================================================="
           echo "Scan environment for packages with known vulnerabilities"
           echo "(Temporarily ignoring PYSEC-2022-237, required by nbconvert)"
+          echo "(Temporarily ignoring OSV-2022-715, in Pillow, required by matplotlib)"
           echo "============================================================="
-          python -m pip_audit --ignore-vuln PYSEC-2022-237
+          python -m pip_audit --ignore-vuln OSV-2022-715 --ignore-vuln PYSEC-2022-237
 
       - name: Run tests
         run: |

--- a/openmdao/visualization/inputs_report/inputs_report.py
+++ b/openmdao/visualization/inputs_report/inputs_report.py
@@ -13,7 +13,8 @@ except ImportError:
 
 from openmdao.core.problem import Problem
 from openmdao.utils.mpi import MPI
-from openmdao.utils.general_utils import printoptions
+from openmdao.utils.general_utils import printoptions, issue_warning
+from openmdao.utils.om_warnings import OMDeprecationWarning
 from openmdao.utils.reports_system import register_report
 from openmdao.visualization.tables.table_builder import generate_table
 
@@ -104,7 +105,13 @@ def inputs_report(prob, outfile=None, display=True, precision=6, title=None,
             sprom = model._var_allprocs_abs2prom['output'][src]
             val = model.get_val(target, get_remote=True, from_src=not src.startswith('_auto_ivc.'))
             smeta = model._var_allprocs_abs2meta['output'][src]
-            src_is_ivc = 'openmdao:indep_var' in smeta['tags']
+            src_is_ivc = 'openmdao:indep_var' in smeta['tags'] or 'indep_var' in smeta['tags']
+            if 'indep_var' in smeta['tags'] and 'openmdao:indep_var' not in smeta['tags']:
+                issue_warning(f'source output {sprom} is tagged with the deprecated `indep_var`'
+                              f' tag. Please change this tag to `openmdao:indep_var` as'
+                              f' `indep_var` will be deprecated in a future release.',
+                              category=OMDeprecationWarning)
+
             vcell, mincell, maxcell = _get_val_cells(val)
 
             rows.append([target, prom, sprom, src_is_ivc, src in desvars, _unit_str(meta),
@@ -115,7 +122,12 @@ def inputs_report(prob, outfile=None, display=True, precision=6, title=None,
         src = connections[target]
         val = model.get_val(target, get_remote=True, from_src=not src.startswith('_auto_ivc.'))
         smeta = model._var_discrete['output'][src]
-        src_is_ivc = 'openmdao:indep_var' in smeta['tags']
+        src_is_ivc = 'openmdao:indep_var' in smeta['tags'] or 'indep_var' in smeta['tags']
+        if 'indep_var' in smeta['tags'] and 'openmdao:indep_var' not in smeta['tags']:
+            issue_warning(f'source output {src} is tagged with the deprecated `indep_var` tag.'
+                          f' Please change this tag to `openmdao:indep_var` as `indep_var` will be'
+                          f' deprecated in a future release.',
+                          category=OMDeprecationWarning)
 
         rows.append([target, prom, src, src_is_ivc, src in desvars, '', None, sorted(meta['tags']),
                      val, None, None])

--- a/openmdao/visualization/inputs_report/tests/test_inputs_report.py
+++ b/openmdao/visualization/inputs_report/tests/test_inputs_report.py
@@ -1,5 +1,6 @@
 """Test the Newton nonlinear solver. """
 import unittest
+import tempfile
 
 import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import DoubleSellar
@@ -58,12 +59,10 @@ class TestInputsReport(unittest.TestCase):
 | g2.d2.z       | g2.z       | _auto_ivc.v1 |     True      |    False     |       | (2,)  | []   | [0 0]  |       0 |       0 | _auto_ivc.v1    |
 | g2.d2.y1      | g2.y1      | g2.y1        |     False     |    False     |       | (1,)  | []   | [0.64] |    0.64 |    0.64 | g2.d1.y1        |
 """
-        inputs_report(prob, outfile='temp.md', display=True, precision=6, title=None, tablefmt='github')
-
-        with open('temp.md') as f:
+        report_file = tempfile.NamedTemporaryFile()
+        inputs_report(prob, outfile=report_file.name, display=True, precision=6, title=None, tablefmt='github')
+        with open(report_file.name) as f:
             report_content = f.read()
-
-
         self.assertEqual(expected, report_content)
 
     def test_deprecated_flag(self):
@@ -97,14 +96,12 @@ class TestInputsReport(unittest.TestCase):
 | c2.x          | x          | x           |     True      |    False     |       | (1,)  | []   | [2] |       2 |       2 | c1.x            |
 | c2.y          | y          | y           |     True      |    False     |       | (1,)  | []   | [5] |       5 |       5 | c1.y            |
 """
-
+        report_file = tempfile.NamedTemporaryFile()
         with assert_warning(om.OMDeprecationWarning, 'source output x is tagged with the deprecated'
                                                      ' `indep_var` tag. Please change this tag to'
                                                      ' `openmdao:indep_var` as `indep_var` will'
                                                      ' be deprecated in a future release.'):
-            inputs_report(prob, outfile='temp2.md', display=True, precision=6, title=None, tablefmt='github')
-
-        with open('temp2.md') as f:
+            inputs_report(prob, outfile=report_file.name, display=True, precision=6, title=None, tablefmt='github')
+        with open(report_file.name) as f:
             report_content = f.read()
-
         self.assertEqual(expected, report_content)

--- a/openmdao/visualization/inputs_report/tests/test_inputs_report.py
+++ b/openmdao/visualization/inputs_report/tests/test_inputs_report.py
@@ -1,4 +1,4 @@
-"""Test the Newton nonlinear solver. """
+"""Test the inputs report. """
 import unittest
 
 import openmdao.api as om

--- a/openmdao/visualization/inputs_report/tests/test_inputs_report.py
+++ b/openmdao/visualization/inputs_report/tests/test_inputs_report.py
@@ -1,10 +1,10 @@
 """Test the Newton nonlinear solver. """
 import unittest
-import tempfile
 
 import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.visualization.inputs_report.inputs_report import inputs_report
 
 
@@ -13,7 +13,7 @@ try:
 except ImportError:
     PETScVector = None
 
-
+@use_tempdirs
 class TestInputsReport(unittest.TestCase):
 
     def test_inputs_reports(self):
@@ -59,9 +59,8 @@ class TestInputsReport(unittest.TestCase):
 | g2.d2.z       | g2.z       | _auto_ivc.v1 |     True      |    False     |       | (2,)  | []   | [0 0]  |       0 |       0 | _auto_ivc.v1    |
 | g2.d2.y1      | g2.y1      | g2.y1        |     False     |    False     |       | (1,)  | []   | [0.64] |    0.64 |    0.64 | g2.d1.y1        |
 """
-        report_file = tempfile.NamedTemporaryFile()
-        inputs_report(prob, outfile=report_file.name, display=True, precision=6, title=None, tablefmt='github')
-        with open(report_file.name) as f:
+        inputs_report(prob, outfile='temp_inputs_report.md', display=True, precision=6, title=None, tablefmt='github')
+        with open('temp_inputs_report.md') as f:
             report_content = f.read()
         self.assertEqual(expected, report_content)
 
@@ -96,12 +95,11 @@ class TestInputsReport(unittest.TestCase):
 | c2.x          | x          | x           |     True      |    False     |       | (1,)  | []   | [2] |       2 |       2 | c1.x            |
 | c2.y          | y          | y           |     True      |    False     |       | (1,)  | []   | [5] |       5 |       5 | c1.y            |
 """
-        report_file = tempfile.NamedTemporaryFile()
         with assert_warning(om.OMDeprecationWarning, 'source output x is tagged with the deprecated'
                                                      ' `indep_var` tag. Please change this tag to'
                                                      ' `openmdao:indep_var` as `indep_var` will'
                                                      ' be deprecated in a future release.'):
-            inputs_report(prob, outfile=report_file.name, display=True, precision=6, title=None, tablefmt='github')
-        with open(report_file.name) as f:
+            inputs_report(prob, outfile='temp_inputs_report.md', display=True, precision=6, title=None, tablefmt='github')
+        with open('temp_inputs_report.md') as f:
             report_content = f.read()
         self.assertEqual(expected, report_content)

--- a/openmdao/visualization/inputs_report/tests/test_inputs_report.py
+++ b/openmdao/visualization/inputs_report/tests/test_inputs_report.py
@@ -1,0 +1,110 @@
+"""Test the Newton nonlinear solver. """
+import unittest
+
+import openmdao.api as om
+from openmdao.test_suite.components.double_sellar import DoubleSellar
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.visualization.inputs_report.inputs_report import inputs_report
+
+
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
+
+
+class TestInputsReport(unittest.TestCase):
+
+    def test_inputs_reports(self):
+        prob = om.Problem(model=DoubleSellar(), reports=None)
+        model = prob.model
+
+        g1 = model.g1
+        g1.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        g1.nonlinear_solver.options['rtol'] = 1.0e-5
+        g1.linear_solver = om.DirectSolver(assemble_jac=True)
+        g1.options['assembled_jac_type'] = 'dense'
+
+        g2 = model.g2
+        g2.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        g2.nonlinear_solver.options['rtol'] = 1.0e-5
+        g2.linear_solver = om.DirectSolver(assemble_jac=True)
+        g2.options['assembled_jac_type'] = 'dense'
+
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
+        model.options['assembled_jac_type'] = 'dense'
+
+        model.nonlinear_solver.options['solve_subsystems'] = True
+
+        prob.setup()
+        prob.run_model()
+
+        assert_near_equal(prob['g1.y1'], 0.64, .00001)
+        assert_near_equal(prob['g1.y2'], 0.80, .00001)
+        assert_near_equal(prob['g2.y1'], 0.64, .00001)
+        assert_near_equal(prob['g2.y2'], 0.80, .00001)
+
+        expected = """| Absolute Name | Input Name | Source Name  | Source is IVC | Source is DV | Units | Shape | Tags | Val    | Min Val | Max Val | Absolute Source |
+| :------------ | :--------- | :----------- | :-----------: | :----------: | :---- | :---- | :--- | :----- | ------: | ------: | :-------------- |
+| g1.d1.z       | g1.z       | _auto_ivc.v0 |     True      |    False     |       | (2,)  | []   | [0 0]  |       0 |       0 | _auto_ivc.v0    |
+| g1.d1.x       | g1.x       | g2.y2        |     False     |    False     |       | (1,)  | []   | [0.8]  |     0.8 |     0.8 | g2.d2.y2        |
+| g1.d1.y2      | g1.y2      | g1.y2        |     False     |    False     |       | (1,)  | []   | [0.8]  |     0.8 |     0.8 | g1.d2.y2        |
+| g1.d2.z       | g1.z       | _auto_ivc.v0 |     True      |    False     |       | (2,)  | []   | [0 0]  |       0 |       0 | _auto_ivc.v0    |
+| g1.d2.y1      | g1.y1      | g1.y1        |     False     |    False     |       | (1,)  | []   | [0.64] |    0.64 |    0.64 | g1.d1.y1        |
+| g2.d1.z       | g2.z       | _auto_ivc.v1 |     True      |    False     |       | (2,)  | []   | [0 0]  |       0 |       0 | _auto_ivc.v1    |
+| g2.d1.x       | g2.x       | g1.y2        |     False     |    False     |       | (1,)  | []   | [0.8]  |     0.8 |     0.8 | g1.d2.y2        |
+| g2.d1.y2      | g2.y2      | g2.y2        |     False     |    False     |       | (1,)  | []   | [0.8]  |     0.8 |     0.8 | g2.d2.y2        |
+| g2.d2.z       | g2.z       | _auto_ivc.v1 |     True      |    False     |       | (2,)  | []   | [0 0]  |       0 |       0 | _auto_ivc.v1    |
+| g2.d2.y1      | g2.y1      | g2.y1        |     False     |    False     |       | (1,)  | []   | [0.64] |    0.64 |    0.64 | g2.d1.y1        |
+"""
+        inputs_report(prob, outfile='temp.md', display=True, precision=6, title=None, tablefmt='github')
+
+        with open('temp.md') as f:
+            report_content = f.read()
+
+
+        self.assertEqual(expected, report_content)
+
+    def test_deprecated_flag(self):
+
+        prob = om.Problem(reports=None)
+        model = prob.model
+
+        # Kludge to fake something like an IndepVarComp with an 'indep_var' tag on an output.
+        class _SimpleIVC(om.ExecComp):
+
+            def setup(self):
+                self.add_output('x', val=2.0, tags=['indep_var'])
+                self.add_output('y', val=5.0, tags=['openmdao:indep_var'])
+
+            def compute(self, inputs, outputs):
+                pass
+
+        model.add_subsystem('c1', _SimpleIVC(), promotes_outputs=['x', 'y'])
+        model.add_subsystem('c2', om.ExecComp('z = x + y'), promotes_inputs=['x', 'y'], promotes_outputs=['z'])
+
+        prob.setup()
+
+        prob.run_model()
+
+        z = prob.get_val('z')
+
+        assert_near_equal(7, z)
+
+        expected = """| Absolute Name | Input Name | Source Name | Source is IVC | Source is DV | Units | Shape | Tags | Val | Min Val | Max Val | Absolute Source |
+| :------------ | :--------- | :---------- | :-----------: | :----------: | :---- | :---- | :--- | :-- | ------: | ------: | :-------------- |
+| c2.x          | x          | x           |     True      |    False     |       | (1,)  | []   | [2] |       2 |       2 | c1.x            |
+| c2.y          | y          | y           |     True      |    False     |       | (1,)  | []   | [5] |       5 |       5 | c1.y            |
+"""
+
+        with assert_warning(om.OMDeprecationWarning, 'source output x is tagged with the deprecated'
+                                                     ' `indep_var` tag. Please change this tag to'
+                                                     ' `openmdao:indep_var` as `indep_var` will'
+                                                     ' be deprecated in a future release.'):
+            inputs_report(prob, outfile='temp2.md', display=True, precision=6, title=None, tablefmt='github')
+
+        with open('temp2.md') as f:
+            report_content = f.read()
+
+        self.assertEqual(expected, report_content)


### PR DESCRIPTION
### Summary

We changed the tag `indep_var` to `openmdao:indep_var`, and while this wasn't being used by anything prior to the creation of the inputs report, the fact that some users may have had components which used this tag will cause incorrect behavior in the inputs report.

This tag is now recognized and generates an `OMDeprecationWarning` during the creation of the inputs report.

Tests were added to test the basic behavior of the inputs report and the behavior of this warning.

This PR also temporarily allows pip-audit to pass on CI given the vulnerability described in #2682 

### Related Issues

- Resolves #2682 
- Resolves #2678 

### Backwards incompatibilities

OMDeprecationWarning is now raised if a user builds an inputs_report and an input is found with the `'indep_var'` tag.

### New Dependencies

None
