### PR TITLE
Update GitHub workflow to work properly with Python 3.11

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -29,7 +29,7 @@ jobs:
             PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: true
+            JAX: '0.3.22'
             BANDIT: true
             TESTS: true
 
@@ -44,7 +44,7 @@ jobs:
             # PAROPT: true
             # SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: true
+            JAX: '0.3.22'
             TESTS: true
 
           # test latest versions
@@ -55,10 +55,10 @@ jobs:
             SCIPY: 1
             PETSc: 3
             PYOPTSPARSE: 'latest'
-            PAROPT: true
+            # PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: true
+            JAX: 'dev'
             TESTS: true
 
           # test minimal install
@@ -95,7 +95,7 @@ jobs:
             PYOPTSPARSE: 'v2.8.3'
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: true
+            JAX: '0.3.22'
             BUILD_DOCS: true
 
     runs-on: ${{ matrix.OS }}
@@ -139,6 +139,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.PY }}
+          conda-version: "*"
           channels: conda-forge,defaults
           channel-priority: true
 
@@ -146,14 +147,14 @@ jobs:
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
+          python -m pip install --upgrade pip
+
           if [[ "${{ matrix.OPTIONAL }}" == "[all]" ]]; then
             echo "============================================================="
-            echo "Install jupyter dependencies with conda"
+            echo "Pre-install jupyter dependencies"
             echo "============================================================="
-            conda install jupyter jupyter-book 'lxml>=4.9.1'
+            python -m pip install 'jupyter-core>=4.11.2' git+https://github.com/executablebooks/jupyter-book
           fi
-
-          python -m pip install --upgrade pip
 
           echo "============================================================="
           echo "Install OpenMDAO"
@@ -166,28 +167,43 @@ jobs:
           echo "============================================================="
           echo "Install jax"
           echo "============================================================="
-          python -m pip install jax jaxlib
+
+          if [[ "${{ matrix.JAX }}" == "dev" ]]; then
+            python -m pip install git+https://github.com/google/jax
+          else
+            python -m pip install jaxlib jax=='${{ matrix.JAX}}'
+          fi
 
       - name: Install PETSc
         if: matrix.PETSc
         run: |
           echo "============================================================="
-          echo "Install PETSc"
+          echo "Install compilers for PETSc"
           echo "============================================================="
           if [[ "${{ matrix.OPENMPI }}" ]]; then
             COMPILERS="cython compilers openmpi-mpicc=${{ matrix.OPENMPI }}"
           else
             COMPILERS="cython compilers openmpi-mpicc"
           fi
+          conda install $COMPILERS -q -y
 
-          if [[ "${{ matrix.MPI4PY }}" ]]; then
-            MPI4PY="mpi4py=${{ matrix.MPI4PY }}"
+          echo "============================================================="
+          echo "Install PETSc"
+          echo "============================================================="
+          if [[ "${{ matrix.PETSc }}" == "3" ]]; then
+            python -m pip install git+https://github.com/mpi4py/mpi4py
+            python -m pip install petsc petsc4py
           else
-            MPI4PY="mpi4py"
+            if [[ "${{ matrix.MPI4PY }}" ]]; then
+              conda install mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
+            else
+              conda install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
+            fi
           fi
 
-          conda install $COMPILERS $MPI4PY petsc4py=${{ matrix.PETSc }} -q -y
-
+          echo "============================================================="
+          echo "Check MPI and PETSc installation"
+          echo "============================================================="
           export OMPI_MCA_rmaps_base_oversubscribe=1
           echo "-----------------------"
           echo "Quick test of mpi4py:"
@@ -219,7 +235,7 @@ jobs:
 
             conda install -c conda-forge pyoptsparse
           else
-            pip install git+https://github.com/OpenMDAO/build_pyoptsparse
+            python -m pip install git+https://github.com/OpenMDAO/build_pyoptsparse
 
             if [[ "${{ matrix.PYOPTSPARSE }}" == "latest" ]]; then
               LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/mdolab/pyoptsparse/releases/latest`
@@ -437,12 +453,12 @@ jobs:
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
-          echo "============================================================="
-          echo "Install jupyter dependencies with conda"
-          echo "============================================================="
-          conda install jupyter jupyter-book 'lxml>=4.9.1'
-
           python -m pip install --upgrade pip
+
+          echo "============================================================="
+          echo "Pre-install jupyter dependencies"
+          echo "============================================================="
+          python -m pip install 'jupyter-core>=4.11.2' git+https://github.com/executablebooks/jupyter-book
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -458,7 +458,7 @@ jobs:
           echo "============================================================="
           echo "Pre-install jupyter dependencies"
           echo "============================================================="
-          python -m pip install 'jupyter-core>=4.11.2' git+https://github.com/executablebooks/jupyter-book
+          conda install jupyter jupyter-book 'lxml>=4.9.1'
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/openmdao/devtools/iprof_utils.py
+++ b/openmdao/devtools/iprof_utils.py
@@ -77,7 +77,7 @@ def find_qualified_name(filename, line, cache, full=True):
     if filename not in cache:
         fcache = {}
 
-        with open(filename, 'Ur') as f:
+        with open(filename, 'r') as f:
             contents = f.read()
             if len(contents) > 0 and contents[-1] != '\n':
                 contents += '\n'

--- a/openmdao/visualization/meta_model_viewer/meta_model_visualization.py
+++ b/openmdao/visualization/meta_model_viewer/meta_model_visualization.py
@@ -492,8 +492,8 @@ class MetaModelVisualization(object):
                       (self.output_select.value, "@z")], tools='')
         contour_plot.x_range.range_padding = 0
         contour_plot.y_range.range_padding = 0
-        contour_plot.plot_width = 600
-        contour_plot.plot_height = 500
+        contour_plot.width = 600
+        contour_plot.height = 500
         contour_plot.xaxis.axis_label = self.x_input_select.value
         contour_plot.yaxis.axis_label = self.y_input_select.value
         contour_plot.min_border_left = 0
@@ -576,7 +576,7 @@ class MetaModelVisualization(object):
 
         # Create and format figure
         self.right_plot_fig = right_plot_fig = figure(
-            plot_width=250, plot_height=500,
+            width=250, height=500,
             title="{} vs {}".format(y_idx, self.output_select.value), tools="pan")
         right_plot_fig.xaxis.axis_label = self.output_select.value
         right_plot_fig.yaxis.axis_label = y_idx
@@ -664,7 +664,7 @@ class MetaModelVisualization(object):
 
         # Create and format figure
         self.bottom_plot_fig = bottom_plot_fig = figure(
-            plot_width=550, plot_height=250,
+            width=550, height=250,
             title="{} vs {}".format(x_idx, self.output_select.value), tools="")
         bottom_plot_fig.xaxis.axis_label = x_idx
         bottom_plot_fig.yaxis.axis_label = self.output_select.value

--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,15 @@ with open(Path(__file__).parent / "README.md", encoding="utf-8") as f:
 optional_dependencies = {
     'docs': [
         'matplotlib',
-        'jupyter',
-        'nbconvert',
-        'testflo',
-        'ipyparallel',
         'numpydoc>=1.1',
-        'jupyter-book<0.13',
+        'jupyter-core>=4.11.2',
+        'jupyter-book>=0.8.0,<0.13',
+        'jupyter-client>=7.4.0',
+        'jupyter',
         'jupyter-sphinx',
-        'sphinx-sitemap'
+        'sphinx-sitemap',
+        'ipyparallel',
+        'nbconvert>=6.3'
     ],
     'doe': [
         'pyDOE2'


### PR DESCRIPTION
### Summary

Updates to GitHub Workflow:

- specify JAX version (`0.3.22` or `dev`, which is required for Python 3.11)
- pre-install jupyter-book from github
- install latest PETSc from pypi after installing mpi4py 4.0.0-dev from github (for Latest/Python 3.11)
- disable ParOpt on Latest build, as it fails to build with mpi4py 4.0

Also:
- remove deprecated -U arg from open() call (removed in Python 3.11)
- change deprecated plot_width/plot_height attributes, removed in latest version of bokeh
- updated dependency versions in setup.py to conform with requirements and security vulnerabilities

### Related Issues

- Resolves #2697

### Backwards incompatibilities

None

### New Dependencies

None
