### PR TITLE
Separate vulnerabilities check from the CI build process

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -1,0 +1,137 @@
+# Audit OpenMDAO dependencies
+name: OpenMDAO Audit
+
+on:
+
+  # Run the workflow daily a 0200 UTC
+  schedule:
+    - cron: '0 2 * * *'
+
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  audit:
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        include:
+          # Audit dependencies on Ubuntu
+          - NAME: Audit Ubuntu
+            OS: ubuntu-latest
+
+          # Audit dependencies on MacOS
+          - NAME: Audit MacOS
+            OS: macos-latest
+
+          # Audit dependencies on Windows
+          - NAME: Audit Windows
+            OS: windows-latest
+
+    runs-on: ${{ matrix.OS }}
+
+    name: ${{ matrix.NAME }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3
+          conda-version: "*"
+          channels: conda-forge,defaults
+          channel-priority: true
+
+      - name: Install lxml
+        if: matrix.OS == 'windows-latest'
+        run: |
+          echo "============================================================="
+          echo "Install lxml for Windows (No Python 3.11 version on pypi)"
+          echo "============================================================="
+          conda install lxml
+
+      - name: Install OpenMDAO
+        run: |
+          conda install numpy scipy -q -y
+
+          echo "============================================================="
+          echo "Pre-install jupyter dependencies"
+          echo "============================================================="
+          conda install jupyter-book -q -y
+
+          echo "============================================================="
+          echo "Install OpenMDAO with all optional dependencies"
+          echo "============================================================="
+          python -m pip install .[all]
+
+      - name: Install additional packages
+        run: |
+          echo "============================================================="
+          echo "Install additional relevant packages"
+          echo "============================================================="
+          python -m pip install psutil objgraph
+          python -m pip install git+https://github.com/mdolab/pyxdsm
+          python -m pip install git+https://github.com/google/jax
+
+      - name: Install PETSc
+        if: matrix.OS != 'windows-latest'
+        run: |
+          echo "============================================================="
+          echo "Install compilers for PETSc"
+          echo "============================================================="
+          conda install cython compilers openmpi-mpicc -q -y
+
+          echo "============================================================="
+          echo "Install PETSc"
+          echo "============================================================="
+          if [[ "${{ matrix.OS }}" == "macos-latest" ]]; then
+              conda install mpi4py petsc4py -q -y
+          else
+            python -m pip install git+https://github.com/mpi4py/mpi4py
+            python -m pip install petsc petsc4py
+          fi
+
+      - name: Install pyOptSparse
+        if: matrix.OS != 'macos-latest'
+        run: |
+          echo "============================================================="
+          echo "Install pyoptsparse"
+          echo "============================================================="
+          conda install pyoptsparse
+
+      - name: Display environment info
+        run: |
+          conda info
+          conda list
+
+      - name: Audit dependencies
+        run: |
+          python -m pip install pip-audit
+          echo "======================================================================="
+          echo "Scan environment for pypi packages with known vulnerabilities"
+          echo "found in the Python Packaging Advisory Database"
+          echo "(Temporarily ignoring PYSEC-2022-237 in mistune, required by nbconvert)"
+          echo "======================================================================="
+          python -m pip_audit -s pypi --ignore-vuln PYSEC-2022-237
+
+          echo "======================================================================="
+          echo "Scan environment for packages with known vulnerabilities"
+          echo "found in the Open Source Vulnerability database"
+          echo "======================================================================="
+          python -m pip_audit -s osv
+
+      - name: Notify slack
+        uses: act10ns/slack@v1.6.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          status: ${{ job.status }}
+        if: failure()

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ master ]
 
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
 
   tests:
@@ -129,7 +132,7 @@ jobs:
           echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch tags
         run: |
@@ -153,7 +156,7 @@ jobs:
             echo "============================================================="
             echo "Pre-install jupyter dependencies"
             echo "============================================================="
-            python -m pip install 'jupyter-core>=4.11.2' git+https://github.com/executablebooks/jupyter-book
+            conda install jupyter-book -q -y
           fi
 
           echo "============================================================="
@@ -291,16 +294,6 @@ jobs:
           python -c "import scipy; assert str(scipy.__version__).startswith(str(${{ matrix.SCIPY }})), \
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
-      - name: Audit dependencies
-        run: |
-          python -m pip install pip-audit
-          echo "============================================================="
-          echo "Scan environment for packages with known vulnerabilities"
-          echo "(Temporarily ignoring PYSEC-2022-237, required by nbconvert)"
-          echo "(Temporarily ignoring OSV-2022-715, in Pillow, required by matplotlib)"
-          echo "============================================================="
-          python -m pip_audit --ignore-vuln OSV-2022-715 --ignore-vuln PYSEC-2022-237 --ignore-vuln GHSA-fpfv-jqm9-f5jm
-
       - name: Run tests
         if: matrix.TESTS
         run: |
@@ -395,7 +388,7 @@ jobs:
           python -m bandit -c bandit.yml -ll -r openmdao
 
       - name: Notify slack
-        uses: act10ns/slack@v1
+        uses: act10ns/slack@v1.6.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
@@ -435,7 +428,7 @@ jobs:
           echo "============================================================="
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch tags
         run: |
@@ -456,9 +449,14 @@ jobs:
           python -m pip install --upgrade pip
 
           echo "============================================================="
+          echo "Install lxml for Windows (No Python 3.11 version on pypi)"
+          echo "============================================================="
+          conda install lxml
+
+          echo "============================================================="
           echo "Pre-install jupyter dependencies"
           echo "============================================================="
-          conda install jupyter jupyter-book 'lxml>=4.9.1'
+          conda install jupyter-book -q -y
 
           echo "============================================================="
           echo "Install OpenMDAO"
@@ -523,7 +521,7 @@ jobs:
           coveralls --basedir $SITE_DIR
 
       - name: Notify slack
-        uses: act10ns/slack@v1
+        uses: act10ns/slack@v1.6.0
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:


### PR DESCRIPTION
### Summary

Remove pip-audit step from test workflow and put it in it's own workflow

- audit workflow is run daily at 0200 UTC
- checks all three platforms (ubuntu, osx and windows) with Python 3.11 and latest dependencies
- mpi and petsc are included on ubuntu and macos
- pyoptsparse is included on ubuntu and windows
- both pypa and osv databases are checked
 
Also:
- add `workflow_dispatch` trigger to test workflow to facilitate ad hoc testing
- upgrade the checkout action to v3 in test workflow
- upgrade the slack action to v1.6.0 in test workflow
- clean up some pre-install steps in test workflow

### Related Issues

- Resolves #2700

### Backwards incompatibilities

None

### New Dependencies

None
