### PR TITLE
Update GitHub test workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -156,7 +156,7 @@ jobs:
             echo "============================================================="
             echo "Pre-install jupyter dependencies"
             echo "============================================================="
-            conda install jupyter-book -q -y
+            python -m pip install git+https://github.com/executablebooks/jupyter-book
           fi
 
           echo "============================================================="


### PR DESCRIPTION
### Summary

This reverts a change to the GitHub test workflow in #2703.  

Pre-installing the `jupyter-book` dependency via `conda-forge` takes an inordinate amount of time in the `Ubuntu Oldest` build.  This change goes back to installing the latest version from the GitHub repository with `pip`,

### Related Issues

- Resolves #2700

### Backwards incompatibilities

None

### New Dependencies

None
