### PR TITLE
Update version of JAX used in GitHub workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -61,7 +61,7 @@ jobs:
             # PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: 'dev'
+            JAX: '0.3.24'
             TESTS: true
 
           # test minimal install
@@ -170,12 +170,7 @@ jobs:
           echo "============================================================="
           echo "Install jax"
           echo "============================================================="
-
-          if [[ "${{ matrix.JAX }}" == "dev" ]]; then
-            python -m pip install git+https://github.com/google/jax
-          else
-            python -m pip install jaxlib jax=='${{ matrix.JAX}}'
-          fi
+          python -m pip install jaxlib=='${{ matrix.JAX }}' jax=='${{ matrix.JAX }}'
 
       - name: Install PETSc
         if: matrix.PETSc

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -32,7 +32,7 @@ jobs:
             PAROPT: true
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: '0.3.22'
+            JAX: '0.3.24'
             BANDIT: true
             TESTS: true
 
@@ -47,7 +47,7 @@ jobs:
             # PAROPT: true
             # SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: '0.3.22'
+            JAX: '0.3.24'
             TESTS: true
 
           # test latest versions
@@ -98,7 +98,7 @@ jobs:
             PYOPTSPARSE: 'v2.8.3'
             SNOPT: 7.7
             OPTIONAL: '[all]'
-            JAX: '0.3.22'
+            JAX: '0.3.24'
             BUILD_DOCS: true
 
     runs-on: ${{ matrix.OS }}


### PR DESCRIPTION
### Summary

[jax](https://pypi.org/project/jax/) [0.3.24](https://github.com/google/jax/blob/main/CHANGELOG.md) was released today.

This simultaneously broke some current tests and solved the Python 3.11 incompatibility issue.

The OpenMDAO test workflow is updated to use the new version for all builds.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
