### PR TITLE
Fixing numpy deprecation warnings

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -4,7 +4,7 @@ from itertools import product
 from contextlib import contextmanager
 
 import numpy as np
-from numpy import ndarray, imag, complex as npcomplex
+from numpy import ndarray, imag, complex128 as npcomplex
 
 from openmdao.core.constants import INT_DTYPE
 from openmdao.core.explicitcomponent import ExplicitComponent

--- a/openmdao/surrogate_models/response_surface.py
+++ b/openmdao/surrogate_models/response_surface.py
@@ -4,7 +4,7 @@ Surrogate Model based on second order response surface equations.
 """
 
 from numpy import zeros, einsum
-from numpy.dual import lstsq
+from numpy.linalg import lstsq
 from openmdao.surrogate_models.surrogate_model import SurrogateModel
 
 

--- a/openmdao/surrogate_models/response_surface.py
+++ b/openmdao/surrogate_models/response_surface.py
@@ -5,6 +5,7 @@ Surrogate Model based on second order response surface equations.
 
 from numpy import zeros, einsum
 import numpy as np
+from packaging.version import Version
 if Version(np.__version__) >= Version("1.20"):
     from numpy.linalg import lstsq
 else:

--- a/openmdao/surrogate_models/response_surface.py
+++ b/openmdao/surrogate_models/response_surface.py
@@ -4,7 +4,11 @@ Surrogate Model based on second order response surface equations.
 """
 
 from numpy import zeros, einsum
-from numpy.linalg import lstsq
+import numpy as np
+if Version(np.__version__) >= Version("1.20"):
+    from numpy.linalg import lstsq
+else:
+    from numpy.dual import lstsq
 from openmdao.surrogate_models.surrogate_model import SurrogateModel
 
 


### PR DESCRIPTION
### Summary

Fixing deprecation warnings for numpy.complex/numpy.dual during import.

Fixes the following deprecation warnings:

```
/usr/share/miniconda/envs/test/lib/python3.8/site-packages/openmdao/components/exec_comp.py:7: DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.

/usr/share/miniconda/envs/test/lib/python3.8/site-packages/openmdao/surrogate_models/response_surface.py:7: DeprecationWarning: The module numpy.dual is deprecated.  Instead of using dual, use the functions directly from numpy or scipy.
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
