### PR TITLE
change default for Driver supports['optimization'] to False

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -149,6 +149,7 @@ class Driver(object):
 
         # What the driver supports.
         self.supports = OptionsDictionary(parent_name=type(self).__name__)
+        self.supports.declare('optimization', types=bool, default=False)
         self.supports.declare('inequality_constraints', types=bool, default=False)
         self.supports.declare('equality_constraints', types=bool, default=False)
         self.supports.declare('linear_constraints', types=bool, default=False)
@@ -160,7 +161,6 @@ class Driver(object):
         self.supports.declare('simultaneous_derivatives', types=bool, default=False)
         self.supports.declare('total_jac_sparsity', types=bool, default=False)
         self.supports.declare('distributed_design_vars', types=bool, default=True)
-        self.supports.declare('optimization', types=bool, default=True)
 
         self.iter_count = 0
         self.cite = ""

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -73,6 +73,7 @@ class DifferentialEvolutionDriver(Driver):
         super().__init__(**kwargs)
 
         # What we support
+        self.supports['optimization'] = True
         self.supports['inequality_constraints'] = True
         self.supports['equality_constraints'] = True
         self.supports['multiple_objectives'] = True

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -78,6 +78,7 @@ class SimpleGADriver(Driver):
         super().__init__(**kwargs)
 
         # What we support
+        self.supports['optimization'] = True
         self.supports['integer_design_vars'] = True
         self.supports['inequality_constraints'] = True
         self.supports['equality_constraints'] = True

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -203,6 +203,7 @@ class pyOptSparseDriver(Driver):
         super().__init__(**kwargs)
 
         # What we support
+        self.supports['optimization'] = True
         self.supports['inequality_constraints'] = True
         self.supports['equality_constraints'] = True
         self.supports['multiple_objectives'] = True

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -120,6 +120,7 @@ class ScipyOptimizeDriver(Driver):
         super().__init__(**kwargs)
 
         # What we support
+        self.supports['optimization'] = True
         self.supports['inequality_constraints'] = True
         self.supports['equality_constraints'] = True
         self.supports['two_sided_constraints'] = True

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -163,8 +163,14 @@ class TestOptimizationReport(unittest.TestCase):
                                           )
         expect = {'obj_calls': 0, 'deriv_calls': 0}
         self.check_opt_result(expected=expect)
-        opt_report(self.prob)
-        self.check_opt_report(expected=expect)
+
+        expected_warning_msg = "The optimizer report is not applicable for the Driver Driver " \
+                               "which does not support optimization"
+        with assert_warning(DriverWarning, expected_warning_msg):
+            opt_report(self.prob)
+
+        outfilepath = str(pathlib.Path(self.prob.get_reports_dir()).joinpath(_default_optimizer_report_filename))
+        self.assertFalse(os.path.exists(outfilepath))
 
     def test_opt_report_scipyopt_SLSQP(self):
         self.setup_problem_and_run_driver(om.ScipyOptimizeDriver,


### PR DESCRIPTION
### Summary

The `supports['optimization']` option previously [defaulted](https://github.com/OpenMDAO/OpenMDAO/blob/master/openmdao/core/driver.py#L163) to True in the Driver base class.

Since the base Driver class does not in fact support optimization, the default has been changed to `False` and Driver sub-classes have been updated set the option as appropriate rather than relying on the default.

### Related Issues

- Resolves #2714

### Backwards incompatibilities

For outside developers that may have developed their own drivers, the optimization report will not be automatically generated unless the `supports['optimization']` option is set to `True`.  Previously this was the default.

### New Dependencies

None
