### PR TITLE
Add pyoptsparse to windows build on GitHub Actions

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -458,6 +458,14 @@ jobs:
           echo "============================================================="
           python -m pip install .[all]
 
+      - name: Install pyOptSparse
+        if: matrix.PYOPTSPARSE
+        run: |
+          echo "============================================================="
+          echo "Install pyoptsparse from conda-forge"
+          echo "============================================================="
+          conda install -c conda-forge pyoptsparse
+
       - name: Install optional dependencies
         run: |
           echo "============================================================="

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -404,6 +404,7 @@ jobs:
             PY: 3
             NUMPY: 1
             SCIPY: 1
+            PYOPTSPARSE: '2.9.1'
 
     name: ${{ matrix.NAME }}
 
@@ -464,7 +465,7 @@ jobs:
           echo "============================================================="
           echo "Install pyoptsparse from conda-forge"
           echo "============================================================="
-          conda install -c conda-forge pyoptsparse
+          conda install -c conda-forge pyoptsparse=${{ matrix.PYOPTSPARSE }} -q -y
 
       - name: Install optional dependencies
         run: |


### PR DESCRIPTION
### Summary

Add pyoptsparse to windows build on GitHub Actions

### Related Issues

- Resolves #2717

### Backwards incompatibilities

None

### New Dependencies

None
