### PR TITLE
Remove pyparsing as an explicit OpenMDAO dependency.

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -270,7 +270,7 @@ jobs:
           echo "============================================================="
           echo "Install additional packages for testing/coverage"
           echo "============================================================="
-          python -m pip install psutil objgraph git+https://github.com/mdolab/pyxdsm
+          python -m pip install pyparsing psutil objgraph git+https://github.com/mdolab/pyxdsm
 
       - name: Display environment info
         run: |

--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -60,7 +60,7 @@ sphinx:
     html_theme_path: ['.'] # make sphinx search for themes in current dir
 
   extra_extensions:
-  # This line is a workaround for https://github.com/spatialaudio/nbsphinx/issues/24
+  # This line is a workaround for https://github.com/jupyter/nbconvert/issues/528
   - 'IPython.sphinxext.ipython_console_highlighting'
   - 'sphinx.ext.autodoc'
   - 'sphinx.ext.autosummary'

--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -60,6 +60,8 @@ sphinx:
     html_theme_path: ['.'] # make sphinx search for themes in current dir
 
   extra_extensions:
+  # This line is a workaround for https://github.com/spatialaudio/nbsphinx/issues/24
+  - 'IPython.sphinxext.ipython_console_highlighting'
   - 'sphinx.ext.autodoc'
   - 'sphinx.ext.autosummary'
   - 'sphinx.ext.viewcode'

--- a/openmdao/utils/file_wrap.py
+++ b/openmdao/utils/file_wrap.py
@@ -7,8 +7,12 @@ Note: This is a work in progress.
 
 import re
 
-from pyparsing import CaselessLiteral, Combine, OneOrMore, Optional, \
-    TokenConverter, Word, nums, oneOf, printables, ParserElement, alphanums
+try:
+    import pyparsing
+    from pyparsing import CaselessLiteral, Combine, OneOrMore, Optional, \
+        TokenConverter, Word, nums, oneOf, printables, ParserElement, alphanums
+except ImportError:
+    pyparsing = None
 
 import numpy as np
 
@@ -294,6 +298,10 @@ class InputFileGenerator(object):
         """
         Initialize attributes.
         """
+        if pyparsing is None:
+            raise RuntimeError("The 'pyparsing' package is required to use the file wrapping "
+                               "utilities but it is not installed. Try 'pip install pyparsing'.")
+
         self._template_filename = None
         self._output_filename = None
 
@@ -621,6 +629,10 @@ class FileParser(object):
         """
         Initialize attributes.
         """
+        if pyparsing is None:
+            raise RuntimeError("The 'pyparsing' package is required to use the file wrapping "
+                               "utilities but it is not installed. Try 'pip install pyparsing'.")
+
         self._filename = None
         self._data = []
 

--- a/openmdao/utils/tests/test_file_wrap.py
+++ b/openmdao/utils/tests/test_file_wrap.py
@@ -13,11 +13,17 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays
 import numpy
 from numpy import array, isnan, isinf
 
-from openmdao.utils.file_wrap import InputFileGenerator, FileParser
+try:
+    import pyparsing
+    from openmdao.utils.file_wrap import InputFileGenerator, FileParser
+except ImportError:
+    pyparsing = None
+
 
 DIRECTORY = os.path.dirname((os.path.abspath(__file__)))
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class TestCase(unittest.TestCase):
     """ Test file wrapping functions. """
 
@@ -611,6 +617,7 @@ class TestCase(unittest.TestCase):
         self.assertEqual(val, '#$%')
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class FileGenFeature(unittest.TestCase):
 
     # output data for each test
@@ -725,6 +732,7 @@ class FileGenFeature(unittest.TestCase):
                          '\n'.join(self.output_data[self._testMethodName]))
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class FileParserFeature(unittest.TestCase):
 
     def setUp(self):
@@ -804,6 +812,7 @@ class FileParserFeature(unittest.TestCase):
         ]))
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class FileParser2dFeature(unittest.TestCase):
 
     def setUp(self):
@@ -836,6 +845,7 @@ class FileParser2dFeature(unittest.TestCase):
         ]))
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class FileParserDelimFeature(unittest.TestCase):
 
     def setUp(self):
@@ -864,6 +874,7 @@ class FileParserDelimFeature(unittest.TestCase):
         self.assertEqual((var, type(var)), (7, int))
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class FileParserColumnsFeature(unittest.TestCase):
 
     def setUp(self):
@@ -889,6 +900,7 @@ class FileParserColumnsFeature(unittest.TestCase):
         self.assertEqual((var1, var2, var3), ('F', 3.7, -9.4434967))
 
 
+@unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
 class FileParserArrayColumnsFeature(unittest.TestCase):
 
     def setUp(self):

--- a/setup.py
+++ b/setup.py
@@ -190,7 +190,6 @@ setup(
     install_requires=[
         'networkx>=2.0',
         'numpy',
-        'pyparsing',
         'scipy',
         'requests',
         'packaging'


### PR DESCRIPTION
### Summary

Remove [pyparsing](https://pypi.org/project/pyparsing/) as an explicit OpenMDAO dependency.

It is still an indirect dependency, via [packaging](https://pypi.org/project/packaging/) which is required for Version checking in both [ScipyOptimizeDriver ](https://github.com/OpenMDAO/OpenMDAO/blob/master/openmdao/drivers/scipy_optimizer.py#L33) and [pyOptSparseDriver ](https://github.com/OpenMDAO/OpenMDAO/blob/master/openmdao/drivers/pyoptsparse_driver.py#L34) as well as in various tests.

### Related Issues

- Resolves #2693

### Backwards incompatibilities

None

### New Dependencies

None
