### PR TITLE
Raise an exception if a solver is assigned to more than one System

### DIFF
--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -60,7 +60,7 @@ sphinx:
     html_theme_path: ['.'] # make sphinx search for themes in current dir
 
   extra_extensions:
-  # This line is a workaround for https://github.com/spatialaudio/nbsphinx/issues/24
+  # This line is a workaround for https://github.com/jupyter/nbconvert/issues/528
   - 'IPython.sphinxext.ipython_console_highlighting'
   - 'sphinx.ext.autodoc'
   - 'sphinx.ext.autosummary'

--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -60,6 +60,8 @@ sphinx:
     html_theme_path: ['.'] # make sphinx search for themes in current dir
 
   extra_extensions:
+  # This line is a workaround for https://github.com/spatialaudio/nbsphinx/issues/24
+  - 'IPython.sphinxext.ipython_console_highlighting'
   - 'sphinx.ext.autodoc'
   - 'sphinx.ext.autosummary'
   - 'sphinx.ext.viewcode'

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -274,12 +274,13 @@ class Solver(object):
         depth : int
             depth of the current system (already incremented).
         """
-        if self._system and self._system != weakref.ref(system):
+        if self._system is None:
+            self._system = weakref.ref(system)
+        elif self._system != weakref.ref(system):
             raise RuntimeError(f"{type(self).__name__} has already been assigned to "
                                f"{self._system().msginfo} and cannot also be assigned to "
                                f"{system.msginfo}.")
 
-        self._system = weakref.ref(system)
         self._depth = depth
         self._problem_meta = system._problem_meta
 

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -274,6 +274,11 @@ class Solver(object):
         depth : int
             depth of the current system (already incremented).
         """
+        if self._system:
+            raise RuntimeError(f"{type(self).__name__} has already been assigned to "
+                               f"{self._system().msginfo} and cannot also be assigned to "
+                               f"{system.msginfo}.")
+
         self._system = weakref.ref(system)
         self._depth = depth
         self._problem_meta = system._problem_meta

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -274,7 +274,7 @@ class Solver(object):
         depth : int
             depth of the current system (already incremented).
         """
-        if self._system:
+        if self._system and self._system != weakref.ref(system):
             raise RuntimeError(f"{type(self).__name__} has already been assigned to "
                                f"{self._system().msginfo} and cannot also be assigned to "
                                f"{system.msginfo}.")


### PR DESCRIPTION
### Summary

Add check inside of Solver `_setup_solvers` that will raise an exception if `_system weakref` has already been set to a different System.
### Related Issues

- Resolves #2665

### Backwards incompatibilities

None

### New Dependencies

None
