### PR TITLE
add skipUnless to a couple distributed recording tests that need pyDOE2

### DIFF
--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -22,6 +22,11 @@ if MPI:
 else:
     PETScVector = None
 
+try:
+    import pyDOE2
+except ImportError:
+    pyDOE2 = None
+
 from openmdao.test_suite.components.paraboloid import Paraboloid
 
 
@@ -302,6 +307,7 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.run_model()
         prob.record('final')
 
+    @unittest.skipUnless(pyDOE2, "This test uses full factorial from pyDOE2.")
     def test_sql_meta_file_exists(self):
         # Check that an existing sql_meta file will be deleted/overwritten
         # if it already exists before a run. (see Issue #2062)
@@ -358,6 +364,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
         prob.cleanup()
 
+    @unittest.skipUnless(pyDOE2, "This test uses full factorial from pyDOE2.")
     def test_record_on_one_proc(self):
         # This test verifies that cases can be recorded on a single process in an MPI environment
         # with more than one process, and the recorded cases can then be processed in parallel


### PR DESCRIPTION
### Summary

add skipUnless to a couple distributed recording tests that need pyDOE2

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
