### PR TITLE
Temporarily ignore GitPython vulnerability in audit

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -126,7 +126,7 @@ jobs:
           echo "Scan environment for packages with known vulnerabilities"
           echo "found in the Open Source Vulnerability database"
           echo "======================================================================="
-          python -m pip_audit -s osv
+          python -m pip_audit -s osv --ignore-vuln GHSA-hcpj-qp55-gfph
 
       - name: Notify slack
         uses: act10ns/slack@v1.6.0

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -120,7 +120,7 @@ jobs:
           echo "found in the Python Packaging Advisory Database"
           echo "(Temporarily ignoring PYSEC-2022-237 in mistune, required by nbconvert)"
           echo "======================================================================="
-          python -m pip_audit -s pypi --ignore-vuln PYSEC-2022-237
+          python -m pip_audit -s pypi --ignore-vuln PYSEC-2022-237 --ignore-vuln GHSA-hcpj-qp55-gfph
 
           echo "======================================================================="
           echo "Scan environment for packages with known vulnerabilities"


### PR DESCRIPTION
### Summary

A new [RCE vulnerability](https://github.com/advisories/GHSA-hcpj-qp55-gfph) has been reported for the GitPython package, which is a dependency of jupyter-book.   [GitPython ](https://github.com/gitpython-developers/GitPython)is in maintenance mode and there is no  fix available yet.  This change allows the audit to pass given this known vulnerability.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
