### PR TITLE
Updates for numpy 1.24

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -70,7 +70,7 @@ jobs:
             PY: 3
             NUMPY: 1
             SCIPY: 1
-#            PYOPTSPARSE: 'latest'
+            # PYOPTSPARSE: 'latest'
             OPTIONAL: '[test]'
             TESTS: true
 
@@ -401,9 +401,9 @@ jobs:
         include:
           # baseline versions
           - NAME: Windows Baseline
-            PY: 3
-            NUMPY: 1
-            SCIPY: 1
+            PY: 3.10
+            NUMPY: 1.23
+            SCIPY: 1.9.0
             PYOPTSPARSE: '2.9.1'
 
     name: ${{ matrix.NAME }}

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -401,9 +401,9 @@ jobs:
         include:
           # baseline versions
           - NAME: Windows Baseline
-            PY: 3.10
-            NUMPY: 1.23
-            SCIPY: 1.9.0
+            PY: '3.10'
+            NUMPY: '1.23'
+            SCIPY: '1.9.0'
             PYOPTSPARSE: '2.9.1'
 
     name: ${{ matrix.NAME }}

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -70,7 +70,7 @@ jobs:
             PY: 3
             NUMPY: 1
             SCIPY: 1
-            PYOPTSPARSE: 'conda-forge'
+#            PYOPTSPARSE: 'latest'
             OPTIONAL: '[test]'
             TESTS: true
 

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -402,8 +402,8 @@ jobs:
           # baseline versions
           - NAME: Windows Baseline
             PY: '3.10'
-            NUMPY: '1.23'
-            SCIPY: '1.9.0'
+            NUMPY: 1.22
+            SCIPY: 1.7
             PYOPTSPARSE: '2.9.1'
 
     name: ${{ matrix.NAME }}

--- a/openmdao/components/cross_product_comp.py
+++ b/openmdao/components/cross_product_comp.py
@@ -72,7 +72,7 @@ class CrossProductComp(ExplicitComponent):
 
         self._k = np.array([[0, 0, 0, -1, 0, 1],
                             [0, 1, 0, 0, -1, 0],
-                            [-1, 0, 1, 0, 0, 0]], dtype=np.float64)
+                            [-1, 0, 1, 0, 0, 0]], dtype=float)
 
     def add_product(self, c_name, a_name='a', b_name='b',
                     c_units=None, a_units=None, b_units=None,

--- a/openmdao/components/interp_util/interp_scipy.py
+++ b/openmdao/components/interp_util/interp_scipy.py
@@ -185,7 +185,7 @@ class InterpScipy(InterpAlgorithm):
         # for spline based methods
 
         # requires floating point input
-        xi = xi.astype(np.float)
+        xi = xi.astype(float)
 
         # ensure xi is 2D list of points to evaluate
         if xi.ndim == 1:

--- a/openmdao/components/ks_comp.py
+++ b/openmdao/components/ks_comp.py
@@ -206,7 +206,7 @@ class KSComp(ExplicitComponent):
                                 ref0=opts['ref0'], ref=opts['ref'],
                                 parallel_deriv_color=opts['parallel_deriv_color'])
 
-        rows = np.zeros(width, dtype=np.int)
+        rows = np.zeros(width, dtype=int)
         cols = range(width)
         rows = np.tile(rows, vec_size) + np.repeat(np.arange(vec_size), width)
         cols = np.tile(cols, vec_size) + np.repeat(np.arange(vec_size), width) * width

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -304,8 +304,8 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
               [ 0.3914706 ,  0.09852519],
               [ 0.86565585,  0.85350002],
               [ 0.40806563,  0.91465314]]]
-        y = np.array([[branin(case) for case in x[0]],
-                      [branin_low_fidelity(case) for case in x[1]]])
+        y = [[branin(case) for case in x[0]],
+             [branin_low_fidelity(case) for case in x[1]]]
 
         mm.options['train_x'] = x[0]
         mm.options['train_y'] = y[0]

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -702,7 +702,7 @@ class Driver(object):
                     # Setting an integer value with a 1D array - don't want to convert to array.
                     value = int(value)
                 else:
-                    value = value.astype(np.int)
+                    value = value.astype(int)
 
             problem.model._discrete_outputs[src_name] = value
 

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -997,7 +997,7 @@ class GeneticAlgorithm(object):
         -------
         ndarray
             New shuffled population.
-        ndarray(dtype=np.int)
+        ndarray(dtype=int)
             Index array that maps the shuffle from old to new.
         """
         temp = np.random.rand(self.npop)
@@ -1016,7 +1016,7 @@ class GeneticAlgorithm(object):
             Lower bound array.
         vub : ndarray
             Upper bound array.
-        bits : ndarray(dtype=np.int)
+        bits : ndarray(dtype=int)
             Number of bits for decoding.
 
         Returns
@@ -1055,7 +1055,7 @@ class GeneticAlgorithm(object):
             Lower bound array.
         vub : ndarray
             Upper bound array.
-        bits : ndarray(dtype=np.int)
+        bits : ndarray(dtype=int)
             Number of bits for decoding.
 
         Returns

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -78,7 +78,7 @@ class ParaboloidDiscreteArray(om.ExplicitComponent):
         x = discrete_inputs['x']
         y = discrete_inputs['y']
         f_xy = (x - 3.0)**2 + x * y + (y + 4.0)**2 - 3.0
-        discrete_outputs['f_xy'] = f_xy.astype(np.int)
+        discrete_outputs['f_xy'] = f_xy.astype(int)
 
 
 class TestErrors(unittest.TestCase):
@@ -1255,8 +1255,8 @@ class TestDOEDriver(unittest.TestCase):
 
         # Add independent variables
         indeps = model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
-        indeps.add_discrete_output('x', np.ones((2, ), dtype=np.int))
-        indeps.add_discrete_output('y', np.ones((2, ), dtype=np.int))
+        indeps.add_discrete_output('x', np.ones((2, ), dtype=int))
+        indeps.add_discrete_output('y', np.ones((2, ), dtype=int))
 
         # Add components
         model.add_subsystem('parab', ParaboloidDiscreteArray(), promotes=['*'])
@@ -1311,8 +1311,8 @@ class TestDOEDriver(unittest.TestCase):
 
         prob.setup()
 
-        prob.set_val('x', np.ones((2, ), dtype=np.int))
-        prob.set_val('y', np.ones((2, ), dtype=np.int))
+        prob.set_val('x', np.ones((2, ), dtype=int))
+        prob.set_val('y', np.ones((2, ), dtype=int))
 
         prob.run_driver()
         prob.cleanup()

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -311,7 +311,7 @@ class Jacobian(object):
         """
         for meta in self._subjacs_info.values():
             if active:
-                meta['val'] = meta['val'].astype(np.complex)
+                meta['val'] = meta['val'].astype(complex)
             else:
                 meta['val'] = meta['val'].real
 

--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -273,7 +273,7 @@ class COOMatrix(Matrix):
                 self._coo.dtype = complex
         else:
             self._coo.data = self._coo.data.real
-            self._coo.dtype = np.float
+            self._coo.dtype = float
 
     def _convert_mask(self, mask):
         """

--- a/openmdao/matrices/csc_matrix.py
+++ b/openmdao/matrices/csc_matrix.py
@@ -89,6 +89,6 @@ class CSCMatrix(COOMatrix):
                 self._coo.dtype = complex
         else:
             self._matrix.data = self._matrix.data.real
-            self._matrix.dtype = np.float
+            self._matrix.dtype = float
             self._coo.data = self._coo.data.real
-            self._coo.dtype = np.float
+            self._coo.dtype = float

--- a/openmdao/surrogate_models/multifi_cokriging.py
+++ b/openmdao/surrogate_models/multifi_cokriging.py
@@ -60,7 +60,7 @@ def constant_regression(x):
     array_like
         Constant regression output.
     """
-    x = np.asarray(x, dtype=np.float)
+    x = np.asarray(x, dtype=float)
     n_eval = x.shape[0]
     f = np.ones([n_eval, 1])
     return f
@@ -82,7 +82,7 @@ def linear_regression(x):
     array_like
         Linear regression output.
     """
-    x = np.asarray(x, dtype=np.float)
+    x = np.asarray(x, dtype=float)
     n_eval = x.shape[0]
     f = np.hstack([np.ones([n_eval, 1]), x])
     return f
@@ -114,8 +114,8 @@ def squared_exponential_correlation(theta, d):
         An array with shape (n_eval, ) containing the values of the
         autocorrelation model.
     """
-    theta = np.asarray(theta, dtype=np.float)
-    d = np.asarray(d, dtype=np.float)
+    theta = np.asarray(theta, dtype=float)
+    d = np.asarray(d, dtype=float)
 
     if d.ndim > 1:
         n_features = d.shape[1]

--- a/openmdao/surrogate_models/tests/test_multifi_cokriging.py
+++ b/openmdao/surrogate_models/tests/test_multifi_cokriging.py
@@ -45,12 +45,11 @@ class CoKrigingSurrogateTest(unittest.TestCase):
         def f_cheap(x):
             return 0.5*((x*6-2)**2)*np.sin((x*6-2)*2)+(x-0.5)*10. - 5
 
+        x = [[[0.0], [0.4], [0.6], [1.0]],
+             [[0.1], [0.2], [0.3], [0.5], [0.7], [0.8], [0.9], [0.0], [0.4], [0.6], [1.0]]]
 
-        x = np.array([[[0.0], [0.4], [0.6], [1.0]],
-                      [[0.1], [0.2], [0.3], [0.5], [0.7],
-                       [0.8], [0.9], [0.0], [0.4], [0.6], [1.0]]])
-        y = np.array([[f_expensive(v) for v in np.array(x[0]).ravel()],
-                      [f_cheap(v) for v in np.array(x[1]).ravel()]])
+        y = [[f_expensive(v) for v in np.array(x[0]).ravel()],
+             [f_cheap(v) for v in np.array(x[1]).ravel()]]
 
         cokrig = MultiFiCoKrigingSurrogate()
         cokrig.train_multifi(x, y)
@@ -68,9 +67,8 @@ class CoKrigingSurrogateTest(unittest.TestCase):
             y = (x[1]-(5.1/(4.*np.pi**2.))*x[0]**2.+5.*x[0]/np.pi-6.)**2.+10.*(1.-1./(8.*np.pi))*np.cos(x[0])+10.
             return y
 
-        x = np.array([[-2., 0.], [-0.5, 1.5], [1., 3.], [8.5, 4.5],
-                    [-3.5, 6.], [4., 7.5], [-5., 9.], [5.5, 10.5],
-                    [10., 12.], [7., 13.5], [2.5, 15.]])
+        x = [[-2., 0.], [-0.5, 1.5], [1., 3.], [8.5, 4.5], [-3.5, 6.],
+             [4., 7.5], [-5., 9.], [5.5, 10.5], [10., 12.], [7., 13.5], [2.5, 15.]]
         y = np.array([branin(case) for case in x])
         krig1 = MultiFiCoKrigingSurrogate()
         krig1.train(x, y)
@@ -137,9 +135,8 @@ class CoKrigingSurrogateTest(unittest.TestCase):
               [ 0.3914706 ,  0.09852519],
               [ 0.86565585,  0.85350002],
               [ 0.40806563,  0.91465314]]]
-        y = np.array([[branin(case) for case in x[0]],
-                      [branin_low_fidelity(case) for case in x[1]]])
-        nfi=2
+        y = [[branin(case) for case in x[0]],
+             [branin_low_fidelity(case) for case in x[1]]]
         cokrig = MultiFiCoKrigingSurrogate(normalize=False)
         cokrig.train_multifi(x, y)
 


### PR DESCRIPTION
### Summary

Deals with numpy deprecations.

- `numpy.int` changed to `int`
- `numpy.float` changed to `float`

### Related Issues

- Resolves #2737 

### Backwards incompatibilities

None

### New Dependencies

None
