### PR TITLE
fix bug that caused warnings when assigning a new driver

### DIFF
--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -88,13 +88,20 @@ class Report(object):
             kw['inst_id'] = None if instance is None else instance._get_inst_id()
             _register_hook(*hook_args, **kw)
 
-    def unregister_hooks(self):
+    def unregister_hooks(self, instance=None):
         """
-        Unregister all hooks associated with this report.
+        Unregister hooks associated with this report.
+
+        Parameters
+        ----------
+        instance : object or None
+            If not None, only unregister reports for this instance.
         """
         keep = {'fname', 'class_name', 'inst_id', 'pre', 'post'}
         for args, kw in self.hooks:
             kwargs = {k: v for k, v in kw.items() if k in keep}
+            if instance is not None:
+                kwargs['inst_id'] = instance
             _unregister_hook(*args, **kwargs)
 
     def __getattr__(self, name):
@@ -582,7 +589,7 @@ def clear_reports(instance=None):
         elif inst_id != active_inst_id:
             continue
         if name in _reports_registry:
-            _reports_registry[name].unregister_hooks()
+            _reports_registry[name].unregister_hooks(inst_id)
         else:
             issue_warning(f"No report with the name '{name}' is registered.")
 

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -15,6 +15,7 @@ from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.reports_system import set_reports_dir, _reports_dir, register_report, \
     list_reports, clear_reports, _reset_reports_dir, activate_report, _reports_registry
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.assert_utils import assert_no_warning
 from openmdao.utils.mpi import MPI
 from openmdao.utils.tests.test_hooks import hooks_active
 from openmdao.visualization.n2_viewer.n2_viewer import _default_n2_filename, _run_n2_report
@@ -72,10 +73,11 @@ class TestReportsSystem(unittest.TestCase):
         model.add_design_var('y', lower=0.0, upper=1.0)
         model.add_objective('f_xy')
 
-        if driver:
-            prob.driver = driver
-        else:
-            prob.driver = om.ScipyOptimizeDriver()
+        with assert_no_warning(om.OpenMDAOWarning):
+            if driver:
+                prob.driver = driver
+            else:
+                prob.driver = om.ScipyOptimizeDriver()
 
         prob.setup(check=False)
         prob.run_driver()
@@ -361,7 +363,6 @@ class TestReportsSystem(unittest.TestCase):
         self.assertTrue('User report' in _reports_registry, "'User report' not found in registry.")
         om.unregister_report('User report')
         self.assertFalse('User report' in _reports_registry, "'User report' found in registry.")
-
 
     @hooks_active
     def test_report_generation_various_locations(self):


### PR DESCRIPTION
### Summary

When clearing active reports, as is done when assigning a new driver, the instance argument was not being passed all the way down to where the report hooks were being removed.

### Related Issues

- Resolves #2741

### Backwards incompatibilities

None

### New Dependencies

None
