### PR TITLE
fix bug in COBYLA desvar bounds conditions

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -219,8 +219,8 @@ class ScipyOptimizeDriver(Driver):
             for name, meta in self._designvars.items():
                 lower = meta['lower']
                 upper = meta['upper']
-                if isinstance(lower, np.ndarray) or lower >= -INF_BOUND \
-                        or isinstance(upper, np.ndarray) or upper <= INF_BOUND:
+                if isinstance(lower, np.ndarray) or lower > -INF_BOUND \
+                        or isinstance(upper, np.ndarray) or upper < INF_BOUND:
                     self._cons[name] = meta.copy()
                     self._cons[name]['equals'] = None
                     self._cons[name]['linear'] = True

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -390,7 +390,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver(optimizer='COBYLA', tol=1e-9, disp=False)
 
-        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('x')  # note: no bounds
         model.add_design_var('y', lower=-50.0, upper=50.0)
         model.add_objective('f_xy')
 

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -193,6 +193,17 @@ class TestOptimizationReport(unittest.TestCase):
         opt_report(self.prob)
         self.check_opt_report(expected=expect)
 
+    def test_opt_report_scipyopt_COBYLA_nobounds(self):
+        self.setup_problem_and_run_driver(om.ScipyOptimizeDriver,
+                                          # no bounds on design vars
+                                          cons_lower=0, cons_upper=10.,
+                                          optimizer='COBYLA',
+                                          )
+        expect = {'deriv_calls': None}
+        self.check_opt_result(expected=expect)
+        opt_report(self.prob)
+        self.check_opt_report(expected=expect)
+
     @require_pyoptsparse('SNOPT')
     def test_opt_report_pyoptsparse_snopt(self):
         self.setup_problem_and_run_driver(om.pyOptSparseDriver,


### PR DESCRIPTION
### Summary

Since COBYLA does not support bounds on design variables, we translate any provided bounds into a constraint.  When a design variable does not have bounds, this is represented by upper/lower bounds values of +/- INF_BOUND.  The condition for creating the COBYLA constraint was incorrectly including design variables with bounds of  +/- INF_BOUND.  This has been fixed and tests added/updated.

### Related Issues

- Resolves #2706 

### Backwards incompatibilities

None

### New Dependencies

None
