### PR TITLE
Fix bug in System.get_io_metadata()

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4066,7 +4066,7 @@ class System(object):
                         includes=None, excludes=None, tags=(), get_remote=False, rank=None,
                         return_rel_names=True):
         """
-        Retrieve metdata for a filtered list of variables.
+        Retrieve metadata for a filtered list of variables.
 
         Parameters
         ----------
@@ -4229,7 +4229,7 @@ class System(object):
                         continue
 
                     ret_meta['prom_name'] = prom
-                    ret_meta['discrete'] = abs_name not in all2meta
+                    ret_meta['discrete'] = abs_name not in all2meta[iotype]
 
                     if return_rel_names:
                         result[rel_name] = ret_meta

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -721,6 +721,62 @@ class DiscreteTestCase(unittest.TestCase):
 
         self.assertEqual(prob['x'], 10)
 
+    def test_get_io_metadata_discrete(self):
+        prob = om.Problem()
+        model = prob.model
+
+        indep = model.add_subsystem('indep', om.IndepVarComp())
+        indep.add_discrete_output('x', 11)
+        model.add_subsystem('comp', ModCompEx(3))
+
+        model.connect('indep.x', 'comp.x')
+
+        prob.setup()
+        prob.run_model()
+
+        assert_near_equal(prob.model.get_io_metadata(includes='comp.*'), {
+                          'comp.a': {'copy_shape': None,
+                                     'desc': '',
+                                     'discrete': False,
+                                     'distributed': False,
+                                     'global_shape': (1,),
+                                     'global_size': 1,
+                                     'has_src_indices': False,
+                                     'prom_name': 'comp.a',
+                                     'shape': (1,),
+                                     'shape_by_conn': False,
+                                     'size': 1,
+                                     'tags': set(),
+                                     'units': None},
+                          'comp.b': {'copy_shape': None,
+                                     'desc': '',
+                                     'discrete': False,
+                                     'distributed': False,
+                                     'global_shape': (1,),
+                                     'global_size': 1,
+                                     'lower': None,
+                                     'prom_name': 'comp.b',
+                                     'ref': 1.0,
+                                     'ref0': 0.0,
+                                     'res_ref': 1.0,
+                                     'shape': (1,),
+                                     'shape_by_conn': False,
+                                     'size': 1,
+                                     'tags': set(),
+                                     'units': None,
+                                     'upper': None},
+                          'comp.x': {'desc': '',
+                                     'discrete': True,
+                                     'prom_name': 'comp.x',
+                                     'tags': {'tagx'},
+                                     'type': int},
+                          'comp.y': {'desc': '',
+                                     'discrete': True,
+                                     'prom_name': 'comp.y',
+                                     'tags': {'tagy'},
+                                     'type': int}
+                          })
+
 
 class SolverDiscreteTestCase(unittest.TestCase):
     def _setup_model(self, solver_class):

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -386,6 +386,46 @@ class TestSystem(unittest.TestCase):
         with assert_warning(UserWarning, msg):
             prob.model.list_inputs(units=True, prom_name=True)
 
+    def test_get_io_metadata(self):
+        from openmdao.test_suite.components.sellar_feature import SellarMDA
+
+        prob = Problem()
+        prob.model = SellarMDA()
+
+        prob.setup()
+        prob.set_solver_print(level=0)
+
+        prob.run_model()
+
+        assert_near_equal(prob.model.get_io_metadata(includes='x'), {
+                          'cycle.d1.x': {'copy_shape': None,
+                                         'desc': '',
+                                         'discrete': False,
+                                         'distributed': False,
+                                         'global_shape': (1,),
+                                         'global_size': 1,
+                                         'has_src_indices': False,
+                                         'prom_name': 'x',
+                                         'shape': (1,),
+                                         'shape_by_conn': False,
+                                         'size': 1,
+                                         'tags': set(),
+                                         'units': None},
+                          'obj_cmp.x':  {'copy_shape': None,
+                                         'desc': '',
+                                         'discrete': False,
+                                         'distributed': False,
+                                         'global_shape': (1,),
+                                         'global_size': 1,
+                                         'has_src_indices': False,
+                                         'prom_name': 'x',
+                                         'shape': (1,),
+                                         'shape_by_conn': False,
+                                         'size': 1,
+                                         'tags': set(),
+                                         'units': None}
+                            })
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -497,6 +497,12 @@ def assert_near_equal(actual, desired, tolerance=1e-15):
     if type(actual) != type(desired):
         raise ValueError('actual %s, desired %s have different types' % (actual, desired))
 
+    if isinstance(actual, type) and isinstance(desired, type):
+        if actual != desired:
+            raise ValueError(
+                'actual type %s, and desired type %s are different' % (actual, desired))
+        return 0
+
     # The code below can only handle these data types
     _supported_types = [dict, set, str, bool, np.ndarray, type(None)]
     if type(actual) not in _supported_types:
@@ -544,16 +550,16 @@ def assert_near_equal(actual, desired, tolerance=1e-15):
 
         error = 0.
 
-    elif isinstance(actual, str) and isinstance(desired, str):
-        if actual != desired:
-            raise ValueError(
-                'actual %s, desired %s strings have different values' % (actual, desired))
-        error = 0.0
-
     elif isinstance(actual, bool) and isinstance(desired, bool):
         if actual != desired:
             raise ValueError(
                 'actual %s, desired %s booleans have different values' % (actual, desired))
+        error = 0.0
+
+    elif isinstance(actual, str) and isinstance(desired, str):
+        if actual != desired:
+            raise ValueError(
+                'actual %s, desired %s strings have different values' % (actual, desired))
         error = 0.0
 
     elif actual is None and desired is None:

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -550,16 +550,16 @@ def assert_near_equal(actual, desired, tolerance=1e-15):
 
         error = 0.
 
-    elif isinstance(actual, bool) and isinstance(desired, bool):
-        if actual != desired:
-            raise ValueError(
-                'actual %s, desired %s booleans have different values' % (actual, desired))
-        error = 0.0
-
     elif isinstance(actual, str) and isinstance(desired, str):
         if actual != desired:
             raise ValueError(
                 'actual %s, desired %s strings have different values' % (actual, desired))
+        error = 0.0
+
+    elif isinstance(actual, bool) and isinstance(desired, bool):
+        if actual != desired:
+            raise ValueError(
+                'actual %s, desired %s booleans have different values' % (actual, desired))
         error = 0.0
 
     elif actual is None and desired is None:

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -498,7 +498,7 @@ def assert_near_equal(actual, desired, tolerance=1e-15):
         raise ValueError('actual %s, desired %s have different types' % (actual, desired))
 
     # The code below can only handle these data types
-    _supported_types = [dict, str, bool, np.ndarray, type(None)]
+    _supported_types = [dict, set, str, bool, np.ndarray, type(None)]
     if type(actual) not in _supported_types:
         warnings.warn(
             f"The function, assert_near_equal, does not support the actual value type: '"
@@ -533,6 +533,16 @@ def assert_near_equal(actual, desired, tolerance=1e-15):
             except KeyError as exception:
                 msg = '{}: '.format(key) + str(exception)
                 raise KeyError(msg) from None
+
+    elif isinstance(actual, set) and isinstance(desired, set):
+        if actual.symmetric_difference(desired):
+            actual_extra = actual.difference(desired)
+            desired = desired.difference(actual)
+            raise KeyError("Actual and desired sets differ. "
+                           f"Actual extra values: {actual_extra}, "
+                           f"Desired extra values: {desired_extra}")
+
+        error = 0.
 
     elif isinstance(actual, str) and isinstance(desired, str):
         if actual != desired:


### PR DESCRIPTION
### Summary

Fix bug in System.get_io_metadata() that caused the discrete property to always be reported as True

Also:
- added tests
- added `set` and `type` to the types that can be compared in assert_near_equal.

### Related Issues

- Resolves #2710 

### Backwards incompatibilities

None

### New Dependencies

None
