### PR TITLE
I2727 set_solver_print changes printing even in multi-run scenarios

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1206,8 +1206,7 @@ class Problem(object):
         #  this part of _final_setup still needs to happen so that change takes effect
         #  in subsequent runs
         if self._metadata['setup_status'] >= _SetupStatus.POST_FINAL_SETUP:
-            if self.model._solver_print_cache:
-                self.model._setup_solver_print()
+           self.model._setup_solver_print()
 
         driver._setup_driver(self)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1206,7 +1206,7 @@ class Problem(object):
         #  this part of _final_setup still needs to happen so that change takes effect
         #  in subsequent runs
         if self._metadata['setup_status'] >= _SetupStatus.POST_FINAL_SETUP:
-           self.model._setup_solver_print()
+            self.model._setup_solver_print()
 
         driver._setup_driver(self)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1202,6 +1202,13 @@ class Problem(object):
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
             self.model._final_setup(self.comm)
 
+        # If set_solver_print is called after an initial run, in a multi-run scenario,
+        #  this part of _final_setup still needs to happen so that change takes effect
+        #  in subsequent runs
+        if self._metadata['setup_status'] >= _SetupStatus.POST_FINAL_SETUP:
+            if self.model._solver_print_cache:
+                self.model._setup_solver_print()
+
         driver._setup_driver(self)
 
         info = driver._coloring_info

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -183,6 +183,34 @@ class TestNonlinearSolvers(unittest.TestCase):
         with open(self.filename, 'r') as f:
             self.assertEqual(f.read(), self.expected_data)
 
+    def test_solver_debug_print_multi_run_scenario(self):
+
+        p = om.Problem()
+        model = p.model
+
+        model.add_subsystem('circuit', Circuit())
+
+        p.setup()
+
+        nl = model.circuit.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+        nl.options['iprint'] = 2
+        nl.options['debug_print'] = True
+        nl.options['err_on_non_converge'] = False
+
+        # set some poor initial guesses so that we don't converge
+        p.set_val('circuit.I_in', 0.1, units='A')
+        p.set_val('circuit.Vg', 0.0, units='V')
+        p.set_val('circuit.n1.V', 10.)
+        p.set_val('circuit.n2.V', 1e-3)
+
+        p.run_model()
+        p.set_solver_print(level=-1)
+        output = run_model(p)
+
+        # Should be empty since solver debugging printing was turned off
+        self.assertEqual(output, '')
+
 
 class TestNonlinearSolversIsolated(unittest.TestCase):
     """


### PR DESCRIPTION
### Summary

Currently, if this is executed, 

```prob.setup()
prob.run_model()
prob.set_solver_print(level=-1)
prob.run_model()
```
the call to `set_solver_print` will have no effect on the printing of solver info during the second `run_model`. This PR fixes that.

### Related Issues

- Resolves #2727 

### Backwards incompatibilities

None

### New Dependencies

None
