### PR TITLE
N2: Display connections when in NodeInfo mode

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/Diagram.js
+++ b/openmdao/visualization/n2_viewer/gen/Diagram.js
@@ -506,7 +506,7 @@ class Diagram {
     mouseOverOnDiagonal(e, cell) {
         if (this.matrix.cellExists(cell)) {
             this.matrix.mouseOverOnDiagonal(cell);
-            this.ui.showInfoBox(e, cell.obj, cell.color());
+            this.ui.showInfoBox(e, cell.obj, cell.color(), false);
         }
     }
 
@@ -527,6 +527,7 @@ class Diagram {
     mouseOverOffDiagonal(e, cell) {
         if (this.matrix.cellExists(cell)) {
             this.matrix.mouseOverOffDiagonal(cell);
+            this.ui.showCellInfoBox(e, cell, cell.color(), true);
         }
     }
 

--- a/openmdao/visualization/n2_viewer/gen/InfoProp.js
+++ b/openmdao/visualization/n2_viewer/gen/InfoProp.js
@@ -250,4 +250,43 @@ class InfoPropArray extends InfoPropDefault {
     canShow(node) { return node.propExists(this.key); }
 }
 
+/** Display connections associated with a node */
+class InfoPropConns extends InfoPropDefault {
+    constructor(key, desc) {
+        super(key, desc, false);
+    }
+
+    addRow(tbody, node) {
+        tbody.append('tr').append('th').attr('colspan', '3')
+            .attr('class', 'options-header')
+            .text(this.desc);
+
+            /*
+        // TODO: Add children
+        for (const conn of node.connTargets) {
+            const newRow = tbody.append('tr');
+
+            newRow.append('td')
+                .attr('scope', 'row')
+                .text(node.path);
+
+            newRow.append('td').text(' --> ');
+    
+            newRow.append('td').text(conn);
+        }
+
+        for (const conn of node.connSources) {
+            const newRow = tbody.append('tr');
+    
+            newRow.append('td').text(conn);
+
+            newRow.append('td').text(' --> ');
+
+            newRow.append('td')
+                .attr('scope', 'row')
+                .text(node.path);
+        } */
+    }
+}
+
 InfoPropDefault.floatFormatter = d3.format('g');

--- a/openmdao/visualization/n2_viewer/gen/Matrix.js
+++ b/openmdao/visualization/n2_viewer/gen/Matrix.js
@@ -397,11 +397,11 @@ class Matrix {
 
                 return `translate(${transX},${transY})`;
             })
-            .each(function (d) {
+            .each(function(d) {
                 // "this" refers to the element here, so leave it alone:
                 d.renderer.renderCurrent(this)
-                    .on('mouseover', d.mouseover())
-                    .on('mousemove', d.mousemove())
+                    .on('mouseover', d.getMouseoverFunc())
+                    .on('mousemove', d.getMousemoveFunc())
                     .on('mouseleave', n2MouseFuncs.out)
                     .on('click', (e,d) => n2MouseFuncs.click(d))
             });
@@ -624,7 +624,7 @@ class Matrix {
                             'tgtId': cell.tgtObj.id
                         },
                         'matrixSize': this.diagNodes.length,
-                        'label': offscreenNode.absPathName,
+                        'label': offscreenNode.path,
                         'offscreenId': offscreenNode.id
                     });
                 }

--- a/openmdao/visualization/n2_viewer/gen/MatrixCell.js
+++ b/openmdao/visualization/n2_viewer/gen/MatrixCell.js
@@ -81,16 +81,15 @@ class MatrixCell {
      * Select the mouseover callback depending on whether we're on the diagonal.
      * TODO: Remove these globals
      */
-    mouseover() {
-        return (this.onDiagonal() ? n2MouseFuncs.overOnDiag :
-            n2MouseFuncs.overOffDiag);
+    getMouseoverFunc() {
+        return (this.onDiagonal() ? n2MouseFuncs.overOnDiag : n2MouseFuncs.overOffDiag);
     }
 
     /**
     * Select the mousemove callback depending on whether we're on the diagonal.
     * TODO: Remove these globals
     */
-    mousemove() {
+    getMousemoveFunc() {
         return (this.onDiagonal() ? n2MouseFuncs.moveOnDiag : null);
     }
 

--- a/openmdao/visualization/n2_viewer/gen/ModelData.js
+++ b/openmdao/visualization/n2_viewer/gen/ModelData.js
@@ -39,8 +39,6 @@ class ModelData {
         this.root = this.tree = modelJSON.tree = this._adoptNodes(modelJSON.tree);
         this._setDepth(this.root, 1);
 
-        console.log(this.tree)
-
         for (const conn of this.conns) {
             this.connObjs.push(this._newConnectionObj(conn));
         }

--- a/openmdao/visualization/n2_viewer/gen/NodeConnection.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeConnection.js
@@ -18,6 +18,7 @@ class NodeConnection {
         this.conn = conn;
 
         this.srcObj = nodes[conn.src];
+        this.srcObj.connTargets.add(conn.tgt);
         const srcObjParents = [];
         if (!this.srcObj) {
             console.warn(`Cannot find connection source ${conn.src}.`);
@@ -31,6 +32,7 @@ class NodeConnection {
         }
 
         this.tgtObj = nodes[conn.tgt];
+        this.tgtObj.connSources.add(conn.src);
         const tgtObjParents = [];
         if (!this.tgtObj) {
             console.warn(`Cannot find connection target ${conn.tgt}.`);

--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -246,7 +246,10 @@ class PersistentNodeInfo extends WindowResizable {
     }
 }
 
-
+/**
+ * Display all connections represented by the current off-diagonal cell.
+ * @typedef NodeConnectionInfo
+ */
 class NodeConnectionInfo extends NodeInfo {
     /**
      * Build a list of the properties we care about and set up
@@ -257,6 +260,12 @@ class NodeConnectionInfo extends NodeInfo {
         this.propList = [];
     }
 
+    /**
+     * Gather all connections between the two cells that this one represents.
+     * @param {Array} connList The connections discovered so far.
+     * @param {TreeNode} srcNode The source node to search.
+     * @param {TreeNode} tgtNode The target node to search.
+     */
     _getConnections(connList, srcNode, tgtNode) {
         if (srcNode.hasChildren()) {
             for (const child of srcNode.children) {
@@ -273,7 +282,10 @@ class NodeConnectionInfo extends NodeInfo {
         }
     }
 
-    /** Create a new persistent window by copying our contents */
+    /**
+     * Create a new persistent window by copying our contents. Set the
+     * max initial height of the window at 300px.
+     */
     pin() {
         if (this.tbody.html() == '') return; // Was already pinned so is empty
 
@@ -283,6 +295,12 @@ class NodeConnectionInfo extends NodeInfo {
         return this;
     }
 
+    /**
+     * Load the NodeInfo window with connection information for an off-diagonal cell.
+     * @param {Object} event Reference to the event that triggered the function.
+     * @param {MatrixCell} cell Reference to the cell that was hovered.
+     * @param {String} color The color of the title bar.
+     */
     update(event, cell, color) {
         if (!this.active) return;
         this.clear();
@@ -299,13 +317,13 @@ class NodeConnectionInfo extends NodeInfo {
                 .attr('scope', 'row')
                 .text(conn.src);
 
-            newRow.append('td').html(' &#x2192; ');
+            newRow.append('td').html(' &#x2501;&#x2501;&#x2501;&#x25ba; ');
 
-            newRow.append('td').text(conn.tgt);              
+            newRow.append('td').text(conn.tgt);
         }
 
-        this.sizeToContent()
-            .title('Connections')
+        this.title(`Connections from ${cell.srcObj.path} to ${cell.tgtObj.path}`)
+            .sizeToContent(0, 2, true)
             .moveNearMouse(event)
             .show();
     }

--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -261,6 +261,15 @@ class NodeConnectionInfo extends NodeInfo {
     }
 
     /**
+     * Find the best label for a connected node.
+     * @param {TreeNode} node The node to determine a name for.
+     * @returns The promoted name if it has one, otherwise the absolute path.
+     */
+    nodeName(node) {
+        return node.promotedName? node.promotedName : node.path;
+    }
+
+    /**
      * Gather all connections between the two cells that this one represents.
      * @param {Array} connList The connections discovered so far.
      * @param {TreeNode} srcNode The source node to search.
@@ -273,10 +282,14 @@ class NodeConnectionInfo extends NodeInfo {
             }
         }
         else {
+            if (srcNode.parent === tgtNode.parent) {
+                const newConn = { 'src': this.nodeName(srcNode), 'tgt': this.nodeName(tgtNode) };
+                connList.push(newConn);
+            }
             for (const tgt of srcNode.targetParentSet) {
                 if (tgt.isLeaf() && tgt.hasParent(tgtNode, null, true)) {
-                    const newConn = { 'src': srcNode.path, 'tgt': tgt.path};
-                    connList.push(newConn)
+                    const newConn = { 'src': this.nodeName(srcNode), 'tgt': this.nodeName(tgt) };
+                    connList.push(newConn);
                 }
             }
         }
@@ -318,11 +331,15 @@ class NodeConnectionInfo extends NodeInfo {
                 .text(conn.src);
 
             newRow.append('td').html(' &#x2501;&#x2501;&#x2501;&#x25ba; ');
-
             newRow.append('td').text(conn.tgt);
         }
 
-        this.title(`Connections from ${cell.srcObj.path} to ${cell.tgtObj.path}`)
+        let title = 'Connections';
+        if ( ! (cell.srcObj.isLeaf() || cell.tgtObj.isLeaf()) ) {
+            title += ` from ${this.nodeName(cell.srcObj)} to ${this.nodeName(cell.tgtObj)}`;
+        }
+
+        this.title(title)
             .sizeToContent(0, 2, true)
             .moveNearMouse(event)
             .show();

--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -266,7 +266,9 @@ class NodeConnectionInfo extends NodeInfo {
      * @returns The promoted name if it has one, otherwise the absolute path.
      */
     nodeName(node) {
-        return node.promotedName? node.promotedName : node.path;
+        let name = node.path;
+        if (node.path != node.promotedName) name += `<br><i>(${node.promotedName}</i>)`;
+        return name;
     }
 
     /**
@@ -328,15 +330,15 @@ class NodeConnectionInfo extends NodeInfo {
 
             newRow.append('td')
                 .attr('scope', 'row')
-                .text(conn.src);
+                .html(conn.src);
 
             newRow.append('td').html(' &#x2501;&#x2501;&#x2501;&#x25ba; ');
-            newRow.append('td').text(conn.tgt);
+            newRow.append('td').html(conn.tgt);
         }
 
         let title = 'Connections';
         if ( ! (cell.srcObj.isLeaf() || cell.tgtObj.isLeaf()) ) {
-            title += ` from ${this.nodeName(cell.srcObj)} to ${this.nodeName(cell.tgtObj)}`;
+            title += ` from ${cell.srcObj.path} to ${cell.tgtObj.path}`;
         }
 
         this.title(title)

--- a/openmdao/visualization/n2_viewer/gen/UserInterface.js
+++ b/openmdao/visualization/n2_viewer/gen/UserInterface.js
@@ -69,20 +69,45 @@ class UserInterface {
     }
 
     /**
+     * Create a new node connection info window.
+     * @param {Selection} svgNodeGroup Placeholder for subclasses.
+     */
+    _newConnInfoBox(svgNodeGroup) { 
+        this.nodeInfoBox = new NodeConnectionInfo(this);
+    }
+
+    /**
      * If node info mode is active, create a new node info window, populate, and display it.
      * @param {Event} event The Event object created by the trigger.
      * @param {TreeNode} node The node associated with the HTML object.
      * @param {String} [color = null] The color of the titlebard. Autoselected if null.
+     * @param {Boolean} [isConnection = false] If true, make a connection info window.
      */
-    showInfoBox(event, node, color = null) {
+    showInfoBox(event, node, color = null, isConnection = false) {
         if (this.click.isNodeInfo) {
             const svgNodeGroup = d3.select(event.currentTarget);
             if (!color) color = svgNodeGroup.select('rect').style('fill');
 
-            this._newInfoBox(svgNodeGroup);
+            if (isConnection) {
+                this._newConnInfoBox(svgNodeGroup)
+            }
+            else this._newInfoBox(svgNodeGroup);
+
             this.nodeInfoBox.activate();
             this.click.update(this.nodeInfoBox);
             this.nodeInfoBox.update(event, node, color);
+        }
+    }
+
+    showCellInfoBox(event, cell, color = null) {
+        if (this.click.isNodeInfo) {
+            const svgNodeGroup = d3.select(event.currentTarget);
+            if (!color) color = svgNodeGroup.select('rect').style('fill');
+
+            this._newConnInfoBox(svgNodeGroup);
+            this.nodeInfoBox.activate();
+            this.click.update(this.nodeInfoBox);
+            this.nodeInfoBox.update(event, cell, color);
         }
     }
 

--- a/openmdao/visualization/n2_viewer/gen/Window.js
+++ b/openmdao/visualization/n2_viewer/gen/Window.js
@@ -349,11 +349,13 @@ class Window {
      * MutationObserver.
      * @returns {Window} Reference to this.
      */
-    sizeToContent(extraWidth = 0, extraHeight = 2) {
-        let contentWidth = this.body.node().scrollWidth + extraWidth,
-            contentHeight = this.body.node().scrollHeight,
-            headerHeight = this.header.node().offsetHeight,
-            footerHeight = this.hasFooter() ? this.footer.node().offsetHeight : 0;
+    sizeToContent(extraWidth = 0, extraHeight = 2, considerTitle = false) {
+        const bodyWidth = this.body.node().scrollWidth;
+        const titleWidth = this._title.node().scrollWidth + 60;
+        const contentWidth = ((!considerTitle || bodyWidth > titleWidth)? bodyWidth : titleWidth) + extraWidth;
+        const contentHeight = this.body.node().scrollHeight;
+        const headerHeight = this.header.node().offsetHeight
+        const footerHeight = this.hasFooter() ? this.footer.node().offsetHeight : 0;
 
         const totalHeight = contentHeight + headerHeight + footerHeight + extraHeight;
 

--- a/openmdao/visualization/n2_viewer/src/OmMatrix.js
+++ b/openmdao/visualization/n2_viewer/src/OmMatrix.js
@@ -202,6 +202,7 @@ class OmMatrix extends Matrix {
         if (cell.row > cell.col) {
             const src = this.diagNodes[cell.row],
                 tgt = this.diagNodes[cell.col];
+
             // Get an array of all the parents and children of the target with cycle arrows
             const relativesWithCycleArrows = tgt.getNodesWithCycleArrows();
 

--- a/openmdao/visualization/n2_viewer/style/window.css
+++ b/openmdao/visualization/n2_viewer/style/window.css
@@ -288,7 +288,8 @@
     min-width: 200px;
     border-collapse: separate;
     border-spacing: 0;
-    width: fit-content;
+    /* width: fit-content; */
+    width: 100%;
     height: fit-content;
 }
 
@@ -1104,3 +1105,8 @@ p.help-text > span {
 
 
 /* ^^^^^^^^^^ End Child Select Window theme ^^^^^^^^^^ */
+
+.scrollable {
+    overflow-y: scroll;
+    overflow-x: hidden;
+}

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -573,20 +573,14 @@ n2_gui_test_scripts = {
             "selector": "#p1_A",
         },
         {
-            "desc": "Click p1.A to make Node Info window persistent",
-            "test": "click",
-            "selector": "#p1_A",
-            "button": "left"
-        },
-        {
-            "desc": "Hover to bring up Node Info window for p2.b",
+            "desc": "Hover to bring up Node Info window for lingrp.lin.x",
             "test": "hover",
-            "selector": "#p2_b",
+            "selector": "#lingrp_lin_x",
         },
         {
-            "desc": "Click p2.b to make Node Info window persistent",
+            "desc": "Click lingrp.lin.x to make Node Info window persistent",
             "test": "click",
-            "selector": "#p2_b",
+            "selector": "#lingrp_lin_x",
             "button": "left"
         },
         {
@@ -601,32 +595,16 @@ n2_gui_test_scripts = {
             "button": "left"
         },
         {
-            "desc": "Hover to bring up Node Info window for lingrp.lin.b",
-            "test": "hover",
-            "selector": "#lingrp_lin_b",
-        },
-        {
-            "desc": "Click lingrp.lin.b to make Node Info window persistent",
+            "desc": "Click p1.A to make Node Info window persistent",
             "test": "click",
-            "selector": "#lingrp_lin_b",
+            "selector": "#p1_A",
             "button": "left"
         },
         {
-            "desc": "Hover to bring up Node Info window for lingrp.lin.x",
-            "test": "hover",
-            "selector": "#lingrp_lin_x",
-        },
-        {
-            "desc": "Click lingrp.lin.x to make Node Info window persistent",
-            "test": "click",
-            "selector": "#lingrp_lin_x",
-            "button": "left"
-        },
-        {
-            "desc": "Check for 5 open persistent Node Info windows",
+            "desc": "Check for 3 open persistent Node Info windows",
             "test": "count",
             "selector": "[id^='persistentNodeInfo']",
-            "count": 5
+            "count": 3
         },
         {
             "desc": "Close All Node Info windows",


### PR DESCRIPTION
### Summary

In the N2 diagram with NodeInfo mode active, hovering over an off-diagonal connection square will now list all connections between the children of the two nodes. When just hovering, the list may be long enough to go off screen, but clicking and making the window persistent will reduce the size and add a scrollbar. The list can then be searched with the browser's built-in Find function.

### Related Issues

- Resolves #2725 
- Resolves #2720 

### Backwards incompatibilities

None

### New Dependencies

None
