### PR TITLE
Updated the attribute doc test to error out if an attribute is documented but doesn't exist.

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -98,12 +98,6 @@ class ExecComp(ExplicitComponent):
         List of code objects.
     _exprs_info : list
         List of tuples containing output and inputs for each expression.
-    _has_diag_partials : bool
-        If True, treat all array/array partials as diagonal if both arrays have size > 1.
-        All arrays with size > 1 must have the same flattened size or an exception will be raised.
-    _units : str or None
-        Units to be assigned to all variables in this component.
-        Default is None, which means units are provided for variables individually.
     complex_stepsize : double
         Step size used for complex step which is used for derivatives.
     _manual_decl_partials : bool

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -117,9 +117,6 @@ class InterpND(object):
         Cache of computed gradients with respect to table values.
     _interp : class
         Class specified as interpolation algorithm, used to regenerate if needed.
-    _interp_config : dict
-        Configuration object that stores the number of points required for each interpolation
-        method.
     _interp_options : dict
         Dictionary of cached interpolator-specific options.
     _xi : ndarray

--- a/openmdao/components/interp_util/interp_scipy.py
+++ b/openmdao/components/interp_util/interp_scipy.py
@@ -45,15 +45,10 @@ class InterpScipy(InterpAlgorithm):
     ----------
     _d_dx : ndarray
         Cache of computed gradients with respect to evaluation point.
-    _interp_config : dict
-        Configuration object that stores the number of points required for each interpolation
-        method.
     _ki : list
         Interpolation order to be used in each dimension.
     _supports_d_dvalues : bool
         If True, this algorithm can compute the derivatives with respect to table values.
-    _xi : ndarray
-        Cache of current evaluation point.
     """
 
     def __init__(self, grid, values, interp=None, **kwargs):

--- a/openmdao/components/interp_util/interp_semi.py
+++ b/openmdao/components/interp_util/interp_semi.py
@@ -60,9 +60,6 @@ class InterpNDSemi(object):
         Cache of computed gradients with respect to table values.
     _interp : class
         Class specified as interpolation algorithm, used to regenerate if needed.
-    _interp_config : dict
-        Configuration object that stores the number of points required for each interpolation
-        method.
     _interp_options : dict
         Dictionary of cached interpolator-specific options.
     _xi : ndarray

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -66,8 +66,6 @@ class Component(System):
 
     Attributes
     ----------
-    _approx_schemes : OrderedDict
-        A mapping of approximation types to the associated ApproximationScheme.
     _var_rel2meta : dict
         Dictionary mapping relative names to metadata.
         This is only needed while adding inputs and outputs. During setup, these are used to

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -352,9 +352,6 @@ class System(object):
     _relevant : dict
         Mapping of a VOI to a tuple containing dependent inputs, dependent outputs,
         and dependent systems.
-    _vois : dict
-        Either design vars or responses metadata, depending on the direction of
-        derivatives.
     _mode : str
         Indicates derivative direction for the model, either 'fwd' or 'rev'.
     _scope_cache : dict

--- a/openmdao/recorders/case_recorder.py
+++ b/openmdao/recorders/case_recorder.py
@@ -33,8 +33,6 @@ class CaseRecorder(object):
         System inputs values, post-filtering, to be used by a derived recorder.
     _outputs : dict
         System or Solver output values, post-filtering, to be used by a derived recorder.
-    _resids : dict
-        System or Solver residual values, post-filtering, to be used by a derived recorder.
     _abs_error : float
         Solver abs_error value, to be used by a derived recorder.
     _rel_error : float

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -128,8 +128,6 @@ class Recording(object):
         Current counter of iterations completed.
     recording_requester : weakref to object
         The object that wants to be recorded.
-    stack : list
-        Stack containing names and iteration counts.
     abs : float
         Absolute error.
     rel : float

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -49,8 +49,6 @@ class SqliteCaseReader(BaseCaseReader):
         Metadata about each system in the recorded model, including options and scaling factors.
     _format_version : int
         The version of the format assumed when loading the file.
-    _solver_metadata : dict
-        Metadata for all the solvers in the model, including their type and options
     _filename : str
         The path to the filename containing the recorded data.
     _abs2meta : dict
@@ -66,8 +64,6 @@ class SqliteCaseReader(BaseCaseReader):
         connections or a promoted input name for multiple connections. This is for output display.
     _driver_cases : DriverCases
         Helper object for accessing cases from the driver_iterations table.
-    _deriv_cases : DerivCases
-        Helper object for accessing cases from the driver_derivatives table.
     _system_cases : SystemCases
         Helper object for accessing cases from the system_iterations table.
     _solver_cases : SolverCases

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -62,8 +62,6 @@ class OptionsDictionary(object):
         If True, no options can be set after declaration.
     _all_recordable : bool
         Flag to determine if all options in UserOptions are recordable.
-    _widget : OptionsWidget
-        If running in a Jupyter notebook, a widget for viewing/setting options.
     """
 
     def __init__(self, parent_name=None, read_only=False):

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -42,8 +42,6 @@ else:
         ----------
         _scatter : method
             Method that performs a PETSc scatter.
-        _transfer : method
-            Method that performs either a normal transfer or a multi-transfer.
         """
 
         def __init__(self, in_vec, out_vec, in_inds, out_inds, comm):

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -55,10 +55,6 @@ class Vector(object):
         Specific kind of vector, either 'input', 'output', or 'residual'.
     _system : System
         Pointer to the owning system.
-    _iproc : int
-        Global processor index.
-    _length : int
-        Length of flattened vector.
     _views : dict
         Dictionary mapping absolute variable names to the ndarray views.
     _views_flat : dict


### PR DESCRIPTION
### Summary

Added a function that finds all self.* assignments in the class and uses that set of attributes to determine if a documented attribute exists.  Using that information, instead of just the self.* assignments in the __init__ method, the documented attributes are compared to the full set of attributes and an error is raised if there are documented attributes that don't exist anywhere in the class.   Did *not* add a check for opposite problem (where attribute exists in class outside of __init__ but is not documented), because that would result in a large number of failures in the current code base.

### Related Issues

- Resolves #2776

### Backwards incompatibilities

None

### New Dependencies

None
