### PR TITLE
Release notes for 3.24.0. Not yet complete.

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -13,7 +13,7 @@ NodeInfo mode.
 
 ## New Deprecations
 
-- **POEM 75** implementation: Problems involving systems with distributed inputs will raise a deprecation regarding upcoming changes to their behavior. [#TBD](https://github.com/OpenMDAO/OpenMDAO/pull/TBD)
+- **POEM 75** implementation: Problems involving systems with distributed inputs will raise a deprecation regarding upcoming changes to their behavior. [#2784](https://github.com/OpenMDAO/OpenMDAO/pull/2784)
 
 ## Backwards Incompatible API Changes
 
@@ -26,6 +26,7 @@ NodeInfo mode.
 ## New Features
 
 - N2: Connections displayed during mouseover of a connection node when in NodeInfo mode [#2778](https://github.com/OpenMDAO/OpenMDAO/pull/2778)
+- Added set_val as a method of System. [#2785](https://github.com/OpenMDAO/OpenMDAO/pull/2785)
 
 ## Bug Fixes
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,6 +8,9 @@ Moving forward from 3.25.0 onward, users developing components involving distrib
 [POEM 075](https://github.com/OpenMDAO/POEMs/blob/master/POEM_075.md), as OpenMDAO is changing to this convention
 and the switch will not be backwards compatible.
 
+For the N2 diagram, we've added information about connections between systems when a connection node is highlighted in
+NodeInfo mode.
+
 ## New Deprecations
 
 - **POEM 75** implementation: Problems involving systems with distributed inputs will raise a deprecation regarding upcoming changes to their behavior. [#TBD](https://github.com/OpenMDAO/OpenMDAO/pull/TBD)
@@ -22,7 +25,7 @@ and the switch will not be backwards compatible.
 
 ## New Features
 
-- None
+- N2: Connections displayed during mouseover of a connection node when in NodeInfo mode [#2778](https://github.com/OpenMDAO/OpenMDAO/pull/2778)
 
 ## Bug Fixes
 
@@ -30,6 +33,7 @@ and the switch will not be backwards compatible.
 - Fixed bug in System.get_io_metadata() that caused the `discrete` property to always be shown as `True`. [#2771](https://github.com/OpenMDAO/OpenMDAO/pull/2771)
 - Fixed a bug that prevented `Problem.set_solver_print` from impacting output in multi-run scenarios [#2773](https://github.com/OpenMDAO/OpenMDAO/pull/2773)
 - Fixed a bug in `set_output_solver_options`, `set_design_var_options`, and `set_constraint_options` that prevented them from working when given vector values. [#2782](https://github.com/OpenMDAO/OpenMDAO/pull/2782)
+- Fixed KeyError when total coloring done on model with an unconnected input constraint in a ParallelGroup [#2774](https://github.com/OpenMDAO/OpenMDAO/pull/2774)
 
 ## Miscellaneous
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,4 +1,42 @@
 ***********************************
+# Release Notes for OpenMDAO 3.24.0
+
+January 23, 2023
+
+OpenMDAO 3.24.0 serves as a transitional release that marks a change in the way distributed I/O is handled.
+Moving forward from 3.25.0 onward, users developing components involving distributed inputs should consult 
+[POEM 075](https://github.com/OpenMDAO/POEMs/blob/master/POEM_075.md), as OpenMDAO is changing to this convention
+and the switch will not be backwards compatible.
+
+## New Deprecations
+
+- **POEM 75** implementation: Problems involving systems with distributed inputs will raise a deprecation regarding upcoming changes to their behavior. [#TBD](https://github.com/OpenMDAO/OpenMDAO/pull/TBD)
+
+## Backwards Incompatible API Changes
+
+- None
+
+## Backwards Incompatible Non-API Changes
+
+- None
+
+## New Features
+
+- None
+
+## Bug Fixes
+
+- Fixed a bug in the handling of design variable bounds conditions by COBYLA. [#2770](https://github.com/OpenMDAO/OpenMDAO/pull/2770)
+- Fixed bug in System.get_io_metadata() that caused the `discrete` property to always be shown as `True`. [#2771](https://github.com/OpenMDAO/OpenMDAO/pull/2771)
+- Fixed a bug that prevented `Problem.set_solver_print` from impacting output in multi-run scenarios [#2773](https://github.com/OpenMDAO/OpenMDAO/pull/2773)
+- Fixed a bug in `set_output_solver_options`, `set_design_var_options`, and `set_constraint_options` that prevented them from working when given vector values. [#2782](https://github.com/OpenMDAO/OpenMDAO/pull/2782)
+
+## Miscellaneous
+
+- Fixed a bug in our docstring linting so that now we can detect class attributes that aren't created in __init__. [#2780](https://github.com/OpenMDAO/OpenMDAO/pull/2780)
+
+
+***********************************
 # Release Notes for OpenMDAO 3.23.0
 
 January 10, 2023

--- a/release_notes.md
+++ b/release_notes.md
@@ -34,7 +34,6 @@ NodeInfo mode.
 - Fixed bug in System.get_io_metadata() that caused the `discrete` property to always be shown as `True`. [#2771](https://github.com/OpenMDAO/OpenMDAO/pull/2771)
 - Fixed a bug that prevented `Problem.set_solver_print` from impacting output in multi-run scenarios [#2773](https://github.com/OpenMDAO/OpenMDAO/pull/2773)
 - Fixed a bug in `set_output_solver_options`, `set_design_var_options`, and `set_constraint_options` that prevented them from working when given vector values. [#2782](https://github.com/OpenMDAO/OpenMDAO/pull/2782)
-- Fixed KeyError when total coloring done on model with an unconnected input constraint in a ParallelGroup [#2774](https://github.com/OpenMDAO/OpenMDAO/pull/2774)
 
 ## Miscellaneous
 


### PR DESCRIPTION
### Summary

Adds release notes for 3.24.0.  This is omitting a few nearly-complete PRs that will probably be ready, as well as a needed deprecation warning informing users with distributed systems that OpenMDAO's behavior will be changing with 3.25.0.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
