### PR TITLE
removed broken caching scheme for initial values

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -547,19 +547,13 @@ class Problem(object):
         """
         Set all initial conditions that have been saved in cache after setup.
         """
-        cache = {}
-        for abs_name, tup in self.model._initial_condition_cache.items():
-            value, set_units, pathname, name = tup
+        for value, set_units, pathname, name in self.model._initial_condition_cache.values():
             if pathname:
-                if pathname in cache:
-                    cache[pathname].set_val(name, units=set_units)
+                system = self.model._get_subsystem(pathname)
+                if system is None:
+                    self.model.set_val(pathname + '.' + name, value, units=set_units)
                 else:
-                    system = self.model._get_subsystem(pathname)
-                    if system is None:
-                        self.model.set_val(pathname + '.' + name, value, units=set_units)
-                    else:
-                        cache[pathname] = system
-                        system.set_val(name, value, units=set_units)
+                    system.set_val(name, value, units=set_units)
             else:
                 self.model.set_val(name, value, units=set_units)
 

--- a/openmdao/core/tests/test_getset_vars.py
+++ b/openmdao/core/tests/test_getset_vars.py
@@ -125,7 +125,6 @@ class TestGetSetVariables(unittest.TestCase):
         with self.assertRaises(KeyError) as ctx:
             p['x'] = 5.0
         self.assertEqual(str(ctx.exception), msg.format('x'))
-        p._initial_condition_cache = {}
 
         with self.assertRaises(KeyError) as ctx:
             p['x']
@@ -135,7 +134,6 @@ class TestGetSetVariables(unittest.TestCase):
         with self.assertRaises(KeyError) as ctx:
             p['y'] = 5.0
         self.assertEqual(str(ctx.exception), msg.format('y'))
-        p._initial_condition_cache = {}
 
         with self.assertRaises(KeyError) as ctx:
             p['y']

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -255,7 +255,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaisesRegex(ValueError,
                 "<model> <class Group>: Failed to set value of '.*': could not broadcast input array from shape (.*) into shape (.*)."):
             prob.final_setup()
-        prob._initial_condition_cache = {}
+        prob.model._initial_condition_cache = {}
 
         # check assign scalar to array
         arr_val = new_val*np.ones((10, 1))


### PR DESCRIPTION
### Summary

Some caching I was doing when setting Problem initial values had a bug in it that rob found, so I just removed the caching scheme.  It wasn't really necessary anyway.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
