### PR TITLE
removed broken checking for dynamic overrides of matrix free methods

### DIFF
--- a/openmdao/components/implicit_func_comp.py
+++ b/openmdao/components/implicit_func_comp.py
@@ -82,6 +82,7 @@ class ImplicitFuncComp(ImplicitComponent):
 
         if solve_nonlinear:
             self.solve_nonlinear = self._user_solve_nonlinear
+            self._has_solve_nl = True
         if linearize:
             self.linearize = self._user_linearize
         if solve_linear:

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -541,7 +541,6 @@ class MetaModelUnStructuredComp(ExplicitComponent):
                             j2 = j1 + out_size * sz
                             partials[out_name, in_name][j1:j2] = derivs[:, idx:idx + sz].flat
                             idx += sz
-
             else:
                 if overrides_method('linearize', surrogate, SurrogateModel):
                     sjac = surrogate.linearize(flat_inputs)

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -9,8 +9,6 @@ from openmdao.utils.class_util import overrides_method
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.core.constants import INT_DTYPE, _UNDEFINED
 
-_inst_functs = ['compute_jacvec_product']
-
 
 class ExplicitComponent(Component):
     """
@@ -23,8 +21,6 @@ class ExplicitComponent(Component):
 
     Attributes
     ----------
-    _inst_functs : dict
-        Dictionary of names mapped to bound methods.
     _has_compute_partials : bool
         If True, the instance overrides compute_partials.
     """
@@ -35,7 +31,6 @@ class ExplicitComponent(Component):
         """
         super().__init__(**kwargs)
 
-        self._inst_functs = {name: getattr(self, name, None) for name in _inst_functs}
         self._has_compute_partials = overrides_method('compute_partials', self, ExplicitComponent)
         self.options.undeclare('assembled_jac_type')
 
@@ -73,10 +68,8 @@ class ExplicitComponent(Component):
         """
         new_jacvec_prod = getattr(self, 'compute_jacvec_product', None)
 
-        self.matrix_free = (
-            overrides_method('compute_jacvec_product', self, ExplicitComponent) or
-            (new_jacvec_prod is not None and
-             new_jacvec_prod != self._inst_functs['compute_jacvec_product']))
+        if self.matrix_free is _UNDEFINED:
+            self.matrix_free = overrides_method('compute_jacvec_product', self, ExplicitComponent)
 
         if self.matrix_free:
             self._check_matfree_deprecation()

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -469,6 +469,7 @@ class Group(System):
         for n, lst in self._group_inputs.items():
             self._group_inputs[n] = lst.copy()
 
+        self.matrix_free = False
         for subsys in self._subsystems_myproc:
             subsys._configure()
             subsys._setup_var_data()

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -12,7 +12,6 @@ from openmdao.utils.general_utils import format_as_float_or_array
 from openmdao.utils.units import simplify_unit
 
 
-_inst_functs = ['apply_linear', 'solve_nonlinear']
 _full_slice = slice(None)
 
 
@@ -53,10 +52,11 @@ class ImplicitComponent(Component):
 
     Attributes
     ----------
-    _inst_functs : dict
-        Dictionary of names mapped to bound methods.
     _declared_residuals : dict
         Contains local residual names mapped to metadata.
+    _has_solve_nl : bool
+        If True, this component has a solve_nonlinear method that overrides the ImplicitComponent
+        class method.
     """
 
     def __init__(self, **kwargs):
@@ -65,8 +65,7 @@ class ImplicitComponent(Component):
         """
         self._declared_residuals = {}
         super().__init__(**kwargs)
-
-        self._inst_functs = {name: getattr(self, name, None) for name in _inst_functs}
+        self._has_solve_nl = _UNDEFINED
 
     def _configure(self):
         """
@@ -76,15 +75,11 @@ class ImplicitComponent(Component):
         """
         self._has_guess = overrides_method('guess_nonlinear', self, ImplicitComponent)
 
-        solve_nl = getattr(self, 'solve_nonlinear')
-        self._has_solve_nl = (overrides_method('solve_nonlinear', self, ImplicitComponent) or
-                              solve_nl != self._inst_functs['solve_nonlinear'])
+        if self._has_solve_nl is _UNDEFINED:
+            self._has_solve_nl = overrides_method('solve_nonlinear', self, ImplicitComponent)
 
-        new_apply_linear = getattr(self, 'apply_linear', None)
-
-        self.matrix_free = (overrides_method('apply_linear', self, ImplicitComponent) or
-                            (new_apply_linear is not None and
-                             self._inst_functs['apply_linear'] != new_apply_linear))
+        if self.matrix_free is _UNDEFINED:
+            self.matrix_free = overrides_method('apply_linear', self, ImplicitComponent)
 
         if self.matrix_free:
             self._check_matfree_deprecation()

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -492,7 +492,7 @@ class System(object):
         self._approx_schemes = {}
         self._subjacs_info = {}
         self._approx_subjac_keys = None
-        self.matrix_free = False
+        self.matrix_free = _UNDEFINED
 
         self._owns_approx_jac = False
         self._owns_approx_jac_meta = {}

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -348,7 +348,10 @@ class System(object):
         Driver responses added outside of setup.
     matrix_free : bool
         This is set to True if the component overrides the appropriate function with a user-defined
-        matrix vector product with the Jacobian or any of its subsystems do.
+        matrix vector product with the Jacobian or any of its subsystems do. Note that the framework
+        will not set the matrix_free flag correctly for Component instances having a matrix vector
+        product function that is added dynamically (not declared as part of the class) and in that
+        case the matrix_free flag must be set manually to True.
     _relevant : dict
         Mapping of a VOI to a tuple containing dependent inputs, dependent outputs,
         and dependent systems.

--- a/openmdao/core/tests/test_matrix_free.py
+++ b/openmdao/core/tests/test_matrix_free.py
@@ -1,0 +1,94 @@
+import unittest
+import openmdao.api as om
+
+
+class MatrixFreeTestCase(unittest.TestCase):
+    def test_dyn_matfree_explicit(self):
+        class MyExplComp(om.ExplicitComponent):
+            def __init__(self, dyn, **kwargs):
+                super().__init__(**kwargs)
+                self._dyn = dyn
+
+            def setup(self):
+                self.add_input('length', val=1.)
+                self.add_input('width', val=1.)
+                self.add_output('area', val=1.)
+                if self._dyn:
+                    self.compute_jacvec_product = self._my_compute_jacvec_product
+                    self.matrix_free = True
+
+            def compute(self, inputs, outputs):
+                outputs['area'] = inputs['length'] * inputs['width']
+
+            def _my_compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                if mode == 'fwd':
+                    if 'area' in d_outputs:
+                        if 'length' in d_inputs:
+                            d_outputs['area'] += inputs['width'] * d_inputs['length']
+                        if 'width' in d_inputs:
+                            d_outputs['area'] += inputs['length'] * d_inputs['width']
+                elif mode == 'rev':
+                    if 'area' in d_outputs:
+                        if 'length' in d_inputs:
+                            d_inputs['length'] += inputs['width'] * d_outputs['area']
+                        if 'width' in d_inputs:
+                            d_inputs['width'] += inputs['length'] * d_outputs['area']
+
+        p = om.Problem()
+        comp = p.model.add_subsystem('comp', MyExplComp(dyn=False))
+        comp_dyn = p.model.add_subsystem('comp_dyn', MyExplComp(dyn=True))
+        p.setup()
+
+        p.run_model()
+
+        self.assertEqual(comp.matrix_free, False)
+        self.assertEqual(comp_dyn.matrix_free, True)
+
+
+    def test_dyn_matfree_implicit(self):
+        class MyImplComp(om.ImplicitComponent):
+            def __init__(self, dyn, **kwargs):
+                super().__init__(**kwargs)
+                self._dyn = dyn
+
+            def setup(self):
+                self.add_input('b')
+                self.add_output('a')
+                if self._dyn:
+                    self.apply_linear = self._my_apply_linear
+                    self.matrix_free = True
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['a'] = 6 * outputs['a'] + 1 * inputs['b']
+
+            def _my_apply_linear(self, inputs, outputs,
+                            d_inputs, d_outputs, d_residuals, mode):
+                if mode == 'fwd':
+                    if 'a' in d_residuals:
+                        if 'a' in d_outputs:
+                            d_residuals['a'] += 6 * d_outputs['a']
+                        if 'b' in d_inputs:
+                            d_residuals['a'] += 1 * d_inputs['b']
+                if mode == 'rev':
+                    if 'a' in d_residuals:
+                        if 'a' in d_outputs:
+                            d_outputs['a'] += 6 * d_residuals['a']
+                        if 'b' in d_inputs:
+                            d_inputs['b'] += 1 * d_residuals['a']
+
+            def solve_linear(self, d_outputs, d_residuals, mode):
+                if mode == 'fwd':
+                    d_outputs['a'] = 1./6. * d_residuals['a']
+                elif mode == 'rev':
+                    d_residuals['a'] = 1./6. * d_outputs['a']
+
+        p = om.Problem()
+        comp = p.model.add_subsystem('comp', MyImplComp(dyn=False))
+        comp_dyn = p.model.add_subsystem('comp_dyn', MyImplComp(dyn=True))
+        p.setup()
+
+        p.run_model()
+
+        self.assertEqual(comp.matrix_free, False)
+        self.assertEqual(comp_dyn.matrix_free, True)
+

--- a/openmdao/test_suite/components/cycle_comps.py
+++ b/openmdao/test_suite/components/cycle_comps.py
@@ -105,6 +105,7 @@ class ExplicitCycleComp(ExplicitComponent):
 
         if self.options['jacobian_type'] == 'matvec':
             self.compute_jacvec_product = self.jacvec_product
+            self.matrix_free = True
 
         if self.options['connection_type'] == 'implicit':
             idx = self.options['index']

--- a/openmdao/utils/class_util.py
+++ b/openmdao/utils/class_util.py
@@ -7,6 +7,10 @@ def overrides_method(method_name, obj, base):
     """
     Return True if the named base class method is overridden by obj.
 
+    Note that this only works if the overriding method is declared as part of the class, i.e.,
+    if the overriding method is added to the object instance dynamically, it will not be detected
+    and this function will return False.
+
     Parameters
     ----------
     method_name : str
@@ -20,8 +24,8 @@ def overrides_method(method_name, obj, base):
     Returns
     -------
     bool
-        True if the named base clas is overridden by the given obj, otherwise
-        False.
+        True if the named base class method is overridden by obj's class or some class in its
+        class' mro, otherwise False.
     """
     for klass in obj.__class__.__mro__:
         if method_name in klass.__dict__:


### PR DESCRIPTION
### Summary

Checking for dynamic overrides of matrix free methods was broken in cases where decorators were applied to those methods.  That checking was removed, so now only 'static' checking is done, i.e., if the class overrides the method we will automatically detect it as before, but if the method is added dynamically, it's now the responsibility of the component author to set the `matrix_free` attribute for that component to True manually because the framework will not attempt to detect it.

The same also applies to the `_has_solve_nl` flag in ImplicitComponent which suffered from the same problem as the `matrix_free` flag.

### Related Issues

- Resolves #2735

### Backwards incompatibilities

In certain cases where `compute_jacvec_product`, `apply_linear`, or `solve_nonlinear` methods were added dynamically to a component, it's possible that the framework used to detect them correctly (in the absence of decorators) but now will not.  The fix for this is to set the component's `matrix_free` attribute to True manually.

### New Dependencies

None
