### PR TITLE
Fixed bug to display derivative method in _assemble_derivative_data()

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2590,8 +2590,6 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                     forward = derivative_info['J_fwd']
 
                     fd_desc = f"{fd_opts['method']}:{fd_opts['form']}"
-                    # print(type(fd_opts['method']))
-                    # sys.exit()
 
                     # Magnitudes
                     if directional:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2590,6 +2590,8 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                     forward = derivative_info['J_fwd']
 
                     fd_desc = f"{fd_opts['method']}:{fd_opts['form']}"
+                    # print(type(fd_opts['method']))
+                    # sys.exit()
 
                     # Magnitudes
                     if directional:
@@ -2684,9 +2686,9 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                         fd = 0.
 
                     if directional:
-                        out_buffer.write(f'    Directional FD Derivative (Jfd)\n{fd}\n')
+                        out_buffer.write(f"    Directional {fd_opts['method'].upper()} Derivative (J{fd_opts['method']})\n{fd}\n")
                     else:
-                        out_buffer.write(f'    Raw FD Derivative (Jfd)\n{fd}\n')
+                        out_buffer.write(f"    Raw {fd_opts['method'].upper()} Derivative (J{fd_opts['method']})\n{fd}\n")
 
                     out_buffer.write(' -' * 30 + '\n')
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2686,9 +2686,11 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
                         fd = 0.
 
                     if directional:
-                        out_buffer.write(f"    Directional {fd_opts['method'].upper()} Derivative (J{fd_opts['method']})\n{fd}\n")
+                        out_buffer.write(f"    Directional {fd_opts['method'].upper()}"
+                                         " Derivative (J{fd_opts['method']})\n{fd}\n")
                     else:
-                        out_buffer.write(f"    Raw {fd_opts['method'].upper()} Derivative (J{fd_opts['method']})\n{fd}\n")
+                        out_buffer.write(f"    Raw {fd_opts['method'].upper()}"
+                                         " Derivative (J{fd_opts['method']})\n{fd}\n")
 
                     out_buffer.write(' -' * 30 + '\n')
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -18,6 +18,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.tests.test_hooks import hooks_active
 
 try:
@@ -2109,6 +2110,7 @@ class TestProblem(unittest.TestCase):
             self.fail("'setup raised RuntimeError unexpectedly")
 
 
+@use_tempdirs
 class RelevanceTestCase(unittest.TestCase):
     def _setup_relevance_problem(self):
         p = om.Problem()


### PR DESCRIPTION
### Summary

_assemble_derivative_data() in problem.py would only output 'Directional FD Derivative' or 'Raw FD Derivative', so to make it account for different derivative methods, fd_opts['method'] was used in place of 'FD' in those output strings.

### Related Issues

- Resolves #2749 

### Backwards incompatibilities

None

### New Dependencies

None
