### PR TITLE
Added conditional to check os.environ to determine use of `use_tempdirs`

### DIFF
--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -917,6 +917,23 @@ def env_truthy(env_var):
     return is_truthy(os.environ.get(env_var, ''))
 
 
+def env_none(env_var):
+    """
+    Return True if the given environment variable is None.
+
+    Parameters
+    ----------
+    env_var : str
+        The name of the environment variable.
+
+    Returns
+    -------
+    bool
+        True if the specified environment variable is None.
+    """
+    return os.environ.get(env_var) is None
+
+
 def common_subpath(pathnames):
     """
     Return the common dotted subpath found in all of the given dotted pathnames.

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -77,13 +77,14 @@ def use_tempdirs(cls):
     TestCase
         The decorated TestCase class.
     """
-    if getattr(cls, 'setUp', None):
-        setattr(cls, 'original_setUp', getattr(cls, 'setUp'))
-    setattr(cls, 'setUp', _new_setup)
+    if os.environ.get('USE_TEMPDIRS') in ['true', 'True', None]:
+        if getattr(cls, 'setUp', None):
+            setattr(cls, 'original_setUp', getattr(cls, 'setUp'))
+        setattr(cls, 'setUp', _new_setup)
 
-    if getattr(cls, 'tearDown', None):
-        setattr(cls, 'original_tearDown', getattr(cls, 'tearDown'))
-    setattr(cls, 'tearDown', _new_teardown)
+        if getattr(cls, 'tearDown', None):
+            setattr(cls, 'original_tearDown', getattr(cls, 'tearDown'))
+        setattr(cls, 'tearDown', _new_teardown)
 
     return cls
 

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -4,6 +4,7 @@ import functools
 import builtins
 import os
 from contextlib import contextmanager
+from openmdao.utils.general_utils import env_truthy, env_none
 
 try:
     from parameterized import parameterized
@@ -77,7 +78,7 @@ def use_tempdirs(cls):
     TestCase
         The decorated TestCase class.
     """
-    if os.environ.get('USE_TEMPDIRS') in ['true', 'True', None]:
+    if env_truthy('USE_TEMPDIRS') or env_none('USE_TEMPDIRS'):
         if getattr(cls, 'setUp', None):
             setattr(cls, 'original_setUp', getattr(cls, 'setUp'))
         setattr(cls, 'setUp', _new_setup)


### PR DESCRIPTION
### Summary

Checks if the environment variable USE_TEMPDIRS is set to (T/t)rue or None to use the decorator function. Otherwise, it just returns the function that was passed as an argument.

### Related Issues

- Resolves #2712 

### Backwards incompatibilities

None

### New Dependencies

None
