### PR TITLE
Add GitHub workflow to test with latest/pre-release dependencies

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -3,9 +3,9 @@ name: OpenMDAO Audit
 
 on:
 
-  # Run the workflow daily a 0200 UTC
+  # Run the workflow daily a 0400 UTC
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 3 * * *'
 
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -3,7 +3,7 @@ name: OpenMDAO Audit
 
 on:
 
-  # Run the workflow daily a 0400 UTC
+  # Run the workflow daily a 0300 UTC
   schedule:
     - cron: '0 3 * * *'
 

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -3,7 +3,7 @@ name: OpenMDAO Audit
 
 on:
 
-  # Run the workflow daily a 0300 UTC
+  # Run the workflow daily at 0300 UTC
   schedule:
     - cron: '0 3 * * *'
 

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -1,0 +1,300 @@
+# Run OpenMDAO tests on latest/pre-release versions
+name: OpenMDAO Latest
+
+on:
+
+  # Run the workflow daily a 0400 UTC
+  schedule:
+    - cron: '0 4 * * *'
+
+  # Allow running the workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+
+  tests:
+
+    timeout-minutes: 120
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # test latest versions on ubuntu
+          - NAME: Ubuntu Latest
+            OS: ubuntu-latest
+            PY: 3
+            PETSc: 3
+            SNOPT: 7.7
+
+    runs-on: ${{ matrix.OS }}
+
+    name: ${{ matrix.NAME }}
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Display run details
+        run: |
+          echo "============================================================="
+          echo "Run #${GITHUB_RUN_NUMBER}"
+          echo "Run ID: ${GITHUB_RUN_ID}"
+          echo "Testing: ${GITHUB_REPOSITORY}"
+          echo "Triggered by: ${GITHUB_EVENT_NAME}"
+          echo "Initiated by: ${GITHUB_ACTOR}"
+          echo "============================================================="
+
+      - name: Create SSH key
+        if: (matrix.SNOPT || matrix.BUILD_DOCS)
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_KNOWN_HOSTS: ${{ secrets.SSH_KNOWN_HOSTS }}
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          sudo chmod 600 ~/.ssh/id_rsa
+          echo "$SSH_KNOWN_HOSTS" > ~/.ssh/known_hosts
+
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: ${{ matrix.PY }}
+          conda-version: "*"
+          channels: conda-forge
+          channel-priority: true
+
+      - name: Install OpenMDAO
+        run: |
+          echo "============================================================="
+          echo "Upgrade conda environment to latest"
+          echo "============================================================="
+          conda upgrade -c conda-forge --all
+
+          echo "============================================================="
+          echo "Define useful functions"
+          echo "============================================================="
+          function latest_version() {
+            local REPO_URL=$1/releases/latest
+            local LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} $REPO_URL`
+            local LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,"/tag/"); print a[2]}'`
+            echo $LATEST_VER
+          }
+          function latest_branch() {
+            local LATEST_VER=$(latest_version $1)
+            echo git+$1@$LATEST_VER
+          }
+
+          echo "============================================================="
+          echo "Upgrade to latest pip"
+          echo "============================================================="
+          python -m pip install --upgrade pip
+
+          echo "============================================================="
+          echo "Install latest versions of NumPy/SciPy"
+          echo "============================================================="
+          python -m pip install --pre numpy
+          python -m pip install --pre scipy
+
+          # remember versions so we can check them later
+          NUMPY_VER=`python -c "import numpy; print(numpy.__version__)"`
+          SCIPY_VER=`python -c "import scipy; print(scipy.__version__)"`
+          echo "NUMPY_VER=$NUMPY_VER" >> $GITHUB_ENV
+          echo "SCIPY_VER=$SCIPY_VER" >> $GITHUB_ENV
+
+          echo "============================================================="
+          echo "Install latest versions of 'docs' dependencies"
+          echo "============================================================="
+          python -m pip install --pre matplotlib
+          python -m pip install --pre numpydoc
+          python -m pip install git+https://github.com/executablebooks/jupyter-book
+          python -m pip install --pre sphinx-sitemap
+          python -m pip install --pre ipyparallel
+          python -m pip install --pre nbconvert
+
+          echo "============================================================="
+          echo "Install latest versions of 'doe' dependencies"
+          echo "============================================================="
+          python -m pip install --pre pyDOE2
+
+          echo "============================================================="
+          echo "Install latest versions of 'notebooks' dependencies"
+          echo "============================================================="
+          python -m pip install --pre notebook
+          python -m pip install --pre ipympl
+
+          echo "============================================================="
+          echo "Install latest versions of 'visualization' dependencies"
+          echo "============================================================="
+          python -m pip install --pre bokeh
+          python -m pip install --pre colorama
+
+          echo "============================================================="
+          echo "Install latest versions of 'test' dependencies"
+          echo "============================================================="
+          python -m pip install --pre parameterized
+          python -m pip install --pre numpydoc
+          python -m pip install --pre pycodestyle
+          python -m pip install --pre pydocstyle
+          python -m pip install --pre testflo
+          python -m pip install --pre websockets
+          python -m pip install --pre aiounittest
+          python -m pip install --pre playwright
+          python -m pip install --pre num2words
+
+          echo "============================================================="
+          echo "Install latest versions of other optional packages"
+          echo "============================================================="
+          python -m pip install --pre pyparsing psutil objgraph pyxdsm
+          python -m pip install --pre jax jaxlib
+
+          echo "============================================================="
+          echo "Install latest pyoptsparse"
+          echo "============================================================="
+          python -m pip install git+https://github.com/OpenMDAO/build_pyoptsparse
+          BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
+          if [[ "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
+              echo "  > Secure copying SNOPT 7.7 over SSH"
+              mkdir SNOPT
+              scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT
+              SNOPT="-s SNOPT/src"
+          else
+              echo "SNOPT source is not available"
+          fi
+          build_pyoptsparse $BRANCH $SNOPT
+
+          echo "============================================================="
+          echo "Install OpenMDAO"
+          echo "============================================================="
+          python -m pip install .
+
+      - name: Install PETSc
+        if: matrix.PETSc
+        run: |
+          echo "============================================================="
+          echo "Install latest PETSc"
+          echo "============================================================="
+          conda install mpi4py petsc petsc4py -q -y
+
+          echo "============================================================="
+          echo "Check MPI and PETSc installation"
+          echo "============================================================="
+          export OMPI_MCA_rmaps_base_oversubscribe=1
+          echo "-----------------------"
+          echo "Quick test of mpi4py:"
+          mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
+          echo "-----------------------"
+          echo "Quick test of petsc4py:"
+          mpirun -n 3 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; \
+                                 import petsc4py; petsc4py.init(); \
+                                 x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  \
+                                 print(x.getArray())"
+          echo "-----------------------"
+
+          echo "============================================================="
+          echo "Export MPI-related environment variables"
+          echo "============================================================="
+          echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
+          echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
+          echo "TMPDIR=/tmp" >> $GITHUB_ENV
+
+      - name: Display environment info
+        run: |
+          conda info
+          conda list
+
+          echo "============================================================="
+          echo "Check installed versions of Python, Numpy and Scipy"
+          echo "============================================================="
+          python -c "import platform; assert  platform.python_version().startswith(str(${{ matrix.PY }})), \
+                    f'Python was changed from version ${{ matrix.PY }} to {platform.python_version()}'"
+
+          python -c "import numpy; assert str(numpy.__version__).startswith('$NUMPY_VER'), \
+                    f'NumPy was changed from version $NUMPY_VER to {numpy.__version__}'"
+
+          python -c "import scipy; assert str(scipy.__version__).startswith('$SCIPY_VER'), \
+                    f'SciPy was changed from version $SCIPY_VER to {scipy.__version__}'"
+
+      - name: Run tests
+        id: run_tests
+        continue-on-error: true
+        run: |
+          echo "============================================================="
+          echo "Run tests (from directory other than repo root)"
+          echo "============================================================="
+          cd $HOME
+          RPT_FILE=`pwd`/deprecations.txt
+          echo "RPT_FILE=$RPT_FILE" >> $GITHUB_ENV
+          testflo -n 1 openmdao --timeout=240 --deprecations_report=$RPT_FILE --exclude=test_warnings_filters
+
+      - name: Build docs
+        id: build_docs
+        continue-on-error: true
+        run: |
+          export OPENMDAO_REPORTS=0
+          export PYDEVD_DISABLE_FILE_VALIDATION=1
+
+          cd openmdao/docs
+          if [[ "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
+            echo "============================================================="
+            echo "Building docs with SNOPT examples."
+            echo "============================================================="
+          else
+            echo "============================================================="
+            echo "Disabling SNOPT cells in notebooks."
+            echo "============================================================="
+            python openmdao_book/other/disable_snopt_cells.py
+          fi
+
+          # start ipcluster to run MPI under notebooks
+          ./ipcluster_start.sh
+          sleep 12
+
+          echo "============================================================="
+          echo "Build the docs"
+          echo "============================================================="
+          python build_source_docs.py
+          jupyter-book build -W --keep-going openmdao_book
+          python copy_build_artifacts.py
+
+      - name: Display doc build reports
+        if: failure() && steps.build_docs.outcome == 'failure'
+        run: |
+          for f in /home/runner/work/OpenMDAO/OpenMDAO/openmdao/docs/openmdao_book/_build/html/reports/*; do
+            echo "============================================================="
+            echo $f
+            echo "============================================================="
+            cat $f
+          done
+
+      - name: Deprecations Report
+        id: deprecations_report
+        run: |
+          echo "============================================================="
+          echo "Display deprecations report"
+          echo "============================================================="
+          cat $RPT_FILE
+
+          echo 'summary<<EOF' >> $GITHUB_OUTPUT
+          head -n 6 $RPT_FILE | cut -d':' -f 1 >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+      - name: Slack summary
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+          message: |
+            ```${{ steps.deprecations_report.outputs.summary }}```
+        if: always()
+
+      - name: Slack status
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: ${{ job.status }}
+        if: always()

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -3,7 +3,7 @@ name: OpenMDAO Latest
 
 on:
 
-  # Run the workflow daily a 0400 UTC
+  # Run the workflow daily at 0400 UTC
   schedule:
     - cron: '0 4 * * *'
 

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -24,15 +24,15 @@ jobs:
           # test baseline versions on Ubuntu
           - NAME: Ubuntu Baseline
             OS: ubuntu-latest
-            PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PETSc: 3.16
-            PYOPTSPARSE: 'v2.8.3'
+            PY: '3.11'
+            NUMPY: '1.24'
+            SCIPY: '1.10'
+            PETSc: '3.18'
+            PYOPTSPARSE: 'v2.9.2'
             PAROPT: true
-            SNOPT: 7.7
+            SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.3.24'
+            JAX: '0.4.2'
             BANDIT: true
             TESTS: true
             # set DEBUG to create an interactive debugging session just before testflo is run.
@@ -50,66 +50,51 @@ jobs:
           # test baseline versions on MacOS
           - NAME: MacOS Baseline
             OS: macos-latest
-            PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PETSc: 3.16
-            # PYOPTSPARSE: 'v2.8.3'
+            PY: '3.11'
+            NUMPY: '1.24'
+            SCIPY: '1.10'
+            PETSc: '3.18'
+            # PYOPTSPARSE: 'v2.9.2'
             # PAROPT: true
-            # SNOPT: 7.7
+            # SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.3.24'
-            TESTS: true
-
-          # test latest versions
-          - NAME: Ubuntu Latest
-            OS: ubuntu-latest
-            PY: 3
-            NUMPY: 1
-            SCIPY: 1
-            PETSc: 3
-            PYOPTSPARSE: 'latest'
-            # PAROPT: true
-            SNOPT: 7.7
-            OPTIONAL: '[all]'
-            JAX: '0.3.24'
+            JAX: '0.4.2'
             TESTS: true
 
           # test minimal install
           - NAME: Ubuntu Minimal
             OS: ubuntu-latest
-            PY: 3
-            NUMPY: 1
-            SCIPY: 1
-            # PYOPTSPARSE: 'latest'
+            PY: '3'
+            NUMPY: '1.24'
+            SCIPY: '1.10'
             OPTIONAL: '[test]'
             TESTS: true
 
           # test oldest supported versions
           - NAME: Ubuntu Oldest
             OS: ubuntu-latest
-            PY: 3.7
-            NUMPY: 1.21
-            SCIPY: 1.7
+            PY: '3.7'
+            NUMPY: '1.21'
+            SCIPY: '1.7'
             OPENMPI: '4.0'
             MPI4PY: '3.0'
-            PETSc: 3.13
+            PETSc: '3.13'
             PYOPTSPARSE: 'v1.2'
-            SNOPT: 7.2
+            SNOPT: '7.2'
             OPTIONAL: '[all]'
             TESTS: true
 
           # build docs (baseline versions)
           - NAME: Build Docs
             OS: ubuntu-latest
-            PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PETSc: 3.16
-            PYOPTSPARSE: 'v2.8.3'
-            SNOPT: 7.7
+            PY: '3.11'
+            NUMPY: '1.24'
+            SCIPY: '1.10'
+            PETSc: '3.18'
+            PYOPTSPARSE: 'v2.9.2'
+            SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.3.24'
+            JAX: '0.4.2'
             BUILD_DOCS: true
 
     runs-on: ${{ matrix.OS }}
@@ -247,9 +232,13 @@ jobs:
             python -m pip install git+https://github.com/OpenMDAO/build_pyoptsparse
 
             if [[ "${{ matrix.PYOPTSPARSE }}" == "latest" ]]; then
-              LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} https://github.com/mdolab/pyoptsparse/releases/latest`
-              LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,"/tag/"); print a[2]}'`
-              BRANCH="-b $LATEST_VER"
+              function latest_version() {
+                local REPO_URL=$1/releases/latest
+                local LATEST_URL=`curl -fsSLI -o /dev/null -w %{url_effective} $REPO_URL`
+                local LATEST_VER=`echo $LATEST_URL | awk '{split($0,a,"/tag/"); print a[2]}'`
+                echo $LATEST_VER
+              }
+              BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
             else
               BRANCH="-b ${{ matrix.PYOPTSPARSE }}"
             fi
@@ -281,7 +270,7 @@ jobs:
           echo "============================================================="
           echo "Install additional packages for testing/coverage"
           echo "============================================================="
-          python -m pip install pyparsing psutil objgraph git+https://github.com/mdolab/pyxdsm
+          python -m pip install pyparsing psutil objgraph pyxdsm
 
       - name: Display environment info
         run: |
@@ -291,8 +280,8 @@ jobs:
           echo "============================================================="
           echo "Check installed versions of Python, Numpy and Scipy"
           echo "============================================================="
-          python -c "import sys; assert str(sys.version).startswith(str(${{ matrix.PY }})), \
-                    f'Python version {sys.version} is not the requested version (${{ matrix.PY }})'"
+          python -c "import platform; assert  platform.python_version().startswith(str(${{ matrix.PY }})), \
+                    f'Python version {platform.python_version()} is not the requested version (${{ matrix.PY }})'"
 
           python -c "import numpy; assert str(numpy.__version__).startswith(str(${{ matrix.NUMPY }})), \
                     f'Numpy version {numpy.__version__} is not the requested version (${{ matrix.NUMPY }})'"
@@ -337,6 +326,7 @@ jobs:
         id: build_docs
         run: |
           export OPENMDAO_REPORTS=0
+          export PYDEVD_DISABLE_FILE_VALIDATION=1
 
           cd openmdao/docs
           if [[ "${{ secrets.SNOPT_LOCATION_72 }}" || "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
@@ -530,10 +520,9 @@ jobs:
           coveralls --basedir $SITE_DIR
 
       - name: Notify slack
-        uses: act10ns/slack@v1.6.0
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        uses: act10ns/slack@v2.0.0
         with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}
         if: always()
 

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -3,8 +3,7 @@ import os
 import sys
 import re
 
-import numpy.distutils
-from numpy.distutils.exec_command import find_executable
+from shutil import which
 
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.core.explicitcomponent import ExplicitComponent
@@ -82,13 +81,13 @@ class ExternalCodeDelegate(object):
         else:
             program_to_execute = comp.options['command'][0]
             if sys.platform == 'win32':
-                if not find_executable(program_to_execute):
+                if not which(program_to_execute):
                     missing = self._check_for_files([program_to_execute])
                     if missing:
                         logger.error("The command to be executed, '%s', "
                                      "cannot be found" % program_to_execute)
             else:
-                if not find_executable(program_to_execute):
+                if not which(program_to_execute):
                     logger.error("The command to be executed, '%s', "
                                  "cannot be found" % program_to_execute)
 
@@ -200,11 +199,8 @@ class ExternalCodeDelegate(object):
         else:
             program_to_execute = command[0]
 
-        # Suppress message from find_executable function, we'll handle it
-        numpy.distutils.log.set_verbosity(-1)
-
         if sys.platform == 'win32':
-            if not find_executable(program_to_execute):
+            if not which(program_to_execute):
                 missing = self._check_for_files([program_to_execute])
                 if missing:
                     raise ValueError("The command to be executed, '%s', "
@@ -215,7 +211,7 @@ class ExternalCodeDelegate(object):
                 command_for_shell_proc = 'cmd.exe /c ' + str(command)
 
         else:
-            if not find_executable(program_to_execute):
+            if not which(program_to_execute):
                 raise ValueError("The command to be executed, '%s', "
                                  "cannot be found" % program_to_execute)
             command_for_shell_proc = command

--- a/openmdao/docs/copy_build_artifacts.py
+++ b/openmdao/docs/copy_build_artifacts.py
@@ -20,17 +20,27 @@ def copy_build_artifacts(book_dir='openmdao_book'):
         dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS]
         rel_path = pathlib.PurePath(dirpath).parts[1:]
         target_path = pathlib.PurePath(book_dir, TARGET_DIR, 'html', *rel_path)
+
         files_to_copy = set()
         for pattern in PATTERNS_TO_COPY:
             files_to_copy |= set(fnmatch.filter(files, pattern))
+
         for f in files_to_copy:
             src = pathlib.PurePath(dirpath, f)
             dst = pathlib.PurePath(target_path, f)
             os.makedirs(os.path.dirname(dst), exist_ok=True)
             shutil.copyfile(src, dst)
 
+    # jupyter-book build is not copying 'sphinx-book-theme.css' to the build directory
+    # we need this because our own 'om-theme.css' extends from it
+    import sphinx_book_theme
+    theme_path = pathlib.PurePath(sphinx_book_theme.__file__).parent
+    style_path = pathlib.PurePath(theme_path, 'theme/sphinx_book_theme/static/styles')
+    target_path = pathlib.PurePath(book_dir, TARGET_DIR, 'html/_static')
+    for f in os.listdir(style_path):
+        shutil.copy(pathlib.PurePath(style_path, f), target_path)
+
 
 if __name__ == '__main__':
     copy_build_artifacts('openmdao_book')
-
 

--- a/openmdao/docs/openmdao_book/_config.yml
+++ b/openmdao/docs/openmdao_book/_config.yml
@@ -60,10 +60,9 @@ sphinx:
     html_theme_path: ['.'] # make sphinx search for themes in current dir
 
   extra_extensions:
-  # This line is a workaround for https://github.com/jupyter/nbconvert/issues/528
-  - 'IPython.sphinxext.ipython_console_highlighting'
   - 'sphinx.ext.autodoc'
   - 'sphinx.ext.autosummary'
   - 'sphinx.ext.viewcode'
   - 'sphinx_sitemap'
   - 'numpydoc'
+

--- a/openmdao/docs/openmdao_book/examples/examples.ipynb
+++ b/openmdao/docs/openmdao_book/examples/examples.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "This document is intended to show run files that provide\n",
     "techniques for using certain features in combination, or examples of solving canonical problems in OpenMDAO.\n",
-    "If you need to learn the basics of how things work, please see the :ref:`User Guide <UserGuide>`.\n",
+    "If you need to learn the basics of how things work, please see the [User Guide](../basic_user_guide/basic_user_guide).\n",
     "\n",
     "- [Optimizing a Paraboloid – The TL;DR Version](tldr_paraboloid.ipynb)\n",
     "- [Optimizing a Paraboloid](paraboloid.ipynb)\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/main.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/main.ipynb
@@ -36,7 +36,7 @@
     "There are a number of special cases where a model has a particular structure that can be exploited to\n",
     "reduce the cost of linear solves used to compute total derivatives. You can learn details of how to determine if\n",
     "your problem has the necessary structure to use one of these features, or how to restructure your problem to\n",
-    "make use of them in the :ref:`Theory Manual entry on how OpenMDAO computes total derivatives<total_derivs_theory>`\n",
+    "make use of them in the [Theory Manual entry on how OpenMDAO computes total derivatives](../../../theory_manual/total_derivs_theory)`\n",
     "\n",
     "- [In-Memory Assembly of Jacobians](assembled_jacobian.ipynb)\n",
     "- [Simultaneous Total Derivative Coloring For Separable Problems](simul_derivs.ipynb)\n",

--- a/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/api_translation.ipynb
@@ -40,8 +40,9 @@
     "## Building Component Models\n",
     "### Declare a Component with distributed variables\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "class DistribComp(ExplicitComponent):\n",
     "\n",
     "    def __init__(self, size):\n",
@@ -51,8 +52,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "import openmdao.api as om\n",
     "\n",
     "\n",
@@ -61,8 +62,9 @@
     "\n",
     "    def initialize(self):\n",
     "        self.options['distributed'] = True\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -124,17 +126,20 @@
    "source": [
     "### Declare a variable that is explicitly unitless\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "prob.model.add_subsystem('tgt', om.ExecComp('y = 3 * x', x={'units': 'unitless'}))\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "prob.model.add_subsystem('tgt', om.ExecComp('y = 3 * x', x={'units': None}))\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
+
    ]
   },
   {
@@ -173,17 +178,19 @@
    "source": [
     "### Add a subsystem to a Group\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "indeps = prob.model.add('indeps', om.IndepVarComp())\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "prob.model.add_subsystem('parab', Paraboloid(), promotes_inputs=['x', 'y'])\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -225,19 +232,21 @@
    "source": [
     "### Add a linear or nonlinear solver to a Group\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "self.nl_solver = om.NewtonSolver()\n",
     "self.ln_solver = om.DirectSolver()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "self.nonlinear_solver = om.NewtonSolver()\n",
     "self.linear_solver = om.DirectSolver()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -276,8 +285,9 @@
    "source": [
     "### Declare an option with an explicit type\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "def initialize(self):\n",
     "    \"\"\"\n",
     "    Declare options.\n",
@@ -287,16 +297,17 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "def initialize(self):\n",
     "    \"\"\"\n",
     "    Declare options.\n",
     "    \"\"\"\n",
     "    self.options.declare('vec_size', types=int, default=1,\n",
     "                         desc='The number of points at which the vector magnitude is computed')\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -344,8 +355,9 @@
     "## Component Library\n",
     "### Create an interpolating component using Akima spline with uniform grid\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "import openmdao.api as om\n",
     "\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",
@@ -365,8 +377,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",
     "ncp = len(ycp)\n",
     "n = 11\n",
@@ -383,8 +395,9 @@
     "\n",
     "prob.setup()\n",
     "prob.run_model()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -455,8 +468,9 @@
    "source": [
     "### Create an interpolating component using Akima spline with custom grid\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",
     "ncp = len(xcp)\n",
@@ -481,8 +495,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])\n",
     "ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])\n",
     "n = 50\n",
@@ -500,8 +514,9 @@
     "\n",
     "prob.setup(force_alloc_complex=True)\n",
     "prob.run_model()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -577,8 +592,9 @@
    "source": [
     "### Create an interpolating component using Bsplines\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "prob = om.Problem()\n",
     "model = prob.model\n",
     "\n",
@@ -605,8 +621,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "from openmdao.utils.spline_distributions import sine_distribution\n",
     "\n",
     "prob = om.Problem()\n",
@@ -636,8 +652,9 @@
     "\n",
     "prob.setup()\n",
     "prob.run_model()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -726,21 +743,23 @@
    "source": [
     "### Create an ExecComp with diagonal partials\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.add_subsystem('comp', ExecComp('y=3.0*x + 2.5',\n",
     "                                     vectorize=True,\n",
     "                                     x=np.ones(5), y=np.ones(5)))\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.add_subsystem('comp', om.ExecComp('y=3.0*x + 2.5',\n",
     "                                        has_diag_partials=True,\n",
     "                                        x=np.ones(5), y=np.ones(5)))\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -787,8 +806,9 @@
    "source": [
     "### Create an IndepVarComp with multiple outputs\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "comp = om.IndepVarComp((\n",
     "    ('indep_var_1', 1.0, {'lower': 0, 'upper': 10}),\n",
     "    ('indep_var_2', 2.0, {'lower': 1., 'upper': 20}),\n",
@@ -796,13 +816,14 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "comp = om.IndepVarComp()\n",
     "comp.add_output('indep_var_1', val=1.0)\n",
     "comp.add_output('indep_var_2', val=2.0)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -844,17 +865,19 @@
    "source": [
     "### Create an ExternalCodeComp\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "class ParaboloidExternalCodeCompDerivs(om.ExternalCode):\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "class ParaboloidExternalCodeCompDerivs(om.ExternalCodeComp):\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -893,17 +916,19 @@
    "source": [
     "### Create a KSComponent\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.add_subsystem('ks', om.KSComponent(width=2))\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.add_subsystem('ks', om.KSComp(width=2))\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -942,17 +967,19 @@
    "source": [
     "### Create a MetaModel\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "sin_mm = om.MetaModel()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "sin_mm = om.MetaModelUnStructuredComp()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -989,17 +1016,19 @@
    "source": [
     "### Create a MetaModelUnstructured\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "sin_mm = om.MetaModelUnstructured()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "sin_mm = om.MetaModelUnStructuredComp()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1036,17 +1065,19 @@
    "source": [
     "### Create a MetaModelStructured\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "interp = om.MetaModelStructured(method='scipy_cubic', vec_size=2)\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "interp = om.MetaModelStructuredComp(method='scipy_cubic', vec_size=2)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1083,17 +1114,19 @@
    "source": [
     "### Create a MultiFiMetaModel\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "mm = om.MultiFiMetaModel(nfi=2)\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "mm = om.MultiFiMetaModelUnStructuredComp(nfi=2)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1130,17 +1163,19 @@
    "source": [
     "### Create a MultiFiMetaModelUnStructured\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "mm = om.MultiFiMetaModelUnStructured(nfi=2)\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "mm = om.MultiFiMetaModelUnStructuredComp(nfi=2)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1177,17 +1212,19 @@
    "source": [
     "### Add a FloatKrigingSurrogate to a MetaModelStructuredComp\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "sin_mm.add_output('f_x', 0., surrogate=om.FloatKrigingSurrogate())\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "sin_mm.add_output('f_x', 0., surrogate=om.KrigingSurrogate())\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1224,18 +1261,20 @@
    "source": [
     "### Specify a default surrogate model for MetaModelStructuredComp\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "trig = om.MetaModelUnStructuredComp(vec_size=size)\n",
     "trig.default_surrogate = om.KrigingSurrogate()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "trig = om.MetaModelUnStructuredComp(vec_size=size, default_surrogate=om.KrigingSurrogate())\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1274,17 +1313,19 @@
     "## Solvers\n",
     "### Declare a NewtonSolver with solve_subsystems set to False\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "newton = model.nonlinear_solver = om.NewtonSolver()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "newton = model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1321,21 +1362,23 @@
    "source": [
     "### Control how a solver handles an error raised in a subsolver\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "newton = model.nonlinear_solver = NewtonSolver()\n",
     "newton.options['maxiter'] = 1\n",
     "newton.options['err_on_maxiter'] = True\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "newton = model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
     "newton.options['maxiter'] = 1\n",
     "newton.options['err_on_non_converge'] = True\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1376,18 +1419,20 @@
    "source": [
     "### Declare a BroydenSolver with the BoundsEnforceLS line search\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.circuit.nonlinear_solver = om.BroydenSolver()\n",
     "model.circuit.nonlinear_solver.linesearch = om.BoundsEnforceLS()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.nonlinear_solver = om.BroydenSolver()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1427,18 +1472,20 @@
    "source": [
     "### Declare a NewtonSolver with the BoundsEnforceLS line search\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "newton = model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
     "newton.linesearch = om.BoundsEnforceLS()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1478,19 +1525,21 @@
    "source": [
     "### Add a preconditioner to PETScKrylov\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.linear_solver = om.PETScKrylov()\n",
     "model.linear_solver.preconditioner = om.LinearBlockGS()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.linear_solver = om.PETScKrylov()\n",
     "model.linear_solver.precon = om.LinearBlockGS()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1540,17 +1589,19 @@
    "source": [
     "### Add a preconditioner to ScipyKrylov\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.linear_solver.preconditioner = om.LinearBlockGS()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.linear_solver.precon = om.LinearBlockGS()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1591,8 +1642,9 @@
    "source": [
     "### Add a ArmijoGoldsteinLS to a NewtonSolver\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "top.model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
     "top.model.nonlinear_solver.options['maxiter'] = 10\n",
     "top.model.linear_solver = om.ScipyKrylov()\n",
@@ -1601,15 +1653,16 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "top.model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)\n",
     "top.model.nonlinear_solver.options['maxiter'] = 10\n",
     "top.model.linear_solver = om.ScipyKrylov()\n",
     "\n",
     "ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1658,17 +1711,19 @@
    "source": [
     "### Create a NonLinearRunOnce\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.nonlinear_solver = om.NonLinearRunOnce()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.nonlinear_solver = om.NonlinearRunOnce()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1707,17 +1762,19 @@
    "source": [
     "### Create a PetscKSP\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.linear_solver = om.PetscKSP()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.linear_solver = om.PETScKrylov()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1760,17 +1817,19 @@
    "source": [
     "### Create a ScipyIterativeSolver\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "model.linear_solver = om.ScipyIterativeSolver()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "model.linear_solver = om.ScipyKrylov()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1810,17 +1869,19 @@
     "## Drivers\n",
     "### Activate dynamic coloring on a Driver\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "p.driver.options['dynamic_simul_derivs'] = True\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "p.driver.declare_coloring()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1859,17 +1920,19 @@
    "source": [
     "### Add a ScipyOptimizer to a Problem\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "prob.driver = om.ScipyOptimizer()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "prob.driver = om.ScipyOptimizeDriver()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1909,17 +1972,19 @@
     "## Working with Derivatives\n",
     "### Use a pre-computed coloring on a model\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "p.driver.set_simul_deriv_color()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "p.driver.use_fixed_coloring()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -1961,8 +2026,9 @@
     "## Case Reading\n",
     "### Query the iteration coordinate for a case\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "cr = om.CaseReader(self.filename)\n",
     "\n",
     "for i, c in enumerate(cr.list_cases()):\n",
@@ -1972,16 +2038,17 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "cr = om.CaseReader(filename)\n",
     "\n",
     "for i, c in enumerate(cr.list_cases(out_stream=None)):\n",
     "    case = cr.get_case(c)\n",
     "\n",
     "    coord = case.name\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -2079,17 +2146,19 @@
     "## Running a Model\n",
     "### Run a Driver\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "prob.run()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "prob.run_driver()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -2129,17 +2198,19 @@
    "source": [
     "### Run a Model without Running the Driver\n",
     "\n",
-    "````{tabbed} OpenMDAO 2.x\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} OpenMDAO 2.x\n",
+    "```\n",
     "prob.run_once()\n",
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} OpenMDAO 3.0\n",
-    "````python\n",
+    "````{tab-item} OpenMDAO 3.0\n",
+    "```\n",
     "prob.run_model()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
@@ -38,9 +38,10 @@
    "source": [
     "## Declaring Design Variables\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
     "This is what we used to do\n",
-    "```python\n",
+    "```\n",
     "import openmdao.api as om\n",
     "\n",
     "prob = om.Problem()\n",
@@ -66,10 +67,9 @@
     "prob.run_driver()\n",
     "```\n",
     "````\n",
-    "\n",
-    "`````{tabbed} With Auto IVC\n",
+    "````{tab-item} With Auto IVC\n",
     "This is how we handle IVCs now\n",
-    "````python\n",
+    "```\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",
@@ -90,8 +90,9 @@
     "prob['y'] = -4.0\n",
     "\n",
     "prob.run_driver()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -173,8 +174,9 @@
    "source": [
     "## Declaring a Multi-Component Input as a Design Variable\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
+    "```\n",
     "import openmdao.api as om\n",
     "\n",
     "prob = om.Problem()\n",
@@ -207,8 +209,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} With Auto IVC\n",
-    "````python\n",
+    "````{tab-item} With Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "prob.model.add_subsystem('parab', Paraboloid(),\n",
     "                         promotes_inputs=['x', 'y'])\n",
@@ -235,8 +237,9 @@
     "\n",
     "prob.setup()\n",
     "prob.run_driver()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -329,8 +332,9 @@
    "source": [
     "## Declaring a New Name for a Promoted Input\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
@@ -347,8 +351,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} With Auto IVC\n",
-    "````python\n",
+    "````{tab-item} With Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",
@@ -360,8 +364,9 @@
     "prob.model.set_input_defaults('length', -4.0)\n",
     "\n",
     "prob.setup()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -424,8 +429,9 @@
    "source": [
     "## Declare an Input Defined with Source Indices as a Design Variable\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
+    "```\n",
     "class MyComp1(om.ExplicitComponent):\n",
     "    def setup(self):\n",
     "        # this input will connect to entries 0, 1, and 2 of its source\n",
@@ -457,8 +463,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} With Auto IVC\n",
-    "````python\n",
+    "````{tab-item} With Auto IVC\n",
+    "```\n",
     "class MyComp1(om.ExplicitComponent):\n",
     "    def setup(self):\n",
     "        # this input will connect to entries 0, 1, and 2 of its source\n",
@@ -488,8 +494,9 @@
     "p.model.add_design_var('x')\n",
     "p.setup()\n",
     "p.run_model()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -588,8 +595,9 @@
    "source": [
     "## Setting Default Units for an Input\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "\n",
     "ivc = om.IndepVarComp()\n",
@@ -613,8 +621,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} With Auto IVC\n",
-    "````python\n",
+    "````{tab-item} With Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "\n",
     "# Input units in degF\n",
@@ -632,8 +640,9 @@
     "prob.model.set_input_defaults('x2', 100.0, units='degC')\n",
     "\n",
     "prob.setup()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
@@ -710,8 +719,9 @@
    "source": [
     "## Creating a Distributed Component with Unconnected Inputs\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
+    "```\n",
     "size = 4\n",
     "\n",
     "prob = om.Problem()\n",
@@ -731,8 +741,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} With Auto IVC\n",
-    "````python\n",
+    "````{tab-item} With Auto IVC\n",
+    "```\n",
     "size = 4\n",
     "\n",
     "prob = om.Problem()\n",
@@ -751,14 +761,20 @@
     "prob.set_val('P.invec', np.array([1.0, 3.0, 5.0, 7.0]))\n",
     "\n",
     "prob.run_model()\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
    "outputs": [],
    "source": [
     "%%px\n",
@@ -837,8 +853,9 @@
     "## Setting and Getting Inputs\n",
     "\n",
     "\n",
-    "````{tabbed} Pre Auto IVC\n",
-    "```python\n",
+    "`````{tab-set}\n",
+    "````{tab-item} Pre Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "indeps = prob.model.add_subsystem('indeps', om.IndepVarComp())\n",
     "indeps.add_output('x', 3.0)\n",
@@ -857,8 +874,8 @@
     "```\n",
     "````\n",
     "\n",
-    "`````{tabbed} With Auto IVC\n",
-    "````python\n",
+    "````{tab-item} With Auto IVC\n",
+    "```\n",
     "prob = om.Problem()\n",
     "\n",
     "prob.model.add_subsystem('paraboloid',\n",
@@ -869,8 +886,9 @@
     "\n",
     "x = prob.get_val('x')\n",
     "prob.set_val('y', 15.0)\n",
+    "```\n",
     "````\n",
-    "`````"
+    "`````\n"
    ]
   },
   {

--- a/openmdao/utils/tests/test_om_warnings.py
+++ b/openmdao/utils/tests/test_om_warnings.py
@@ -6,6 +6,13 @@ from contextlib import redirect_stderr
 
 class TestOMWarnings(unittest.TestCase):
 
+    def setUp(self):
+        """
+        Ensure that OpenMDAO warnings are using their default filter action.
+        """
+        import openmdao.api as om
+        om.reset_warnings()
+
     def test_warnings_filters(self):
         # OMDeprecationWarning should only generate one warning
         # because it has the 'once' filter

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,7 @@ optional_dependencies = {
     'docs': [
         'matplotlib',
         'numpydoc>=1.1',
-        'jupyter-core>=4.11.2',
-        'jupyter-book>=0.8.0,<0.13',
-        'jupyter-client>=7.4.0',
-        'jupyter',
-        'jupyter-sphinx',
+        'jupyter-book',
         'sphinx-sitemap',
         'ipyparallel',
         'nbconvert>=6.3'
@@ -32,10 +28,7 @@ optional_dependencies = {
     ],
     'notebooks': [
         'notebook',
-        'ipython',
-        'ipywidgets>=7.6.5',
-        'ipympl',
-        'myst_nb'
+        'ipympl'
     ],
     'visualization': [
         'bokeh>=1.3.4',


### PR DESCRIPTION
### Summary

Add a GitHub workflow that tests against latest/pre-release versions of dependencies.  This new workflow is scheduled to run daily.

Also:
- uses a new feature of `testflo` to generate a deprecations report in the Latest workflow
- updated `ExternalCodeComp` to resolve `distutils` deprecation
- cleaned up the dependencies in `setup.py` to remove pins to outdated versions of `jupyter-book` and related packages
- updated api translation docs to use current method of creating tabbed panes
- fixed some broken links in the docs
- updated baseline versions in test workflow to use Python 3.11
- rescheduled the audit workflow to run an hour later

### Related Issues

- Resolves #2772 

### Backwards incompatibilities

None

### New Dependencies

None
