### PR TITLE
prevented copy/deepcopy from making a copy of _ReprClass objects

### DIFF
--- a/openmdao/core/constants.py
+++ b/openmdao/core/constants.py
@@ -89,6 +89,38 @@ class _ReprClass(object):
     def __hash__(self):
         return hash(self._repr_string)
 
+    def __copy__(self):
+        """
+        Return self instead of a copy.
+
+        This ensures that 'is' and 'is not' comparisons to copies of this object don't break.
+
+        Returns
+        -------
+        _ReprClass instance
+            Return self instead of a copy.
+        """
+        return self
+
+    def __deepcopy__(self, memo):
+        """
+        Return self instead of a copy.
+
+        This ensures that 'is' and 'is not' comparisons to deep copies of this object don't break.
+
+        Parameters
+        ----------
+        memo : dict
+            Keeps track of already copied objects.
+
+        Returns
+        -------
+        _ReprClass instance
+            Return self instead of a copy.
+        """
+        memo[id(self)] = self
+        return self
+
 
 # unique object to check if default is given (when None is an allowed value)
 _UNDEFINED = _ReprClass("UNDEFINED")

--- a/openmdao/core/tests/test_constants.py
+++ b/openmdao/core/tests/test_constants.py
@@ -1,0 +1,19 @@
+import unittest
+import copy
+from openmdao.core.constants import _UNDEFINED
+
+
+class Foo(object):
+    def __init__(self):
+        self.bar = _UNDEFINED
+
+
+class ConstantsTestCase(unittest.TestCase):
+    def test_repr_copy(self):
+        cp = copy.copy(_UNDEFINED)
+        self.assertTrue(cp is _UNDEFINED, "Constants don't match!")
+
+    def test_repr_deepcopy(self):
+        f = Foo()
+        cpf = copy.deepcopy(f)
+        self.assertTrue(cpf.bar is _UNDEFINED, "Constants don't match!")


### PR DESCRIPTION
### Summary

We treat _ReprClass objects as global constants and do 'is' and 'is not' comparisons to them throughout the codebase, but these comparisons break if the _ReprClass objects are copied, so this PR makes copy/deepcopy return the original object so a copy is never made.

### Related Issues

- Resolves #2809

### Backwards incompatibilities

None

### New Dependencies

None
