### PR TITLE
Change DOEDriver to record unscaled derivatives

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -941,7 +941,7 @@ class Driver(object):
         return self._problem()._metadata['recording_iter']
 
     def _compute_totals(self, of=None, wrt=None, return_format='flat_dict',
-                        use_abs_names=True):
+                        use_abs_names=True, driver_scaling=True):
         """
         Compute derivatives of desired quantities with respect to desired inputs.
 
@@ -961,6 +961,9 @@ class Driver(object):
             the scipy optimizer, 'array' is also supported.
         use_abs_names : bool
             Set to True when passing in absolute names to skip some translation steps.
+        driver_scaling : bool
+            If True (default), scale derivative values by the quantities specified when the desvars
+            and responses were added. If False, leave them unscaled.
 
         Returns
         -------
@@ -983,7 +986,8 @@ class Driver(object):
             try:
                 if total_jac is None:
                     total_jac = _TotalJacInfo(problem, of, wrt, use_abs_names,
-                                              return_format, approx=True, debug_print=debug_print)
+                                              return_format, approx=True, debug_print=debug_print,
+                                              driver_scaling=driver_scaling)
 
                     if total_jac.has_lin_cons:
                         # if we're doing a scaling report, cache the linear total jacobian so we
@@ -1002,7 +1006,7 @@ class Driver(object):
         else:
             if total_jac is None:
                 total_jac = _TotalJacInfo(problem, of, wrt, use_abs_names, return_format,
-                                          debug_print=debug_print)
+                                          debug_print=debug_print, driver_scaling=driver_scaling)
 
                 if total_jac.has_lin_cons:
                     # if we're doing a scaling report, cache the linear total jacobian so we

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -236,7 +236,8 @@ class DOEDriver(Driver):
         if opts['record_derivatives']:
             self._compute_totals(of=self._quantities,
                                  wrt=self._indep_list,
-                                 return_format=self._total_jac_format)
+                                 return_format=self._total_jac_format,
+                                 driver_scaling=False)
 
     def _parallel_generator(self, design_vars, model=None):
         """

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1500,6 +1500,42 @@ class TestDOEDriver(unittest.TestCase):
             for dv in ('x', 'y'):
                 self.assertEqual(derivs['f_xy', dv], expected_deriv['f_xy', dv])
 
+    def test_derivative_scaled_recording(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+        model.set_input_defaults('x', 0.0)
+        model.set_input_defaults('y', 0.0)
+        model.add_design_var('x', lower=0.0, upper=1.0, ref=5.0)
+        model.add_design_var('y', lower=0.0, upper=1.0, ref=10.0)
+        model.add_objective('f_xy')
+
+        prob.driver = om.DOEDriver(generator=om.FullFactorialGenerator(levels=3))
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+        prob.driver.recording_options['record_derivatives'] = True
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        expected_vals = self.expected_fullfact3
+        expected_derivs = self.expected_fullfact3_derivs
+
+        cr = om.CaseReader("cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 9)
+
+        for case, expected_val, expected_deriv in zip(cases, expected_vals, expected_derivs):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y', 'f_xy'):
+                self.assertEqual(outputs[name], expected_val[name])
+
+            derivs = cr.get_case(case).derivatives
+            for dv in ('x', 'y'):
+                self.assertEqual(derivs['f_xy', dv], expected_deriv['f_xy', dv])
+
     def test_derivative_no_recording(self):
         prob = om.Problem()
         model = prob.model

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1500,6 +1500,7 @@ class TestDOEDriver(unittest.TestCase):
             for dv in ('x', 'y'):
                 self.assertEqual(derivs['f_xy', dv], expected_deriv['f_xy', dv])
 
+    @unittest.skipUnless(pyDOE2, "requires 'pyDOE2', install openmdao[doe]")
     def test_derivative_scaled_recording(self):
         prob = om.Problem()
         model = prob.model
@@ -1509,7 +1510,7 @@ class TestDOEDriver(unittest.TestCase):
         model.set_input_defaults('y', 0.0)
         model.add_design_var('x', lower=0.0, upper=1.0, ref=5.0)
         model.add_design_var('y', lower=0.0, upper=1.0, ref=10.0)
-        model.add_objective('f_xy')
+        model.add_objective('f_xy', ref=2.0)
 
         prob.driver = om.DOEDriver(generator=om.FullFactorialGenerator(levels=3))
         prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))


### PR DESCRIPTION
### Summary

This PR changes the behavior of the DOEDriver when recording derivatives. As is, the DOEDriver records derivatives with driver scaling applied to them. When plotting the derivatives against the recorded function values, it appears as if the derivative values are incorrect since the function values are not scaled. This changes the behavior to record unscaled derivatives so that it is consistent with the unscaled function outputs. I've added a test that ensures that the recorded derivatives are the same regardless of driver scaling.

### Related Issues

None

### Backwards incompatibilities

Changes DOEDriver to record unscaled derivatives instead of scaled derivatives.

### New Dependencies

None
