### PR TITLE
POEM 78: Add is_indep_var and is_design_var filters to list_inputs/list_outputs

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4088,10 +4088,6 @@ class System(object):
             which includes all variables.
         excludes : str, iter of str or None
             Collection of glob patterns for pathnames of variables to exclude. Default is None.
-        tags : str or iter of strs
-            User defined tags that can be used to filter what gets listed. Only inputs with the
-            given tags will be listed.
-            Default is None, which means there will be no filtering based on tags.
         is_indep_var : bool or None
             If None (the default), do no additional filtering of the inputs.
             If True, list only inputs connected to an output tagged `openmdao:indep_var`.
@@ -4100,6 +4096,10 @@ class System(object):
             If None (the default), do no additional filtering of the inputs.
             If True, list only inputs connected to outputs that are driver design variables.
             If False, list only inputs _not_ connected to outputs that are driver design variables.
+        tags : str or iter of strs
+            User defined tags that can be used to filter what gets listed. Only inputs with the
+            given tags will be listed.
+            Default is None, which means there will be no filtering based on tags.
         get_remote : bool
             If True, retrieve variables from other MPI processes as well.
         rank : int or None

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4244,17 +4244,18 @@ class System(object):
 
                     if is_indep_var is not None:
                         if iotype == 'output':
-                            src_meta = ret_meta
+                            src_meta = meta
                         else:
                             src_name = self.get_source(abs_name)
                             try:
-                                src_meta = metadict['output'][src_name]  # TODO: test continuous
+                                src_meta = metadict['output'][src_name]
                             except KeyError:
                                 src_meta = disc_metadict['output'][src_name]  # TODO: test discrete
 
-                        if is_indep_var is True and 'openmdao:indep_var' not in src_meta['tags']:
+                        src_tags = src_meta['tags'] if 'tags' in src_meta else {}
+                        if is_indep_var is True and 'openmdao:indep_var' not in src_tags:
                             continue
-                        elif is_indep_var is False and 'openmdao:indep_var' in src_meta['tags']:
+                        elif is_indep_var is False and 'openmdao:indep_var' in src_tags:
                             continue
 
                     ret_meta['prom_name'] = prom
@@ -4430,6 +4431,8 @@ class System(object):
                      tags=None,
                      includes=None,
                      excludes=None,
+                     is_indep_var=None,
+                     is_design_var=None,
                      all_procs=False,
                      list_autoivcs=False,
                      out_stream=_DEFAULT_OUT_STREAM,
@@ -4485,6 +4488,14 @@ class System(object):
             which includes all output variables.
         excludes : None, str, or iter of str
             Collection of glob patterns for pathnames of variables to exclude. Default is None.
+        is_indep_var : bool or None
+            If None (the default), do no additional filtering of the inputs.
+            If True, list only outputs tagged `openmdao:indep_var`.
+            If False, list only outputs that are _not_ tagged `openmdao:indep_var`.
+        is_design_var : bool or None
+            If None (the default), do no additional filtering of the inputs.
+            If True, list only inputs connected to outputs that are driver design variables.
+            If False, list only inputs _not_ connected to outputs that are driver design variables.
         all_procs : bool, optional
             When True, display output on all processors. Default is False.
         list_autoivcs : bool
@@ -4522,7 +4533,8 @@ class System(object):
         if scaling:
             keys.extend(('ref', 'ref0', 'res_ref'))
 
-        outputs = self.get_io_metadata(('output',), keys, includes, excludes, tags,
+        outputs = self.get_io_metadata(('output',), keys, includes, excludes,
+                                       is_indep_var, is_design_var, tags,
                                        get_remote=True,
                                        rank=None if all_procs or val or residuals else 0,
                                        return_rel_names=False)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4248,7 +4248,7 @@ class System(object):
                             try:
                                 out_meta = metadict['output'][src_name]
                             except KeyError:
-                                out_meta = disc_metadict['output'][src_name]  # TODO: test discrete
+                                out_meta = disc_metadict['output'][src_name]
 
                         src_tags = out_meta['tags'] if 'tags' in out_meta else {}
                         if is_indep_var is True and 'openmdao:indep_var' not in src_tags:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4242,20 +4242,33 @@ class System(object):
                     if tags and not tagset & ret_meta['tags']:
                         continue
 
+                    # handle is_indep_var
                     if is_indep_var is not None:
                         if iotype == 'output':
-                            src_meta = meta
+                            out_meta = meta
                         else:
                             src_name = self.get_source(abs_name)
                             try:
-                                src_meta = metadict['output'][src_name]
+                                out_meta = metadict['output'][src_name]
                             except KeyError:
-                                src_meta = disc_metadict['output'][src_name]  # TODO: test discrete
+                                out_meta = disc_metadict['output'][src_name]  # TODO: test discrete
 
-                        src_tags = src_meta['tags'] if 'tags' in src_meta else {}
+                        src_tags = out_meta['tags'] if 'tags' in out_meta else {}
                         if is_indep_var is True and 'openmdao:indep_var' not in src_tags:
                             continue
                         elif is_indep_var is False and 'openmdao:indep_var' in src_tags:
+                            continue
+
+                    # handle is_design_var
+                    if is_design_var is not None:
+                        if iotype == 'output':
+                            out_name = abs_name
+                        else:
+                            out_name = self.get_source(abs_name)
+
+                        if is_design_var is True and out_name not in self._design_vars:
+                            continue
+                        elif is_design_var is False and out_name in self._design_vars:
                             continue
 
                     ret_meta['prom_name'] = prom

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4239,9 +4239,6 @@ class System(object):
                             ret_meta = None
 
                 if ret_meta is not None:
-                    if tags and not tagset & ret_meta['tags']:
-                        continue
-
                     # handle is_indep_var
                     if is_indep_var is not None:
                         if iotype == 'output':
@@ -4261,15 +4258,19 @@ class System(object):
 
                     # handle is_design_var
                     if is_design_var is not None:
+                        des_vars = self.get_design_vars(use_prom_ivc=False)
                         if iotype == 'output':
                             out_name = abs_name
                         else:
                             out_name = self.get_source(abs_name)
+                        if is_design_var is True and out_name not in des_vars:
+                            continue
+                        elif is_design_var is False and out_name in des_vars:
+                            continue
 
-                        if is_design_var is True and out_name not in self._design_vars:
-                            continue
-                        elif is_design_var is False and out_name in self._design_vars:
-                            continue
+                    # handle tags
+                    if tags and not tagset & ret_meta['tags']:
+                        continue
 
                     ret_meta['prom_name'] = prom
                     ret_meta['discrete'] = abs_name not in all2meta[iotype]

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4170,6 +4170,9 @@ class System(object):
 
         it = self._var_allprocs_abs2prom if get_remote else self._var_abs2prom
 
+        if is_design_var is not None:
+            des_vars = self.get_design_vars(get_sizes=False, use_prom_ivc=False)
+
         for iotype in iotypes:
             cont2meta = metadict[iotype]
             disc2meta = disc_metadict[iotype]
@@ -4258,7 +4261,6 @@ class System(object):
 
                     # handle is_design_var
                     if is_design_var is not None:
-                        des_vars = self.get_design_vars(use_prom_ivc=False)
                         if iotype == 'output':
                             out_name = abs_name
                         else:

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -447,6 +447,47 @@ class DiscreteTestCase(unittest.TestCase):
             ('impl.y', {}),
         ])
 
+    def test_list_input_outputs_discrete_indep_desvar(self):
+        prob = om.Problem()
+        model = prob.model
+
+        indep = model.add_subsystem('indep', om.IndepVarComp())
+        indep.add_output('x', 1.0)
+        indep.add_discrete_output('a', 1)
+
+        model.add_subsystem('comp', CompDiscWDerivs())
+        model.connect('indep.x', 'comp.x')
+
+        model.add_design_var('indep.x')
+        model.add_objective('comp.y')
+
+        prob.setup()
+        prob.final_setup()
+
+        indeps = model.list_inputs(is_indep_var=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in indeps]), ['comp.N', 'comp.x'])
+
+        desvars = model.list_inputs(is_design_var=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in desvars]), ['comp.x'])
+
+        non_desvars = model.list_inputs(is_design_var=False, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in non_desvars]), ['comp.N'])
+
+        nonDV_indeps = model.list_inputs(is_indep_var=True, is_design_var=False, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in nonDV_indeps]), ['comp.N'])
+
+        indeps = model.list_outputs(is_indep_var=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in indeps]), ['indep.a', 'indep.x'])
+
+        desvars = model.list_outputs(is_design_var=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in desvars]), ['indep.x'])
+
+        non_desvars = model.list_outputs(is_design_var=False, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in non_desvars]), ['comp.Nout', 'comp.y', 'indep.a'])
+
+        nonDV_indeps = model.list_outputs(is_indep_var=True, is_design_var=False, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in nonDV_indeps]), ['indep.a'])
+
     def test_float_to_discrete_error(self):
         prob = om.Problem(name='float_to_discrete_error')
         model = prob.model

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -575,6 +575,8 @@ class MPIFeatureTests(unittest.TestCase):
         model.connect('indep.x', 'C2.invec')
         model.connect('C2.outvec', 'C3.invec', src_indices=om.slicer[:])
 
+        model.add_design_var('indep.x')
+
         prob = om.Problem(model)
         prob.setup()
 
@@ -599,16 +601,32 @@ class MPIFeatureTests(unittest.TestCase):
         inputs = model.list_inputs(all_procs=True)
         self.assertEqual(['C2.invec', 'C3.invec'], [name for name, _ in inputs])
 
-        # list model outputs that are an indep_var
+        # list all model outputs
+        outputs = model.list_outputs(all_procs=True)
+        self.assertEqual(['indep.x', 'C2.outvec', 'C3.sum'], [name for name, _ in outputs])
+
+        # list all model outputs that are an indep_var
         outputs = model.list_outputs(is_indep_var=True, all_procs=True)
         self.assertEqual(['indep.x'], [name for name, _ in outputs])
 
-        # list inputs that are connected to an indep_var
+        # list all model inputs that are connected to an indep_var
         inputs = model.list_inputs(is_indep_var=True, all_procs=True)
         self.assertEqual(['C2.invec'], [name for name, _ in inputs])
 
-        # list inputs that are not connected to an indep_var
+        # list all model inputs that are not connected to an indep_var
         inputs = model.list_inputs(is_indep_var=False, all_procs=True)
+        self.assertEqual(['C3.invec'], [name for name, _ in inputs])
+
+        # list all model outputs that are design vars
+        outputs = model.list_outputs(is_design_var=True, all_procs=True)
+        self.assertEqual(['indep.x'], [name for name, _ in outputs])
+
+        # list all model inputs that are connected to a design var
+        inputs = model.list_inputs(is_design_var=True, all_procs=True)
+        self.assertEqual(['C2.invec'], [name for name, _ in inputs])
+
+        # list all model inputs that are not connected to a design var
+        inputs = model.list_inputs(is_design_var=False, all_procs=True)
         self.assertEqual(['C3.invec'], [name for name, _ in inputs])
 
         assert_near_equal(prob['C3.sum'], -5.)

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -595,6 +595,18 @@ class MPIFeatureTests(unittest.TestCase):
         # is different on each processor, use the all_procs argument to display on all processors
         model.C3.list_inputs(hierarchical=False, shape=True, global_shape=True, print_arrays=True, all_procs=True)
 
+        # list all model inputs
+        inputs = model.list_inputs(all_procs=True)
+        self.assertEqual(['C2.invec', 'C3.invec'], [name for name, _ in inputs])
+
+        # list inputs that are connected to an indep_var
+        inputs = model.list_inputs(is_indep_var=True, all_procs=True)
+        self.assertEqual(['C2.invec'], [name for name, _ in inputs])
+
+        # list inputs that are not connected to an indep_var
+        inputs = model.list_inputs(is_indep_var=False, all_procs=True)
+        self.assertEqual(['C3.invec'], [name for name, _ in inputs])
+
         assert_near_equal(prob['C3.sum'], -5.)
 
 

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -599,6 +599,10 @@ class MPIFeatureTests(unittest.TestCase):
         inputs = model.list_inputs(all_procs=True)
         self.assertEqual(['C2.invec', 'C3.invec'], [name for name, _ in inputs])
 
+        # list model outputs that are an indep_var
+        outputs = model.list_outputs(is_indep_var=True, all_procs=True)
+        self.assertEqual(['indep.x'], [name for name, _ in outputs])
+
         # list inputs that are connected to an indep_var
         inputs = model.list_inputs(is_indep_var=True, all_procs=True)
         self.assertEqual(['C2.invec'], [name for name, _ in inputs])

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -300,7 +300,7 @@ class TestSystem(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             self.assertEqual(meta['comp.a']['value'], 1)
 
-    def test_list_inputs_is_indep_is_des_var(self):
+    def test_list_inputs_outputs_is_indep_is_des_var(self):
         from openmdao.test_suite.components.sellar_feature import SellarMDA
 
         model = SellarMDA()
@@ -334,6 +334,23 @@ class TestSystem(unittest.TestCase):
         nonDV_indeps = model.list_inputs(is_indep_var=True, is_design_var=False, out_stream=None)
         self.assertEqual(sorted([name for name, _ in nonDV_indeps]),
                          ['cycle.d1.x', 'obj_cmp.x'])
+
+        indeps = model.list_outputs(is_indep_var=True, list_autoivcs=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in indeps]),
+                         ['_auto_ivc.v0', '_auto_ivc.v1'])
+
+        desvars = model.list_outputs(is_design_var=True, list_autoivcs=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in desvars]),
+                         ['_auto_ivc.v0'])
+
+        non_desvars = model.list_outputs(is_design_var=False, list_autoivcs=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in non_desvars]),
+                         ['_auto_ivc.v1', 'con_cmp1.con1', 'con_cmp2.con2',
+                          'cycle.d1.y1', 'cycle.d2.y2', 'obj_cmp.obj'])
+
+        nonDV_indeps = model.list_outputs(is_indep_var=True, is_design_var=False, list_autoivcs=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in nonDV_indeps]),
+                         ['_auto_ivc.v1'])
 
     def test_setup_check_group(self):
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -300,6 +300,41 @@ class TestSystem(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             self.assertEqual(meta['comp.a']['value'], 1)
 
+    def test_list_inputs_is_indep_is_des_var(self):
+        from openmdao.test_suite.components.sellar_feature import SellarMDA
+
+        model = SellarMDA()
+
+        model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
+        # model.add_design_var('x', lower=0.0, upper=10.0)
+        model.add_objective('obj')
+        model.add_constraint('con1', upper=0.0)
+        model.add_constraint('con2', upper=0.0)
+
+        prob = Problem(model)
+
+        prob.setup()
+        prob.final_setup()
+
+        indeps = model.list_inputs(is_indep_var=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in indeps]),
+                         ['cycle.d1.x', 'cycle.d1.z', 'cycle.d2.z',
+                          'obj_cmp.x', 'obj_cmp.z'])
+
+        desvars = model.list_inputs(is_design_var=True, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in desvars]),
+                         ['cycle.d1.z', 'cycle.d2.z', 'obj_cmp.z'])
+
+        non_desvars = model.list_inputs(is_design_var=False, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in non_desvars]),
+                         ['con_cmp1.y1', 'con_cmp2.y2',
+                          'cycle.d1.x', 'cycle.d1.y2', 'cycle.d2.y1',
+                          'obj_cmp.x', 'obj_cmp.y1', 'obj_cmp.y2'])
+
+        nonDV_indeps = model.list_inputs(is_indep_var=True, is_design_var=False, out_stream=None)
+        self.assertEqual(sorted([name for name, _ in nonDV_indeps]),
+                         ['cycle.d1.x', 'obj_cmp.x'])
+
     def test_setup_check_group(self):
 
         class CustomGroup(Group):

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -276,6 +276,97 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### *List Independent Variables and Design Variables*\n",
+    "\n",
+    "The `System.list_inputs` method also provides a way to determine which inputs you are ultimately responsible for setting. The inputs report achieves this in a graphical format, but this method allows it to be done programmatically.\n",
+    "\n",
+    "Consider the following simple example using the Sellar model, where we intentionally have not added the variable `x` as a design variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import openmdao.api as om\n",
+    "\n",
+    "from openmdao.test_suite.components.sellar_feature import SellarMDA\n",
+    "\n",
+    "\n",
+    "model = SellarMDA()\n",
+    "\n",
+    "model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))\n",
+    "# model.add_design_var('x', lower=0.0, upper=10.0)\n",
+    "model.add_objective('obj')\n",
+    "model.add_constraint('con1', upper=0.0)\n",
+    "model.add_constraint('con2', upper=0.0)\n",
+    "\n",
+    "prob = om.Problem(model)\n",
+    "\n",
+    "prob.setup()\n",
+    "prob.final_setup();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `is_indep_var` argument provides inputs that the user can ultimately change, though some of them maybe be overridden by the Driver as design variables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "indeps = model.list_inputs(is_indep_var=True, prom_name=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also get a list of design variables using the `is_design_var` argument:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "desvars = model.list_inputs(is_design_var=True, prom_name=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Combining these two arguments will show those variables that should be set by the user and whose values will not be overridden by the Driver:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "nonDV_indeps = model.list_inputs(is_indep_var=True, is_design_var=False, prom_name=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### *List Variables Filtered by Tags*\n",
     "\n",
     "When you add inputs and outputs to components, you can optionally set tags on the variables. These tags can then be used to filter what variables are printed and returned by the `System.list_inputs` and `System.list_outputs` methods. Each of those methods has an optional argument `tags` for that purpose.\n",
@@ -1066,7 +1157,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.0"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -278,7 +278,7 @@
    "source": [
     "### *List Independent Variables and Design Variables*\n",
     "\n",
-    "The `System.list_inputs` method also provides a way to determine which inputs you are ultimately responsible for setting. The inputs report achieves this in a graphical format, but this method allows it to be done programmatically.\n",
+    "The `System.list_inputs` method also provides a way to determine which inputs you are ultimately responsible for setting. The [inputs report](../reports/reports_system.ipynb) achieves this in a graphical format, but this method allows it to be done programmatically.\n",
     "\n",
     "Consider the following simple example using the Sellar model, where we intentionally have not added the variable `x` as a design variable:"
    ]

--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -346,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.0"
   },
   "orphan": true
  },

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -404,6 +404,8 @@ class Case(object):
                     tags=None,
                     includes=None,
                     excludes=None,
+                    is_indep_var=None,
+                    is_design_var=None,
                     out_stream=_DEFAULT_OUT_STREAM,
                     values=None,
                     print_min=False,
@@ -481,6 +483,9 @@ class Case(object):
             print_options = np.get_printoptions()
             np_precision = print_options['precision']
 
+            if is_design_var is not None:
+                des_vars = self._get_variables_of_type('desvar')
+
             for var_name in self.inputs.absolute_names():
                 meta = abs2meta[var_name]
 
@@ -492,6 +497,27 @@ class Case(object):
 
                 if not match_prom_or_abs(var_name, var_name_prom, includes, excludes):
                     continue
+
+                # handle is_indep_var
+                if is_indep_var is not None:
+                    src_name = self._conns[var_name]
+                    src_name_prom = self._abs2prom['output'][src_name]
+                    src_meta = abs2meta[src_name]
+                    if is_indep_var is True and 'openmdao:indep_var' not in src_meta['tags']:
+                        continue
+                    elif is_indep_var is False and 'openmdao:indep_var' in src_meta['tags']:
+                        continue
+
+                # handle is_design_var
+                if is_design_var is not None:
+                    src_name = self._conns[var_name]
+                    src_name_prom = self._abs2prom['output'][src_name]
+                    if src_name_prom.startswith('_auto_ivc.'):
+                        src_name_prom = self._auto_ivc_map[src_name_prom]
+                    if is_design_var is True and src_name_prom not in des_vars:
+                        continue
+                    elif is_design_var is False and src_name_prom in des_vars:
+                        continue
 
                 val = self.inputs[var_name]
 
@@ -546,6 +572,8 @@ class Case(object):
                      tags=None,
                      includes=None,
                      excludes=None,
+                     is_indep_var=None,
+                     is_design_var=None,
                      list_autoivcs=False,
                      out_stream=_DEFAULT_OUT_STREAM,
                      values=None,
@@ -640,6 +668,9 @@ class Case(object):
         print_options = np.get_printoptions()
         np_precision = print_options['precision']
 
+        if is_design_var is not None:
+            des_vars = self._get_variables_of_type('desvar')
+
         for var_name in self.outputs.absolute_names():
             if not list_autoivcs and var_name.startswith('_auto_ivc.'):
                 continue
@@ -654,6 +685,23 @@ class Case(object):
 
             if not match_prom_or_abs(var_name, var_name_prom, includes, excludes):
                 continue
+
+            # handle is_indep_var
+            if is_indep_var is not None:
+                if is_indep_var is True and 'openmdao:indep_var' not in meta['tags']:
+                    continue
+                elif is_indep_var is False and 'openmdao:indep_var' in meta['tags']:
+                    continue
+
+            # handle is_design_var
+            if is_design_var is not None:
+                var_name_prom = self._abs2prom['output'][var_name]
+                if var_name_prom.startswith('_auto_ivc.'):
+                    var_name_prom = self._auto_ivc_map[var_name_prom]
+                if is_design_var is True and var_name_prom not in des_vars:
+                    continue
+                elif is_design_var is False and var_name_prom in des_vars:
+                    continue
 
             # check if residuals were recorded, skip if within specifed tolerance
             if residuals and self.residuals and var_name in self.residuals.absolute_names():

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -444,6 +444,14 @@ class Case(object):
         excludes : str, iter of str, or None
             Glob patterns for pathnames to exclude from the check. Default is None, which
             excludes nothing.
+        is_indep_var : bool or None
+            If None (the default), do no additional filtering of the inputs.
+            If True, list only inputs connected to an output tagged `openmdao:indep_var`.
+            If False, list only inputs _not_ connected to outputs tagged `openmdao:indep_var`.
+        is_design_var : bool or None
+            If None (the default), do no additional filtering of the inputs.
+            If True, list only inputs connected to outputs that are driver design variables.
+            If False, list only inputs _not_ connected to outputs that are driver design variables.
         out_stream : file-like object
             Where to send human readable output. Default is sys.stdout.
             Set to None to suppress.
@@ -627,6 +635,14 @@ class Case(object):
         excludes : str, iter of str, or None
             Glob patterns for pathnames to exclude from the check. Default is None, which
             excludes nothing.
+        is_indep_var : bool or None
+            If None (the default), do no additional filtering of the inputs.
+            If True, list only inputs connected to an output tagged `openmdao:indep_var`.
+            If False, list only inputs _not_ connected to outputs tagged `openmdao:indep_var`.
+        is_design_var : bool or None
+            If None (the default), do no additional filtering of the inputs.
+            If True, list only inputs connected to outputs that are driver design variables.
+            If False, list only inputs _not_ connected to outputs that are driver design variables.
         list_autoivcs : bool
             If True, include auto_ivc outputs in the listing.  Defaults to False.
         out_stream : file-like


### PR DESCRIPTION
### Summary

[POEM78 ](https://github.com/OpenMDAO/POEMs/pull/158) Implementation.  Adds `is_indep_var` and `is_design_var` filters to the `list_inputs()` and `list_outputs()` methods on `System` and `Case`.  This gives users a way of knowing which inputs they are ultimately responsible for setting. 

### Related Issues

- Resolves #2804

### Backwards incompatibilities

None

### New Dependencies

None
