### PR TITLE
fix for MPI bug when total jacobian is singular and model has dist vars

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -307,7 +307,7 @@ jobs:
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage --coverpkg openmdao --durations=20
 
       - name: Submit coverage
-        if: false
+        if: matrix.TESTS
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
@@ -506,7 +506,6 @@ jobs:
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage  --coverpkg openmdao --durations=20
 
       - name: Submit coverage
-        if: false
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -307,7 +307,7 @@ jobs:
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage --coverpkg openmdao --durations=20
 
       - name: Submit coverage
-        if: matrix.TESTS
+        if: false
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
@@ -506,6 +506,7 @@ jobs:
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage  --coverpkg openmdao --durations=20
 
       - name: Submit coverage
+        if: false
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -1360,6 +1360,7 @@ class MPITestsBug(unittest.TestCase):
         totals = p.check_totals(of=of, wrt=wrt, compact_print=False, show_only_incorrect=True)
         assert_check_totals(totals, atol=1e-5, rtol=1e-6)
 
+    @unittest.skipUnless(pyoptsparse_opt, "pyOptsparse is required.")
     def test_zero_entry_distrib(self):
         # this test errored out before the fix
         dist_shape = 1 if MPI.COMM_WORLD.rank > 0 else 2

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1573,7 +1573,7 @@ class _TotalJacInfo(object):
             Index array of zero entries.
         """
         inds = tup[1]  # these must be indices into the flattened var
-        shname = 'shape' if self.get_remote else 'global_shape'
+        shname = 'global_shape' if self.get_remote else 'shape'
         shape = self.model._var_allprocs_abs2meta['output'][name][shname]
         vslice = jac_arr[tup[0]]
 


### PR DESCRIPTION
### Summary

During checking for total jacobian singularity we were using variable 'shape' instead of 'global_shape'.

### Related Issues

- Resolves #2827

### Backwards incompatibilities

None

### New Dependencies

None
