### PR TITLE
Remove deprecation that allowed use of `value` in place of `val`

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -28,7 +28,7 @@ jobs:
             NUMPY: '1.24'
             SCIPY: '1.10'
             PETSc: '3.18'
-            PYOPTSPARSE: 'v2.9.2'
+            PYOPTSPARSE: 'v2.9.3'
             PAROPT: true
             SNOPT: '7.7'
             OPTIONAL: '[all]'
@@ -54,7 +54,7 @@ jobs:
             NUMPY: '1.24'
             SCIPY: '1.10'
             PETSc: '3.18'
-            # PYOPTSPARSE: 'v2.9.2'
+            # PYOPTSPARSE: 'v2.9.3'
             # PAROPT: true
             # SNOPT: '7.7'
             OPTIONAL: '[all]'
@@ -91,7 +91,7 @@ jobs:
             NUMPY: '1.24'
             SCIPY: '1.10'
             PETSc: '3.18'
-            PYOPTSPARSE: 'v2.9.2'
+            PYOPTSPARSE: 'v2.9.3'
             SNOPT: '7.7'
             OPTIONAL: '[all]'
             JAX: '0.4.2'
@@ -446,11 +446,6 @@ jobs:
           echo "Install lxml for Windows (No Python 3.11 version on pypi)"
           echo "============================================================="
           conda install lxml
-
-          echo "============================================================="
-          echo "Pre-install jupyter dependencies"
-          echo "============================================================="
-          conda install jupyter-book -q -y
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -28,7 +28,7 @@ jobs:
             NUMPY: '1.24'
             SCIPY: '1.10'
             PETSc: '3.18'
-            PYOPTSPARSE: 'v2.9.3'
+            PYOPTSPARSE: 'v2.9.2'
             PAROPT: true
             SNOPT: '7.7'
             OPTIONAL: '[all]'
@@ -54,7 +54,7 @@ jobs:
             NUMPY: '1.24'
             SCIPY: '1.10'
             PETSc: '3.18'
-            # PYOPTSPARSE: 'v2.9.3'
+            # PYOPTSPARSE: 'v2.9.2'
             # PAROPT: true
             # SNOPT: '7.7'
             OPTIONAL: '[all]'
@@ -91,7 +91,7 @@ jobs:
             NUMPY: '1.24'
             SCIPY: '1.10'
             PETSc: '3.18'
-            PYOPTSPARSE: 'v2.9.3'
+            PYOPTSPARSE: 'v2.9.2'
             SNOPT: '7.7'
             OPTIONAL: '[all]'
             JAX: '0.4.2'

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -409,17 +409,6 @@ class ExecComp(ExplicitComponent):
                                        "recognized for variable '%s': %s" %
                                        (self.msginfo, arg, sorted(diff)))
 
-                if 'val' in val and 'value' in val:
-                    raise RuntimeError(f"{self.msginfo}: 'val' and 'value' at the same time, use "
-                                       "'val'.")
-                elif 'value' in val and not warned:
-                    warn_deprecation(f"{self.msginfo}: 'value' will be deprecated in 4.0. Please "
-                                     "use 'val' in the future.")
-
-                if 'value' in val:
-                    val['val'] = val.pop('value')
-                    warned = True
-
                 kwargs2[arg] = val.copy()
 
                 if units is not None:

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -978,49 +978,49 @@ class TestExecComp(unittest.TestCase):
         prob.run_model()
 
         # Inputs no tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None)
+        inputs = prob.model.list_inputs(val=False, out_stream=None)
         self.assertEqual(sorted(inputs), [
             ('C1.x', {}),
             ('C1.z', {}),
         ])
 
         # Inputs with tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags="tagx")
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags="tagx")
         self.assertEqual(sorted(inputs), [
             ('C1.x', {}),
         ])
 
         # Inputs with multiple tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags=["tagx", "tagz"])
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags=["tagx", "tagz"])
         self.assertEqual(sorted(inputs), [
             ('C1.x', {}),
             ('C1.z', {}),
         ])
 
         # Inputs with tag that does not match
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags="tag_wrong")
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags="tag_wrong")
         self.assertEqual(sorted(inputs), [])
 
         # Outputs no tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None)
+        outputs = prob.model.list_outputs(val=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
             ('C1.y', {}),
         ])
 
         # Outputs with tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="tagy")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="tagy")
         self.assertEqual(sorted(outputs), [
             ('C1.y', {}),
         ])
 
         # Outputs with multiple tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags=["tagy", "tagx"])
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags=["tagy", "tagx"])
         self.assertEqual(sorted(outputs), [
             ('C1.y', {}),
         ])
 
         # Outputs with tag that does not match
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="tag_wrong")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="tag_wrong")
         self.assertEqual(sorted(outputs), [])
 
     def test_feature_has_diag_partials(self):
@@ -1169,9 +1169,9 @@ class TestExecComp(unittest.TestCase):
             "quad_1",
             om.ExecComp(
                 "y = a * x ** 2 + b * x + c",
-                a={"value": 2.0},
-                b={"value": 5.0},
-                c={"value": 3.0},
+                a={"val": 2.0},
+                b={"val": 5.0},
+                c={"val": 3.0},
                 x={"shape": (2,)},
                 y={"shape": (2,)},
             ),
@@ -1365,31 +1365,6 @@ class TestExecComp(unittest.TestCase):
 
         self.assertEquals(cm.exception.args[0],
                           "'zzz' <class ExecComp>: The output 'y' has already been defined by an expression.")
-
-    def test_value_deprecation(self):
-        p = om.Problem()
-
-        msg = ("'zzz' <class ExecComp>: 'value' will be deprecated in 4.0. Please use 'val' in the future.")
-
-        excomp = om.ExecComp('y=x**2', x={'value': np.ones(10)}, y={'val': np.ones(10)})
-
-        p.model.add_subsystem('zzz', excomp)
-        with assert_warning(OMDeprecationWarning, msg):
-            p.setup()
-
-    def test_val_value_error(self):
-        p = om.Problem()
-
-        msg = ("Cannot use 'val' and 'value' at the same time, use 'val'.")
-
-        excomp = om.ExecComp('y=x**2', x={'value': np.ones(10), 'val': np.ones(10)},
-                                       y={'val': np.ones(10)})
-
-        p.model.add_subsystem('zzz', excomp)
-
-        with self.assertRaises(RuntimeError) as cm:
-            p.setup()
-            self.assertEquals(cm.exception.args[0], msg)
 
     def test_feature_add_expr(self):
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -11,7 +11,7 @@ from numpy import ndarray, isscalar, ndim, atleast_1d, atleast_2d, promote_types
 from scipy.sparse import issparse, coo_matrix
 
 from openmdao.core.system import System, _supported_methods, _DEFAULT_COLORING_META, \
-    global_meta_names, _MetadataDict, collect_errors
+    global_meta_names, collect_errors
 from openmdao.core.constants import INT_DTYPE
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.array_utils import shape_to_len
@@ -568,7 +568,7 @@ class Component(System):
             # using ._dict below to avoid tons of deprecation warnings
             distributed = distributed or self.options._dict['distributed']['val']
 
-        metadata = _MetadataDict()
+        metadata = {}
 
         metadata.update({
             'val': val,
@@ -635,7 +635,7 @@ class Component(System):
         if tags is not None and not isinstance(tags, (str, list)):
             raise TypeError('%s: The tags argument should be a str or list' % self.msginfo)
 
-        metadata = _MetadataDict()
+        metadata = {}
 
         metadata.update({
             'val': val,
@@ -806,7 +806,7 @@ class Component(System):
             # using ._dict below to avoid tons of deprecation warnings
             distributed = distributed or self.options._dict['distributed']['val']
 
-        metadata = _MetadataDict()
+        metadata = {}
 
         metadata.update({
             'val': val,
@@ -877,7 +877,7 @@ class Component(System):
         if tags is not None and not isinstance(tags, (str, set, list)):
             raise TypeError('%s: The tags argument should be a str, set, or list' % self.msginfo)
 
-        metadata = _MetadataDict()
+        metadata = {}
 
         metadata.update({
             'val': val,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -100,8 +100,6 @@ resp_size_checks = {
 }
 resp_types = {'con': 'constraint', 'obj': 'objective'}
 
-value_deprecated_msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'."
-
 
 class _MatchType(IntEnum):
     """
@@ -120,31 +118,6 @@ class _MatchType(IntEnum):
     NAME = 0
     RENAME = 1
     PATTERN = 2
-
-
-class _MetadataDict(dict):
-    """
-    A dict wrapper for a dict of metadata, to throw deprecation if a user indexes in using value.
-    """
-
-    def __getitem__(self, key):
-        try:
-            return dict.__getitem__(self, key)
-        except KeyError:
-            if key == 'value':
-                warn_deprecation(value_deprecated_msg)
-                return dict.__getitem__(self, 'val')
-            raise
-
-    def __setitem__(self, key, val):
-        try:
-            dict.__setitem__(self, key, val)
-        except KeyError:
-            if key == 'value':
-                dict.__setitem__(self, 'val', val)
-                warn_deprecation(value_deprecated_msg)
-            else:
-                raise
 
 
 def collect_errors(method):
@@ -4142,12 +4115,6 @@ class System(object):
         need_gather = get_remote and self.comm.size > 1
         if metadata_keys is not None:
             keyset = set(metadata_keys)
-            # DEPRECATION: if 'value' in keyset, replace with 'val'
-            if 'value' in keyset:
-                keyset.remove('value')
-                keyset.add('val')
-                warn_deprecation(value_deprecated_msg)
-
             diff = keyset - allowed_meta_names
             if diff:
                 raise RuntimeError(f"{self.msginfo}: {sorted(diff)} are not valid metadata entry "
@@ -4196,9 +4163,9 @@ class System(object):
                     ret_meta = None
                 else:
                     if metadata_keys is None:
-                        ret_meta = _MetadataDict(meta)
+                        ret_meta = dict(meta)
                     else:
-                        ret_meta = _MetadataDict()
+                        ret_meta = {}
                         for key in keyset:
                             try:
                                 ret_meta[key] = meta[key]
@@ -4214,7 +4181,7 @@ class System(object):
 
                         if rank is None or self.comm.rank == rank:
                             if not ret_meta:
-                                ret_meta = _MetadataDict()
+                                ret_meta = {}
                             if distrib:
                                 if 'val' in keyset:
                                     # assemble the full distributed value
@@ -4300,7 +4267,6 @@ class System(object):
                     is_design_var=None,
                     all_procs=False,
                     out_stream=_DEFAULT_OUT_STREAM,
-                    values=None,
                     print_min=False,
                     print_max=False):
         """
@@ -4352,8 +4318,6 @@ class System(object):
         out_stream : file-like object
             Where to send human readable output. Default is sys.stdout.
             Set to None to suppress.
-        values : bool, optional
-            This argument has been deprecated and will be removed in 4.0.
         print_min : bool
             When true, if the input value is an array, print its smallest value.
         print_max : bool
@@ -4364,20 +4328,12 @@ class System(object):
         list of (name, metadata)
             List of input names and other optional information about those inputs.
         """
-        if values is not None:
-            warn_deprecation(f"{self.msginfo}: The 'values' argument to 'list_inputs()' is "
-                             "deprecated and will be removed in 4.0. Please use 'val' instead.")
-        elif not val and values:
-            values = True
-        else:
-            values = val
-
         if self._problem_meta['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
             issue_warning("Calling `list_inputs` before `final_setup` will only "
                           "display the default values of variables and will not show the result of "
                           "any `set_val` calls.")
 
-        metavalues = values and self._inputs is None
+        metavalues = val and self._inputs is None
 
         keynames = ['val', 'units', 'shape', 'global_shape', 'desc', 'tags']
         keyvals = [metavalues, units, shape, global_shape, desc, tags is not None]
@@ -4399,7 +4355,7 @@ class System(object):
                 for key in to_remove:
                     del meta[key]
 
-        if values and self._inputs is not None:
+        if val and self._inputs is not None:
             # we want value from the input vector, not from the metadata
             print_options = np.get_printoptions()
             np_precision = print_options['precision']
@@ -4452,7 +4408,6 @@ class System(object):
                      all_procs=False,
                      list_autoivcs=False,
                      out_stream=_DEFAULT_OUT_STREAM,
-                     values=None,
                      print_min=False,
                      print_max=False):
         """
@@ -4519,8 +4474,6 @@ class System(object):
         out_stream : file-like
             Where to send human readable output. Default is sys.stdout.
             Set to None to suppress.
-        values : bool, optional
-            This argument has been deprecated and will be removed in 4.0.
         print_min : bool
             When true, if the output value is an array, print its smallest value.
         print_max : bool
@@ -4531,16 +4484,8 @@ class System(object):
         list of (name, metadata)
             List of output names and other optional information about those outputs.
         """
-        if values is not None:
-            warn_deprecation(f"{self.msginfo}: The 'values' argument to 'list_outputs()' is "
-                             "deprecated and will be removed in 4.0. Please use 'val' instead.")
-        elif not val and values:
-            values = True
-        else:
-            values = val
-
         keynames = ['val', 'units', 'shape', 'global_shape', 'desc', 'tags']
-        keyflags = [values, units, shape, global_shape, desc, tags]
+        keyflags = [val, units, shape, global_shape, desc, tags]
 
         keys = [name for i, name in enumerate(keynames) if keyflags[i]]
 
@@ -4560,13 +4505,13 @@ class System(object):
             outputs = {n: m for n, m in outputs.items() if not n.startswith('_auto_ivc.')}
 
         # get values & resids
-        if self._outputs is not None and (values or residuals or residuals_tol):
+        if self._outputs is not None and (val or residuals or residuals_tol):
             to_remove = []
             print_options = np.get_printoptions()
             np_precision = print_options['precision']
 
             for name, meta in outputs.items():
-                if values:
+                if val:
                     # we want value from the input vector, not from the metadata
                     meta['val'] = self._abs_get_val(name, get_remote=True,
                                                     rank=None if all_procs else 0, kind='output')

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -296,25 +296,6 @@ class TestExplicitComponent(unittest.TestCase):
         # pretend we reconfigured
         prob.setup()
 
-    def test_value_getitem_deprecation(self):
-        comp = TestExplCompSimple()
-        prob = Problem(comp).setup()
-
-        # check optional metadata (desc)
-        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'.")
-
-        prob.setup()
-        with assert_warning(OMDeprecationWarning, msg):
-            comp._var_rel2meta['length']['value']
-
-    def test_return_metadata_value_deprecation(self):
-        prob = Problem()
-        idv = prob.model.add_subsystem('idv', IndepVarComp())
-        meta = idv.add_output('x', 1.0)
-
-        msg = ("The metadata key 'value' will be deprecated in 4.0. Please use 'val'.")
-        with assert_warning(OMDeprecationWarning, msg):
-            meta['value']
 
 class TestImplicitComponent(unittest.TestCase):
 

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -282,7 +282,7 @@ class DiscreteTestCase(unittest.TestCase):
         # list inputs, not hierarchical
         #
         stream = StringIO()
-        prob.model.list_inputs(values=True, hierarchical=False, out_stream=stream)
+        prob.model.list_inputs(val=True, hierarchical=False, out_stream=stream)
         text = stream.getvalue()
 
         self.assertEqual(1, text.count("3 Input(s) in 'model'"))
@@ -294,7 +294,7 @@ class DiscreteTestCase(unittest.TestCase):
         # list inputs, hierarchical
         #
         stream = StringIO()
-        prob.model.list_inputs(values=True, hierarchical=True, out_stream=stream)
+        prob.model.list_inputs(val=True, hierarchical=True, out_stream=stream)
         text = stream.getvalue()
 
         self.assertEqual(1, text.count("3 Input(s) in 'model'"))
@@ -307,7 +307,7 @@ class DiscreteTestCase(unittest.TestCase):
         # list outputs, not hierarchical
         #
         stream = StringIO()
-        prob.model.list_outputs(values=True, residuals=True, hierarchical=False, out_stream=stream)
+        prob.model.list_outputs(val=True, residuals=True, hierarchical=False, out_stream=stream)
         text = stream.getvalue()
 
         self.assertEqual(text.count('3 Explicit Output'), 1)
@@ -321,7 +321,7 @@ class DiscreteTestCase(unittest.TestCase):
         # list outputs, hierarchical
         #
         stream = StringIO()
-        prob.model.list_outputs(values=True, residuals=True, hierarchical=True, out_stream=stream)
+        prob.model.list_outputs(val=True, residuals=True, hierarchical=True, out_stream=stream)
         text = stream.getvalue()
 
         self.assertEqual(text.count('\nindep'), 1)
@@ -417,7 +417,7 @@ class DiscreteTestCase(unittest.TestCase):
         prob.run_model()
 
         # list inputs, no tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None)
+        inputs = prob.model.list_inputs(val=False, out_stream=None)
         self.assertEqual(sorted(inputs), [
             ('expl.a', {}),
             ('expl.x', {}),
@@ -425,14 +425,14 @@ class DiscreteTestCase(unittest.TestCase):
         ])
 
         # list inputs, with tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags='tagx')
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags='tagx')
         self.assertEqual(sorted(inputs), [
             ('expl.x', {}),
             ('impl.x', {}),
         ])
 
         # list outputs, no tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None)
+        outputs = prob.model.list_outputs(val=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
             ('expl.b', {}),
             ('expl.y', {}),
@@ -441,7 +441,7 @@ class DiscreteTestCase(unittest.TestCase):
         ])
 
         # list outputs, with tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags='tagy')
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags='tagy')
         self.assertEqual(sorted(outputs), [
             ('expl.y', {}),
             ('impl.y', {}),

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -87,7 +87,7 @@ class DistributedListVarsTest(unittest.TestCase):
 
         stream = StringIO()
         with multi_proc_exception_check(prob.comm):
-            inputs = sorted(prob.model.list_inputs(values=True, print_arrays=True, out_stream=stream))
+            inputs = sorted(prob.model.list_inputs(val=True, print_arrays=True, out_stream=stream))
             if prob.comm.rank:
                 self.assertEqual(inputs, [])
             else:
@@ -111,7 +111,7 @@ class DistributedListVarsTest(unittest.TestCase):
 
         stream = StringIO()
         with multi_proc_exception_check(prob.comm):
-            outputs = sorted(prob.model.list_outputs(values=True,
+            outputs = sorted(prob.model.list_outputs(val=True,
                                                      units=True,
                                                      shape=True,
                                                      bounds=True,
@@ -192,7 +192,7 @@ class DistributedListVarsTest(unittest.TestCase):
 
         stream = StringIO()
         with multi_proc_exception_check(prob.comm):
-            inputs = sorted(prob.model.list_inputs(values=True, print_arrays=True, out_stream=stream))
+            inputs = sorted(prob.model.list_inputs(val=True, print_arrays=True, out_stream=stream))
             if prob.comm.rank:
                 self.assertEqual(inputs, [])
             else:
@@ -218,7 +218,7 @@ class DistributedListVarsTest(unittest.TestCase):
 
         stream = StringIO()
         with multi_proc_exception_check(prob.comm):
-            outputs = sorted(prob.model.list_outputs(values=True,
+            outputs = sorted(prob.model.list_outputs(val=True,
                                                      units=True,
                                                      shape=True,
                                                      bounds=True,
@@ -274,7 +274,7 @@ class DistributedListVarsTest(unittest.TestCase):
         #
         stream = StringIO()
         with printoptions(**print_opts):
-            prob.model.list_inputs(values=True, hierarchical=False, out_stream=stream)
+            prob.model.list_inputs(val=True, hierarchical=False, out_stream=stream)
 
         with multi_proc_exception_check(prob.comm):
             if prob.comm.rank == 0:  # Only rank 0 prints
@@ -303,7 +303,7 @@ class DistributedListVarsTest(unittest.TestCase):
         #
         stream = StringIO()
         with printoptions(**print_opts):
-            prob.model.list_inputs(values=True, hierarchical=True, out_stream=stream)
+            prob.model.list_inputs(val=True, hierarchical=True, out_stream=stream)
 
         with multi_proc_exception_check(prob.comm):
             if prob.comm.rank == 0:
@@ -339,7 +339,7 @@ class DistributedListVarsTest(unittest.TestCase):
         #
         stream = StringIO()
         with printoptions(**print_opts):
-            prob.model.list_outputs(values=True, residuals=True, hierarchical=False, out_stream=stream)
+            prob.model.list_outputs(val=True, residuals=True, hierarchical=False, out_stream=stream)
 
         with multi_proc_exception_check(prob.comm):
             if prob.comm.rank == 0:
@@ -372,7 +372,7 @@ class DistributedListVarsTest(unittest.TestCase):
         #
         stream = StringIO()
         with printoptions(**print_opts):
-            prob.model.list_outputs(values=True, residuals=True, hierarchical=True, out_stream=stream)
+            prob.model.list_outputs(val=True, residuals=True, hierarchical=True, out_stream=stream)
 
         with multi_proc_exception_check(prob.comm):
             if prob.comm.rank == 0:

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -510,12 +510,12 @@ class MPITests(unittest.TestCase):
 
             def configure(self):
                 # verify list_inputs/list_outputs work in configure
-                inputs = self.C2.list_inputs(shape=True, values=True, out_stream=None)
-                outputs = self.C2.list_outputs(shape=True, values=True, out_stream=None)
+                inputs = self.C2.list_inputs(shape=True, val=True, out_stream=None)
+                outputs = self.C2.list_outputs(shape=True, val=True, out_stream=None)
                 verify(inputs, outputs, full_size=size*2, loc_size=size, pathnames=False, rank=0)
 
-                inputs = self.C2.list_inputs(shape=True, values=True, all_procs=True, out_stream=None)
-                outputs = self.C2.list_outputs(shape=True, values=True, all_procs=True, out_stream=None)
+                inputs = self.C2.list_inputs(shape=True, val=True, all_procs=True, out_stream=None)
+                outputs = self.C2.list_outputs(shape=True, val=True, all_procs=True, out_stream=None)
                 verify(inputs, outputs, full_size=size*2, loc_size=size, pathnames=False)
 
         p = om.Problem(Model())
@@ -542,12 +542,12 @@ class MPITests(unittest.TestCase):
         p.setup()
 
         # verify list_inputs/list_outputs work before final_setup
-        inputs = p.model.C2.list_inputs(shape=True, values=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, values=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, val=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, val=True, out_stream=None)
         verify(inputs, outputs, size*2, size, pathnames=False, rank=0)
 
-        inputs = p.model.C2.list_inputs(shape=True, values=True, all_procs=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, values=True, all_procs=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, val=True, all_procs=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, val=True, all_procs=True, out_stream=None)
         verify(inputs, outputs, size*2, size, pathnames=False)
 
         p.final_setup()
@@ -555,23 +555,23 @@ class MPITests(unittest.TestCase):
         p['C1.invec'] = np.ones(size, float) * 5.0
 
         # verify list_inputs/list_outputs work before run
-        inputs = p.model.C2.list_inputs(shape=True, values=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, values=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, val=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, val=True, out_stream=None)
         verify(inputs, outputs, size*2, size, pathnames=False, rank=0)
 
-        inputs = p.model.C2.list_inputs(shape=True, values=True, all_procs=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, values=True, all_procs=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, val=True, all_procs=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, val=True, all_procs=True, out_stream=None)
         verify(inputs, outputs, size*2, size, pathnames=False)
 
         p.run_model()
 
         # verify list_inputs/list_outputs work after run
-        inputs = p.model.C2.list_inputs(shape=True, values=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, values=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, val=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, val=True, out_stream=None)
         verify(inputs, outputs, size*2, size, in_vals=10., out_vals=7.5, pathnames=False, rank=0)
 
-        inputs = p.model.C2.list_inputs(shape=True, values=True, all_procs=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, values=True, all_procs=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, val=True, all_procs=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, val=True, all_procs=True, out_stream=None)
         verify(inputs, outputs, size*2, size, in_vals=10., out_vals=7.5, pathnames=False)
 
     def test_distrib_list_inputs_outputs(self):
@@ -617,26 +617,26 @@ class MPITests(unittest.TestCase):
 
             def configure(self):
                 # verify list_inputs/list_outputs work in configure for distributed comp on rank 0 only
-                inputs = self.C2.list_inputs(shape=True, global_shape=True, values=True, out_stream=None)
-                outputs = self.C2.list_outputs(shape=True, global_shape=True, values=True, out_stream=None)
+                inputs = self.C2.list_inputs(shape=True, global_shape=True, val=True, out_stream=None)
+                outputs = self.C2.list_outputs(shape=True, global_shape=True, val=True, out_stream=None)
                 verify(inputs, outputs, pathnames=False, comm=self.comm, final=False, rank=0)
 
                 # verify list_inputs/list_outputs work in configure for distributed comp on all ranks
-                inputs = self.C2.list_inputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
-                outputs = self.C2.list_outputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
+                inputs = self.C2.list_inputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
+                outputs = self.C2.list_outputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
                 verify(inputs, outputs, pathnames=False, comm=self.comm, final=False)
 
         p = om.Problem(Model())
         p.setup()
 
         # verify list_inputs/list_outputs work before final_setup for distributed comp on rank 0 only
-        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, values=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, values=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, val=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, val=True, out_stream=None)
         verify(inputs, outputs, pathnames=False, comm=p.comm, final=True, rank=0)
 
         # verify list_inputs/list_outputs work before final_setup for distributed comp on all ranks
-        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
         verify(inputs, outputs, pathnames=False, comm=p.comm, final=True)
 
         p.final_setup()
@@ -644,25 +644,25 @@ class MPITests(unittest.TestCase):
         p['C1.invec'] = np.ones(size, float) * 5.0
 
         # verify list_inputs/list_outputs work before run for distributed comp on rank 0 only
-        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, values=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, values=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, val=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, val=True, out_stream=None)
         verify(inputs, outputs, pathnames=False, comm=p.comm, final=True, rank=0)
 
         # verify list_inputs/list_outputs work before run for distributed comp on all ranks
-        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
         verify(inputs, outputs, pathnames=False, comm=p.comm, final=True)
 
         p.run_model()
 
         # verify list_inputs/list_outputs work after run for distributed comp on rank 0 only
-        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, values=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, values=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, val=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, val=True, out_stream=None)
         verify(inputs, outputs, in_vals=10., out_vals=20., pathnames=False, comm=p.comm, final=True, rank=0)
 
         # verify list_inputs/list_outputs work after run for distributed comp on all ranks
-        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
-        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, values=True, all_procs=True, out_stream=None)
+        inputs = p.model.C2.list_inputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
+        outputs = p.model.C2.list_outputs(shape=True, global_shape=True, val=True, all_procs=True, out_stream=None)
         verify(inputs, outputs, in_vals=10., out_vals=20., pathnames=False, comm=p.comm, final=True)
 
     def test_distrib_idx_in_full_out(self):

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -324,7 +324,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         # list outputs with out_stream and all the optional display values True
         stream = StringIO()
-        outputs = prob.model.list_outputs(values=True,
+        outputs = prob.model.list_outputs(val=True,
                                           units=True,
                                           shape=True,
                                           bounds=True,
@@ -393,7 +393,7 @@ class ExplCompTestCase(unittest.TestCase):
         print(inputs)
 
         outputs = prob.model.list_outputs(implicit=False,
-                                          values=True,
+                                          val=True,
                                           units=True,
                                           shape=True,
                                           bounds=True,
@@ -412,7 +412,7 @@ class ExplCompTestCase(unittest.TestCase):
         ])
 
         outputs = prob.model.list_outputs(implicit=False,
-                                          values=True,
+                                          val=True,
                                           units=True,
                                           shape=True,
                                           bounds=True,
@@ -457,7 +457,7 @@ class ExplCompTestCase(unittest.TestCase):
         # logging inputs
         # out_stream - not hierarchical - extras - no print_arrays
         stream = StringIO()
-        prob.model.list_inputs(values=True,
+        prob.model.list_inputs(val=True,
                                units=True,
                                hierarchical=False,
                                print_arrays=False,
@@ -480,7 +480,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         # out_stream - hierarchical - extras - no print_arrays
         stream = StringIO()
-        prob.model.list_inputs(values=True,
+        prob.model.list_inputs(val=True,
                                units=True,
                                hierarchical=True,
                                print_arrays=False,
@@ -498,7 +498,7 @@ class ExplCompTestCase(unittest.TestCase):
         # logging outputs
         # out_stream - not hierarchical - extras - no print_arrays
         stream = StringIO()
-        prob.model.list_outputs(values=True,
+        prob.model.list_outputs(val=True,
                                 units=True,
                                 shape=True,
                                 bounds=True,
@@ -518,7 +518,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         # Hierarchical
         stream = StringIO()
-        prob.model.list_outputs(values=True,
+        prob.model.list_outputs(val=True,
                                 units=True,
                                 shape=True,
                                 bounds=True,
@@ -568,7 +568,7 @@ class ExplCompTestCase(unittest.TestCase):
         # logging inputs
         # out_stream - not hierarchical - extras - no print_arrays
         stream = StringIO()
-        prob.model.list_inputs(values=True,
+        prob.model.list_inputs(val=True,
                                units=True,
                                hierarchical=False,
                                print_arrays=False,
@@ -581,7 +581,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         # out_stream - hierarchical - extras - no print_arrays
         stream = StringIO()
-        prob.model.list_inputs(values=True,
+        prob.model.list_inputs(val=True,
                                units=True,
                                hierarchical=True,
                                print_arrays=False,
@@ -596,7 +596,7 @@ class ExplCompTestCase(unittest.TestCase):
         # logging outputs
         # out_stream - not hierarchical - extras - no print_arrays
         stream = StringIO()
-        prob.model.list_outputs(values=True,
+        prob.model.list_outputs(val=True,
                                 units=True,
                                 shape=True,
                                 bounds=True,
@@ -614,7 +614,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         # Promoted names - no print arrays
         stream = StringIO()
-        prob.model.list_outputs(values=True,
+        prob.model.list_outputs(val=True,
                                 prom_name=True,
                                 print_arrays=False,
                                 out_stream=stream)
@@ -626,7 +626,7 @@ class ExplCompTestCase(unittest.TestCase):
 
         # Hierarchical - no print arrays
         stream = StringIO()
-        prob.model.list_outputs(values=True,
+        prob.model.list_outputs(val=True,
                                 units=True,
                                 shape=True,
                                 bounds=True,
@@ -665,7 +665,7 @@ class ExplCompTestCase(unittest.TestCase):
             # logging outputs
             # out_stream - not hierarchical - extras - print_arrays
             stream = StringIO()
-            prob.model.list_outputs(values=True,
+            prob.model.list_outputs(val=True,
                                     units=True,
                                     shape=True,
                                     bounds=True,
@@ -686,7 +686,7 @@ class ExplCompTestCase(unittest.TestCase):
 
             # Hierarchical
             stream = StringIO()
-            prob.model.list_outputs(values=True,
+            prob.model.list_outputs(val=True,
                                     units=True,
                                     shape=True,
                                     bounds=True,
@@ -736,7 +736,7 @@ class ExplCompTestCase(unittest.TestCase):
         prob['x'] = np.arange(size)
         prob.run_driver()
 
-        prob.model.list_inputs(values=True,
+        prob.model.list_inputs(val=True,
                                units=True,
                                hierarchical=True,
                                print_arrays=True)
@@ -745,7 +745,7 @@ class ExplCompTestCase(unittest.TestCase):
                           linewidth=75, nanstr='nan', precision=8,
                           suppress=False, threshold=1000, formatter=None):
 
-            prob.model.list_outputs(values=True,
+            prob.model.list_outputs(val=True,
                                     implicit=False,
                                     units=True,
                                     shape=True,
@@ -755,7 +755,7 @@ class ExplCompTestCase(unittest.TestCase):
                                     hierarchical=False,
                                     print_arrays=True)
 
-            prob.model.list_outputs(values=True,
+            prob.model.list_outputs(val=True,
                                     implicit=False,
                                     units=True,
                                     shape=True,
@@ -975,49 +975,49 @@ class ExplCompTestCase(unittest.TestCase):
         prob.run_model()
 
         # Inputs no tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None)
+        inputs = prob.model.list_inputs(val=False, out_stream=None)
         self.assertEqual(sorted(inputs), [
             ('length', {}),
             ('width', {}),
         ])
 
         # Inputs with tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags="tag1")
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags="tag1")
         self.assertEqual(sorted(inputs), [
             ('length', {}),
         ])
 
         # Inputs with multiple tags
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags=["tag1", "tag2"])
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags=["tag1", "tag2"])
         self.assertEqual(sorted(inputs), [
             ('length', {}),
             ('width', {}),
         ])
 
         # Inputs with tag that does not match
-        inputs = prob.model.list_inputs(values=False, out_stream=None, tags="tag3")
+        inputs = prob.model.list_inputs(val=False, out_stream=None, tags="tag3")
         self.assertEqual(sorted(inputs), [])
 
         # Outputs no tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None)
+        outputs = prob.model.list_outputs(val=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
             ('area', {}),
         ])
 
         # Outputs with tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="tag1")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="tag1")
         self.assertEqual(sorted(outputs), [
             ('area', {}),
         ])
 
         # Outputs with multiple tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags=["tag1", "tag3"])
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags=["tag1", "tag3"])
         self.assertEqual(sorted(outputs), [
             ('area', {}),
         ])
 
         # Outputs with tag that does not match
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="tag3")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="tag3")
         self.assertEqual(sorted(outputs), [])
 
     def test_compute_inputs_read_only(self):

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -306,7 +306,7 @@ class ImplicitCompTestCase(unittest.TestCase):
         self.prob.run_model()
 
         # No tags
-        inputs = self.prob.model.list_inputs(values=False, hierarchical=False, out_stream=None)
+        inputs = self.prob.model.list_inputs(val=False, hierarchical=False, out_stream=None)
         self.assertEqual(sorted(inputs), [
             ('comp1.a', {}),
             ('comp1.b', {}),
@@ -317,14 +317,14 @@ class ImplicitCompTestCase(unittest.TestCase):
         ])
 
         # With tag
-        inputs = self.prob.model.list_inputs(values=False, hierarchical=False, out_stream=None, tags='tag_a')
+        inputs = self.prob.model.list_inputs(val=False, hierarchical=False, out_stream=None, tags='tag_a')
         self.assertEqual(sorted(inputs), [
             ('comp1.a', {}),
             ('comp2.a', {}),
         ])
 
         # Wrong tag
-        inputs = self.prob.model.list_inputs(values=False, hierarchical=False, out_stream=None, tags='tag_wrong')
+        inputs = self.prob.model.list_inputs(val=False, hierarchical=False, out_stream=None, tags='tag_wrong')
         self.assertEqual(sorted(inputs), [])
 
     def test_list_inputs_prom_name(self):
@@ -408,7 +408,7 @@ class ImplicitCompTestCase(unittest.TestCase):
         self.prob.run_model()
 
         stream = StringIO()
-        resids = self.prob.model.list_outputs(values=False, residuals=True, hierarchical=False,
+        resids = self.prob.model.list_outputs(val=False, residuals=True, hierarchical=False,
                                               out_stream=stream)
         self.assertEqual(sorted(resids), [
             ('comp1.x', {'resids': [0.]}),
@@ -968,7 +968,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
             def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs=None,
                 discrete_outputs=None):
                 pass
-            
+
         group = om.Group()
 
         group.add_subsystem('px', om.IndepVarComp('x', 77.0))
@@ -1404,23 +1404,23 @@ class ListFeatureTestCase(unittest.TestCase):
 
     def test_for_docs_list_no_values(self):
         # list inputs
-        inputs = prob.model.list_inputs(values=False)
+        inputs = prob.model.list_inputs(val=False)
 
         # list only explicit outputs
-        outputs = prob.model.list_outputs(implicit=False, values=False)
+        outputs = prob.model.list_outputs(implicit=False, val=False)
 
     def test_for_docs_list_includes_excludes(self):
         # list inputs
-        inputs = prob.model.list_inputs(values=False, includes=['*comp2*',])
-        inputs = prob.model.list_inputs(values=False, excludes=['*comp2*',])
+        inputs = prob.model.list_inputs(val=False, includes=['*comp2*',])
+        inputs = prob.model.list_inputs(val=False, excludes=['*comp2*',])
 
         # list only explicit outputs
-        outputs = prob.model.list_outputs(implicit=False, values=False, includes=['*b',])
-        outputs = prob.model.list_outputs(implicit=False, values=False, excludes=['*b',])
+        outputs = prob.model.list_outputs(implicit=False, val=False, includes=['*b',])
+        outputs = prob.model.list_outputs(implicit=False, val=False, excludes=['*b',])
 
     def test_list_no_values(self):
         # list inputs
-        inputs = prob.model.list_inputs(values=False)
+        inputs = prob.model.list_inputs(val=False)
         self.assertEqual([n[0] for n in sorted(inputs)], [
             'sub.comp1.a',
             'sub.comp1.b',
@@ -1461,7 +1461,7 @@ class ListFeatureTestCase(unittest.TestCase):
 
         # list_inputs test
         stream = StringIO()
-        inputs = prob.model.list_inputs(values=False, out_stream=stream)
+        inputs = prob.model.list_inputs(val=False, out_stream=stream)
         text = stream.getvalue()
         self.assertEqual(sorted(inputs), [
             ('sub.comp2.a', {}),

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -119,25 +119,25 @@ class TestIndepVarComp(unittest.TestCase):
         prob.run_model()
 
         # Outputs no tags
-        outputs = prob.model.list_outputs(values=False, out_stream=None)
+        outputs = prob.model.list_outputs(val=False, out_stream=None)
         self.assertEqual(sorted(outputs), [
             ('openmdao:indep_var', {}),
         ])
 
         # Outputs with automatically added indep_var_comp tag
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="openmdao:indep_var")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="openmdao:indep_var")
         self.assertEqual(sorted(outputs), [
             ('openmdao:indep_var', {}),
         ])
 
         # Outputs with tag
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="tag1")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="tag1")
         self.assertEqual(sorted(outputs), [
             ('openmdao:indep_var', {}),
         ])
 
         # Outputs with wrong tag
-        outputs = prob.model.list_outputs(values=False, out_stream=None, tags="tag_wrong")
+        outputs = prob.model.list_outputs(val=False, out_stream=None, tags="tag_wrong")
         self.assertEqual(sorted(outputs), [])
 
     def test_add_output_with_tags(self):

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -251,55 +251,6 @@ class TestSystem(unittest.TestCase):
         outputs = model.list_outputs(excludes=['circuit*'], implicit=False, out_stream=None)
         self.assertEqual(len(outputs), 2)
 
-    def test_list_inputs_outputs_val_deprecation(self):
-        p = Problem()
-        p.model.add_subsystem('comp', ExecComp('b=2*a'), promotes=['a', 'b'])
-        p.setup()
-        p.run_model()
-
-        msg = "<model> <class Group>: The 'values' argument to 'list_inputs()' " \
-              "is deprecated and will be removed in 4.0. Please use 'val' instead."
-
-        with assert_warning(OMDeprecationWarning, msg):
-            inputs = p.model.list_inputs(values=False, out_stream=None)
-        self.assertEqual(inputs, [('comp.a', {})])
-
-        with assert_warning(OMDeprecationWarning, msg):
-            inputs = p.model.list_inputs(values=True, out_stream=None)
-        self.assertEqual(inputs, [('comp.a', {'val': 1})])
-
-        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'."
-        with assert_warning(OMDeprecationWarning, msg):
-            self.assertEqual(inputs[0][1]['value'], 1)
-
-        msg = "<model> <class Group>: The 'values' argument to 'list_outputs()' " \
-              "is deprecated and will be removed in 4.0. Please use 'val' instead."
-
-        with assert_warning(OMDeprecationWarning, msg):
-            outputs = p.model.list_outputs(values=False, out_stream=None)
-        self.assertEqual(outputs, [('comp.b', {})])
-
-        with assert_warning(OMDeprecationWarning, msg):
-            outputs = p.model.list_outputs(values=True, out_stream=None)
-        self.assertEqual(outputs, [('comp.b', {'val': 2})])
-
-        msg = "The metadata key 'value' will be deprecated in 4.0. Please use 'val'."
-        with assert_warning(OMDeprecationWarning, msg):
-            self.assertEqual(outputs[0][1]['value'], 2)
-
-        meta = p.model.get_io_metadata(metadata_keys=('val',))
-        with assert_warning(OMDeprecationWarning, msg):
-            self.assertEqual(meta['comp.a']['value'], 1)
-
-        with assert_warning(OMDeprecationWarning, msg):
-            meta = p.model.get_io_metadata(metadata_keys=('value',))
-        self.assertEqual(meta['comp.a']['val'], 1)
-
-        with assert_warning(OMDeprecationWarning, msg):
-            meta = p.model.get_io_metadata(metadata_keys=('value',))
-        with assert_warning(OMDeprecationWarning, msg):
-            self.assertEqual(meta['comp.a']['value'], 1)
-
     def test_list_inputs_outputs_is_indep_is_des_var(self):
         from openmdao.test_suite.components.sellar_feature import SellarMDA
 

--- a/openmdao/docs/openmdao_book/features/recording/case_reader_data.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_reader_data.ipynb
@@ -493,10 +493,10 @@
    },
    "outputs": [],
    "source": [
-    "assert_near_equal(case_inputs[0][1]['value'], [1.], tolerance=1e-10) # d1.x\n",
-    "assert_near_equal(case_inputs[1][1]['value'], [12.27257053], tolerance=1e-10) # d1.y2\n",
-    "assert_near_equal(case_inputs[2][1]['value'], [5., 2.], tolerance=1e-10) # d1.z\n",
-    "assert_near_equal(case_outputs[0][1]['value'], [25.545485893882876], tolerance=1e-10) # d1.y1"
+    "assert_near_equal(case_inputs[0][1]['val'], [1.], tolerance=1e-10) # d1.x\n",
+    "assert_near_equal(case_inputs[1][1]['val'], [12.27257053], tolerance=1e-10) # d1.y2\n",
+    "assert_near_equal(case_inputs[2][1]['val'], [5., 2.], tolerance=1e-10) # d1.z\n",
+    "assert_near_equal(case_outputs[0][1]['val'], [25.545485893882876], tolerance=1e-10) # d1.y1"
    ]
   },
   {
@@ -623,7 +623,7 @@
    "source": [
     "assert len(inputs) == 1\n",
     "assert inputs[0][0] == 'rect.width'\n",
-    "assert inputs[0][1]['value'] == 60."
+    "assert inputs[0][1]['val'] == 60."
    ]
   },
   {
@@ -654,7 +654,7 @@
    "source": [
     "assert len(outputs) == 1\n",
     "assert outputs[0][0] == 'rect.area'\n",
-    "assert outputs[0][1]['value'] == 6000."
+    "assert outputs[0][1]['val'] == 6000."
    ]
   },
   {
@@ -735,7 +735,7 @@
    "source": [
     "assert len(inputs) == 1\n",
     "assert inputs[0][0] == 'rect.length'\n",
-    "assert inputs[0][1]['value'] == 100."
+    "assert inputs[0][1]['val'] == 100."
    ]
   },
   {
@@ -766,9 +766,9 @@
    "source": [
     "assert len(inputs) == 2\n",
     "assert inputs[0][0] == 'rect.length'\n",
-    "assert inputs[0][1]['value'] == 100.\n",
+    "assert inputs[0][1]['val'] == 100.\n",
     "assert inputs[1][0] == 'rect.width'\n",
-    "assert inputs[1][1]['value'] == 60."
+    "assert inputs[1][1]['val'] == 60."
    ]
   },
   {
@@ -799,7 +799,7 @@
    "source": [
     "assert len(outputs) == 1\n",
     "assert outputs[0][0] == 'rect.area'\n",
-    "assert outputs[0][1]['value'] == 6000."
+    "assert outputs[0][1]['val'] == 6000."
    ]
   },
   {
@@ -1233,7 +1233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.11.0"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/loading_cases.ipynb
@@ -109,11 +109,11 @@
     "\n",
     "inputs = case.list_inputs(val=True,out_stream=None)\n",
     "for name, val in inputs:\n",
-    "    assert_near_equal(val['value'], model._inputs[name])\n",
+    "    assert_near_equal(val['val'], model._inputs[name])\n",
     "\n",
     "outputs = case.list_outputs(val=True, out_stream=None)\n",
     "for name, val in outputs:\n",
-    "    assert_near_equal(val['value'], model._outputs[name])"
+    "    assert_near_equal(val['val'], model._outputs[name])"
    ]
   },
   {

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -16,7 +16,6 @@ from openmdao.utils.variable_table import write_var_table
 from openmdao.utils.general_utils import make_set, match_prom_or_abs
 from openmdao.utils.units import unit_conversion, simplify_unit
 from openmdao.recorders.sqlite_recorder import format_version as current_version
-from openmdao.utils.om_warnings import issue_warning
 
 _AMBIGOUS_PROM_NAME = object()
 
@@ -407,7 +406,6 @@ class Case(object):
                     is_indep_var=None,
                     is_design_var=None,
                     out_stream=_DEFAULT_OUT_STREAM,
-                    values=None,
                     print_min=False,
                     print_max=False):
         """
@@ -455,8 +453,6 @@ class Case(object):
         out_stream : file-like object
             Where to send human readable output. Default is sys.stdout.
             Set to None to suppress.
-        values : bool, optional
-            This argument has been deprecated and will be removed in 4.0.
         print_min : bool, optional
             When true, if the input value is an array, print its smallest value.
         print_max : bool, optional
@@ -472,14 +468,6 @@ class Case(object):
 
         # string to display when an attribute is not available (e.g. for a discrete)
         NA = 'Unavailable'
-
-        if values is not None:
-            issue_warning("'value' is deprecated and will be removed in 4.0. "
-                          "Please index in using 'val'")
-        elif not val and values:
-            values = True
-        else:
-            values = val
 
         if isinstance(includes, str):
             includes = [includes, ]
@@ -527,18 +515,17 @@ class Case(object):
                     elif is_design_var is False and src_name_prom in des_vars:
                         continue
 
-                val = self.inputs[var_name]
+                var_val = self.inputs[var_name]
 
                 var_meta = {}
-                if values:
-                    var_meta['val'] = val
-                    var_meta['value'] = val
-                    if isinstance(val, np.ndarray):
+                if val:
+                    var_meta['val'] = var_val
+                    if isinstance(var_val, np.ndarray):
                         if print_min:
-                            var_meta['min'] = np.round(np.min(val), np_precision)
+                            var_meta['min'] = np.round(np.min(var_val), np_precision)
 
                         if print_max:
-                            var_meta['max'] = np.round(np.max(val), np_precision)
+                            var_meta['max'] = np.round(np.max(var_val), np_precision)
 
                 if prom_name:
                     var_meta['prom_name'] = var_name_prom
@@ -546,7 +533,7 @@ class Case(object):
                     var_meta['units'] = meta.get('units', NA)
                 if shape:
                     try:
-                        var_meta['shape'] = val.shape
+                        var_meta['shape'] = var_val.shape
                     except AttributeError:
                         var_meta['shape'] = NA
                 if desc:
@@ -584,7 +571,6 @@ class Case(object):
                      is_design_var=None,
                      list_autoivcs=False,
                      out_stream=_DEFAULT_OUT_STREAM,
-                     values=None,
                      print_min=False,
                      print_max=False):
         """
@@ -667,14 +653,6 @@ class Case(object):
         # string to display when an attribute is not available (e.g. for a discrete)
         NA = 'Unavailable'
 
-        if values is not None:
-            issue_warning("'value' is deprecated and will be removed in 4.0. "
-                          "Please index in using 'val'")
-        elif not val and values:
-            values = True
-        else:
-            values = val
-
         if isinstance(includes, str):
             includes = [includes, ]
 
@@ -727,18 +705,17 @@ class Case(object):
             else:
                 resids = 'Not Recorded'
 
-            val = self.outputs[var_name]
+            var_val = self.outputs[var_name]
 
             var_meta = {}
-            if values:
-                var_meta['val'] = val
-                var_meta['value'] = val
-                if isinstance(val, np.ndarray):
+            if val:
+                var_meta['val'] = var_val
+                if isinstance(var_val, np.ndarray):
                     if print_min:
-                        var_meta['min'] = np.round(np.min(val), np_precision)
+                        var_meta['min'] = np.round(np.min(var_val), np_precision)
 
                     if print_max:
-                        var_meta['max'] = np.round(np.max(val), np_precision)
+                        var_meta['max'] = np.round(np.max(var_val), np_precision)
             if prom_name:
                 var_meta['prom_name'] = var_name_prom
             if residuals:
@@ -747,7 +724,7 @@ class Case(object):
                 var_meta['units'] = meta.get('units', NA)
             if shape:
                 try:
-                    var_meta['shape'] = val.shape
+                    var_meta['shape'] = var_val.shape
                 except AttributeError:
                     var_meta['shape'] = NA
             if bounds:

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -634,8 +634,6 @@ class Case(object):
         out_stream : file-like
             Where to send human readable output. Default is sys.stdout.
             Set to None to suppress.
-        values : bool, optional
-            This argument has been deprecated and will be removed in 4.0.
         print_min : bool, optional
             When true, if the output value is an array, print its smallest value.
         print_max : bool, optional

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -1052,7 +1052,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         system_cases = cr.list_cases('root.d1', out_stream=None)
         case = cr.get_case(system_cases[-1])
 
-        outputs = case.list_outputs(explicit=True, implicit=True, values=True,
+        outputs = case.list_outputs(explicit=True, implicit=True, val=True,
                                     residuals=True, residuals_tol=None,
                                     units=True, shape=True, bounds=True, desc=True,
                                     scaling=True, hierarchical=True, print_arrays=True,
@@ -1236,7 +1236,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         case = cr.get_case(system_cases[-1])
 
-        inputs = case.list_inputs(values=True, desc=True, out_stream=None)
+        inputs = case.list_inputs(val=True, desc=True, out_stream=None)
 
         for name, meta in inputs:
             expected = expected_inputs_case[name]
@@ -2077,7 +2077,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.run_model()
 
         # make sure the loaded unit strings are compatible with `convert_units`
-        outputs = case.list_outputs(explicit=True, implicit=True, values=True,
+        outputs = case.list_outputs(explicit=True, implicit=True, val=True,
                                     units=True, shape=True, out_stream=None)
         meta = {}
         for name, vals in outputs:
@@ -2110,8 +2110,8 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
-        inputs_before = prob.model.list_inputs(values=True, units=True, out_stream=None)
-        outputs_before = prob.model.list_outputs(values=True, units=True, out_stream=None)
+        inputs_before = prob.model.list_inputs(val=True, units=True, out_stream=None)
+        outputs_before = prob.model.list_outputs(val=True, units=True, out_stream=None)
 
         cr = om.CaseReader(self.filename)
 
@@ -2136,8 +2136,8 @@ class TestSqliteCaseReader(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
-        inputs_after = prob.model.list_inputs(values=True, units=True, out_stream=None)
-        outputs_after = prob.model.list_outputs(values=True, units=True, out_stream=None)
+        inputs_after = prob.model.list_inputs(val=True, units=True, out_stream=None)
+        outputs_after = prob.model.list_outputs(val=True, units=True, out_stream=None)
 
         iter_count_after = driver.iter_count
 
@@ -2972,7 +2972,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         # list inputs
         # out_stream - not hierarchical - extras - no print_arrays
         stream = StringIO()
-        case.list_inputs(values=True,
+        case.list_inputs(val=True,
                          units=True,
                          prom_name=True,
                          hierarchical=False,
@@ -2987,7 +2987,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # out_stream - hierarchical - extras - no print_arrays
         stream = StringIO()
-        case.list_inputs(values=True,
+        case.list_inputs(val=True,
                          units=True,
                          shape=True,
                          hierarchical=True,
@@ -3003,7 +3003,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         # list outputs
         # out_stream - not hierarchical - extras - no print_arrays
         stream = StringIO()
-        case.list_outputs(values=True,
+        case.list_outputs(val=True,
                           units=True,
                           shape=True,
                           bounds=True,
@@ -3022,7 +3022,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # Promoted names - no print arrays
         stream = StringIO()
-        case.list_outputs(values=True,
+        case.list_outputs(val=True,
                           prom_name=True,
                           print_arrays=False,
                           out_stream=stream)
@@ -3034,7 +3034,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         # Hierarchical - no print arrays
         stream = StringIO()
-        case.list_outputs(values=True,
+        case.list_outputs(val=True,
                           units=True,
                           shape=True,
                           bounds=True,
@@ -3073,7 +3073,7 @@ class TestSqliteCaseReader(unittest.TestCase):
             # list outputs
             # out_stream - not hierarchical - extras - print_arrays
             stream = StringIO()
-            case.list_outputs(values=True,
+            case.list_outputs(val=True,
                               units=True,
                               shape=True,
                               bounds=True,
@@ -3095,7 +3095,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
             # Hierarchical
             stream = StringIO()
-            case.list_outputs(values=True,
+            case.list_outputs(val=True,
                               units=True,
                               shape=True,
                               bounds=True,

--- a/openmdao/test_suite/test_examples/test_betz_limit.py
+++ b/openmdao/test_suite/test_examples/test_betz_limit.py
@@ -201,8 +201,8 @@ class TestBetzLimit(unittest.TestCase):
 
         prob.run_driver()
 
-        prob.model.list_inputs(values = False, hierarchical=False)
-        prob.model.list_outputs(values = False, hierarchical=False)
+        prob.model.list_inputs(val=False, hierarchical=False)
+        prob.model.list_outputs(val=False, hierarchical=False)
 
         # minimum value
         assert_near_equal(prob['a_disk.Cp'], 16./27., 1e-4)


### PR DESCRIPTION
### Summary

The ability to use the deprecated `value` keyword has been removed for the OpenMDAO 3.26.0 release in:
- ExecComp()
- System.get_io_metadata()
- System.list_inputs()
- System.list_outputs()
- Case.list_inputs()
- Case.list_outputs()


Users are expected to have changed to the use of `val` by this point, as a deprecation has been in place for several releases.

### Related Issues

- Resolves #2753 

### Backwards incompatibilities

It is now required to use the `val` keyword in places where the deprecated `value` keyword was previously allowed.

### New Dependencies

None
