### PR TITLE
Remove deprecated simple_warning() function

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -176,7 +176,7 @@ class Group(System):
     _order_set : bool
         Flag to check if set_order has been called.
     _auto_ivc_warnings : list
-        List of Auto IVC warnings to be raised later with simple_warnings.
+        List of Auto IVC warnings to be raised later.
     _shapes_graph : nx.Graph
         Dynamic shape dependency graph, or None.
     _shape_knowns : set

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -43,24 +43,6 @@ def _convert_auto_ivc_to_conn_name(conns_dict, name):
             return key
 
 
-def simple_warning(msg, category=UserWarning, stacklevel=2):
-    """
-    Display a simple warning message without the annoying extra line showing the warning call.
-
-    Parameters
-    ----------
-    msg : str
-        The warning message.
-    category : class
-        The warning class.
-    stacklevel : int
-        Number of levels up the stack to identify as the warning location.
-    """
-    warn_deprecation('simple_warning is deprecated. '
-                     'Use openmdao.utils.om_warnings.issue_warning instead.')
-    issue_warning(msg, stacklevel=stacklevel, category=category)
-
-
 def ensure_compatible(name, value, shape=None, indices=None):
     """
     Make value compatible with the specified shape or the shape of indices.


### PR DESCRIPTION
### Summary

Remove deprecated `simple_warning()` in favor of `issue_warning()`.

Users are expected to have changed to the use of `issue_warning()` by this point, as a deprecation has been in place for several releases.

### Related Issues

- Resolves #2754

### Backwards incompatibilities

None

### New Dependencies

None
