### PR TITLE
Fixing Out of Bounds Error in Serial Derivative Consistency Check

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1702,7 +1702,7 @@ class Component(System):
 
         if self._serial_idxs is None:
             ranges = defaultdict(list)
-            output_len = 0 if self.is_explicit() else len(self._outputs) 
+            output_len = 0 if self.is_explicit() else len(self._outputs)
             for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
                 if dist_sizes is None:  # not distributed
                     if offset != end:

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1702,10 +1702,14 @@ class Component(System):
 
         if self._serial_idxs is None:
             ranges = defaultdict(list)
+            globaloffset = 0
             for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
-                if dist_sizes is None:  # not distributed
+                if name.split(".")[-1] in self._var_rel_names["output"]:
+                    globaloffset += (end - offset)
+                elif dist_sizes is None:  # not distributed
                     if offset != end:
-                        ranges[vec].append(range(offset, end))
+                        ranges[vec].append(range(offset - globaloffset, end - globaloffset))
+
 
             self._serial_idxs = []
             for vec, rlist in ranges.items():

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1702,13 +1702,18 @@ class Component(System):
 
         if self._serial_idxs is None:
             ranges = defaultdict(list)
-            globaloffset = 0
+            output_len = 0
             for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
-                if name.split(".")[-1] in self._var_rel_names["output"]:
-                    globaloffset += (end - offset)
+                if vec is self._outputs:
+                    output_len = len(self._outputs)
+                    break
+            for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
                 if dist_sizes is None:  # not distributed
                     if offset != end:
-                        ranges[vec].append(range(offset - globaloffset, end - globaloffset))
+                        if vec is self._outputs:
+                            ranges[vec].append(range(offset, end))
+                        else:
+                            ranges[vec].append(range(offset - output_len, end - output_len))
 
             self._serial_idxs = []
             for vec, rlist in ranges.items():

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1706,10 +1706,9 @@ class Component(System):
             for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
                 if name.split(".")[-1] in self._var_rel_names["output"]:
                     globaloffset += (end - offset)
-                elif dist_sizes is None:  # not distributed
+                if dist_sizes is None:  # not distributed
                     if offset != end:
                         ranges[vec].append(range(offset - globaloffset, end - globaloffset))
-
 
             self._serial_idxs = []
             for vec, rlist in ranges.items():

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1702,11 +1702,7 @@ class Component(System):
 
         if self._serial_idxs is None:
             ranges = defaultdict(list)
-            output_len = 0
-            for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
-                if vec is self._outputs:
-                    output_len = len(self._outputs)
-                    break
+            output_len = 0 if self.is_explicit() else len(self._outputs) 
             for name, offset, end, vec, slc, dist_sizes in self._jac_wrt_iter():
                 if dist_sizes is None:  # not distributed
                     if offset != end:

--- a/openmdao/core/tests/test_serial_implicit_deriv_consist.py
+++ b/openmdao/core/tests/test_serial_implicit_deriv_consist.py
@@ -1,0 +1,140 @@
+"""Test serial derivatives in implicit group when running in parallel"""
+import unittest
+
+import numpy as np
+from mpi4py import MPI
+
+import openmdao.api as om
+from openmdao.utils.assert_utils import assert_near_equal
+
+
+dist_shape = 20 if MPI.COMM_WORLD.rank > 0 else 2
+
+
+class SerialImplicitDerivConsist(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_serialImplicitDerivConsist(self):
+        class MixedSerialInComp(om.ExplicitComponent):
+            def setup(self):
+                self.add_input("aoa_serial")
+                self.add_output(
+                    "flow_state_dist", shape=dist_shape, distributed=True
+                )
+
+            def compute(self, inputs, outputs):
+                outputs["flow_state_dist"][:] = 0.5 * inputs["aoa_serial"]
+
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                if mode == "fwd":
+                    if "flow_state_dist" in d_outputs:
+                        if "aoa_serial" in d_inputs:
+                            d_outputs["flow_state_dist"] += (
+                                0.5 * d_inputs["aoa_serial"]
+                            )
+                if mode == "rev":
+                    if "flow_state_dist" in d_outputs:
+                        if "aoa_serial" in d_inputs:
+                            d_inputs["aoa_serial"] += 0.5 * self.comm.allreduce(
+                                np.sum(d_outputs["flow_state_dist"])
+                            )
+
+        class MixedSerialOutComp(om.ExplicitComponent):
+            def setup(self):
+                self.add_input("aoa_serial")
+                self.add_input("force_dist", shape=dist_shape, distributed=True)
+                self.add_output("lift_serial")
+
+            def compute(self, inputs, outputs):
+                outputs["lift_serial"] = 2.0 * inputs[
+                    "aoa_serial"
+                ] + self.comm.allreduce(3.0 * np.sum(inputs["force_dist"]))
+
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                if mode == "fwd":
+                    if "lift_serial" in d_outputs:
+                        if "aoa_serial" in d_inputs:
+                            d_outputs["lift_serial"] += (
+                                2.0 * d_inputs["aoa_serial"]
+                            )
+                        if "force_dist" in d_inputs:
+                            d_outputs[
+                                "lift_serial"
+                            ] += 3.0 * self.comm.allreduce(
+                                np.sum(d_inputs["force_dist"])
+                            )
+                if mode == "rev":
+                    if "lift_serial" in d_outputs:
+                        if "aoa_serial" in d_inputs:
+                            d_inputs["aoa_serial"] += (
+                                2.0 * d_outputs["lift_serial"]
+                            )
+                        if "force_dist" in d_inputs:
+                            d_inputs["force_dist"] += (
+                                3.0 * d_outputs["lift_serial"]
+                            )
+
+        class DistComp(om.ImplicitComponent):
+            def setup(self):
+                self.add_output(
+                    "force_dist", shape=dist_shape, distributed=True
+                )
+                self.add_input(
+                    "flow_state_dist", shape=dist_shape, distributed=True
+                )
+
+                self.add_input("aoa_serial")
+
+            def solve_nonlinear(self, inputs, outputs):
+                outputs["force_dist"] = np.linspace(0, dist_shape, dist_shape)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals["force_dist"] = outputs["force_dist"] - np.linspace(
+                    0, dist_shape, dist_shape
+                )
+
+            def apply_linear(
+                self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode
+            ):
+                if mode == "fwd":
+                    if "force_dist" in d_outputs:
+                        if "flow_state_dist" in d_inputs:
+                            d_outputs["force_dist"] += 1.0
+                        if "aoa_serial" in d_inputs:
+                            d_outputs["force_dist"] += 0.0
+                if mode == "rev":
+                    if "force_dist" in d_outputs:
+                        if "flow_state_dist" in d_inputs:
+                            d_inputs["flow_state_dist"] += 1.0
+                        if "aoa_serial" in d_inputs:
+                            d_inputs["aoa_serial"] += 0.0
+
+        p = om.Problem()
+
+        ivc = om.IndepVarComp()
+        ivc.add_output("dv", val=1.0)
+
+        p.model.add_subsystem("ivc", ivc)
+        p.model.add_subsystem("mixed_in_comp", MixedSerialInComp())
+        p.model.add_subsystem("dist_comp", DistComp())
+        p.model.add_subsystem("mixed_out_comp", MixedSerialOutComp())
+        p.model.connect("ivc.dv", "mixed_in_comp.aoa_serial")
+        p.model.connect(
+            "mixed_in_comp.flow_state_dist", "dist_comp.flow_state_dist"
+        )
+        p.model.connect("ivc.dv", "dist_comp.aoa_serial")
+        p.model.connect("ivc.dv", "mixed_out_comp.aoa_serial")
+        p.model.connect("dist_comp.force_dist", "mixed_out_comp.force_dist")
+
+        p.model.add_design_var("ivc.dv")
+        p.model.add_objective("mixed_out_comp.lift_serial")
+        p.setup(mode="rev")
+        p.run_model()
+        totals = p.check_totals()
+        for var, err in totals.items():
+            rel_err = err["rel error"]
+            assert_near_equal(rel_err.forward, 0.0, 5e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/core/tests/test_serial_implicit_deriv_consist.py
+++ b/openmdao/core/tests/test_serial_implicit_deriv_consist.py
@@ -2,135 +2,73 @@
 import unittest
 
 import numpy as np
-from mpi4py import MPI
-
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
-
-
-dist_shape = 20 if MPI.COMM_WORLD.rank > 0 else 2
 
 
 class SerialImplicitDerivConsist(unittest.TestCase):
     N_PROCS = 2
 
     def test_serialImplicitDerivConsist(self):
-        class MixedSerialInComp(om.ExplicitComponent):
+        class Imp(om.ImplicitComponent):
             def setup(self):
-                self.add_input("aoa_serial")
+                self.add_input("x", shape_by_conn=True, distributed=True)
+                self.add_input("s0")
+                self.add_input("s1")
                 self.add_output(
-                    "flow_state_dist", shape=dist_shape, distributed=True
+                    "y", shape=5 if self.comm.rank == 0 else 0, distributed=True
                 )
-
-            def compute(self, inputs, outputs):
-                outputs["flow_state_dist"][:] = 0.5 * inputs["aoa_serial"]
-
-            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
-                if mode == "fwd":
-                    if "flow_state_dist" in d_outputs:
-                        if "aoa_serial" in d_inputs:
-                            d_outputs["flow_state_dist"] += (
-                                0.5 * d_inputs["aoa_serial"]
-                            )
-                if mode == "rev":
-                    if "flow_state_dist" in d_outputs:
-                        if "aoa_serial" in d_inputs:
-                            d_inputs["aoa_serial"] += 0.5 * self.comm.allreduce(
-                                np.sum(d_outputs["flow_state_dist"])
-                            )
-
-        class MixedSerialOutComp(om.ExplicitComponent):
-            def setup(self):
-                self.add_input("aoa_serial")
-                self.add_input("force_dist", shape=dist_shape, distributed=True)
-                self.add_output("lift_serial")
-
-            def compute(self, inputs, outputs):
-                outputs["lift_serial"] = 2.0 * inputs[
-                    "aoa_serial"
-                ] + self.comm.allreduce(3.0 * np.sum(inputs["force_dist"]))
-
-            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
-                if mode == "fwd":
-                    if "lift_serial" in d_outputs:
-                        if "aoa_serial" in d_inputs:
-                            d_outputs["lift_serial"] += (
-                                2.0 * d_inputs["aoa_serial"]
-                            )
-                        if "force_dist" in d_inputs:
-                            d_outputs[
-                                "lift_serial"
-                            ] += 3.0 * self.comm.allreduce(
-                                np.sum(d_inputs["force_dist"])
-                            )
-                if mode == "rev":
-                    if "lift_serial" in d_outputs:
-                        if "aoa_serial" in d_inputs:
-                            d_inputs["aoa_serial"] += (
-                                2.0 * d_outputs["lift_serial"]
-                            )
-                        if "force_dist" in d_inputs:
-                            d_inputs["force_dist"] += (
-                                3.0 * d_outputs["lift_serial"]
-                            )
-
-        class DistComp(om.ImplicitComponent):
-            def setup(self):
-                self.add_output(
-                    "force_dist", shape=dist_shape, distributed=True
-                )
-                self.add_input(
-                    "flow_state_dist", shape=dist_shape, distributed=True
-                )
-
-                self.add_input("aoa_serial")
-
-            def solve_nonlinear(self, inputs, outputs):
-                outputs["force_dist"] = np.linspace(0, dist_shape, dist_shape)
 
             def apply_nonlinear(self, inputs, outputs, residuals):
-                residuals["force_dist"] = outputs["force_dist"] - np.linspace(
-                    0, dist_shape, dist_shape
+                residuals["y"] = outputs["y"] - (
+                    np.sum(inputs["x"]) + inputs["s0"] + inputs["s1"]
                 )
+
+            def solve_nonlinear(self, inputs, outputs):
+                outputs["y"] = np.sum(inputs["x"]) + inputs["s0"] + inputs["s1"]
 
             def apply_linear(
                 self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode
             ):
-                if mode == "fwd":
-                    if "force_dist" in d_outputs:
-                        if "flow_state_dist" in d_inputs:
-                            d_outputs["force_dist"] += 1.0
-                        if "aoa_serial" in d_inputs:
-                            d_outputs["force_dist"] += 0.0
                 if mode == "rev":
-                    if "force_dist" in d_outputs:
-                        if "flow_state_dist" in d_inputs:
-                            d_inputs["flow_state_dist"] += 1.0
-                        if "aoa_serial" in d_inputs:
-                            d_inputs["aoa_serial"] += 0.0
+                    if "y" in d_residuals:
+                        if "x" in d_inputs:
+                            d_inputs["x"] = -np.sum(d_residuals["y"])
+                        if "s0" in d_inputs:
+                            d_inputs["s0"] = self.comm.allreduce(
+                                -np.sum(d_residuals["y"])
+                            )
+                        if "s1" in d_inputs:
+                            d_inputs["s1"] = self.comm.allreduce(
+                                -np.sum(d_residuals["y"])
+                            )
+                        if "y" in d_outputs:
+                            d_outputs["y"] = d_residuals["y"]
 
-        p = om.Problem()
+        class Exp(om.ExplicitComponent):
+            def setup(self):
+                self.add_input("y", distributed=True, shape_by_conn=True)
+                self.add_output("total")
 
-        ivc = om.IndepVarComp()
-        ivc.add_output("dv", val=1.0)
+            def compute(self, inputs, outputs):
+                outputs["total"] = self.comm.allreduce(np.sum(inputs["y"]))
 
-        p.model.add_subsystem("ivc", ivc)
-        p.model.add_subsystem("mixed_in_comp", MixedSerialInComp())
-        p.model.add_subsystem("dist_comp", DistComp())
-        p.model.add_subsystem("mixed_out_comp", MixedSerialOutComp())
-        p.model.connect("ivc.dv", "mixed_in_comp.aoa_serial")
-        p.model.connect(
-            "mixed_in_comp.flow_state_dist", "dist_comp.flow_state_dist"
-        )
-        p.model.connect("ivc.dv", "dist_comp.aoa_serial")
-        p.model.connect("ivc.dv", "mixed_out_comp.aoa_serial")
-        p.model.connect("dist_comp.force_dist", "mixed_out_comp.force_dist")
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                if mode == "rev":
+                    d_inputs["y"] += d_outputs["total"]
 
-        p.model.add_design_var("ivc.dv")
-        p.model.add_objective("mixed_out_comp.lift_serial")
-        p.setup(mode="rev")
-        p.run_model()
-        totals = p.check_totals()
+        prob = om.Problem()
+        ivc = prob.model.add_subsystem("ivc", om.IndepVarComp(), promotes=["*"])
+        ivc.add_output("x", val=1, distributed=True)
+        ivc.add_output("s0", val=2.0)
+        ivc.add_output("s1", val=3.0)
+
+        prob.model.add_subsystem("Imp", Imp(), promotes=["*"])
+        prob.model.add_subsystem("Exp", Exp(), promotes=["*"])
+
+        prob.setup(mode="rev")
+        prob.run_model()
+        totals = prob.check_totals(of="total", wrt="s0")
         for var, err in totals.items():
             rel_err = err["rel error"]
             assert_near_equal(rel_err.forward, 0.0, 5e-3)

--- a/openmdao/core/tests/test_serial_implicit_deriv_consist.py
+++ b/openmdao/core/tests/test_serial_implicit_deriv_consist.py
@@ -4,8 +4,15 @@ import unittest
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.mpi import MPI  # MPI will be None here if MPI is not active
+
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
 
 
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class SerialImplicitDerivConsist(unittest.TestCase):
     N_PROCS = 2
 


### PR DESCRIPTION
### Summary

For specific scenarios, we found that OpenMDAO was throwing an out of bounds error in the new serial derivative consistency check. This came up for components that had several serial and distributed inputs and outputs. When running `check_totals()` in parallel we would run into errors such as:

```
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/system.py", line 2967, in _call_user_function
    self.gen.throw(typ, value, traceback)
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/system.py", line 2967, in _call_user_function
    raise err_type(
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/system.py", line 2961, in _call_user_function
    raise err_type(
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/system.py", line 2961, in _call_user_function
    yield
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/implicitcomponent.py", line 265, in _apply_linear
    yield
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/implicitcomponent.py", line 265, in _apply_linear
    self._apply_linear_wrapper(self._inputs, self._outputs,
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/implicitcomponent.py", line 217, in _apply_linear_wrapper
    self._apply_linear_wrapper(self._inputs, self._outputs,
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/implicitcomponent.py", line 217, in _apply_linear_wrapper
    self._check_consistent_serial_dinputs(nzdresids)
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/component.py", line 1723, in _check_consistent_serial_dinputs
    self._check_consistent_serial_dinputs(nzdresids)
  File "/home/bpacini/MDOLabCodes/repos/OpenMDAO/openmdao/core/component.py", line 1723, in _check_consistent_serial_dinputs
    result = inconsistent_across_procs(self.comm, v.asarray()[inds])
IndexError: 'cruise.coupling.solver' <class DAFoamSolver>: Error calling apply_linear(), index 16808 is out of bounds for axis 0 with size 5357
    result = inconsistent_across_procs(self.comm, v.asarray()[inds])
IndexError: 'cruise.coupling.solver' <class DAFoamSolver>: Error calling apply_linear(), index 16367 is out of bounds for axis 0 with size 5027
Finalising parallel run
Finalising parallel run
```

Digging into this function it seems that the search for indices is done on a vector that includes both the inputs AND outputs, but the check is later done on vectors of either the inputs OR the outputs. In our case, our input was at the end of the combined input and output vector so it would be significantly out of bounds of the input-only vector.

I am not sure if this fix is the best approach or if it is the intended behavior, but it fixes our issues and the serial derivative consistency check passes.

### Related Issues

This does not resolve any issue on the repo, though it is related to POEM 75 (#2769) which that implemented in PR #2751.

Edit:
- Resolves: #2840

### Backwards incompatibilities

As far as I can tell, none.

### New Dependencies

None
