### PR TITLE
Refactor for complex step around Newton.

### DIFF
--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -203,8 +203,8 @@ class BalanceComp(ImplicitComponent):
             lhs = inputs[lhs_name]
             rhs = inputs[rhs_name]
 
-            _scale_factor = np.ones((rhs.shape))
-            _dscale_drhs = np.zeros((rhs.shape))
+            _scale_factor = np.ones((rhs.shape), dtype=rhs.dtype)
+            _dscale_drhs = np.zeros((rhs.shape), dtype=rhs.dtype)
 
             if options['normalize']:
                 # Indices where the rhs is near zero or not near zero

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2685,10 +2685,10 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
 
                     if directional:
                         out_buffer.write(f"    Directional {fd_opts['method'].upper()}"
-                                         " Derivative (J{fd_opts['method']})\n{fd}\n")
+                                         f" Derivative (J{fd_opts['method']})\n{fd}\n")
                     else:
                         out_buffer.write(f"    Raw {fd_opts['method'].upper()}"
-                                         " Derivative (J{fd_opts['method']})\n{fd}\n")
+                                         f" Derivative (J{fd_opts['method']})\n{fd}\n")
 
                     out_buffer.write(' -' * 30 + '\n')
 

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -1426,7 +1426,7 @@ class TestGroupComplexStep(unittest.TestCase):
         assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
         assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-6)
 
-    def test_subbed_newton_gs(self):
+    def test_subbed_newton_assembled_csc(self):
 
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
         class SellarDerivatives(om.Group):
@@ -1456,14 +1456,12 @@ class TestGroupComplexStep(unittest.TestCase):
                 con2.declare_partials(of='*', wrt='*', method='cs')
 
                 self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
-                self.linear_solver = om.LinearBlockGS()
-                self.linear_solver.options['maxiter'] = 25
-                self.linear_solver.options['atol'] = 1e-16
+                self.linear_solver = om.DirectSolver(assemble_jac=False)
 
         prob = om.Problem()
         prob.model = SellarDerivatives()
 
-        prob.setup()
+        prob.setup(force_alloc_complex=True)
 
         prob.model.approx_totals(method='cs')
 
@@ -1473,67 +1471,14 @@ class TestGroupComplexStep(unittest.TestCase):
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_near_equal(J['obj', 'x'][0][0], 2.958960774, 1.0e-6)
-        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_near_equal(J['con1', 'x'][0][0], -0.9589613073511289, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-8)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-8)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-8)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-8)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-8)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-8)
 
-    def test_subbed_newton_gs_csc_external_mtx(self):
-
-        from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
-        class SellarDerivatives(om.Group):
-
-            def setup(self):
-                self.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
-                self.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
-
-                self.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
-                self.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
-                sub = self.add_subsystem('sub', om.Group(), promotes=['*'])
-
-                sub.linear_solver = om.DirectSolver(assemble_jac=True)
-                sub.options['assembled_jac_type'] = 'csc'
-
-                obj = sub.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)', obj=0.0,
-                                                         x=0.0, z=np.array([0.0, 0.0]), y1=0.0, y2=0.0),
-                                  promotes=['obj', 'x', 'z', 'y1', 'y2'])
-
-                con1 = sub.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1', con1=0.0, y1=0.0),
-                                  promotes=['con1', 'y1'])
-                con2 = sub.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0', con2=0.0, y2=0.0),
-                                  promotes=['con2', 'y2'])
-                obj.declare_partials(of='*', wrt='*', method='cs')
-                con1.declare_partials(of='*', wrt='*', method='cs')
-                con2.declare_partials(of='*', wrt='*', method='cs')
-
-                self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
-                self.linear_solver = om.LinearBlockGS()
-                self.linear_solver.options['maxiter'] = 25
-                self.linear_solver.options['atol'] = 1e-16
-
-        prob = om.Problem()
-        prob.model = SellarDerivatives()
-
-        prob.setup()
-
-        prob.model.approx_totals(method='cs')
-
-        prob.run_model()
-
-        wrt = ['z', 'x']
-        of = ['obj', 'con1', 'con2']
-
-        J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_near_equal(J['obj', 'x'][0][0], 2.958960774, 1.0e-6)
-        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_near_equal(J['con1', 'x'][0][0], -0.9589613073511289, 1.0e-6)
-
-    def test_subbed_newton_gs_dense_external_mtx(self):
+    def test_subbed_newton_assembled_dense(self):
 
         from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives
         class SellarDerivatives(om.Group):
@@ -1563,14 +1508,12 @@ class TestGroupComplexStep(unittest.TestCase):
                 con2.declare_partials(of='*', wrt='*', method='cs')
 
                 self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
-                self.linear_solver = om.LinearBlockGS()
-                self.linear_solver.options['maxiter'] = 25
-                self.linear_solver.options['atol'] = 1e-16
+                self.linear_solver = om.DirectSolver(assemble_jac=False)
 
         prob = om.Problem()
         prob.model = SellarDerivatives()
 
-        prob.setup()
+        prob.setup(force_alloc_complex=True)
 
         prob.model.approx_totals(method='cs')
 
@@ -1580,12 +1523,12 @@ class TestGroupComplexStep(unittest.TestCase):
         of = ['obj', 'con1', 'con2']
 
         J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-6)
-        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-6)
-        assert_near_equal(J['obj', 'x'][0][0], 2.958960774, 1.0e-6)
-        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-6)
-        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-6)
-        assert_near_equal(J['con1', 'x'][0][0], -0.9589613073511289, 1.0e-6)
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, 1.0e-8)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, 1.0e-8)
+        assert_near_equal(J['obj', 'x'][0][0], 2.98061391, 1.0e-8)
+        assert_near_equal(J['con1', 'z'][0][0], -9.61002186, 1.0e-8)
+        assert_near_equal(J['con1', 'z'][0][1], -0.78449158, 1.0e-8)
+        assert_near_equal(J['con1', 'x'][0][0], -0.98061448, 1.0e-8)
 
     def test_newton_with_krylov_solver(self):
         # Basic sellar test.

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -3552,7 +3552,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
         prob.run_model()
 
-        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs', out_stream=None)
+        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs')
 
         for key, val in totals.items():
             assert_near_equal(val['rel error'][0], 0.0, 3e-8)

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -3413,7 +3413,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
     def test_cs_around_newton_new_method(self):
         # The old method of nudging the Newton and forcing it to reconverge could not achieve the
-        # same accuracy on this model.
+        # same accuracy on this model. (1e8 vs 1e12)
 
         class SellarDerivatives(om.Group):
 

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -3598,7 +3598,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.model.linear_solver = om.DirectSolver(assemble_jac=True)
         prob.run_model()
 
-        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs')
+        totals = prob.check_totals(of=['obj', 'con1'], wrt=['x', 'z'], method='cs', out_stream=None)
 
         for key, val in totals.items():
             assert_near_equal(val['rel error'][0], 0.0, 3e-8)

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -3411,6 +3411,52 @@ class TestProblemCheckTotals(unittest.TestCase):
         for key, val in totals.items():
             assert_near_equal(val['rel error'][0], 0.0, 1e-10)
 
+    def test_cs_around_newton_new_method(self):
+        # The old method of nudging the Newton and forcing it to reconverge could not achieve the
+        # same accuracy on this model.
+
+        class SellarDerivatives(om.Group):
+
+            def setup(self):
+                self.add_subsystem('px', om.IndepVarComp('x', 1.0), promotes=['x'])
+                self.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
+
+                self.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])
+                self.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])
+                sub = self.add_subsystem('sub', om.Group(), promotes=['*'])
+
+                sub.linear_solver = om.DirectSolver(assemble_jac=True)
+                sub.options['assembled_jac_type'] = 'csc'
+
+                obj = sub.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)', obj=0.0,
+                                                         x=0.0, z=np.array([0.0, 0.0]), y1=0.0, y2=0.0),
+                                  promotes=['obj', 'x', 'z', 'y1', 'y2'])
+                obj.declare_partials(of='*', wrt='*', method='cs')
+
+                con1 = sub.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1', con1=0.0, y1=0.0),
+                                  promotes=['con1', 'y1'])
+                con2 = sub.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0', con2=0.0, y2=0.0),
+                                  promotes=['con2', 'y2'])
+                con1.declare_partials(of='*', wrt='*', method='cs')
+                con2.declare_partials(of='*', wrt='*', method='cs')
+
+                self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+                self.linear_solver = om.DirectSolver(assemble_jac=False)
+
+
+        prob = om.Problem()
+        prob.model = SellarDerivatives()
+        prob.set_solver_print(level=0)
+        prob.setup(force_alloc_complex=True)
+
+        prob.run_model()
+
+        wrt = ['z', 'x']
+        of = ['obj', 'con1', 'con2']
+
+        totals = prob.check_totals(of=of, wrt=wrt, method='cs', compact_print=False)
+        assert_check_totals(totals, atol=1e-12, rtol=1e-12)
+
     def test_cs_around_newton_in_comp(self):
         # CS around Newton in an ImplicitComponent.
         class MyComp(om.ImplicitComponent):

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1252,9 +1252,12 @@ class TestGroup(unittest.TestCase):
         class Discipline(om.Group):
 
             def setup(self):
-                self.add_subsystem('comp0', om.ExecComp('y=x**2'))
-                self.add_subsystem('comp1', om.ExecComp('z=2*external_input'),
-                                   promotes_inputs=['external_input'])
+                comp0 = self.add_subsystem('comp0', om.ExecComp('y=x**2'))
+                comp0.declare_partials(of='*', wrt='*', method='cs')
+
+                comp1 = self.add_subsystem('comp1', om.ExecComp('z=2*external_input'),
+                                           promotes_inputs=['external_input'])
+                comp1.declare_partials(of='*', wrt='*', method='cs')
 
                 self.add_subsystem('balance', om.BalanceComp('x', lhs_name='y', rhs_name='z'),
                                    promotes_outputs=['x'])

--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -72,7 +72,11 @@ class COOMatrix(Matrix):
             key_ranges[key] = (start, end, dense, rows)
             start = end
 
-        data = np.zeros(end)
+        if system is not None and system.under_complex_step:
+            data = np.zeros(end, dtype=complex)
+        else:
+            data = np.zeros(end)
+
         rows = np.empty(end, dtype=INT_DTYPE)
         cols = np.empty(end, dtype=INT_DTYPE)
 

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -184,10 +184,14 @@ class NewtonSolver(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration of Newton.
         if system.under_complex_step and self.options['cs_reconverge']:
-            #system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
+
+            # Absolute seems to work the best.
             delta = 1e-12
             system._outputs += delta
-            #system._outputs *= 1.0 + delta
+
+            # We experimented with relative, but there are cases where it can be too large
+            # or too small.
+            # system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -184,7 +184,10 @@ class NewtonSolver(NonlinearSolver):
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
         # one iteration of Newton.
         if system.under_complex_step and self.options['cs_reconverge']:
-            system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
+            #system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
+            delta = 1e-12
+            system._outputs += delta
+            #system._outputs *= 1.0 + delta
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -150,7 +150,7 @@ class NewtonSolver(NonlinearSolver):
         bool
             Flag for indicating child linerization
         """
-        return (self.options['solve_subsystems']
+        return (self.options['solve_subsystems'] and not system.under_complex_step
                 and self._iter_count <= self.options['max_sub_solves'])
 
     def _linearize(self):
@@ -175,31 +175,18 @@ class NewtonSolver(NonlinearSolver):
             error at the first iteration.
         """
         system = self._system()
+        solve_subsystems = self.options['solve_subsystems'] and not system.under_complex_step
 
         if self.options['debug_print']:
             self._err_cache['inputs'] = system._inputs._copy_views()
             self._err_cache['outputs'] = system._outputs._copy_views()
-
-        # When under a complex step from higher in the hierarchy, sometimes the step is too small
-        # to trigger reconvergence, so nudge the outputs slightly so that we always get at least
-        # one iteration of Newton.
-        if system.under_complex_step and self.options['cs_reconverge']:
-
-            # Absolute seems to work the best.
-            delta = 1e-12
-            system._outputs += delta
-
-            # We experimented with relative, but there are cases where it can be too large
-            # or too small.
-            # system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
         # Execute guess_nonlinear if specified.
         system._guess_nonlinear()
 
         with Recording('Newton_subsolve', 0, self) as rec:
 
-            if self.options['solve_subsystems'] and \
-               (self._iter_count <= self.options['max_sub_solves']):
+            if solve_subsystems and self._iter_count <= self.options['max_sub_solves']:
 
                 self._solver_info.append_solver()
 
@@ -223,7 +210,7 @@ class NewtonSolver(NonlinearSolver):
         """
         system = self._system()
         self._solver_info.append_subsolver()
-        do_subsolve = self.options['solve_subsystems'] and \
+        do_subsolve = self.options['solve_subsystems'] and not system.under_complex_step and \
             (self._iter_count < self.options['max_sub_solves'])
         do_sub_ln = self.linear_solver._linearize_children()
 
@@ -243,7 +230,7 @@ class NewtonSolver(NonlinearSolver):
 
         self.linear_solver.solve('fwd')
 
-        if self.linesearch:
+        if self.linesearch and not system.under_complex_step:
             self.linesearch._do_subsolve = do_subsolve
             self.linesearch.solve()
         else:

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -963,13 +963,7 @@ class LinearSolver(Solver):
 
         self._mpi_print(self._iter_count, norm, norm / norm0)
 
-        force_one_iteration = system.under_complex_step
-
-        while ((self._iter_count < maxiter and norm > atol and norm / norm0 > rtol) or
-               force_one_iteration):
-
-            if system.under_complex_step:
-                force_one_iteration = False
+        while self._iter_count < maxiter and norm > atol and norm / norm0 > rtol:
 
             with Recording(type(self).__name__, self._iter_count, self) as rec:
                 self._single_iteration()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -637,7 +637,9 @@ class NonlinearSolver(Solver):
         if stall_limit > 0:
             stall_norm = norm0
 
-        while self._iter_count < maxiter and norm > atol and norm / norm0 > rtol and not stalled:
+        while ((self._iter_count < maxiter and norm > atol and norm / norm0 > rtol and
+               not stalled) or
+               (self._system().under_complex_step and self._iter_count == 0)):
             with Recording(type(self).__name__, self._iter_count, self) as rec:
 
                 if stall_count == 3 and not self.linesearch.options['print_bound_enforce']:
@@ -804,6 +806,7 @@ class NonlinearSolver(Solver):
         if the 'restart_from_successful' option is True.
         """
         system = self._system()
+
         if (self.options['restart_from_successful'] and self.options['maxiter'] > 1 and
                 not system.under_approx):
             try:


### PR DESCRIPTION
### Summary

Previously, when we performed complex step around a model with a Newton solver in it, we needed to "nudge" the outputs vector by some small quantity in order to force it to reconverge, and thereby propagate the imaginary part throughout the vector. This worked in many cases, but sometimes the size of the nudge could be too small or large and this would affect the accuracy of the approximated derivatives.

This PR implements a new method, where Newton is forced to compute a single iteration (because a complex step of 1e-40 is too small to rise above the solver's tolerances). We also disable any special sub iteration, such as subsystem solves or linesearches so that we just get a pure Newton step that propagates the complex step into the rest of the vector via the local derivative.

1.  If the newton solver uses an iterative linear solver such as Linear Gauss-Seidel, the approximated totals are not that great. Note that these derivatives weren't very good with the old method either, but our test was comparing against some wrong values.
2. There may be some issues with ExecComp's "cs"-computed derivatives, but that is unrelated to this PR and there will be a bug story soon.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
