### PR TITLE
Remove deprecated 'factorial' support in ExecComp

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -157,8 +157,6 @@ class ExecComp(ExplicitComponent):
         erfc(x)                    Complementary error function
         exp(x)                     Exponential function
         expm1(x)                   exp(x) - 1
-        factorial(x)               Factorial of all numbers in x
-                                   (DEPRECATED, not available with SciPy >=1.5)
         fmax(x, y)                 Element-wise maximum of x and y
         fmin(x, y)                 Element-wise minimum of x and y
         inner(x, y)                Inner product of arrays x and y
@@ -1261,25 +1259,6 @@ except ImportError:
     pass
 else:
     _import_functs(scipy.special, _expr_dict, names=['erf', 'erfc'])
-
-    from packaging.version import Version
-    if Version(scipy.__version__) >= Version("1.5.0"):
-        def factorial(*args):
-            """
-            Raise a RuntimeError stating that the factorial function is not supported.
-            """
-            raise RuntimeError("The 'factorial' function is not supported for SciPy "
-                               f"versions >= 1.5, current version: {scipy.__version__}")
-    else:
-        def factorial(*args):
-            """
-            Raise a warning stating that the factorial function is deprecated.
-            """
-            warn_deprecation("The 'factorial' function is deprecated. "
-                             "It is no longer supported for SciPy versions >= 1.5.")
-            return scipy.special.factorial(*args)
-
-    _expr_dict['factorial'] = factorial
 
 
 # put any functions that need custom complex-safe versions here

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -278,28 +278,6 @@ _ufunc_test_data = {
 }
 
 
-# 'factorial' will raise a RuntimeError or a deprecation warning depending on scipy version
-if Version(scipy.__version__) >= Version("1.5.0"):
-    _ufunc_test_data['factorial'] = {
-        'str': 'f=factorial(x)',
-        'args': {'f': {'val': np.zeros(6)},
-                 'x': {'val': np.random.random(6)}},
-        'error': (RuntimeError,
-                  "The 'factorial' function is not supported for SciPy "
-                  f"versions >= 1.5, current version: {scipy.__version__}")
-    }
-else:
-    _ufunc_test_data['factorial'] = {
-        'str': 'f=factorial(x)',
-        'check_func': scipy.special.factorial,
-        'args': {'f': {'val': np.zeros(6)},
-                 'x': {'val': np.random.random(6)}},
-        'warning': (OMDeprecationWarning,
-                    "The 'factorial' function is deprecated. "
-                    "It is no longer supported for SciPy versions >= 1.5.")
-    }
-
-
 class TestExecComp(unittest.TestCase):
 
     def test_missing_partial_warn(self):


### PR DESCRIPTION
### Summary

OpenMDAO's `ExecComp` has been raising a deprecation warning when the factorial function is used. While the function lives on in `scipy.special.factorial`, it is not complex safe and therefore has now been removed.

### Related Issues

- Resolves #2757

### Backwards incompatibilities

None

### New Dependencies

None
