### PR TITLE
change step_calc 'rel' to be same as 'rel_avg', remove deprecation, update docs

### DIFF
--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -131,13 +131,6 @@ class FiniteDifference(ApproximationScheme):
                 raise ValueError(f"{system.msginfo}: Option 'directional' is not supported when "
                                  "'step_calc' is set to 'rel_element.'")
 
-            elif step_calc == 'rel':
-                warn_deprecation("When using 'rel' as the step_calc, the fd stepsize is currently "
-                                 "scaled by the norm of the vector variable. This is not ideal for"
-                                 " larger vectors, and this behavior is being changed in "
-                                 "OpenMDAO 3.12.0. To preserve the older way of doing this "
-                                 "calculation, set step_calc to 'rel_legacy'.")
-
         options['vector'] = vector
         wrt = abs_key[1]
         if wrt in self._wrt_meta:
@@ -190,14 +183,13 @@ class FiniteDifference(ApproximationScheme):
                 var_local = False
 
             if var_local:
-                # TODO - behavior or 'rel' will switch to 'rel_avg' in an upcoming release.
-                if step_calc == 'rel_legacy' or step_calc == 'rel':
+                if step_calc == 'rel_legacy':
                     step *= np.linalg.norm(wrt_val)
 
                     if step < minimum_step:
                         step = minimum_step
 
-                elif step_calc == 'rel_avg':
+                elif step_calc == 'rel_avg' or step_calc == 'rel':
                     step *= np.sum(np.abs(wrt_val)) / len(wrt_val)
 
                     if step < minimum_step:

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -500,9 +500,8 @@ class MetaModelUnStructuredComp(ExplicitComponent):
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
             can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
-            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
-            future will default to 'rel_avg'. Defaults to None, in which case the approximation
-            method provides its default value.
+            compatibilty, it can be 'rel', which is equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value.
         """
         if method == 'cs':
             raise ValueError('Complex step has not been tested for MetaModelUnStructuredComp')

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1087,9 +1087,8 @@ class Component(System):
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
             can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
-            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
-            future will default to 'rel_avg'. Defaults to None, in which case the approximation
-            method provides its default value.
+            compatibilty, it can be 'rel', which is equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value.
         minimum_step : float
             Minimum step size allowed when using one of the relative step_calc options.
 
@@ -1279,9 +1278,8 @@ class Component(System):
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
             can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
-            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
-            future will default to 'rel_avg'. Defaults to None, in which case the approximation
-            method provides its default value.
+            compatibilty, it can be 'rel', which is equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value..
         minimum_step : float
             Minimum step size allowed when using one of the relative step_calc options.
         directional : bool

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2801,9 +2801,8 @@ class Group(System):
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
             can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
-            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
-            future will default to 'rel_avg'. Defaults to None, in which case the approximation
-            method provides its default value.
+            compatibilty, it can be 'rel', which is equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value.
         """
         self._has_approx = True
         self._approx_schemes = {}

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1079,9 +1079,8 @@ class Problem(object):
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
             can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
-            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
-            future will default to 'rel_avg'. Defaults to None, in which case the approximation
-            method provides its default value.
+            compatibilty, it can be 'rel', which is equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value.
         minimum_step : float
             Minimum step size allowed when using one of the relative step_calc options.
         force_dense : bool
@@ -1574,9 +1573,8 @@ class Problem(object):
             absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
             'rel_element' for a size relative to each value in the vector input. In addition, it
             can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
-            compatibilty, it can be 'rel', which currently defaults to 'rel_legacy', but in the
-            future will default to 'rel_avg'. Defaults to None, in which case the approximation
-            method provides its default value.
+            compatibilty, it can be 'rel', which is equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value..
         show_progress : bool
             True to show progress of check_totals.
         show_only_incorrect : bool, optional

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2534,23 +2534,6 @@ class TestFDRelative(unittest.TestCase):
         # This derivative requires rel_element to be accurate.
         self.assertTrue(np.abs(totals['comp.y', 'comp.x_element']['J_fd'][2, 2]) < 1e-9)
 
-    def test_deprecation(self):
-        prob = om.Problem()
-        model = prob.model
-        comp = model.add_subsystem('comp', Paraboloid())
-
-        prob.setup()
-        prob.run_model()
-
-        msg = "When using 'rel' as the step_calc, the fd stepsize is currently " + \
-            "scaled by the norm of the vector variable. This is not ideal for" + \
-            " larger vectors, and this behavior is being changed in " + \
-            "OpenMDAO 3.12.0. To preserve the older way of doing this " + \
-            "calculation, set step_calc to 'rel_legacy'."
-
-        with assert_warning(OMDeprecationWarning, msg):
-            prob.check_partials(out_stream=None, method='fd', step_calc='rel')
-
 
 class ParallelFDParametricTestCase(unittest.TestCase):
 

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_partial_derivatives.ipynb
@@ -132,6 +132,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "ce28a62a",
    "metadata": {},
@@ -153,7 +154,7 @@
     "| \"rel_avg\"       | Average absolute value of the vector.           |\n",
     "| \"rel_element\"   | Absolute value of each vector element.          |\n",
     "| \"rel_legacy\"    | Norm of the vector.                             |\n",
-    "| \"rel\"           | Same as \"rel_legacy\" currently, but will become \"rel_avg\" in the OpenMDAO 3.12.0.  |"
+    "| \"rel\"           | Same as \"rel_avg\".                              |"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/check_partials_settings.ipynb
@@ -366,6 +366,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "noble-triumph",
    "metadata": {},
@@ -385,7 +386,7 @@
     "| \"rel_avg\"       | Average absolute value of the vector.           |\n",
     "| \"rel_element\"   | Absolute value of each vector element.          |\n",
     "| \"rel_legacy\"    | Norm of the vector.                             |\n",
-    "| \"rel\"           | Same as \"rel_legacy\" currently, but will become \"rel_avg\" in the OpenMDAO 3.12.0.  |\n"
+    "| \"rel\"           | Same as \"rel__avg\".                             |\n"
    ]
   },
   {


### PR DESCRIPTION
### Summary

The step size for finite differencing behavior when using the `rel` option has been throwing a deprecation warning since before OpenMDAO 3.12.  This PR changes the semantics of the `rel` option from being equivalent to `rel_legacy` to being equivalent to `rel_avg`.

- remove deprecation warning
- change `rel` to be equivalent to `rel_avg`
- update documentation

### Related Issues

- Resolves #2756

### Backwards incompatibilities

None

### New Dependencies

None
