### PR TITLE
Remove deprecated OPENMDAO_REQUIRE_MPI check

### DIFF
--- a/openmdao/utils/mpi.py
+++ b/openmdao/utils/mpi.py
@@ -76,11 +76,7 @@ def check_mpi_env():
     bool
         True if MPI is required, False if it's to be skipped, None if not set.
     """
-    if 'OPENMDAO_REQUIRE_MPI' in os.environ:
-        warn_deprecation("Set OPENMDAO_USE_MPI instead of OPENMDAO_REQUIRE_MPI.")
-
-    mpi_selection = os.environ.get('OPENMDAO_USE_MPI',
-                                   os.environ.get('OPENMDAO_REQUIRE_MPI', None))
+    mpi_selection = os.environ.get('OPENMDAO_USE_MPI', None))
 
     # If OPENMDAO_USE_MPI is set to a postive value, the run will fail
     # immediately if the import fails

--- a/openmdao/utils/mpi.py
+++ b/openmdao/utils/mpi.py
@@ -76,7 +76,7 @@ def check_mpi_env():
     bool
         True if MPI is required, False if it's to be skipped, None if not set.
     """
-    mpi_selection = os.environ.get('OPENMDAO_USE_MPI', None))
+    mpi_selection = os.environ.get('OPENMDAO_USE_MPI', None)
 
     # If OPENMDAO_USE_MPI is set to a postive value, the run will fail
     # immediately if the import fails


### PR DESCRIPTION
### Summary

The environment variable `OPENMDAO_REQUIRE_MPI` has long been deprecated in favor of `OPENMDAO_USE_MPI`.

OpenMDAO will no longer look for the deprecated variable and will only use the latter.

### Related Issues

- Resolves #2764

### Backwards incompatibilities

Handling of the deprecated `OPENMDAO_REQUIRE_MPI` environment variable has been removed.

### New Dependencies

None
