### PR TITLE
Remove deprecated get_conversion() utility function

### DIFF
--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -6,7 +6,7 @@ import warnings
 
 import openmdao.api as om
 from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, \
-    add_unit, add_offset_unit, unit_conversion, get_conversion, simplify_unit
+    add_unit, add_offset_unit, unit_conversion, simplify_unit
 from openmdao.utils.assert_utils import assert_warning, assert_near_equal
 from openmdao.utils.om_warnings import OMDeprecationWarning
 
@@ -257,20 +257,6 @@ class TestPhysicalUnit(unittest.TestCase):
             self.assertEqual(str(err), "The units '1.0' are invalid.")
         else:
             self.fail("Expecting RuntimeError")
-
-    def test_get_conversion(self):
-        msg = "'get_conversion' has been deprecated. Use 'unit_conversion' instead."
-        with assert_warning(OMDeprecationWarning, msg):
-            get_conversion('km', 'm'), (1000., 0.)
-
-        self.assertEqual(get_conversion('km', 'm'), (1000., 0.))
-
-        try:
-            get_conversion('km', 1.0)
-        except ValueError as err:
-            self.assertEqual(str(err), "The units '1.0' are invalid.")
-        else:
-            self.fail("Expecting ValueError")
 
     def test_unit_simplification(self):
         test_strings = ['ft/s*s',

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -1019,28 +1019,6 @@ def unit_conversion(old_units, new_units):
     return _find_unit(old_units, error=True).conversion_tuple_to(_find_unit(new_units, error=True))
 
 
-def get_conversion(old_units, new_units):
-    """
-    Return conversion factor and offset between old and new units (deprecated).
-
-    Parameters
-    ----------
-    old_units : str
-        Original units as a string.
-    new_units : str
-        New units to return the value in.
-
-    Returns
-    -------
-    (float, float)
-        Conversion factor and offset.
-    """
-    warn_deprecation("'get_conversion' has been deprecated. Use "
-                     "'unit_conversion' instead.")
-
-    return unit_conversion(old_units, new_units)
-
-
 def convert_units(val, old_units, new_units=None):
     """
     Take a given quantity and return in different units.


### PR DESCRIPTION
### Summary

The utility function `get_conversion()` has long been deprecated in favor of `unit_conversion()`.

The deprecated function has been removed and users are expected to use the latter.

### Related Issues

- Resolves #2765

### Backwards incompatibilities

The deprecated `get_conversion()` function has been removed.

### New Dependencies

None
