### PR TITLE
Removed deprecated CaseReader attributes

### DIFF
--- a/openmdao/recorders/base_case_reader.py
+++ b/openmdao/recorders/base_case_reader.py
@@ -42,34 +42,6 @@ class BaseCaseReader(object):
         self._system_options = {}
 
     @property
-    def system_options(self):
-        """
-        Provide '_system_options' property for backwards compatibility.
-
-        Returns
-        -------
-        dict
-            reference to the _system_options attribute.
-        """
-        warn_deprecation("The system_options attribute is deprecated. "
-                         "Use `list_model_options` instead.")
-        return self._system_options
-
-    @property
-    def system_metadata(self):
-        """
-        Provide 'system_metadata' property for backwards compatibility.
-
-        Returns
-        -------
-        dict
-            reference to the '_system_options' attribute.
-        """
-        warn_deprecation("The BaseCaseReader.system_metadata attribute is deprecated. "
-                         "Use `list_model_options` instead.")
-        return self._system_options
-
-    @property
     def openmdao_version(self):
         """
         Provide the version of OpenMDAO that was used to record this file.

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -288,7 +288,7 @@ class SqliteCaseReader(BaseCaseReader):
         """
         Load data from the system table.
 
-        Populates the `system_options` attribute of this CaseReader.
+        Populates the `_system_options` attribute of this CaseReader.
 
         Parameters
         ----------

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2284,7 +2284,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         self.assertEqual(cr._format_version, format_version)
 
-        self.assertEqual(set(cr.system_options.keys()),
+        self.assertEqual(set(cr._system_options.keys()),
                          set(['root'] + list(prob.model._subsystems_allprocs)))
 
         self.assertEqual(set(cr.problem_metadata.keys()), {
@@ -2312,7 +2312,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         self.assertEqual(cr._format_version, format_version)
 
-        self.assertEqual(set(cr.system_options.keys()),
+        self.assertEqual(set(cr._system_options.keys()),
                          set(['root'] + list(prob.model._subsystems_allprocs)))
 
         self.assertEqual(set(cr.problem_metadata.keys()), {
@@ -3115,33 +3115,6 @@ class TestSqliteCaseReader(unittest.TestCase):
             self.assertEqual(text.count('\n  y'), 1)
             num_non_empty_lines = sum([1 for s in text.splitlines() if s.strip()])
             self.assertEqual(num_non_empty_lines, 46)
-
-    def test_system_metadata_attribute_deprecated(self):
-        model = om.Group()
-        model.add_recorder(self.recorder)
-        prob = om.Problem(model)
-        prob.setup()
-        prob.run_model()
-        prob.cleanup()
-
-        cr = om.CaseReader(self.filename)
-        msg = "The BaseCaseReader.system_metadata attribute is deprecated. " \
-        "Use `list_model_options` instead."
-        with assert_warning(OMDeprecationWarning, msg):
-            options = cr.system_metadata
-
-    def test_system_options_attribute_deprecated(self):
-        model = om.Group()
-        model.add_recorder(self.recorder)
-        prob = om.Problem(model)
-        prob.setup()
-        prob.run_model()
-        prob.cleanup()
-
-        cr = om.CaseReader(self.filename)
-        msg = "The system_options attribute is deprecated. Use `list_model_options` instead."
-        with assert_warning(OMDeprecationWarning, msg):
-            options = cr.system_options
 
     def test_sqlite_reader_problem_derivatives(self):
 


### PR DESCRIPTION
### Summary

Removed the deprecated `system_options` and `system_metadata` attributes on `CaseReader` since they have been replaced by the `list_model_options()` function.

### Related Issues

- Resolves #2762

### Backwards incompatibilities

The deprecated `system_options` and `system_metadata` attributes on `CaseReader` have been removed.

### New Dependencies

None
