### PR TITLE
Install openssl=3.0 for docs upload in GitHub workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -146,7 +146,6 @@ jobs:
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
-
           python -m pip install --upgrade pip
 
           echo "============================================================="
@@ -364,7 +363,7 @@ jobs:
             echo "============================================================="
             echo "Install version of openssl compatible with hosting service"
             echo "============================================================="
-            conda install -c conda-forge 'openssl<3.1.0'
+            conda install -c conda-forge 'openssl=3.0'
 
             echo "============================================================="
             echo "Publish docs"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -364,7 +364,7 @@ jobs:
             echo "============================================================="
             echo "Install version of openssl compatible with hosting service"
             echo "============================================================="
-            conda install 'openssl<3.1.0'
+            conda install -c conda-forge 'openssl<3.1.0'
 
             echo "============================================================="
             echo "Publish docs"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -146,6 +146,7 @@ jobs:
         run: |
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
+
           python -m pip install --upgrade pip
 
           echo "============================================================="
@@ -360,6 +361,11 @@ jobs:
           DOCS_LOCATION: ${{ secrets.DOCS_LOCATION }}
         run: |
           if [[ "${#DOCS_LOCATION}" ]]; then
+            echo "============================================================="
+            echo "Install version of openssl compatible with hosting service"
+            echo "============================================================="
+            conda install 'openssl<3.1.0'
+
             echo "============================================================="
             echo "Publish docs"
             echo "============================================================="

--- a/openmdao/docs/upload_doc_version.py
+++ b/openmdao/docs/upload_doc_version.py
@@ -1,7 +1,5 @@
 import sys
 import subprocess
-import pipes
-import os
 
 
 def get_tag_info():


### PR DESCRIPTION
### Summary

We started getting the following error when trying to upload the doc build in the GitHub workflow:
```
Publish docs
OpenSSL version mismatch. Built against 30000020, you have 30100000
=============================================================
rsync: connection unexpectedly closed (0 bytes received so far) [sender]
```
This is apparently due to the new 3.1 version of openssl.  The solution for now is to install the previous version (3.0) from `conda-forge`.


Also removed some unused imports from the upload script, one of which was throwing a deprecation warning.

### Related Issues

- Resolves #2852

### Backwards incompatibilities

None

### New Dependencies

None
