### PR TITLE
Changed handling of _no_check_partials

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -288,6 +288,8 @@ jobs:
 
       - name: Run tests
         if: matrix.TESTS
+        env:
+          OPENMDAO_CI: true
         run: |
           echo "============================================================="
           echo "Run tests with coverage (from directory other than repo root)"
@@ -490,6 +492,8 @@ jobs:
                     f'Scipy version {scipy.__version__} is not the requested version (${{ matrix.SCIPY }})'"
 
       - name: Run tests
+        env:
+          OPENMDAO_CI: true
         run: |
           echo "============================================================="
           echo "Run tests with coverage (from directory other than repo root)"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Run tests
         if: matrix.TESTS
         env:
-          OPENMDAO_CI: true
+          OPENMDAO_CHECK_ALL_PARTIALS: true
         run: |
           echo "============================================================="
           echo "Run tests with coverage (from directory other than repo root)"
@@ -493,7 +493,7 @@ jobs:
 
       - name: Run tests
         env:
-          OPENMDAO_CI: true
+          OPENMDAO_CHECK_ALL_PARTIALS: true
         run: |
           echo "============================================================="
           echo "Run tests with coverage (from directory other than repo root)"

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -13,6 +13,7 @@ from openmdao.components.interp_util.interp import InterpND, SPLINE_METHODS, TAB
 from openmdao.components.interp_util.interp_semi import InterpNDSemi
 from openmdao.components.interp_util.outofbounds_error import OutOfBoundsError
 from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, assert_warning, assert_check_partials
+from openmdao.utils.testing_utils import force_check_partials
 from openmdao.utils.om_warnings import OMDeprecationWarning
 
 def rel_error(actual, computed):
@@ -902,7 +903,7 @@ class TestInterpNDPython(unittest.TestCase):
             prob.setup(force_alloc_complex=True)
             prob.run_model()
 
-            derivs = prob.check_partials(method='fd', out_stream=None)
+            derivs = force_check_partials(prob, method='fd', out_stream=None)
             assert_check_partials(derivs, atol=1e-3, rtol=1e-4)
 
 

--- a/openmdao/components/meta_model_unstructured_comp.py
+++ b/openmdao/components/meta_model_unstructured_comp.py
@@ -384,7 +384,7 @@ class MetaModelUnStructuredComp(ExplicitComponent):
                     output_shape = (vec_size, ) + shape
                 else:
                     output_shape = (vec_size, )
-                predicted = np.zeros(output_shape)
+                predicted = np.zeros(output_shape, dtype=flat_inputs.dtype)
                 rmse = self._metadata(name)['rmse'] = []
                 for i in range(vec_size):
                     pred_i = surrogate.predict(flat_inputs[i])
@@ -409,16 +409,11 @@ class MetaModelUnStructuredComp(ExplicitComponent):
         ndarray
             flattened array of input data
         """
-        array_real = True
-
-        arr = np.zeros(self._input_size)
+        arr = np.zeros(self._input_size, dtype=vec.asarray().dtype)
 
         idx = 0
         for name, sz in self._surrogate_input_names:
             val = vec[name]
-            if array_real and np.issubdtype(val.dtype, np.complexfloating):
-                array_real = False
-                arr = arr.astype(np.complexfloating)
             arr[idx:idx + sz] = val.flat
             idx += sz
 
@@ -439,17 +434,12 @@ class MetaModelUnStructuredComp(ExplicitComponent):
             2d array, self._vectorize rows of flattened input data.
         """
         vec_size = self.options['vec_size']
-        array_real = True
+        arr = np.zeros((vec_size, self._input_size), dtype=vec.asarray().dtype)
 
-        arr = np.zeros((vec_size, self._input_size))
-
+        vecvals = [(vec[n], sz) for n, sz in self._surrogate_input_names]
         for row in range(vec_size):
             idx = 0
-            for name, sz in self._surrogate_input_names:
-                val = vec[name]
-                if array_real and np.issubdtype(val.dtype, np.complexfloating):
-                    array_real = False
-                    arr = arr.astype(np.complexfloating)
+            for val, sz in vecvals:
                 arr[row][idx:idx + sz] = val[row].flat
                 idx += sz
 

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestAddSubtractCompScalars(unittest.TestCase):
@@ -41,7 +42,7 @@ class TestAddSubtractCompScalars(unittest.TestCase):
         assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -82,7 +83,7 @@ class TestAddSubtractCompNx1(unittest.TestCase):
         assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -123,7 +124,7 @@ class TestAddSubtractCompNx3(unittest.TestCase):
         assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -168,7 +169,7 @@ class TestAddSubtractMultipleInputs(unittest.TestCase):
         assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -213,7 +214,7 @@ class TestAddSubtractScalingFactors(unittest.TestCase):
         assert_near_equal(out, expected,1e-16)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -256,7 +257,7 @@ class TestAddSubtractMIMO(unittest.TestCase):
         assert_near_equal(z, 3.3*a - 1.5*b + 5*c,1e-16)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -302,7 +303,7 @@ class TestAddSubtractUnits(unittest.TestCase):
         assert_near_equal(out, expected,1e-8)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 
@@ -353,7 +354,7 @@ class TestAddSubtractInit(unittest.TestCase):
         assert_near_equal(out, expected, 1e-8)
 
     def test_partials(self):
-        partials = self.p.check_partials(method='fd', out_stream=None)
+        partials = force_check_partials(self.p, method='fd', out_stream=None)
         assert_check_partials(partials)
 
 

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -9,7 +9,7 @@ from numpy.testing import assert_almost_equal
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_no_warning, assert_check_partials
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, force_check_partials
 
 
 @use_tempdirs
@@ -42,7 +42,7 @@ class TestBalanceComp(unittest.TestCase):
 
         prob.run_model()
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=2e-5, rtol=2e-5)
 
@@ -56,7 +56,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -114,7 +114,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -171,7 +171,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(1.5), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -211,7 +211,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=2e-5, rtol=2e-5)
 
@@ -251,7 +251,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(1.7), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -295,7 +295,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -337,7 +337,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -409,7 +409,7 @@ class TestBalanceComp(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.filterwarnings(action="error", category=np.ComplexWarning)
-            cpd = prob.check_partials(out_stream=None, method='cs')
+            cpd = force_check_partials(prob, out_stream=None, method='cs')
 
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)
 
@@ -449,7 +449,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -490,7 +490,7 @@ class TestBalanceComp(unittest.TestCase):
         # should converge with no iteration due to the guess function
         self.assertEqual(model.nonlinear_solver._iter_count, 1)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
     def test_scalar_with_guess_func_additional_input(self):
@@ -640,7 +640,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], 2.0, decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -684,7 +684,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -728,7 +728,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -833,7 +833,7 @@ class TestBalanceComp(unittest.TestCase):
 
         assert_almost_equal(prob['balance.x'], np.sqrt(2), decimal=7)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 

--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestCrossProductCompNx3(unittest.TestCase):
@@ -53,7 +54,7 @@ class TestCrossProductCompNx3(unittest.TestCase):
             np.testing.assert_almost_equal(c_i, expected_i)
 
     def test_partials(self):
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -108,7 +109,7 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
             np.testing.assert_almost_equal(c_i, expected_i)
 
     def test_partials(self):
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -161,7 +162,7 @@ class TestCrossProductCompNonVectorized(unittest.TestCase):
         np.testing.assert_almost_equal(c_i.ravel(), expected)
 
     def test_partials(self):
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -212,7 +213,7 @@ class TestUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -275,7 +276,7 @@ class TestMultipleUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -340,7 +341,7 @@ class TestMultipleConfigure(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -401,7 +402,7 @@ class TestMultipleCommonA(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -462,7 +463,7 @@ class TestMultipleCommonB(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestDotProductCompNx3(unittest.TestCase):
@@ -49,7 +50,7 @@ class TestDotProductCompNx3(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -96,7 +97,7 @@ class TestDotProductCompNx4(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -147,7 +148,7 @@ class TestUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -211,7 +212,7 @@ class TestMultipleUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -280,7 +281,7 @@ class TestMultipleConfigure(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -341,7 +342,7 @@ class TestMultipleCommonA(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -402,7 +403,7 @@ class TestMultipleCommonB(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -7,6 +7,7 @@ from numpy.testing import assert_almost_equal
 import openmdao.api as om
 from openmdao.test_suite.components.sellar_feature import SellarIDF
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestEQConstraintComp(unittest.TestCase):
@@ -22,7 +23,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         prob.run_model()
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -83,7 +84,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], 27.)
         assert_almost_equal(prob['g.y'], 27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -120,7 +121,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], 27.)
         assert_almost_equal(prob['g.y'], 27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -171,7 +172,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], 27.)
         assert_almost_equal(prob['g.y'], 27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -208,7 +209,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], np.ones(n)*27.)
         assert_almost_equal(prob['g.y'], np.ones(n)*27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -245,7 +246,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], np.ones(n)*27.)
         assert_almost_equal(prob['g.y'], np.ones(n)*27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -290,7 +291,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], np.ones(n)*27.)
         assert_almost_equal(prob['g.y'], np.ones(n)*27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -322,7 +323,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_near_equal(prob['indep.x'], 2., 1e-6)
         assert_near_equal(prob['f.y'], 4., 1e-6)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -352,7 +353,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.filterwarnings(action="error", category=np.ComplexWarning)
-            cpd = prob.check_partials(out_stream=None, method='cs')
+            cpd = force_check_partials(prob, out_stream=None, method='cs')
 
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)
 
@@ -388,7 +389,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_near_equal(prob['indep.x'], np.ones(n)*2., 1e-6)
         assert_near_equal(prob['f.y'], np.ones(n)*4., 1e-6)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -422,7 +423,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_near_equal(prob['indep.x'], np.ones(n)*2., 1e-6)
         assert_near_equal(prob['f.y'], np.ones(n)*4., 1e-6)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -450,7 +451,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_near_equal(prob['indep.x'], 2., 1e-6)
         assert_near_equal(prob['f.y'], 4., 1e-6)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -484,7 +485,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_near_equal(prob['indep.x'], np.ones(n)*2., 1e-6)
         assert_near_equal(prob['f.y'], np.ones(n)*4., 1e-6)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=2e-5, rtol=2e-5)
 
@@ -507,7 +508,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         assert_near_equal(prob['equal.y'], np.ones(shape) - rhs, 1e-6)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -542,7 +543,7 @@ class TestEQConstraintComp(unittest.TestCase):
         assert_almost_equal(prob['f.y'], 27.)
         assert_almost_equal(prob['g.y'], 27.)
 
-        cpd = prob.check_partials(out_stream=None)
+        cpd = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(cpd, atol=1e-5, rtol=1e-5)
 
@@ -619,7 +620,7 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.set_val('eq_comp.k2', np.random.rand(n) * 10)
 
         prob.run_model()
-    
+
     def test_indices(self):
         prob = om.Problem()
         model = prob.model
@@ -628,7 +629,7 @@ class TestEQConstraintComp(unittest.TestCase):
 
         model.add_subsystem('indep', om.IndepVarComp('x', np.ones(n)))
         model.add_subsystem('f', om.ExecComp('y=x**2', x=np.ones(n), y=np.ones(n)))
-        model.add_subsystem('eq_comp', om.EQConstraintComp('y', val=np.ones(n), 
+        model.add_subsystem('eq_comp', om.EQConstraintComp('y', val=np.ones(n),
                             indices=[n-2,n-1],
                             flat_indices=True, add_constraint=True))
 

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -7,6 +7,7 @@ import openmdao.api as om
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_stress import MultipointBeamGroup
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestKSFunction(unittest.TestCase):
@@ -58,9 +59,7 @@ class TestKSFunction(unittest.TestCase):
         assert_near_equal(prob.get_val('ks.KS', indices=1), 34.0)
         assert_near_equal(prob.get_val('ks.KS', indices=2), 51.0)
 
-        prob.model.ks._no_check_partials = False  # override skipping of check_partials
-
-        partials = prob.check_partials(includes=['ks'], out_stream=None)
+        partials = force_check_partials(prob, includes=['ks'], out_stream=None)
 
         for (of, wrt) in partials['ks']:
             assert_near_equal(partials['ks'][of, wrt]['abs error'][0], 0.0, 1e-6)

--- a/openmdao/components/tests/test_linear_system_comp.py
+++ b/openmdao/components/tests/test_linear_system_comp.py
@@ -6,6 +6,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestLinearSystemComp(unittest.TestCase):
@@ -166,13 +167,11 @@ class TestLinearSystemComp(unittest.TestCase):
         sol = d_residuals['lin.x']
         assert_near_equal(sol, x, .0001)
 
-        prob.model.lingrp.lin._no_check_partials = False  # override skipping of check_partials
-
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b', 'lin.x'], return_format='flat_dict')
         assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         abs_errors = data['lingrp.lin'][('x', 'x')]['abs error']
         self.assertTrue(len(abs_errors) > 0)
@@ -229,13 +228,11 @@ class TestLinearSystemComp(unittest.TestCase):
         sol = d_residuals['lin.x']
         assert_near_equal(sol, x, .0001)
 
-        prob.model.lingrp.lin._no_check_partials = False  # override skipping of check_partials
-
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b'], return_format='flat_dict')
         assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         abs_errors = data['lingrp.lin'][('x', 'x')]['abs error']
         self.assertTrue(len(abs_errors) > 0)
@@ -301,13 +298,11 @@ class TestLinearSystemComp(unittest.TestCase):
         sol = d_residuals['lin.x']
         assert_near_equal(sol, x, .0001)
 
-        prob.model.lingrp.lin._no_check_partials = False  # override skipping of check_partials
-
         J = prob.compute_totals(['lin.x'], ['p1.A', 'p2.b'], return_format='flat_dict')
         assert_near_equal(J['lin.x', 'p1.A'], dx_dA, .0001)
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         abs_errors = data['lingrp.lin'][('x', 'x')]['abs error']
         self.assertTrue(len(abs_errors) > 0)

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -5,6 +5,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.units import convert_units
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestMatrixVectorProductComp3x3(unittest.TestCase):
@@ -47,7 +48,7 @@ class TestMatrixVectorProductComp3x3(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -96,7 +97,7 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
             np.testing.assert_almost_equal(b_i, expected_i)
 
     def test_partials(self):
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -142,7 +143,7 @@ class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -193,7 +194,7 @@ class TestUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -266,7 +267,7 @@ class TestMultipleUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -338,7 +339,7 @@ class TestMultipleConfigure(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -407,7 +408,7 @@ class TestMultipleCommonMatrix(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -474,7 +475,7 @@ class TestMultipleCommonVector(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(out_stream=None, method='cs')
+        cpd = force_check_partials(self.p, out_stream=None, method='cs')
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:

--- a/openmdao/components/tests/test_meta_model_semi_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_semi_structured_comp.py
@@ -9,6 +9,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.components.tests.test_meta_model_structured_comp import SampleMap
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.testing_utils import force_check_partials
 
 
 # Data for example used in the docs.
@@ -179,7 +180,6 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         comp = om.MetaModelSemiStructuredComp(method='slinear', extrapolate=True,
                                               training_data_gradients=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         # Convert to the flat table format.
         grid = np.array(list(itertools.product(*[params[0]['values'],
@@ -203,7 +203,7 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         assert_check_partials(partials, rtol=1e-10)
 
     def test_vectorized_lagrange2(self):
@@ -229,7 +229,6 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         comp = om.MetaModelSemiStructuredComp(method='lagrange2', extrapolate=True,
                                               training_data_gradients=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         # Convert to the flat table format.
         grid = np.array(list(itertools.product(*[params[0]['values'],
@@ -253,7 +252,7 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         assert_check_partials(partials, rtol=1e-10)
 
     def test_vectorized_lagrange3(self):
@@ -279,7 +278,6 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         comp = om.MetaModelSemiStructuredComp(method='lagrange3', extrapolate=True,
                                               training_data_gradients=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         # Convert to the flat table format.
         grid = np.array(list(itertools.product(*[params[0]['values'],
@@ -303,7 +301,7 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         assert_check_partials(partials, rtol=1e-10)
 
     def test_vectorized_akima(self):
@@ -329,7 +327,6 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         comp = om.MetaModelSemiStructuredComp(method='akima', extrapolate=True,
                                               training_data_gradients=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         # Convert to the flat table format.
         grid = np.array(list(itertools.product(*[params[0]['values'],
@@ -353,7 +350,7 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         assert_check_partials(partials, rtol=1e-10)
 
     def test_error_dim(self):

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -12,7 +12,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning, asser
      assert_check_totals
 
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, force_check_partials
 
 scipy_gte_019 = True
 try:
@@ -691,9 +691,7 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
 
         prob.run_model()
 
-        prob.model.comp._no_check_partials = False  # override skipping of check_partials
-
-        derivs = prob.check_partials(out_stream=None)
+        derivs = force_check_partials(prob, out_stream=None)
 
         for i in derivs['comp'].keys():
             if verbose:
@@ -779,9 +777,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         prob.run_model()
 
-        prob.model.comp._no_check_partials = False  # override skipping of check_partials
-
-        derivs = prob.check_partials(method='cs', out_stream=None)
+        derivs = force_check_partials(prob, method='cs', out_stream=None)
 
         for i in derivs['comp'].keys():
             if verbose:
@@ -877,7 +873,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         model.add_subsystem('des_vars', ivc, promotes=["*"])
 
         comp = om.MetaModelStructuredComp(method='slinear', extrapolate=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         for param in params:
             comp.add_input(param['name'], np.array([param['default'], param['default'], param['default']]),
@@ -896,7 +891,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         assert_check_partials(partials, rtol=1e-8)
 
     def test_vectorized_lagrange2(self):
@@ -920,7 +915,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         model.add_subsystem('des_vars', ivc, promotes=["*"])
 
         comp = om.MetaModelStructuredComp(method='lagrange2', extrapolate=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         for param in params:
             comp.add_input(param['name'], np.array([param['default'], param['default'], param['default']]),
@@ -939,7 +933,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         # Derivs are large, so ignore atol.
         assert_check_partials(partials, atol=1e10, rtol=1e-10)
 
@@ -954,7 +948,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         outs = mapdata.output_data
 
         comp = om.MetaModelStructuredComp(method='lagrange3', extrapolate=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         for param in params:
             comp.add_input(param['name'], np.array([param['default'], param['default'], param['default']]),
@@ -973,7 +966,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         # Derivs are large, so ignore atol.
         assert_check_partials(partials, atol=1e10, rtol=1e-10)
 
@@ -998,7 +991,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         model.add_subsystem('des_vars', ivc, promotes=["*"])
 
         comp = om.MetaModelStructuredComp(method='akima', extrapolate=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         for param in params:
             comp.add_input(param['name'], np.array([param['default'], param['default'], param['default']]),
@@ -1017,7 +1009,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         # Derivs are large, so ignore atol.
         assert_check_partials(partials, atol=1e10, rtol=1e-10)
 
@@ -1042,7 +1034,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         model.add_subsystem('des_vars', ivc, promotes=["*"])
 
         comp = om.MetaModelStructuredComp(method='cubic', extrapolate=True, vec_size=3)
-        comp._no_check_partials = False  # override skipping of check_partials
 
         for param in params:
             comp.add_input(param['name'], np.array([param['default'], param['default'], param['default']]),
@@ -1061,7 +1052,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
         prob.run_model()
 
-        partials = prob.check_partials(method='cs', out_stream=None)
+        partials = force_check_partials(prob, method='cs', out_stream=None)
         # Derivs are large, so ignore atol.
         assert_check_partials(partials, atol=1e10, rtol=1e-10)
 
@@ -1204,7 +1195,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
                 comp.add_output('C_L', 0.0, grid)
 
                 self.add_subsystem('comp', comp, promotes=["*"])
-                self.comp._no_check_partials = False  # override skipping of check_partials
 
         model = om.Group()
         model.add_subsystem('InterpSubsystem', MGroup())
@@ -1214,7 +1204,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         p.set_val('InterpSubsystem.mach', 7.0)
         p.run_model()
 
-        cpd = p.check_partials(compact_print=False, out_stream=None, method='cs')
+        cpd = force_check_partials(p, compact_print=False, out_stream=None, method='cs')
         assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
     def test_training_gradient_unsupported(self):
@@ -1314,7 +1304,6 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
 
         # Create regular grid interpolator instance
         xor_interp = om.MetaModelStructuredComp(method='scipy_slinear')
-        xor_interp._no_check_partials = False  # override skipping of check_partials
 
         # set up inputs and outputs
         xor_interp.add_input('x', 0.0, training_data=np.array([0.0, 1.0]), units=None)
@@ -1343,7 +1332,7 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
         assert_almost_equal(computed, actual)
 
         # we can verify all gradients by checking against finite-difference
-        prob.check_partials(compact_print=True)
+        force_check_partials(prob, compact_print=True)
 
     @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")
     def test_shape(self):
@@ -1362,7 +1351,6 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
 
         # Create regular grid interpolator instance
         interp = om.MetaModelStructuredComp(method='scipy_cubic')
-        interp._no_check_partials = False  # override skipping of check_partials
 
         interp.add_input('p1', 0.5, training_data=p1)
         interp.add_input('p2', 0.0, training_data=p2)
@@ -1389,7 +1377,7 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
         assert_almost_equal(computed, actual)
 
         # we can verify all gradients by checking against finite-difference
-        prob.check_partials(compact_print=True)
+        force_check_partials(prob, compact_print=True)
 
     @unittest.skipIf(not scipy_gte_019, "only run if scipy>=0.19.")
     def test_vectorized(self):
@@ -1446,7 +1434,6 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
 
         # Create regular grid interpolator instance
         interp = om.MetaModelStructuredComp(method='scipy_cubic', training_data_gradients=True)
-        interp._no_check_partials = False  # override skipping of check_partials
 
         interp.add_input('p1', 0.5, p1)
         interp.add_input('p2', 0.0, p2)
@@ -1473,7 +1460,7 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
         assert_almost_equal(computed, actual)
 
         # we can verify all gradients by checking against finite-difference
-        prob.check_partials(compact_print=True)
+        force_check_partials(prob, compact_print=True)
 
     def test_error_messages_scalar_only(self):
         prob = om.Problem()

--- a/openmdao/components/tests/test_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_meta_model_unstructured_comp.py
@@ -11,6 +11,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_partials
 from openmdao.utils.logger_utils import TestLogger
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class MetaModelTestCase(unittest.TestCase):
@@ -441,9 +442,7 @@ class MetaModelTestCase(unittest.TestCase):
         prob['x'] = 0.125
         prob.run_model()
 
-        mm._no_check_partials = False  # override skipping of check_partials
-
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         Jf = data['mm'][('f', 'x')]['J_fwd']
 
@@ -454,7 +453,7 @@ class MetaModelTestCase(unittest.TestCase):
         # Complex step
         prob.setup(force_alloc_complex=True)
         prob.model.mm.set_check_partial_options(wrt='*', method='cs')
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(data, atol=1e-11, rtol=1e-11)
 
@@ -540,7 +539,36 @@ class MetaModelTestCase(unittest.TestCase):
                          np.array(.5*np.sin(prob['trig.x'])),
                          1e-4)
 
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
+
+        assert_check_partials(data, atol=1e-6, rtol=1e-6)
+
+    def test_vectorized_cs(self):
+        size = 3
+
+        # create a vectorized MetaModelUnStructuredComp for sine
+        trig = om.MetaModelUnStructuredComp(vec_size=size, default_surrogate=om.KrigingSurrogate())
+        trig.add_input('x', np.zeros(size))
+        trig.add_output('y', np.zeros(size))
+
+        # add it to a Problem
+        prob = om.Problem()
+        prob.model.add_subsystem('trig', trig)
+        prob.setup(force_alloc_complex=True)
+        prob.model.trig.set_check_partial_options(wrt='*', method='cs')
+
+        # provide training data
+        trig.options['train_x'] = np.linspace(0, 10, 20)
+        trig.options['train_y'] = .5*np.sin(trig.options['train_x'])
+
+        # train the surrogate and check predicted value
+        prob['trig.x'] = np.array([2.1, 3.2, 4.3])
+        prob.run_model()
+        assert_near_equal(prob['trig.y'],
+                         np.array(.5*np.sin(prob['trig.x'])),
+                         1e-4)
+
+        data = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(data, atol=1e-6, rtol=1e-6)
 
@@ -614,14 +642,14 @@ class MetaModelTestCase(unittest.TestCase):
 
         prob.run_model()
 
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(data, atol=1e-5, rtol=1e-5)
 
         # Complex step
         prob.setup(force_alloc_complex=True)
         prob.model.mm.set_check_partial_options(wrt='*', method='cs')
-        data = prob.check_partials(out_stream=None)
+        data = force_check_partials(prob, out_stream=None)
 
         assert_check_partials(data, atol=1e-11, rtol=1e-11)
 

--- a/openmdao/components/tests/test_mux_comp.py
+++ b/openmdao/components/tests/test_mux_comp.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestMuxCompOptions(unittest.TestCase):
@@ -100,7 +101,7 @@ class TestMuxCompScalar(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=False, method='cs', out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=False, method='cs', out_stream=None)
         assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
 
@@ -153,7 +154,7 @@ class TestMuxComp1D(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=False, method='cs', out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=False, method='cs', out_stream=None)
         assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
 
@@ -213,7 +214,7 @@ class TestMuxComp2D(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=False, method='cs', out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=False, method='cs', out_stream=None)
         assert_check_partials(cpd, atol=1.0E-8, rtol=1.0E-8)
 
 

--- a/openmdao/components/tests/test_spline_comp.py
+++ b/openmdao/components/tests/test_spline_comp.py
@@ -11,6 +11,7 @@ from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.spline_distributions import cell_centered, sine_distribution
 from openmdao.components.interp_util.interp import InterpND
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class SplineCompTestCase(unittest.TestCase):
@@ -108,7 +109,7 @@ class SplineCompTestCase(unittest.TestCase):
 
         assert_near_equal(akima_y.flatten(), self.prob['akima1.y_val'].flatten(), tolerance=1e-8)
 
-        derivs = self.prob.check_partials(out_stream=None, method='cs')
+        derivs = force_check_partials(self.prob, out_stream=None, method='cs')
         assert_check_partials(derivs, atol=1e-14, rtol=1e-14)
 
     def test_no_ycp_val(self):
@@ -147,7 +148,7 @@ class SplineCompTestCase(unittest.TestCase):
 
         assert_near_equal(y.flatten(), self.prob['akima1.y_val'].flatten(), tolerance=1e-8)
 
-        derivs = self.prob.check_partials(out_stream=None, method='cs')
+        derivs = force_check_partials(self.prob, out_stream=None, method='cs')
         assert_check_partials(derivs, atol=1e-14, rtol=1e-14)
 
     def test_vectorized_all_derivs(self):
@@ -178,11 +179,11 @@ class SplineCompTestCase(unittest.TestCase):
             prob.run_model()
 
             if method.startswith('scipy'):
-                derivs = prob.check_partials(out_stream=None)
+                derivs = force_check_partials(prob, out_stream=None)
                 assert_check_partials(derivs, atol=1e-7, rtol=1e-7)
 
             else:
-                derivs = prob.check_partials(out_stream=None, method='cs')
+                derivs = force_check_partials(prob, out_stream=None, method='cs')
                 assert_check_partials(derivs, atol=1e-12, rtol=1e-12)
 
     def test_bspline_interp_basic(self):
@@ -222,7 +223,7 @@ class SplineCompTestCase(unittest.TestCase):
         # And that it gets middle points a little better.
         self.assertLess(max(delta[15:-15]), .06)
 
-        derivs = prob.check_partials(out_stream=None, method='cs')
+        derivs = force_check_partials(prob, out_stream=None, method='cs')
         assert_check_partials(derivs, atol=1e-14, rtol=1e-14)
 
     def test_bsplines_vectorized(self):
@@ -274,7 +275,7 @@ class SplineCompTestCase(unittest.TestCase):
             ]), 1e-5)
 
 
-        derivs = prob.check_partials(out_stream=None, method='cs')
+        derivs = force_check_partials(prob, out_stream=None, method='cs')
         assert_check_partials(derivs, atol=1e-14, rtol=1e-14)
 
     def test_bspline_bug(self):

--- a/openmdao/components/tests/test_vector_magnitude_comp.py
+++ b/openmdao/components/tests/test_vector_magnitude_comp.py
@@ -3,8 +3,8 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.units import convert_units
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
 
 
 class TestVectorMagnitudeCompNx3(unittest.TestCase):
@@ -43,7 +43,7 @@ class TestVectorMagnitudeCompNx3(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=False, method='fd', step=1.0E-9, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=False, method='fd', step=1.0E-9, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -87,7 +87,7 @@ class TestVectorMagnitudeCompNx4(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=False, method='fd', step=1.0E-9, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=False, method='fd', step=1.0E-9, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -132,7 +132,7 @@ class TestUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -186,7 +186,7 @@ class TestMultipleUnits(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:
@@ -237,7 +237,7 @@ class TestMultipleConfigure(unittest.TestCase):
 
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
-        cpd = self.p.check_partials(compact_print=True, out_stream=None)
+        cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
 
         for comp in cpd:
             for (var, wrt) in cpd[comp]:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1117,7 +1117,7 @@ class Problem(object):
         excludes = [excludes] if isinstance(excludes, str) else excludes
 
         comps = []
-        under_CI = env_truthy('OPENMDAO_CI')
+        under_CI = env_truthy('OPENMDAO_CHECK_ALL_PARTIALS')
 
         for comp in model.system_iter(typ=Component, include_self=True):
             # if we're under CI, do all of the partials, ignoring _no_check_partials

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1117,7 +1117,7 @@ class Problem(object):
         excludes = [excludes] if isinstance(excludes, str) else excludes
 
         comps = []
-        under_CI = env_truthy('CI')
+        under_CI = env_truthy('OPENMDAO_CI')
 
         for comp in model.system_iter(typ=Component, include_self=True):
             # if we're under CI, do all of the partials, ignoring _no_check_partials

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -269,7 +269,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         comp2._no_check_partials = True
 
         # Make check_partials think we're not on CI so we'll get the expected  non-CI behavior
-        with set_env_vars_context(OPENMDAO_CI='0'):
+        with set_env_vars_context(OPENMDAO_CHECK_ALL_PARTIALS='0'):
             data = prob.check_partials(out_stream=None)
 
         # no derivative data for 'comp2'

--- a/openmdao/core/tests/test_check_derivs.py
+++ b/openmdao/core/tests/test_check_derivs.py
@@ -269,7 +269,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         comp2._no_check_partials = True
 
         # Make check_partials think we're not on CI so we'll get the expected  non-CI behavior
-        with set_env_vars_context(CI='0'):
+        with set_env_vars_context(OPENMDAO_CI='0'):
             data = prob.check_partials(out_stream=None)
 
         # no derivative data for 'comp2'

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -248,7 +248,7 @@ def set_env_vars_context(**kwargs):
                 os.environ[k] = v
 
 
-@set_env_vars(OPENMDAO_CI="1")
+@set_env_vars(OPENMDAO_CHECK_ALL_PARTIALS="1")
 def force_check_partials(prob, *args, **kwargs):
     r"""
     Force the checking of partials even for components with _no_check_partials set.

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -197,6 +197,7 @@ class set_env_vars(object):
         fnc : function
             The function being wrapped.
         """
+        @functools.wraps(fnc)
         def wrap(*args, **kwargs):
             saved = {}
             try:
@@ -245,6 +246,28 @@ def set_env_vars_context(**kwargs):
                 del os.environ[k]
             else:
                 os.environ[k] = v
+
+
+@set_env_vars(OPENMDAO_CI="1")
+def force_check_partials(prob, *args, **kwargs):
+    r"""
+    Force the checking of partials even for components with _no_check_partials set.
+
+    Parameters
+    ----------
+    prob : Problem
+        The Problem being checked.
+    *args : list
+        Positional args.
+    **kwargs : dict
+        Keyword args.
+
+    Returns
+    -------
+    dict
+        Total derivative comparison data.
+    """
+    return prob.check_partials(*args, **kwargs)
 
 
 class _ModelViewerDataTreeEncoder(json.JSONEncoder):


### PR DESCRIPTION
### Summary

- Environment variable being checked is now `OPENMDAO_CI` instead of `CI`
- Set `OPENMDAO_CI` in our workflow yaml file
- created a testing function called `force_check_partials` that will always check partials regardless of the value of `OPENMDAO_CI` so that tests designed to check partials for a particular component will always check those partials.
- In a number of tests, replaced manually setting _no_check_partials to False with calling `force_check_partials` instead.
- Added calls to `force_check_partials` in a few places where checking of partials wasn't being forced but should have been.
- Fixed the bug in MetaModelUnStructuredComp where the derivatives were wrong when vec_size > 1 and using complex step.

### Related Issues

- Resolves #2858

### Backwards incompatibilities

None

### New Dependencies

None
