### PR TITLE
Changed 'class' member of model data tree to be the full class path.

### DIFF
--- a/openmdao/test_suite/scripts/sellar.py
+++ b/openmdao/test_suite/scripts/sellar.py
@@ -34,31 +34,32 @@ class SellarMDAConnect(om.Group):
         self.connect('cycle.d2.y2', ['obj_cmp.y2', 'con_cmp2.y2'])
 
 
-prob = om.Problem()
+if __name__ == '__main__':
+    prob = om.Problem()
 
-prob.model = SellarMDAConnect()
+    prob.model = SellarMDAConnect()
 
-prob.driver = om.ScipyOptimizeDriver()
-prob.driver.options['optimizer'] = 'SLSQP'
-# prob.driver.options['maxiter'] = 100
-prob.driver.options['tol'] = 1e-8
+    prob.driver = om.ScipyOptimizeDriver()
+    prob.driver.options['optimizer'] = 'SLSQP'
+    # prob.driver.options['maxiter'] = 100
+    prob.driver.options['tol'] = 1e-8
 
-prob.set_solver_print(level=0)
+    prob.set_solver_print(level=0)
 
-prob.model.add_design_var('x', lower=0, upper=10)
-prob.model.add_design_var('z', lower=0, upper=10)
-prob.model.add_objective('obj_cmp.obj')
-prob.model.add_constraint('con_cmp1.con1', upper=0)
-prob.model.add_constraint('con_cmp2.con2', upper=0)
+    prob.model.add_design_var('x', lower=0, upper=10)
+    prob.model.add_design_var('z', lower=0, upper=10)
+    prob.model.add_objective('obj_cmp.obj')
+    prob.model.add_constraint('con_cmp1.con1', upper=0)
+    prob.model.add_constraint('con_cmp2.con2', upper=0)
 
-prob.setup()
+    prob.setup()
 
-prob.set_val('x', 2.0)
-prob.set_val('z', [0., 0.])
+    prob.set_val('x', 2.0)
+    prob.set_val('z', [0., 0.])
 
-prob.run_driver()
-print('minimum found at')
-print(prob.get_val('x')[0])
-print(prob.get_val('z'))
-print('minumum objective')
-print(prob.get_val('obj_cmp.obj')[0])
+    prob.run_driver()
+    print('minimum found at')
+    print(prob.get_val('x')[0])
+    print(prob.get_val('z'))
+    print('minumum objective')
+    print(prob.get_val('obj_cmp.obj')[0])

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -217,9 +217,9 @@ def _serialize_single_option(option):
 def _get_tree_dict(system, is_parallel=False):
     """Get a dictionary representation of the system hierarchy."""
     try:
-        class_path = '.'.join((system.__class__.__module__, system.__class__.__name__))
+        class_path = ':'.join((system.__class__.__module__, system.__class__.__qualname__))
     except Exception:
-        class_path = system.__class__.__name__
+        class_path = system.__class__.__qualname__
 
     tree_dict = {
         'name': system.name if system.name else 'root',

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -217,9 +217,9 @@ def _serialize_single_option(option):
 def _get_tree_dict(system, is_parallel=False):
     """Get a dictionary representation of the system hierarchy."""
     try:
-        class_path = ':'.join((system.__class__.__module__, system.__class__.__qualname__))
+        class_path = ':'.join((type(system).__module__, type(system).__qualname__))
     except Exception:
-        class_path = system.__class__.__qualname__
+        class_path = type(system).__qualname__
 
     tree_dict = {
         'name': system.name if system.name else 'root',

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -216,10 +216,15 @@ def _serialize_single_option(option):
 
 def _get_tree_dict(system, is_parallel=False):
     """Get a dictionary representation of the system hierarchy."""
+    try:
+        class_path = '.'.join((system.__class__.__module__, system.__class__.__name__))
+    except Exception:
+        class_path = system.__class__.__name__
+
     tree_dict = {
         'name': system.name if system.name else 'root',
         'type': 'subsystem' if system.name else 'root',
-        'class': system.__class__.__name__,
+        'class': class_path,
         'expressions': None,
         'nonlinear_solver': "",
         'nonlinear_solver_options': None,

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -215,16 +215,13 @@ def _serialize_single_option(option):
 
 
 def _get_tree_dict(system, is_parallel=False):
-    """Get a dictionary representation of the system hierarchy."""
-    try:
-        class_path = ':'.join((type(system).__module__, type(system).__qualname__))
-    except Exception:
-        class_path = type(system).__qualname__
-
+    """
+    Get a dictionary representation of the system hierarchy.
+    """
     tree_dict = {
         'name': system.name if system.name else 'root',
         'type': 'subsystem' if system.name else 'root',
-        'class': class_path,
+        'class': ':'.join((type(system).__module__, type(system).__qualname__)),
         'expressions': None,
         'nonlinear_solver': "",
         'nonlinear_solver_options': None,

--- a/openmdao/visualization/n2_viewer/tests/betz_tree.json
+++ b/openmdao/visualization/n2_viewer/tests/betz_tree.json
@@ -1,7 +1,7 @@
 {
     "name": "root",
     "type": "root",
-    "class": "openmdao.core.group.Group",
+    "class": "openmdao.core.group:Group",
     "expressions": null,
     "component_type": null,
     "subsystem_type": "group",
@@ -23,7 +23,7 @@
         {
             "name": "indeps",
             "type": "subsystem",
-            "class": "openmdao.core.indepvarcomp.IndepVarComp",
+            "class": "openmdao.core.indepvarcomp:IndepVarComp",
             "expressions": null,
             "subsystem_type": "component",
             "is_parallel": false,
@@ -138,7 +138,7 @@
         {
             "name": "a_disk",
             "type": "subsystem",
-            "class": "openmdao.test_suite.test_examples.test_betz_limit.ActuatorDisc",
+            "class": "openmdao.test_suite.test_examples.test_betz_limit:ActuatorDisc",
             "expressions": null,
             "subsystem_type": "component",
             "is_parallel": false,

--- a/openmdao/visualization/n2_viewer/tests/betz_tree.json
+++ b/openmdao/visualization/n2_viewer/tests/betz_tree.json
@@ -1,7 +1,7 @@
 {
     "name": "root",
     "type": "root",
-    "class": "Group",
+    "class": "openmdao.core.group.Group",
     "expressions": null,
     "component_type": null,
     "subsystem_type": "group",
@@ -23,7 +23,7 @@
         {
             "name": "indeps",
             "type": "subsystem",
-            "class": "IndepVarComp",
+            "class": "openmdao.core.indepvarcomp.IndepVarComp",
             "expressions": null,
             "subsystem_type": "component",
             "is_parallel": false,
@@ -138,7 +138,7 @@
         {
             "name": "a_disk",
             "type": "subsystem",
-            "class": "ActuatorDisc",
+            "class": "openmdao.test_suite.test_examples.test_betz_limit.ActuatorDisc",
             "expressions": null,
             "subsystem_type": "component",
             "is_parallel": false,

--- a/openmdao/visualization/n2_viewer/tests/sellar_tree.json
+++ b/openmdao/visualization/n2_viewer/tests/sellar_tree.json
@@ -1,7 +1,7 @@
 {
     "name": "root",
     "type": "root",
-    "class": "openmdao.test_suite.components.sellar.SellarStateConnection",
+    "class": "openmdao.test_suite.components.sellar:SellarStateConnection",
     "expressions": null,
     "component_type": null,
     "subsystem_type": "group",
@@ -38,7 +38,7 @@
         {
             "name": "_auto_ivc",
             "type": "subsystem",
-            "class": "openmdao.core.indepvarcomp._AutoIndepVarComp",
+            "class": "openmdao.core.indepvarcomp:_AutoIndepVarComp",
             "expressions": null,
             "subsystem_type": "component",
             "is_parallel": false,
@@ -112,7 +112,7 @@
         {
             "name": "sub",
             "type": "subsystem",
-            "class": "openmdao.core.group.Group",
+            "class": "openmdao.core.group:Group",
             "expressions": null,
             "component_type": null,
             "subsystem_type": "group",
@@ -136,7 +136,7 @@
                 {
                     "name": "state_eq_group",
                     "type": "subsystem",
-                    "class": "openmdao.core.group.Group",
+                    "class": "openmdao.core.group:Group",
                     "expressions": null,
                     "component_type": null,
                     "subsystem_type": "group",
@@ -160,7 +160,7 @@
                         {
                             "name": "state_eq",
                             "type": "subsystem",
-                            "class": "openmdao.test_suite.components.sellar.StateConnection",
+                            "class": "openmdao.test_suite.components.sellar:StateConnection",
                             "expressions": null,
                             "subsystem_type": "component",
                             "is_parallel": false,
@@ -226,7 +226,7 @@
                 {
                     "name": "d1",
                     "type": "subsystem",
-                    "class": "openmdao.test_suite.components.sellar.SellarDis1withDerivatives",
+                    "class": "openmdao.test_suite.components.sellar:SellarDis1withDerivatives",
                     "expressions": null,
                     "subsystem_type": "component",
                     "is_parallel": false,
@@ -327,7 +327,7 @@
                 {
                     "name": "d2",
                     "type": "subsystem",
-                    "class": "openmdao.test_suite.components.sellar.SellarDis2withDerivatives",
+                    "class": "openmdao.test_suite.components.sellar:SellarDis2withDerivatives",
                     "expressions": null,
                     "subsystem_type": "component",
                     "is_parallel": false,
@@ -413,7 +413,7 @@
         {
             "name": "obj_cmp",
             "type": "subsystem",
-            "class": "openmdao.components.exec_comp.ExecComp",
+            "class": "openmdao.components.exec_comp:ExecComp",
             "expressions": [
                 "obj = x**2 + z[1] + y1 + exp(-y2)"
             ],
@@ -541,7 +541,7 @@
         {
             "name": "con_cmp1",
             "type": "subsystem",
-            "class": "openmdao.components.exec_comp.ExecComp",
+            "class": "openmdao.components.exec_comp:ExecComp",
             "expressions": [
                 "con1 = 3.16 - y1"
             ],
@@ -608,7 +608,7 @@
         {
             "name": "con_cmp2",
             "type": "subsystem",
-            "class": "openmdao.components.exec_comp.ExecComp",
+            "class": "openmdao.components.exec_comp:ExecComp",
             "expressions": [
                 "con2 = y2 - 24.0"
             ],

--- a/openmdao/visualization/n2_viewer/tests/sellar_tree.json
+++ b/openmdao/visualization/n2_viewer/tests/sellar_tree.json
@@ -1,7 +1,7 @@
 {
     "name": "root",
     "type": "root",
-    "class": "SellarStateConnection",
+    "class": "openmdao.test_suite.components.sellar.SellarStateConnection",
     "expressions": null,
     "component_type": null,
     "subsystem_type": "group",
@@ -38,7 +38,7 @@
         {
             "name": "_auto_ivc",
             "type": "subsystem",
-            "class": "_AutoIndepVarComp",
+            "class": "openmdao.core.indepvarcomp._AutoIndepVarComp",
             "expressions": null,
             "subsystem_type": "component",
             "is_parallel": false,
@@ -112,7 +112,7 @@
         {
             "name": "sub",
             "type": "subsystem",
-            "class": "Group",
+            "class": "openmdao.core.group.Group",
             "expressions": null,
             "component_type": null,
             "subsystem_type": "group",
@@ -136,7 +136,7 @@
                 {
                     "name": "state_eq_group",
                     "type": "subsystem",
-                    "class": "Group",
+                    "class": "openmdao.core.group.Group",
                     "expressions": null,
                     "component_type": null,
                     "subsystem_type": "group",
@@ -160,7 +160,7 @@
                         {
                             "name": "state_eq",
                             "type": "subsystem",
-                            "class": "StateConnection",
+                            "class": "openmdao.test_suite.components.sellar.StateConnection",
                             "expressions": null,
                             "subsystem_type": "component",
                             "is_parallel": false,
@@ -226,7 +226,7 @@
                 {
                     "name": "d1",
                     "type": "subsystem",
-                    "class": "SellarDis1withDerivatives",
+                    "class": "openmdao.test_suite.components.sellar.SellarDis1withDerivatives",
                     "expressions": null,
                     "subsystem_type": "component",
                     "is_parallel": false,
@@ -327,7 +327,7 @@
                 {
                     "name": "d2",
                     "type": "subsystem",
-                    "class": "SellarDis2withDerivatives",
+                    "class": "openmdao.test_suite.components.sellar.SellarDis2withDerivatives",
                     "expressions": null,
                     "subsystem_type": "component",
                     "is_parallel": false,
@@ -413,7 +413,7 @@
         {
             "name": "obj_cmp",
             "type": "subsystem",
-            "class": "ExecComp",
+            "class": "openmdao.components.exec_comp.ExecComp",
             "expressions": [
                 "obj = x**2 + z[1] + y1 + exp(-y2)"
             ],
@@ -541,7 +541,7 @@
         {
             "name": "con_cmp1",
             "type": "subsystem",
-            "class": "ExecComp",
+            "class": "openmdao.components.exec_comp.ExecComp",
             "expressions": [
                 "con1 = 3.16 - y1"
             ],
@@ -608,7 +608,7 @@
         {
             "name": "con_cmp2",
             "type": "subsystem",
-            "class": "ExecComp",
+            "class": "openmdao.components.exec_comp.ExecComp",
             "expressions": [
                 "con2 = y2 - 24.0"
             ],

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -579,7 +579,7 @@ class TestUnderMPI(unittest.TestCase):
             """
             if subsys['type'] == 'subsystem':
                 # Group or Component, recurse to children
-                parallel = parallel or subsys['class'] == 'openmdao.core.parallel_group.ParallelGroup'
+                parallel = parallel or subsys['class'] == 'openmdao.core.parallel_group:ParallelGroup'
                 for child in subsys['children']:
                     check_initial_value(child, parallel)
             else:

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -579,7 +579,7 @@ class TestUnderMPI(unittest.TestCase):
             """
             if subsys['type'] == 'subsystem':
                 # Group or Component, recurse to children
-                parallel = parallel or subsys['class'] == 'ParallelGroup'
+                parallel = parallel or subsys['class'] == 'openmdao.core.parallel_group.ParallelGroup'
                 for child in subsys['children']:
                     check_initial_value(child, parallel)
             else:


### PR DESCRIPTION
### Summary

The old value of the 'class' entry was the class name, and now it's (module path + ':' + qualified class name).

### Related Issues

- Resolves #2847

### Backwards incompatibilities

None

### New Dependencies

None
