### PR TITLE
Show warning about list_inputs values situationally

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4333,7 +4333,7 @@ class System(object):
         list of (name, metadata)
             List of input names and other optional information about those inputs.
         """
-        if self._problem_meta['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
+        if (self._problem_meta['setup_status'] < _SetupStatus.POST_FINAL_SETUP) and val:
             issue_warning("Calling `list_inputs` before `final_setup` will only "
                           "display the default values of variables and will not show the result of "
                           "any `set_val` calls.")


### PR DESCRIPTION
A user called `list_inputs(val=False)` and saw a warning about this not including the results of any `set_val` commands, which seems unnecessary because they don't care about the values anyway.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
