### PR TITLE
OptionsDictionary update: Added context manager for temporary options values and a set method for setting multiple values at once.

### DIFF
--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -335,11 +335,15 @@ class OptionsDictionary(object):
             and the associated values are the temporary values for those options.
         """
         for option, val in kwargs.items():
-            self._context_cache[option] = self[option]
+            if option not in self._context_cache:
+                self._context_cache[option] = []
+            self._context_cache[option].append(self[option])
             self[option] = val
         yield
         for option, val in kwargs.items():
-            self[option] = self._context_cache.pop(option)
+            self[option] = self._context_cache[option].pop()
+            if len(self._context_cache[option]) == 0:
+                self._context_cache.pop(option)
 
     def declare(self, name, default=_UNDEFINED, values=None, types=None, desc='',
                 upper=None, lower=None, check_valid=None, allow_none=False, recordable=True,

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -309,8 +309,21 @@ class OptionsDictionary(object):
         if meta['check_valid'] is not None:
             meta['check_valid'](name, value)
 
+    def set(self, **kwargs):
+        """
+        Set one or more options in the options dictionary simultaneously.
+
+        Parameters
+        ----------
+        **kwargs
+            Keyword arguments where the option names in the OptionsDictionary are the keywords
+            and the associated values are the values for those options.
+        """
+        for option, val in kwargs.items():
+            self[option] = val
+
     @contextlib.contextmanager
-    def __call__(self, **kwargs):
+    def temporary(self, **kwargs):
         """
         Provide a context manager for temporary option values within the context.
 

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -62,6 +62,8 @@ class OptionsDictionary(object):
         If True, no options can be set after declaration.
     _all_recordable : bool
         Flag to determine if all options in UserOptions are recordable.
+    _context_cache : dict
+        A dictionary to store cached option/value pairs when using the OptionsDictionary as a context manager.
     """
 
     def __init__(self, parent_name=None, read_only=False):
@@ -310,7 +312,7 @@ class OptionsDictionary(object):
     @contextlib.contextmanager
     def __call__(self, **kwargs):
         """
-        A context manager that provides temporary option values within the context.
+        Provide a context manager for temporary option values within the context.
 
         Parameters
         ----------

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -63,7 +63,8 @@ class OptionsDictionary(object):
     _all_recordable : bool
         Flag to determine if all options in UserOptions are recordable.
     _context_cache : dict
-        A dictionary to store cached option/value pairs when using the OptionsDictionary as a context manager.
+        A dictionary to store cached option/value pairs when using the
+        OptionsDictionary as a context manager.
     """
 
     def __init__(self, parent_name=None, read_only=False):

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -407,6 +407,10 @@ test       **Required**  ['a', 'b']         N/A                    Test integer 
         with options.temporary(foo='c', bar=5):
             self.assertEqual(options['foo'], 'c')
             self.assertEqual(options['bar'], 5)
+            with options.temporary(foo='a'):
+                self.assertEqual(options['foo'], 'a')
+            self.assertEqual(options['foo'], 'c')
+            self.assertEqual(options['bar'], 5)
 
         self.assertEqual(options['foo'], 'b')
         self.assertAlmostEqual(options['bar'], 3.14)

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -393,6 +393,24 @@ test       **Required**  ['a', 'b']         N/A                    Test integer 
         with assert_warning(OMDeprecationWarning, msg):
             opt.declare('foo:bar', 1.0)
 
+    def test_context_manager(self):
+        options = OptionsDictionary()
+        options.declare('foo', values=['a', 'b', 'c'], default=None, allow_none=True)
+        options.declare('bar', types=(float, int))
+
+        options['foo'] = 'b'
+        options['bar'] = 3.14
+
+        self.assertEqual(options['foo'], 'b')
+        self.assertAlmostEqual(options['bar'], 3.14)
+
+        with options(foo='c', bar=5):
+            self.assertEqual(options['foo'], 'c')
+            self.assertEqual(options['bar'], 5)
+
+        self.assertEqual(options['foo'], 'b')
+        self.assertAlmostEqual(options['bar'], 3.14)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -404,12 +404,26 @@ test       **Required**  ['a', 'b']         N/A                    Test integer 
         self.assertEqual(options['foo'], 'b')
         self.assertAlmostEqual(options['bar'], 3.14)
 
-        with options(foo='c', bar=5):
+        with options.temporary(foo='c', bar=5):
             self.assertEqual(options['foo'], 'c')
             self.assertEqual(options['bar'], 5)
 
         self.assertEqual(options['foo'], 'b')
         self.assertAlmostEqual(options['bar'], 3.14)
+
+    def test_call(self):
+        options = OptionsDictionary()
+        options.declare('foo', values=['a', 'b', 'c'], default=None, allow_none=True)
+        options.declare('bar', types=(float, int))
+
+        options['foo'] = 'b'
+        options['bar'] = 3.14
+
+        self.assertEqual(options['foo'], 'b')
+        self.assertAlmostEqual(options['bar'], 3.14)
+        options.set(foo='c', bar=5)
+        self.assertEqual(options['foo'], 'c')
+        self.assertEqual(options['bar'], 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Summary

When testing, I find myself wanting to change options values temporarily, run a test, and then reset the option back to its default value. This usually looks something like:

```
cache = my_options['name']
my_options['name'] = temp_val

run_tests()

my_options['name'] = cache
```

This seems similar to numpy's printoptions, and so it seemed like the right use for a context manager.
With this change you can now temporarily set and option value within the context.

```
with my_options.temporary(name=temp_val):
    run_tests()
```

I also often prefer to write a setter method to set multiple options in one line rather than using several lines and accessing the various options names with the `__setitem__` interface. This PR adds a `set` method that allows multiple options in the dictionary to be set simultaneously.

```
my_options.set(name='foo', units='kg')
```

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
