### PR TITLE
Remove note that invalid_desvar_behavior will change to "raise".

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -464,7 +464,6 @@ class Driver(object):
                          f'\n    lower: {lower}\n    upper: {upper}'
                 s += '\nSet the initial value of the design variable to a valid value or set ' \
                      'the driver option[\'invalid_desvar_behavior\'] to \'ignore\'.'
-                s += '\nThis warning will become an error by default in OpenMDAO version 3.25.'
                 if self.options['invalid_desvar_behavior'] == 'raise':
                     raise ValueError(s)
                 else:

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -321,8 +321,7 @@ class TestDifferentialEvolution(unittest.TestCase):
                         "\n    lower: [-10.   0.]"
                         "\n    upper: [10.  3.]"
                         "\nSet the initial value of the design variable to a valid value or set "
-                        "the driver option['invalid_desvar_behavior'] to 'ignore'."
-                        "\nThis warning will become an error by default in OpenMDAO version 3.25.")
+                        "the driver option['invalid_desvar_behavior'] to 'ignore'.")
 
         for option in ['warn', 'raise', 'ignore']:
             with self.subTest(f'invalid_desvar_behavior = {option}'):

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -478,8 +478,7 @@ class TestSimpleGA(unittest.TestCase):
                         "\n    lower: 0.0"
                         "\n    upper: 15.0"
                         "\nSet the initial value of the design variable to a valid value or set "
-                        "the driver option['invalid_desvar_behavior'] to 'ignore'."
-                        "\nThis warning will become an error by default in OpenMDAO version 3.25.")
+                        "the driver option['invalid_desvar_behavior'] to 'ignore'.")
 
         for option in ['warn', 'raise', 'ignore']:
             with self.subTest(f'invalid_desvar_behavior = {option}'):

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -1913,8 +1913,7 @@ class TestPyoptSparse(unittest.TestCase):
                         "\n    lower: -50.0"
                         "\n    upper: 50.0"
                         "\nSet the initial value of the design variable to a valid value or set "
-                        "the driver option['invalid_desvar_behavior'] to 'ignore'."
-                        "\nThis warning will become an error by default in OpenMDAO version 3.25.")
+                        "the driver option['invalid_desvar_behavior'] to 'ignore'.")
 
         for option in ['warn', 'raise', 'ignore']:
             with self.subTest(f'invalid_desvar_behavior = {option}'):

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -567,8 +567,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                         "\n    lower: -50.0"
                         "\n    upper: 50.0"
                         "\nSet the initial value of the design variable to a valid value or set "
-                        "the driver option['invalid_desvar_behavior'] to 'ignore'."
-                        "\nThis warning will become an error by default in OpenMDAO version 3.25.")
+                        "the driver option['invalid_desvar_behavior'] to 'ignore'.")
 
         for option in ['warn', 'raise', 'ignore']:
             with self.subTest(f'invalid_desvar_behavior = {option}'):
@@ -620,8 +619,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                         "\n    lower: -50.0"
                         "\n    upper: 50.0"
                         "\nSet the initial value of the design variable to a valid value or set "
-                        "the driver option['invalid_desvar_behavior'] to 'ignore'."
-                        "\nThis warning will become an error by default in OpenMDAO version 3.25.")
+                        "the driver option['invalid_desvar_behavior'] to 'ignore'.")
 
         for option in ['warn', 'raise', 'ignore']:
             with self.subTest(f'invalid_desvar_behavior = {option}'):


### PR DESCRIPTION
### Summary

Removes note that `invalid_desvar_behavior` will change to "raise".
This will be left as a warning for the time being.

### Related Issues

- Resolves #2868 

### Backwards incompatibilities

None

### New Dependencies

None
