### PR TITLE
Implemented a way of getting all independent variables from a Problem.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2188,8 +2188,8 @@ class Problem(object):
 
         return reports_dirpath
 
-    def list_indep_vars(self, include_design_vars=True, print_arrays=False,
-                        options=None, out_stream=_DEFAULT_OUT_STREAM):
+    def list_indep_vars(self, include_design_vars=True, options=None,
+                        print_arrays=False, out_stream=_DEFAULT_OUT_STREAM):
         """
         Retrieve the independent variables in the Problem.
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2211,8 +2211,9 @@ class Problem(object):
         options : list of str or None
             List of optional columns to be displayed in the independent variable table.
             Allowed values are:
-            ['name', 'units', 'shape', 'size', 'desc', 'ref', 'ref0', 'res_ref', 'distributed', 'lower', 'upper',
-            'tags', 'shape_by_conn', 'copy_shape', 'global_size', 'global_shape', 'value'].
+            ['name', 'units', 'shape', 'size', 'desc', 'ref', 'ref0', 'res_ref',
+            'distributed', 'lower', 'upper', 'tags', 'shape_by_conn', 'copy_shape',
+            'global_size', 'global_shape', 'value'].
         print_arrays : bool, optional
             When False, in the columnar display, just display norm of any ndarrays with size > 1.
             The norm is surrounded by vertical bars to indicate that it is a norm.
@@ -2234,7 +2235,9 @@ class Problem(object):
                                "run for the Problem.")
 
         connections = model._conn_global_abs_in2out
-        desvar_prom_names = model.get_design_vars(recurse=True, use_prom_ivc=True, get_sizes=False).keys()
+        desvar_prom_names = model.get_design_vars(recurse=True,
+                                                  use_prom_ivc=True,
+                                                  get_sizes=False).keys()
         problem_indep_vars = []
 
         default_col_names = ['name', 'units', 'value']
@@ -2263,7 +2266,7 @@ class Problem(object):
             else:
                 if out_stream is _DEFAULT_OUT_STREAM:
                     out_stream = sys.stdout
-                hr = '-'*len(header)
+                hr = '-' * len(header)
                 print(f'{hr}\n{header}\n{hr}', file=out_stream)
                 print(f'None found', file=out_stream)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2231,7 +2231,7 @@ class Problem(object):
         """
         model = self.model
         if model._outputs is None:
-            raise RuntimeError("get_indep_vars requires that final_setup has been "
+            raise RuntimeError("list_indep_vars requires that final_setup has been "
                                "run for the Problem.")
 
         connections = model._conn_global_abs_in2out

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2188,7 +2188,8 @@ class Problem(object):
 
         return reports_dirpath
 
-    def get_indep_vars(self, include_design_vars=True):
+    def list_indep_vars(self, include_design_vars=True, print_arrays=False,
+                        options=None, out_stream=_DEFAULT_OUT_STREAM):
         """
         Retrieve the independent variables in the Problem.
 
@@ -2198,7 +2199,7 @@ class Problem(object):
         A output is designated as an independent variable if it is tagged with
         'openmdao:indep_var'. This includes IndepVarComp by default, and users are
         able to apply this tag to their own component outputs if they wish
-        to provide components with IndepVarComp-like capaability.
+        to provide components with IndepVarComp-like capability.
 
         Parameters
         ----------
@@ -2206,6 +2207,20 @@ class Problem(object):
             If True, include design variables in the list of problem inputs.
             The user may provide values for these but ultimately they will
             be overwritten by the Driver.
+            Default is False.
+        options : list of str or None
+            List of optional columns to be displayed in the independent variable table.
+            Allowed values are:
+            ['name', 'units', 'shape', 'size', 'desc', 'ref', 'ref0', 'res_ref', 'distributed', 'lower', 'upper',
+            'tags', 'shape_by_conn', 'copy_shape', 'global_size', 'global_shape', 'value'].
+        print_arrays : bool, optional
+            When False, in the columnar display, just display norm of any ndarrays with size > 1.
+            The norm is surrounded by vertical bars to indicate that it is a norm.
+            When True, also display full values of the ndarray below the row. Format is affected
+            by the values set with numpy.set_printoptions.
+        out_stream : file-like object
+            Where to send human readable output. Default is sys.stdout.
+            Set to None to suppress.
 
         Returns
         -------
@@ -2219,20 +2234,40 @@ class Problem(object):
                                "run for the Problem.")
 
         connections = model._conn_global_abs_in2out
-        desvar_prom_names = set(model.get_design_vars(recurse=True, use_prom_ivc=True).keys())
-        problem_inputs = {}
+        desvar_prom_names = model.get_design_vars(recurse=True, use_prom_ivc=True).keys()
+        problem_indep_vars = []
+
+        default_col_names = ['name', 'units', 'value']
+        col_names = default_col_names + ([] if options is None else options)
 
         for target, meta in model._var_allprocs_abs2meta['input'].items():
-            prom = model._var_allprocs_abs2prom['input'][target]
             src = connections[target]
             smeta = model._var_allprocs_abs2meta['output'][src]
             src_is_ivc = 'openmdao:indep_var' in smeta['tags']
             input_name = model._var_allprocs_abs2prom['input'][target]
 
-            if src_is_ivc and (include_design_vars or input_name not in desvar_prom_names):
-                problem_inputs[input_name] = model._var_allprocs_abs2meta['output'][src]
+            smeta = {key: val for key, val in smeta.items() if key in col_names}
+            smeta['value'] = self.get_val(input_name)
 
-        return problem_inputs
+            if src_is_ivc and (include_design_vars or input_name not in desvar_prom_names):
+                problem_indep_vars.append((input_name, smeta))
+
+        if out_stream is not None:
+            header = f'Problem {self._name} Independent Variables'
+            if problem_indep_vars:
+                meta = {key: meta for key, meta in problem_indep_vars}
+                vals = {key: self.get_val(key) for key in meta}
+                self._write_var_info_table(header, col_names, meta, vals, print_arrays=print_arrays,
+                                           show_promoted_name=True, col_spacing=1,
+                                           out_stream=out_stream)
+            else:
+                if out_stream is _DEFAULT_OUT_STREAM:
+                    out_stream = sys.stdout
+                hr = '-'*len(header)
+                print(f'{hr}\n{header}\n{hr}', file=out_stream)
+                print(f'None found', file=out_stream)
+
+        return problem_indep_vars
 
 
 _ErrorTuple = namedtuple('ErrorTuple', ['forward', 'reverse', 'forward_reverse'])

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2234,7 +2234,7 @@ class Problem(object):
                                "run for the Problem.")
 
         connections = model._conn_global_abs_in2out
-        desvar_prom_names = model.get_design_vars(recurse=True, use_prom_ivc=True).keys()
+        desvar_prom_names = model.get_design_vars(recurse=True, use_prom_ivc=True, get_sizes=False).keys()
         problem_indep_vars = []
 
         default_col_names = ['name', 'units', 'value']

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2211,6 +2211,26 @@ class RelevanceTestCase(unittest.TestCase):
 
         self._finish_setup_and_check(p, ['C2', 'C3', 'C4', 'C5', 'C6'])
 
+    def test_get_indep_vars(self):
+        prob = om.Problem()
+        prob.model = SellarDerivatives()
+        prob.model.add_design_var('x')
+        prob.model.add_design_var('z')
+
+        prob.setup()
+        prob.final_setup()
+
+        all_indep_vars = prob.get_indep_vars()
+
+        self.assertIn('x', all_indep_vars)
+        self.assertIn('z', all_indep_vars)
+
+        indep_vars_no_desvars = prob.get_indep_vars(include_design_vars=False)
+
+        self.assertNotIn('x', indep_vars_no_desvars)
+        self.assertNotIn('z', indep_vars_no_desvars)
+
+
 class NestedProblemTestCase(unittest.TestCase):
 
     def test_nested_prob(self):

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2229,8 +2229,8 @@ class RelevanceTestCase(unittest.TestCase):
         output = strout.getvalue()
         self.assertRegex(output.split('\n')[1], r'Problem \w+ Independent Variables')
         self.assertEqual(output.split('\n')[3].split(), ['name', 'units', 'value'])
-        self.assertEqual(output.split('\n')[5].split(), ['z', 'None', '|5.38516481|'])
-        self.assertEqual(output.split('\n')[6].split(), ['x', 'None', '[1.]'])
+        self.assertRegex(output.split('\n')[5], r'\s*z\s+None\s+|[0-9.]+|')
+        self.assertRegex(output.split('\n')[6], r'\s*x\s+None\s+|[0-9.]+|')
 
         strout = StringIO()
         indep_var_names_no_desvars = [name for name, _ in

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2211,7 +2211,7 @@ class RelevanceTestCase(unittest.TestCase):
 
         self._finish_setup_and_check(p, ['C2', 'C3', 'C4', 'C5', 'C6'])
 
-    def test_get_indep_vars(self):
+    def test_list_indep_vars(self):
         prob = om.Problem()
         prob.model = SellarDerivatives()
         prob.model.add_design_var('x')
@@ -2220,15 +2220,29 @@ class RelevanceTestCase(unittest.TestCase):
         prob.setup()
         prob.final_setup()
 
-        all_indep_vars = prob.get_indep_vars()
+        strout = StringIO()
+        all_indep_var_names = [name for name, _ in prob.list_indep_vars(out_stream=strout)]
 
-        self.assertIn('x', all_indep_vars)
-        self.assertIn('z', all_indep_vars)
+        self.assertIn('x', all_indep_var_names)
+        self.assertIn('z', all_indep_var_names)
 
-        indep_vars_no_desvars = prob.get_indep_vars(include_design_vars=False)
+        output = strout.getvalue()
+        self.assertRegex(output.split('\n')[1], r'Problem \w+ Independent Variables')
+        self.assertEqual(output.split('\n')[3].split(), ['name', 'units', 'value'])
+        self.assertEqual(output.split('\n')[5].split(), ['z', 'None', '|5.38516481|'])
+        self.assertEqual(output.split('\n')[6].split(), ['x', 'None', '[1.]'])
 
-        self.assertNotIn('x', indep_vars_no_desvars)
-        self.assertNotIn('z', indep_vars_no_desvars)
+        strout = StringIO()
+        indep_var_names_no_desvars = [name for name, _ in
+                                      prob.list_indep_vars(include_design_vars=False,
+                                                           out_stream=strout)]
+
+        self.assertNotIn('x', indep_var_names_no_desvars)
+        self.assertNotIn('z', indep_var_names_no_desvars)
+
+        output = strout.getvalue()
+        self.assertRegex(output.split('\n')[1], r'Problem \w+ Independent Variables')
+        self.assertEqual(output.split('\n')[3].split(), ['None', 'found'])
 
 
 class NestedProblemTestCase(unittest.TestCase):


### PR DESCRIPTION
### Summary

User's often need a succinct list of the variables they are expected to provide for a problem.  As the complexity of models grows, it can be easy to overlook an input to the problem.

This PR addresses this by adding a `Problem.get_indep_vars` method. This method returns any variable tagged with `'openmdao:is_indep_var'`. This allows the inclusion of both IndepVarComp outputs and outputs from user models with IndepVarComp-like behavior.

The method allows for optional exclusion of design variables from the returned list.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
