### PR TITLE
Removed dead code that handled a non-Group model

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1496,8 +1496,6 @@ class System(object):
 
         self._top_level_post_sizes()
 
-        # The try/except can be removed when support for the
-        # "Component as a model" deprecation is removed
         try:
             self._problem_meta['relevant'] = self._init_relevance(mode)
         except RuntimeError:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1502,17 +1502,7 @@ class System(object):
             self._problem_meta['relevant'] = self._init_relevance(mode)
         except RuntimeError:
             type_exc, exc, tb = sys.exc_info()
-            from openmdao.core.group import Group
-            if not isinstance(self, Group) and "Output not found for design variable" in str(exc):
-                msg = f"The model is of type '{self.__class__.__name__}'. " \
-                      "Components must be placed in a Group in order for unconnected inputs " \
-                      "to be used as design variables. A future release will require that " \
-                      "the model be a Group or a sub-class of Group."
-                self._collect_error(str(exc), exc_type=type_exc, tback=tb)
-                self._collect_error(msg)
-                return
-            else:
-                self._collect_error(str(exc), exc_type=type_exc, tback=tb)
+            self._collect_error(str(exc), exc_type=type_exc, tback=tb)
 
         # determine which connections are managed by which group, and check validity of connections
         self._setup_connections()


### PR DESCRIPTION
### Summary

PR #2869 missed this bit of code, which was intended to handle the situation where the model was not a Group.  Since this is no longer possible, the code has been removed.

### Related Issues

- Resolves #2761

### Backwards incompatibilities

None

### New Dependencies

None
