### PR TITLE
Cleaned up some deprecations

### DIFF
--- a/openmdao/components/interp_util/interp_akima.py
+++ b/openmdao/components/interp_util/interp_akima.py
@@ -386,7 +386,7 @@ class InterpAkima(InterpAlgorithm):
                 w31 = abs_complex(m2 - m1)
 
         # Special case to avoid divide by zero.
-        jj1 = np.where(w2 + w31 > eps)
+        jj1 = np.where(np.atleast_1d(w2 + w31) > eps)
         b = 0.5 * (m2 + m3)
         if compute_local_train:
             db_dv = 0.5 * (dm2_dv + dm3_dv)
@@ -437,7 +437,7 @@ class InterpAkima(InterpAlgorithm):
                 w4 = abs_complex(m3 - m2)
 
         # Special case to avoid divide by zero.
-        jj2 = np.where(w32 + w4 > eps)
+        jj2 = np.where(np.atleast_1d(w32 + w4) > eps)
         bp1 = 0.5 * (m3 + m4)
         if compute_local_train:
             dbp1_dv = 0.5 * (dm3_dv + dm4_dv)

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1328,14 +1328,14 @@ class TestExecComp(unittest.TestCase):
                             z={'shape' : (1, ), 'units' : 's'})
 
         self.assertEqual(cm.exception.args[0],
-                          "Defaults for 'x' have already been defined in a previous "
-                          "expression.")
+                         "Defaults for 'x' have already been defined in a previous "
+                         "expression.")
 
         with self.assertRaises(TypeError) as cm:
             excomp.add_expr(p)
 
         self.assertEqual(cm.exception.args[0],
-                          "Argument 'expr' must be of type 'str', but type 'Problem' was found.")
+                         "Argument 'expr' must be of type 'str', but type 'Problem' was found.")
 
         excomp.add_expr('y = 2.9*x')
         p.model.add_subsystem('zzz', excomp)
@@ -1343,7 +1343,7 @@ class TestExecComp(unittest.TestCase):
             p.setup()
 
         self.assertEqual(cm.exception.args[0],
-                          "'zzz' <class ExecComp>: The output 'y' has already been defined by an expression.")
+                         "'zzz' <class ExecComp>: The output 'y' has already been defined by an expression.")
 
     def test_feature_add_expr(self):
 
@@ -1572,7 +1572,7 @@ class TestFunctionRegistration(unittest.TestCase):
             with self.assertRaises(Exception) as cm:
                 data = force_check_partials(p, out_stream=None)
             self.assertEqual(cm.exception.args[0],
-                              "'comp' <class ExecComp>: expression contains functions ['area'] that are not complex safe. To fix this, call declare_partials('*', ['x'], method='fd') on this component prior to setup.")
+                             "'comp' <class ExecComp>: expression contains functions ['area'] that are not complex safe. To fix this, call declare_partials('*', ['x'], method='fd') on this component prior to setup.")
 
     def test_register_check_partials_not_safe_mult_expr(self):
         with _temporary_expr_dict():
@@ -1626,7 +1626,7 @@ class TestFunctionRegistration(unittest.TestCase):
             with self.assertRaises(Exception) as cm:
                 data = force_check_partials(p, out_stream=None, step=1e-7)
             self.assertEqual(cm.exception.args[0],
-                              "'comp' <class ExecComp>: expression contains functions ['unsafe'] that are not complex safe. To fix this, call declare_partials('*', ['z'], method='fd') on this component prior to setup.")
+                             "'comp' <class ExecComp>: expression contains functions ['unsafe'] that are not complex safe. To fix this, call declare_partials('*', ['z'], method='fd') on this component prior to setup.")
 
     def test_register_check_partials_safe(self):
         with _temporary_expr_dict():
@@ -1776,7 +1776,7 @@ class TestFunctionRegistration(unittest.TestCase):
             with self.assertRaises(Exception) as cm:
                 om.ExecComp.register('shape', lambda x: x, complex_safe=True)
             self.assertEqual(cm.exception.args[0], "ExecComp: cannot register name 'shape' because "
-                              "it's a reserved keyword.")
+                             "it's a reserved keyword.")
 
     def test_register_err_not_callable(self):
         with _temporary_expr_dict():

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1327,14 +1327,14 @@ class TestExecComp(unittest.TestCase):
                             x={'val' : 3.0, 'units' : 'cm'},
                             z={'shape' : (1, ), 'units' : 's'})
 
-        self.assertEquals(cm.exception.args[0],
+        self.assertEqual(cm.exception.args[0],
                           "Defaults for 'x' have already been defined in a previous "
                           "expression.")
 
         with self.assertRaises(TypeError) as cm:
             excomp.add_expr(p)
 
-        self.assertEquals(cm.exception.args[0],
+        self.assertEqual(cm.exception.args[0],
                           "Argument 'expr' must be of type 'str', but type 'Problem' was found.")
 
         excomp.add_expr('y = 2.9*x')
@@ -1342,7 +1342,7 @@ class TestExecComp(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             p.setup()
 
-        self.assertEquals(cm.exception.args[0],
+        self.assertEqual(cm.exception.args[0],
                           "'zzz' <class ExecComp>: The output 'y' has already been defined by an expression.")
 
     def test_feature_add_expr(self):
@@ -1571,7 +1571,7 @@ class TestFunctionRegistration(unittest.TestCase):
 
             with self.assertRaises(Exception) as cm:
                 data = force_check_partials(p, out_stream=None)
-            self.assertEquals(cm.exception.args[0],
+            self.assertEqual(cm.exception.args[0],
                               "'comp' <class ExecComp>: expression contains functions ['area'] that are not complex safe. To fix this, call declare_partials('*', ['x'], method='fd') on this component prior to setup.")
 
     def test_register_check_partials_not_safe_mult_expr(self):
@@ -1625,7 +1625,7 @@ class TestFunctionRegistration(unittest.TestCase):
 
             with self.assertRaises(Exception) as cm:
                 data = force_check_partials(p, out_stream=None, step=1e-7)
-            self.assertEquals(cm.exception.args[0],
+            self.assertEqual(cm.exception.args[0],
                               "'comp' <class ExecComp>: expression contains functions ['unsafe'] that are not complex safe. To fix this, call declare_partials('*', ['z'], method='fd') on this component prior to setup.")
 
     def test_register_check_partials_safe(self):
@@ -1775,20 +1775,20 @@ class TestFunctionRegistration(unittest.TestCase):
         with _temporary_expr_dict():
             with self.assertRaises(Exception) as cm:
                 om.ExecComp.register('shape', lambda x: x, complex_safe=True)
-            self.assertEquals(cm.exception.args[0], "ExecComp: cannot register name 'shape' because "
+            self.assertEqual(cm.exception.args[0], "ExecComp: cannot register name 'shape' because "
                               "it's a reserved keyword.")
 
     def test_register_err_not_callable(self):
         with _temporary_expr_dict():
             with self.assertRaises(Exception) as cm:
                 om.ExecComp.register('foo', 99, complex_safe=True)
-            self.assertEquals(cm.exception.args[0], "ExecComp: 'foo' passed to register() of type 'int' is not callable.")
+            self.assertEqual(cm.exception.args[0], "ExecComp: 'foo' passed to register() of type 'int' is not callable.")
 
     def test_register_err_dup(self):
         with _temporary_expr_dict():
             with self.assertRaises(Exception) as cm:
                 om.ExecComp.register('exp', lambda x: x, complex_safe=True)
-            self.assertEquals(cm.exception.args[0], "ExecComp: 'exp' has already been registered.")
+            self.assertEqual(cm.exception.args[0], "ExecComp: 'exp' has already been registered.")
 
 
 _MASK = np.array(

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -60,7 +60,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
-        self.assertEqual(np.sum(v.size for v in derivs.values()), 2)
+        self.assertEqual(np.sum(list(v.size for v in derivs.values())), 2)
 
     def test_fd_count(self):
         # Make sure we aren't doing extra FD steps.
@@ -986,7 +986,7 @@ class TestGroupComplexStep(unittest.TestCase):
         assert_near_equal(derivs['f_xy', 'y'], [[8.0]], 1e-6)
 
         # 1 output x 2 inputs
-        self.assertEqual(np.sum(v.size for v in derivs.values()), 2)
+        self.assertEqual(np.sum(list(v.size for v in derivs.values())), 2)
 
     def test_paraboloid_subbed(self):
 

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -2072,7 +2072,7 @@ class TestDistribBugs(unittest.TestCase):
             assert_check_totals(data)
 
         msg = "During total derivative computation, the following partial derivatives resulted in serial inputs that were inconsistent across processes: ['D1.out_dist wrt D1.in_nd']."
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_check_partials_cs_old(self):
         prob = self.get_problem(Distrib_Derivs_Matfree_Old)

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -223,7 +223,7 @@ class TestPassSizeDistributed(unittest.TestCase):
             prob.setup()
 
         msg = "\nCollected errors for problem 'serial_start':\n   <model> <class Group>: dynamic sizing of non-distributed input 'E.in' from distributed output 'D.out' is not supported.\n   <model> <class Group>: Can't connect distributed output 'D.out' to non-distributed input 'E.in' without specifying src_indices.\n   <model> <class Group>: The source indices slice(None, None, 1) do not specify a valid shape for the connection 'B.out' to 'C.in'. The target shape is (4,) but indices are shape (12,)."
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_distributed_start(self):
         """the size information starts in the distributed component C"""
@@ -254,7 +254,7 @@ class TestPassSizeDistributed(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.setup()
 
-        self.assertEquals(str(cm.exception),
+        self.assertEqual(str(cm.exception),
            "\nCollected errors for problem 'distributed_start':"
            "\n   <model> <class Group>: dynamic sizing of non-distributed output 'A.out' from "
            "distributed input 'B.in' is not supported because not all B.in ranks are the same size "
@@ -794,7 +794,7 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.model.connect('indeps.x', 'comp.x')
         with self.assertRaises(Exception) as cm:
             p.setup()
-        self.assertEquals(cm.exception.args[0],
+        self.assertEqual(cm.exception.args[0],
            "\nCollected errors for problem 'ser_unknown_dist_known_err':"
            "\n   <model> <class Group>: dynamic sizing of non-distributed output 'indeps.x' from "
            "distributed input 'comp.x' is not supported because not all comp.x ranks are the same "
@@ -811,7 +811,7 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.model.connect('indeps.x', 'comp.x')
         with self.assertRaises(Exception) as cm:
             p.setup()
-        self.assertEquals(cm.exception.args[0],
+        self.assertEqual(cm.exception.args[0],
             "\nCollected errors for problem 'dist_known_ser_unknown':"
             "\n   <model> <class Group>: dynamic sizing of non-distributed input 'comp.x' from "
             "distributed output 'indeps.x' is not supported."
@@ -826,7 +826,7 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.model.connect('indeps.x', 'comp.x')
         with self.assertRaises(Exception) as cm:
             p.setup()
-        self.assertEquals(cm.exception.args[0],
+        self.assertEqual(cm.exception.args[0],
             "\nCollected errors for problem 'dist_unknown_ser_known':"
             "\n   <model> <class Group>: Can't connect distributed output 'indeps.x' to "
             "non-distributed input 'comp.x' without specifying src_indices.")

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -66,10 +66,10 @@ class CacheLinearTestCase(unittest.TestCase):
 
                 if mode == 'fwd':
                     print("incoming initial guess", d_outputs['states'])
-                    d_outputs['states'] = gmres(self.state_jac, d_residuals['states'], x0=d_outputs['states'])[0]
+                    d_outputs['states'] = gmres(self.state_jac, d_residuals['states'], x0=d_outputs['states'], atol='legacy')[0]
 
                 elif mode == 'rev':
-                    d_residuals['states'] = gmres(self.state_jac, d_outputs['states'], x0=d_residuals['states'])[0]
+                    d_residuals['states'] = gmres(self.state_jac, d_outputs['states'], x0=d_residuals['states'], atol='legacy')[0]
 
         p = om.Problem()
         p.driver = om.ScipyOptimizeDriver()
@@ -94,4 +94,3 @@ class CacheLinearTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -94,3 +94,4 @@ class CacheLinearTestCase(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2133,7 +2133,7 @@ class TestConnect(unittest.TestCase):
                 self.sub.connect('src.x', 'tgt.x', src_indices=[1.0])
 
         msg = "'sub' <class Group>: When connecting from 'src.x' to 'tgt.x': Can't create an index array using indices of non-integral type 'float64'."
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_src_indices_as_float_array(self):
         self.prob._name = 'src_indices_as_float_array'
@@ -2142,7 +2142,7 @@ class TestConnect(unittest.TestCase):
             self.prob.setup()
             self.prob.run_model()
 
-        self.assertEquals(str(cm.exception),
+        self.assertEqual(str(cm.exception),
            "\nCollected errors for problem 'src_indices_as_float_array':"
            "\n   'sub' <class Group>: When connecting from 'src.x' to 'tgt.x': Can't create an "
            "index array using indices of non-integral type 'float64'.")
@@ -2161,7 +2161,7 @@ class TestConnect(unittest.TestCase):
             with self.assertRaises(Exception) as cm:
                 self.sub.connect('cmp.x', 'tgt.x', src_indices=[1])
 
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_invalid_source(self):
         self.prob._name = 'invalid_source'

--- a/openmdao/core/tests/test_parallel_fd.py
+++ b/openmdao/core/tests/test_parallel_fd.py
@@ -194,7 +194,7 @@ class SerialDiamondFDTestCase(TestCase):
         try:
             setup_diamond_model(0, 10, 'fd', 'model')
         except Exception as err:
-            self.assertEquals(str(err), "Value (0) of option 'num_par_fd' is less than minimum allowed value of 1.")
+            self.assertEqual(str(err), "Value (0) of option 'num_par_fd' is less than minimum allowed value of 1.")
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1714,11 +1714,11 @@ class TestProblem(unittest.TestCase):
         finally:
             sys.stdout = stdout
         output = strout.getvalue().split('\n')
-        self.assertEquals(output[1], r'Design Variables')
+        self.assertEqual(output[1], r'Design Variables')
         self.assertRegex(output[5], r'^z +\|[0-9. e+-]+\| +2')
-        self.assertEquals(output[9], r'Constraints')
+        self.assertEqual(output[9], r'Constraints')
         self.assertRegex(output[14], r'^con2 +\[[0-9. e+-]+\] +1')
-        self.assertEquals(output[17], r'Objectives')
+        self.assertEqual(output[17], r'Objectives')
         self.assertRegex(output[21], r'^obj +\[[0-9. e+-]+\] +1')
 
         # With show_promoted_name=False
@@ -1794,37 +1794,37 @@ class TestProblem(unittest.TestCase):
         self.assertRegex(output[13], r'^\s+array+\(+\[[0-9., e+-]+\]+\)')
 
         # design vars
-        self.assertEquals(l['design_vars'][0][1]['name'], 'z')
-        self.assertEquals(l['design_vars'][0][1]['size'], 2)
+        self.assertEqual(l['design_vars'][0][1]['name'], 'z')
+        self.assertEqual(l['design_vars'][0][1]['size'], 2)
         assert(all(l['design_vars'][0][1]['val'] == prob.get_val('z')))
-        self.assertEquals(l['design_vars'][0][1]['scaler'], None)
-        self.assertEquals(l['design_vars'][0][1]['adder'], None)
+        self.assertEqual(l['design_vars'][0][1]['scaler'], None)
+        self.assertEqual(l['design_vars'][0][1]['adder'], None)
 
-        self.assertEquals(l['design_vars'][1][1]['name'], 'x')
-        self.assertEquals(l['design_vars'][1][1]['size'], 1)
+        self.assertEqual(l['design_vars'][1][1]['name'], 'x')
+        self.assertEqual(l['design_vars'][1][1]['size'], 1)
         assert(all(l['design_vars'][1][1]['val'] == prob.get_val('x')))
-        self.assertEquals(l['design_vars'][1][1]['scaler'], None)
-        self.assertEquals(l['design_vars'][1][1]['adder'], None)
+        self.assertEqual(l['design_vars'][1][1]['scaler'], None)
+        self.assertEqual(l['design_vars'][1][1]['adder'], None)
 
         # constraints
-        self.assertEquals(l['constraints'][0][1]['name'], 'con1')
-        self.assertEquals(l['constraints'][0][1]['size'], 1)
+        self.assertEqual(l['constraints'][0][1]['name'], 'con1')
+        self.assertEqual(l['constraints'][0][1]['size'], 1)
         assert(all(l['constraints'][0][1]['val'] == prob.get_val('con1')))
-        self.assertEquals(l['constraints'][0][1]['scaler'], None)
-        self.assertEquals(l['constraints'][0][1]['adder'], None)
+        self.assertEqual(l['constraints'][0][1]['scaler'], None)
+        self.assertEqual(l['constraints'][0][1]['adder'], None)
 
-        self.assertEquals(l['constraints'][1][1]['name'], 'con2')
-        self.assertEquals(l['constraints'][1][1]['size'], 1)
+        self.assertEqual(l['constraints'][1][1]['name'], 'con2')
+        self.assertEqual(l['constraints'][1][1]['size'], 1)
         assert(all(l['constraints'][1][1]['val'] == prob.get_val('con2')))
-        self.assertEquals(l['constraints'][1][1]['scaler'], None)
-        self.assertEquals(l['constraints'][1][1]['adder'], None)
+        self.assertEqual(l['constraints'][1][1]['scaler'], None)
+        self.assertEqual(l['constraints'][1][1]['adder'], None)
 
         # objectives
-        self.assertEquals(l['objectives'][0][1]['name'], 'obj')
-        self.assertEquals(l['objectives'][0][1]['size'], 1)
+        self.assertEqual(l['objectives'][0][1]['name'], 'obj')
+        self.assertEqual(l['objectives'][0][1]['size'], 1)
         assert(all(l['objectives'][0][1]['val'] == prob.get_val('obj')))
-        self.assertEquals(l['objectives'][0][1]['scaler'], None)
-        self.assertEquals(l['objectives'][0][1]['adder'], None)
+        self.assertEqual(l['objectives'][0][1]['scaler'], None)
+        self.assertEqual(l['objectives'][0][1]['adder'], None)
 
     def test_list_problem_vars_before_final_setup(self):
         prob = om.Problem()

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -227,7 +227,7 @@ class TestJacobianFeatures(unittest.TestCase):
         with self.assertRaises(ValueError) as ex:
             problem.setup()
             problem.run_model()
-        self.assertRegexpMatches(str(ex.exception), error_msg)
+        self.assertRegex(str(ex.exception), error_msg)
 
     @parameterized.expand([
         ({'of': 'q', 'wrt': 'z'}, "'simple' <class SimpleCompKwarg>: " + 'No matches were found for of="q"'),
@@ -243,7 +243,7 @@ class TestJacobianFeatures(unittest.TestCase):
         problem.setup()
         with self.assertRaises(ValueError) as ex:
             problem.run_model()
-        self.assertEquals(str(ex.exception), error_msg)
+        self.assertEqual(str(ex.exception), error_msg)
 
     def test_const_jacobian(self):
         model = om.Group()

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -794,7 +794,7 @@ class TestSqliteCaseReader(unittest.TestCase):
                     mda_counter += 1
                 if source.startswith('root.'):     # count all cases for/under root solver
                     root_counter += 1
-                self.assertRegexpMatches(case, expected)
+                self.assertRegex(case, expected)
 
         self.assertEqual(counter, global_iterations)
 
@@ -1007,7 +1007,7 @@ class TestSqliteCaseReader(unittest.TestCase):
                     mda_counter += 1
                 if source.startswith('root.'):     # count all cases for/under root solver
                     root_counter += 1
-                self.assertRegexpMatches(case.name, expected)
+                self.assertRegex(case.name, expected)
 
         self.assertEqual(counter, global_iterations)
 
@@ -1882,19 +1882,19 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             case['a']
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
         with self.assertRaises(RuntimeError) as cm:
             case.get_val('a')
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
         with self.assertRaises(RuntimeError) as cm:
             case.get_val('a', units='m')
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
         with self.assertRaises(RuntimeError) as cm:
             case.get_val('a', units='ft')
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
         # 'a' is ambiguous.. which input's units do you want when accessing 'a'?
         # (test the underlying function, currently only called from inside get_val)
@@ -1904,7 +1904,7 @@ class TestSqliteCaseReader(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as cm:
             case._get_units('a')
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_get_vars(self):
         prob = SellarProblem(nonlinear_solver=om.NonlinearBlockGS,

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -221,16 +221,16 @@ class ScipyKrylov(LinearSolver):
         if solver is gmres:
             if Version(scipy.__version__) < Version("1.1"):
                 x, info = solver(linop, b_vec.asarray(True), M=M, restart=restart,
-                                 x0=x_vec_combined, maxiter=maxiter, tol=atol,
-                                 callback=self._monitor)
+                                 x0=x_vec_combined, maxiter=maxiter, tol=atol, atol='legacy',
+                                 callback=self._monitor, callback_type='legacy')
             else:
                 x, info = solver(linop, b_vec.asarray(True), M=M, restart=restart,
                                  x0=x_vec_combined, maxiter=maxiter, tol=atol, atol='legacy',
-                                 callback=self._monitor)
+                                 callback=self._monitor, callback_type='legacy')
         else:
             x, info = solver(linop, b_vec.asarray(True), M=M,
-                             x0=x_vec_combined, maxiter=maxiter, tol=atol,
-                             callback=self._monitor)
+                             x0=x_vec_combined, maxiter=maxiter, tol=atol, atol='legacy',
+                             callback=self._monitor, callback_type='legacy')
 
         fail |= (info != 0)
         x_vec.set_val(x)

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -290,6 +290,9 @@ def array_connection_compatible(shape1, shape2):
     else:
         fundamental_shape2 = np.ones((1,))
 
+    if len(fundamental_shape1) != len(fundamental_shape2):
+        return False
+
     return np.all(fundamental_shape1 == fundamental_shape2)
 
 

--- a/openmdao/visualization/n2_viewer/tests/gen_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/gen_gui_test.py
@@ -36,7 +36,7 @@ if 'win32' in sys.platform:
     # Windows specific event-loop policy & cmd
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
-my_loop = asyncio.get_event_loop()
+my_loop = asyncio.get_event_loop_policy().get_event_loop()
 
 """ A set of toolbar tests that runs on each model. """
 toolbar_script = [

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -36,7 +36,7 @@ if 'win32' in sys.platform:
     # Windows specific event-loop policy & cmd
     asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
-my_loop = asyncio.get_event_loop()
+my_loop = asyncio.get_event_loop_policy().get_event_loop()
 
 """ A set of toolbar tests that runs on each model. """
 toolbar_script = [
@@ -718,7 +718,7 @@ n2_gui_test_scripts = {
             "test": "click",
             "selector": "#filter-target",
             "button": "left"
-        },   
+        },
     ]
 }
 

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -8,11 +8,6 @@ import sys
 
 from openmdao.utils.gui_testing_utils import _GuiTestCase
 
-try:
-    from parameterized import parameterized
-except ImportError:
-    from openmdao.utils.assert_utils import SkipParameterized as parameterized
-
 # set DEBUG to True if you want to view the generated HTML file
 GUI_TEST_SUBDIR = 'gui_test_models'
 GUI_N2_SUFFIX = '_N2_TEST.html'
@@ -1033,27 +1028,28 @@ class n2_gui_test_case(_GuiTestCase):
             print(msg)
             self.fail(msg)
 
-    @parameterized.expand(n2_gui_test_models)
     @async_test(loop=my_loop)
-    async def test_n2_gui(self, basename):
-        if (basename[:2] == "__"):
-            return
+    async def test_n2_gui(self):
+        for model in n2_gui_test_models:
+            with self.subTest(model=model):
+                if (model[:2] == "__"):
+                    return
 
-        print("\n" + LINE_STR + "\n" + basename + "\n" + LINE_STR)
+                print("\n" + LINE_STR + "\n" + model + "\n" + LINE_STR)
 
-        self.current_test_desc = ''
-        self.current_model = basename
+                self.current_test_desc = ''
+                self.current_model = model
 
-        self.generate_n2_file()
+                self.generate_n2_file()
 
-        async with async_playwright() as playwright:
-            await self.run_gui_tests(playwright)
+                async with async_playwright() as playwright:
+                    await self.run_gui_tests(playwright)
 
-        if not DEBUG:
-            try:
-                for n2html in self.n2files:
-                    os.remove(self.n2files[n2html])
-            except OSError:
-                # Don't want the test to fail if the test file is
-                # already removed
-                pass
+                if not DEBUG:
+                    try:
+                        for n2html in self.n2files:
+                            os.remove(self.n2files[n2html])
+                    except OSError:
+                        # Don't want the test to fail if the test file is
+                        # already removed
+                        pass

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -339,7 +339,7 @@ class TestViewModelData(unittest.TestCase):
         with self.assertRaises(TypeError) as cm:
             _get_viewer_data(None)
 
-        self.assertEquals(str(cm.exception), msg)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_handle_ndarray_system_option(self):
         class SystemWithNdArrayOption(om.ExplicitComponent):


### PR DESCRIPTION
### Summary

Running `testflo --deprecations_report` on `OpenMDAO 3.25.1-dev` with the latest versions of all dependencies has reported:
```
Deprecations Report
===================
14 unique deprecation warnings were captured:
```

This PR cleans up all of those deprecations that were addressable in the OpenMDAO code base.

There are still a couple of deprecations reported due to code in `bokeh` and `pyoptsparse`'s `pyALPSO`:

```
Deprecations Report
===================
2 unique deprecation warnings were captured:
```

### Related Issues

- Resolves #2876

### Backwards incompatibilities

None

### New Dependencies

None
