### PR TITLE
fix for hang in check_totals under MPI

### DIFF
--- a/openmdao/core/tests/test_remote_vois.py
+++ b/openmdao/core/tests/test_remote_vois.py
@@ -72,8 +72,8 @@ class RemoteVOITestCase(unittest.TestCase):
         assert_near_equal(J['par.G2.c', 'par.G2.x'], np.array([[1.0]]), 1e-6)
 
     def test_check_totals_matfree_w_remote(self):
-        # this test used to hang before the fix for issue # 2884
-        # See https://github.com/OpenMDAO/OpenMDAO/issues/2883#issue-1660920684 for details.
+        # check_totals was hanging in some cases when all variables of interest didn't exist on
+        # all procs. (Issue #2884)
         class DummyComp(om.ExplicitComponent):
             def initialize(self):
                 self.options.declare('a',default=0.)

--- a/openmdao/core/tests/test_remote_vois.py
+++ b/openmdao/core/tests/test_remote_vois.py
@@ -1,13 +1,11 @@
 
 import unittest
 import numpy as np
-import time
-import random
 
 import openmdao.api as om
 
 from openmdao.utils.mpi import MPI
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_totals
 
 if MPI:
     from openmdao.api import PETScVector
@@ -72,6 +70,46 @@ class RemoteVOITestCase(unittest.TestCase):
         assert_near_equal(J['par.G1.c', 'par.G2.x'], np.array([[0.0]]), 1e-6)
         assert_near_equal(J['par.G2.c', 'par.G1.x'], np.array([[0.0]]), 1e-6)
         assert_near_equal(J['par.G2.c', 'par.G2.x'], np.array([[1.0]]), 1e-6)
+
+    def test_check_totals_matfree_w_remote(self):
+        # this test used to hang before the fix for issue # 2884
+        class DummyComp(om.ExplicitComponent):
+            def initialize(self):
+                self.options.declare('a',default=0.)
+                self.options.declare('b',default=0.)
+
+            def setup(self):
+                self.add_input('x')
+                self.add_output('y', 0.)
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = self.options['a']*inputs['x'] + self.options['b']
+
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                if mode=='rev':
+                    if 'y' in d_outputs:
+                        if 'x' in d_inputs:
+                            d_inputs['x'] += self.options['a'] * d_outputs['y']
+
+        class DummyGroup(om.ParallelGroup):
+            def setup(self):
+                self.add_subsystem('comp1',DummyComp(a=1,b=2.))
+                self.add_subsystem('comp2',DummyComp(a=3.,b=4.))
+
+        class Top(om.Group):
+            def setup(self):
+                self.add_subsystem('dvs',om.IndepVarComp(), promotes=['*'])
+                self.dvs.add_output('x',1.)
+                self.add_subsystem('parallel_group',DummyGroup())
+                self.connect('x','parallel_group.comp1.x')
+                self.connect('x','parallel_group.comp2.x')
+
+        prob = om.Problem(model=Top())
+        prob.setup(mode='rev')
+        prob.run_model()
+
+        data = prob.check_totals(of='parallel_group.comp1.y',wrt='x', out_stream=None)
+        assert_check_totals(data, atol=1e-6, rtol=1e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_remote_vois.py
+++ b/openmdao/core/tests/test_remote_vois.py
@@ -73,6 +73,7 @@ class RemoteVOITestCase(unittest.TestCase):
 
     def test_check_totals_matfree_w_remote(self):
         # this test used to hang before the fix for issue # 2884
+        # See https://github.com/OpenMDAO/OpenMDAO/issues/2883#issue-1660920684 for details.
         class DummyComp(om.ExplicitComponent):
             def initialize(self):
                 self.options.declare('a',default=0.)


### PR DESCRIPTION
### Summary

check_totals was hanging in some cases when all variables of interest didn't exist on all procs.

### Related Issues

- Resolves #2884

### Backwards incompatibilities

None

### New Dependencies

None
