### PR TITLE
removed promotion warning if either old or new is '*'

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2677,7 +2677,7 @@ class System(object):
                                            f"'{tup[0]}' because '{name}' has already been promoted "
                                            f"as '{old_key}'.")
 
-                if old_key != '*':
+                if old_using != "'*'" and new_using != "'*'":
                     msg = f"{io} variable '{name}', promoted using {new_using}, " \
                           f"was already promoted using {old_using}."
                     issue_warning(msg, prefix=self.msginfo, category=PromotionWarning)

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1616,6 +1616,25 @@ class TestGroupPromotes(unittest.TestCase):
 
         self.assertEqual(top['bb'], 4.0)
 
+    def test_promotes_star1(self):
+        class SubGroup(om.Group):
+            def setup(self):
+                self.add_subsystem('comp1', om.ExecComp('x=2.0*a+3.0*b', a=3.0, b=4.0))
+
+            def configure(self):
+                self.promotes('comp1', inputs=['b*'])
+
+        class TopGroup(om.Group):
+            def setup(self):
+                self.add_subsystem('sub', SubGroup())
+
+            def configure(self):
+                self.sub.promotes('comp1', inputs=['*'])
+
+        top = om.Problem(model=TopGroup())
+        with assert_no_warning(PromotionWarning):
+            top.setup()
+
     def test_promotes_alias_from_parent(self):
         class SubGroup(om.Group):
             def setup(self):


### PR DESCRIPTION

### Related Issues

- Resolves #2856

### Backwards incompatibilities

None

### New Dependencies

None
