### PR TITLE
fix for bug in n2 causing load failure if a Broyden solver is in the model.

### DIFF
--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -178,7 +178,7 @@ def _get_used_before_calc_subs(group, input_srcs):
             hierarchy_check = True if oparts[glen + 1] == iparts[glen + 1] else False
 
             if (src_sys in parallel_solver and tgt_sys in parallel_solver and
-                    (parallel_solver[src_sys] not in ["NL: NLBJ", "NL: Newton", "BROYDEN"]) and
+                    (parallel_solver[src_sys] not in ["NL: NLBJ", "NL: Newton", "NL: BROYDEN"]) and
                     src_sys == tgt_sys and
                     not hierarchy_check):
                 msg = f"Need to attach NonlinearBlockJac, NewtonSolver, or BroydenSolver " \

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -152,9 +152,7 @@ class BroydenSolver(NonlinearSolver):
         super()._setup_solvers(system, depth)
         self._recompute_jacobian = True
         self._computed_jacobians = 0
-        iproc = system.comm.rank
 
-        rank = MPI.COMM_WORLD.rank if MPI is not None else 0
         self._disallow_discrete_outputs()
 
         if self.linear_solver is not None:

--- a/openmdao/visualization/n2_viewer/src/OmStyle.js
+++ b/openmdao/visualization/n2_viewer/src/OmStyle.js
@@ -29,7 +29,7 @@ class OmStyle extends Style {
     * 6. LN: LNBGS          NL: NLBGS
     * 7. LN: USER
     * 8.                    NL: Newton
-    * 9.                    BROYDEN
+    * 9.                    NL: BROYDEN
     * 10. solve_linear      solve_nonlinear
     * 11. other             other
 
@@ -48,7 +48,7 @@ class OmStyle extends Style {
         ['LN: LNBGS',       'NL: NLBGS',       '#b3de69'],
         ['LN: USER',        null,              '#fccde5'],
         [null,              'NL: Newton',      '#d9d9d9'],
-        [null,              'BROYDEN',         '#bc80bd'],
+        [null,              'NL: BROYDEN',     '#bc80bd'],
         ['solve_linear',    'solve_nonlinear', '#ccebc5'],
         ['other',           'other',           '#ffed6f'],
     ];


### PR DESCRIPTION
### Summary

Identifier for the Broyden solver in the n2 was "BROYDEN" instead of "NL: BROYDEN", causing the corresponding style to be undefined.

### Related Issues

- Resolves #2815

### Backwards incompatibilities

None

### New Dependencies

None
