### PR TITLE
Removed deprecated `value` argument from `Problem.set_val()`

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -14,8 +14,7 @@ from openmdao.core.constants import INT_DTYPE
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.utils.units import valid_units
 from openmdao.utils import cs_safe
-from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation, \
-    SetupWarning
+from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, SetupWarning
 from openmdao.utils.array_utils import get_random_arr
 
 

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -18,7 +18,6 @@ from openmdao.components.interp_util.interp_slinear import InterpLinear, Interp3
     Interp1DSlinear, Interp2DSlinear
 
 from openmdao.components.interp_util.outofbounds_error import OutOfBoundsError
-from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.utils.array_utils import shape_to_len
 
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -512,7 +512,7 @@ class Problem(object):
         """
         self.set_val(name, value)
 
-    def set_val(self, name, val=None, units=None, indices=None, value=None):
+    def set_val(self, name, val=None, units=None, indices=None):
         """
         Set an output/input variable.
 
@@ -528,16 +528,7 @@ class Problem(object):
             Units that value is defined in.
         indices : int or list of ints or tuple of ints or int ndarray or Iterable or None, optional
             Indices or slice to set to specified value.
-        value : object
-            Deprecated `value` arg.  Use `val` instead.
         """
-        if value is not None:
-            val = value
-            if not self._warned:
-                self._warned = True
-                warn_deprecation(f"{self.msginfo} 'value' will be deprecated in 4.0. Please use "
-                                 "'val' in the future.")
-
         if self._metadata is None:
             raise RuntimeError(f"{self.msginfo}: '{name}' Cannot call set_val before setup.")
 

--- a/openmdao/recorders/base_case_reader.py
+++ b/openmdao/recorders/base_case_reader.py
@@ -2,7 +2,6 @@
 Base class for all CaseReaders.
 """
 
-from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.core.constants import _DEFAULT_OUT_STREAM
 
 

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -15,7 +15,7 @@ from openmdao.core.component import Component
 from openmdao.core.group import Group
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.general_utils import pad_name
-from openmdao.utils.om_warnings import warn_deprecation, reset_warning_registry
+from openmdao.utils.om_warnings import reset_warning_registry
 
 
 @contextmanager

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -15,6 +15,7 @@ from collections.abc import Iterable
 import numpy as np
 
 from openmdao.core.constants import INF_BOUND
+from openmdao.utils.om_warnings import issue_warning
 from openmdao.utils.array_utils import shape_to_len
 
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -15,7 +15,6 @@ from collections.abc import Iterable
 import numpy as np
 
 from openmdao.core.constants import INF_BOUND
-from openmdao.utils.om_warnings import issue_warning, warn_deprecation
 from openmdao.utils.array_utils import shape_to_len
 
 

--- a/openmdao/utils/mpi.py
+++ b/openmdao/utils/mpi.py
@@ -10,7 +10,6 @@ import functools
 from types import FunctionType, MethodType, BuiltinMethodType
 
 from openmdao.core.analysis_error import AnalysisError
-from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.utils.notebook_utils import notebook
 from openmdao.utils.general_utils import env_truthy
 

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -16,7 +16,6 @@ import os.path
 from collections import OrderedDict
 
 from configparser import RawConfigParser as ConfigParser
-from openmdao.utils.om_warnings import warn_deprecation
 
 # pylint: disable=E0611, F0401
 from math import floor, pi


### PR DESCRIPTION
### Summary

Removed deprecated `value` argument from `Problem.set_val()`

Also cleaned up unused imports of warn_deprecation, leftover from removing deprecations.

### Related Issues

- Resolves #2891

### Backwards incompatibilities

None

### New Dependencies

None
