### PR TITLE
Fixed bug where multi-level promotion aliasing could result in an unrecognized connection.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1568,8 +1568,9 @@ class Group(System):
             dup_info = [(n, srcs) for n, srcs in dup_info.items() if len(srcs) > 1]
             if dup_info:
                 dup = ["%s from %s" % (tgt, sorted(srcs)) for tgt, srcs in dup_info]
+                dupstr = ', '.join(dup)
                 self._collect_error(f"{self.msginfo}: The following inputs have multiple "
-                                    f"connections: {', '.join(dup)}.")
+                                    f"connections: {dupstr}.", ident=dupstr)
 
         if self.comm.size > 1 and self._mpi_proc_allocator.parallel:
             # If running in parallel, allgather

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1440,9 +1440,9 @@ class Group(System):
         for prom_name in allprocs_prom2abs_list_out:
             if prom_name in allprocs_prom2abs_list_in:
                 abs_out = allprocs_prom2abs_list_out[prom_name][0]
-                out_subsys = abs_out[path_len:].split('.', 1)[0]
+                out_subsys = abs_out.rpartition('.')[0]
                 for abs_in in allprocs_prom2abs_list_in[prom_name]:
-                    in_subsys = abs_in[path_len:].split('.', 1)[0]
+                    in_subsys = abs_in.rpartition('.')[0]
                     if out_subsys != in_subsys:
                         abs_in2out[abs_in] = abs_out
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1415,11 +1415,7 @@ class Group(System):
         abs_in2out = {}
         new_conns = {}
 
-        if pathname:
-            path_len = len(pathname) + 1
-            nparts = len(pathname.split('.'))
-        else:
-            path_len = nparts = 0
+        nparts = len(pathname.split('.')) if pathname else 0
 
         if conns is not None:
             for abs_in, abs_out in conns.items():
@@ -1438,13 +1434,10 @@ class Group(System):
 
         # Add implicit connections (only ones owned by this group)
         for prom_name in allprocs_prom2abs_list_out:
-            if prom_name in allprocs_prom2abs_list_in:
+            if prom_name in allprocs_prom2abs_list_in:  # names match ==> a connection
                 abs_out = allprocs_prom2abs_list_out[prom_name][0]
-                out_subsys = abs_out.rpartition('.')[0]
                 for abs_in in allprocs_prom2abs_list_in[prom_name]:
-                    in_subsys = abs_in.rpartition('.')[0]
-                    if out_subsys != in_subsys:
-                        abs_in2out[abs_in] = abs_out
+                    abs_in2out[abs_in] = abs_out
 
         src_ind_inputs = set()
         abs2meta = self._var_abs2meta['input']

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -479,10 +479,9 @@ class TestMultiConns(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             prob.setup()
 
-        self.assertEqual(str(context.exception),
-           "\nCollected errors for problem 'mult_conns':"
-           "\n   <model> <class Group>: The following inputs have multiple connections: "
-                   "sub.c2.y from ['indeps.y', 'sub.c1.y'].")
+        self.assertEqual(str(context.exception), """
+Collected errors for problem 'mult_conns':
+   <model> <class Group>: Input 'sub.c2.y' cannot be connected to 'indeps.y' because it's already connected to 'sub.c1.y'.""")
 
     def test_mixed_conns_same_level(self):
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2123,8 +2123,8 @@ class MyComp(om.ExplicitComponent):
 
 class TestConnect(unittest.TestCase):
 
-    def setUp(self):
-        prob = om.Problem(om.Group())
+    def setup_problem(self, probname):
+        prob = om.Problem(om.Group(), name=probname)
 
         sub = prob.model.add_subsystem('sub', om.Group())
 
@@ -2136,30 +2136,31 @@ class TestConnect(unittest.TestCase):
         sub.add_subsystem('cmp', om.ExecComp('z = x'))
         sub.add_subsystem('arr', om.ExecComp('a = x', x=np.zeros(2)))
 
-        self.sub = sub
-        self.prob = prob
+        return prob
 
     def test_src_indices_as_int_list(self):
-        self.sub.connect('src.x', 'tgt.x', src_indices=[1])
+        p = self.setup_problem('test_src_indices_as_int_list')
+        p.model.sub.connect('src.x', 'tgt.x', src_indices=[1])
 
     def test_src_indices_as_int_array(self):
-        self.sub.connect('src.x', 'tgt.x', src_indices=np.zeros(1, dtype=int))
+        p = self.setup_problem('test_src_indices_as_int_array')
+        p.model.sub.connect('src.x', 'tgt.x', src_indices=np.zeros(1, dtype=int))
 
     def test_src_indices_as_float_list(self):
-
+        p = self.setup_problem('test_src_indices_as_float_list')
         with set_env_vars_context(OPENMDAO_FAIL_FAST='1'):
             with self.assertRaises(Exception) as cm:
-                self.sub.connect('src.x', 'tgt.x', src_indices=[1.0])
+                p.model.sub.connect('src.x', 'tgt.x', src_indices=[1.0])
 
         msg = "'sub' <class Group>: When connecting from 'src.x' to 'tgt.x': Can't create an index array using indices of non-integral type 'float64'."
         self.assertEqual(str(cm.exception), msg)
 
     def test_src_indices_as_float_array(self):
-        self.prob._name = 'src_indices_as_float_array'
-        self.sub.connect('src.x', 'tgt.x', src_indices=np.zeros(1))
+        p = self.setup_problem('src_indices_as_float_array')
+        p.model.sub.connect('src.x', 'tgt.x', src_indices=np.zeros(1))
         with self.assertRaises(Exception) as cm:
-            self.prob.setup()
-            self.prob.run_model()
+            p.setup()
+            p.run_model()
 
         self.assertEqual(str(cm.exception),
            "\nCollected errors for problem 'src_indices_as_float_array':"
@@ -2167,29 +2168,33 @@ class TestConnect(unittest.TestCase):
            "index array using indices of non-integral type 'float64'.")
 
     def test_src_indices_as_str(self):
+        p = self.setup_problem('src_indices_as_str')
         msg = "'sub' <class Group>: src_indices must be a slice, int, or index array. Did you mean connect('src.x', ['tgt.x', 'cmp.x'])?"
         with set_env_vars_context(OPENMDAO_FAIL_FAST='1'):
             with self.assertRaisesRegex(Exception, msg):
-                self.sub.connect('src.x', 'tgt.x', 'cmp.x')
+                p.model.sub.connect('src.x', 'tgt.x', 'cmp.x')
 
     def test_already_connected(self):
+        p = self.setup_problem('test_already_connected')
+        sub = p.model.sub
+
         msg = "'sub' <class Group>: Input 'tgt.x' is already connected to 'src.x'."
 
         with set_env_vars_context(OPENMDAO_FAIL_FAST='1'):
-            self.sub.connect('src.x', 'tgt.x', src_indices=[1])
+            sub.connect('src.x', 'tgt.x', src_indices=[1])
             with self.assertRaises(Exception) as cm:
-                self.sub.connect('cmp.x', 'tgt.x', src_indices=[1])
+                sub.connect('cmp.x', 'tgt.x', src_indices=[1])
 
         self.assertEqual(str(cm.exception), msg)
 
     def test_invalid_source(self):
-        self.prob._name = 'invalid_source'
+        p = self.setup_problem('invalid_source')
         # source and target names can't be checked until setup
         # because setup is not called until then
-        self.sub.connect('src.z', 'tgt.x', src_indices=[1])
+        p.model.sub.connect('src.z', 'tgt.x', src_indices=[1])
 
         with self.assertRaises(Exception) as context:
-            self.prob.setup()
+            p.setup()
 
         self.assertEqual(str(context.exception),
            "\nCollected errors for problem 'invalid_source':"
@@ -2198,31 +2203,31 @@ class TestConnect(unittest.TestCase):
            "['src.x', 'src.s', 'cmp.z']."
 )
     def test_connect_to_output(self):
-        self.prob._name = 'connect_to_output'
+        p = self.setup_problem('connect_to_output')
         msg = "\nCollected errors for problem 'connect_to_output':\n   'sub' <class Group>: " + \
               "Attempted to connect from 'tgt.y' to 'cmp.z', but 'cmp.z' is an output. " + \
               "All connections must be from an output to an input."
 
         # source and target names can't be checked until setup
         # because setup is not called until then
-        self.sub.connect('tgt.y', 'cmp.z')
+        p.model.sub.connect('tgt.y', 'cmp.z')
 
         with self.assertRaises(Exception) as context:
-            self.prob.setup()
+            p.setup()
 
         self.assertEqual(str(context.exception), msg)
 
     def test_connect_from_input(self):
-        self.prob._name = 'connect_from_input'
+        p = self.setup_problem('connect_from_input')
         msg = "\nCollected errors for problem 'connect_from_input':\n   'sub' <class Group>: " + \
               "Attempted to connect from 'tgt.x' to 'cmp.x', but 'tgt.x' is an input. " + \
               "All connections must be from an output to an input."
 
         # source and target names can't be checked until setup
         # because setup is not called until then
-        self.sub.connect('tgt.x', 'cmp.x')
+        p.model.sub.connect('tgt.x', 'cmp.x')
         with self.assertRaises(Exception) as context:
-            self.prob.setup()
+            p.setup()
 
         self.assertEqual(str(context.exception), msg)
 
@@ -2239,27 +2244,28 @@ class TestConnect(unittest.TestCase):
         p['x']
 
     def test_invalid_target(self):
-        self.prob._name = 'invalid_target'
+        p = self.setup_problem('invalid_target')
         msg = "\nCollected errors for problem 'invalid_target':\n   'sub' <class Group>: " + \
               "Attempted to connect from 'src.x' to 'tgt.z', but 'tgt.z' doesn't exist. " + \
               "Perhaps you meant to connect to one of the following inputs: ['tgt.x']."
 
         # source and target names can't be checked until setup
         # because setup is not called until then
-        self.sub.connect('src.x', 'tgt.z', src_indices=[1])
+        p.model.sub.connect('src.x', 'tgt.z', src_indices=[1])
 
         with self.assertRaises(Exception) as context:
-            self.prob.setup()
+            p.setup()
 
         self.assertEqual(str(context.exception), msg)
 
     def test_connect_within_system(self):
+        p = self.setup_problem('connect_within_system')
         msg = "Output and input are in the same System for connection " + \
               "from 'tgt.y' to 'tgt.x'."
 
         with set_env_vars_context(OPENMDAO_FAIL_FAST='1'):
             with self.assertRaisesRegex(Exception, msg):
-                self.sub.connect('tgt.y', 'tgt.x', src_indices=[1])
+                p.model.sub.connect('tgt.y', 'tgt.x', src_indices=[1])
 
     def test_connect_within_system_with_promotes(self):
         prob = om.Problem(name='connect_within_system_with_promotes')
@@ -2400,8 +2406,8 @@ class TestConnect(unittest.TestCase):
         assert_near_equal(prob['G1.par1.c4.y'], 8.0)
 
     def test_bad_shapes(self):
-        self.prob._name = 'bad_shapes'
-        self.sub.connect('src.s', 'arr.x')
+        p = self.setup_problem('bad_shapes')
+        p.model.sub.connect('src.s', 'arr.x')
 
         msg = "\nCollected errors for problem 'bad_shapes':" + \
               "\n   'sub' <class Group>: The source and target shapes do not match or are ambiguous " + \
@@ -2409,7 +2415,7 @@ class TestConnect(unittest.TestCase):
               "but the target shape is (2,)."
 
         with self.assertRaises(Exception) as context:
-            self.prob.setup()
+            p.setup()
 
         self.assertEqual(str(context.exception), msg)
 
@@ -2431,32 +2437,32 @@ class TestConnect(unittest.TestCase):
         self.assertEqual(str(context.exception), msg)
 
     def test_bad_indices_dimensions(self):
-        self.prob._name = 'bad_indices_dimensions'
-        self.sub.connect('src.x', 'arr.x', src_indices=[[2,2],[-1,2],[2,2]],
-                         flat_src_indices=False)
+        p = self.setup_problem('bad_indices_dimensions')
+        p.model.sub.connect('src.x', 'arr.x', src_indices=([2,2],[-1,2],[2,2]),
+                            flat_src_indices=False)
 
         msg = "\nCollected errors for problem 'bad_indices_dimensions':\n   <model> <class Group>: " + \
               "When connecting 'sub.src.x' to 'sub.arr.x': Can't set source shape to (5, 3) because " + \
               "indexer ([2, 2], [-1, 2], [2, 2]) expects 3 dimensions."
         try:
-            self.prob.setup()
+            p.setup()
         except Exception as err:
             self.assertEqual(str(err), msg)
         else:
             self.fail('Exception expected.')
 
     def test_bad_indices_index(self):
-        self.prob._name = 'bad_indices_index'
+        p = self.setup_problem('bad_indices_index')
         # the index value within src_indices is outside the valid range for the source
-        self.sub.connect('src.x', 'arr.x', src_indices=[[2, 4],[-1, 4]],
-                         flat_src_indices=False)
+        p.model.sub.connect('src.x', 'arr.x', src_indices=([2, 4],[-1, 4]),
+                            flat_src_indices=False)
 
         msg = "\nCollected errors for problem 'bad_indices_index':\n   <model> <class Group>: " + \
               "When connecting 'sub.src.x' to 'sub.arr.x': index 4 is out of bounds for source " + \
               "dimension of size 3."
 
         try:
-            self.prob.setup()
+            p.setup()
         except Exception as err:
             self.assertEqual(str(err), msg)
         else:


### PR DESCRIPTION
### Summary

Old code was doing an erroneous check that skipped a connection if input and output both lived in a direct child of the group.

- also fixed some tests in test_group that were failing outside of testflo due to report hook issues.

### Related Issues

- Resolves #2873

### Backwards incompatibilities

None

### New Dependencies

None
