### PR TITLE
Updated documentation of guess_nonlinear method to use run_apply_nonlinear.

### DIFF
--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -3953,8 +3953,11 @@ class TestFeatureGuessNonlinear(unittest.TestCase):
                 self.linear_solver = om.DirectSolver()
 
             def guess_nonlinear(self, inputs, outputs, residuals):
-                # Check residuals
-                if np.abs(residuals['x']) > 1.0E-2:
+                # Update the residuals based on the inputs
+                self.run_apply_nonlinear()
+
+                # Check residuals so that we don't reset x if we're nearly converged.
+                if np.any(np.abs(residuals.asarray()) > 1.0E-2):
                     # inputs are addressed using full path name, regardless of promotion
                     external_input = inputs['comp1.external_input']
 

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -50,7 +50,7 @@
     "This model contains a two copies of the same Discipline Group.\n",
     "One of these groups provides a `guess_nonlinear` method, while the other one does not.\n",
     "\n",
-    "The following example prints the iteration history of the nonlienar solver to demonstrate how using `guess_nonlinear` can reduce the number of iterations required."
+    "The following example prints the iteration history of the nonlinear solver to demonstrate how using `guess_nonlinear` can reduce the number of iterations required."
    ]
   },
   {
@@ -86,7 +86,7 @@
     "        self.run_apply_nonlinear()\n",
     "        \n",
     "        # Check residuals so that we don't reset x if we're nearly converged.\n",
-    "        if np.any(np.abs(list(residuals.values())) > 1.0E-2):\n",
+    "        if np.any(np.abs(residuals.asarray()) > 1.0E-2):\n",
     "            # inputs are addressed using full path name, regardless of promotion\n",
     "            external_input = inputs['comp1.external_input']\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -41,7 +41,16 @@
     "\n",
     "Given our knowledge of the relationship between the two equations, we can supply\n",
     "an initial guess for the implicit state variable, $x$, that makes it\n",
-    "unnecessary for the solver to iterate."
+    "unnecessary for the solver to iterate.\n",
+    "\n",
+    "In `guess_nonlinear` we explicitly run the `run_apply_nonlinear` method to make sure the residual values are in sync with the input values.\n",
+    "\n",
+    "In this case we test _all_ of the residual values. If we tested only the residual of `'x'`, it would be exactly zero on the first iteration based on the way the `BalanceComp` computes its residuals and the initial values of the inputs. Testing all of the residuals provides a better check to see if the system is nearly converged.\n",
+    "\n",
+    "This model contains a two copies of the same Discipline Group.\n",
+    "One of these groups provides a `guess_nonlinear` method, while the other one does not.\n",
+    "\n",
+    "The following example prints the iteration history of the nonlienar solver to demonstrate how using `guess_nonlinear` can reduce the number of iterations required."
    ]
   },
   {
@@ -73,8 +82,11 @@
     "        self.linear_solver = om.DirectSolver()\n",
     "\n",
     "    def guess_nonlinear(self, inputs, outputs, residuals):\n",
-    "        # Check residuals\n",
-    "        if np.abs(residuals['x']) > 1.0E-2:\n",
+    "        # Update the residuals based on the inputs\n",
+    "        self.run_apply_nonlinear()\n",
+    "        \n",
+    "        # Check residuals so that we don't reset x if we're nearly converged.\n",
+    "        if np.any(np.abs(list(residuals.values())) > 1.0E-2):\n",
     "            # inputs are addressed using full path name, regardless of promotion\n",
     "            external_input = inputs['comp1.external_input']\n",
     "\n",
@@ -84,17 +96,33 @@
     "            # outputs are addressed by the their promoted names\n",
     "            outputs['x'] = x_guess # perfect guess should converge in 0 iterations\n",
     "\n",
+    "\n",
+    "class DisciplineNoGuess(Discipline):\n",
+    "    \n",
+    "    def guess_nonlinear(self, inputs, outputs, residuals):\n",
+    "        pass\n",
+    "            \n",
+    "\n",
     "p = om.Problem()\n",
     "\n",
     "p.model.add_subsystem('discipline', Discipline(), promotes_inputs=['external_input'])\n",
+    "p.model.add_subsystem('discipline_no_guess', DisciplineNoGuess(), promotes_inputs=['external_input'])\n",
     "\n",
     "p.setup()\n",
-    "p.set_val('external_input', 1.)\n",
+    "\n",
+    "p.set_val('external_input', 1.1)\n",
+    "\n",
     "p.run_model()\n",
     "\n",
-    "print(p.model.nonlinear_solver._iter_count)\n",
     "\n",
-    "print(p.get_val('discipline.x'))"
+    "print('\\nchanging external input to a different value and rerunning the model')\n",
+    "p.set_val('external_input', 1.0)\n",
+    "\n",
+    "p.run_model()\n",
+    "\n",
+    "print()\n",
+    "print(f\"x_with_guess = {p.get_val('discipline.x')}\")\n",
+    "print(f\"x_no_guess = {p.get_val('discipline_no_guess.x')}\")"
    ]
   },
   {
@@ -111,14 +139,15 @@
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
     "assert(p.model.nonlinear_solver._iter_count == 0)\n",
-    "assert_near_equal(p.get_val('discipline.x'), 1.41421356, 1e-6)"
+    "assert_near_equal(p.get_val('discipline.x'), 1.41421356, 1e-6)\n",
+    "assert_near_equal(p.get_val('discipline_no_guess.x'), 1.41421356, 1e-6)"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -132,7 +161,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.0"
   },
   "orphan": true
  },


### PR DESCRIPTION
### Summary

In the documentation of `guess_nonlinear`, the residuals were not in sync with the inputs.  Testing the residuals to see if they were acceptably small before applying a new guess for the implicit output was therefore not testing an accurate value of the residual.

This change fixes the example so that it tests all residuals in the system, which seems to be a more reliably way checking to see if the system is close to convergence.

### Related Issues

- Resolves #2898 

### Backwards incompatibilities

None

### New Dependencies

None
