### PR TITLE
Fixed issue where list_indep_vars would sometimes return duplicates.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2229,8 +2229,9 @@ class Problem(object):
                                                   use_prom_ivc=True,
                                                   get_sizes=False).keys()
         problem_indep_vars = []
+        indep_var_names = set()
 
-        default_col_names = ['name', 'units', 'value']
+        default_col_names = ['name', 'units', 'val']
         col_names = default_col_names + ([] if options is None else options)
 
         for target, meta in model._var_allprocs_abs2meta['input'].items():
@@ -2240,10 +2241,13 @@ class Problem(object):
             input_name = model._var_allprocs_abs2prom['input'][target]
 
             smeta = {key: val for key, val in smeta.items() if key in col_names}
-            smeta['value'] = self.get_val(input_name)
+            smeta['val'] = self.get_val(input_name)
 
-            if src_is_ivc and (include_design_vars or input_name not in desvar_prom_names):
+            if src_is_ivc \
+                    and (include_design_vars or input_name not in desvar_prom_names) \
+                    and input_name not in indep_var_names:
                 problem_indep_vars.append((input_name, smeta))
+                indep_var_names.add(input_name)
 
         if out_stream is not None:
             header = f'Problem {self._name} Independent Variables'

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2245,6 +2245,24 @@ class RelevanceTestCase(unittest.TestCase):
         self.assertRegex(output.split('\n')[1], r'Problem \w+ Independent Variables')
         self.assertEqual(output.split('\n')[3].split(), ['None', 'found'])
 
+    def test_list_indep_vars_duplicate_inputs(self):
+        prob = om.Problem()
+        prob.model.add_subsystem('a', om.ExecComp('y = x**2'),
+                                 promotes_inputs=['x'], promotes_outputs=['y'])
+
+        prob.model.add_subsystem('b', om.ExecComp('z = x**3'),
+                                 promotes_inputs=['x'], promotes_outputs=['z'])
+
+        prob.model.add_design_var('x', lower=-1, upper=1)
+        prob.model.add_objective('y')
+
+        prob.setup()
+
+        prob.final_setup()
+
+        indep_vars = prob.list_indep_vars()
+
+        self.assertEqual(len(indep_vars), 1)
 
 class NestedProblemTestCase(unittest.TestCase):
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2229,7 +2229,7 @@ class RelevanceTestCase(unittest.TestCase):
 
         output = strout.getvalue()
         self.assertRegex(output.split('\n')[1], r'Problem \w+ Independent Variables')
-        self.assertEqual(output.split('\n')[3].split(), ['name', 'units', 'value'])
+        self.assertEqual(output.split('\n')[3].split(), ['name', 'units', 'val'])
         self.assertRegex(output.split('\n')[5], r'\s*z\s+None\s+|[0-9.]+|')
         self.assertRegex(output.split('\n')[6], r'\s*x\s+None\s+|[0-9.]+|')
 


### PR DESCRIPTION
### Summary

When a system contained multiple inputs tied to the same IVC output, the returned list would duplicate the entry for that IVC output.

### Related Issues

- Resolves #2901

### Backwards incompatibilities

None

### New Dependencies

None
