### PR TITLE
Made `list_indep_vars` return only one var per source

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2264,30 +2264,32 @@ class Problem(object):
             raise RuntimeError("list_indep_vars requires that final_setup has been "
                                "run for the Problem.")
 
-        connections = model._conn_global_abs_in2out
         desvar_prom_names = model.get_design_vars(recurse=True,
                                                   use_prom_ivc=True,
                                                   get_sizes=False).keys()
+
         problem_indep_vars = []
         indep_var_names = set()
 
         default_col_names = ['name', 'units', 'val']
         col_names = default_col_names + ([] if options is None else options)
 
-        for target, meta in model._var_allprocs_abs2meta['input'].items():
-            src = connections[target]
-            smeta = model._var_allprocs_abs2meta['output'][src]
-            src_is_ivc = 'openmdao:indep_var' in smeta['tags']
-            input_name = model._var_allprocs_abs2prom['input'][target]
+        abs2meta = model._var_allprocs_abs2meta['output']
+        prom2abs = self.model._var_allprocs_prom2abs_list['input']
 
-            smeta = {key: val for key, val in smeta.items() if key in col_names}
-            smeta['val'] = self.get_val(input_name)
+        prom2src = {prom: model.get_source(prom) for prom in prom2abs.keys()
+                    if 'openmdao:indep_var' in abs2meta[model.get_source(prom)]['tags']}
 
-            if src_is_ivc \
-                    and (include_design_vars or input_name not in desvar_prom_names) \
-                    and input_name not in indep_var_names:
-                problem_indep_vars.append((input_name, smeta))
-                indep_var_names.add(input_name)
+        for prom, src in prom2src.items():
+            name = prom if '_auto_ivc' in src else src
+            meta = abs2meta[src]
+            meta = {key: val for key, val in meta.items() if key in col_names}
+            meta['val'] = self.get_val(prom)
+
+            if (include_design_vars or name not in desvar_prom_names) \
+                    and name not in indep_var_names:
+                problem_indep_vars.append((name, meta))
+                indep_var_names.add(name)
 
         if out_stream is not None:
             header = f'Problem {self._name} Independent Variables'

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2281,7 +2281,7 @@ class Problem(object):
                     if 'openmdao:indep_var' in abs2meta[model.get_source(prom)]['tags']}
 
         for prom, src in prom2src.items():
-            name = prom if src.startswith('_auto_ivc') else src
+            name = prom if src.startswith('_auto_ivc.') else src
             meta = abs2meta[src]
             meta = {key: val for key, val in meta.items() if key in col_names}
             meta['val'] = self.get_val(prom)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2281,7 +2281,7 @@ class Problem(object):
                     if 'openmdao:indep_var' in abs2meta[model.get_source(prom)]['tags']}
 
         for prom, src in prom2src.items():
-            name = prom if '_auto_ivc' in src else src
+            name = prom if src.startswith('_auto_ivc') else src
             meta = abs2meta[src]
             meta = {key: val for key, val in meta.items() if key in col_names}
             meta['val'] = self.get_val(prom)

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2280,7 +2280,8 @@ class RelevanceTestCase(unittest.TestCase):
         prob.final_setup()
 
         indep_vars = prob.list_indep_vars()
-        self.assertEqual(len(indep_vars), 2)
+        self.assertEqual(indep_vars[0][0], 'indep_r.r')
+        self.assertEqual(indep_vars[1][0], 'indep_theta.theta')
 
 
 class NestedProblemTestCase(unittest.TestCase):

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2264,6 +2264,25 @@ class RelevanceTestCase(unittest.TestCase):
 
         self.assertEqual(len(indep_vars), 1)
 
+    def test_list_indep_vars_no_auto_ivc(self):
+        prob = om.Problem()
+
+        prob.model.add_subsystem('indep_theta', om.IndepVarComp('theta'))
+        prob.model.add_subsystem('indep_r', om.IndepVarComp('r'))
+
+        prob.model.add_subsystem('xComp', om.ExecComp('x = r1*cos(theta1)'))
+        prob.model.add_subsystem('yComp', om.ExecComp('y = r2*sin(theta2)'))
+
+        prob.model.connect('indep_theta.theta', ['xComp.theta1', 'yComp.theta2'])
+        prob.model.connect('indep_r.r', ['xComp.r1', 'yComp.r2'])
+
+        prob.setup()
+        prob.final_setup()
+
+        indep_vars = prob.list_indep_vars()
+        self.assertEqual(len(indep_vars), 2)
+
+
 class NestedProblemTestCase(unittest.TestCase):
 
     def test_nested_prob(self):


### PR DESCRIPTION
### Summary

`list_indep_vars` would previously track prom names and return vars whose sources were tagged 'openmdao:indep_var'. However, this can mean there are repeated variables returned  since multiple vars can be connected to the same source. This update makes `list_indep_vars` return the sources tagged 'openmdao:indep_var' if the names aren't auto ivcs. If they are auto ivcs, then it returns the associated prom name.

### Related Issues

- Resolves #2905 

### Backwards incompatibilities

None

### New Dependencies

None
