### PR TITLE
Added path argument to N2 function

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/TreeNode.js
+++ b/openmdao/visualization/n2_viewer/gen/TreeNode.js
@@ -124,7 +124,7 @@ class TreeNode {
     isFilter() { return (this.type == 'filter'); }
 
     /** True if this node can use filters (always false for base class) */
-    canFilter() { return false; } 
+    canFilter() { return false; }
 
     /** Not connectable if this is an input group or parents are minimized. */
     isConnectable() {
@@ -199,6 +199,24 @@ class TreeNode {
         if (this.hasParent(compareNode, parentLimit)) return true;
 
         return this.hasNodeInChildren(compareNode);
+    }
+
+    /**
+     * Look for a node with the given path in the lineage of this one.
+     * @param {string} path The path of the node to find.
+     * @returns {TreeNode} The node with the given path.
+     */
+    findNode(path) {
+        if (this.path == path)
+            return this;
+        else if (this.hasChildren()) {
+            for (let child of this.children) {
+                let node = child.findNode(path);
+                if (node != undefined)
+                    return node;
+            }
+        }
+        return undefined;
     }
 
     /**
@@ -344,7 +362,7 @@ class FilterNode extends TreeNode {
         node.doFilter(this);
         this.show();
     }
-    
+
     /**
      * Update the node's state and remove it from our children. If nothing is left in
      * the children array, delete it and hide ourselves.
@@ -393,7 +411,7 @@ class FilterNode extends TreeNode {
 
     /** Return the length of the children array or 0 if it doesn't exist. */
     get count() { return (this.hasChildren()? this.children.length : 0); }
-    
+
     /** Don't expand, always stay minimized. */
     expand() { return this; }
 

--- a/openmdao/visualization/n2_viewer/index.html
+++ b/openmdao/visualization/n2_viewer/index.html
@@ -320,6 +320,7 @@
 
 <script type="text/javascript">
     var compressedModel = "<<hpp_pyvar model_data compress>>";
+    var initialPath = "<<hpp_pyvar initial_path>>";
 </script>
 
 <!--<<hpp_script src/main.js>>-->

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -561,8 +561,8 @@ def _get_viewer_data(data_source, case_id=None):
     return data_dict
 
 
-def n2(data_source, outfile=_default_n2_filename, path=None, case_id=None, show_browser=True, embeddable=False,
-       title=None, display_in_notebook=True):
+def n2(data_source, outfile=_default_n2_filename, path=None, case_id=None,
+       show_browser=True, embeddable=False, title=None, display_in_notebook=True):
     """
     Generate an HTML file containing a tree viewer.
 

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -561,7 +561,7 @@ def _get_viewer_data(data_source, case_id=None):
     return data_dict
 
 
-def n2(data_source, outfile=_default_n2_filename, case_id=None, show_browser=True, embeddable=False,
+def n2(data_source, outfile=_default_n2_filename, path=None, case_id=None, show_browser=True, embeddable=False,
        title=None, display_in_notebook=True):
     """
     Generate an HTML file containing a tree viewer.
@@ -574,6 +574,9 @@ def n2(data_source, outfile=_default_n2_filename, case_id=None, show_browser=Tru
         The Problem or case recorder database containing the model or model data.
     outfile : str, optional
         The name of the final output file.
+    path : str, optional
+        If specified, the n2 viewer will begin in a state that is zoomed in on the selected path.
+        This path should be the absolute path of a system in the model.
     case_id : int, str, or None
         Case name or index of case in SQL file if data_source is a database.
     show_browser : bool, optional
@@ -617,7 +620,8 @@ def n2(data_source, outfile=_default_n2_filename, case_id=None, show_browser=Tru
         'title': title,
         'embeddable': "embedded-diagram" if embeddable else "non-embedded-diagram",
         'openmdao_version': openmdao_version,
-        'model_data': model_data
+        'model_data': model_data,
+        'initial_path': path
     }
 
     if err_msg:

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -703,6 +703,8 @@ def _n2_setup_parser(parser):
                         help="create embeddable version.")
     parser.add_argument('--title', default=None,
                         action='store', dest='title', help='diagram title.')
+    parser.add_argument('--path', default=None,
+                        action='store', dest='path', help='initial path to zoom into.')
 
 
 def _n2_cmd(options, user_args):
@@ -725,12 +727,12 @@ def _n2_cmd(options, user_args):
                 # only run the n2 here if we've had setup errors. Normally we'd wait until
                 # after final_setup in order to have correct values for all of the I/O variables.
                 n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
-                   title=options.title, embeddable=options.embeddable)
+                   title=options.title, path=options.path, embeddable=options.embeddable)
                 # errors will result in exit at the end of the _check_collected_errors method
 
         def _view_model_no_errors(prob):
             n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
-               title=options.title, embeddable=options.embeddable)
+               title=options.title, path=options.path, embeddable=options.embeddable)
 
         hooks._register_hook('_check_collected_errors', 'Problem', pre=_view_model_w_errors)
         hooks._register_hook('final_setup', 'Problem', post=_view_model_no_errors, exit=True)
@@ -742,5 +744,5 @@ def _n2_cmd(options, user_args):
         _load_and_exec(options.file[0], user_args)
     else:
         # assume the file is a recording, run standalone
-        n2(filename, outfile=options.outfile, title=options.title,
+        n2(filename, outfile=options.outfile, title=options.title, path=options.path,
            show_browser=not options.no_browser, embeddable=options.embeddable)

--- a/openmdao/visualization/n2_viewer/src/main.js
+++ b/openmdao/visualization/n2_viewer/src/main.js
@@ -19,6 +19,13 @@ function n2main() {
     n2MouseFuncs = n2Diag.getMouseFuncs();
 
     n2Diag.update(false);
+
+    if (initialPath) {
+        node = n2Diag.layout.model.root.findNode(initialPath);
+        if (node != undefined) {
+            n2Diag.ui._setupLeftClick(node)
+        }
+    };
 }
 
 // wintest();

--- a/openmdao/visualization/n2_viewer/src/main.js
+++ b/openmdao/visualization/n2_viewer/src/main.js
@@ -14,18 +14,21 @@ delete compressedModel;
 
 var n2MouseFuncs = null;
 
+function zoomToInitial(n2Diag) {
+    // if an initial path is specified, zoom the diagram to that node
+    if (initialPath) {
+        node = n2Diag.layout.model.root.findNode(initialPath);
+        if (node != undefined) {
+            n2Diag.ui._setupLeftClick(node);
+        }
+    };
+}
+
 function n2main() {
     const n2Diag = new OmDiagram(modelData);
     n2MouseFuncs = n2Diag.getMouseFuncs();
 
-    n2Diag.update(false);
-
-    if (initialPath) {
-        node = n2Diag.layout.model.root.findNode(initialPath);
-        if (node != undefined) {
-            n2Diag.ui._setupLeftClick(node)
-        }
-    };
+    n2Diag.update().then(zoomToInitial(n2Diag));
 }
 
 // wintest();

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -108,6 +108,13 @@ n2_gui_test_scripts = {
             "arrowCount": 4
         },
         {
+            "desc": "Check number of cells indicating diagram is zoomed on R2",
+            "test": "count",
+            "selector": "g#n2elements > g.n2cell",
+            "count": 5
+        },
+        {"test": "root"},
+        {
             "desc": "Hover on an N2 cell with cycle arrows and count",
             "test": "hoverArrow",
             "selector": "#cellShape_conn_33_to_13",
@@ -719,6 +726,9 @@ n2_gui_test_scripts = {
 
 n2_gui_test_models = n2_gui_test_scripts.keys()
 
+n2_gui_test_cmd_args = {
+    "circuit": ["--path", "circuit.R2"],
+}
 
 class n2_gui_test_case(_GuiTestCase):
 
@@ -729,7 +739,7 @@ class n2_gui_test_case(_GuiTestCase):
         print("  Test {:04}".format(current_test) + ": " + msg)
         current_test += 1
 
-    def generate_n2_file(self):
+    def generate_n2_file(self, args=None):
         """ Generate N2 HTML files from all models in GUI_TEST_SUBDIR. """
         self.parentDir = os.path.dirname(os.path.realpath(__file__))
         self.modelDir = os.path.join(self.parentDir, GUI_TEST_SUBDIR)
@@ -743,7 +753,9 @@ class n2_gui_test_case(_GuiTestCase):
         self.n2files[self.current_model] = n2file
         print("Creating " + n2file)
 
-        cmd = ['openmdao', 'n2', '-o', n2file,  '--no_browser', pyfile]
+        cmd = ['openmdao', 'n2', '-o', n2file, '--no_browser', pyfile]
+        if args:
+            cmd.extend(args)
         subprocess.run(cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)  # nosec: trusted input
 
     async def load_test_page(self):
@@ -1040,7 +1052,7 @@ class n2_gui_test_case(_GuiTestCase):
                 self.current_test_desc = ''
                 self.current_model = model
 
-                self.generate_n2_file()
+                self.generate_n2_file(n2_gui_test_cmd_args.get(model))
 
                 async with async_playwright() as playwright:
                     await self.run_gui_tests(playwright)

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -3,8 +3,8 @@ import unittest
 import os
 
 os.system("playwright install")
-from n2_gui_test import n2_gui_test_case
-from gen_gui_test import gen_gui_test_case
+from .n2_gui_test import n2_gui_test_case
+from .gen_gui_test import gen_gui_test_case
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

- added `path` argument to `n2` function
- added `--path` argument to `n2` command line option
- when the `path` argument is used, the `n2` diagram will open zoomed in on the specified path
- added a test to `n2_gui_test` to check that the new argument functions properly

### Related Issues

- Resolves #2907 

### Backwards incompatibilities

None

### New Dependencies

None
