### PR TITLE
Fixed several failing tests where an exception was raised from pyOptSparseDriver _gradfunc and _objfunc

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -611,7 +611,8 @@ class ScipyOptimizeDriver(Driver):
             self._con_cache = self.get_constraint_values()
 
         except Exception as msg:
-            self._exc_info = sys.exc_info()
+            if self._exc_info is None:  # only record the first one
+                self._exc_info = sys.exc_info()
             return 0
 
         # print("Functions calculated")
@@ -725,7 +726,8 @@ class ScipyOptimizeDriver(Driver):
                 self._check_jac = False
 
         except Exception as msg:
-            self._exc_info = sys.exc_info()
+            if self._exc_info is None:  # only record the first one
+                self._exc_info = sys.exc_info()
             return np.array([[]])
 
         # print("Gradients calculated for objective")
@@ -791,7 +793,9 @@ class ScipyOptimizeDriver(Driver):
         """
         Reraise any exception encountered when scipy calls back into our method.
         """
-        raise self._exc_info[1].with_traceback(self._exc_info[2])
+        exc_info = self._exc_info
+        self._exc_info = None  # clear since we're done with it
+        raise exc_info[1].with_traceback(exc_info[2])
 
 
 def signature_extender(fcn, extra_args):


### PR DESCRIPTION
### Summary

I got rid of the error by making sure that the dict that pyoptsparse expects is always populated in cases where an exception occurs in `_gradfunc` or `_objfunc`.

There was also an issue where an existing `_exc_info` value could be overwritten before the original error had been re-raised, which could hide the original error, so I added checking to prevent this.


### Related Issues

- Resolves #2921

### Backwards incompatibilities

None

### New Dependencies

None
