### PR TITLE
Implemented POEM_085: Added capability for view_connections to export csv instead of html.

### DIFF
--- a/openmdao/visualization/connection_viewer/tests/test_viewconns.py
+++ b/openmdao/visualization/connection_viewer/tests/test_viewconns.py
@@ -7,7 +7,7 @@ from openmdao.utils.assert_utils import assert_warning
 
 
 @use_tempdirs
-class TestSellarFeature(unittest.TestCase):
+class TestSellarFeatureHTML(unittest.TestCase):
 
     # no output checking, just make sure no exceptions raised
     # Just tests Newton on Sellar with FD derivs.
@@ -22,6 +22,22 @@ class TestSellarFeature(unittest.TestCase):
         om.view_connections(prob, outfile= "sellar_connections.html", show_browser=False)
 
 
+@use_tempdirs
+class TestSellarFeatureCSV(unittest.TestCase):
+
+    # no output checking, just make sure no exceptions raised
+    # Just tests Newton on Sellar with FD derivs.
+    def test_feature_sellar(self):
+
+        prob = om.Problem()
+        prob.model = SellarNoDerivatives()
+
+        prob.setup()
+        prob.final_setup()
+
+        om.view_connections(prob, outfile= "sellar_connections.csv")
+
+
 class TestComp(om.ExplicitComponent):
 
     def setup(self):
@@ -34,7 +50,7 @@ class TestComp(om.ExplicitComponent):
 
 
 @use_tempdirs
-class TestDiscreteViewConns(unittest.TestCase):
+class TestDiscreteViewConnsHTML(unittest.TestCase):
     def test_discrete(self):
         p = om.Problem()
 
@@ -59,6 +75,33 @@ class TestDiscreteViewConns(unittest.TestCase):
         with assert_warning(om.OpenMDAOWarning, msg):
             om.view_connections(prob, outfile= "sellar_connections.html",
                                 show_values=True, show_browser=False)
+
+
+@use_tempdirs
+class TestDiscreteViewConnsCSV(unittest.TestCase):
+    def test_discrete(self):
+        p = om.Problem()
+
+        ivc = p.model.add_subsystem('ivc', om.IndepVarComp(), promotes=['*'])
+        ivc.add_discrete_output('foo', val='3')
+
+        p.model.add_subsystem('test_comp', TestComp(), promotes=['*'])
+
+        p.setup()
+
+        om.view_connections(p, outfile="connections.csv")
+
+    def test_no_setup_warning(self):
+
+        prob = om.Problem()
+        prob.model = SellarNoDerivatives()
+
+        prob.setup()
+
+        msg = "<model> <class SellarNoDerivatives>: Values will not be shown because final_setup has not been called yet."
+
+        with assert_warning(om.OpenMDAOWarning, msg):
+            om.view_connections(prob, outfile= "sellar_connections.csv", show_values=True)
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -36,7 +36,7 @@ def _val2str(val):
 def view_connections(root, outfile='connections.html', show_browser=True,
                      show_values=True, precision=6, title=None):
     """
-    Generate a self-contained html (or csv) file containing a detailed connection viewer.
+    Generate an html or csv file containing a detailed connection viewer.
 
     Optionally pops up a web browser to view the file.
 
@@ -47,6 +47,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
 
     outfile : str, optional
         The name of the output file.  Defaults to 'connections.html'.
+        The extension specified in the file name will determine the output file format
 
     show_browser : bool, optional
         If True, pop up a browser to view the generated html file.
@@ -206,7 +207,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
         'show_values': show_values,
     }
 
-    if '.html' in outfile:
+    if outfile.endswith('.html'):
         viewer = 'connect_table.html'
 
         code_dir = os.path.dirname(os.path.abspath(__file__))
@@ -242,7 +243,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
             from openmdao.utils.webview import webview
             webview(outfile)
             
-    elif '.csv' in outfile:
+    elif outfile.endswith('.csv'):
         import csv
         column_headings = list(table[0].keys())
 
@@ -253,6 +254,9 @@ def view_connections(root, outfile='connections.html', show_browser=True,
             for var_dict in table:
                 row = var_dict.values()
                 writer.writerow(row)
+    
+    else:
+        raise RuntimeError("Invalid file extension for output file, should be '.html' or '.csv'")
 
 # connections report definition
 def _run_connections_report(prob, report_filename='connections.html'):

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -189,7 +189,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
             r['outpromto'] = outpromto
             children.append(r)
 
-        if children:
+        if children and outfile.endswith('.html'):
             row['_children'] = children
 
         table.append(row)
@@ -248,7 +248,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
         column_headings = list(table[0].keys())
 
         # open the file in the write mode
-        with open(outfile, 'w') as f:
+        with open(outfile, 'w', encoding='utf-8') as f:
             writer = csv.writer(f)
             writer.writerow(column_headings)
             for var_dict in table:

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -47,7 +47,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
 
     outfile : str, optional
         The name of the output file.  Defaults to 'connections.html'.
-        The extension specified in the file name will determine the output file format
+        The extension specified in the file name will determine the output file format.
 
     show_browser : bool, optional
         If True, pop up a browser to view the generated html file.
@@ -242,7 +242,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
             # open it up in the browser
             from openmdao.utils.webview import webview
             webview(outfile)
-            
+
     elif outfile.endswith('.csv'):
         import csv
         column_headings = list(table[0].keys())
@@ -254,9 +254,10 @@ def view_connections(root, outfile='connections.html', show_browser=True,
             for var_dict in table:
                 row = var_dict.values()
                 writer.writerow(row)
-    
+
     else:
         raise RuntimeError("Invalid file extension for output file, should be '.html' or '.csv'")
+
 
 # connections report definition
 def _run_connections_report(prob, report_filename='connections.html'):

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -36,7 +36,7 @@ def _val2str(val):
 def view_connections(root, outfile='connections.html', show_browser=True,
                      show_values=True, precision=6, title=None):
     """
-    Generate a self-contained html file containing a detailed connection viewer.
+    Generate a self-contained html (or csv) file containing a detailed connection viewer.
 
     Optionally pops up a web browser to view the file.
 
@@ -46,7 +46,7 @@ def view_connections(root, outfile='connections.html', show_browser=True,
         The root for the desired tree.
 
     outfile : str, optional
-        The name of the output html file.  Defaults to 'connections.html'.
+        The name of the output file.  Defaults to 'connections.html'.
 
     show_browser : bool, optional
         If True, pop up a browser to view the generated html file.
@@ -206,41 +206,53 @@ def view_connections(root, outfile='connections.html', show_browser=True,
         'show_values': show_values,
     }
 
-    viewer = 'connect_table.html'
+    if '.html' in outfile:
+        viewer = 'connect_table.html'
 
-    code_dir = os.path.dirname(os.path.abspath(__file__))
-    libs_dir = os.path.join(os.path.dirname(code_dir), 'common', 'libs')
-    style_dir = os.path.join(os.path.dirname(code_dir), 'common', 'style')
+        code_dir = os.path.dirname(os.path.abspath(__file__))
+        libs_dir = os.path.join(os.path.dirname(code_dir), 'common', 'libs')
+        style_dir = os.path.join(os.path.dirname(code_dir), 'common', 'style')
 
-    with open(os.path.join(code_dir, viewer), "r", encoding='utf-8') as f:
-        template = f.read()
+        with open(os.path.join(code_dir, viewer), "r", encoding='utf-8') as f:
+            template = f.read()
 
-    with open(os.path.join(libs_dir, 'tabulator.5.4.4.min.js'), "r", encoding='utf-8') as f:
-        tabulator_src = f.read()
+        with open(os.path.join(libs_dir, 'tabulator.5.4.4.min.js'), "r", encoding='utf-8') as f:
+            tabulator_src = f.read()
 
-    with open(os.path.join(style_dir, 'tabulator.5.4.4.min.css'), "r", encoding='utf-8') as f:
-        tabulator_style = f.read()
+        with open(os.path.join(style_dir, 'tabulator.5.4.4.min.css'), "r", encoding='utf-8') as f:
+            tabulator_style = f.read()
 
-    jsontxt = json.dumps(data)
+        jsontxt = json.dumps(data)
 
-    with open(outfile, 'w', encoding='utf-8') as f:
-        s = template.replace("<connection_data>", jsontxt)
-        s = s.replace("<tabulator_src>", tabulator_src)
-        s = s.replace("<tabulator_style>", tabulator_style)
-        f.write(s)
+        with open(outfile, 'w', encoding='utf-8') as f:
+            s = template.replace("<connection_data>", jsontxt)
+            s = s.replace("<tabulator_src>", tabulator_src)
+            s = s.replace("<tabulator_style>", tabulator_style)
+            f.write(s)
 
-    if notebook:
-        # display in Jupyter Notebook
-        if not colab:
-            display(IFrame(src=outfile, width=1000, height=1000))
-        else:
-            display(HTML(outfile))
+        if notebook:
+            # display in Jupyter Notebook
+            if not colab:
+                display(IFrame(src=outfile, width=1000, height=1000))
+            else:
+                display(HTML(outfile))
 
-    elif show_browser:
-        # open it up in the browser
-        from openmdao.utils.webview import webview
-        webview(outfile)
+        elif show_browser:
+            # open it up in the browser
+            from openmdao.utils.webview import webview
+            webview(outfile)
+            
+    elif '.csv' in outfile:
+        import csv
+        column_headings = list(table[0].keys())
 
+        # open the file in the write mode
+        with open(outfile, 'w') as f:
+            writer = csv.writer(f)
+            writer.writerow(column_headings)
+            for var_dict in table:
+                row = var_dict.values()
+                writer.writerow(row)
 
 # connections report definition
 def _run_connections_report(prob, report_filename='connections.html'):


### PR DESCRIPTION
Added capability for results to be exported as csv instead of html.

### Summary

Expand view_connections to check file extension for html or csv.
This allows for formatting the export of the data automatically.

### Related Issues

- Resolves #2924

### Backwards incompatibilities

None

### New Dependencies

None
