### PR TITLE
Added -W flag to doc build in test workflow

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -343,7 +343,7 @@ jobs:
           echo "Build the docs"
           echo "============================================================="
           python build_source_docs.py
-          jupyter-book build openmdao_book
+          jupyter-book build -W --keep-going openmdao_book
           python copy_build_artifacts.py
 
       - name: Display doc build reports

--- a/openmdao/docs/openmdao_book/advanced_user_guide/jax_derivatives/partial_derivs_explicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/jax_derivatives/partial_derivs_explicit.ipynb
@@ -352,7 +352,8 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
-  }
+  },
+  "orphan": true
  },
  "nbformat": 4,
  "nbformat_minor": 4


### PR DESCRIPTION
### Summary

The job in the GitHub test workflow that builds the docs was not updated to add the -W flag in PR #2941, allowing a build warning to get though on PR #2933.  This was flagged by the Latest workflow.

This PR adds the missing flag and fixes the warning that was missed. 

### Related Issues

- Resolves #2938

### Backwards incompatibilities

None

### New Dependencies

None
