### PR TITLE
Removed hard coded `set_solver_print` in `SubmodelComp`

### DIFF
--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -29,8 +29,6 @@ class SubmodelComp(ExplicitComponent):
     reports : bool
         Determines if reports should be include in subproblem. Default is False because
         submodelcomp runs faster without reports.
-    solver_print_options : dict
-        Dict for any options the user would want for the internal problems solver print.
     **kwargs : named args
         All remaining named args that become options for `SubmodelComp`.
 
@@ -38,8 +36,6 @@ class SubmodelComp(ExplicitComponent):
     ----------
     _subprob : <Problem>
         Instantiated problem used to run the model.
-    _subprob_solver_print_options: dict
-        Arguments for the subproblems solver print.
     submodel_inputs : list of tuple
         List of inputs requested by user to be used as inputs in the
         subproblem's system.
@@ -48,8 +44,7 @@ class SubmodelComp(ExplicitComponent):
         subproblem's system.
     """
 
-    def __init__(self, problem, inputs=None, outputs=None, reports=False,
-                 solver_print_options={'level': 2, 'depth': 1e99, 'type_': 'all'}, **kwargs):
+    def __init__(self, problem, inputs=None, outputs=None, reports=False, **kwargs):
         """
         Initialize all attributes.
         """
@@ -58,8 +53,6 @@ class SubmodelComp(ExplicitComponent):
         if not reports:
             clear_reports(problem)
         self._subprob = problem
-
-        self._subprob_solver_print_options = solver_print_options
 
         self.submodel_inputs = {}
         self.submodel_outputs = {}
@@ -81,27 +74,6 @@ class SubmodelComp(ExplicitComponent):
                     self.submodel_outputs[out[0]] = {'iface_name': out[1]}
                 else:
                     raise Exception(f'Expected output of type str or tuple, got {type(out)}.')
-
-    def set_subprob_solver_print(self, level=2, depth=1e99, type_='all'):
-        """
-        Cache options to be used in self._subprob.set_solver_print later.
-
-        Parameters
-        ----------
-        level : int
-            Iprint level. Set to 2 to print residuals each iteration; set to 1
-            to print just the iteration totals; set to 0 to disable all printing
-            except for failures, and set to -1 to disable all printing including failures.
-        depth : int
-            How deep to recurse. For example, you can set this to 0 if you only want
-            to print the top level linear and nonlinear solver messages. Default
-            prints everything.
-        type_ : str
-            Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
-        """
-        self._subprob_solver_print_options['level'] = level
-        self._subprob_solver_print_options['depth'] = depth
-        self._subprob_solver_print_options['type_'] = type_
 
     def add_input(self, path, name=None, **kwargs):
         """
@@ -410,7 +382,6 @@ class SubmodelComp(ExplicitComponent):
             p.model.add_constraint(prom_name)
 
         # setup again to compute coloring
-        p.set_solver_print(**self._subprob_solver_print_options)
         if self._problem_meta is None:
             p.setup(force_alloc_complex=False)
         else:

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -79,11 +79,27 @@ class SubmodelComp(ExplicitComponent):
                     self.submodel_outputs[out[0]] = {'iface_name': out[1]}
                 else:
                     raise Exception(f'Expected output of type str or tuple, got {type(out)}.')
-    
+
     def set_subprob_solver_print(self, level=2, depth=1e99, type_='all'):
-        self._subprob_solver_options['level'] = level
-        self._subprob_solver_options['depth'] = depth
-        self._subprob_solver_options['type_'] = type_
+        """
+        Cache options to be used in self._subprob.set_solver_print later.
+
+        Parameters
+        ----------
+        level : int
+            Iprint level. Set to 2 to print residuals each iteration; set to 1
+            to print just the iteration totals; set to 0 to disable all printing
+            except for failures, and set to -1 to disable all printing including failures.
+        depth : int
+            How deep to recurse. For example, you can set this to 0 if you only want
+            to print the top level linear and nonlinear solver messages. Default
+            prints everything.
+        type_ : str
+            Type of solver to set: 'LN' for linear, 'NL' for nonlinear, or 'all' for all.
+        """
+        self._subprob_solver_print_options['level'] = level
+        self._subprob_solver_print_options['depth'] = depth
+        self._subprob_solver_print_options['type_'] = type_
 
     def add_input(self, path, name=None, **kwargs):
         """

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -29,6 +29,8 @@ class SubmodelComp(ExplicitComponent):
     reports : bool
         Determines if reports should be include in subproblem. Default is False because
         submodelcomp runs faster without reports.
+    solver_print_options : dict
+        Dict for any options the user would want for the internal problems solver print.
     **kwargs : named args
         All remaining named args that become options for `SubmodelComp`.
 

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -450,7 +450,7 @@ class TestSubmodelComp(unittest.TestCase):
         submodel.add_input('r', name='new_r', val=20)
         submodel.add_input('theta', name='new_theta', val=0.5)
         submodel.add_output('x', name='new_x', val=100)
-        
+
         submodel.set_subprob_solver_print(level=3, depth=20, type_='NL')
 
         p.model.add_subsystem('submodel', submodel, promotes=['*'])

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -451,11 +451,8 @@ class TestSubmodelComp(unittest.TestCase):
         submodel.add_input('theta', name='new_theta', val=0.5)
         submodel.add_output('x', name='new_x', val=100)
 
-        submodel.set_subprob_solver_print(level=3, depth=20, type_='NL')
+        submodel._subprob.set_solver_print(level=3, depth=20, type_='NL')
 
         p.model.add_subsystem('submodel', submodel, promotes=['*'])
 
-        p.setup()
-        p.final_setup()
-        print()
         self.assertTrue((3, 20, 'NL') in p.model.submodel._subprob.model._solver_print_cache)

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -440,3 +440,22 @@ class TestSubmodelComp(unittest.TestCase):
         self.assertEqual(p.get_val('new_r'), 20)
         self.assertEqual(p.get_val('new_theta'), 0.5)
         self.assertEqual(p.get_val('new_x'), 100)
+
+    def test_subprob_solver_print(self):
+        p = om.Problem()
+        subprob = om.Problem()
+        subprob.model.add_subsystem('comp', om.ExecComp('x = r*cos(theta)'), promotes=['*'])
+        submodel = om.SubmodelComp(problem=subprob)
+
+        submodel.add_input('r', name='new_r', val=20)
+        submodel.add_input('theta', name='new_theta', val=0.5)
+        submodel.add_output('x', name='new_x', val=100)
+        
+        submodel.set_subprob_solver_print(level=3, depth=20, type_='NL')
+
+        p.model.add_subsystem('submodel', submodel, promotes=['*'])
+
+        p.setup()
+        p.final_setup()
+        print()
+        self.assertTrue((3, 20, 'NL') in p.model.submodel._subprob.model._solver_print_cache)


### PR DESCRIPTION
### Summary

Sometimes the user wants to have the submodel's internal problem print its solver output. Before, the internal problem's solver output was disabled via hard coding `set_solver_print(-1)` in SubmodelComp's setup method. Getting rid of this now allows the user to set the solver print by doing `comp._subprob.set_solver_print()`.

### Related Issues

- Resolves #2949 

### Backwards incompatibilities

None

### New Dependencies

None
