### PR TITLE
Updated some GUI tests to be skipped if playwright is not installed

### DIFF
--- a/openmdao/docs/openmdao_book/tests/jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/jupyter_gui_test.py
@@ -1,5 +1,6 @@
 """Test Jupyter doc GUI mods specific to OpenMDAO using Playwright."""
 import asyncio
+from aiounittest import async_test
 import contextlib
 import http.server
 import os
@@ -8,11 +9,6 @@ import socket
 import sys
 import threading
 import unittest
-
-try:
-    from aiounittest import async_test
-except ImportError:
-    from unittest import skip as async_test
 
 from playwright.async_api import async_playwright
 

--- a/openmdao/docs/openmdao_book/tests/jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/jupyter_gui_test.py
@@ -1,6 +1,5 @@
 """Test Jupyter doc GUI mods specific to OpenMDAO using Playwright."""
 import asyncio
-from aiounittest import async_test
 import contextlib
 import http.server
 import os
@@ -9,6 +8,11 @@ import socket
 import sys
 import threading
 import unittest
+
+try:
+    from aiounittest import async_test
+except ImportError:
+    from unittest import skip as async_test
 
 from playwright.async_api import async_playwright
 

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -4,12 +4,15 @@ import os
 
 try:
     import playwright
+    import aiounittest
 except ImportError:
-    playwright = None
-
-if playwright:
+    class TestOpenMDAOJupyterBookDocs(unittest.TestCase):
+        def test_jupyter_book_docs(self):
+            raise unittest.SkipTest("tests require the 'playwright' and 'aiounittest' packages.")
+else:
     os.system("playwright install")
     from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs
 
-    if __name__ == "__main__":
-        unittest.main()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -2,8 +2,14 @@
 import unittest
 import os
 
-os.system("playwright install")
-from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs
+try:
+    import playwright
+except ImportError:
+    playwright = None
 
-if __name__ == "__main__":
-    unittest.main()
+if playwright:
+    os.system("playwright install")
+    from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs
+
+    if __name__ == "__main__":
+        unittest.main()

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -2,9 +2,15 @@
 import unittest
 import os
 
-os.system("playwright install")
-from .n2_gui_test import n2_gui_test_case
-from .gen_gui_test import gen_gui_test_case
+try:
+    import playwright
+except ImportError:
+    playwright = None
 
-if __name__ == "__main__":
-    unittest.main()
+if playwright:
+    os.system("playwright install")
+    from .n2_gui_test import n2_gui_test_case
+    from .gen_gui_test import gen_gui_test_case
+
+    if __name__ == "__main__":
+        unittest.main()

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -5,12 +5,13 @@ import os
 try:
     import playwright
 except ImportError:
-    playwright = None
-
-if playwright:
+    class TestOpenMDAOn2GUI(unittest.TestCase):
+        def test_n2_gui(self):
+            raise unittest.SkipTest("tests require the 'playwright' package.")
+else:
     os.system("playwright install")
     from .n2_gui_test import n2_gui_test_case
     from .gen_gui_test import gen_gui_test_case
 
-    if __name__ == "__main__":
-        unittest.main()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

Updated some GUI tests to be skipped if playwright is not installed.

A user friendly message explains why the tests were skipped.

### Related Issues

- Resolves #2958

### Backwards incompatibilities

None

### New Dependencies

None
