### PR TITLE
fix for IndepVarComp compute not running in mphys

### DIFF
--- a/openmdao/core/indepvarcomp.py
+++ b/openmdao/core/indepvarcomp.py
@@ -199,22 +199,6 @@ class IndepVarComp(ExplicitComponent):
         # define this for IndepVarComp to avoid overhead of ExplicitComponent._linearize.
         pass
 
-    def _apply_nonlinear(self):
-        """
-        Compute residuals. The model is assumed to be in a scaled state.
-        """
-        # define this for IndepVarComp to avoid overhead of
-        # ExplicitComponent._apply_nonlinear.
-        self.iter_count_apply += 1
-
-    def _solve_nonlinear(self):
-        """
-        Compute outputs. The model is assumed to be in a scaled state.
-        """
-        # define this for IndepVarComp to avoid overhead of ExplicitComponent._solve_nonlinear.
-        with Recording(self.pathname + '._solve_nonlinear', self.iter_count, self):
-            pass
-
 
 class _AutoIndepVarComp(IndepVarComp):
     """

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -4,7 +4,6 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
-from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestIndepVarComp(unittest.TestCase):
@@ -267,6 +266,92 @@ class TestIndepVarComp(unittest.TestCase):
 
         self.assertEqual(len(prob.get_val('num_x')), 4)
         self.assertEqual(prob.get_val('val_y'), 2.5)
+
+
+
+num_nodes = 3
+
+class CounterIVC(om.IndepVarComp):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.ncompute = 0
+
+
+class CounterComp(om.ExplicitComponent):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.ncompute = 0
+
+
+
+class MeshComp(CounterIVC):
+    def setup(self):
+        self.add_output('x_aero0', val=np.ones(num_nodes*3), tags=['mphys_coordinates'])
+
+
+class PreCouplingComp(CounterIVC):
+    def setup(self):
+        self.add_input('x_aero', shape_by_conn=True, tags=['mphys_coordinates'])
+        self.add_output('prestate_aero', tags=['mphys_coupling'])
+
+    def compute(self, inputs, outputs):
+        outputs['prestate_aero'] = np.sum(inputs['x_aero'])
+        self.ncompute += 1
+
+
+class CouplingComp(CounterComp):
+    def setup(self):
+        self.add_input('x_aero', shape_by_conn=True, tags=['mphys_coordinates'])
+        self.add_input('prestate_aero', tags=['mphys_coupling'])
+        self.add_output('f_aero', shape=num_nodes*3, tags=['mphys_coupling'])
+
+    def compute(self, inputs, outputs):
+        outputs['f_aero'] = inputs['x_aero'] + inputs['prestate_aero']
+        self.ncompute += 1
+
+
+class PostCouplingComp(CounterIVC):
+    def setup(self):
+        self.add_input('prestate_aero', tags=['mphys_coupling'])
+        self.add_input('x_aero', shape_by_conn=True, tags=['mphys_coordinates'])
+        self.add_input('f_aero', shape_by_conn=True, tags=['mphys_coupling'])
+        self.add_output('func_aero', val=1.0, tags=['mphys_result'])
+
+    def compute(self, inputs, outputs):
+        outputs['func_aero'] = np.sum(inputs['f_aero'] + inputs['prestate_aero'] + inputs['x_aero'])
+        self.ncompute += 1
+
+
+class Geometry(CounterComp):
+    def setup(self):
+        self.add_input('x_aero_in', shape_by_conn=True)
+        self.add_output('x_aero0', shape=3*num_nodes, tags=['mphys_coordinates'])
+
+    def compute(self, inputs, outputs):
+        outputs['x_aero0'] = inputs['x_aero_in']
+        self.ncompute += 1
+
+
+class TestScenario(unittest.TestCase):
+
+    def setUp(self):
+        self.scenarios = ['cruise', 'maneuver']
+        self.prob = om.Problem()
+        self.prob.model.add_subsystem('mesh', MeshComp())
+        for scenario in self.scenarios:
+            scen = self.prob.model.add_subsystem(scenario, om.Group())
+            scen.add_subsystem('aero_pre', PreCouplingComp(), promotes=['*'])
+            scen.add_subsystem('coupling', CouplingComp(), promotes=['*'])
+            scen.add_subsystem('aero_post', PostCouplingComp(), promotes=['*'])
+            self.prob.model.connect('mesh.x_aero0', f'{scenario}.x_aero')
+        self.prob.setup()
+
+    def test_run_model(self):
+        self.prob.run_model()
+        for scenario in self.scenarios:
+            for name in ['aero_pre', 'coupling', 'aero_post']:
+                comp = self.prob.model._get_subsystem(f'{scenario}.{name}')
+                self.assertEqual(comp.ncompute, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

The _solve_nonlinear/_apply_nonlinear methods of IndepVarComp had been turned into no-ops in an earlier PR as an optimization, but it turns out that some people are inheriting from IndepVarComp and overriding the compute method.  So the _solve_nonlinear/_apply_nonlinear no-op methods were removed.

### Related Issues

- Resolves #2962

### Backwards incompatibilities

None

### New Dependencies

None
