### PR TITLE
Added check for valid 'return_format' argument to list_inputs/list_ouputs

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4046,6 +4046,11 @@ class System(object):
                           "display the default values of variables and will not show the result of "
                           "any `set_val` calls.")
 
+        if return_format not in ('list', 'dict'):
+            badarg = f"'{return_format}'" if isinstance(return_format, str) else f"{return_format}"
+            raise ValueError(f"Invalid value ({badarg}) for return_format, "
+                             "must be a string value of 'list' or 'dict'")
+
         metavalues = val and self._inputs is None
 
         keynames = ['val', 'units', 'shape', 'global_shape', 'desc', 'tags']
@@ -4205,6 +4210,11 @@ class System(object):
         list of (name, metadata) or dict of {name: metadata}
             List or dict of output names and other optional information about those outputs.
         """
+        if return_format not in ('list', 'dict'):
+            badarg = f"'{return_format}'" if isinstance(return_format, str) else f"{return_format}"
+            raise ValueError(f"Invalid value ({badarg}) for return_format, "
+                             "must be a string value of 'list' or 'dict'")
+
         keynames = ['val', 'units', 'shape', 'global_shape', 'desc', 'tags']
         keyflags = [val, units, shape, global_shape, desc, tags]
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -6,7 +6,6 @@ import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.utils.om_warnings import OMDeprecationWarning
 
 
 class TestSystem(unittest.TestCase):
@@ -198,6 +197,29 @@ class TestSystem(unittest.TestCase):
         # assign bad list shape to array
         with self.assertRaisesRegex(ValueError, msg):
             residuals['C2.y'] = bad_val.tolist()
+
+    def test_list_inputs_outputs_invalid_return_format(self):
+        from openmdao.test_suite.components.paraboloid_problem import ParaboloidProblem
+        prob = ParaboloidProblem()
+        prob.setup()
+        prob.final_setup()
+
+        with self.assertRaises(ValueError) as cm:
+            prob.model.list_inputs(return_format=dict)
+
+        msg = f"Invalid value (<class 'dict'>) for return_format, " \
+              "must be a string value of 'list' or 'dict'"
+
+        self.assertEqual(str(cm.exception), msg)
+
+        with self.assertRaises(ValueError) as cm:
+            prob.model.list_outputs(return_format='dct')
+
+        msg = f"Invalid value ('dct') for return_format, " \
+              "must be a string value of 'list' or 'dict'"
+
+        self.assertEqual(str(cm.exception), msg)
+
 
     def test_list_inputs_output_with_includes_excludes(self):
         from openmdao.test_suite.scripts.circuit_analysis import Circuit

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -468,6 +468,11 @@ class Case(object):
         list of (name, metadata) or dict of {name: metadata}
             List or dict of input names and other optional information about those inputs.
         """
+        if return_format not in ('list', 'dict'):
+            badarg = f"'{return_format}'" if isinstance(return_format, str) else f"{return_format}"
+            raise ValueError(f"Invalid value ({badarg}) for return_format, "
+                             "must be a string value of 'list' or 'dict'")
+
         abs2meta = self._abs2meta
         inputs = []
 
@@ -657,6 +662,11 @@ class Case(object):
         list of (name, metadata) or dict of {name: metadata}
             List or dict of output names and other optional information about those outputs.
         """
+        if return_format not in ('list', 'dict'):
+            badarg = f"'{return_format}'" if isinstance(return_format, str) else f"{return_format}"
+            raise ValueError(f"Invalid value ({badarg}) for return_format, "
+                             "must be a string value of 'list' or 'dict'")
+
         abs2meta = self._abs2meta
         expl_outputs = []
         impl_outputs = []

--- a/openmdao/recorders/tests/test_list_outputs.py
+++ b/openmdao/recorders/tests/test_list_outputs.py
@@ -8,6 +8,33 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 @use_tempdirs
 class ListOutputsTest(unittest.TestCase):
+
+    def test_invalid_return_format(self):
+        prob = ParaboloidProblem()
+        rec = om.SqliteRecorder('test_list_outputs.db')
+        prob.model.add_recorder(rec)
+
+        prob.setup()
+        prob.run_model()
+
+        case = om.CaseReader('test_list_outputs.db').get_case(-1)
+
+        with self.assertRaises(ValueError) as cm:
+            case.list_inputs(return_format=dict)
+
+        msg = f"Invalid value (<class 'dict'>) for return_format, " \
+              "must be a string value of 'list' or 'dict'"
+
+        self.assertEqual(str(cm.exception), msg)
+
+        with self.assertRaises(ValueError) as cm:
+            case.list_outputs(return_format='dct')
+
+        msg = f"Invalid value ('dct') for return_format, " \
+              "must be a string value of 'list' or 'dict'"
+
+        self.assertEqual(str(cm.exception), msg)
+
     def test_list_outputs(self):
         """
         Confirm that includes/excludes has the same result between System.list_inputs() and


### PR DESCRIPTION
### Summary

Added check for valid 'return_format' argument to list_inputs/list_ouputs.

### Related Issues

- Resolves #2960 

### Backwards incompatibilities

None

### New Dependencies

None
