### PR TITLE
Added argument to show_options_table to allow the attribute name of the options table to be passed.

### DIFF
--- a/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/problem_recording.ipynb
@@ -63,7 +63,7 @@
    "outputs": [],
    "source": [
     "import openmdao.api as om\n",
-    "om.show_options_table(\"openmdao.core.problem.Problem\", recording_options=True)"
+    "om.show_options_table(\"openmdao.core.problem.Problem\", options_dict=\"recording_options\")"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/solver_recording.ipynb
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "import openmdao.api as om\n",
-    "om.show_options_table(\"openmdao.solvers.solver.Solver\", recording_options=True)"
+    "om.show_options_table(\"openmdao.solvers.solver.Solver\", options_dict=\"recording_options\")"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/system_recording.ipynb
@@ -59,7 +59,7 @@
    "outputs": [],
    "source": [
     "import openmdao.api as om\n",
-    "om.show_options_table(\"openmdao.core.system.System\", recording_options=True)"
+    "om.show_options_table(\"openmdao.core.system.System\", options_dict=\"recording_options\")"
    ]
   },
   {

--- a/openmdao/utils/notebook_utils.py
+++ b/openmdao/utils/notebook_utils.py
@@ -120,10 +120,10 @@ def show_options_table(reference, recording_options=False, options_dict='options
                              '`options_dict="recording_options" to remove this '
                              'warning.')
             opt = obj.recording_options
-        elif has_attr(obj, options_dict):
+        elif hasattr(obj, options_dict):
             opt = getattr(obj, options_dict)
         else:
-            raise AttributeError('Object {reference} has no attribute {options_dict}.')
+            raise AttributeError(f'Object {reference} has no attribute {options_dict}.')
 
         return display(HTML(str(opt.to_table(fmt='html', display=False))))
     else:

--- a/openmdao/utils/notebook_utils.py
+++ b/openmdao/utils/notebook_utils.py
@@ -11,7 +11,6 @@ except ImportError:
     ipy = display = HTML = IFrame = None
 
 from openmdao.utils.om_warnings import issue_warning
-from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.om_warnings import warn_deprecation
 
 colab = 'google.colab' in sys.modules
@@ -125,10 +124,6 @@ def show_options_table(reference, recording_options=False, options_dict='options
             opt =  getattr(obj, options_dict)
         else:
             raise AttributeError('Object {reference} has no attribute {options_dict}.')
-
-        if not isinstance(opt, om.OptionsDictionary):
-            raise AttributeError('Object {reference} attribute {options_dict} is not '
-                                 'an OpenMDAO OptionsDictionary.')
 
         return display(HTML(str(opt.to_table(fmt='html', display=False))))
     else:

--- a/openmdao/utils/notebook_utils.py
+++ b/openmdao/utils/notebook_utils.py
@@ -121,7 +121,7 @@ def show_options_table(reference, recording_options=False, options_dict='options
                              'warning.')
             opt = obj.recording_options
         elif has_attr(obj, options_dict):
-            opt =  getattr(obj, options_dict)
+            opt = getattr(obj, options_dict)
         else:
             raise AttributeError('Object {reference} has no attribute {options_dict}.')
 

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -32,9 +32,12 @@ class TestNotebookUtils(unittest.TestCase):
         from openmdao.utils import notebook_utils
         notebook_utils.ipy = True
 
-        options = om.show_options_table("openmdao.utils.tests.test_notebook_utils.StateOptionsDictionary")
+        with self.assertRaises(AttributeError) as e:
+            om.show_options_table("openmdao.utils.tests.test_notebook_utils.StateOptionsDictionary")
 
-        self.assertEqual(options, None)
+        self.assertEqual(str(e.exception),
+                         'Object openmdao.utils.tests.test_notebook_utils.StateOptionsDictionary '
+                         'has no attribute options.')
 
     def test_show_options_w_attr(self):
         from openmdao.utils import notebook_utils


### PR DESCRIPTION
### Summary

Allows docs to display options tables stored in attributes with arbitrary names.

The use of `recording_options` as an argument is **deprecated**.

### Related Issues

- Resolves #2969 

### Backwards incompatibilities

None

### New Dependencies

None
