### PR TITLE
Updated Note for doc pages that require MPI and may not work with Colab/Binder

### DIFF
--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -192,6 +192,15 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "```{note}\n",
+     "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+     "```"
+    ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/genetic_algorithm.ipynb
@@ -65,6 +65,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -80,6 +81,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -102,6 +104,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -137,6 +140,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -179,6 +183,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -218,6 +223,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -257,6 +263,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -422,6 +429,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -524,6 +532,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -592,12 +601,23 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "## Running a GA on a Parallel Model in Parallel\n",
     "\n",
     "If you have a model that does contain distributed components or parallel groups, you can also use SimpleGADriver to optimize it. If you have enough processors, you can also simultaneously evaluate multiple points in your population by turning on the “run_parallel” option and setting the “procs_per_model” to the number of processors that your model requires. Take care that you submit your parallel run with enough processors such that the number of processors the model requires divides evenly into it, as in this example, where the model requires 2 and we give it 4."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+    "```"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/adding_desvars_cons_objs/adding_constraint.ipynb
@@ -34,15 +34,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
-    "This feature requires MPI, and may not be able to be run on Colab.\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Adding Constraints\n",
     "\n",
     "To add a constraint to an optimization, use the `add_constraint` method on System."
@@ -250,6 +241,15 @@
    ]
   },
   {
+    "cell_type": "markdown",
+    "metadata": {},
+    "source": [
+     "```{note}\n",
+     "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+     "```"
+    ]
+   },
+ {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
@@ -29,15 +29,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```{note}\n",
-    "     \"This feature requires MPI, and may not be able to be run on Colab or Binder.\\n\",\n",
-    "```"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "# Distributed Variables\n",
     "\n",
     "At times when you need to perform a computation using large input arrays, you may want to perform that computation in multiple processes, where each process operates on some subset of the input values. This may be done purely for performance reasons, or it may be necessary because the entire input will not fit in the memory of a single machine. In any case, this can be accomplished in OpenMDAO by declaring those inputs and outputs as distributed. By definition, a `distributed variable` is an input or output where each process contains only a part of the whole variable. Distributed variables are declared by setting the optional \"distributed\" argument to True when adding the variable to a component. A component that has at least one distributed variable can also be called a distributed component.\n",
@@ -45,6 +36,16 @@
     "Any variable that is not distributed is called a `non-distributed variable`. When the model is run under MPI, every process contains a copy of the entire variable.\n",
     "\n",
     "We’ve already seen that by using [src_indices](connect-with-src-indices), we can connect an input to only a subset of an output variable. By giving different values for src_indices in each MPI process, we can distribute computations on a distributed output across the processes. All of the scenarios that involve connecting distributed and non-distributed variables are detailed in [Connections involving distributed variables](../working_with_groups/dist_serial.ipynb)."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+    "```"
    ]
   },
   {
@@ -91,6 +92,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -168,6 +170,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -279,6 +282,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
@@ -25,11 +25,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "```{note}\n",
-    "This feature requires MPI, and may not be able to be run on Colab.\n",
+    "     \"This feature requires MPI, and may not be able to be run on Colab or Binder.\\n\",\n",
     "```"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_derivs.ipynb
@@ -3,6 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "94d7a6cc",
    "metadata": {
     "tags": [
      "remove-input",
@@ -22,11 +23,12 @@
     "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
     "    !python -m pip install openmdao[notebooks]"
-   ],
-   "id": "94d7a6cc"
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "id": "45f5bd8c",
    "metadata": {},
    "source": [
     "# Parallel Coloring for Multipoint or Fan-Out Problems\n",
@@ -38,11 +40,23 @@
     "```\n",
     "\n",
     "Parallel coloring is specified via the `parallel_deriv_color` argument to the [add_constraint()](../adding_desvars_cons_objs/adding_constraint) method. The color specified can be any hashable object (e.g. string, int, tuple). Two constraints, pointing to variables from different components on different processors, given the same `parallel_deriv_color` argument will be solved for in parallel with each other."
-   ],
-   "id": "45f5bd8c"
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "id": "415a3416",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+    "```"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "945d0dee",
    "metadata": {},
    "source": [
     "## Usage Example\n",
@@ -50,12 +64,12 @@
     "Here is a toy problem that runs on two processors showing how to use this feature\n",
     "\n",
     "### Class definitions for a simple problem"
-   ],
-   "id": "945d0dee"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "860b0d19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,12 +92,12 @@
     "\n",
     "    def compute_partials(self, inputs, partials):\n",
     "        partials['y', 'x'] = np.ones(inputs['x'].size)\n"
-   ],
-   "id": "860b0d19"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3923e6f4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,12 +127,12 @@
     "    def _apply_linear(self, jac, vec_names, rel_systems, mode, scope_out=None, scope_in=None):\n",
     "        time.sleep(self.delay)\n",
     "        super()._apply_linear(jac, vec_names, rel_systems, mode, scope_out, scope_in)"
-   ],
-   "id": "3923e6f4"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "c9cb1619",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,20 +161,21 @@
     "        self.add_design_var('Comp1.x')\n",
     "        self.add_constraint('ParallelGroup1.Con1.y', lower=0.0, parallel_deriv_color=color)\n",
     "        self.add_constraint('ParallelGroup1.Con2.y', upper=0.0, parallel_deriv_color=color)"
-   ],
-   "id": "c9cb1619"
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "id": "7ac18fde",
    "metadata": {},
    "source": [
     "### Run script"
-   ],
-   "id": "7ac18fde"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "a6f84fbf",
    "metadata": {
     "tags": [
      "remove-input",
@@ -172,11 +187,12 @@
     "from openmdao.utils.notebook_utils import get_code\n",
     "from myst_nb import glue\n",
     "glue(\"code_src65\", get_code(\"openmdao.core.tests.test_parallel_derivatives.PartialDependGroup\"), display=False)"
-   ],
-   "id": "a6f84fbf"
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "id": "b8d6ae8a",
    "metadata": {},
    "source": [
     ":::{Admonition} `PartialDependGroup` class definition \n",
@@ -184,12 +200,12 @@
     "\n",
     "{glue:}`code_src65`\n",
     ":::"
-   ],
-   "id": "b8d6ae8a"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "ae0530ee",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,12 +229,12 @@
     "\n",
     "print(J['ParallelGroup1.Con1.y']['Comp1.x'][0])\n",
     "print(J['ParallelGroup1.Con2.y']['Comp1.x'][0])"
-   ],
-   "id": "ae0530ee"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "89a0ad26",
    "metadata": {
     "scrolled": true,
     "tags": [
@@ -236,8 +252,7 @@
     "expected = np.array([[2., 2., 2., 2.],[-3., -3., -3., -3.]])\n",
     "assert_near_equal(J['ParallelGroup1.Con1.y']['Comp1.x'][0], expected[0])\n",
     "assert_near_equal(J['ParallelGroup1.Con2.y']['Comp1.x'][0], expected[1])"
-   ],
-   "id": "89a0ad26"
+   ]
   }
  ],
  "metadata": {

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_fd.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/parallel_fd.ipynb
@@ -26,6 +26,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "b26341c6",
    "metadata": {},
@@ -35,6 +36,17 @@
     "If you have multiple processors available to you, it’s possible to speed up the calculation of approximated partials or totals by computing multiple columns of the approximated Jacobian matrix simultaneously across multiple processes. Setting up *parallel* finite difference or *parallel* complex step is identical to setting up for serial execution, except for the addition of a single `__init__` arg that sets `num_par_fd` on the System(s) where you want to compute the approximate derivatives. The `num_par_fd` arg specifies the number of approximated Jacobian columns that will be computed in parallel, assuming that enough processes are provided when the problem script is executed.\n",
     "\n",
     "As a simple example, lets use parallel finite difference to compute the partial and total derivatives using a simple model containing a component that computes its outputs by multiplying its inputs by a constant matrix. The partial jacobian for that component will be identical to that constant matrix. The component we’ll use is shown below:"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "7e36763f",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+    "```"
    ]
   },
   {
@@ -72,6 +84,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "1cfe11be",
    "metadata": {},
@@ -82,6 +95,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "e8d96de8",
    "metadata": {},
@@ -97,6 +111,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "68c4dc1e",
    "metadata": {},
@@ -175,6 +190,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "id": "dd2ac6c7",
    "metadata": {},

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/dist_serial.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/dist_serial.ipynb
@@ -51,6 +51,16 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/parallel_group.ipynb
@@ -25,15 +25,17 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "```{note}\n",
-    "This feature requires MPI, and may not be able to be run on Colab.\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
     "```"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -97,6 +99,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/src_indices.ipynb
@@ -3,6 +3,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "active-ipynb",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
    "source": [
     "%matplotlib inline\n",
     "from ipyparallel import Client, error\n",
@@ -14,18 +22,12 @@
     "    from openmdao.utils.notebook_utils import notebook_mode\n",
     "except ImportError:\n",
     "    !python -m pip install openmdao[notebooks]"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": [
-     "remove-input",
-     "active-ipynb",
-     "remove-output"
-    ]
-   }
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "# Using src_indices with Promoted Variables\n",
     "\n",
@@ -44,12 +46,13 @@
     "## Basic Example\n",
     "\n",
     "Here is a simple example showing how to connect an independent array variable to two different components where each component gets part of the array."
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
@@ -97,40 +100,41 @@
     "print(p.get_val('G1.comp2.x'))\n",
     "print(p.get_val('G1.comp1.y'))\n",
     "print(p.get_val('G1.comp2.y'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "assert_near_equal(p.get_val('G1.comp1.x'), inp[:3])\n",
     "assert_near_equal(p.get_val('G1.comp2.x'), inp[3:])\n",
     "assert_near_equal(p.get_val('G1.comp1.y'), np.sum(inp[:3]*2))\n",
     "assert_near_equal(p.get_val('G1.comp2.y'), np.sum(inp[3:]*4))"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": [
-     "remove-input",
-     "remove-output"
-    ]
-   }
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Using src_indices with 2D Arrays\n",
     "\n",
     "In this example, the source array is shape (4,3) and the input array is shape (2,2)"
-   ],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "class MyComp(om.ExplicitComponent):\n",
     "    def setup(self):\n",
@@ -160,29 +164,29 @@
     "\n",
     "print(p.get_val('C1.x'))\n",
     "print(p.get_val('C1.y'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "source": [
-    "assert_near_equal(p.get_val('C1.x'),\n",
-    "                 np.array([[0., 10.],\n",
-    "                           [7., 4.]]))\n",
-    "assert_near_equal(p.get_val('C1.y'), 21.)"
-   ],
-   "outputs": [],
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
-   }
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(p.get_val('C1.x'),\n",
+    "                 np.array([[0., 10.],\n",
+    "                           [7., 4.]]))\n",
+    "assert_near_equal(p.get_val('C1.y'), 21.)"
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "If the source array is shape (4,3), the input is scalar, and we want to\n",
     "connect it to the (3, 1) entry of the source, then the `promotes`\n",
@@ -199,41 +203,55 @@
     "    p.model.promotes('C1', inputs=['x'], src_indices=(3, 1), shape=1)\n",
     "\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "5: If the source array is flat and the input is shape (2,2), the `promotes` call might look like this:\n",
     "```\n",
     "    p.model.promotes('C1', inputs=['x'], src_indices=[0, 10, 7, 4], shape=(2,2))\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "```{note}\n",
     "If the source array is flat, we allow the use of flat src_indices even without \n",
     "setting `flat_src_indices=True`.\n",
     "```"
-   ],
-   "metadata": {}
+   ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Distributed component example\n",
     "\n",
     "In the example, a distributed component promotes its input and receives certain entries of the source array based on its rank.  Note that negative indices are supported."
-   ],
-   "metadata": {}
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{note}\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
+    "```"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%%px\n",
     "\n",
@@ -275,25 +293,30 @@
     "\n",
     "# each rank holds the assigned portion of the input array\n",
     "print(p.get_val('C1.x'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "%%px\n",
     "\n",
     "# the output in each rank is based on the local inputs\n",
     "print(p.get_val('C1.y'))"
-   ],
-   "outputs": [],
-   "metadata": {}
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
    "source": [
     "%%px\n",
     "from openmdao.utils.assert_utils import assert_near_equal\n",
@@ -303,14 +326,7 @@
     "\n",
     "# the output in each rank is based on the local inputs\n",
     "assert_near_equal(p['C1.y'], 6. if p.model.C1.comm.rank == 0 else 14.)"
-   ],
-   "outputs": [],
-   "metadata": {
-    "tags": [
-     "remove-input",
-     "remove-output"
-    ]
-   }
+   ]
   }
  ],
  "metadata": {

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -25,6 +25,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -90,6 +91,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -122,6 +124,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -143,6 +146,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -161,6 +165,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -188,6 +193,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -210,6 +216,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -228,6 +235,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -246,6 +254,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -273,6 +282,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -310,6 +320,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -328,6 +339,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -346,6 +358,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -364,6 +377,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -566,6 +580,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -591,6 +606,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -618,6 +634,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -668,6 +685,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -765,6 +783,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -834,6 +853,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -864,6 +884,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -904,6 +925,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -916,11 +938,12 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "```{note}\n",
-    "This feature requires MPI, and may not be able to be run on Colab.\n",
+    "This feature requires MPI, and may not be able to be run on Colab or Binder.\n",
     "```"
    ]
   },
@@ -941,6 +964,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -968,6 +992,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1012,6 +1037,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1049,6 +1075,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1081,6 +1108,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1159,7 +1187,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/other/citing.ipynb
+++ b/openmdao/docs/openmdao_book/other/citing.ipynb
@@ -129,6 +129,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": [
@@ -136,7 +137,7 @@
     ]
    },
    "source": [
-    "If you are in colab, the shell command will not find the file because it is a single notebook without the included file."
+    "If you are in Colab or Binder, the shell command will not find the file because it is a single notebook without the included file."
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/auto_ivc_api_translation.ipynb
@@ -981,7 +981,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -119,6 +119,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "tags": [
@@ -126,7 +127,7 @@
     ]
    },
    "source": [
-    "If you are in colab, the shell command will not find the file because it is a single notebook without the included file."
+    "If you are in Colab or Binder, the shell command will not find the file because it is a single notebook without the included file."
    ]
   },
   {


### PR DESCRIPTION
### Summary

Updated note for doc pages that require MPI and may not work with Colab/Binder

- added Binder to the existing notes that referenced Colab
- added new notes to pages that have parallel code but didn't have a note previously

### Related Issues

- Resolves #2389

### Backwards incompatibilities

None

### New Dependencies

None
