### PR TITLE
Updated documentation to highlight case where matrix-free derivatives are required

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh        text eol=lf
+

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/distributed_components.ipynb
@@ -47,7 +47,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -392,7 +391,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -532,7 +530,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -546,7 +543,11 @@
     "\n",
     "# Derivatives with Distributed Variables\n",
     "\n",
-    "In the following examples, we show how to add analytic derivatives to the distributed examples given above. In most cases it is straighforward, but when you have a distributed output depending on a non-distributed input, or a non-distributed output depending on a distributed input, the [matrix-free](matrix-free-api) format is required, meaning that you will need to define a `compute_jacvec_product` method if your component is an `ExplicitComponent`, or `apply_linear` if your component is an `ImplicitComponent`.  An important thing to keep in mind when deciding whether or not you need to some sort of reduce operation when computing derivatives using the matrix-free API with mixed distributed/non-distributed derivatives is that derivatives of any non-distributed variable in that case must be the same across all ranks.\n",
+    "In the following examples, we show how to add analytic derivatives to the distributed examples given above. In most cases it is straighforward, but there is a special case when a non-distributed output depends on a distributed input or vice versa:\n",
+    "\n",
+    "> When you have a distributed output depending on a non-distributed input, or a non-distributed output depending on a distributed input, the [matrix-free](matrix-free-api) format is required, meaning that you will need to define a `compute_jacvec_product` method if your component is an `ExplicitComponent`, or `apply_linear` if your component is an `ImplicitComponent`.  The reasons for this are a bit subtle, but it boils down to OpenMDAO not knowing what kind of distributed operations are being done in the `compute` and having no way to manage those details when you propagate things in reverse.\n",
+    "\n",
+    "An important thing to keep in mind when deciding whether or not you need to some sort of reduce operation when computing derivatives using the matrix-free API with mixed distributed/non-distributed derivatives is that derivatives of any non-distributed variable in that case must be the same across all ranks.\n",
     "\n",
     "## Derivatives: Distributed I/O and a Non-Distributed Input\n",
     "\n",
@@ -687,7 +688,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -912,7 +912,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -926,7 +926,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.3"
   },
   "orphan": true
  },


### PR DESCRIPTION
### Summary

As Ken mentioned in his response to the issue, there are already comprehensive examples with mixed distributed/serial inputs and outputs that demonstrate use of the matrix-free API.    In this PR, I have made that information more prominent using a blockquote and added a little context that Justin provided in his response on StackOverflow.

(I also added a `.gitattributes` file to ensure that git does not mess up the line endings for shell scripts)

### Related Issues

- Resolves #2261

### Backwards incompatibilities

None

### New Dependencies

None
