### PR TITLE
Fixed issue where show_options_table failed when given an OptionsTable

### DIFF
--- a/openmdao/utils/notebook_utils.py
+++ b/openmdao/utils/notebook_utils.py
@@ -109,6 +109,8 @@ def show_options_table(reference, recording_options=False, options_dict='options
     IPython.display
         Options table of the given class or function.
     """
+    from openmdao.utils.options_dictionary import OptionsDictionary
+
     if isinstance(reference, str):
         obj = _get_object_from_reference(reference)()
     else:
@@ -120,6 +122,8 @@ def show_options_table(reference, recording_options=False, options_dict='options
                              '`options_dict="recording_options" to remove this '
                              'warning.')
             opt = obj.recording_options
+        elif isinstance(obj, OptionsDictionary):
+            opt = obj
         elif hasattr(obj, options_dict):
             opt = getattr(obj, options_dict)
         else:

--- a/openmdao/utils/tests/test_notebook_utils.py
+++ b/openmdao/utils/tests/test_notebook_utils.py
@@ -28,16 +28,14 @@ class StateOptionsDictionary(om.OptionsDictionary):
 @unittest.skipUnless(IPython, "IPython is required")
 class TestNotebookUtils(unittest.TestCase):
 
+    @unittest.skipIf(not IPython, reason='Test requires IPython')
     def test_show_obj_options(self):
         from openmdao.utils import notebook_utils
         notebook_utils.ipy = True
-
-        with self.assertRaises(AttributeError) as e:
+        try:
             om.show_options_table("openmdao.utils.tests.test_notebook_utils.StateOptionsDictionary")
-
-        self.assertEqual(str(e.exception),
-                         'Object openmdao.utils.tests.test_notebook_utils.StateOptionsDictionary '
-                         'has no attribute options.')
+        except Exception as e:
+            self.fail('show_options_table raised the following exception:\n' + str(e))
 
     def test_show_options_w_attr(self):
         from openmdao.utils import notebook_utils


### PR DESCRIPTION
### Summary

A recent update to show options table broke dymos documentation when given the path to an OptionsTable subclass.
The code now checks for this and handles it appropriately.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
