### PR TITLE
MPI fixes for Aviary issues

### DIFF
--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -436,13 +436,6 @@ class SubmodelComp(ExplicitComponent):
         # set initial output vals
         for prom_name, meta in self.submodel_outputs.items():
             p.set_val(prom_name, outputs[meta['iface_name']])
-        
-        for i in inputs:
-            if ('mach' in i) or ('alt' in i) or ('dTs' in i) or ('throttle' in i) or ('electric' in i) or ('rhs:W' in i) or ('BurnerArea' in i):
-                print(self.pathname, i, inputs[i])
-                print()
-
-        # exit()
 
         p.driver.run()
 

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -438,9 +438,8 @@ class SubmodelComp(ExplicitComponent):
             p.set_val(prom_name, outputs[meta['iface_name']])
         
         for i in inputs:
-            if 'mach' in i:
-                print(self.pathname, i)
-                print(inputs[i])
+            if ('mach' in i) or ('alt' in i) or ('dTs' in i) or ('throttle' in i) or ('electric' in i) or ('rhs:W' in i) or ('BurnerArea' in i):
+                print(self.pathname, i, inputs[i])
                 print()
 
         # exit()

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -393,8 +393,6 @@ class SubmodelComp(ExplicitComponent):
             p.model.add_constraint(prom_name)
 
         # setup again to compute coloring
-        p.set_solver_print(level=-1)
-        p.set_solver_print(level=1, depth=2)
         if self._problem_meta is None:
             p.setup(force_alloc_complex=False)
         else:

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -4,6 +4,7 @@ from openmdao.core.constants import _SetupStatus, INF_BOUND
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.utils.general_utils import find_matches
 from openmdao.utils.reports_system import clear_reports
+from openmdao.utils.mpi import MPI, FakeComm
 
 
 class SubmodelComp(ExplicitComponent):
@@ -165,6 +166,16 @@ class SubmodelComp(ExplicitComponent):
         Perform some final setup and checks.
         """
         p = self._subprob
+
+        # make sure comm is correct or at least reasonable.  In cases
+        # where the submodel comp setup() is being called from the parent
+        # setup(), our comm will be None, and we don't want to use the
+        # parent's comm because it could be too big if we're under a ParallelGroup.
+        # If our comm is not None then we'll just set the problem comm to ours.
+        if self.comm is None:
+            p.comm = FakeComm()
+        else:
+            p.comm = self.comm
 
         # if subprob.setup is called before the top problem setup, we can't rely
         # on using the problem meta data, so default to False

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -393,6 +393,8 @@ class SubmodelComp(ExplicitComponent):
             p.model.add_constraint(prom_name)
 
         # setup again to compute coloring
+        p.set_solver_print(level=-1)
+        p.set_solver_print(level=1, depth=2)
         if self._problem_meta is None:
             p.setup(force_alloc_complex=False)
         else:
@@ -434,6 +436,14 @@ class SubmodelComp(ExplicitComponent):
         # set initial output vals
         for prom_name, meta in self.submodel_outputs.items():
             p.set_val(prom_name, outputs[meta['iface_name']])
+        
+        for i in inputs:
+            if 'mach' in i:
+                print(self.pathname, i)
+                print(inputs[i])
+                print()
+
+        # exit()
 
         p.driver.run()
 

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -1,8 +1,15 @@
+import unittest
 from numpy import pi
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
-import unittest
+from openmdao.utils.mpi import MPI
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.test_suite.groups.parallel_groups import FanIn, FanOut
+
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
 
 
 class TestSubmodelComp(unittest.TestCase):
@@ -456,3 +463,25 @@ class TestSubmodelComp(unittest.TestCase):
         p.model.add_subsystem('submodel', submodel, promotes=['*'])
 
         self.assertTrue((3, 20, 'NL') in p.model.submodel._subprob.model._solver_print_cache)
+
+
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class TestSubmodelCompMPI(unittest.TestCase):
+    N_PROCS = 2
+
+    def test_submodel_comp(self):
+        p = om.Problem()
+
+        model = p.model
+
+        par = model.add_subsystem('par', om.ParallelGroup())
+
+        par.add_subsystem('subprob1', om.SubmodelComp(problem=om.Problem(model=FanOut()),
+                                                      inputs=['p.x'], outputs=['comp2.y', 'comp3.y']))
+        par.add_subsystem('subprob2', om.SubmodelComp(problem=om.Problem(model=FanIn()),
+                                                      inputs=['p1.x1', 'p2.x2'], outputs=['comp3.y']))
+
+        p.setup(force_alloc_complex=True)
+        p.run_model()
+        cpd = p.check_partials(method='cs', out_stream=None)
+        assert_check_partials(cpd)

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1528,7 +1528,8 @@ class Group(System):
                     try:
                         if pinfo.src_shape is None:
                             pinfo.set_src_shape(root_shape)
-                        elif pinfo.src_indices is not None and root_shape != pinfo.src_shape:
+                        elif pinfo.src_indices is not None and \
+                                not array_connection_compatible(root_shape, pinfo.src_shape):
                             self._collect_error(f"When connecting '{src}' to "
                                                 f"'{pinfo.prom_path()}': Promoted src_shape of "
                                                 f"{pinfo.src_shape} for "

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -206,12 +206,12 @@ class SerialTests(unittest.TestCase):
         try:
             p.setup()
         except Exception as err:
-            self.assertEqual(str(err),
+            self.assertTrue(
               "\nCollected errors for problem 'discrete_fan_out2':"
               "\n   <model> <class Group>: The following inputs, ['par.C1.x', 'par.C2.x'], promoted "
               "to 'x', are connected but their metadata entries ['val'] differ. Call "
               "<group>.set_input_defaults('x', val=?), where <group> is the Group named 'par' to "
-              "remove the ambiguity.")
+              "remove the ambiguity." in str(err))
         else:
             self.fail("Exception expected.")
 

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -592,10 +592,10 @@ class TestConnectionsDistrib(unittest.TestCase):
         try:
             prob.setup()
         except Exception as err:
-            self.assertEqual(str(err),
+            self.assertTrue(
                              "\nCollected errors for problem 'serial_mpi_error':" \
                              "\n   <model> <class Group>: When connecting 'p1.x' to 'c3.x':" \
-                             " index 2 is out of bounds for source dimension of size 2.")
+                             " index 2 is out of bounds for source dimension of size 2." in str(err))
         else:
             self.fail('Exception expected.')
 
@@ -623,10 +623,10 @@ class TestConnectionsDistrib(unittest.TestCase):
         try:
             prob.setup()
         except Exception as err:
-            self.assertEqual(str(err),
+            self.assertTrue(
                              "\nCollected errors for problem 'serial_mpi_error_flat':" \
                              "\n   <model> <class Group>: When connecting 'p1.x' to 'c3.x':" \
-                             " index 2 is out of bounds for source dimension of size 2.")
+                             " index 2 is out of bounds for source dimension of size 2." in str(err))
         else:
             self.fail('Exception expected.')
 
@@ -678,10 +678,10 @@ class TestConnectionsError(unittest.TestCase):
         with self.assertRaises(Exception) as context:
             prob.setup(check=False, mode='fwd')
 
-        self.assertEqual(str(context.exception),
+        self.assertTrue(
             "\nCollected errors for problem 'incompatible_src_indices':"
             "\n   <model> <class Group>: When connecting 'p1.x' to 'c3.x':"
-            " index 2 is out of bounds for source dimension of size 2.")
+            " index 2 is out of bounds for source dimension of size 2." in str(context.exception))
 
 
 @unittest.skipUnless(MPI, "MPI is required.")

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -852,10 +852,10 @@ class TestAddConstraintMPI(unittest.TestCase):
         with self.assertRaises(RuntimeError) as context:
             prob.setup(mode='rev')
 
-        self.assertEqual(str(context.exception),
+        self.assertTrue(
            "\nCollected errors for problem 'add_bad_con':"
            "\n   <model> <class Group>: 'sub' <class SellarDerivatives>: Output not found for "
-           "response 'd1.junk'.")
+           "response 'd1.junk'." in str(context.exception))
 
 
 class TestObjectiveOnModel(unittest.TestCase):

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -638,20 +638,15 @@ class TestDistribDynShapes(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             p.setup()
 
-        cname = 'G1' if p.model.comm.rank <= 1 else 'G2'
-        self.assertEqual(str(cm.exception),
-           "\nCollected errors for problem 'remote_distrib':"
-           f"\n   'par.{cname}.C1' <class DistribDynShapeComp>: Can't determine src_indices "
-           f"automatically for input 'par.{cname}.C1.x1'. They must be supplied manually."
-           "\n   <model> <class Group>: The source and target shapes do not match or are ambiguous "
-           f"for the connection 'indep.x1' to 'par.{cname}.C1.x1'. The source shape is (32,) but "
-           "the target shape is (8,)."
-           "\n   <model> <class Group>: The source indices slice(None, None, 1) do not specify a "
-           "valid shape for the connection 'par.G1.C2.y1' to 'sink.x1'. The target shape is (8,) "
-           "but indices are shape (16,)."
-           "\n   <model> <class Group>: The source indices slice(None, None, 1) do not specify a "
-           "valid shape for the connection 'par.G2.C2.y1' to 'sink.x2'. The target shape is (8,) "
-           "but indices are shape (16,).")
+        self.assertTrue(
+            "Collected errors for problem 'remote_distrib':\n"
+            "   'par.G1.C1' <class DistribDynShapeComp>: Can't determine src_indices automatically for input 'par.G1.C1.x1'. They must be supplied manually.\n"
+            "   <model> <class Group>: The source and target shapes do not match or are ambiguous for the connection 'indep.x1' to 'par.G1.C1.x1'. The source shape is (32,) but the target shape is (8,).\n"
+            "   <model> <class Group>: The source indices slice(None, None, 1) do not specify a valid shape for the connection 'par.G1.C2.y1' to 'sink.x1'. The target shape is (8,) but indices are shape (16,).\n"
+            "   <model> <class Group>: The source indices slice(None, None, 1) do not specify a valid shape for the connection 'par.G2.C2.y1' to 'sink.x2'. The target shape is (8,) but indices are shape (16,).\n"
+            "   'par.G2.C1' <class DistribDynShapeComp>: Can't determine src_indices automatically for input 'par.G2.C1.x1'. They must be supplied manually.\n"
+            "   <model> <class Group>: The source and target shapes do not match or are ambiguous for the connection 'indep.x1' to 'par.G2.C1.x1'. The source shape is (32,) but the target shape is (8,)."
+           in str(cm.exception))
 
 
 class DynPartialsComp(om.ExplicitComponent):
@@ -826,10 +821,10 @@ class TestDistribDynShapeCombos(unittest.TestCase):
         p.model.connect('indeps.x', 'comp.x')
         with self.assertRaises(Exception) as cm:
             p.setup()
-        self.assertEqual(cm.exception.args[0],
+        self.assertTrue(
             "\nCollected errors for problem 'dist_unknown_ser_known':"
             "\n   <model> <class Group>: Can't connect distributed output 'indeps.x' to "
-            "non-distributed input 'comp.x' without specifying src_indices.")
+            "non-distributed input 'comp.x' without specifying src_indices." in cm.exception.args[0])
 
     def test_dist_known_dist_unknown(self):
         p = om.Problem()

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -779,10 +779,10 @@ class CheckParallelDerivColoringEfficiency(unittest.TestCase):
         prob = om.Problem(model=model, name='parallel_deriv_coloring_overlap_err')
         with self.assertRaises(Exception) as ctx:
             prob.setup(mode='rev')
-        self.assertEqual(str(ctx.exception),
+        self.assertTrue(
            "\nCollected errors for problem 'parallel_deriv_coloring_overlap_err':"
            "\n   <model> <class Group>: response 'pg.dc2.y' has overlapping dependencies on the "
-           "same rank with other responses in parallel_deriv_color 'a'.")
+           "same rank with other responses in parallel_deriv_color 'a'." in str(ctx.exception))
 
 if __name__ == "__main__":
     from openmdao.utils.mpi import mpirun_tests

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -661,14 +661,13 @@ def _run_n2_report(prob, report_filename=_default_n2_filename):
 
 
 def _run_n2_report_w_errors(prob, report_filename=_default_n2_filename):
-    errs = prob._metadata['saved_errors']
-    if errs:
+    if prob._any_rank_has_saved_errors():
         n2_filepath = str(pathlib.Path(prob.get_reports_dir()).joinpath(report_filename))
         # only run the n2 here if we've had setup errors. Normally we'd wait until
         # after final_setup in order to have correct values for all of the I/O variables.
         try:
             n2(prob, show_browser=False, outfile=n2_filepath, display_in_notebook=False)
-        except RuntimeError as err:
+        except Exception as err:
             # We ignore this error
             if str(err) != "Can't compute total derivatives unless " \
                            "both 'of' or 'wrt' variables have been specified.":


### PR DESCRIPTION
### Summary

This fixes a couple of issues resulting in crashes/hangs in some Aviary models.

- updates handling of MPI communicator within SubmodelComp to help handle cases where setup() is called on the SubmodelComp before its actual communicator is known. This is a bit of a hack.  The real fix for this is probably to add another user overridable setup method that gets called inside of `_setup_procs` but after the communicator has been split.

- fixed a check that compared shapes between different variable promotion levels.  Previous check was too strict, requiring an exact match in shapes rather than using `array_connection_compatible`.

- updated handling of collected errors to properly deal with MPI.

### Related Issues

- Resolves #2976

### Backwards incompatibilities

None

### New Dependencies

None
