### PR TITLE
Changed the 'hist_file' and 'hotstart_file' attributes on pyOptSparseDriver to options

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -108,7 +108,7 @@ from openmdao.utils.units import convert_units, unit_conversion
 
 # Warning Options
 from openmdao.utils.om_warnings import issue_warning, reset_warnings, OpenMDAOWarning, \
-    SetupWarning, DistributedComponentWarning, CaseRecorderWarning,\
+    SetupWarning, DistributedComponentWarning, CaseRecorderWarning, \
     DriverWarning, CacheWarning, PromotionWarning, UnusedOptionWarning, DerivativesWarning, \
     MPIWarning, UnitsWarning, SolverWarning, OMDeprecationWarning, \
     OMInvalidCheckDerivativesOptionsWarning

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -9,7 +9,7 @@ import numpy as np
 from openmdao.components.interp_util.interp_akima import InterpAkima, Interp1DAkima
 from openmdao.components.interp_util.interp_bsplines import InterpBSplines
 from openmdao.components.interp_util.interp_cubic import InterpCubic
-from openmdao.components.interp_util.interp_lagrange2 import InterpLagrange2, Interp3DLagrange2,\
+from openmdao.components.interp_util.interp_lagrange2 import InterpLagrange2, Interp3DLagrange2, \
     Interp2DLagrange2, Interp1DLagrange2
 from openmdao.components.interp_util.interp_lagrange3 import InterpLagrange3, Interp3DLagrange3, \
     Interp2DLagrange3, Interp1DLagrange3

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -306,7 +306,6 @@ class pyOptSparseDriver(Driver):
                          "Use the 'hotstart_file' option instead.")
         self.options['hotstart_file'] = file_name
 
-
     def _setup_driver(self, problem):
         """
         Prepare the driver for execution.

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -28,8 +28,7 @@ from openmdao.core.driver import Driver, RecordingDebugging
 import openmdao.utils.coloring as c_mod
 from openmdao.utils.class_util import WeakMethodWrapper
 from openmdao.utils.mpi import FakeComm, MPI
-from openmdao.utils.general_utils import _src_or_alias_name
-from openmdao.utils.om_warnings import issue_warning
+from openmdao.utils.om_warnings import issue_warning, warn_deprecation
 
 # what version of pyoptspare are we working with
 if pyoptsparse and hasattr(pyoptsparse, '__version__'):
@@ -160,11 +159,6 @@ class pyOptSparseDriver(Driver):
     ----------
     fail : bool
         Flag that indicates failure of most recent optimization.
-    hist_file : str or None
-        File location for saving pyopt_sparse optimization history.
-        Default is None for no output.
-    hotstart_file : str
-        Optional file to hot start the optimization.
     opt_settings : dict
         Dictionary for setting optimizer-specific options.
     pyopt_solution : Solution
@@ -223,13 +217,6 @@ class pyOptSparseDriver(Driver):
         # The user places optimizer-specific settings in here.
         self.opt_settings = {}
 
-        # The user can set a file name here to store history
-        self.hist_file = None
-
-        # The user can set a file here to hot start the optimization
-        # with a history file
-        self.hotstart_file = None
-
         # We save the pyopt_solution so that it can be queried later on.
         self.pyopt_solution = None
 
@@ -276,6 +263,49 @@ class pyOptSparseDriver(Driver):
                                   "ignore - don't perform check.")
         self.options.declare('singular_jac_tol', default=1e-16,
                              desc='Tolerance for zero row/column check.')
+        self.options.declare('hist_file', types=str, default=None, allow_none=True,
+                             desc='File location for saving pyopt_sparse optimization history. '
+                                  'Default is None for no output.')
+        self.options.declare('hotstart_file', types=str, default=None, allow_none=True,
+                             desc='File location of a pyopt_sparse optimization history to use '
+                                  'to hot start the optimization. Default is None.')
+
+    @property
+    def hist_file(self):
+        """
+        Get the 'hist_file' option for this driver.
+        """
+        warn_deprecation("The 'hist_file' attribute is deprecated. "
+                         "Use the 'hist_file' option instead.")
+        return self.options['hist_file']
+
+    @hist_file.setter
+    def hist_file(self, file_name):
+        """
+        Set the 'hist_file' option for this driver.
+        """
+        warn_deprecation("The 'hist_file' attribute is deprecated. "
+                         "Use the 'hist_file' option instead.")
+        self.options['hist_file'] = file_name
+
+    @property
+    def hotstart_file(self):
+        """
+        Get the 'hotstart_file' option for this driver.
+        """
+        warn_deprecation("The 'hotstart_file' attribute is deprecated. "
+                         "Use the 'hotstart_file' option instead.")
+        return self.options['hist_file']
+
+    @hotstart_file.setter
+    def hotstart_file(self, file_name):
+        """
+        Set the 'hotstart_file' option for this driver.
+        """
+        warn_deprecation("The 'hotstart_file' attribute is deprecated. "
+                         "Use the 'hotstart_file' option instead.")
+        self.options['hotstart_file'] = file_name
+
 
     def _setup_driver(self, problem):
         """
@@ -529,8 +559,9 @@ class pyOptSparseDriver(Driver):
                 # TODO: Need to get this from OpenMDAO
                 # fd_step = problem.model.deriv_options['step_size']
                 fd_step = 1e-6
-                sol = opt(opt_prob, sens='FD', sensStep=fd_step, storeHistory=self.hist_file,
-                          hotStart=self.hotstart_file)
+                sol = opt(opt_prob, sens='FD', sensStep=fd_step,
+                          storeHistory=self.options['hist_file'],
+                          hotStart=self.options['hotstart_file'])
 
             elif self.options['gradient_method'] == 'snopt_fd':
                 if self.options['optimizer'] == 'SNOPT':
@@ -539,8 +570,9 @@ class pyOptSparseDriver(Driver):
                     # TODO: Need to get this from OpenMDAO
                     # fd_step = problem.model.deriv_options['step_size']
                     fd_step = 1e-6
-                    sol = opt(opt_prob, sens=None, sensStep=fd_step, storeHistory=self.hist_file,
-                              hotStart=self.hotstart_file)
+                    sol = opt(opt_prob, sens=None, sensStep=fd_step,
+                              storeHistory=self.options['hist_file'],
+                              hotStart=self.options['hotstart_file'])
 
                 else:
                     msg = "SNOPT's internal finite difference can only be used with SNOPT"
@@ -549,7 +581,8 @@ class pyOptSparseDriver(Driver):
 
                 # Use OpenMDAO's differentiator for the gradient
                 sol = opt(opt_prob, sens=WeakMethodWrapper(self, '_gradfunc'),
-                          storeHistory=self.hist_file, hotStart=self.hotstart_file)
+                          storeHistory=self.options['hist_file'],
+                          hotStart=self.options['hotstart_file'])
 
         except Exception as c:
             if self._exc_info is None:

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2778,7 +2778,6 @@ class TestPyoptSparse(unittest.TestCase):
 
         # run driver and save history
         prob = ParaboloidProblem()
-
         driver = prob.driver = pyOptSparseDriver(print_results=False)
 
         msg = "The 'hist_file' attribute is deprecated. Use the 'hist_file' option instead."

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2,6 +2,7 @@
 
 import copy
 import unittest
+import os.path
 
 from packaging.version import Version
 
@@ -10,11 +11,13 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
+from openmdao.test_suite.components.paraboloid_problem import ParaboloidProblem
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
 from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
-from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse, set_env_vars_context
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.utils.om_warnings import OMDeprecationWarning
 from openmdao.utils.mpi import MPI
 
 
@@ -2747,6 +2750,65 @@ class TestPyoptSparse(unittest.TestCase):
         assert_near_equal(J[('ALIAS_TEST', 'exec.a')].flatten(), np.array([1.]))
         assert_near_equal(p.get_val('exec.z')[0], 25, tolerance=1e-4)
         assert_near_equal(p.get_val('exec.z')[50], -75, tolerance=1e-4)
+
+    def test_hist_file_hotstart(self):
+        filename = "hist_file"
+
+        # run driver and save history
+        prob = ParaboloidProblem()
+        prob.driver = pyOptSparseDriver(print_results=False, hist_file=filename)
+
+        prob.setup()
+        prob.run_driver()
+
+        self.assertTrue(prob.driver.iter_count > 1)
+        self.assertTrue(os.path.exists(filename))
+
+        # run driver and restart from history
+        prob = ParaboloidProblem()
+        prob.driver = pyOptSparseDriver(print_results=False, hotstart_file=filename)
+
+        prob.setup()
+        prob.run_driver()
+
+        self.assertEqual(prob.driver.iter_count, 1)
+
+    def test_hist_file_hotstart_deprecated(self):
+        filename = "hist_file"
+
+        # run driver and save history
+        prob = ParaboloidProblem()
+
+        driver = prob.driver = pyOptSparseDriver(print_results=False)
+
+        msg = "The 'hist_file' attribute is deprecated. Use the 'hist_file' option instead."
+        with assert_warning(OMDeprecationWarning, msg):
+            driver.hist_file = filename
+        with assert_warning(OMDeprecationWarning, msg):
+            driver.hist_file
+        self.assertEqual(driver.options['hist_file'], filename)
+
+        prob.setup()
+        prob.run_driver()
+
+        self.assertTrue(driver.iter_count > 1)
+        self.assertTrue(os.path.exists(filename))
+
+        # run driver and restart from history
+        prob = ParaboloidProblem()
+        driver = prob.driver = pyOptSparseDriver(print_results=False)
+
+        msg = "The 'hotstart_file' attribute is deprecated. Use the 'hotstart_file' option instead."
+        with assert_warning(OMDeprecationWarning, msg):
+            driver.hotstart_file = filename
+        with assert_warning(OMDeprecationWarning, msg):
+            driver.hotstart_file
+        self.assertEqual(driver.options['hotstart_file'], filename)
+
+        prob.setup()
+        prob.run_driver()
+
+        self.assertEqual(driver.iter_count, 1)
 
 
 @unittest.skipIf(OPT is None or OPTIMIZER is None, "only run if pyoptsparse is installed.")

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -444,12 +444,12 @@ def assert_near_equal(actual, desired, tolerance=1e-15):
         desired = np.asarray(desired)
 
     # In case they are PromAbsDict and other dict-like objects
-    if isinstance(actual, dict) and type(actual) != dict:
+    if isinstance(actual, dict) and type(actual) is not dict:
         actual = dict(actual)
-    if isinstance(desired, dict) and type(desired) != dict:
+    if isinstance(desired, dict) and type(desired) is not dict:
         desired = dict(desired)
 
-    if type(actual) != type(desired):
+    if type(actual) is not type(desired):
         raise ValueError(f'actual {type(actual)}, desired {type(desired)} have different types')
 
     if isinstance(actual, type) and isinstance(desired, type):

--- a/openmdao/visualization/timing_viewer/timer.py
+++ b/openmdao/visualization/timing_viewer/timer.py
@@ -55,8 +55,8 @@ def _timing_file_iter(timing_file):
 def _get_par_child_info(timing_iter, method):
     # puts timing info for direct children of parallel groups into a dict.
     parents = {}
-    for rank, probname, classname, sysname, level, parallel, nprocs, func, ncalls, avg, tmin, tmax,\
-            ttot, tot_time in timing_iter:
+    for rank, probname, classname, sysname, level, parallel, nprocs, func, ncalls, avg, \
+            tmin, tmax, ttot, tot_time in timing_iter:
         if not parallel or method != func:
             continue
 

--- a/openmdao/visualization/timing_viewer/timer.py
+++ b/openmdao/visualization/timing_viewer/timer.py
@@ -42,8 +42,8 @@ def _timing_iter(all_timing_managers):
                 level = len(sysname.split('.')) if sysname else 0
                 for t, parallel, nprocs, classname in timers:
                     if t.ncalls > 0:
-                        yield rank, probname, classname, sysname, level, parallel, nprocs, t.name,\
-                            t.ncalls, t.avg(), t.min, t.max, t.tot, tot_time
+                        yield rank, probname, classname, sysname, level, parallel, nprocs, \
+                            t.name, t.ncalls, t.avg(), t.min, t.max, t.tot, tot_time
 
 
 def _timing_file_iter(timing_file):


### PR DESCRIPTION
### Summary

Changed the `hist_file` and `hotstart_file` attributes on `pyOptSparseDriver` to options, which are self-documenting via the options table  on the [pyOptSparseDriver page](https://openmdao.org/swryan/newdocversions/latest/features/building_blocks/drivers/pyoptsparse_driver.html#pyoptsparsedriver-options).

Also,
- deprecated the old attributes
- added tests
- cleaned up some new PEP8 errors

### Related Issues

- Resolves #2988

### Backwards incompatibilities

None

### New Dependencies

None
