### PR TITLE
Updated support for `jax` to require Python 3.8 and jax>=0.4.0

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -82,6 +82,7 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: '7.2'
             OPTIONAL: '[all]'
+            JAX: '0.3.24'
             TESTS: true
 
           # build docs (baseline versions)

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -32,7 +32,7 @@ jobs:
             # PAROPT: true
             SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.4.2'
+            JAX: '0.4.14'
             BANDIT: true
             TESTS: true
             # set DEBUG to create an interactive debugging session just before testflo is run.
@@ -58,7 +58,7 @@ jobs:
             # PAROPT: true
             # SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.4.2'
+            JAX: '0.4.14'
             TESTS: true
 
           # test minimal install
@@ -95,7 +95,7 @@ jobs:
             PYOPTSPARSE: 'v2.9.2'
             SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.4.2'
+            JAX: '0.4.14'
             BUILD_DOCS: true
 
     runs-on: ${{ matrix.OS }}

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -82,7 +82,7 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: '7.2'
             OPTIONAL: '[all]'
-            JAX: '0.3.0'
+            JAX: '0.4.0'
             TESTS: true
 
           # build docs (baseline versions)

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -82,7 +82,6 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: '7.2'
             OPTIONAL: '[all]'
-            JAX: '0.4.0'
             TESTS: true
 
           # build docs (baseline versions)

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -82,7 +82,7 @@ jobs:
             PYOPTSPARSE: 'v1.2'
             SNOPT: '7.2'
             OPTIONAL: '[all]'
-            JAX: '0.3.24'
+            JAX: '0.3.0'
             TESTS: true
 
           # build docs (baseline versions)

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -30,7 +30,7 @@ if jax is not None:
         # versions of jax before 0.3.18 do not have the jax.Array base class
         raise RuntimeError(f"An unsupported version of jax is installed. "
                            "OpenMDAO requires 'jax>=4.0' and 'jaxlib>=4.0'. "
-                           "Try 'pip install openmdao[jax]'.")
+                           "Try 'pip install openmdao[jax]' with Python>=3.8.")
 
 
 class ExplicitFuncComp(ExplicitComponent):

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -15,6 +15,7 @@ try:
     import jax
     from jax import jit
     import jax.numpy as jnp
+    from jax import Array as JaxArray
     from jax.config import config
     config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
@@ -22,12 +23,6 @@ except Exception:
     if not isinstance(err, ImportError):
         traceback.print_tb(tb)
     jax = None
-
-if jax:
-    try:
-        from jax.numpy import DeviceArray as JaxArray
-    except ImportError:
-        from jax import Array as JaxArray
 
 
 class ExplicitFuncComp(ExplicitComponent):

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -75,7 +75,7 @@ class ExplicitFuncComp(ExplicitComponent):
         if self.options['use_jax']:
             if jax is None:
                 raise RuntimeError(f"{self.msginfo}: jax is not installed. "
-                                   "Try 'pip install openmdao[jax]'.")
+                                   "Try 'pip install openmdao[jax]' with Python>=3.8.")
             self._compute_jax = omf.jax_decorate(self._compute._f)
 
         self._tangents = None

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -15,7 +15,6 @@ try:
     import jax
     from jax import jit
     import jax.numpy as jnp
-    from jax import Array as JaxArray
     from jax.config import config
     config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
@@ -23,6 +22,13 @@ except Exception:
     if not isinstance(err, ImportError):
         traceback.print_tb(tb)
     jax = None
+
+if jax is not None:
+    try:
+        from jax import Array as JaxArray
+    except ImportError:
+        # versions of jax before 0.3.18 do not have the jax.Array base class
+        from jax.numpy import DeviceArray as JaxArray
 
 
 class ExplicitFuncComp(ExplicitComponent):

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -28,7 +28,9 @@ if jax is not None:
         from jax import Array as JaxArray
     except ImportError:
         # versions of jax before 0.3.18 do not have the jax.Array base class
-        from jax.numpy import DeviceArray as JaxArray
+        raise RuntimeError(f"An unsupported version of jax is installed. "
+                           "OpenMDAO requires 'jax>=4.0' and 'jaxlib>=4.0'. "
+                           "Try 'pip install openmdao[jax]'.")
 
 
 class ExplicitFuncComp(ExplicitComponent):
@@ -72,7 +74,8 @@ class ExplicitFuncComp(ExplicitComponent):
 
         if self.options['use_jax']:
             if jax is None:
-                raise RuntimeError(f"{self.msginfo}: jax is not installed. Try 'pip install jax'.")
+                raise RuntimeError(f"{self.msginfo}: jax is not installed. "
+                                   "Try 'pip install openmdao[jax]'.")
             self._compute_jax = omf.jax_decorate(self._compute._f)
 
         self._tangents = None

--- a/openmdao/components/implicit_func_comp.py
+++ b/openmdao/components/implicit_func_comp.py
@@ -97,7 +97,8 @@ class ImplicitFuncComp(ImplicitComponent):
 
         if self.options['use_jax']:
             if jax is None:
-                raise RuntimeError(f"{self.msginfo}: jax is not installed. Try 'pip install jax'.")
+                raise RuntimeError(f"{self.msginfo}: jax is not installed. "
+                                   "Try 'pip install openmdao[jax]'.")
             self._apply_nonlinear_func_jax = omf.jax_decorate(self._apply_nonlinear_func._f)
 
         if self.options['use_jax'] and self.options['use_jit']:

--- a/openmdao/components/implicit_func_comp.py
+++ b/openmdao/components/implicit_func_comp.py
@@ -98,7 +98,7 @@ class ImplicitFuncComp(ImplicitComponent):
         if self.options['use_jax']:
             if jax is None:
                 raise RuntimeError(f"{self.msginfo}: jax is not installed. "
-                                   "Try 'pip install openmdao[jax]'.")
+                                   "Try 'pip install openmdao[jax]' with Python>=3.8.")
             self._apply_nonlinear_func_jax = omf.jax_decorate(self._apply_nonlinear_func._f)
 
         if self.options['use_jax'] and self.options['use_jit']:

--- a/openmdao/components/tests/test_explicit_func_comp.py
+++ b/openmdao/components/tests/test_explicit_func_comp.py
@@ -6,8 +6,7 @@ from numpy.testing import assert_almost_equal
 from io import StringIO
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_check_totals, \
-    assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_check_totals
 from openmdao.utils.cs_safe import abs, arctan2
 import openmdao.func_api as omf
 from openmdao.utils.coloring import compute_total_coloring

--- a/openmdao/func_api.py
+++ b/openmdao/func_api.py
@@ -280,7 +280,9 @@ class OMWrappedFunc(object):
         jaxerr = False
         if 'method' in kwargs and kwargs['method'] == 'jax':
             if jax is None:
-                raise RuntimeError("jax is not installed.  Try 'pip install openmdao[jax]'.")
+                raise RuntimeError("jax is not installed. "
+                                   "Try 'pip install openmdao[jax]' with Python>=3.8.")
+
             if self._declare_partials and not self._use_jax:
                 jaxerr = True
             self._use_jax = True
@@ -317,7 +319,8 @@ class OMWrappedFunc(object):
             self._declare_coloring['wrt'] = wrt
             if 'method' in kwargs and kwargs['method'] == 'jax':
                 if jax is None:
-                    raise RuntimeError("jax is not installed.  Try 'pip install openmdao[jax]'.")
+                    raise RuntimeError("jax is not installed. "
+                                       "Try 'pip install openmdao[jax]' with Python>=3.8.")
                 self._use_jax = True
             return self
         raise RuntimeError("declare_coloring has already been called.")

--- a/openmdao/func_api.py
+++ b/openmdao/func_api.py
@@ -280,7 +280,7 @@ class OMWrappedFunc(object):
         jaxerr = False
         if 'method' in kwargs and kwargs['method'] == 'jax':
             if jax is None:
-                raise RuntimeError("jax is not installed.  Try 'pip install jax'.")
+                raise RuntimeError("jax is not installed.  Try 'pip install openmdao[jax]'.")
             if self._declare_partials and not self._use_jax:
                 jaxerr = True
             self._use_jax = True
@@ -317,7 +317,7 @@ class OMWrappedFunc(object):
             self._declare_coloring['wrt'] = wrt
             if 'method' in kwargs and kwargs['method'] == 'jax':
                 if jax is None:
-                    raise RuntimeError("jax is not installed. Try 'pip install jax'.")
+                    raise RuntimeError("jax is not installed.  Try 'pip install openmdao[jax]'.")
                 self._use_jax = True
             return self
         raise RuntimeError("declare_coloring has already been called.")

--- a/openmdao/func_api.py
+++ b/openmdao/func_api.py
@@ -282,7 +282,6 @@ class OMWrappedFunc(object):
             if jax is None:
                 raise RuntimeError("jax is not installed. "
                                    "Try 'pip install openmdao[jax]' with Python>=3.8.")
-
             if self._declare_partials and not self._use_jax:
                 jaxerr = True
             self._use_jax = True

--- a/openmdao/utils/jax_utils.py
+++ b/openmdao/utils/jax_utils.py
@@ -58,7 +58,7 @@ def register_jax_component(comp_class):
         If jax is not available.
     """
     if jax is None:
-        raise RuntimeError('jax is not available. Try `pip install jax jaxlib`')
+        raise RuntimeError("jax is not available. Try 'pip install openmdao[jax]'.")
 
     if not hasattr(comp_class, '_tree_flatten'):
         raise NotImplementedError(f'class {comp_class} does not implement method _tree_flatten.'

--- a/openmdao/utils/jax_utils.py
+++ b/openmdao/utils/jax_utils.py
@@ -58,7 +58,8 @@ def register_jax_component(comp_class):
         If jax is not available.
     """
     if jax is None:
-        raise RuntimeError("jax is not available. Try 'pip install openmdao[jax]'.")
+        raise RuntimeError("jax is not available. "
+                           "Try 'pip install openmdao[jax]' with Python>=3.8.")
 
     if not hasattr(comp_class, '_tree_flatten'):
         raise NotImplementedError(f'class {comp_class} does not implement method _tree_flatten.'

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ optional_dependencies = {
         'pyDOE2'
     ],
     'jax': [
-        'jax>=0.4.0',
-        'jaxlib>=0.4.0'
+        'jax>=0.4.0; python_version>="3.8"',
+        'jaxlib>=0.4.0; python_version>="3.8"'
     ],
     'notebooks': [
         'notebook',

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ optional_dependencies = {
         'pyDOE2'
     ],
     'jax': [
-        'jax>4.0',
-        'jaxlib>4.0'
+        'jax>=0.4.0',
+        'jaxlib>=0.4.0'
     ],
     'notebooks': [
         'notebook',

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,10 @@ optional_dependencies = {
     'doe': [
         'pyDOE2'
     ],
+    'jax': [
+        'jax>4.0',
+        'jaxlib>4.0'
+    ],
     'notebooks': [
         'notebook',
         'ipympl'


### PR DESCRIPTION
### Summary

Version 0.4.14 of `jax`, released on [July 27](https://github.com/google/jax/blob/main/CHANGELOG.md#jax-0414-july-27-2023) has done away with the `DeviceArray` class as described [here](https://jax.readthedocs.io/en/latest/jax_array_migration.html).

Per the `jax` [CHANGELOG](https://github.com/google/jax/blob/main/CHANGELOG.md#jax-0318-sep-26-2022), the `jax.Array` class can be used instead of `DeviceArray` for `isinstance` checks..

This base class goes back to [jax 0.3.18](https://github.com/google/jax/blob/jaxlib-v0.3.18/jax/__init__.py#L38) so the check in ExplicitFuncComp was changed to address all versions.   

Since the tests in the `openmdao.jax` sub-package will fail with a Type error for `jax<0.4.0`, I have added `jax>=0.4.0` to the optional dependencies in `setup.py`.   This dependency requires Python>=3.8 because `jax` dropped support for Python 3.7 in these versions.

The GitHub test workflow has been updated to use the latest version of `jax`, 0.4.14.

### Related Issues

- Resolves #2990

### Backwards incompatibilities

None

### New Dependencies

None
