### PR TITLE
Added a relevance check for constraints to the `run_driver` function

### DIFF
--- a/openmdao/components/tests/test_implicit_func_comp.py
+++ b/openmdao/components/tests/test_implicit_func_comp.py
@@ -126,7 +126,12 @@ class TestImplicitFuncComp(unittest.TestCase):
             z0 = z[0]
             z1 = z[1]
 
-            return 0., (y1**.5 + z0 + z1) - y2, (z0**2 + z1 + x - 0.2*y2) - y1 - R_y1, (y1**.5 + z0 + z1) - y2 - R_y2
+            return (
+                0.,
+                (y1**.5 + z0 + z1) - y2,
+                (z0**2 + z1 + x - 0.2*y2) - y1 - R_y1,
+                (y1**.5 + z0 + z1) - y2 - R_y2
+            )
 
         f = (omf.wrap(apply_nonlinear)
                 .add_input('z', val=np.array([-1., -1.]))
@@ -170,7 +175,7 @@ class TestImplicitFuncComp(unittest.TestCase):
         p_opt.driver = om.ScipyOptimizeDriver()
         p_opt.driver.options['disp'] = False
 
-        p_opt.model.add_design_var('y1', lower=-10, upper=10)
+        p_opt.model.add_design_var('x', lower=-10, upper=10)
         p_opt.model.add_constraint('R_y1', equals=0)
 
         p_opt.model.add_objective('y2')
@@ -183,9 +188,9 @@ class TestImplicitFuncComp(unittest.TestCase):
 
         p_opt.run_driver()
 
-        np.testing.assert_almost_equal(p_opt['y1'], 2.109516506074582, decimal=5)
-        np.testing.assert_almost_equal(p_opt['y2'], -0.5475825303740725, decimal=5)
-        np.testing.assert_almost_equal(p_opt['x'], 2.0, decimal=5)
+        np.testing.assert_almost_equal(p_opt['y1'], 5., decimal=5)
+        np.testing.assert_almost_equal(p_opt['y2'], 0.2360679774997898, decimal=5)
+        np.testing.assert_almost_equal(p_opt['x'], 5.047213595499958, decimal=5)
         np.testing.assert_almost_equal(p_opt['z'], np.array([-1., -1.]), decimal=5)
 
     def test_apply_nonlinear(self):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -922,7 +922,6 @@ class Driver(object):
 
         This usually indicates something is wrong with the problem formulation.
         """
-
         # relevance not relevant if not using derivatives
         if not self.supports['gradients']:
             return

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -925,15 +925,14 @@ class Driver(object):
         problem = self._problem()
         model = problem.model
 
-        # relevance not relevant if derivatives are approximated?
-        if model._approx_schemes:
+        # relevance not relevant if not using derivatives
+        if not self.supports['gradients'] or model._approx_schemes:
             return
 
         relevant = model._relevant
         fwd = problem._mode == 'fwd'
 
         des_vars = self._designvars
-        responses = self._responses
         constraints = self._cons
 
         indep_list = list(des_vars)
@@ -958,9 +957,7 @@ class Driver(object):
             #       implements bounds on design variables by adding them as constraints.
             #       These design variables as constraints will not appear in the wrt list.
             if not wrt and name not in indep_list:
-                rtype = response_type[responses[name]['type']]
-
-                raise RuntimeError(f"{self.msginfo}: {rtype} '{name}' does not depend on any "
+                raise RuntimeError(f"{self.msginfo}: Constraint '{name}' does not depend on any "
                                    "design variables. Please check your problem formulation.")
 
     def run(self):

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -922,26 +922,19 @@ class Driver(object):
 
         This usually indicates something is wrong with the problem formulation.
         """
-        problem = self._problem()
-        model = problem.model
 
         # relevance not relevant if not using derivatives
-        if not self.supports['gradients'] or model._approx_schemes:
+        if not self.supports['gradients']:
             return
 
-        relevant = model._relevant
+        problem = self._problem()
+        relevant = problem.model._relevant
         fwd = problem._mode == 'fwd'
 
         des_vars = self._designvars
         constraints = self._cons
 
         indep_list = list(des_vars)
-
-        response_type = defaultdict(lambda: 'Response')
-        response_type.update({
-            'con': 'Constraint',
-            'obj': 'Objective'
-        })
 
         for name, meta in constraints.items():
 

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -852,19 +852,6 @@ class TestCheckRelevance(unittest.TestCase):
         # does not depend on a design variable should not trigger a RuntimeError
         prob.run_driver()
 
-    def test_simple_paraboloid_irrelevant_objective_run_once(self):
-        # define model with default driver
-        prob = self.setup_problem()
-
-        # add objective that does not depend on a design var
-        prob.model.add_objective('bad')
-
-        prob.setup()
-
-        # the default driver does not support optimization, so an objective that
-        # does not depend on a design variable should not trigger a RuntimeError
-        prob.run_driver()
-
     def test_simple_paraboloid_irrelevant_constraint(self):
         # define model with optimizing driver
         prob = self.setup_problem(driver=om.ScipyOptimizeDriver())
@@ -882,23 +869,6 @@ class TestCheckRelevance(unittest.TestCase):
             prob.run_driver()
 
         self.assertTrue("Constraint 'bad.bad' does not depend on any design variables."
-                        in str(err.exception))
-
-    def test_simple_paraboloid_irrelevant_objective(self):
-        # define model with optimizing driver
-        prob = self.setup_problem(driver=om.ScipyOptimizeDriver())
-
-        # add objective that does not depend on a design var
-        prob.model.add_objective('bad')
-
-        prob.setup()
-
-        # since driver is an optimizer, an objective that does not depend
-        # on a design variable should trigger a RuntimeError
-        with self.assertRaises(RuntimeError) as err:
-            prob.run_driver()
-
-        self.assertTrue("Objective 'bad.bad' does not depend on any design variables."
                         in str(err.exception))
 
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1339,7 +1339,7 @@ class TestProblem(unittest.TestCase):
         model.connect('G2.C6.y', 'G2.C7.b')
         model.connect('G2.C5.x', 'C8.b')
         model.connect('G2.C7.x', 'C8.a')
-        
+
         model.add_design_var('indep1.x')
         model.add_design_var('indep2.x')
         model.add_constraint('C8.y')
@@ -1349,7 +1349,7 @@ class TestProblem(unittest.TestCase):
         p.final_setup()
 
         relevant = model._relevant
-        
+
         indep1_ins = {'C8.b', 'G2.C5.a', 'G1.C1.a'}
         indep1_outs = {'C8.y', 'G1.C1.z', 'G2.C5.x', 'indep1.x'}
         indep1_sys = {'C8', 'G1.C1', 'G2.C5', 'indep1', 'G1', 'G2', ''}
@@ -1835,8 +1835,8 @@ class TestProblem(unittest.TestCase):
     def test_list_problem_w_multi_constraints(self):
         p = om.Problem()
 
-        exec = om.ExecComp(['y = x**2',
-                            'z = a + x**2'],
+        exec = om.ExecComp(['y = a + x**2',
+                            'z = a * x**2'],
                         a={'shape': (1,)},
                         y={'shape': (101,)},
                         x={'shape': (101,)},

--- a/openmdao/core/tests/test_scaling_report_mpi.py
+++ b/openmdao/core/tests/test_scaling_report_mpi.py
@@ -2,7 +2,7 @@
 import os
 import unittest
 
-import  openmdao.core.tests.test_scaling_report as NonMPI
+import openmdao.core.tests.test_scaling_report as NonMPI
 
 
 @unittest.skipIf(os.environ.get("GITHUB_ACTION"), "Unreliable on GitHub Actions workflows.")

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/implicit_func_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/implicit_func_comp.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# ImplicitFuncComp\n",
     "\n",
-    "`ImplicitFuncComp` is a component that provides a shortcut for building an ImplicitComponent based on a python function. That function takes inputs and states as arguments and returns residual values. The function may take some inputs that are non-differentable and are assumed to be static during the computation of derivatives.  These static values may be of any hashable type.  All other arguments and return values must be either floats or numpy arrays. The mapping between a state argument and its residual output must be specified in the metadata when the output (state) is added by setting 'resid' to the name of the residual.\n",
+    "`ImplicitFuncComp` is a component that provides a shortcut for building an ImplicitComponent based on a python function. That function takes inputs and states as arguments and returns residual values. The function may take some inputs that are non-differentiable and are assumed to be static during the computation of derivatives.  These static values may be of any hashable type.  All other arguments and return values must be either floats or numpy arrays. The mapping between a state argument and its residual output must be specified in the metadata when the output (state) is added by setting 'resid' to the name of the residual.\n",
     "\n",
     "It may seem confusing to use `add_output` to specify state variables since the state variables\n",
     "are actually input arguments to the function, but in OpenMDAO's view of the world, states are outputs so we use `add_output` to specify them.  Also, using the metadata to specify which input arguments are actually states gives more flexibility in terms of how the function arguments are ordered. For example, if it's desirable for a function to be passable to `scipy.optimize.newton`, then the function's arguments can be ordered with the states first, followed by the inputs, in order to match the order expected by `scipy.optimize.newton`.\n",
@@ -279,7 +279,7 @@
     "\n",
     "If the function used to instantiate the ExplicitFuncComp declares partials or coloring that use `method='jax'`, or if the component's `use_jax` option is set, then the jax AD package will be used to compute all of the component's derivatives.  Currently it's not possible to mix jax with finite difference methods ('cs' and 'fd') in the same component.\n",
     "\n",
-    "Note that `jax` is not an OpenMDAO dependency, so you'll have to install it manually.\n",
+    "Note that `jax` is an optional OpenMDAO dependency, but you can install it manually.\n",
     "\n",
     "```python\n",
     "pip install jax\n",

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -26,7 +26,12 @@ _gradient_optimizers = {'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B', 'TNC', 'SLSQP', '
 _hessian_optimizers = {'trust-constr', 'trust-ncg'}
 _bounds_optimizers = {'L-BFGS-B', 'TNC', 'SLSQP', 'trust-constr', 'dual_annealing', 'shgo',
                       'differential_evolution', 'basinhopping'}
+if Version(scipy_version) >= Version("1.11"):
+    # COBYLA supports bounds starting with SciPy Version 1.11
+    _bounds_optimizers |= {'COBYLA'}
+
 _constraint_optimizers = {'COBYLA', 'SLSQP', 'trust-constr', 'shgo'}
+
 _constraint_grad_optimizers = _gradient_optimizers & _constraint_optimizers
 _eq_constraint_optimizers = {'SLSQP', 'trust-constr'}
 _global_optimizers = {'differential_evolution', 'basinhopping'}
@@ -213,9 +218,9 @@ class ScipyOptimizeDriver(Driver):
             msg = '{} currently does not support multiple objectives.'
             raise RuntimeError(msg.format(self.msginfo))
 
-        # Since COBYLA does not support bounds, we need to add to the _cons metadata
-        # for any bounds that need to be translated into a constraint
-        if opt == 'COBYLA':
+        # Since COBYLA did not support bounds in versions of SciPy prior to 1.11, we need to
+        # add to the _cons metadata for any bounds that need to be translated into a constraint
+        if opt == 'COBYLA' and Version(scipy_version) < Version("1.11"):
             for name, meta in self._designvars.items():
                 lower = meta['lower']
                 upper = meta['upper']

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1108,7 +1108,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                 # Outputs
                 self.add_output('Vd', 0.0, units="m/s",
                                 desc="Slipstream air velocity, downstream of rotor")
-                
+
                 self.declare_partials('*', '*')  # do this else compute_partials won't run at all
 
             def compute(self, inputs, outputs):

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3032,7 +3032,7 @@ class TestSqliteCaseReader(unittest.TestCase):
     def test_constraints_with_aliases(self):
         p = om.Problem()
 
-        exec = om.ExecComp(['y = x**2',
+        exec = om.ExecComp(['y = a + x**2',
                             'z = a * x**2'],
                         a={'shape': (1,)},
                         y={'shape': (3,)},


### PR DESCRIPTION
### Summary

This draft PR adds a relevance check to the `run_driver` function that checks for constraints that are not dependent on any design variables and raises an error if any are found, as requested in Issue #2980.

Implementing this check exposes a conflict with the `singular_jac_behavior` option on ScipyOptimizeDriver and pyOptSparseDriver, which currently defaults to `warn`.  As seen here, the warning will not happen because the relevance check will raise an Exception first.

The alternative of changing the default value of the option to `error` is explored in PR #2996.


### Related Issues

- Resolves #2980

### Backwards incompatibilities

None

### New Dependencies

None
