### PR TITLE
Parallel derivatives bug was caused by treating AutoIVC vars as distributed when connected to remote vars

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -4123,7 +4123,6 @@ class Group(System):
                 self.comm.bcast(val, root=owner)
             else:
                 val = self.comm.bcast(None, root=owner)
-            self.comm.Bcast(val, root=owner)
 
             info = (tgt, val, False)
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -26,7 +26,8 @@ from openmdao.solvers.linear.linear_runonce import LinearRunOnce
 from openmdao.utils.array_utils import array_connection_compatible, _flatten_src_indices, \
     shape_to_len
 from openmdao.utils.general_utils import common_subpath, all_ancestors, \
-    convert_src_inds, ContainsAll, shape2tuple, get_connection_owner, ensure_compatible
+    convert_src_inds, ContainsAll, shape2tuple, get_connection_owner, ensure_compatible, \
+    _src_name_iter
 from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismatch, _find_unit, \
     _is_unitless, simplify_unit
 from openmdao.utils.graph_utils import get_sccs_topo
@@ -186,6 +187,10 @@ class Group(System):
         Sorted list of pathnames of components that are executed prior to the optimization loop.
     _post_components : list of str or None
         Sorted list of pathnames of components that are executed after the optimization loop.
+    _abs_desvars : set
+        Set of absolute design variable names.
+    _abs_responses : set
+        Set of absolute response names.
     """
 
     def __init__(self, **kwargs):
@@ -214,6 +219,8 @@ class Group(System):
         self._shape_knowns = None
         self._pre_components = None
         self._post_components = None
+        self._abs_desvars = None
+        self._abs_responses = None
 
         # TODO: we cannot set the solvers with property setters at the moment
         # because our lint check thinks that we are defining new attributes
@@ -773,13 +780,14 @@ class Group(System):
         dict
             The relevance dictionary.
         """
+        abs_desvars = self.get_design_vars(recurse=True, get_sizes=False, use_prom_ivc=False)
+        abs_responses = self.get_responses(recurse=True, get_sizes=False, use_prom_ivc=False)
+        self._abs_desvars = set(_src_name_iter(abs_desvars))
+        self._abs_responses = set(_src_name_iter(abs_responses))
+
         if self._use_derivatives:
-            desvars = self.get_design_vars(recurse=True, get_sizes=False, use_prom_ivc=False)
-            responses = self.get_responses(recurse=True, get_sizes=False, use_prom_ivc=False)
-
-            responses = self._check_alias_overlaps(responses)
-
-            return self.get_relevant_vars(desvars, responses, mode)
+            return self.get_relevant_vars(abs_desvars,
+                                          self._check_alias_overlaps(abs_responses), mode)
 
         return {'@all': ({'input': ContainsAll(), 'output': ContainsAll()}, ContainsAll())}
 
@@ -2685,8 +2693,8 @@ class Group(System):
                 self._discrete_transfer(sub)
             return
 
-        print(self.pathname, "transfer to", sub)
-        
+        # print(self.pathname, "transfer to", sub)
+
         vec_inputs = self._vectors['input'][vec_name]
 
         if mode == 'fwd':
@@ -3946,108 +3954,119 @@ class Group(System):
 
         info = None
         for tgt in tgts:
-            # if tgt in vars_to_gather and tgt not in abs2meta_in:
-            if tgt in vars_to_gather and self.comm.rank != vars_to_gather[tgt]:
-                if info is None or max_size < 0:
-                    info = (tgt, np.zeros(0), True)
-                    max_size = 0
-                continue
+            # if tgt in vars_to_gather and self.comm.rank != vars_to_gather[tgt]:
+            #     if info is None or max_size < 0:
+            #         info = (tgt, np.zeros(0), True)
+            #         max_size = 0
+            #     continue
 
-            # if we get here, tgt is local
-            meta = abs2meta_in[tgt]
-            size = meta['size']
-            value = meta['val']
-            src_indices = None
-            if tgt in abs_in2prom_info:
-                # traverse down the promotes list, (abs_in2prom_info[tgt]), to get the
-                # final src_indices down at the component level so we can set the value of
-                # that component input into the appropriate place(s) in the auto_ivc output.
-                # If a tgt has no src_indices anywhere, it will not be found in
-                # abs_in2prom_info.
-                newshape = val_shape
-                for pinfo in abs_in2prom_info[tgt]:
-                    if pinfo is None:
-                        continue
-                    inds, _, shape = pinfo
-                    if inds is not None:
-                        if shape is None:
-                            shape = newshape
-                            if inds._src_shape is None:
-                                try:
-                                    inds.set_src_shape(shape)
-                                except IndexError:
-                                    exc_class, exc, tb = sys.exc_info()
-                                    self._collect_error(f"When promoting '{pinfo.prom}' from system"
-                                                        f" '{pinfo.promoted_from}' with src_indices"
-                                                        f" {inds} and src_shape {shape}: {exc}",
-                                                        exc_type=exc_class, tback=tb,
-                                                        ident=(pinfo.prom, pinfo.promoted_from))
+            if tgt in abs2meta_in:  # tgt is local
+                meta = abs2meta_in[tgt]
+                size = meta['size']
+                value = meta['val']
+                src_indices = None
+                if tgt in abs_in2prom_info:
+                    # traverse down the promotes list, (abs_in2prom_info[tgt]), to get the
+                    # final src_indices down at the component level so we can set the value of
+                    # that component input into the appropriate place(s) in the auto_ivc output.
+                    # If a tgt has no src_indices anywhere, it will not be found in
+                    # abs_in2prom_info.
+                    newshape = val_shape
+                    for pinfo in abs_in2prom_info[tgt]:
+                        if pinfo is None:
+                            continue
+                        inds, _, shape = pinfo
+                        if inds is not None:
+                            if shape is None:
+                                shape = newshape
+                                if inds._src_shape is None:
+                                    try:
+                                        inds.set_src_shape(shape)
+                                    except IndexError:
+                                        exc_class, exc, tb = sys.exc_info()
+                                        self._collect_error(f"When promoting '{pinfo.prom}' from "
+                                                            f"system '{pinfo.promoted_from}' with "
+                                                            f"src_indices {inds} and src_shape "
+                                                            f"{shape}: {exc}",
+                                                            exc_type=exc_class, tback=tb,
+                                                            ident=(pinfo.prom, pinfo.promoted_from))
 
-                        if src_indices is None:
-                            src_indices = inds
-                        else:
-                            sinds = convert_src_inds(src_indices, newshape, inds, shape)
-                            # final src_indices are wrt original full sized source and are flat,
-                            # so use val_shape and flat_src=True
-                            src_indices = indexer(sinds, src_shape=val_shape, flat_src=True)
-                        newshape = src_indices.indexed_src_shape
+                            if src_indices is None:
+                                src_indices = inds
+                            else:
+                                sinds = convert_src_inds(src_indices, newshape, inds, shape)
+                                # final src_indices are wrt original full sized source and are flat,
+                                # so use val_shape and flat_src=True
+                                src_indices = indexer(sinds, src_shape=val_shape, flat_src=True)
+                            newshape = src_indices.indexed_src_shape
 
-            if src_indices is None:
-                src_indices = meta['src_indices']
+                if src_indices is None:
+                    src_indices = meta['src_indices']
 
-            if src_indices is not None:
-                if val is None:
-                    if val_shape is None and not found_dup:
-                        src_idx_found.append(tgt)
-                    val = value
-                else:
-                    try:
-                        if src_indices._flat_src:
-                            val.ravel()[src_indices.flat()] = value.flat
-                        else:
-                            val[src_indices()] = value
-                    except Exception as err:
-                        src = self._conn_global_abs_in2out[tgt]
-                        msg = f"{self.msginfo}: The source indices " + \
-                              f"{src_indices} do not specify a " + \
-                              f"valid shape for the connection '{src}' to " + \
-                              f"'{tgt}'. (target shape=" + \
-                              f"{meta['shape']}, indices_shape=" + \
-                              f"{src_indices.indexed_src_shape}): {err}"
-                        self._collect_error(msg, ident=(src, tgt))
-                        continue
-            else:
-                if val is None:
-                    val = value
-                elif np.ndim(value) == 0:
-                    if val.size > 1:
-                        src = self._conn_global_abs_in2out[tgt]
-                        self._collect_error(f"Shape of input '{tgt}', (), doesn't match shape "
-                                            f"{val.shape}.", ident=(src, tgt))
-                        continue
-                elif np.squeeze(val).shape != np.squeeze(value).shape:
-                    src = self._conn_global_abs_in2out[tgt]
-                    self._collect_error(f"Shape of input '{tgt}', {value.shape}, doesn't match "
-                                        f"shape {val.shape}.", ident=(src, tgt))
-                    continue
-
-                if val is not value:
-                    if val.shape:
-                        val = np.reshape(value, newshape=val.shape)
-                    else:
+                if src_indices is not None:
+                    if val is None:
+                        if val_shape is None and not found_dup:
+                            src_idx_found.append(tgt)
                         val = value
+                    else:
+                        try:
+                            if src_indices._flat_src:
+                                val.ravel()[src_indices.flat()] = value.flat
+                            else:
+                                val[src_indices()] = value
+                        except Exception as err:
+                            src = self._conn_global_abs_in2out[tgt]
+                            msg = f"{self.msginfo}: The source indices " + \
+                                f"{src_indices} do not specify a " + \
+                                f"valid shape for the connection '{src}' to " + \
+                                f"'{tgt}'. (target shape=" + \
+                                f"{meta['shape']}, indices_shape=" + \
+                                f"{src_indices.indexed_src_shape}): {err}"
+                            self._collect_error(msg, ident=(src, tgt))
+                            continue
+                else:
+                    if val is None:
+                        val = value
+                    elif np.ndim(value) == 0:
+                        if val.size > 1:
+                            src = self._conn_global_abs_in2out[tgt]
+                            self._collect_error(f"Shape of input '{tgt}', (), doesn't match shape "
+                                                f"{val.shape}.", ident=(src, tgt))
+                            continue
+                    elif np.squeeze(val).shape != np.squeeze(value).shape:
+                        src = self._conn_global_abs_in2out[tgt]
+                        self._collect_error(f"Shape of input '{tgt}', {value.shape}, doesn't match "
+                                            f"shape {val.shape}.", ident=(src, tgt))
+                        continue
 
-                if tgt not in vars_to_gather:
-                    found_dup = True
+                    if val is not value:
+                        if val.shape:
+                            val = np.reshape(value, newshape=val.shape)
+                        else:
+                            val = value
 
-            if tgt == chosen_tgt:
-                max_size = size
-                info = (tgt, val, False)
-            elif chosen_tgt is None and size > max_size:
-                max_size = size
-                info = (tgt, val, False)
+                    if tgt not in vars_to_gather:
+                        found_dup = True
 
-            val = start_val
+                if tgt == chosen_tgt or (chosen_tgt is None and size > max_size):
+                    max_size = size
+                    info = (tgt, val, False)
+
+                keep_val = val
+                val = start_val
+
+        if tgt in vars_to_gather:
+            if vars_to_gather[tgt] == self.comm.rank:  # this rank 'owns' the var
+                val = keep_val
+            else:
+                val = None
+
+            for v in self.comm.allgather(val):
+                if v is not None:
+                    val = v
+                    break
+
+            info = (tgt, val, False)
 
         if src_idx_found:  # auto_ivc connected to local vars with src_indices
             self._collect_error("Attaching src_indices to inputs requires that the shape of the "

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2685,6 +2685,8 @@ class Group(System):
                 self._discrete_transfer(sub)
             return
 
+        print(self.pathname, "transfer to", sub)
+        
         vec_inputs = self._vectors['input'][vec_name]
 
         if mode == 'fwd':

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2738,8 +2738,6 @@ class Group(System):
                 self._discrete_transfer(sub)
             return
 
-        # print(self.pathname, "transfer to", sub)
-
         vec_inputs = self._vectors['input'][vec_name]
 
         if mode == 'fwd':

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -964,6 +964,7 @@ class Problem(object):
             'model_ref': weakref.ref(model),  # ref to the model (needed to get out-of-scope
                                               # src data for inputs)
             'using_par_deriv_color': False,  # True if parallel derivative coloring is being used
+            'par_deriv_color': None,  # current parallel deriv color if parallel coloring is active
             'mode': mode,  # mode (derivative direction) set by the user.  'auto' by default
             'abs_in2prom_info': {},  # map of abs input name to list of length = sys tree height
                                      # down to var location, to allow quick resolution of local

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -967,7 +967,6 @@ class Problem(object):
             'model_ref': weakref.ref(model),  # ref to the model (needed to get out-of-scope
                                               # src data for inputs)
             'using_par_deriv_color': False,  # True if parallel derivative coloring is being used
-            'par_deriv_color': None,  # current parallel deriv color if parallel coloring is active
             'mode': mode,  # mode (derivative direction) set by the user.  'auto' by default
             'abs_in2prom_info': {},  # map of abs input name to list of length = sys tree height
                                      # down to var location, to allow quick resolution of local

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3052,6 +3052,7 @@ class System(object):
         dv['indices'] = indices
         dv['flat_indices'] = flat_indices
         dv['parallel_deriv_color'] = parallel_deriv_color
+        dv['total_scaler'] = None
 
         design_vars[name] = dv
 
@@ -3241,6 +3242,7 @@ class System(object):
         resp['cache_linear_solution'] = cache_linear_solution
         resp['parallel_deriv_color'] = parallel_deriv_color
         resp['flat_indices'] = flat_indices
+        resp['total_scaler'] = None
 
         if alias in responses:
             raise TypeError(f"{self.msginfo}: Constraint alias '{alias}' is a duplicate of an "

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1017,7 +1017,9 @@ class System(object):
         #   this var
         new_desvar_metadata = {
             'scaler': scaler,
+            'total_scaler': scaler,
             'adder': adder,
+            'total_adder': adder,
             'upper': upper,
             'lower': lower,
             'ref': ref,
@@ -1215,7 +1217,9 @@ class System(object):
             'lower': lower,
             'upper': upper,
             'adder': adder,
+            'total_adder': adder,
             'scaler': scaler,
+            'total_scaler': scaler,
         }
 
         responses[name].update(new_cons_metadata)
@@ -1264,7 +1268,7 @@ class System(object):
             responses = self._responses
 
         # Look through responses to see if there are multiple responses with that name
-        aliases = [resp['alias'] for key, resp in responses.items() if resp['name'] == name]
+        aliases = [resp['alias'] for resp in responses.values() if resp['name'] == name]
         if len(aliases) > 1 and alias is _UNDEFINED:
             msg = "{}: set_objective_options called with objective variable '{}' that has " \
                   "multiple aliases: {}. Call set_objective_options with the 'alias' argument " \
@@ -1290,8 +1294,6 @@ class System(object):
         if ref0 is _UNDEFINED:
             ref0 = None
 
-        new_obj_metadata = {}
-
         # Convert ref/ref0 to ndarray/float as necessary
         ref = format_as_float_or_array('ref', ref, val_if_none=None, flatten=True)
         ref0 = format_as_float_or_array('ref0', ref0, val_if_none=None, flatten=True)
@@ -1311,10 +1313,14 @@ class System(object):
         elif adder == 0.0:
             adder = None
 
-        new_obj_metadata['scaler'] = scaler
-        new_obj_metadata['adder'] = adder
-        new_obj_metadata['ref'] = ref
-        new_obj_metadata['ref0'] = ref0
+        new_obj_metadata = {
+            'ref': ref,
+            'ref0': ref0,
+            'adder': adder,
+            'total_adder': adder,
+            'scaler': scaler,
+            'total_scaler': scaler,
+        }
 
         responses[name].update(new_obj_metadata)
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3028,6 +3028,7 @@ class System(object):
         elif scaler == 1.0:
             scaler = None
         dv['scaler'] = scaler
+        dv['total_scaler'] = scaler
 
         if isinstance(adder, np.ndarray):
             if not np.any(adder):
@@ -3035,6 +3036,7 @@ class System(object):
         elif adder == 0.0:
             adder = None
         dv['adder'] = adder
+        dv['total_adder'] = adder
 
         dv['name'] = name
         dv['upper'] = upper
@@ -3052,8 +3054,6 @@ class System(object):
         dv['indices'] = indices
         dv['flat_indices'] = flat_indices
         dv['parallel_deriv_color'] = parallel_deriv_color
-        dv['total_scaler'] = None
-        dv['total_adder'] = None
 
         design_vars[name] = dv
 
@@ -3228,6 +3228,7 @@ class System(object):
         elif scaler == 1.0:
             scaler = None
         resp['scaler'] = scaler
+        resp['total_scaler'] = scaler
 
         if isinstance(adder, np.ndarray):
             if not np.any(adder):
@@ -3235,6 +3236,7 @@ class System(object):
         elif adder == 0.0:
             adder = None
         resp['adder'] = adder
+        resp['total_adder'] = adder
 
         resp['ref'] = ref
         resp['ref0'] = ref0
@@ -3243,8 +3245,6 @@ class System(object):
         resp['cache_linear_solution'] = cache_linear_solution
         resp['parallel_deriv_color'] = parallel_deriv_color
         resp['flat_indices'] = flat_indices
-        resp['total_scaler'] = None
-        resp['total_adder'] = None
 
         if alias in responses:
             raise TypeError(f"{self.msginfo}: Constraint alias '{alias}' is a duplicate of an "

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3053,6 +3053,7 @@ class System(object):
         dv['flat_indices'] = flat_indices
         dv['parallel_deriv_color'] = parallel_deriv_color
         dv['total_scaler'] = None
+        dv['total_adder'] = None
 
         design_vars[name] = dv
 
@@ -3243,6 +3244,7 @@ class System(object):
         resp['parallel_deriv_color'] = parallel_deriv_color
         resp['flat_indices'] = flat_indices
         resp['total_scaler'] = None
+        resp['total_adder'] = None
 
         if alias in responses:
             raise TypeError(f"{self.msginfo}: Constraint alias '{alias}' is a duplicate of an "

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -464,12 +464,18 @@ class IndicesTestCase2(unittest.TestCase):
         class Top(om.Group):
             def setup(self):
                 self.add_subsystem('dvs',om.IndepVarComp(), promotes=['*'])
-                #if self.comm.rank == 0:
-                    #self.dvs.add_output('x', [1.], distributed=True)
-                #else:
-                    #self.dvs.add_output('x', [2.], distributed=True)
 
-                self.dvs.add_output('x',[1.,2.])
+                # this only currently works if we make dvs.x a distributed output.
+                if self.comm.rank == 0:
+                    self.dvs.add_output('x', [1.], distributed=True)
+                else:
+                    self.dvs.add_output('x', [2.], distributed=True)
+
+                # making dvs.x a non-distributed variable as below results in
+                # one deriv being zero and the other being the sum of the two
+                # parallel derivs.
+                # self.dvs.add_output('x',[1.,2.])
+
                 self.add_subsystem('par',DummyGroup())
                 self.connect('x','par.C1.x',src_indices=[0])
                 self.connect('x','par.C2.x',src_indices=[1])

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -452,7 +452,7 @@ class IndicesTestCase2(unittest.TestCase):
                     if 'y' in d_outputs:
                         if 'x' in d_inputs:
                             d_inputs['x'] += self.options['a'] * d_outputs['y']
-                            print(self.pathname, 'compute_jvp: dinputs[x]', d_inputs['x'])
+                            # print(self.pathname, 'compute_jvp: dinputs[x]', d_inputs['x'])
                 else:
                     raise RuntimeError("fwd mode not supported")
 

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1243,7 +1243,7 @@ class _TotalJacInfo(object):
                     vec_names.add(vnames[0])
 
         print(self.comm.rank, 'invec', mode, self.input_vec[mode]._data)
-        
+
         if vec_names:
             return all_rel_systems, sorted(vec_names), (inds[0], mode)
         else:

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1243,8 +1243,6 @@ class _TotalJacInfo(object):
                 if vnames is not None:
                     vec_names.add(vnames[0])
 
-        # print(self.comm.rank, 'invec', mode, self.input_vec[mode]._data)
-
         if vec_names:
             return all_rel_systems, sorted(vec_names), (inds[0], mode)
         else:
@@ -1311,7 +1309,6 @@ class _TotalJacInfo(object):
         if mode == 'fwd':
             self.J[jac_idxs, i] = deriv_val[deriv_idxs]
         else:  # rev
-            # print(f'J[{i}, {jac_idxs}] = {deriv_val}   [{deriv_idxs}]')
             self.J[i, jac_idxs] = deriv_val[deriv_idxs]
 
     def _jac_setter_dist(self, i, mode):

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1242,6 +1242,8 @@ class _TotalJacInfo(object):
                 if vnames is not None:
                     vec_names.add(vnames[0])
 
+        print(self.comm.rank, 'invec', mode, self.input_vec[mode]._data)
+        
         if vec_names:
             return all_rel_systems, sorted(vec_names), (inds[0], mode)
         else:
@@ -1308,6 +1310,7 @@ class _TotalJacInfo(object):
         if mode == 'fwd':
             self.J[jac_idxs, i] = deriv_val[deriv_idxs]
         else:  # rev
+            print(f'J[{i}, {jac_idxs}] = {deriv_val}   [{deriv_idxs}]')
             self.J[i, jac_idxs] = deriv_val[deriv_idxs]
 
     def _jac_setter_dist(self, i, mode):
@@ -2035,9 +2038,8 @@ def _fix_pdc_lengths(idx_iter_dict):
         Dict of a name/color mapped to indexing information.
     """
     for imeta, _ in idx_iter_dict.values():
-        par_deriv_color = imeta['par_deriv_color']
-        range_list = imeta['idx_list']
-        if par_deriv_color:
+        if imeta['par_deriv_color']:
+            range_list = imeta['idx_list']
             lens = np.array([end - start for start, end in range_list])
             maxlen = np.max(lens)
             diffs = lens - maxlen

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1243,7 +1243,7 @@ class _TotalJacInfo(object):
                 if vnames is not None:
                     vec_names.add(vnames[0])
 
-        print(self.comm.rank, 'invec', mode, self.input_vec[mode]._data)
+        # print(self.comm.rank, 'invec', mode, self.input_vec[mode]._data)
 
         if vec_names:
             return all_rel_systems, sorted(vec_names), (inds[0], mode)

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -91,7 +91,7 @@ class _TotalJacInfo(object):
         (local indices, local sizes).
     in_idx_map : dict
         Mapping of jacobian row/col index to a tuple of the form
-        (ndups, relevant_systems, cache_linear_solutions_flag, name, parallel_deriv_color)
+        (ndups, relevant_systems, cache_linear_solutions_flag)
     total_relevant_systems : set
         The set of names of all systems relevant to the computation of the total derivatives.
     directional : bool
@@ -803,10 +803,10 @@ class _TotalJacInfo(object):
                 relsystems = relevant[path]['@all'][1]
                 if self.total_relevant_systems is not _contains_all:
                     self.total_relevant_systems.update(relsystems)
-                tup = (ndups, relsystems, cache_lin_sol, name, parallel_deriv_color)
+                tup = (ndups, relsystems, cache_lin_sol, name)
             else:
                 self.total_relevant_systems = _contains_all
-                tup = (ndups, _contains_all, cache_lin_sol, name, parallel_deriv_color)
+                tup = (ndups, _contains_all, cache_lin_sol, name)
 
             idx_map.extend([tup] * (end - start))
             start = end
@@ -830,7 +830,7 @@ class _TotalJacInfo(object):
             locs = None
             for ilist in simul_coloring.color_iter(mode):
                 for i in ilist:
-                    _, rel_systems, cache_lin_sol, _, _ = idx_map[i]
+                    _, rel_systems, cache_lin_sol, _ = idx_map[i]
                     _update_rel_systems(all_rel_systems, rel_systems)
                     cache |= cache_lin_sol
 
@@ -1161,8 +1161,7 @@ class _TotalJacInfo(object):
         int or None
             key used for storage of cached linear solve (if active, else None).
         """
-        _, rel_systems, cache_lin_sol, _, par_deriv_color = self.in_idx_map[mode][idx]
-        self.model._problem_meta['par_deriv_color'] = par_deriv_color
+        _, rel_systems, cache_lin_sol, _ = self.in_idx_map[mode][idx]
 
         self._zero_vecs(mode)
 
@@ -1271,7 +1270,7 @@ class _TotalJacInfo(object):
             Not used.
         """
         for i in inds:
-            _, rel_systems, _, _, _ = self.in_idx_map[mode][i]
+            _, rel_systems, _, _ = self.in_idx_map[mode][i]
             break
 
         self._zero_vecs(mode)
@@ -1333,7 +1332,7 @@ class _TotalJacInfo(object):
         elif mode == 'rev':
             # for rows corresponding to serial 'of' vars, we need to correct for
             # duplication of their seed values by dividing by the number of duplications.
-            ndups, _, _, _, par_deriv_color = self.in_idx_map[mode][i]
+            ndups, _, _, _ = self.in_idx_map[mode][i]
             if self.get_remote:
                 scratch = self.jac_scratch['rev'][0]
                 scratch[:] = self.J[i]

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1103,7 +1103,7 @@ class BlockLinearSolver(LinearSolver):
             self._rhs_vec[:] = self._system()._dresiduals.asarray()
         else:
             self._rhs_vec[:] = self._system()._doutputs.asarray()
-        print(self._system().pathname, "Updating RHS vec to", self._rhs_vec)  # DO NOT DELETE
+        # print(self._system().pathname, "Updating RHS vec to", self._rhs_vec)  # DO NOT DELETE
 
     def _set_complex_step_mode(self, active):
         """

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1103,7 +1103,7 @@ class BlockLinearSolver(LinearSolver):
             self._rhs_vec[:] = self._system()._dresiduals.asarray()
         else:
             self._rhs_vec[:] = self._system()._doutputs.asarray()
-        # print("Updating RHS vec to", self._rhs_vec)
+        print(self._system().pathname, "Updating RHS vec to", self._rhs_vec)  # DO NOT DELETE
 
     def _set_complex_step_mode(self, active):
         """

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -168,21 +168,21 @@ else:
                                            sizes_in[myproc, idx_in], dtype=INT_DTYPE)
 
                     # Now the indices are ready - input_inds, output_inds
-                    sub_in = abs_in[mypathlen:].split('.', 1)[0]
+                    sub_in = abs_in[mypathlen:].partition('.')[0]
                     fwd_xfer_in[sub_in].append(input_inds)
                     fwd_xfer_out[sub_in].append(output_inds)
                     if rev:
-                        sub_out = abs_out[mypathlen:].split('.', 1)[0]
+                        sub_out = abs_out[mypathlen:].partition('.')[0]
                         rev_xfer_in[sub_out].append(input_inds)
                         rev_xfer_out[sub_out].append(output_inds)
                 else:
                     # not a local input but still need entries in the transfer dicts to
                     # avoid hangs
-                    sub_in = abs_in[mypathlen:].split('.', 1)[0]
+                    sub_in = abs_in[mypathlen:].partition('.')[0]
                     fwd_xfer_in[sub_in]  # defaultdict will create an empty list there
                     fwd_xfer_out[sub_in]
                     if rev:
-                        sub_out = abs_out[mypathlen:].split('.', 1)[0]
+                        sub_out = abs_out[mypathlen:].partition('.')[0]
                         rev_xfer_in[sub_out]
                         rev_xfer_out[sub_out]
 

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -242,7 +242,8 @@ else:
             in_petsc = in_vec._petsc
             out_petsc = out_vec._petsc
 
-            print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode, 'PRE', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)
+            # print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode,
+            #       'PRE', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)
 
             # For Complex Step, need to disassemble real and imag parts, transfer them separately,
             # then reassemble them.
@@ -279,5 +280,5 @@ else:
                     data = in_vec._get_data()
                     data[:] = in_petsc.array
 
-                print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode, 'POST', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)
-
+                # print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode,
+                #       'POST', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -242,9 +242,6 @@ else:
             in_petsc = in_vec._petsc
             out_petsc = out_vec._petsc
 
-            # print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode,
-            #       'PRE', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)
-
             # For Complex Step, need to disassemble real and imag parts, transfer them separately,
             # then reassemble them.
             if in_vec._under_complex_step and out_vec._alloc_complex:
@@ -279,6 +276,3 @@ else:
                 if in_vec._alloc_complex:
                     data = in_vec._get_data()
                     data[:] = in_petsc.array
-
-                # print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode,
-                #       'POST', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -242,6 +242,8 @@ else:
             in_petsc = in_vec._petsc
             out_petsc = out_vec._petsc
 
+            print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode, 'PRE', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)
+
             # For Complex Step, need to disassemble real and imag parts, transfer them separately,
             # then reassemble them.
             if in_vec._under_complex_step and out_vec._alloc_complex:
@@ -276,3 +278,6 @@ else:
                 if in_vec._alloc_complex:
                     data = in_vec._get_data()
                     data[:] = in_petsc.array
+
+                print(in_vec._system().pathname, 'rank', in_vec._system().comm.rank, mode, 'POST', 'invec:', in_petsc.array, 'outvec:', out_petsc.array)
+


### PR DESCRIPTION
### Summary

Removed a memory optimization in AutoIndepVarComp that had treated auto ivc outputs connected to remote (non-distributed) inputs as distributed outputs with zero size everywhere except for on the 'owning' rank.  This memory optimization saved memory by not allocating the auto ivc output outside of the owning rank.  Unfortunately, in some cases when parallel derivatives were used, this caused certain total derivatives to have erroneous zero values, so the memory optimization was removed and now memory is allocated on all ranks for each auto ivc output that isn't connected to only distributed inputs.

Also fixed a couple of places where 'total_scaler' and 'total_adder' were not being initialized correctly in design variables and responses.

### Related Issues

- Resolves #2986

### Backwards incompatibilities

None

### New Dependencies

None
