### PR TITLE
Disabled `guess_nonlinear` when the solver option `restart_from_successful` is activated 

### DIFF
--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
@@ -254,7 +254,7 @@
    "metadata": {},
    "source": [
     "```{Note}\n",
-    "When the solver is restarted after a failed solve due to having the `restart_from_sucessful` option set to `True`, the `guess_nonlinear` function will not be called.\n",
+    "When a solver is restarted from the last successful solve due to having the `restart_from_sucessful` option set to `True`, the `guess_nonlinear` function will not be called.\n",
     "```"
    ]
   },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/implicit_component.ipynb
@@ -250,6 +250,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{Note}\n",
+    "When the solver is restarted after a failed solve due to having the `restart_from_sucessful` option set to `True`, the `guess_nonlinear` function will not be called.\n",
+    "```"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -330,7 +339,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -344,7 +353,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.11.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -47,7 +47,7 @@
     "\n",
     "In this case we test _all_ of the residual values. If we tested only the residual of `'x'`, it would be exactly zero on the first iteration based on the way the `BalanceComp` computes its residuals and the initial values of the inputs. Testing all of the residuals provides a better check to see if the system is nearly converged.\n",
     "\n",
-    "This model contains a two copies of the same Discipline Group.\n",
+    "This model contains two copies of the same Discipline Group.\n",
     "One of these groups provides a `guess_nonlinear` method, while the other one does not.\n",
     "\n",
     "The following example prints the iteration history of the nonlinear solver to demonstrate how using `guess_nonlinear` can reduce the number of iterations required."
@@ -142,6 +142,15 @@
     "assert_near_equal(p.get_val('discipline.x'), 1.41421356, 1e-6)\n",
     "assert_near_equal(p.get_val('discipline_no_guess.x'), 1.41421356, 1e-6)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```{Note}\n",
+    "When the solver is restarted after a failed solve due to having the `restart_from_sucessful` option set to `True`, the `guess_nonlinear` function will not be called.\n",
+    "```"
+   ]
   }
  ],
  "metadata": {
@@ -161,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.11.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_groups/guess_method.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "source": [
     "```{Note}\n",
-    "When the solver is restarted after a failed solve due to having the `restart_from_sucessful` option set to `True`, the `guess_nonlinear` function will not be called.\n",
+    "When a solver is restarted from the last successful solve due to having the `restart_from_sucessful` option set to `True`, the `guess_nonlinear` function will not be called.\n",
     "```"
    ]
   }

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -307,8 +307,8 @@ class BroydenSolver(NonlinearSolver):
         self._computed_jacobians = 0
 
         # Execute guess_nonlinear if specified and
-        # we have not sucessfully restarted from a saved point
-        if not (self._restarted and not self._prev_fail):
+        # we have not restarted from a saved point
+        if not self._restarted:
             system._guess_nonlinear()
 
         # When under a complex step from higher in the hierarchy, sometimes the step is too small

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -306,8 +306,9 @@ class BroydenSolver(NonlinearSolver):
         self._converge_failures = 0
         self._computed_jacobians = 0
 
-        # Execute guess_nonlinear if specified.
-        system._guess_nonlinear()
+        # Execute guess_nonlinear if specified and not restarting from a successful point
+        if not self._restarted:
+            system._guess_nonlinear()
 
         # When under a complex step from higher in the hierarchy, sometimes the step is too small
         # to trigger reconvergence, so nudge the outputs slightly so that we always get at least

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -306,8 +306,9 @@ class BroydenSolver(NonlinearSolver):
         self._converge_failures = 0
         self._computed_jacobians = 0
 
-        # Execute guess_nonlinear if specified and not restarting from a successful point
-        if not self._restarted:
+        # Execute guess_nonlinear if specified and
+        # we have not sucessfully restarted from a saved point
+        if not (self._restarted and not self._prev_fail):
             system._guess_nonlinear()
 
         # When under a complex step from higher in the hierarchy, sometimes the step is too small

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -181,8 +181,9 @@ class NewtonSolver(NonlinearSolver):
             self._err_cache['inputs'] = system._inputs._copy_views()
             self._err_cache['outputs'] = system._outputs._copy_views()
 
-        # Execute guess_nonlinear if specified.
-        system._guess_nonlinear()
+        # Execute guess_nonlinear if specified and not restarting from a successful point
+        if not self._restarted:
+            system._guess_nonlinear()
 
         with Recording('Newton_subsolve', 0, self) as rec:
 

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -182,8 +182,8 @@ class NewtonSolver(NonlinearSolver):
             self._err_cache['outputs'] = system._outputs._copy_views()
 
         # Execute guess_nonlinear if specified and
-        # we have not sucessfully restarted from a saved point
-        if not (self._restarted and not self._prev_fail):
+        # we have not restarted from a saved point
+        if not self._restarted:
             system._guess_nonlinear()
 
         with Recording('Newton_subsolve', 0, self) as rec:

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -181,8 +181,9 @@ class NewtonSolver(NonlinearSolver):
             self._err_cache['inputs'] = system._inputs._copy_views()
             self._err_cache['outputs'] = system._outputs._copy_views()
 
-        # Execute guess_nonlinear if specified and not restarting from a successful point
-        if not self._restarted:
+        # Execute guess_nonlinear if specified and
+        # we have not sucessfully restarted from a saved point
+        if not (self._restarted and not self._prev_fail):
             system._guess_nonlinear()
 
         with Recording('Newton_subsolve', 0, self) as rec:

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -101,8 +101,9 @@ class NonlinearBlockGS(NonlinearSolver):
         if system.under_complex_step and self.options['cs_reconverge']:
             system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
-        # Execute guess_nonlinear if specified.
-        system._guess_nonlinear()
+        # Execute guess_nonlinear if specified and not restarting from a successful point
+        if not self._restarted:
+            system._guess_nonlinear()
 
         return super()._iter_initialize()
 

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -102,8 +102,8 @@ class NonlinearBlockGS(NonlinearSolver):
             system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
         # Execute guess_nonlinear if specified and
-        # we have not sucessfully restarted from a saved point
-        if not (self._restarted and not self._prev_fail):
+        # we have not restarted from a saved point
+        if not self._restarted:
             system._guess_nonlinear()
 
         return super()._iter_initialize()

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -101,8 +101,9 @@ class NonlinearBlockGS(NonlinearSolver):
         if system.under_complex_step and self.options['cs_reconverge']:
             system._outputs += np.linalg.norm(system._outputs.asarray()) * 1e-10
 
-        # Execute guess_nonlinear if specified and not restarting from a successful point
-        if not self._restarted:
+        # Execute guess_nonlinear if specified and
+        # we have not sucessfully restarted from a saved point
+        if not (self._restarted and not self._prev_fail):
             system._guess_nonlinear()
 
         return super()._iter_initialize()

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -524,6 +524,8 @@ class NonlinearSolver(Solver):
         Saved output values from last successful solve, if any.
     _prev_fail : bool
         If True, previous solve failed.
+    _restarted : bool
+        If True, solve was restarted from a sucessful point.
     """
 
     def __init__(self, **kwargs):

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -823,6 +823,8 @@ class NonlinearSolver(Solver):
                 if self._prev_fail and self._output_cache is not None:
                     system._outputs.set_val(self._output_cache)
                     self._restarted = True
+                else:
+                    self._restarted = False
 
                 self.solve()
 

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -534,6 +534,7 @@ class NonlinearSolver(Solver):
         self._err_cache = {}
         self._output_cache = None
         self._prev_fail = False
+        self._restarted = False
 
     def _declare_options(self):
         """
@@ -819,6 +820,7 @@ class NonlinearSolver(Solver):
                 # the outputs using the cache.
                 if self._prev_fail and self._output_cache is not None:
                     system._outputs.set_val(self._output_cache)
+                    self._restarted = True
 
                 self.solve()
 

--- a/openmdao/solvers/tests/test_output_cache.py
+++ b/openmdao/solvers/tests/test_output_cache.py
@@ -88,6 +88,14 @@ class NLBGSGroup(om.Group):
         solver.options["err_on_non_converge"] = True
         self.linear_solver = om.DirectSolver(assemble_jac=True)
 
+    def initialize(self):
+        self.options.declare('use_guess', types=bool, default=False)
+
+    def guess_nonlinear(self, inputs, outputs, residuals):
+        if self.options['use_guess']:
+            # this guess will cause an AnalysisError
+            outputs["coupling.balance.x"] = -1.
+
 
 class TestOutputCache(unittest.TestCase):
     def test_coupled_system(self):
@@ -141,3 +149,52 @@ class TestOutputCache(unittest.TestCase):
         expected = "NewtonSolver in 'coupling' <class CoupledGroup>: Option 'restart_from_successful' does nothing unless option 'err_on_non_converge' is set to True."
         with assert_warning(om.SolverWarning, expected):
             prob.run_model()
+
+    def test_coupled_system_with_guess_nonlinear(self):
+        prob = om.Problem()
+        model = prob.model
+        simple = model.add_subsystem(f"simple", NLBGSGroup())
+
+        prob.setup()
+
+        #
+        # initial run, result will be cached since 'restart_from_successful' is enabled
+        #
+
+        prob.set_val("simple.coupling.sub_comp1.a", val=5.0)
+        prob.set_val("simple.coupling.sub_comp2.b", val=10.0)
+
+        prob.run_model()
+
+        assert_near_equal(prob['simple.coupling.sub_comp1.z'][0], 15.66717076361843, 1e-6)
+        assert_near_equal(prob['simple.coupling.sub_comp2.z'][0], 15.66717076361843, 1e-6)
+        assert_near_equal(prob['simple.coupling.balance.x'][0], 6.6054982979676495, 1e-6)
+
+        #
+        # use the guess which will cause the run to fail
+        #
+
+        simple.options['use_guess'] = True
+
+        try:
+            prob.run_model()
+        except om.AnalysisError:
+            pass
+        else:
+            self.fail("Expected AnalysisError")
+
+        #
+        # run again, should restart from valid point and NOT use the guess
+        #
+
+        prob.set_val("simple.coupling.sub_comp1.x", val=2.0)
+        prob.set_val("simple.coupling.sub_comp2.b", val=3.0)
+        prob.run_model()
+
+        assert_near_equal(prob['simple.coupling.sub_comp1.z'][0], 8.51905504, 1e-6)
+        assert_near_equal(prob['simple.coupling.sub_comp2.z'][0], 8.51905504, 1e-6)
+        assert_near_equal(prob['simple.coupling.balance.x'][0], 6.28613102, 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/solvers/tests/test_output_cache.py
+++ b/openmdao/solvers/tests/test_output_cache.py
@@ -101,7 +101,7 @@ class TestOutputCache(unittest.TestCase):
     def test_coupled_system(self):
         prob = om.Problem()
         model = prob.model
-        model.add_subsystem(f"simple", NLBGSGroup())
+        model.add_subsystem("simple", NLBGSGroup())
 
         prob.setup()
 
@@ -153,7 +153,7 @@ class TestOutputCache(unittest.TestCase):
     def test_coupled_system_with_guess_nonlinear(self):
         prob = om.Problem()
         model = prob.model
-        simple = model.add_subsystem(f"simple", NLBGSGroup())
+        simple = model.add_subsystem("simple", NLBGSGroup())
 
         prob.setup()
 

--- a/openmdao/solvers/tests/test_output_cache.py
+++ b/openmdao/solvers/tests/test_output_cache.py
@@ -152,8 +152,7 @@ class TestOutputCache(unittest.TestCase):
 
     def test_coupled_system_with_guess_nonlinear(self):
         prob = om.Problem()
-        model = prob.model
-        simple = model.add_subsystem("simple", NLBGSGroup())
+        simple = prob.model.add_subsystem("simple", NLBGSGroup())
 
         prob.setup()
 


### PR DESCRIPTION
### Summary

Nonlinear solvers will no longer call `guess_nonlinear` when restarting from a previous successful point due to the `restart_from_successful` option being set to `True`.

### Related Issues

- Resolves #2593 

### Backwards incompatibilities

Nonlinear solvers will no longer call `guess_nonlinear` when restarting from a previous successful point due to the `restart_from_successful` option being set to `True`.

### New Dependencies

None
