### PR TITLE
Fixed an uncaught TypeError in the Dymos Linkage report

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/NodeConnection.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeConnection.js
@@ -18,12 +18,14 @@ class NodeConnection {
         this.conn = conn;
 
         this.srcObj = nodes[conn.src];
-        this.srcObj.connTargets.add(conn.tgt);
         const srcObjParents = [];
+
         if (!this.srcObj) {
             console.warn(`Cannot find connection source ${conn.src}.`);
         }
         else {
+            this.srcObj.connTargets.add(conn.tgt);
+
             // Collect all parents of the source node.
             srcObjParents.push(this.srcObj);
             for (let parentObj = this.srcObj.parent; parentObj != null; parentObj = parentObj.parent) {
@@ -44,7 +46,7 @@ class NodeConnection {
                 tgtObjParents.push(parentObj);
             }
         }
-    
+
         // Make sure all parents of the source and target are aware of the
         // connection. Required for handling collapsed or offscreen node connections.
         for (const srcParent of srcObjParents) {

--- a/openmdao/visualization/n2_viewer/gen/NodeConnection.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeConnection.js
@@ -35,6 +35,7 @@ class NodeConnection {
 
         this.tgtObj = nodes[conn.tgt];
         const tgtObjParents = [];
+
         if (!this.tgtObj) {
             console.warn(`Cannot find connection target ${conn.tgt}.`);
         }

--- a/openmdao/visualization/n2_viewer/gen/NodeConnection.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeConnection.js
@@ -34,12 +34,13 @@ class NodeConnection {
         }
 
         this.tgtObj = nodes[conn.tgt];
-        this.tgtObj.connSources.add(conn.src);
         const tgtObjParents = [];
         if (!this.tgtObj) {
             console.warn(`Cannot find connection target ${conn.tgt}.`);
         }
         else {
+            this.tgtObj.connSources.add(conn.src);
+
             // Collect all parents of the target node.
             tgtObjParents.push(this.tgtObj);
             for (let parentObj = this.tgtObj.parent; parentObj != null; parentObj = parentObj.parent) {


### PR DESCRIPTION
### Summary

The Dymos Linkage report only contains a subset of the model, primarily the trajectory.  When a connection has a source that is not in this subset, a warning is generated in the JavaScript console.  Previously, the source object was referenced before the warning was issued and outside the resulting conditional block, causing a TypeError.

This PR fixes the error, although it may be desirable as a separate issue to handle those connections that come from a source outside the subset of the model represented in this report more appropriately.

### Related Issues

- Resolves https://github.com/OpenMDAO/dymos/issues/966

### Backwards incompatibilities

None

### New Dependencies

None
