### PR TITLE
Changed bug report template so that entire example section isn't rendered as python.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,6 @@ body:
     attributes:
       label: Example
       description: Please provide an example of the code that triggers the unexpected behavior. If possible, we would appreciate a minimal test case that reproduces the issue. Alternatively, link to a file in another repository where the issue is demonstrated.
-      render: python
     validations:
       required: true
   - type: input


### PR DESCRIPTION
### Summary

The bug report template was previously rendering the entire section as python code.
Users submitting bug reports should now wrap code sections in block backticks.

### Related Issues

- Resolves #3019

### Backwards incompatibilities

None

### New Dependencies

None
