### PR TITLE
Fixed the `openmdao n2` command to work properly with subproblems

### DIFF
--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -255,10 +255,13 @@
     "To make use of the `--problem` argument, it is helpful to give your subproblem a meaningful name when it is instantiated, which you can use to identify it on the command line. \n",
     "\n",
     "For example:\n",
+    "\n",
     "    subprob = om.Problem(name='subproblem1')\n",
+    "\n",
     "    subcomp = om.SubmodelComp(problem=prob)\n",
     "\n",
-    "Then you can:\n",
+    "Then:\n",
+    "\n",
     "    openmdao n2 --problem subproblem1\n",
     "```"
    ]

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -251,6 +251,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "```{note}\n",
+    "To make use of the `--problem` argument, it is helpful to give your subproblem a meaningful name when it is instantiated, which you can use to identify it on the command line. \n",
+    "\n",
+    "For example:\n",
+    "    subprob = om.Problem(name='subproblem1')\n",
+    "    subcomp = om.SubmodelComp(problem=prob)\n",
+    "\n",
+    "Then you can:\n",
+    "    openmdao n2 --problem subproblem1\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "If the test module happens to be part of a python package, then you can also use the dotted\n",
     "module pathname of the test module instead of the filename.\n",
     "\n",

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -258,7 +258,7 @@
     "\n",
     "    subprob = om.Problem(name='subproblem1')\n",
     "\n",
-    "    subcomp = om.SubmodelComp(problem=prob)\n",
+    "    subcomp = om.SubmodelComp(problem=subprob)\n",
     "\n",
     "Then:\n",
     "\n",

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -20,7 +20,6 @@ from openmdao.visualization.tables.table_builder import generate_table
 _reports_registry = {}
 _default_reports = ['scaling', 'total_coloring', 'n2', 'optimizer', 'inputs']
 _active_reports = set()  # these reports will actually run (assuming their hook funcs are triggered)
-_cmdline_reports = set()  # cmdline reports registered here so default reports aren't modified
 _reports_dir = os.environ.get('OPENMDAO_REPORTS_DIR', './reports')  # top dir for the reports
 _plugins_loaded = False  # use this to ensure plugins only loaded once
 
@@ -122,11 +121,6 @@ class Report(object):
                 return args[1]
         else:
             raise AttributeError(f"Attribute '{name}' not found.")
-
-
-def _register_cmdline_report(name):
-    global _cmdline_reports
-    _cmdline_reports.add(name)
 
 
 def reports_active():
@@ -252,8 +246,6 @@ def activate_report(name, instance=None):
     if name not in _reports_registry:
         issue_warning(f"No report with the name '{name}' is registered.")
         return
-    if name in _cmdline_reports:
-        return  # skip it if it's already being run from the command line
 
     if not reports_active():
         return

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -33,7 +33,7 @@ from openmdao.visualization.htmlpp import HtmlPreprocessor
 from openmdao import __version__ as openmdao_version
 
 _MAX_ARRAY_SIZE_FOR_REPR_VAL = 1000  # If var has more elements than this do not pass to N2
-_MAX_OBJECT_SIZE = 1000000           # If object is bigger than this do not pass to N2
+_MAX_OBJECT_SIZE = int(1e7)          # If option value is bigger than this do not pass to N2
 
 _default_n2_filename = 'n2.html'
 

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -164,11 +164,8 @@ def _get_var_dict(system, typ, name, is_parallel, is_implicit, values):
                     # which could be remote under MPI
                     _get_array_info(system, vec, name, prom, var_dict, from_src=False)
 
-            else:
-                var_dict['val'] = None
         except Exception as err:
             issue_warning(str(err))
-            var_dict['val'] = None
     else:  # discrete
         meta = system._var_discrete[typ][name]
         val = meta['val']
@@ -181,8 +178,6 @@ def _get_var_dict(system, typ, name, is_parallel, is_implicit, values):
         if values:
             if MPI is None or isinstance(val, (int, str, list, dict, complex, np.ndarray)):
                 var_dict['val'] = default_noraise(system.get_val(name))
-        else:
-            var_dict['val'] = None
 
     if 'surrogate_name' in meta:
         var_dict['surrogate_name'] = meta['surrogate_name']
@@ -468,7 +463,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
                     stack.pop()
                 elif child['type'] == 'input':
                     if case is None:
-                        child['val'] = None
+                        child.pop('val')
                         for key in ['val_min', 'val_max', 'val_min_indices', 'val_max_indices']:
                             del child[key]
                     elif case.inputs is None:
@@ -478,7 +473,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
                         child['val'] = case.inputs[path]
                 elif child['type'] == 'output':
                     if case is None:
-                        child['val'] = None
+                        child.pop('val')
                         for key in ['val_min', 'val_max', 'val_min_indices', 'val_max_indices']:
                             del child[key]
                     elif case.outputs is None:

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -1,6 +1,7 @@
 """Code for generating N2 diagram."""
 import inspect
 import os
+import sys
 import pathlib
 from operator import itemgetter
 
@@ -32,6 +33,7 @@ from openmdao.visualization.htmlpp import HtmlPreprocessor
 from openmdao import __version__ as openmdao_version
 
 _MAX_ARRAY_SIZE_FOR_REPR_VAL = 1000  # If var has more elements than this do not pass to N2
+_MAX_OBJECT_SIZE = 1000000           # If object is bigger than this do not pass to N2
 
 _default_n2_filename = 'n2.html'
 
@@ -209,8 +211,12 @@ def _serialize_single_option(option):
         return 'Not Recordable'
 
     val = option['val']
+
     if val is _UNDEFINED:
         return str(val)
+
+    if sys.getsizeof(val) > _MAX_OBJECT_SIZE:
+        return 'Too Large to Display'
 
     return default_noraise(val)
 
@@ -732,8 +738,8 @@ def _n2_setup_parser(parser):
     """
     parser.add_argument('file', nargs=1,
                         help='Python script or recording containing the model. '
-                        'If metadata from a parallel run was recorded in a separate file, '
-                        'specify both database filenames delimited with a comma.')
+                             'If metadata from a parallel run was recorded in a separate file, '
+                             'specify both database filenames delimited with a comma.')
     parser.add_argument('-o', default=_default_n2_filename, action='store', dest='outfile',
                         help='html output file.')
     parser.add_argument('--no_values', action='store_true', dest='no_values',
@@ -742,10 +748,12 @@ def _n2_setup_parser(parser):
                         help="don't display in a browser.")
     parser.add_argument('--embed', action='store_true', dest='embeddable',
                         help="create embeddable version.")
-    parser.add_argument('--title', default=None,
-                        action='store', dest='title', help='diagram title.')
-    parser.add_argument('--path', default=None,
-                        action='store', dest='path', help='initial path to zoom into.')
+    parser.add_argument('--title', default=None, action='store', dest='title',
+                        help='diagram title.')
+    parser.add_argument('--path', default=None, action='store', dest='path',
+                        help='initial system path to zoom into.')
+    parser.add_argument('--problem', default=None, action='store', dest='problem_name',
+                        help='name of sub-problem, if target is a sub-problem')
 
 
 def _n2_cmd(options, user_args):
@@ -760,29 +768,35 @@ def _n2_cmd(options, user_args):
         Command line options after '--' (if any).  Passed to user script.
     """
     filename = _to_filename(options.file[0])
+    probname = options.problem_name
 
     if filename.endswith('.py'):
-        def _view_model_w_errors(prob):
-            errs = prob._metadata['saved_errors']
-            if errs:
-                # only run the n2 here if we've had setup errors. Normally we'd wait until
-                # after final_setup in order to have correct values for all of the I/O variables.
-                n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
-                   values=not options.no_values, title=options.title, path=options.path,
-                   embeddable=options.embeddable)
-                # errors will result in exit at the end of the _check_collected_errors method
+        # disable the reports system, we only want the N2 report and then we exit
+        os.environ['OPENMDAO_REPORTS'] = '0'
 
-        def _view_model_no_errors(prob):
-            n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
-               values=not options.no_values, title=options.title, path=options.path,
-               embeddable=options.embeddable)
+        def _view_model_w_errors(prob):
+            # if problem name is not specified, use top-level problem (no delimiter in pathname)
+            pathname = prob._metadata['pathname']
+            if (probname is None and '/' not in pathname) or (probname == prob._name):
+                errs = prob._metadata['saved_errors']
+                if errs:
+                    # only run the n2 here if we've had setup errors. Normally we'd wait until
+                    # after final_setup in order to have correct values for all of the variables.
+                    n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
+                       values=not options.no_values, title=options.title, path=options.path,
+                       embeddable=options.embeddable)
+                    # errors will result in exit at the end of the _check_collected_errors method
+                else:
+                    # no errors, generate n2 after final_setup
+                    def _view_model_no_errors(prob):
+                        n2(prob, outfile=options.outfile, show_browser=not options.no_browser,
+                           values=not options.no_values, title=options.title, path=options.path,
+                           embeddable=options.embeddable)
+                    hooks._register_hook('final_setup', 'Problem',
+                                         post=_view_model_no_errors, exit=True)
+                    hooks._setup_hooks(prob)
 
         hooks._register_hook('_check_collected_errors', 'Problem', pre=_view_model_w_errors)
-        hooks._register_hook('final_setup', 'Problem', post=_view_model_no_errors, exit=True)
-
-        from openmdao.utils.reports_system import _register_cmdline_report
-        # tell report system not to duplicate effort
-        _register_cmdline_report('n2')
 
         _load_and_exec(options.file[0], user_args)
     else:

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -33,7 +33,7 @@ from openmdao.visualization.htmlpp import HtmlPreprocessor
 from openmdao import __version__ as openmdao_version
 
 _MAX_ARRAY_SIZE_FOR_REPR_VAL = 1000  # If var has more elements than this do not pass to N2
-_MAX_OBJECT_SIZE = int(1e7)          # If option value is bigger than this do not pass to N2
+_MAX_OPTION_SIZE = int(1e7)          # If option value is bigger than this do not pass to N2
 
 _default_n2_filename = 'n2.html'
 
@@ -210,7 +210,7 @@ def _serialize_single_option(option):
     if val is _UNDEFINED:
         return str(val)
 
-    if sys.getsizeof(val) > _MAX_OBJECT_SIZE:
+    if sys.getsizeof(val) > _MAX_OPTION_SIZE:
         return 'Too Large to Display'
 
     return default_noraise(val)

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -33,7 +33,7 @@ from openmdao.visualization.htmlpp import HtmlPreprocessor
 from openmdao import __version__ as openmdao_version
 
 _MAX_ARRAY_SIZE_FOR_REPR_VAL = 1000  # If var has more elements than this do not pass to N2
-_MAX_OPTION_SIZE = int(1e7)          # If option value is bigger than this do not pass to N2
+_MAX_OPTION_SIZE = int(1e4)          # If option value is bigger than this do not pass to N2
 
 _default_n2_filename = 'n2.html'
 

--- a/openmdao/visualization/n2_viewer/tests/gen_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/gen_gui_test.py
@@ -8,11 +8,6 @@ import sys
 
 from openmdao.utils.gui_testing_utils import _GuiTestCase
 
-try:
-    from parameterized import parameterized
-except ImportError:
-    from openmdao.utils.assert_utils import SkipParameterized as parameterized
-
 # set DEBUG to True if you want to view the generated HTML file
 GUI_DIAG_SUFFIX = '_GEN_TEST.html'
 GUI_TEST_SUBDIR = 'gui_test_models'

--- a/openmdao/visualization/n2_viewer/tests/sellar_no_values.json
+++ b/openmdao/visualization/n2_viewer/tests/sellar_no_values.json
@@ -57,8 +57,7 @@
                     "shape": "(2,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "v1",
@@ -69,8 +68,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {
@@ -160,8 +158,7 @@
                                     "distributed": false,
                                     "shape": "(1,)",
                                     "desc": "",
-                                    "units": "None",
-                                    "val": null
+                                    "units": "None"
                                 },
                                 {
                                     "name": "y2_command",
@@ -172,8 +169,7 @@
                                     "shape": "(1,)",
                                     "desc": "",
                                     "implicit": true,
-                                    "units": "None",
-                                    "val": null
+                                    "units": "None"
                                 }
                             ],
                             "options": {
@@ -210,8 +206,7 @@
                             "distributed": false,
                             "shape": "(2,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "x",
@@ -221,8 +216,7 @@
                             "distributed": false,
                             "shape": "(1,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y2",
@@ -232,8 +226,7 @@
                             "distributed": false,
                             "shape": "(1,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y1",
@@ -244,8 +237,7 @@
                             "shape": "(1,)",
                             "desc": "",
                             "implicit": false,
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         }
                     ],
                     "options": {
@@ -275,8 +267,7 @@
                             "distributed": false,
                             "shape": "(2,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y1",
@@ -286,8 +277,7 @@
                             "distributed": false,
                             "shape": "(1,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y2",
@@ -298,8 +288,7 @@
                             "shape": "(1,)",
                             "desc": "",
                             "implicit": false,
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         }
                     ],
                     "options": {
@@ -337,8 +326,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "y1",
@@ -348,8 +336,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "y2",
@@ -359,8 +346,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "z",
@@ -370,8 +356,7 @@
                     "distributed": false,
                     "shape": "(2,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "obj",
@@ -382,8 +367,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {
@@ -420,8 +404,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "con1",
@@ -432,8 +415,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {
@@ -470,8 +452,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "con2",
@@ -482,8 +463,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {

--- a/openmdao/visualization/n2_viewer/tests/sellar_no_values_run.json
+++ b/openmdao/visualization/n2_viewer/tests/sellar_no_values_run.json
@@ -57,8 +57,7 @@
                     "shape": "(2,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "v1",
@@ -69,8 +68,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {
@@ -160,8 +158,7 @@
                                     "distributed": false,
                                     "shape": "(1,)",
                                     "desc": "",
-                                    "units": "None",
-                                    "val": null
+                                    "units": "None"
                                 },
                                 {
                                     "name": "y2_command",
@@ -172,8 +169,7 @@
                                     "shape": "(1,)",
                                     "desc": "",
                                     "implicit": true,
-                                    "units": "None",
-                                    "val": null
+                                    "units": "None"
                                 }
                             ],
                             "options": {
@@ -210,8 +206,7 @@
                             "distributed": false,
                             "shape": "(2,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "x",
@@ -221,8 +216,7 @@
                             "distributed": false,
                             "shape": "(1,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y2",
@@ -232,8 +226,7 @@
                             "distributed": false,
                             "shape": "(1,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y1",
@@ -244,8 +237,7 @@
                             "shape": "(1,)",
                             "desc": "",
                             "implicit": false,
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         }
                     ],
                     "options": {
@@ -275,8 +267,7 @@
                             "distributed": false,
                             "shape": "(2,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y1",
@@ -286,8 +277,7 @@
                             "distributed": false,
                             "shape": "(1,)",
                             "desc": "",
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         },
                         {
                             "name": "y2",
@@ -298,8 +288,7 @@
                             "shape": "(1,)",
                             "desc": "",
                             "implicit": false,
-                            "units": "None",
-                            "val": null
+                            "units": "None"
                         }
                     ],
                     "options": {
@@ -337,8 +326,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "y1",
@@ -348,8 +336,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "y2",
@@ -359,8 +346,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "z",
@@ -370,8 +356,7 @@
                     "distributed": false,
                     "shape": "(2,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "obj",
@@ -382,8 +367,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {
@@ -420,8 +404,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "con1",
@@ -432,8 +415,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {
@@ -470,8 +452,7 @@
                     "distributed": false,
                     "shape": "(1,)",
                     "desc": "",
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 },
                 {
                     "name": "con2",
@@ -482,8 +463,7 @@
                     "shape": "(1,)",
                     "desc": "",
                     "implicit": false,
-                    "units": "None",
-                    "val": null
+                    "units": "None"
                 }
             ],
             "options": {

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -33,8 +33,7 @@ except ImportError:
 # Whether to pop up a browser window for each N2
 DEBUG_BROWSER = False
 
-# set DEBUG_FILES to True if you want to view the generated HTML file(s)
-DEBUG_FILES = False
+parent_dir = os.path.dirname(os.path.realpath(__file__))
 
 
 def extract_compressed_model(filename):
@@ -54,6 +53,7 @@ def extract_compressed_model(filename):
     return model_data
 
 
+@use_tempdirs
 def save_viewer_data(viewer_data, filename):
     """
     Save viewer data to JSON file for use in future testing.
@@ -65,31 +65,12 @@ def save_viewer_data(viewer_data, filename):
 
 class TestViewerData(unittest.TestCase):
 
-    def setUp(self):
-        if not DEBUG_FILES:
-            self.dir = mkdtemp()
-            os.chdir(self.dir)
-        else:
-            self.dir = os.getcwd()
-
-        self.parent_dir = os.path.dirname(os.path.realpath(__file__))
-
-    def tearDown(self):
-        if not DEBUG_FILES:
-            os.chdir(self.parent_dir)
-            try:
-                rmtree(self.dir)
-            except OSError as e:
-                # If directory already deleted, keep going
-                if e.errno not in (errno.ENOENT, errno.EACCES, errno.EPERM):
-                    raise e
-
     def check_viewer_data(self, viewer_data, filename, partials=True):
         """
         Check viewer data against expected.
         """
         # check model tree from JSON file
-        with open(os.path.join(self.parent_dir, filename)) as json_file:
+        with open(os.path.join(parent_dir, filename)) as json_file:
             expected_tree = json.load(json_file)
 
         np.testing.assert_equal(viewer_data['tree'], expected_tree, err_msg='', verbose=True)

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -337,7 +337,7 @@ class TestViewerData(unittest.TestCase):
 
         prob = om.Problem()
         comp = prob.model.add_subsystem('comp', SystemWithLargeOption())
-        comp.options['large_option'] = np.zeros(int(1e7))
+        comp.options['large_option'] = np.zeros(int(1e4))
         prob.setup()
 
         viewer_data = _get_viewer_data(prob)

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -346,6 +346,8 @@ class TestViewerData(unittest.TestCase):
 
     def test_viewer_data_with_submodel(self):
 
+        self.maxDiff = None
+
         def check_viewer_data_with_submodel(sql_filename):
             # create sub problem
             submodel = om.Group()
@@ -356,11 +358,11 @@ class TestViewerData(unittest.TestCase):
             # create top-level problem
             p = om.Problem(name='top')
             p.model.add_subsystem('submodelcomp',
-                                om.SubmodelComp(problem=subprob, inputs=['*'], outputs=['*']),
-                                promotes=['*'])
+                                  om.SubmodelComp(problem=subprob, inputs=['*'], outputs=['*']),
+                                  promotes=['*'])
             p.model.add_subsystem('supercomp',
-                                om.ExecComp('z = 3 * y'),
-                                promotes=['*'])
+                                  om.ExecComp('z = 3 * y'),
+                                  promotes=['*'])
 
             p.model.add_recorder(om.SqliteRecorder(sql_filename))
 
@@ -369,18 +371,16 @@ class TestViewerData(unittest.TestCase):
 
             # extract viewer data from N2 for problem and subproblem
             om.n2(p, title='N2 for Problem', outfile='N2problem.html',
-                show_browser=DEBUG_BROWSER)
+                  show_browser=DEBUG_BROWSER)
             problem_data = extract_compressed_model('N2problem.html')
 
             om.n2(subprob, title='N2 for SubProblem', outfile='N2subprob.html',
-                show_browser=DEBUG_BROWSER)
+                  show_browser=DEBUG_BROWSER)
             subprob_data = extract_compressed_model('N2subprob.html')
-
-            self.maxDiff = None
 
             # check problem data generated from recording against data generated from problem
             check_call(f"openmdao n2 {sql_filename} -o N2recording.html"
-                    f"{' --no_browser' if not DEBUG_BROWSER else ''}")
+                       f"{' --no_browser' if not DEBUG_BROWSER else ''}")
             recording_data = extract_compressed_model('N2recording.html')
 
             self.assertDictEqual(problem_data, recording_data)
@@ -419,7 +419,7 @@ class TestViewerData(unittest.TestCase):
 
             # check problem data generated from script against data generated from problem
             check_call("openmdao n2 submodel_script.py -o N2_top.html"
-                    f"{' --no_browser' if not DEBUG_BROWSER else ''}")
+                       f"{' --no_browser' if not DEBUG_BROWSER else ''}")
             n2_top_data = extract_compressed_model('N2_top.html')
 
             self.assertDictEqual(problem_data, n2_top_data)
@@ -428,7 +428,7 @@ class TestViewerData(unittest.TestCase):
             # NOTE: design vars and responses are added in SubmodelComp's setup, which is not executed
             #       when invoking the n2 command on the subproblem, which exits after subproblem setup
             check_call("openmdao n2 submodel_script.py -o N2_subprob.html --problem=subproblem"
-                    f"{' --no_browser' if not DEBUG_BROWSER else ''}")
+                       f"{' --no_browser' if not DEBUG_BROWSER else ''}")
             n2_sub_data = extract_compressed_model('N2_subprob.html')
 
             subprob_data['design_vars'] = {}

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -471,7 +471,6 @@ class TestViewerData(unittest.TestCase):
         self.check_viewer_data_with_submodel('recording1.sql')
 
 
-
 @use_tempdirs
 class TestN2(unittest.TestCase):
 

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -356,7 +356,7 @@ class TestViewerData(unittest.TestCase):
 
         prob = om.Problem()
         comp = prob.model.add_subsystem('comp', SystemWithLargeOption())
-        comp.options['large_option'] = np.zeros(int(1e6))
+        comp.options['large_option'] = np.zeros(int(1e7))
         prob.setup()
 
         viewer_data = _get_viewer_data(prob)

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -346,7 +346,7 @@ class TestViewerData(unittest.TestCase):
 
     def test_viewer_data_with_submodel(self):
 
-        def check_viewer_data_with_submodel(test, sql_filename):
+        def check_viewer_data_with_submodel(sql_filename):
             # create sub problem
             submodel = om.Group()
             submodel.add_subsystem('subcomp', om.ExecComp('y = x1**2 + x2**2 + x3**2'), promotes=['*'])
@@ -376,7 +376,7 @@ class TestViewerData(unittest.TestCase):
                 show_browser=DEBUG_BROWSER)
             subprob_data = extract_compressed_model('N2subprob.html')
 
-            test.maxDiff = None
+            self.maxDiff = None
 
             # check problem data generated from recording against data generated from problem
             check_call(f"openmdao n2 {sql_filename} -o N2recording.html"
@@ -422,7 +422,7 @@ class TestViewerData(unittest.TestCase):
                     f"{' --no_browser' if not DEBUG_BROWSER else ''}")
             n2_top_data = extract_compressed_model('N2_top.html')
 
-            test.assertDictEqual(problem_data, n2_top_data)
+            self.assertDictEqual(problem_data, n2_top_data)
 
             # check subproblem data generated from script against data generated from subproblem
             # NOTE: design vars and responses are added in SubmodelComp's setup, which is not executed
@@ -444,7 +444,7 @@ class TestViewerData(unittest.TestCase):
                     from openmdao.core.problem import _clear_problem_names
                     _clear_problem_names()
 
-                    check_viewer_data_with_submodel(self, f'recording{val}.sql')
+                    check_viewer_data_with_submodel(f'recording{val}.sql')
 
 
 @use_tempdirs

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -521,6 +521,9 @@ def _scaling_cmd(options, user_args):
     user_args : list of str
         Args to be passed to the user script.
     """
+    # disable the reports system, we only want the scaling report and then we exit
+    os.environ['OPENMDAO_REPORTS'] = '0'
+
     def _set_run_driver_flag(problem):
         global _run_driver_called
         _run_driver_called.add(problem._name)
@@ -565,9 +568,6 @@ def _scaling_cmd(options, user_args):
     import atexit
     atexit.register(functools.partial(_exitfunc, options.problem))
 
-    from openmdao.utils.reports_system import _register_cmdline_report
-    # tell report system not to duplicate effort
-    _register_cmdline_report('scaling')
     _load_and_exec(options.file[0], user_args)
 
 


### PR DESCRIPTION
### Summary

- added the `--problem` argument to the N2 command to specify the problem or subproblem to display
  - by default, the top-level problem will be shown, whereas previously it would display a subproblem
- disabled the report system when running the n2 or scaling report command
  - the report system was setting hooks that were interfering with generating the n2 for the desired problem
 
Also:
- set a maximum object size which will exclude very large values (including option values) from the viewer data
  - this prevents a situation where JSON data cannot be encoded/decoded for recording or viewing in the N2
- removed the value key entirely when values are excluded from N2 data, rather than setting values to None

### Related Issues

- Resolves #3023

### Backwards incompatibilities

None

### New Dependencies

None
