### PR TITLE
Fixed issue that was preventing `add_residual` from being called during configure.

### DIFF
--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -420,8 +420,8 @@ class ImplicitComponent(Component):
             raise ValueError(f"{self.msginfo}: Residual name '{name}' already exists.")
 
         if self._problem_meta is not None:
-            if self._problem_meta['setup_status'] >= _SetupStatus.POST_SETUP:
-                raise RuntimeError(f"{self.msginfo}: Can't add residual '{name}' after setup.")
+            if self._problem_meta['setup_status'] > _SetupStatus.POST_CONFIGURE:
+                raise RuntimeError(f"{self.msginfo}: Can't add residual '{name}' after configure.")
 
         # check ref shape
         if ref is not None:

--- a/openmdao/core/tests/test_renamed_resids.py
+++ b/openmdao/core/tests/test_renamed_resids.py
@@ -312,5 +312,61 @@ class ResidNamingTestCase(unittest.TestCase):
             assert_near_equal(val['rel error'][0], 0.0, 1e-12)
 
 
+class _InputResidComp(om.ImplicitComponent):
+
+    def add_residual_from_input(self, name, **kwargs):
+        resid_name = 'resid_' + name
+
+        self.add_input(name, **kwargs)
+        self.add_residual(resid_name, **kwargs)
+        self.declare_partials(of='*', wrt='*', method='fd')
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        residuals.set_val(inputs.asarray())
+
+
+class _TestGroup(om.Group):
+
+    def setup(self):
+        self.add_subsystem('exec_com', om.ExecComp(['res_a = a - x[0]', 'res_b = b - x[1:]'],
+                                                   a={'shape': (1,)},
+                                                   b={'shape': (2,)},
+                                                   res_a={'shape': (1,)},
+                                                   res_b={'shape': (2,)},
+                                                   x={'shape':3}),
+                           promotes_inputs=['*'], promotes_outputs=['*'])
+
+        self.add_subsystem('resid_comp', _InputResidComp(),
+                           promotes_inputs=['*'], promotes_outputs=['*'])
+
+    def configure(self):
+        resid_comp = self._get_subsystem('resid_comp')
+        resid_comp.add_output('x', shape=(3,))
+        resid_comp.add_residual_from_input('res_a', shape=(1,))
+        resid_comp.add_residual_from_input('res_b', shape=(2,))
+        self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        self.linear_solver = om.DirectSolver()
+
+
+class TestAddResidualConfigure(unittest.TestCase):
+
+    def test_add_residual_configure(self):
+        p = om.Problem()
+        p.model.add_subsystem('test_group', _TestGroup())
+        p.setup()
+
+        p.set_val('test_group.a', 3.0)
+        p.set_val('test_group.b', [4.0, 5.0])
+
+        p.run_model()
+
+        a = p.get_val('test_group.a')
+        b = p.get_val('test_group.b')
+        x = p.get_val('test_group.x')
+
+        assert_near_equal(a, x[0], tolerance=1.0E-9)
+        assert_near_equal(b, x[1:], tolerance=1.0E-9)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

OpenMDAO allows `add_input` and `add_output` to be called on a component by a group during its `configure` method, but `add_residual` had logic preventing this. This is now allowed.

### Related Issues

- Resolves #3030

### Backwards incompatibilities

None

### New Dependencies

None
