### PR TITLE
Fixed a broken link in the documentation

### DIFF
--- a/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
@@ -565,7 +565,7 @@
     "There are a few ways to address this. For example, you might implement a function to declare the common options and call it in the relevant subsystems' `initialize` method.\n",
     "Alternatively, those classes can subclass from a class which automatically adds the appropriate options.\n",
     "\n",
-    "For passing options to components nested deeply within the model, the OpenMDAO `Problem` object provides an attribute named `model_options`. `Problem.model_options` is a standard dictionary, keyed by a string that serves as a [glob](https://en.wikipedia.org/wiki/Glob_(programming) filter for system pathnames.\n",
+    "For passing options to components nested deeply within the model, the OpenMDAO `Problem` object provides an attribute named `model_options`. `Problem.model_options` is a standard dictionary, keyed by a string that serves as a [glob](https://en.wikipedia.org/wiki/Glob_(programming)) filter for system pathnames.\n",
     "\n",
     "For each corresponding value, a sub dictionary provides string keys of option names, with corresponding option values as the associated value.\n",
     "\n",


### PR DESCRIPTION
### Summary

There was a missing closing parenthesis in the link to the glob wikipedia page.

### Related Issues

- Resolves #3033

### Backwards incompatibilities

None

### New Dependencies

None
