### PR TITLE
Added a warning when an excludes or includes recording option has no matches

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -525,7 +525,7 @@ class Driver(object):
                 myresiduals = myoutputs
 
         elif recording_options['record_residuals']:
-            match_names = match_names | self._residuals.keys()
+            match_names = match_names | set(model._residuals.keys())
             myresiduals = [n for n in model._residuals._abs_iter()
                            if check_path(abs2prom_output[n], incl, excl)]
 
@@ -539,8 +539,8 @@ class Driver(object):
 
         # inputs (if in options). inputs use _absolute_ names for includes/excludes
         if 'record_inputs' in recording_options:
-            match_names = match_names | set(abs2prom_inputs.keys())
             if recording_options['record_inputs']:
+                match_names = match_names | set(abs2prom_inputs.keys())
                 myinputs = [n for n in abs2prom_inputs if check_path(n, incl, excl)]
 
         # check that all exclude/include globs have at least one matching output or input name

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -541,12 +541,11 @@ class Driver(object):
         for pattern in excl:
             if not has_match(pattern, match_names):
                 issue_warning(f"{obj.msginfo}: No matches for pattern '{pattern}' in "
-                                "recording_options['excludes'].")
+                              "recording_options['excludes'].")
         for pattern in incl:
             if not has_match(pattern, match_names):
                 issue_warning(f"{obj.msginfo}: No matches for pattern '{pattern}' in "
-                                "recording_options['includes'].")
-
+                              "recording_options['includes'].")
 
         # sort lists to ensure that vars are iterated over in the same order on all procs
         vars2record = {

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -812,7 +812,7 @@ class Problem(object):
         """
         Set up case recording.
         """
-        self._filtered_vars_to_record = self.driver._get_vars_to_record(self.recording_options)
+        self._filtered_vars_to_record = self.driver._get_vars_to_record(self)
         self._rec_mgr.startup(self, self.comm)
 
     def add_recorder(self, recorder):
@@ -1098,8 +1098,10 @@ class Problem(object):
 
         # set up recording, including any new recorders since last setup
         if self._metadata['setup_status'] >= _SetupStatus.POST_SETUP:
-            driver._setup_recording()
-            self._setup_recording()
+            if driver._rec_mgr.has_recorders():
+                driver._setup_recording()
+            if self._rec_mgr.has_recorders():
+                self._setup_recording()
             record_viewer_data(self)
 
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -812,8 +812,9 @@ class Problem(object):
         """
         Set up case recording.
         """
-        self._filtered_vars_to_record = self.driver._get_vars_to_record(self)
-        self._rec_mgr.startup(self, self.comm)
+        if self._rec_mgr.has_recorders():
+            self._filtered_vars_to_record = self.driver._get_vars_to_record(self)
+            self._rec_mgr.startup(self, self.comm)
 
     def add_recorder(self, recorder):
         """
@@ -1098,10 +1099,8 @@ class Problem(object):
 
         # set up recording, including any new recorders since last setup
         if self._metadata['setup_status'] >= _SetupStatus.POST_SETUP:
-            if driver._rec_mgr.has_recorders():
-                driver._setup_recording()
-            if self._rec_mgr.has_recorders():
-                self._setup_recording()
+            driver._setup_recording()
+            self._setup_recording()
             record_viewer_data(self)
 
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1980,7 +1980,7 @@ class System(object):
                     myresiduals = myoutputs
 
             elif options['record_residuals']:
-                match_names = match_names | self._residuals.keys()
+                match_names = match_names | set(self._residuals.keys())
                 myresiduals = [n for n in self._residuals._abs_iter()
                                if check_path(abs2prom_output[n], incl, excl)]
 
@@ -1988,11 +1988,11 @@ class System(object):
             for pattern in excl:
                 if not has_match(pattern, match_names):
                     issue_warning(f"{self.msginfo}: No matches for pattern '{pattern}' in "
-                                "recording_options['excludes'].")
+                                  "recording_options['excludes'].")
             for pattern in incl:
                 if not has_match(pattern, match_names):
                     issue_warning(f"{self.msginfo}: No matches for pattern '{pattern}' in "
-                                "recording_options['includes'].")
+                                  "recording_options['includes'].")
 
             self._filtered_vars_to_record = {
                 'input': myinputs,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1960,14 +1960,14 @@ class System(object):
             # includes and excludes for inputs are specified using _absolute_ names
             # vectors are keyed on absolute name, discretes on relative/promoted name
             if options['record_inputs']:
-                match_names = match_names | set(abs2prom_inputs.keys())
+                match_names.update(abs2prom_inputs.keys())
                 myinputs = sorted([n for n in abs2prom_inputs
                                    if check_path(n, incl, excl)])
 
             # includes and excludes for outputs are specified using _promoted_ names
             # vectors are keyed on absolute name, discretes on relative/promoted name
             if options['record_outputs']:
-                match_names = match_names | set(abs2prom_output.values())
+                match_names.update(abs2prom_output.values())
                 myoutputs = sorted([n for n, prom in abs2prom_output.items()
                                     if check_path(prom, incl, excl)])
 
@@ -1980,7 +1980,7 @@ class System(object):
                     myresiduals = myoutputs
 
             elif options['record_residuals']:
-                match_names = match_names | set(self._residuals.keys())
+                match_names.update(self._residuals.keys())
                 myresiduals = [n for n in self._residuals._abs_iter()
                                if check_path(abs2prom_output[n], incl, excl)]
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -23,7 +23,7 @@ from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.vectors.vector import _full_slice
 from openmdao.utils.mpi import MPI, multi_proc_exception_check
 from openmdao.utils.options_dictionary import OptionsDictionary
-from openmdao.utils.record_util import create_local_meta, check_path
+from openmdao.utils.record_util import create_local_meta, check_path, has_match
 from openmdao.utils.units import is_compatible, unit_conversion, simplify_unit
 from openmdao.utils.variable_table import write_var_table
 from openmdao.utils.array_utils import evenly_distrib_idxs, shape_to_len
@@ -1948,16 +1948,27 @@ class System(object):
             incl = options['includes']
             excl = options['excludes']
 
+            # includes and excludes for outputs are specified using promoted names
+            # includes and excludes for inputs are specified using _absolute_ names
+            abs2prom_output = self._var_allprocs_abs2prom['output']
+            abs2prom_inputs = self._var_allprocs_abs2prom['input']
+
+            # set of promoted output names and absolute input and residual names
+            # used for matching includes/excludes
+            match_names = set()
+
             # includes and excludes for inputs are specified using _absolute_ names
             # vectors are keyed on absolute name, discretes on relative/promoted name
             if options['record_inputs']:
-                myinputs = sorted([n for n in self._var_abs2prom['input']
+                match_names = match_names | set(abs2prom_inputs.keys())
+                myinputs = sorted([n for n in abs2prom_inputs
                                    if check_path(n, incl, excl)])
 
             # includes and excludes for outputs are specified using _promoted_ names
             # vectors are keyed on absolute name, discretes on relative/promoted name
             if options['record_outputs']:
-                myoutputs = sorted([n for n, prom in self._var_abs2prom['output'].items()
+                match_names = match_names | set(abs2prom_output.values())
+                myoutputs = sorted([n for n, prom in abs2prom_output.items()
                                     if check_path(prom, incl, excl)])
 
                 if self._var_discrete['output']:
@@ -1969,9 +1980,19 @@ class System(object):
                     myresiduals = myoutputs
 
             elif options['record_residuals']:
-                abs2prom = self._var_abs2prom['output']
+                match_names = match_names | self._residuals.keys()
                 myresiduals = [n for n in self._residuals._abs_iter()
-                               if check_path(abs2prom[n], incl, excl)]
+                               if check_path(abs2prom_output[n], incl, excl)]
+
+            # check that all exclude/include globs have at least one matching output or input name
+            for pattern in excl:
+                if not has_match(pattern, match_names):
+                    issue_warning(f"{self.msginfo}: No matches for pattern '{pattern}' in "
+                                "recording_options['excludes'].")
+            for pattern in incl:
+                if not has_match(pattern, match_names):
+                    issue_warning(f"{self.msginfo}: No matches for pattern '{pattern}' in "
+                                "recording_options['includes'].")
 
             self._filtered_vars_to_record = {
                 'input': myinputs,

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -650,11 +650,11 @@ class TestDriver(unittest.TestCase):
 
         totals = prob.check_totals(out_stream=None, driver_scaling=True)
 
-        for key, val in totals.items():
+        for val in totals.values():
             assert_near_equal(val['rel error'][0], 0.0, 1e-6)
 
         cr = om.CaseReader("cases.sql")
-        cases = cr.list_cases('driver')
+        cases = cr.list_cases('driver', out_stream=None)
         case = cr.get_case(cases[0])
 
         dv = case.get_design_vars()
@@ -817,7 +817,7 @@ class TestDriver(unittest.TestCase):
     def test_get_vars_to_record(self):
         recorder = om.SqliteRecorder("cases.sql")
 
-        prob = om.Problem()
+        prob = om.Problem(name='ABCD')
         prob.add_recorder(recorder)
 
         prob.model.add_subsystem('mag', om.ExecComp('y=x**2'),
@@ -842,8 +842,8 @@ class TestDriver(unittest.TestCase):
         prob.setup()
 
         expected_warnings = (
-            (OpenMDAOWarning, "Problem problem: No matches for pattern '*aa*' in recording_options['excludes']."),
-            (OpenMDAOWarning, "Problem problem: No matches for pattern '*bb*' in recording_options['includes']."),
+            (OpenMDAOWarning, "Problem ABCD: No matches for pattern '*aa*' in recording_options['excludes']."),
+            (OpenMDAOWarning, "Problem ABCD: No matches for pattern '*bb*' in recording_options['includes']."),
             (OpenMDAOWarning, "ScipyOptimizeDriver: No matches for pattern '*cc*' in recording_options['excludes']."),
             (OpenMDAOWarning, "ScipyOptimizeDriver: No matches for pattern '*dd*' in recording_options['includes'].")
         )

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -166,6 +166,7 @@ def check_path(path, includes, excludes, include_all_path=False):
 
     return include_all_path
 
+
 def has_match(pattern, names):
     """
     Determine whether `pattern` matches at least one name in `names`.
@@ -173,7 +174,7 @@ def has_match(pattern, names):
     Parameters
     ----------
     pattern : str
-        glob pattern to match.
+        The glob pattern to match.
     names : list
         List of names to to check for a match.
 
@@ -187,6 +188,7 @@ def has_match(pattern, names):
             return True
 
     return False
+
 
 def deserialize(json_data, abs2meta, prom2abs, conns):
     """

--- a/openmdao/utils/record_util.py
+++ b/openmdao/utils/record_util.py
@@ -166,6 +166,27 @@ def check_path(path, includes, excludes, include_all_path=False):
 
     return include_all_path
 
+def has_match(pattern, names):
+    """
+    Determine whether `pattern` matches at least one name in `names`.
+
+    Parameters
+    ----------
+    pattern : str
+        glob pattern to match.
+    names : list
+        List of names to to check for a match.
+
+    Returns
+    -------
+    bool
+        True if there is a match.
+    """
+    for name in names:
+        if fnmatchcase(name, pattern):
+            return True
+
+    return False
 
 def deserialize(json_data, abs2meta, prom2abs, conns):
     """


### PR DESCRIPTION
### Summary

Added a check that all exclude/include globs in `recording_options` for Problem, Driver or System have at least one matching output or input name in the set of inputs, outputs and/or residuals to be recorded.

### Related Issues

- Resolves #3018 

### Backwards incompatibilities

None

### New Dependencies

None
