### PR TITLE
Allow users to define a preprocessor function for option sets. [POEM 092 Implementation]

### DIFF
--- a/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": [
      "remove-input",
@@ -52,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,9 +88,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2. 4. 6.]\n"
+     ]
+    }
+   ],
    "source": [
     "import openmdao.api as om\n",
     "\n",
@@ -107,14 +115,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "assert_near_equal(prob.get_val('double.y'), [2., 4., 6.])"
@@ -134,9 +153,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'double' <class VectorDoublingComp>: Option 'size' is required but has not been set.\n"
+     ]
+    }
+   ],
    "source": [
     "import openmdao.api as om\n",
     "from openmdao.test_suite.components.options_feature_vector import VectorDoublingComp\n",
@@ -161,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,9 +221,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ 5. 10. 15.]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "\n",
@@ -215,14 +250,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('a_comp.y'), [5., 10., 15.])"
    ]
@@ -236,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,9 +315,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[10.]\n"
+     ]
+    }
+   ],
    "source": [
     "import openmdao.api as om\n",
     "\n",
@@ -291,14 +345,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('f_comp.y'), 10.)"
    ]
@@ -314,7 +379,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,9 +411,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[7.]\n"
+     ]
+    }
+   ],
    "source": [
     "import openmdao.api as om\n",
     "\n",
@@ -365,7 +438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {
     "tags": [
      "remove-input",
@@ -392,9 +465,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2. 4. 6. 8.]\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
@@ -429,14 +510,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "assert_near_equal(prob.get_val('double.y'), [2., 4., 6., 8.])"
    ]
@@ -455,9 +547,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Option 'size' with value 5 must be an even number.\n"
+     ]
+    }
+   ],
    "source": [
     "import numpy as np\n",
     "import openmdao.api as om\n",
@@ -492,7 +592,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "metadata": {
     "tags": [
      "remove-input",
@@ -519,9 +619,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[14.]\n"
+     ]
+    }
+   ],
    "source": [
     "import openmdao.api as om\n",
     "\n",
@@ -541,7 +649,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "metadata": {
     "tags": [
      "remove-input",
@@ -580,7 +688,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 22,
    "metadata": {
     "tags": [
      "remove-input",
@@ -635,9 +743,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 23,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "        <iframe\n",
+       "            width=\"100%\"\n",
+       "            height=\"700\"\n",
+       "            src=\"n2.html\"\n",
+       "            frameborder=\"0\"\n",
+       "            allowfullscreen\n",
+       "        ></iframe>\n",
+       "        "
+      ],
+      "text/plain": [
+       "<IPython.lib.display.IFrame at 0x7f7d6a8b06a0>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "om.n2(prob)"
    ]
@@ -651,9 +780,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 24,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[254.]\n"
+     ]
+    }
+   ],
    "source": [
     "import openmdao.api as om\n",
     "\n",
@@ -689,7 +826,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 25,
    "metadata": {
     "tags": [
      "remove-input",
@@ -723,9 +860,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 26,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[173.]\n"
+     ]
+    }
+   ],
    "source": [
     "class MyGroup(om.Group):\n",
     "\n",
@@ -754,25 +899,146 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 27,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.0"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "c3y = p.get_val('my_group.g1.c3.y')\n",
     "expected = ((4 * 3 + 5) * 3 + 5) * 3 + 5.\n",
     "assert_near_equal(expected, c3y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding a function to pre-process setting an option\n",
+    "\n",
+    "The `OptionsDictionary` has support for custom pre-processing the value before it is set. One potential use for this is to provide a way to convert units while setting an option. The following example shows how to do this:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import unittest\n",
+    "\n",
+    "import openmdao.api as om\n",
+    "from openmdao.utils.units import convert_units\n",
+    "\n",
+    "\n",
+    "# TODO: Turn this into a test.\n",
+    "\n",
+    "def units_setter(opt_meta, value):\n",
+    "    \"\"\"\n",
+    "    Check and convert new units tuple into\n",
+    "\n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    opt_meta : dict\n",
+    "        Dictionary of entries for the option.\n",
+    "    value : any\n",
+    "        New value for the option.\n",
+    "\n",
+    "    Returns\n",
+    "    -------\n",
+    "    any\n",
+    "        Post processed value to set into the option.\n",
+    "    \"\"\"\n",
+    "    new_val, new_units = value\n",
+    "    old_val, units = opt_meta['val']\n",
+    "\n",
+    "    converted_val = convert_units(new_val, new_units, units)\n",
+    "    return (converted_val, units)\n",
+    "\n",
+    "\n",
+    "class MyComp(om.ExplicitComponent):\n",
+    "\n",
+    "    def setup(self):\n",
+    "\n",
+    "        self.add_input('x', 3.0)\n",
+    "        self.add_output('y', 3.0)\n",
+    "\n",
+    "    def initialize(self):\n",
+    "        self.options.declare('length', default=(12.0, 'inch'),\n",
+    "                             set_function=units_setter)\n",
+    "\n",
+    "    def compute(self, inputs, outputs):\n",
+    "        length = self.options['length'][0]\n",
+    "\n",
+    "        x = inputs['x']\n",
+    "        outputs['y'] = length * x\n",
+    "\n",
+    "\n",
+    "class MySubgroup(om.Group):\n",
+    "\n",
+    "    def setup(self):\n",
+    "        self.add_subsystem('mass', MyComp())\n",
+    "\n",
+    "\n",
+    "prob = om.Problem()\n",
+    "model = prob.model\n",
+    "\n",
+    "model.add_subsystem('statics', MySubgroup())\n",
+    "\n",
+    "prob.model_options['*'] = {'length': (2.0, 'ft')}\n",
+    "prob.setup()\n",
+    "\n",
+    "prob.run_model()\n",
+    "\n",
+    "print('The following should be 72 if the units convert correctly.')\n",
+    "print(prob.get_val('statics.mass.y'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "tags": [
+     "hide_input",
+     "hide_output"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.9737298215558337e-16"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "assert_near_equal(prob.get_val('statics.mass.y'), 72, 1e-6)\n"
    ]
   }
  ],
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -786,7 +1052,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.8.10"
   },
   "orphan": true
  },

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -347,7 +347,7 @@ class OptionsDictionary(object):
 
     def declare(self, name, default=_UNDEFINED, values=None, types=None, desc='',
                 upper=None, lower=None, check_valid=None, allow_none=False, recordable=True,
-                deprecation=None):
+                set_function=None, deprecation=None):
         r"""
         Declare an option.
 
@@ -379,6 +379,9 @@ class OptionsDictionary(object):
             If True, allow None as a value regardless of values or types.
         recordable : bool
             If True, add to recorder.
+        set_function : None or function
+            User-supplied function with arguments (Options metadata, value) that pre-processes
+            value and returns a new value.
         deprecation : str or tuple or None
             If None, it is not deprecated. If a str, use as a DeprecationWarning
             during __setitem__ and __getitem__.  If a tuple of the form (msg, new_name),
@@ -437,6 +440,7 @@ class OptionsDictionary(object):
             'has_been_set': default_provided,
             'allow_none': allow_none,
             'recordable': recordable,
+            'set_function': set_function,
             'deprecation': deprecation,
         }
 
@@ -520,6 +524,10 @@ class OptionsDictionary(object):
             name, meta = self._handle_deprecation(name, meta)
 
         self._assert_valid(name, value)
+
+        # General function test
+        if meta['set_function'] is not None:
+            value = meta['set_function'](meta, value)
 
         meta['val'] = value
         meta['has_been_set'] = True

--- a/openmdao/utils/tests/test_options_dictionary_units.py
+++ b/openmdao/utils/tests/test_options_dictionary_units.py
@@ -1,0 +1,59 @@
+import unittest
+
+import openmdao.api as om
+
+# TODO: Turn this into a test.
+
+def units_setter(opt_dict, value):
+    """
+    Check and convert new units tuple into 
+
+    Parameters
+    ----------
+    opt_dict : dict
+        Dictionary of entries for the option.
+    value : any
+        New value for the option.
+
+    Returns
+    -------
+    any
+        Post processed value to set into the option.
+    """
+    new_val, new_unit = value
+
+class AviaryComp(om.ExplicitComponent):
+
+    def setup(self):
+
+        self.add_input('x', 3.0)
+        self.add_output('y', 3.0)
+
+    def initialize(self):
+        self.options.declare('length', default=(12.0, 'inch'), set_function=None)
+
+    def compute(self, inputs, outputs):
+        length = self.options['length'][0]
+
+        x = inputs['x']
+        outputs['y'] = length * x
+
+
+class Fakeviary(om.Group):
+
+    def setup(self):
+        self.add_subsystem('mass', AviaryComp())
+
+
+prob = om.Problem()
+model = prob.model
+
+model.add_subsystem('statics', Fakeviary())
+
+prob.model_options['*'] = {'length': (2.0, 'ft')}
+prob.setup()
+
+prob.run_model()
+print('The following should be 72 if the units convert correctly.')
+print(prob.get_val('statics.mass.y'))
+print('done')

--- a/openmdao/utils/tests/test_options_dictionary_units.py
+++ b/openmdao/utils/tests/test_options_dictionary_units.py
@@ -1,16 +1,18 @@
 import unittest
 
 import openmdao.api as om
+from openmdao.utils.units import convert_units
+
 
 # TODO: Turn this into a test.
 
-def units_setter(opt_dict, value):
+def units_setter(opt_meta, value):
     """
-    Check and convert new units tuple into 
+    Check and convert new units tuple into
 
     Parameters
     ----------
-    opt_dict : dict
+    opt_meta : dict
         Dictionary of entries for the option.
     value : any
         New value for the option.
@@ -20,7 +22,12 @@ def units_setter(opt_dict, value):
     any
         Post processed value to set into the option.
     """
-    new_val, new_unit = value
+    new_val, new_units = value
+    old_val, units = opt_meta['val']
+
+    converted_val = convert_units(new_val, new_units, units)
+    return (converted_val, units)
+
 
 class AviaryComp(om.ExplicitComponent):
 
@@ -30,7 +37,8 @@ class AviaryComp(om.ExplicitComponent):
         self.add_output('y', 3.0)
 
     def initialize(self):
-        self.options.declare('length', default=(12.0, 'inch'), set_function=None)
+        self.options.declare('length', default=(12.0, 'inch'),
+                             set_function=units_setter)
 
     def compute(self, inputs, outputs):
         length = self.options['length'][0]

--- a/openmdao/utils/tests/test_options_dictionary_units.py
+++ b/openmdao/utils/tests/test_options_dictionary_units.py
@@ -1,6 +1,7 @@
 import unittest
 
 import openmdao.api as om
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.units import convert_units
 
 
@@ -53,15 +54,22 @@ class Fakeviary(om.Group):
         self.add_subsystem('mass', AviaryComp())
 
 
-prob = om.Problem()
-model = prob.model
+class TestOptionsDictionaryUnits(unittest.TestCase):
 
-model.add_subsystem('statics', Fakeviary())
+    def test_simple(self):
+        prob = om.Problem()
+        model = prob.model
 
-prob.model_options['*'] = {'length': (2.0, 'ft')}
-prob.setup()
+        model.add_subsystem('statics', Fakeviary())
 
-prob.run_model()
-print('The following should be 72 if the units convert correctly.')
-print(prob.get_val('statics.mass.y'))
-print('done')
+        prob.model_options['*'] = {'length': (2.0, 'ft')}
+        prob.setup()
+
+        prob.run_model()
+
+        y = prob.get_val('statics.mass.y')
+        assert_near_equal(y, 72, 1e-6)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/utils/tests/test_options_dictionary_units.py
+++ b/openmdao/utils/tests/test_options_dictionary_units.py
@@ -5,8 +5,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.units import convert_units
 
 
-# TODO: Turn this into a test.
-
 def units_setter(opt_meta, value):
     """
     Check and convert new units tuple into


### PR DESCRIPTION
### Summary

This is the implementation PR for https://github.com/OpenMDAO/POEMs/pull/186

The user can now specify a preprocessor function that runs whenever you set that option. This can be used to convert units.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
