### PR TITLE
Updated 'latest' workflow for Python 3.12 compatibility

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -143,6 +143,8 @@ jobs:
           python -m pip install --pre testflo
           python -m pip install --pre websockets
           python -m pip install --pre aiounittest
+          echo "greenlet is a playwright dependency that doesn't currently build properly for python 3.12"
+          python -m pip install --pre greenlet
           python -m pip install --pre playwright
           python -m pip install --pre num2words
 

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -96,11 +96,6 @@ jobs:
           python -m pip install --upgrade pip
 
           echo "============================================================="
-          echo "Upgrade to latest setuptools"
-          echo "============================================================="
-          python -m pip install --upgrade setuptools
-
-          echo "============================================================="
           echo "Install latest versions of NumPy/SciPy"
           echo "============================================================="
           python -m pip install --pre numpy
@@ -148,10 +143,10 @@ jobs:
           python -m pip install --pre testflo
           python -m pip install --pre websockets
           python -m pip install --pre aiounittest
-          echo "the current latest version of playwright (1.38.0) is pinned to"
+          echo "the latest version of playwright (1.38.0) is pinned to"
           echo "greenlet 2.0.2 which does not build properly for python 3.12"
           echo "https://github.com/microsoft/playwright-python/issues/2096"
-          python -m pip install --pre playwright  || echo "Skipping playwright..."
+          python -m pip install --pre playwright  || echo "Skipping playwright, no GUI testing!"
           python -m pip install --pre num2words
 
           echo "============================================================="
@@ -174,6 +169,11 @@ jobs:
               echo "SNOPT source is not available"
           fi
           build_pyoptsparse $BRANCH $SNOPT
+
+          echo "============================================================="
+          echo "Ensure we have the latest setuptools"
+          echo "============================================================="
+          python -m pip install --upgrade setuptools
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -143,8 +143,9 @@ jobs:
           python -m pip install --pre testflo
           python -m pip install --pre websockets
           python -m pip install --pre aiounittest
-          echo "greenlet is a playwright dependency that doesn't currently build properly for python 3.12"
-          python -m pip install --pre greenlet
+          echo "greenlet is a playwright dependency that doesn't currently build"
+          echo "properly for python 3.12 for versions less than 3.0"
+          python -m pip install --pre 'greenlet>=3'
           python -m pip install --pre playwright
           python -m pip install --pre num2words
 

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -96,6 +96,11 @@ jobs:
           python -m pip install --upgrade pip
 
           echo "============================================================="
+          echo "Upgrade to latest setuptools"
+          echo "============================================================="
+          python -m pip install --upgrade setuptools
+
+          echo "============================================================="
           echo "Install latest versions of NumPy/SciPy"
           echo "============================================================="
           python -m pip install --pre numpy

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -143,10 +143,10 @@ jobs:
           python -m pip install --pre testflo
           python -m pip install --pre websockets
           python -m pip install --pre aiounittest
-          echo "greenlet is a playwright dependency that doesn't currently build"
-          echo "properly for python 3.12 for versions less than 3.0"
-          python -m pip install --pre 'greenlet>=3'
-          python -m pip install --pre playwright
+          echo "the current latest version of playwright (1.38.0) is pinned to"
+          echo "greenlet 2.0.2 which does not build properly for python 3.12"
+          echo "https://github.com/microsoft/playwright-python/issues/2096"
+          python -m pip install --pre playwright  || echo "Skipping playwright..."
           python -m pip install --pre num2words
 
           echo "============================================================="

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -96,6 +96,11 @@ jobs:
           python -m pip install --upgrade pip
 
           echo "============================================================="
+          echo "Install latest setuptools"
+          echo "============================================================="
+          python -m pip install --upgrade --pre setuptools
+
+          echo "============================================================="
           echo "Install latest versions of NumPy/SciPy"
           echo "============================================================="
           python -m pip install --upgrade --pre numpy
@@ -169,11 +174,6 @@ jobs:
               echo "SNOPT source is not available"
           fi
           build_pyoptsparse $BRANCH $SNOPT
-
-          echo "============================================================="
-          echo "Install latest setuptools"
-          echo "============================================================="
-          python -m pip install --upgrade --pre setuptools
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -98,8 +98,8 @@ jobs:
           echo "============================================================="
           echo "Install latest versions of NumPy/SciPy"
           echo "============================================================="
-          python -m pip install --pre numpy
-          python -m pip install --pre scipy
+          python -m pip install --upgrade --pre numpy
+          python -m pip install --upgrade --pre scipy
 
           # remember versions so we can check them later
           NUMPY_VER=`python -c "import numpy; print(numpy.__version__)"`
@@ -110,50 +110,50 @@ jobs:
           echo "============================================================="
           echo "Install latest versions of 'docs' dependencies"
           echo "============================================================="
-          python -m pip install --pre matplotlib
-          python -m pip install --pre numpydoc
-          python -m pip install --pre jupyter-book
-          python -m pip install --pre sphinx-sitemap
-          python -m pip install --pre ipyparallel
+          python -m pip install --upgrade --pre matplotlib
+          python -m pip install --upgrade --pre numpydoc
+          python -m pip install --upgrade --pre jupyter-book
+          python -m pip install --upgrade --pre sphinx-sitemap
+          python -m pip install --upgrade --pre ipyparallel
 
           echo "============================================================="
           echo "Install latest versions of 'doe' dependencies"
           echo "============================================================="
-          python -m pip install --pre pyDOE2
+          python -m pip install --upgrade --pre pyDOE2
 
           echo "============================================================="
           echo "Install latest versions of 'notebooks' dependencies"
           echo "============================================================="
-          python -m pip install --pre notebook
-          python -m pip install --pre ipympl
+          python -m pip install --upgrade --pre notebook
+          python -m pip install --upgrade --pre ipympl
 
           echo "============================================================="
           echo "Install latest versions of 'visualization' dependencies"
           echo "============================================================="
-          python -m pip install --pre bokeh
-          python -m pip install --pre colorama
+          python -m pip install --upgrade --pre bokeh
+          python -m pip install --upgrade --pre colorama
 
           echo "============================================================="
           echo "Install latest versions of 'test' dependencies"
           echo "============================================================="
-          python -m pip install --pre parameterized
-          python -m pip install --pre numpydoc
-          python -m pip install --pre pycodestyle
-          python -m pip install --pre pydocstyle
-          python -m pip install --pre testflo
-          python -m pip install --pre websockets
-          python -m pip install --pre aiounittest
+          python -m pip install --upgrade --pre parameterized
+          python -m pip install --upgrade --pre numpydoc
+          python -m pip install --upgrade --pre pycodestyle
+          python -m pip install --upgrade --pre pydocstyle
+          python -m pip install --upgrade --pre testflo
+          python -m pip install --upgrade --pre websockets
+          python -m pip install --upgrade --pre aiounittest
           echo "the latest version of playwright (1.38.0) is pinned to"
           echo "greenlet 2.0.2 which does not build properly for python 3.12"
           echo "https://github.com/microsoft/playwright-python/issues/2096"
-          python -m pip install --pre playwright  || echo "Skipping playwright, no GUI testing!"
-          python -m pip install --pre num2words
+          python -m pip install --upgrade --pre playwright  || echo "Skipping playwright, no GUI testing!"
+          python -m pip install --upgrade --pre num2words
 
           echo "============================================================="
           echo "Install latest versions of other optional packages"
           echo "============================================================="
-          python -m pip install --pre pyparsing psutil objgraph pyxdsm
-          python -m pip install --pre jax jaxlib
+          python -m pip install --upgrade --pre pyparsing psutil objgraph pyxdsm
+          python -m pip install --upgrade --pre jax jaxlib
 
           echo "============================================================="
           echo "Install latest pyoptsparse"
@@ -171,9 +171,9 @@ jobs:
           build_pyoptsparse $BRANCH $SNOPT
 
           echo "============================================================="
-          echo "Ensure we have the latest setuptools"
+          echo "Install latest setuptools"
           echo "============================================================="
-          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade --pre setuptools
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -534,10 +534,10 @@ class ApproximationScheme(object):
                         end_time = time.perf_counter()
                         prom_name = _convert_auto_ivc_to_conn_name(
                             system._conn_global_abs_in2out, wrt)
-                        self._progress_out.write(f"{fd_count+1}/{len(result)}: Checking "
+                        self._progress_out.write(f"{fd_count + 1}/{len(result)}: Checking "
                                                  f"derivatives with respect to: "
                                                  f"'{prom_name} [{vecidxs}]' ... "
-                                                 f"{round(end_time-start_time, 4)} seconds\n")
+                                                 f"{round(end_time - start_time, 4)} seconds\n")
                 elif use_parallel_fd:
                     next(jidx_iter)  # skip this column index
 

--- a/openmdao/components/meta_model_semi_structured_comp.py
+++ b/openmdao/components/meta_model_semi_structured_comp.py
@@ -207,7 +207,7 @@ class MetaModelSemiStructuredComp(ExplicitComponent):
                 errmsg = (f"{self.msginfo}: Error interpolating output '{out_name}' "
                           f"because input '{varname_causing_error}' required extrapolation while "
                           f"interpolating dimension {err.idx + 1}, where its value '{err.value}'"
-                          f" exceeded the range ('{ err.lower}', '{err.upper}')")
+                          f" exceeded the range ('{err.lower}', '{err.upper}')")
                 raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()),
                                     self.msginfo)
 

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -212,7 +212,7 @@ class MetaModelStructuredComp(ExplicitComponent):
                 varname_causing_error = '.'.join((self.pathname, self.pnames[err.idx]))
                 errmsg = (f"{self.msginfo}: Error interpolating output '{out_name}' "
                           f"because input '{varname_causing_error}' was out of bounds "
-                          f"('{ err.lower}', '{err.upper}') with value '{err.value}'")
+                          f"('{err.lower}', '{err.upper}') with value '{err.value}'")
                 raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()),
                                     self.msginfo)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2399,7 +2399,7 @@ class Problem(object):
         for c in checks:
             if c not in _all_checks:
                 print(f"WARNING: '{c}' is not a recognized check.  Available checks are: "
-                      f"{ sorted(_all_checks)}")
+                      f"{sorted(_all_checks)}")
                 continue
             logger.info(f'checking {c}')
             _all_checks[c](self, logger)

--- a/openmdao/utils/om_warnings.py
+++ b/openmdao/utils/om_warnings.py
@@ -223,7 +223,7 @@ def _make_table(superclass=OpenMDAOWarning):
     name_header = "Warning Class"
     desc_header = "Description"
     print(f'| {name_header:<{max_name_len}} | {desc_header:<{max_desc_len}} |', file=s)
-    print(f'| {max_name_len*"-"} | {max_desc_len*"-"} |', file=s)
+    print(f'| {max_name_len * "-"} | {max_desc_len * "-"} |', file=s)
 
     for _class in _warnings:
         if isinstance(_class, superclass) or issubclass(_class, superclass):


### PR DESCRIPTION
### Summary

- added a pip install of setuptools to make sure we are starting with the latest version
  - there is in interaction with build_pyoptsparse which may install an older version for older versions of Python
- added the `--upgrade` flag to all pip install commands to make sure we are getting the latest versions
- allowed testing to continue even if playwright fails to install
  - the latest version of playwright (1.38.0) is pinned to greenlet 2.0.2 which does not build properly for python 3.12
  - this should resolve itself when they update playwright
- fixed some new PEP violations due to latest pycodestyle
- pyDOE2 also has a Python 3.12 incompatibility which is causing doc build to fail
  - a [fix](https://github.com/clicumu/pyDOE2/pull/12) has been made it just needs a new release to pypi after which this issue should be resolved

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
