### PR TITLE
Implementation of POEM 038. declare_partials now raises if val == 0

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1159,6 +1159,13 @@ class Component(System):
 
         if dependent:
             meta['val'] = val
+
+            if np.all(val == 0):
+                warn_deprecation(f'{self.msginfo}: d({of})/d({wrt}): Partial was declared to be '
+                                 f'exactly zero. This is inefficient and the declaration should '
+                                 f'be removed. In a future version of OpenMDAO this behavior '
+                                 f'will raise an error.')
+
             if rows is not None:
                 rows = np.array(rows, dtype=INT_DTYPE, copy=False)
                 cols = np.array(cols, dtype=INT_DTYPE, copy=False)

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1160,7 +1160,8 @@ class Component(System):
         if dependent:
             meta['val'] = val
 
-            if np.all(val == 0):
+            _val = val.data if issparse(val) else val
+            if np.all(_val == 0):
                 warn_deprecation(f'{self.msginfo}: d({of})/d({wrt}): Partial was declared to be '
                                  f'exactly zero. This is inefficient and the declaration should '
                                  f'be removed. In a future version of OpenMDAO this behavior '


### PR DESCRIPTION
### Summary

Declaring partials with valeus equal to exactly zero will now result in a deprecation warning, and in the future will result in an error.

### Related Issues

- Resolves #3049

### Backwards incompatibilities

None

### New Dependencies

None

### New Deprecations

`declare_partials` will now raise a deprecation warning if `val` is exactly zero. 