### PR TITLE
Updated baseline dependency versions for Windows testing

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -406,10 +406,10 @@ jobs:
         include:
           # baseline versions
           - NAME: Windows Baseline
-            PY: '3.10'
-            NUMPY: 1.22
-            SCIPY: 1.7
-            PYOPTSPARSE: '2.9.1'
+            PY: '3.11'
+            NUMPY: '1.24'
+            SCIPY: '1.11'
+            PYOPTSPARSE: 'v2.9.2'
 
     name: ${{ matrix.NAME }}
 

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -409,7 +409,7 @@ jobs:
             PY: '3.11'
             NUMPY: '1.24'
             SCIPY: '1.11'
-            PYOPTSPARSE: 'v2.9.2'
+            PYOPTSPARSE: '2.10.1'
 
     name: ${{ matrix.NAME }}
 


### PR DESCRIPTION
### Summary

Updated Windows test to use Python 3.11, Numpy 1.24, Scipy 1.11 and pyOptSparse v2.10.1

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
