### PR TITLE
Changed memleak test to be skipped if coverage is running

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,7 @@
 # .coveragerc to control coverage.py
 
 [run]
-omit =
-    */tests/test_setup_memleak*
+disable_warnings = module-not-measured
 
 [report]
 omit =

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,9 @@
 # .coveragerc to control coverage.py
+
+[run]
+omit =
+    */core/tests/test_setup_memleak.py
+
 [report]
 omit =
     */tests/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,7 @@
 
 [run]
 omit =
-    */core/tests/test_setup_memleak.py
+    */tests/test_setup_memleak*
 
 [report]
 omit =

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -299,7 +299,6 @@ jobs:
           echo "###################################################"
           cp .coveragerc $HOME
           cd $HOME
-          pip install git+https://github.com/swryan/testflo@new_coverage
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage --coverpkg openmdao --durations=20
 
       - name: Submit coverage

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -299,6 +299,7 @@ jobs:
           echo "###################################################"
           cp .coveragerc $HOME
           cd $HOME
+          pip install git+https://github.com/swryan/testflo@new_coverage
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage --coverpkg openmdao --durations=20
 
       - name: Submit coverage

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -42,7 +42,6 @@ class TestSetupMemLeak(unittest.TestCase):
 
         for memtest in ITERS:
             prob.model = SellarMDA()
-            snapshots = []
 
             for i in range(memtest):
                 prob.setup(check=False) # called here causes memory leak

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -1,6 +1,7 @@
 import unittest
 import tracemalloc
 import gc
+import os
 import os.path
 
 import openmdao.api as om
@@ -16,18 +17,7 @@ ITERS = [ 10, 100 ]
 MAX_MEM_DIFF_KB = 200
 
 
-def nocoverage():
-    """
-    Disable coverage for a test case.
-    """
-    def decorator(testcase):
-        testcase.__no_coverage__ = True
-        return testcase
-
-    return decorator
-
-
-@nocoverage()
+@unittest.skipIf(os.environ.get('COVERAGE_RUN') == 'true', "Invalid when running with coverage.")
 class TestSetupMemLeak(unittest.TestCase):
     """ Test for memory leaks when calling setup() multiple times """
 

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -8,7 +8,7 @@ from openmdao.test_suite.components.sellar_feature import SellarMDA
 
 # Compare memory usage after running setup 10 times to
 # running setup 100 times
-ITERS = [ 10, 1000 ]
+ITERS = [ 10, 100 ]
 
 # The code with the leak problem would report a difference of memory
 # used between 10 and 100 iter runs of 36.9MiB. After fixing, it was
@@ -43,18 +43,18 @@ class TestSetupMemLeak(unittest.TestCase):
                 gc.collect()
                 if i == 0:
                     snapshot0 = tracemalloc.take_snapshot()
-                else:
-                    snapshot = tracemalloc.take_snapshot()
-                    top_stats = snapshot.compare_to(snapshot0, 'lineno')
 
-                    total_mem = 0
-                    for stat in top_stats:
-                        tb_str = str(stat.traceback)
-                        # Ignore memory allocations by tracemalloc itself, which throw things off:
-                        if f"{os.path.sep}tracemalloc.py:" not in tb_str:
-                            total_mem += stat.size
+            snapshot = tracemalloc.take_snapshot()
+            top_stats = snapshot.compare_to(snapshot0, 'lineno')
 
-                    mem_used.append(total_mem)
+            total_mem = 0
+            for stat in top_stats:
+                tb_str = str(stat.traceback)
+                # Ignore memory allocations by tracemalloc itself, which throw things off:
+                if f"{os.path.sep}tracemalloc.py:" not in tb_str:
+                    total_mem += stat.size
+
+            mem_used.append(total_mem)
 
         tracemalloc.stop()
         mem_diff = (mem_used[1] - mem_used[0])/1024

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -15,6 +15,19 @@ ITERS = [ 10, 100 ]
 # 0.2 KiB.
 MAX_MEM_DIFF_KB = 200
 
+
+def nocoverage():
+    """
+    Disable coverage for a test case.
+    """
+    def decorator(testcase):
+        testcase.__no_coverage__ = True
+        return testcase
+
+    return decorator
+
+
+@nocoverage()
 class TestSetupMemLeak(unittest.TestCase):
     """ Test for memory leaks when calling setup() multiple times """
 

--- a/openmdao/core/tests/test_setup_memleak.py
+++ b/openmdao/core/tests/test_setup_memleak.py
@@ -8,7 +8,7 @@ from openmdao.test_suite.components.sellar_feature import SellarMDA
 
 # Compare memory usage after running setup 10 times to
 # running setup 100 times
-ITERS = [ 10, 100 ]
+ITERS = [ 10, 1000 ]
 
 # The code with the leak problem would report a difference of memory
 # used between 10 and 100 iter runs of 36.9MiB. After fixing, it was
@@ -41,18 +41,20 @@ class TestSetupMemLeak(unittest.TestCase):
                 # Force garbage collection now instead of waiting for an
                 # optimal/arbitrary point since we're tracking memory usage
                 gc.collect()
-                snapshots.append(tracemalloc.take_snapshot())
+                if i == 0:
+                    snapshot0 = tracemalloc.take_snapshot()
+                else:
+                    snapshot = tracemalloc.take_snapshot()
+                    top_stats = snapshot.compare_to(snapshot0, 'lineno')
 
-            top_stats = snapshots[memtest - 1].compare_to(snapshots[0], 'lineno')
+                    total_mem = 0
+                    for stat in top_stats:
+                        tb_str = str(stat.traceback)
+                        # Ignore memory allocations by tracemalloc itself, which throw things off:
+                        if f"{os.path.sep}tracemalloc.py:" not in tb_str:
+                            total_mem += stat.size
 
-            total_mem = 0
-            for stat in top_stats:
-                tb_str = str(stat.traceback)
-                # Ignore memory allocations by tracemalloc itself, which throw things off:
-                if f"{os.path.sep}tracemalloc.py:" not in tb_str:
-                    total_mem += stat.size
-
-            mem_used.append(total_mem)
+                    mem_used.append(total_mem)
 
         tracemalloc.stop()
         mem_diff = (mem_used[1] - mem_used[0])/1024


### PR DESCRIPTION
### Summary

Changed `test_setup_memleak` test to be skipped if coverage is running.

Also:
- removed some unnecessary snapshot saving in the test
- disable a common warning coming from the new version of coverage

### Related Issues

- Resolves #3054

### Backwards incompatibilities

None

### New Dependencies

None
