### PR TITLE
Added statement to report when constraint bounds are None

### DIFF
--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -679,8 +679,7 @@ def _constraint_plot(kind, meta, val, width=300):
 
     # If lower and upper bounds are None, return an HTML snippet indicating the issue
     if kind == 'constraint' and meta['upper'] == INF_BOUND and meta['lower'] == -INF_BOUND:
-        return '<span class="bounds-unavailable">Both lower and upper bounds are None, ' \
-                   'which is not allowed for a constraint.</span>'
+        return '<span class="bounds-unavailable">Both lower and upper bounds are None.</span>'
 
     if kind == 'desvar' and meta['upper'] == INF_BOUND and meta['lower'] == -INF_BOUND:
         return   # nothing to plot

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -677,6 +677,11 @@ def _constraint_plot(kind, meta, val, width=300):
     else:
         val = val.item()
 
+    # If lower and upper bounds are None, return an HTML snippet indicating the issue
+    if meta['lower'] == -INF_BOUND and meta['upper'] == INF_BOUND:
+        return '<span class="bounds-unavailable">Both lower and upper bounds are None, ' \
+                   'which is not allowed for a constraint.</span>'
+
     if kind == 'desvar' and meta['upper'] == INF_BOUND and meta['lower'] == -INF_BOUND:
         return   # nothing to plot
 
@@ -812,8 +817,6 @@ def var_bounds_plot(kind, ax, value, lower, upper):
     #  - value much greater than upper
 
     # also need to handle one-sided constraints where only one of lower and upper is given
-    if kind == 'constraint' and upper == INF_BOUND and lower == -INF_BOUND:
-        raise ValueError("Upper and lower bounds cannot all be None for a constraint")
 
     # Basic plot setup
     plt.rcParams['hatch.linewidth'] = _out_of_bounds_hatch_width  # can't seem to do this any other

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -678,7 +678,7 @@ def _constraint_plot(kind, meta, val, width=300):
         val = val.item()
 
     # If lower and upper bounds are None, return an HTML snippet indicating the issue
-    if meta['lower'] == -INF_BOUND and meta['upper'] == INF_BOUND:
+    if kind == 'constraint' and meta['upper'] == INF_BOUND and meta['lower'] == -INF_BOUND:
         return '<span class="bounds-unavailable">Both lower and upper bounds are None, ' \
                    'which is not allowed for a constraint.</span>'
 


### PR DESCRIPTION
### Summary

- Added statement to check if constraint upper and lower bounds are None.
- Statement is added to the report stating that both the upper and lower bounds are None.
- Removed raising ValueError if upper and lower bounds for constraint are None.
![image](https://github.com/OpenMDAO/OpenMDAO/assets/112445285/048b6fd7-bed1-4e42-99f0-615e70778415)

### Related Issues

- Resolves #3067 

### Backwards incompatibilities

None

### New Dependencies

None
