### PR TITLE
Allow creation of N2 diagrams for problems that don't exist on global…

### DIFF
--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -641,9 +641,16 @@ def n2(data_source, outfile=_default_n2_filename, path=None, values=_UNDEFINED, 
         err_msg = str(err)
         issue_warning(err_msg)
 
-    # if MPI is active only display one copy of the viewer
-    if MPI and MPI.COMM_WORLD.rank != 0:
-        return
+    # If MPI is active only display one copy of the viewer.
+    # If the data_source is a Problem, only run on the root proc of its comm.
+    # Otherwise, only run on the global root proc.
+    if MPI:
+        try:
+            comm = data_source.comm
+        except AttributeError:
+            comm = MPI.COMM_WORLD
+        if comm.rank != 0:
+            return
 
     options = {}
     model_data['options'] = options


### PR DESCRIPTION
### Summary

Allows the n2 diagram creator to be run for problems that do not exist on the global root proc by running on the root of the problem's comm rather than the root of the global comm.

### Related Issues

- Resolves #3077 

### Backwards incompatibilities

None

### New Dependencies

None
