### PR TITLE
Added a workflow that will check transition a POEM to integrated when a PR is merged

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -10,6 +10,8 @@ on:
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   audit:

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3
+          python-version: 3.11
           conda-version: "*"
           channels: conda-forge,defaults
           channel-priority: true

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -10,6 +10,8 @@ on:
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   tests:

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -11,6 +11,8 @@ on:
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
 
   tests:
@@ -25,10 +27,10 @@ jobs:
           - NAME: Ubuntu Baseline
             OS: ubuntu-latest
             PY: '3.11'
-            NUMPY: '1.24'
+            NUMPY: '1.26'
             SCIPY: '1.11'
             PETSc: '3.18'
-            PYOPTSPARSE: 'v2.9.2'
+            PYOPTSPARSE: 'v2.10.1'
             # PAROPT: true
             SNOPT: '7.7'
             OPTIONAL: '[all]'
@@ -51,10 +53,10 @@ jobs:
           - NAME: MacOS Baseline
             OS: macos-latest
             PY: '3.11'
-            NUMPY: '1.24'
+            NUMPY: '1.26'
             SCIPY: '1.11'
             PETSc: '3.18'
-            # PYOPTSPARSE: 'v2.9.2'
+            # PYOPTSPARSE: 'v2.10.1'
             # PAROPT: true
             # SNOPT: '7.7'
             OPTIONAL: '[all]'
@@ -65,8 +67,8 @@ jobs:
           - NAME: Ubuntu Minimal
             OS: ubuntu-latest
             PY: '3'
-            NUMPY: '1.24'
-            SCIPY: '1.10'
+            NUMPY: '1'
+            SCIPY: '1'
             OPTIONAL: '[test]'
             TESTS: true
 
@@ -88,10 +90,10 @@ jobs:
           - NAME: Build Docs
             OS: ubuntu-latest
             PY: '3.11'
-            NUMPY: '1.24'
-            SCIPY: '1.10'
+            NUMPY: '1.26'
+            SCIPY: '1.11'
             PETSc: '3.18'
-            PYOPTSPARSE: 'v2.9.2'
+            PYOPTSPARSE: 'v2.10.1'
             SNOPT: '7.7'
             OPTIONAL: '[all]'
             JAX: '0.4.14'
@@ -363,7 +365,7 @@ jobs:
       - name: Display doc build reports
         if: failure() && matrix.BUILD_DOCS && steps.build_docs.outcome == 'failure'
         run: |
-          for f in /home/runner/work/OpenMDAO/OpenMDAO/openmdao/docs/openmdao_book/_build/html/reports/*; do
+          for f in $(find /home/runner/work/OpenMDAO/OpenMDAO/openmdao/docs/openmdao_book/_build/html/reports -name '*.log'); do
             echo "============================================================="
             echo $f
             echo "============================================================="

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -66,9 +66,9 @@ jobs:
           # test minimal install
           - NAME: Ubuntu Minimal
             OS: ubuntu-latest
-            PY: '3'
-            NUMPY: '1'
-            SCIPY: '1'
+            PY: '3.11'
+            NUMPY: '1.26'
+            SCIPY: '1.11'
             OPTIONAL: '[test]'
             TESTS: true
 

--- a/.github/workflows/openmdao_update_poem.yml
+++ b/.github/workflows/openmdao_update_poem.yml
@@ -1,0 +1,129 @@
+# When a pull request is opened, check if it resolves an issue that is associated with a POEM
+# When pull request is merged, update the status of any associated POEM to Integrated
+
+name: Check/Update Associated POEM
+
+on:
+  pull_request_target:
+    types: [ opened, closed ]
+    branches: [ master ]
+
+permissions: {}
+
+jobs:
+
+  check_for_poem:
+    if: github.event.action == 'opened' || github.event.pull_request.merged
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+      repository-projects: write
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Display run details
+        run: |
+          echo "============================================================="
+          echo "Run #${GITHUB_RUN_NUMBER}"
+          echo "Run ID: ${GITHUB_RUN_ID}"
+          echo
+          echo "Repository:   ${GITHUB_REPOSITORY}"
+          echo "Triggered by: ${{ github.event_name }} ${{ github.event }}"
+          echo "Initiated by: ${GITHUB_ACTOR}"
+          echo "============================================================="
+
+      - name: Check for Associated POEM
+        id: check_for_poem
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "PULL REQUEST:"
+          echo $BODY
+
+          echo "----------------------"
+
+          while IFS= read -r line; do
+            ISSUE_ID=$(echo $line | grep "Resolves #" -)
+            if [[ "$ISSUE_ID" ]]; then
+              ISSUE_ID=$(echo $ISSUE_ID | cut -d '#' -f 2)
+              break
+            fi
+          done <<< "$BODY"
+
+          ISSUE_ID=$(echo $ISSUE_ID|tr -d '\n\t\r ')
+
+          echo "ISSUE ID: $ISSUE_ID"
+
+          echo "----------------------"
+
+          ISSUE_TEXT=`gh --repo OpenMDAO/OpenMDAO issue view $ISSUE_ID`
+
+          ASSOCIATED_POEM=""
+          POEM_ID=""
+
+          echo "ISSUE:"
+
+          while IFS= read -r line; do
+            echo $line
+            if [[ "$ASSOCIATED_POEM" ]]; then
+              POEM_ID=$(echo $line)
+              if [[ "$POEM_ID" ]]; then
+                break
+              fi
+            else
+              ASSOCIATED_POEM=$(echo $line | grep "Associated POEM" -)
+            fi
+          done <<< "$ISSUE_TEXT"
+
+          if [[ "$POEM_ID" ]]; then
+            echo "----------------------"
+            POEM_ID=$(echo $POEM_ID | tr -d '\n\t\r ')
+            echo "This Pull Request will transition POEM $POEM_ID to Integrated"
+            echo "----------------------"
+          fi
+
+          echo "POEM_ID=$POEM_ID" >> $GITHUB_OUTPUT
+
+      - name: Comment on PR
+        if: github.event.action == 'opened' && steps.check_for_poem.outputs.POEM_ID != ''
+        env:
+          POEM_ID: ${{ steps.check_for_poem.outputs.POEM_ID }}
+          POEM_URL: ${{ github.server_url }}/${{ github.repository_owner }}/POEMs/blob/master/POEM_${{ steps.check_for_poem.outputs.POEM_ID }}.md
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ github.event.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'This pull request will transition [POEM_${{ env.POEM_ID }}](${{ env.POEM_URL }}) to `Integrated`'
+            })
+
+      - name: Slack POEM message
+        if: github.event.action == 'opened' && steps.check_for_poem.outputs.POEM_ID != ''
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: 'warning'
+          message: |
+            Pull Request #${{ github.event.number }} will transition POEM_${{ steps.check_for_poem.outputs.POEM_ID }} to `Integrated`
+            ${{ github.server_url }}/${{ github.repository }}/pull/${{ github.event.number}}
+            ${{ github.server_url }}/${{ github.repository_owner }}/POEMs/blob/master/POEM_091.md
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Update POEM status
+        if: github.event.pull_request.merged == true && steps.check_for_poem.outputs.POEM_ID != ''
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          repo: ${{ github.repository_owner }}/POEMs
+          workflow: Update POEM status to Integrated
+          inputs: '{ "poem_integrated": "${{ steps.check_for_poem.outputs.POEM_ID }}" }'
+          token: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
### Summary

- added the `openmdao_update_poem` workflow
  - this will run when a PR is opened or closed (and merged)
  - when a PR is opened, the `Resolves` tag will be checked to get the associated issue
  - the text of the issue will be checked for an associated POEM
  - If an `Associated POEM` is found:
    -  if PR has just been opened, a message will be sent indicating that the POEM status will be transitioned to Integrated
    -  if PR has just been merged, a workflow_dispatch event will be triggered on the POEMs repo to transition the POEM
  - Note that this relies on PRs and Issues using the prescribed GitHub templates 

Also:
- added an empty permissions dictionary by default for all workflows
- updated NumPy, SciPy and pyOptSparse versions in the test workflow


### Related Issues

- Resolves #3048

### Backwards incompatibilities

None

### New Dependencies

None
