### PR TITLE
Fixed a bug where non-scalar scalers and adders caused exceptions due to any/all ambiguity in Driver.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -447,8 +447,8 @@ class Driver(object):
                 val = np.array([_val]) if np.ndim(_val) == 0 else _val  # Handle discrete desvars
                 idxs = meta['indices']() if meta['indices'] else None
                 flat_idxs = meta['flat_indices']
-                scaler = meta['scaler'] or 1.
-                adder = meta['adder'] or 0.
+                scaler = meta['scaler'] if meta['scaler'] is not None else 1.
+                adder = meta['adder'] if meta['adder'] is not None else 0.
                 lower = meta['lower'] / scaler - adder
                 upper = meta['upper'] / scaler - adder
                 flat_val = val.ravel()[idxs] if flat_idxs else val[idxs].ravel()


### PR DESCRIPTION
### Summary

`Driver. _check_for_invalid_desvar_values` was encountering an exception due to the ambiguity of any/all that is raised by later versions of numpy.

### Related Issues

- Resolves #3081 

### Backwards incompatibilities

None

### New Dependencies

None
