### PR TITLE
Remove unused var opts in _setup_var_data, avoid potential memory waste

### DIFF
--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -144,10 +144,6 @@ class MetaModelStructuredComp(ExplicitComponent):
         Instantiate surrogates for the output variables that use the default surrogate.
         """
         interp_method = self.options['method']
-
-        opts = {}
-        if 'interp_options' in self.options:
-            opts = self.options['interp_options']
         for name, train_data in self.training_outputs.items():
             self.interps[name] = InterpND(method=interp_method,
                                           points=self.inputs, values=train_data,


### PR DESCRIPTION
### Summary
After checking the  _setup_var_data, I verified the opts dictionary is unused.
I remove this variable and the assignment line for this variable.

### Related Issues
- Resolves #2928 
