### PR TITLE
In the Custom report example, make sure the entry point doesn't collide with our default names.

### DIFF
--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -269,7 +269,10 @@
     "        }\n",
     "    ```\n",
     "\n",
-    "    As shown above, report entry points are part of the `openmdao_report` entry point group.\n"
+    "    As shown above, report entry points are part of the `openmdao_report` entry point group.\n",
+    "    \n",
+    "    Note that the name for your entry point needs to be unique. Here, we use the name \"summary_report\" because\n",
+    "    an entry point named \"summary\" already exists for one of the built-in reports.\n"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -264,7 +264,7 @@
     "                \n",
     "                # other report entry points here...\n",
     "                \n",
-    "                'summary=openmdao.devtools.debug:_summary_report_register',\n",
+    "                'summary_report=openmdao.devtools.debug:_summary_report_register',\n",
     "            ],\n",
     "        }\n",
     "    ```\n",
@@ -332,7 +332,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -346,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.0"
+   "version": "3.8.10"
   },
   "orphan": true
  },


### PR DESCRIPTION
### Summary

In the Custom report example, make sure the entry point doesn't collide with our default names.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
