### PR TITLE
Fix an error in the coefficient calculation for 2D slinear interp.

### DIFF
--- a/openmdao/components/interp_util/interp_slinear.py
+++ b/openmdao/components/interp_util/interp_slinear.py
@@ -603,7 +603,7 @@ class Interp2DSlinear(InterpAlgorithmFixed):
 
         a[2] = (c01 - c00) * x1 + (c10 - c11) * x0
 
-        a[3] = c01 + c10 - c11 - c00
+        a[3] = c00 + c11 - c01 - c10
 
         rec_vol = 1.0 / ((x0 - x1) * (y0 - y1))
         return a * rec_vol
@@ -715,7 +715,7 @@ class Interp2DSlinear(InterpAlgorithmFixed):
 
         a[:, 2] = (c01 - c00) * x1 + (c10 - c11) * x0
 
-        a[:, 3] = c01 + c10 - c11 - c00
+        a[:, 3] = c00 + c11 - c01 - c10
 
         rec_vol = 1.0 / ((x0 - x1) * (y0 - y1))
         return np.einsum('i,ij->ij', rec_vol, a)

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -1008,7 +1008,7 @@ class TestInterpNDFixedPython(unittest.TestCase):
 
         # can use meshgrid to create a 3D array of test data
         P1, P2 = np.meshgrid(p1, p2, indexing='ij')
-        f_p = np.sqrt(P1) + (0.1 * P2) ** 2
+        f_p = np.cos(P1 * P2 / 360.0) + (0.01 * P1 * P2) ** 2
 
         x1 = np.linspace(-2, 101, 5)
         x2 = np.linspace(-10.5, 11, 5)


### PR DESCRIPTION
### Summary

We didn't catch this in our unit test because our surface wasn't "interesting" enough. (More specifically, we didn't have any x*y variation.)

### Related Issues

- Resolves #3093

### Backwards incompatibilities

None

### New Dependencies

None
