### PR TITLE
Fixed a bug that caused bounds to not be respected by Nelder-Mead optimizer through ScipyOptimizeDriver.

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -25,7 +25,7 @@ _gradient_optimizers = {'CG', 'BFGS', 'Newton-CG', 'L-BFGS-B', 'TNC', 'SLSQP', '
                         'trust-ncg', 'trust-constr', 'basinhopping', 'shgo'}
 _hessian_optimizers = {'trust-constr', 'trust-ncg'}
 _bounds_optimizers = {'L-BFGS-B', 'TNC', 'SLSQP', 'trust-constr', 'dual_annealing', 'shgo',
-                      'differential_evolution', 'basinhopping'}
+                      'differential_evolution', 'basinhopping', 'Nelder-Mead'}
 if Version(scipy_version) >= Version("1.11"):
     # COBYLA supports bounds starting with SciPy Version 1.11
     _bounds_optimizers |= {'COBYLA'}


### PR DESCRIPTION
### Summary

Nelder-Mead previously did not respect design variable bounds because it was not included in the set of bounds-supporting optimizers.

### Related Issues

- Resolves #3095

### Backwards incompatibilities

None

### New Dependencies

None
