### PR TITLE
Changed the error when attempting to set_val on a remote connected input to a warning

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5397,9 +5397,11 @@ class System(object):
                                     model._outputs.set_var(src, value, src_indices.apply(indices),
                                                            True, var_name=var_name)
                         else:
-                            raise RuntimeError(f"{model.msginfo}: Can't set {abs_name}: remote"
-                                               " connected inputs with src_indices currently not"
-                                               " supported.")
+                            issue_warning(f"{model.msginfo}: Cannot set the value of '{abs_name}':"
+                                          " Setting the value of a remote connected input with"
+                                          " src_indices is currently not supported, you must call"
+                                          " `run_model()` to have the outputs populate their"
+                                          " corresponding inputs.")
                     else:
                         value = np.asarray(value)
                         if indices is not _full_slice:

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -39,6 +39,7 @@ def assert_warning(category, msg, contains_msg=False, ranks=None):
         Set to True to check that the warning text contains msg, rather than checking equality.
     ranks : int or list of int, optional
         The global ranks on which the warning is expected.
+
     Yields
     ------
     None

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -21,10 +21,11 @@ from openmdao.core.group import Group
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.general_utils import pad_name
 from openmdao.utils.om_warnings import reset_warning_registry
+from openmdao.utils.mpi import MPI
 
 
 @contextmanager
-def assert_warning(category, msg, contains_msg=False):
+def assert_warning(category, msg, contains_msg=False, ranks=None):
     """
     Context manager asserting that a warning is issued.
 
@@ -36,7 +37,8 @@ def assert_warning(category, msg, contains_msg=False):
         The text of the expected warning.
     contains_msg : bool
         Set to True to check that the warning text contains msg, rather than checking equality.
-
+    ranks : int or list of int, optional
+        The global ranks on which the warning is expected.
     Yields
     ------
     None
@@ -50,6 +52,15 @@ def assert_warning(category, msg, contains_msg=False):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             yield
+
+    if ranks is not None:
+        if MPI is None:
+            raise RuntimeError("ranks argument has been specified but MPI is not active")
+        else:
+            if not isinstance(ranks, list):
+                ranks = [ranks]
+            if MPI.COMM_WORLD.rank not in ranks:
+                return
 
     for warn in w:
         if contains_msg:


### PR DESCRIPTION
### Summary

Changed the error when attempting to `set_val` on a remote connected input to a warning.

Also:
- added a test
- added a `ranks` argument to the `assert_warning` function for use when a warning is expected on only a subset of ranks.

### Related Issues

- Resolves #3061

### Backwards incompatibilities

None

### New Dependencies

None
