### PR TITLE
remove extraneous code; update CI to use conda-forge only

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -49,8 +49,7 @@ jobs:
         with:
           python-version: 3.11
           conda-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          channels: conda-forge
 
       - name: Install lxml
         if: matrix.OS == 'windows-latest'

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -69,7 +69,6 @@ jobs:
           python-version: ${{ matrix.PY }}
           conda-version: "*"
           channels: conda-forge
-          channel-priority: true
 
       - name: Install OpenMDAO
         run: |

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -467,8 +467,7 @@ jobs:
         with:
           python-version: ${{ matrix.PY }}
           conda-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          channels: conda-forge
 
       - name: Install OpenDMAO
         run: |

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -145,9 +145,6 @@ class MetaModelStructuredComp(ExplicitComponent):
         """
         interp_method = self.options['method']
 
-        opts = {}
-        if 'interp_options' in self.options:
-            opts = self.options['interp_options']
         for name, train_data in self.training_outputs.items():
             self.interps[name] = InterpND(method=interp_method,
                                           points=self.inputs, values=train_data,


### PR DESCRIPTION
### Summary

Removed extraneous code, per PR #3086 but without the unrelated `units` changes.

Also, limited the GitHub workflows to use just the `conda-forge` channel for dependencies.

### Related Issues

- Resolves #2928 

### Backwards incompatibilities

None

### New Dependencies

None
