### PR TITLE
Fixed bug: `list_problem_vars` was writing to the incorrect `out_stream`

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2088,7 +2088,7 @@ class Problem(object):
             self._write_var_info_table(header, col_names, desvars, vals,
                                        show_promoted_name=show_promoted_name,
                                        print_arrays=print_arrays,
-                                       col_spacing=2)
+                                       col_spacing=2, out_stream=out_stream)
 
         des_vars = [[i, j] for i, j in desvars.items()]
         for d in des_vars:
@@ -2108,7 +2108,7 @@ class Problem(object):
             self._write_var_info_table(header, col_names, cons, vals,
                                        show_promoted_name=show_promoted_name,
                                        print_arrays=print_arrays,
-                                       col_spacing=2)
+                                       col_spacing=2, out_stream=out_stream)
 
         cons_vars = [[i, j] for i, j in cons.items()]
         for c in cons_vars:
@@ -2126,7 +2126,7 @@ class Problem(object):
             self._write_var_info_table(header, col_names, objs, vals,
                                        show_promoted_name=show_promoted_name,
                                        print_arrays=print_arrays,
-                                       col_spacing=2)
+                                       col_spacing=2, out_stream=out_stream)
 
         obj_vars = [[i, j] for i, j in objs.items()]
         for o in obj_vars:


### PR DESCRIPTION
### Summary

**Problem**: This `list_problem_vars` attribute of an OpenMDAO `Problem` has an `out_stream` argument where the user can specify the stream to write output to. However, this `out_stream` was never passed to `_write_var_info_table`, the method that actually writes to the `out_stream`. Thus, it was always using the default standard out.

**Fix**: I added the `out_stream` variable to the three calls to `_write_var_info_table`.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
