### PR TITLE
ScipyKrylov will no longer return an invalid solution if the solver did not converge

### DIFF
--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
@@ -95,7 +95,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np \n",
+    "import numpy as np\n",
     "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
     "\n",
@@ -190,8 +190,7 @@
     "  may have to raise it if you have an extremely large number of components in your system (a 1000-component\n",
     "  ring would need 1000 iterations just to make it around once.)\n",
     "\n",
-    "  This example shows what happens if you set maxiter too low (the derivatives should be nonzero, but it stops too\n",
-    "  soon.)"
+    "  This example shows what happens if you set `maxiter` too low. Since iteration is terminated after only 3 iterations, the solver does not converge and the derivatives will not be correct."
    ]
   },
   {
@@ -244,18 +243,55 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Depending on your situation, you may want to set the `err_on_non_converge` option to `True`, so that this will raise an AnalysisError."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "tags": [
-     "remove-input",
-     "remove-output"
-    ]
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "assert_near_equal(J['obj', 'z'][0][0], 0.0, .00001)\n",
-    "assert_near_equal(J['obj', 'z'][0][1], 0.0, .00001)"
+    "from openmdao.test_suite.components.sellar import SellarDis1withDerivatives, SellarDis2withDerivatives\n",
+    "from openmdao.api import AnalysisError\n",
+    "\n",
+    "prob = om.Problem()\n",
+    "model = prob.model\n",
+    "\n",
+    "model.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])\n",
+    "model.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])\n",
+    "\n",
+    "model.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',\n",
+    "                                           z=np.array([0.0, 0.0]), x=0.0),\n",
+    "                    promotes=['obj', 'x', 'z', 'y1', 'y2'])\n",
+    "\n",
+    "model.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1'), promotes=['con1', 'y1'])\n",
+    "model.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0'), promotes=['con2', 'y2'])\n",
+    "\n",
+    "model.nonlinear_solver = om.NonlinearBlockGS()\n",
+    "\n",
+    "model.linear_solver = om.ScipyKrylov()\n",
+    "model.linear_solver.options['maxiter'] = 3\n",
+    "model.linear_solver.options['err_on_non_converge'] = True\n",
+    "\n",
+    "prob.setup()\n",
+    "\n",
+    "prob.set_val('x', 1.)\n",
+    "prob.set_val('z', np.array([5.0, 2.0]))\n",
+    "\n",
+    "prob.run_model()\n",
+    "\n",
+    "wrt = ['z']\n",
+    "of = ['obj']\n",
+    "\n",
+    "try:\n",
+    "    J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')\n",
+    "except AnalysisError as err:\n",
+    "    # Special handling for a failure to converge when computing derivatives\n",
+    "    print(\"===\\nLinear Solver failed to converge, derivatives are not valid.\\n===\")"
    ]
   },
   {
@@ -458,7 +494,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -472,7 +508,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.12.1"
   },
   "orphan": true
  },

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -377,7 +377,11 @@ class PETScKrylov(LinearSolver):
         # stuff the result into the x vector
         x_vec.set_val(sol_array)
 
-        if not self._ksp.converged:
+        # as of petsc4py v3.20, the 'converged' attribute has been renamed to 'is_converged'
+        if hasattr(self._ksp, 'is_converged'):
+            if not self._ksp.is_converged:
+                self._convergence_failure()
+        elif not self._ksp.converged:
             self._convergence_failure()
 
         sol_petsc_vec = rhs_petsc_vec = None

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -377,6 +377,9 @@ class PETScKrylov(LinearSolver):
         # stuff the result into the x vector
         x_vec.set_val(sol_array)
 
+        if not self._ksp.converged:
+            self._convergence_failure()
+
         sol_petsc_vec = rhs_petsc_vec = None
 
     def apply(self, mat, in_vec, result):

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -476,6 +476,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
 
         model.linear_solver = om.PETScKrylov()
         model.linear_solver.options['maxiter'] = 3
+        model.linear_solver.options['err_on_non_converge'] = True
 
         prob.setup()
 
@@ -487,9 +488,11 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         wrt = ['z']
         of = ['obj']
 
-        J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_near_equal(J['obj', 'z'][0][0], 4.93218027, .00001)
-        assert_near_equal(J['obj', 'z'][0][1], 1.73406455, .00001)
+        with self.assertRaises(om.AnalysisError) as cm:
+            J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+
+        msg = "Solver 'LN: PETScKrylov' on system '' failed to converge in 4 iterations."
+        self.assertEqual(str(cm.exception), msg)
 
     def test_feature_atol(self):
 

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -267,6 +267,7 @@ class TestScipyKrylovFeature(unittest.TestCase):
 
         model.linear_solver = om.ScipyKrylov()
         model.linear_solver.options['maxiter'] = 3
+        model.linear_solver.options['err_on_non_converge'] = True
 
         prob.setup()
 
@@ -278,9 +279,11 @@ class TestScipyKrylovFeature(unittest.TestCase):
         wrt = ['z']
         of = ['obj']
 
-        J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
-        assert_near_equal(J['obj', 'z'][0][0], 0.0, .00001)
-        assert_near_equal(J['obj', 'z'][0][1], 0.0, .00001)
+        with self.assertRaises(om.AnalysisError) as cm:
+            J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+
+        msg = "Solver 'LN: SCIPY' on system '' failed to converge in 3 iterations."
+        self.assertEqual(str(cm.exception), msg)
 
     def test_feature_atol(self):
 


### PR DESCRIPTION
### Summary

ScipyKrylov will no longer return an invalid solution if the solver did not converge. Instead it will report the failure to converge and optionally raise an AnalysisError if the `err_on_non_converge` option is set.

Also:
- updated tests
- updated docs
- updated PETScKrylov to handle attribute name change in petsc4py 3.20

### Related Issues

- Resolves #3106

### Backwards incompatibilities

None

### New Dependencies

None
