### PR TITLE
Corrected documentation about use of compute_partials and compute_jacvec_product

### DIFF
--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
@@ -168,7 +168,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the last two are optional, because the class can implement `compute_partials` and/or `compute_jacvec_product`, or neither if the user wants to use the finite-difference or complex-step method."
+    "Note that the last two are optional. A user may use finite-difference or complex-step methods, in which case these methods are not necessary. For efficiency reasons, OpenMDAO does both allow components to implement both `compute_partials` _and_ `compute_jacvec_product`."
    ]
   }
  ],

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_components/explicit_component.ipynb
@@ -168,7 +168,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that the last two are optional. A user may use finite-difference or complex-step methods, in which case these methods are not necessary. For efficiency reasons, OpenMDAO does both allow components to implement both `compute_partials` _and_ `compute_jacvec_product`."
+    "Note that the last two are optional. A user may use finite-difference or complex-step methods, in which case these methods are not necessary. For efficiency reasons, OpenMDAO does not allow components to implement both `compute_partials` _and_ `compute_jacvec_product`."
    ]
   }
  ],


### PR DESCRIPTION
### Summary

The documentation of ExplicitComponent is outdated and states that a component may implement both `compute_partials` and `compute_jacvec_product`.  This is no longer the case.

### Related Issues

- Resolves #3105 

### Backwards incompatibilities

None

### New Dependencies

None
