### PR TITLE
Disabled tests that use the `MissingImports` decorator

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -318,7 +318,9 @@ jobs:
           testflo -n 2 openmdao --timeout=240 --show_skipped --coverage --coverpkg openmdao --durations=20
 
       - name: Submit coverage
+        id: coveralls
         if: matrix.TESTS
+        continue-on-error: true
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_SERVICE_NAME: "github"
@@ -331,6 +333,16 @@ jobs:
           python -m pip install coveralls
           SITE_DIR=`python -c 'import site; print(site.getsitepackages()[-1])'`
           coveralls --basedir $SITE_DIR
+
+      - name: Slack failure to upload to coveralls.io
+        if: steps.coveralls.outcome == 'failure'
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: 'warning'
+          message: |
+            Uploading of coverage data to coveralls.io failed.
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Build docs
         if: matrix.BUILD_DOCS

--- a/openmdao/utils/tests/test_testing_utils.py
+++ b/openmdao/utils/tests/test_testing_utils.py
@@ -4,6 +4,7 @@ from openmdao.utils.testing_utils import use_tempdirs, MissingImports
 
 
 @use_tempdirs
+@unittest.skip("Turns out messing with builtins.__import__ really is a bad idea.")
 class TestMissingImports(unittest.TestCase):
 
     def test_missing_imports_cm(self):


### PR DESCRIPTION
### Summary

Disabled tests that use the `MissingImports` decorator.  This is not safe to use in a multi-threaded environment such as with testflo.

Per the docsrtring:

https://github.com/OpenMDAO/OpenMDAO/blob/848cc9b5fbe1e2d6ac82bcbe45c0a7963bfec7cf/openmdao/utils/testing_utils.py#L299-L301


Also:
- updated the test workflow to not fail if there are problems uploading to [coveralls.io](https://coveralls.io/github/OpenMDAO/OpenMDAO), which happens sometimes.  Instead it will just issue a warning via slack.

### Related Issues

- Resolves #3109

### Backwards incompatibilities

None

### New Dependencies

None
