### PR TITLE
Added option `stall_tol_type` to Nonlinear solvers

### DIFF
--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/broyden.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/broyden.ipynb
@@ -419,7 +419,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**stall_limit and stall_tol**\n",
+    "**stall_limit, stall_tol, and stall_tol_type **\n",
     "\n",
     "  In some cases, nonlinear solvers can stall out where the norm of the residual stops changing at all. This\n",
     "  can happen for a couple of reasons. You can hit numerical noise problems and just be wandering around in\n",
@@ -434,7 +434,8 @@
     "  to True, then an ``AnalysisError`` will be raised just as if we had reached the iteration count limit.\n",
     "\n",
     "  We also set the `stall_tol` to 1e-6, which is the threshold below which a change in the relative residual\n",
-    "  norm is considered to be unchanged."
+    "  norm is considered to be unchanged. The option also exists to use the absolute residual norm by setting\n",
+    "  `stall_tol_type` to `'abs'`."
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/newton.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/newton.ipynb
@@ -635,7 +635,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**stall_limit and stall_tol**\n",
+    "**stall_limit, stall_tol, and stall_tol_type **\n",
     "\n",
     "  In some cases, nonlinear solvers can stall out where the norm of the residual stops changing at all. This\n",
     "  can happen for a couple of reasons. You can hit numerical noise problems and just be wandering around in\n",
@@ -650,7 +650,12 @@
     "  to True, then an ``AnalysisError`` will be raised just as if we had reached the iteration count limit.\n",
     "\n",
     "  We also set the `stall_tol` to 1e-6, which is the threshold below which a change in the relative residual\n",
-    "  norm is considered to be unchanged."
+    "  norm is considered to be unchanged.\n",
+    "\n",
+    "  The option `stall_tol_type` is used to specify whether the absolute or relative norm of the residual is\n",
+    "  used to detect a stall condition. If an outer solver is used in conjunction with `solve_subsystems`, the\n",
+    "  relative change in the residual norm will be small for those residuals converged by the inner solver.\n",
+    "  In such cases, setting this option to 'abs' may more reliably detect a stall."
    ]
   },
   {
@@ -671,6 +676,7 @@
     "newton.options['solve_subsystems'] = True\n",
     "newton.options['stall_limit'] = 3\n",
     "newton.options['stall_tol'] = 1e-8\n",
+    "newton.options['stall_tol_type'] = 'abs'\n",
     "newton.options['maxiter'] = 100\n",
     "\n",
     "prob.model.linear_solver = om.DirectSolver()\n",
@@ -878,7 +884,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.11.4"
   },
   "orphan": true,
   "vscode": {

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -586,6 +586,9 @@ class NonlinearSolver(Solver):
         self.options.declare('stall_tol', default=1e-12,
                              desc='When stall checking is enabled, the threshold below which the '
                                   'residual norm is considered unchanged.')
+        self.options.declare('stall_tol_type', default='rel', values=('abs', 'rel'),
+                             desc='Specifies whether the absolute or relative norm of the '
+                                  'residual is used for stall detection.')
         self.options.declare('restart_from_successful', types=bool, default=False,
                              desc='If True, the states are cached after a successful solve and '
                                   'used to restart the solver in the case of a failed solve.')
@@ -657,6 +660,7 @@ class NonlinearSolver(Solver):
         iprint = self.options['iprint']
         stall_limit = self.options['stall_limit']
         stall_tol = self.options['stall_tol']
+        stall_tol_type = self.options['stall_tol_type']
 
         self._mpi_print_header()
 
@@ -717,15 +721,15 @@ class NonlinearSolver(Solver):
 
                 # Check if convergence is stalled.
                 if stall_limit > 0:
-                    rel_norm = rec.rel
-                    norm_diff = np.abs(stall_norm - rel_norm)
+                    norm_for_stall = rec.rel if stall_tol_type == 'rel' else rec.abs
+                    norm_diff = np.abs(stall_norm - norm_for_stall)
                     if norm_diff <= stall_tol:
                         stall_count += 1
                         if stall_count >= stall_limit:
                             stalled = True
                     else:
                         stall_count = 0
-                        stall_norm = rel_norm
+                        stall_norm = norm_for_stall
 
             self._mpi_print(self._iter_count, norm, norm / norm0)
 


### PR DESCRIPTION
### Summary

The nonlinear solvers now have an option `stall_tol_type` which can be `'abs'` or `'rel'`.
This option determines whether the `stall_tol` specified by the user is the absolute or relative
residual norm.

### Related Issues

- Resolves #3100

### Backwards incompatibilities

None

### New Dependencies

None
