### PR TITLE
updated ScipyKrylov for SciPy 1.12.0, updated 'latest' workflow

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -1,0 +1,112 @@
+# this script will populate a conda environment with the latest versions
+# (including pre-release versions) of all OpenMDAO dependencies
+
+conda upgrade -c conda-forge --all -y
+
+echo "============================================================="
+echo "Upgrade to latest pip"
+echo "============================================================="
+python -m pip install --upgrade pip
+
+echo "============================================================="
+echo "Install latest setuptools"
+echo "============================================================="
+python -m pip install --upgrade --pre setuptools
+
+echo "============================================================="
+echo "Install latest versions of NumPy/SciPy"
+echo "============================================================="
+python -m pip install --upgrade --pre numpy
+python -m pip install --upgrade --pre scipy
+
+# remember versions so we can check them later
+NUMPY_VER=`python -c "import numpy; print(numpy.__version__)"`
+SCIPY_VER=`python -c "import scipy; print(scipy.__version__)"`
+echo "NUMPY_VER=$NUMPY_VER" >> $GITHUB_ENV
+echo "SCIPY_VER=$SCIPY_VER" >> $GITHUB_ENV
+
+echo "============================================================="
+echo "Install latest versions of 'required' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre networkx
+python -m pip install --upgrade --pre requests
+python -m pip install --upgrade --pre packaging
+
+echo "============================================================="
+echo "Install latest versions of 'docs' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre matplotlib
+python -m pip install --upgrade --pre numpydoc
+python -m pip install --upgrade --pre jupyter-book
+python -m pip install --upgrade --pre sphinx-sitemap
+python -m pip install --upgrade --pre ipyparallel
+
+echo "============================================================="
+echo "Install latest versions of 'doe' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre pyDOE3
+
+echo "============================================================="
+echo "Install latest versions of 'notebooks' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre notebook
+python -m pip install --upgrade --pre ipympl
+
+echo "============================================================="
+echo "Install latest versions of 'visualization' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre bokeh
+python -m pip install --upgrade --pre colorama
+
+echo "============================================================="
+echo "Install latest versions of 'test' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre parameterized
+python -m pip install --upgrade --pre numpydoc
+python -m pip install --upgrade --pre pycodestyle
+python -m pip install --upgrade --pre pydocstyle
+python -m pip install --upgrade --pre testflo
+python -m pip install --upgrade --pre websockets
+python -m pip install --upgrade --pre aiounittest
+echo "the latest version of playwright (1.38.0) is pinned to"
+echo "greenlet 2.0.2 which does not build properly for python 3.12"
+echo "https://github.com/microsoft/playwright-python/issues/2096"
+python -m pip install --upgrade --pre playwright  || echo "Skipping playwright, no GUI testing!"
+python -m pip install --upgrade --pre num2words
+
+echo "============================================================="
+echo "Install latest versions of other optional packages"
+echo "============================================================="
+python -m pip install --upgrade --pre pyparsing psutil objgraph pyxdsm
+python -m pip install --upgrade --pre jax jaxlib
+
+echo "============================================================="
+echo "Install latest PETSc"
+echo "============================================================="
+conda install mpi4py petsc petsc4py -q -y
+
+echo "============================================================="
+echo "Check MPI and PETSc installation"
+echo "============================================================="
+export OMPI_MCA_rmaps_base_oversubscribe=1
+export OMPI_MCA_btl=^openib
+
+echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
+echo "OMPI_MCA_btl=^openib" >> $GITHUB_ENV
+
+echo "-----------------------"
+echo "Quick test of mpi4py:"
+mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
+echo "-----------------------"
+echo "Quick test of petsc4py:"
+mpirun -n 3 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; \
+                       import petsc4py; petsc4py.init(); \
+                       x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  \
+                       print(x.getArray())"
+echo "-----------------------"
+
+echo "============================================================="
+echo "Display conda environment"
+echo "============================================================="
+conda info
+conda list

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -3,12 +3,19 @@ name: OpenMDAO Latest
 
 on:
 
-  # Run the workflow Monday, Wednesday and Friday at 0400 UTC
+  # Run the workflow every Monday and Thursday at 0400 UTC
   schedule:
-    - cron: '0 4 * * 1,3,5'
+    - cron: '0 4 * * 1,4'
 
   # Allow running the workflow manually from the Actions tab
   workflow_dispatch:
+
+   inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
 
 permissions: {}
 
@@ -70,13 +77,12 @@ jobs:
           conda-version: "*"
           channels: conda-forge
 
-      - name: Install OpenMDAO
+      - name: Install latest versions of [all] openmdao dependencies
         run: |
-          echo "============================================================="
-          echo "Upgrade conda environment to latest"
-          echo "============================================================="
-          conda upgrade -c conda-forge --all
+          source .github/scripts/install_latest_deps.sh
 
+      - name: Install pyOptSparse
+        run: |
           echo "============================================================="
           echo "Define useful functions"
           echo "============================================================="
@@ -90,76 +96,6 @@ jobs:
             local LATEST_VER=$(latest_version $1)
             echo git+$1@$LATEST_VER
           }
-
-          echo "============================================================="
-          echo "Upgrade to latest pip"
-          echo "============================================================="
-          python -m pip install --upgrade pip
-
-          echo "============================================================="
-          echo "Install latest setuptools"
-          echo "============================================================="
-          python -m pip install --upgrade --pre setuptools
-
-          echo "============================================================="
-          echo "Install latest versions of NumPy/SciPy"
-          echo "============================================================="
-          python -m pip install --upgrade --pre numpy
-          python -m pip install --upgrade --pre scipy
-
-          # remember versions so we can check them later
-          NUMPY_VER=`python -c "import numpy; print(numpy.__version__)"`
-          SCIPY_VER=`python -c "import scipy; print(scipy.__version__)"`
-          echo "NUMPY_VER=$NUMPY_VER" >> $GITHUB_ENV
-          echo "SCIPY_VER=$SCIPY_VER" >> $GITHUB_ENV
-
-          echo "============================================================="
-          echo "Install latest versions of 'docs' dependencies"
-          echo "============================================================="
-          python -m pip install --upgrade --pre matplotlib
-          python -m pip install --upgrade --pre numpydoc
-          python -m pip install --upgrade --pre jupyter-book
-          python -m pip install --upgrade --pre sphinx-sitemap
-          python -m pip install --upgrade --pre ipyparallel
-
-          echo "============================================================="
-          echo "Install latest versions of 'doe' dependencies"
-          echo "============================================================="
-          python -m pip install --upgrade --pre pyDOE3
-
-          echo "============================================================="
-          echo "Install latest versions of 'notebooks' dependencies"
-          echo "============================================================="
-          python -m pip install --upgrade --pre notebook
-          python -m pip install --upgrade --pre ipympl
-
-          echo "============================================================="
-          echo "Install latest versions of 'visualization' dependencies"
-          echo "============================================================="
-          python -m pip install --upgrade --pre bokeh
-          python -m pip install --upgrade --pre colorama
-
-          echo "============================================================="
-          echo "Install latest versions of 'test' dependencies"
-          echo "============================================================="
-          python -m pip install --upgrade --pre parameterized
-          python -m pip install --upgrade --pre numpydoc
-          python -m pip install --upgrade --pre pycodestyle
-          python -m pip install --upgrade --pre pydocstyle
-          python -m pip install --upgrade --pre testflo
-          python -m pip install --upgrade --pre websockets
-          python -m pip install --upgrade --pre aiounittest
-          echo "the latest version of playwright (1.38.0) is pinned to"
-          echo "greenlet 2.0.2 which does not build properly for python 3.12"
-          echo "https://github.com/microsoft/playwright-python/issues/2096"
-          python -m pip install --upgrade --pre playwright  || echo "Skipping playwright, no GUI testing!"
-          python -m pip install --upgrade --pre num2words
-
-          echo "============================================================="
-          echo "Install latest versions of other optional packages"
-          echo "============================================================="
-          python -m pip install --upgrade --pre pyparsing psutil objgraph pyxdsm
-          python -m pip install --upgrade --pre jax jaxlib
 
           echo "============================================================="
           echo "Install latest pyoptsparse"
@@ -176,43 +112,16 @@ jobs:
           fi
           build_pyoptsparse $BRANCH $SNOPT
 
+      - name: Install OpenMDAO
+        run: |
           echo "============================================================="
           echo "Install OpenMDAO"
           echo "============================================================="
           python -m pip install .
 
-      - name: Install PETSc
-        if: matrix.PETSc
-        run: |
-          echo "============================================================="
-          echo "Install latest PETSc"
-          echo "============================================================="
-          conda install mpi4py petsc petsc4py -q -y --freeze-installed
-
-          echo "============================================================="
-          echo "Check MPI and PETSc installation"
-          echo "============================================================="
-          export OMPI_MCA_rmaps_base_oversubscribe=1
-          echo "-----------------------"
-          echo "Quick test of mpi4py:"
-          mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
-          echo "-----------------------"
-          echo "Quick test of petsc4py:"
-          mpirun -n 3 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; \
-                                 import petsc4py; petsc4py.init(); \
-                                 x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  \
-                                 print(x.getArray())"
-          echo "-----------------------"
-
-          echo "============================================================="
-          echo "Export MPI-related environment variables"
-          echo "============================================================="
-          echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
-          echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
-          echo "TMPDIR=/tmp" >> $GITHUB_ENV
-
       - name: Display environment info
         id: env_info
+        if: always()
         continue-on-error: true
         run: |
           conda info
@@ -242,7 +151,18 @@ jobs:
 
           grep changed $GITHUB_OUTPUT || echo ""
 
-        if: always()
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      #
+      # To access the terminal through the web-interface:
+      #    1. Click on the web-browser link printed out in this action from the github
+      #       workflow terminal
+      #    2. Press cntrl + c in the new tab that opens up to reveal the terminal
+      #    3. To activate the conda environment run:
+      #        $ source $CONDA/etc/profile.d/conda.sh
+      #        $ conda activate test
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
 
       - name: Run tests
         id: run_tests
@@ -359,3 +279,20 @@ jobs:
             Deprecations were detected on `Latest` build.
             ```${{ steps.deprecations_report.outputs.summary }}```
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Fail the workflow if tests or doc build failed
+        if: steps.run_tests.outcome == 'failure' || steps.build_docs.outcome == 'failure'
+        uses: actions/github-script@v3
+        with:
+          script: |
+              let test_fail = ${{ steps.run_tests.outcome == 'failure' }};
+              let docs_fail = ${{ steps.build_docs.outcome == 'failure' }};
+              if (test_fail && docs_fail) {
+                  core.setFailed('Tests and doc build failed.');
+              }
+              else if (test_fail) {
+                  core.setFailed('Tests failed.');
+              }
+              else if (docs_fail) {
+                  core.setFailed('Doc build failed.');
+              }

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -194,6 +194,7 @@ jobs:
           echo "Check MPI and PETSc installation"
           echo "============================================================="
           export OMPI_MCA_rmaps_base_oversubscribe=1
+          export OMPI_MCA_btl=^openib
           echo "-----------------------"
           echo "Quick test of mpi4py:"
           mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
@@ -206,6 +207,7 @@ jobs:
           echo "-----------------------"
 
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
+          echo "OMPI_MCA_btl=^openib" >> $GITHUB_ENV
 
           echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
           echo "TMPDIR=/tmp" >> $GITHUB_ENV

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -65,11 +65,10 @@ class CacheLinearTestCase(unittest.TestCase):
             def solve_linear(self, d_outputs, d_residuals, mode):
 
                 if mode == 'fwd':
-                    print("incoming initial guess", d_outputs['states'])
-                    d_outputs['states'] = gmres(self.state_jac, d_residuals['states'], x0=d_outputs['states'], atol='legacy')[0]
+                    d_outputs['states'] = gmres(self.state_jac, d_residuals['states'], x0=d_outputs['states'], atol=0)[0]
 
                 elif mode == 'rev':
-                    d_residuals['states'] = gmres(self.state_jac, d_outputs['states'], x0=d_residuals['states'], atol='legacy')[0]
+                    d_residuals['states'] = gmres(self.state_jac, d_outputs['states'], x0=d_residuals['states'], atol=0)[0]
 
         p = om.Problem()
         p.driver = om.ScipyOptimizeDriver()

--- a/openmdao/docs/ipcluster_start.sh
+++ b/openmdao/docs/ipcluster_start.sh
@@ -4,6 +4,7 @@ echo "additional setup to run MPI under notebooks"
 echo "============================================================="
 
 export OMPI_MCA_rmaps_base_oversubscribe=1
+export OMPI_MCA_btl=^openib
 
 CFG_FILE="$HOME/.ipython/profile_mpi/ipcluster_config.py"
 if [[ -f "$CFG_FILE" ]]; then

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
@@ -379,7 +379,7 @@
    "source": [
     "**rtol**\n",
     "\n",
-    "  The 'rtol' setting is not supported by Scipy GMRES.\n",
+    "  The 'rtol' setting is not supported by SciPy GMRES for versions earlier than SciPy 1.12.0.\n",
     "\n",
     "## Specifying a Preconditioner\n",
     "\n",

--- a/openmdao/solvers/linear/scipy_iter_solver.py
+++ b/openmdao/solvers/linear/scipy_iter_solver.py
@@ -197,6 +197,7 @@ class ScipyKrylov(LinearSolver):
 
         maxiter = self.options['maxiter']
         atol = self.options['atol']
+        rtol = self.options['rtol']
 
         if mode == 'fwd':
             x_vec = system._doutputs
@@ -217,13 +218,13 @@ class ScipyKrylov(LinearSolver):
 
         self._iter_count = 0
         if solver is gmres:
-            if Version(scipy.__version__) < Version("1.1"):
+            if Version(Version(scipy.__version__).base_version) < Version("1.12"):
                 x, info = solver(linop, b_vec.asarray(True), M=M, restart=restart,
                                  x0=x_vec_combined, maxiter=maxiter, tol=atol, atol='legacy',
                                  callback=self._monitor, callback_type='legacy')
             else:
                 x, info = solver(linop, b_vec.asarray(True), M=M, restart=restart,
-                                 x0=x_vec_combined, maxiter=maxiter, tol=atol, atol='legacy',
+                                 x0=x_vec_combined, maxiter=maxiter, atol=atol, rtol=rtol,
                                  callback=self._monitor, callback_type='legacy')
         else:
             x, info = solver(linop, b_vec.asarray(True), M=M,

--- a/openmdao/solvers/tests/test_solver_iprint.py
+++ b/openmdao/solvers/tests/test_solver_iprint.py
@@ -92,7 +92,7 @@ class TestSolverPrint(unittest.TestCase):
 
     def test_feature_iprint_1(self, stdout=None):
 
-        prob = om.Problem()
+        self.prob = prob = om.Problem()
         prob.model = SellarDerivatives()
 
         prob.setup()
@@ -118,9 +118,11 @@ class TestSolverPrint(unittest.TestCase):
         finally:
             sys.stdout = old_stdout
 
+        iters = self.prob.model.nonlinear_solver._iter_count
+
         # Verify output
         self.assertEqual(str_out.getvalue().strip(),
-                         "NL: Newton Converged in 2 iterations")
+                         f"NL: Newton Converged in {iters} iterations")
 
     def test_feature_iprint_2(self):
 


### PR DESCRIPTION
### Summary

Updated the ScipyKrylov solver to address changes in SciPy tolerance arguments in SciPy 1.12.0

Also made some improvements to the 'Latest' workflow:
- captured the steps to build the 'latest' environment in a bash script for easy reuse
- added the option for interactive debugging via tmate
- changed the cron schedule to run twice a week instead of thrice
- changed the workflow to fail if the tests and/or the doc build fails

Also:
- updated tests
- added `OMPI_MCA_btl=^openib` to the test workflow and ipcluster script to silence warning messages

Note:  SciPy 1.12.0 has a [bug](https://github.com/scipy/scipy/issues/19948) that breaks one of our tests.  This bug has been fixed in the current source on GitHub and so should be in the next release.  The affected test is skipped for SciPy version 1.12.0.


### Related Issues

- Resolves #3091

Note: an earlier PR (#3197) resolved one of the test failures described in this Issue.

### Backwards incompatibilities

None

### New Dependencies

None
