### PR TITLE
Skip any relevance/singular_jac checks when `approx_totals` is used

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -386,7 +386,7 @@ class Component(System):
 
     def _get_missing_partials(self, missing):
         """
-        Return a list of (of, wrt) tuples for which derivatives have not been declared.
+        Provide (of, wrt) tuples for which derivatives have not been declared in the component.
 
         Parameters
         ----------

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -8,6 +8,7 @@ import weakref
 
 import numpy as np
 
+from openmdao.core.group import Group
 from openmdao.core.total_jac import _TotalJacInfo
 from openmdao.core.constants import INT_DTYPE, _SetupStatus
 from openmdao.recorders.recording_manager import RecordingManager
@@ -949,6 +950,13 @@ class Driver(object):
             return
 
         problem = self._problem()
+
+        # Do not perform this check if any subgroup uses approximated partials.
+        # This causes the relevance graph to be invalid.
+        for system in problem.model.system_iter(include_self=True, recurse=True, typ=Group):
+            if system._has_approx:
+                return
+
         relevant = problem.model._relevant
         fwd = problem._mode == 'fwd'
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -865,8 +865,8 @@ class Group(System):
 
         if missing_responses:
             msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
-                    " be impacted by the design variables of the problem because no partials "
-                    "were defined for them in their parent component(s).")
+                   " be impacted by the design variables of the problem because no partials "
+                   "were defined for them in their parent component(s).")
             if self._problem_meta['singular_jac_behavior'] == 'error':
                 raise RuntimeError(msg)
             else:
@@ -4026,7 +4026,7 @@ class Group(System):
 
     def _get_missing_partials(self, missing):
         """
-        Return a list of (of, wrt) tuples for which derivatives have not been declared.
+        Provide (of, wrt) tuples for which derivatives have not been declared in the system.
 
         Parameters
         ----------

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -869,8 +869,8 @@ class Group(System):
                     break
             else:
                 msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
-                    " be impacted by the design variables of the problem because no partials "
-                    "were defined for them in their parent component(s).")
+                       " be impacted by the design variables of the problem because no partials "
+                       "were defined for them in their parent component(s).")
                 if self._problem_meta['singular_jac_behavior'] == 'error':
                     raise RuntimeError(msg)
                 else:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -864,13 +864,17 @@ class Group(System):
                     missing_responses.add(output)
 
         if missing_responses:
-            msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
-                   " be impacted by the design variables of the problem because no partials "
-                   "were defined for them in their parent component(s).")
-            if self._problem_meta['singular_jac_behavior'] == 'error':
-                raise RuntimeError(msg)
+            for subsys in self.system_iter(include_self=True, recurse=True, typ=Group):
+                if subsys._has_approx:
+                    break
             else:
-                issue_warning(msg, category=DerivativesWarning)
+                msg = (f"Constraints or objectives [{', '.join(sorted(missing_responses))}] cannot"
+                    " be impacted by the design variables of the problem because no partials "
+                    "were defined for them in their parent component(s).")
+                if self._problem_meta['singular_jac_behavior'] == 'error':
+                    raise RuntimeError(msg)
+                else:
+                    issue_warning(msg, category=DerivativesWarning)
 
         self._relevance_graph = graph
         return graph

--- a/openmdao/core/tests/test_semitotals.py
+++ b/openmdao/core/tests/test_semitotals.py
@@ -319,7 +319,7 @@ class TestSemiTotalsNumCalls(unittest.TestCase):
 
         self.assertEqual(geom_and_aero.geom._counter, 4)
 
-    def test_check_relevlance_approx_totals(self):
+    def test_check_relevance_approx_totals(self):
 
             size = 10
             rho = 1.17573

--- a/openmdao/core/tests/test_semitotals.py
+++ b/openmdao/core/tests/test_semitotals.py
@@ -199,6 +199,7 @@ class FakeGeomComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare("n", types=int)
+        self.options.declare('declare_partials', types=(bool,), default=True)
 
     def setup(self):
         n = self.options["n"]
@@ -206,7 +207,8 @@ class FakeGeomComp(om.ExplicitComponent):
         self.add_input("feather", val=0.0, units="deg")
         self.add_output("x", val=np.zeros(n), units="m")
 
-        self.declare_partials("*", "*", method="fd")
+        if self.options['declare_partials']:
+            self.declare_partials("*", "*", method="fd")
 
         self._counter = 0
 
@@ -222,6 +224,7 @@ class FakeAeroComp(om.ExplicitComponent):
 
     def initialize(self):
         self.options.declare("n", types=int)
+        self.options.declare('declare_partials', types=(bool,), default=True)
 
     def setup(self):
         n = self.options["n"]
@@ -232,7 +235,8 @@ class FakeAeroComp(om.ExplicitComponent):
         self.add_output("CT", val=0.5)
         self.add_output("CP", val=0.5)
 
-        self.declare_partials("*", "*", method="fd")
+        if self.options['declare_partials']:
+            self.declare_partials("*", "*", method="fd")
 
         self._counter = 0
 
@@ -251,15 +255,19 @@ class GeometryAndAero2(om.Group):
         self.options.declare("n", types=int)
         self.options.declare("rho", types=float)
         self.options.declare("vinf", types=float)
+        self.options.declare('declare_partials', types=(bool,), default=True)
 
     def setup(self):
         n = self.options["n"]
+        dp = self.options['declare_partials']
 
         comp = self.add_subsystem("init_geom", om.IndepVarComp(), promotes_outputs=["x0"])
         comp.add_output("x0", val=np.arange(n) + 1.0, units="m")
 
-        self.add_subsystem("geom", FakeGeomComp(n=n), promotes_inputs=["x0", "feather"], promotes_outputs=["x"])
-        self.add_subsystem("aero", FakeAeroComp(n=n), promotes_inputs=["x", "omega"], promotes_outputs=["CT", "CP"])
+        self.add_subsystem("geom", FakeGeomComp(n=n, declare_partials=dp),
+                           promotes_inputs=["x0", "feather"], promotes_outputs=["x"])
+        self.add_subsystem("aero", FakeAeroComp(n=n, declare_partials=dp),
+                           promotes_inputs=["x", "omega"], promotes_outputs=["CT", "CP"])
 
     def reset_count(self):
         self.geom._counter = 0
@@ -310,3 +318,45 @@ class TestSemiTotalsNumCalls(unittest.TestCase):
         assert_check_totals(data, atol=1e-6, rtol=1e-6)
 
         self.assertEqual(geom_and_aero.geom._counter, 4)
+
+    def test_check_relevlance_approx_totals(self):
+
+            size = 10
+            rho = 1.17573
+            minf = 0.111078231621482
+            speedofsound = 344.5760217432
+            vinf = minf*speedofsound
+
+            prob = om.Problem()
+            prob.driver = om.ScipyOptimizeDriver()
+            prob.driver.options["optimizer"] = "SLSQP"
+
+            omega = 7199.759242*2*np.pi/60
+            ivc = prob.model.add_subsystem("ivc", om.IndepVarComp(), promotes_outputs=["*"])
+            ivc.add_output("feather", val=0.0, units="deg")
+            ivc.add_output("omega", val=omega, units="rad/s")
+
+            geom_and_aero = prob.model.add_subsystem('geom_and_aero',
+                                                    GeometryAndAero2(n=size, rho=rho, vinf=vinf, declare_partials=False),
+                                                    promotes_inputs=["feather", "omega"],
+                                                    promotes_outputs=["CT", "CP"])
+            geom_and_aero.approx_totals(step=step, step_calc="abs", method="fd", form="forward")
+
+            prob.model.add_design_var("feather", lower=-5.0, upper=25.0, units="deg", ref=1.0)
+            prob.model.add_design_var("omega", lower=3000*2*np.pi/60, upper=7500*2*np.pi/60, units="rad/s", ref=1.0)
+            prob.model.add_objective("CP", ref=1e0)
+            prob.model.add_constraint("CT", lower=0.0)
+
+            prob.setup(force_alloc_complex=False)
+
+            omega = (6245.096992023524*2*np.pi/60) + step
+            feather = 0.6362159381168669
+            prob.set_val("omega", omega, units="rad/s")
+            prob.set_val("feather", feather, units="deg")
+            fail = prob.run_driver()
+
+            self.assertEqual(fail, False)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/working_with_derivatives/approximating_totals.ipynb
@@ -325,6 +325,88 @@
     "\n",
     "assert_near_equal(derivs['z', 'x'], np.array([[300.]]), tolerance=1e-8)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f9510c93",
+   "metadata": {},
+   "source": [
+    "(approx_totals_relevance)=\n",
+    "## Approx-Totals and Relevance\n",
+    "\n",
+    "OpenMDAO builds a relevancy-graph that helps it be more efficient when executing complex models.\n",
+    "\n",
+    "One feature that uses this graph is the `relevance check` that is performed when a Driver begins to run.\n",
+    "The relevance check is used to verify that each constraint can be impacted by a design variable.\n",
+    "\n",
+    "However, when `approx_totals` is used, users often omit the declaration of any partials.\n",
+    "In this situation, the relevance check would normally fail, so OpenMDAO skips this check if any Group\n",
+    "in the system tree is found to use approximated derivatives."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb70c742",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "import openmdao.api as om\n",
+    "\n",
+    "class AComp(om.ExplicitComponent):\n",
+    "\n",
+    "    def setup(self):\n",
+    "        self.add_input('x', val=0.0)\n",
+    "        self.add_output('y', val=0.0)\n",
+    "\n",
+    "    def compute(self, inputs, outputs):\n",
+    "        outputs['y'] = inputs['x'] - 5.0\n",
+    "\n",
+    "class BComp(om.ExplicitComponent):\n",
+    "\n",
+    "    def setup(self):\n",
+    "        self.add_input('y', val=0.0)\n",
+    "        self.add_output('z', val=0.0)\n",
+    "\n",
+    "    def compute(self, inputs, outputs):\n",
+    "        outputs['z'] = inputs['y'] ** 2\n",
+    "\n",
+    "prob = om.Problem()\n",
+    "prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')\n",
+    "model = prob.model\n",
+    "model.set_input_defaults('x', 0.0)\n",
+    "\n",
+    "model.add_subsystem('a', AComp(), promotes=['x', 'y'])\n",
+    "model.add_subsystem('b', BComp(), promotes=['y', 'z'])\n",
+    "\n",
+    "model.add_design_var('x', lower=-100, upper=100)\n",
+    "model.add_objective('z')\n",
+    "\n",
+    "model.approx_totals(method='cs')\n",
+    "\n",
+    "prob.setup()\n",
+    "prob.run_driver()\n",
+    "\n",
+    "of = ['z']\n",
+    "wrt = ['x']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c771d4",
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "assert_near_equal(prob.get_val('x'), 5.0)"
+   ]
   }
  ],
  "metadata": {
@@ -344,7 +426,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.4"
   },
   "orphan": true
  },


### PR DESCRIPTION
### Summary

When a group in OpenMDAO uses approx_totals, the user is not required to explicitly declare partials in their systems.
This renders the relevance_graph in OpenMDAO useless, because it doesn't capture this dependency information.
Checks that use this relevance graph incorrectly report singular rows or columns in the jacobian, and the driver `check_relevance` method raises an exception unnecessarily.

This PR fixes this behavior by skipping these checks when any group in the system tree uses `approx_totals`.

### Related Issues

- Resolves #3026

### Backwards incompatibilities

None

### New Dependencies

None
