### PR TITLE
removed setting of distributed metadata to False if nprocs==1

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -200,10 +200,6 @@ class Component(System):
             self._has_distrib_vars = self._has_distrib_outputs = False
 
         for meta in self._static_var_rel2meta.values():
-            # variable isn't distributed if we're only running on 1 proc
-            if nprocs == 1 and 'distributed' in meta and meta['distributed']:
-                meta['distributed'] = False
-
             # reset shape if any dynamic shape parameters are set in case this is a resetup
             # NOTE: this is necessary because we allow variables to be added in __init__.
             if 'shape_by_conn' in meta and (meta['shape_by_conn'] or


### PR DESCRIPTION
### Summary

The 'distributed' metadata was being set to False at the component level if nprocs there was 1, but higher up the system tree where nprocs > 1 it was incorrectly flagging a distrib/non-distrib mismatch because it thought the component variable was not distributed.

### Related Issues

- Resolves #3121

### Backwards incompatibilities

None

### New Dependencies

None
