### PR TITLE
Updated check_partials to account for scaling when using the matrix-free API

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1402,7 +1402,7 @@ class Problem(object):
                                 # Matrix Vector Product
                                 self._metadata['checking'] = True
                                 try:
-                                    comp._apply_linear(None, _contains_all, mode)
+                                    comp.run_apply_linear(mode)
                                 finally:
                                     self._metadata['checking'] = False
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1210,11 +1210,12 @@ class Problem(object):
         excludes = [excludes] if isinstance(excludes, str) else excludes
 
         comps = []
-        under_CI = env_truthy('OPENMDAO_CHECK_ALL_PARTIALS')
+
+        # OPENMDAO_CHECK_ALL_PARTIALS overrides _no_check_partials (used for testing)
+        force_check_partials = env_truthy('OPENMDAO_CHECK_ALL_PARTIALS')
 
         for comp in model.system_iter(typ=Component, include_self=True):
-            # if we're under CI, do all of the partials, ignoring _no_check_partials
-            if comp._no_check_partials and not under_CI:
+            if comp._no_check_partials and not force_check_partials:
                 continue
 
             # skip any Component with no outputs

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1983,17 +1983,14 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
             prob.setup(force_alloc_complex=force_alloc_complex)
             return prob, parab
 
-        expected_check_partials_error = f"Problem .*: Checking partials with respect " \
-              "to variable '{var}' in component " \
-              "'{comp.pathname}' using the same " \
-              "method and options as are used to compute the " \
-              "component's derivatives " \
-              "will not provide any relevant information on the " \
-              "accuracy\.\n" \
+        expected_check_partials_error = "Problem {prob._name}: Checking partials " \
+              "with respect to variable '{var}' in component '{comp.pathname}' using the " \
+              "same method and options as are used to compute the component's derivatives " \
+              "will not provide any relevant information on the accuracy.\n" \
               "To correct this, change the options to do the \n" \
               "check_partials using either:\n" \
-              "     - arguments to Problem\.check_partials. \n" \
-              "     - arguments to Component\.set_check_partial_options"
+              "     - arguments to Problem.check_partials. \n" \
+              "     - arguments to Component.set_check_partial_options"
 
         # Scenario 1:
         #    Compute partials: exact
@@ -2008,9 +2005,10 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         #    Expected result: Error
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
-        expected_error_msg = expected_check_partials_error.format(var='x', comp=self.parab)
-        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_partials(method='fd')
+        self.assertEqual(str(cm.exception),
+                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 3:
         #    Compute partials: fd, with default options
@@ -2052,9 +2050,10 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         #    Expected result: Error since using fd to check fd. All options the same
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
-        expected_error_msg = expected_check_partials_error.format(var='x', comp=parab)
-        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_partials(method='cs')
+        self.assertEqual(str(cm.exception),
+                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 7:
         #    Compute partials: fd, with default options
@@ -2074,9 +2073,10 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
         parab.set_check_partial_options('*')
-        expected_error_msg = expected_check_partials_error.format(var='x', comp=parab)
-        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_partials()
+        self.assertEqual(str(cm.exception),
+                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 9:
         #    Compute partials: fd, with default options
@@ -2132,9 +2132,10 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob, parab = create_problem(force_alloc_complex=True)
         parab.declare_partials(of='*', wrt='*', method='cs')
         parab.set_check_partial_options('*', method='cs')
-        expected_error_msg = expected_check_partials_error.format(var='x', comp=parab)
-        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning, expected_error_msg):
+        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_partials()
+        self.assertEqual(str(cm.exception),
+                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 15:
         #    Compute partials: cs, with default options
@@ -2148,12 +2149,11 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.check_partials()
 
         # Now do similar checks for check_totals when approximations are used
-        expected_check_totals_error_msg = "Problem .*: Checking totals using the same " \
-              "method and options as are used to compute the " \
-              "totals will not provide any relevant information on the " \
-              "accuracy\.\n" \
+        expected_check_totals_error_msg = "Problem {prob._name}: Checking totals using the " \
+              "same method and options as are used to compute the totals will not provide " \
+              "any relevant information on the accuracy.\n" \
               "To correct this, change the options to do the " \
-              "check_totals or on the call to approx_totals for the model\."
+              "check_totals or on the call to approx_totals for the model."
 
         # Scenario 16:
         #    Compute totals: no approx on totals
@@ -2172,9 +2172,10 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.model.approx_totals()
         prob.setup()
         prob.run_model()
-        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning,
-                                        expected_check_totals_error_msg) :
+        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_totals()
+        self.assertEqual(str(cm.exception),
+                         expected_check_totals_error_msg.format(prob=prob))
 
         # Scenario 18:
         #    Compute totals: approx on totals using defaults
@@ -2225,9 +2226,10 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.model.approx_totals(method='cs')
         prob.setup()
         prob.run_model()
-        with self.assertRaisesRegex(OMInvalidCheckDerivativesOptionsWarning,
-                               expected_check_totals_error_msg):
+        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_totals(method='cs')
+        self.assertEqual(str(cm.exception),
+                         expected_check_totals_error_msg.format(prob=prob))
 
         # Scenario 22:
         #    Compute totals: fd, the default

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -10,7 +10,8 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayDense
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import force_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompF
 
 
@@ -1432,6 +1433,161 @@ class TestScalingOverhaul(unittest.TestCase):
 
         for (of, wrt) in totals:
             assert_near_equal(totals[of, wrt]['abs error'][0], 0.0, 1e-7)
+
+
+class TestResidualScaling(unittest.TestCase):
+
+    def test_residual_scaling(self):
+        # When the residuals of an implicit component are scaled (for example
+        # using the res_ref argument to add_output), the partial derivatives
+        # computed through the matrix-free API should be modified to account
+        # for this scaling as they are through the standard API.
+
+        # In this test case, an apply_linear method has been added to the
+        # Node component in the circuit analysis example and it's residuals
+        # have been scaled by a factor of 1000 (using res_ref=1e-3).
+
+        class Resistor(om.ExplicitComponent):
+            """Computes current across a resistor using Ohm's law."""
+
+            def initialize(self):
+                self.options.declare("R", default=1.0, desc="Resistance in Ohms")
+
+            def setup(self):
+                self.add_input("V_in", units="V")
+                self.add_input("V_out", units="V")
+                self.add_output("I", units="A")
+
+                # partial derivs are constant, so we can assign their values in setup
+                R = self.options["R"]
+                self.declare_partials("I", "V_in", val=1 / R)
+                self.declare_partials("I", "V_out", val=-1 / R)
+
+            def compute(self, inputs, outputs):
+                deltaV = inputs["V_in"] - inputs["V_out"]
+                outputs["I"] = deltaV / self.options["R"]
+
+        class Diode(om.ExplicitComponent):
+            """Computes current across a diode using the Shockley diode equation."""
+
+            def initialize(self):
+                self.options.declare("Is", default=1e-15, desc="Saturation current in Amps")
+                self.options.declare("Vt", default=0.025875, desc="Thermal voltage in Volts")
+
+            def setup(self):
+                self.add_input("V_in", units="V")
+                self.add_input("V_out", units="V")
+                self.add_output("I", units="A")
+
+                # non-linear component, so we'll declare the partials here but compute them in compute_partials
+                self.declare_partials("I", "V_in")
+                self.declare_partials("I", "V_out")
+
+            def compute(self, inputs, outputs):
+                deltaV = inputs["V_in"] - inputs["V_out"]
+                Is = self.options["Is"]
+                Vt = self.options["Vt"]
+                outputs["I"] = Is * (np.exp(deltaV / Vt) - 1)
+
+            def compute_partials(self, inputs, J):
+                deltaV = inputs["V_in"] - inputs["V_out"]
+                Is = self.options["Is"]
+                Vt = self.options["Vt"]
+                I = Is * np.exp(deltaV / Vt)
+
+                J["I", "V_in"] = I / Vt
+                J["I", "V_out"] = -I / Vt
+
+        class Node(om.ImplicitComponent):
+            """Computes voltage residual across a node based on incoming and outgoing current."""
+
+            def initialize(self):
+                self.options.declare("n_in", default=1, types=int, desc="number of connections with + assumed in")
+                self.options.declare("n_out", default=1, types=int, desc="number of current connections + assumed out")
+
+            def setup(self):
+                self.add_output("V", val=5.0, units="V", res_ref=1e-3)
+
+                for i in range(self.options["n_in"]):
+                    i_name = "I_in:{}".format(i)
+                    self.add_input(i_name, units="A")
+
+                for i in range(self.options["n_out"]):
+                    i_name = "I_out:{}".format(i)
+                    self.add_input(i_name, units="A")
+
+                    # note: we don't declare any partials wrt `V` here,
+                    #      because the residual doesn't directly depend on it
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals["V"] = 0.0
+                for i_conn in range(self.options["n_in"]):
+                    residuals["V"] += inputs["I_in:{}".format(i_conn)]
+                for i_conn in range(self.options["n_out"]):
+                    residuals["V"] -= inputs["I_out:{}".format(i_conn)]
+
+            def apply_linear(self, inputs, outputs, d_inputs, d_outputs, d_residuals, mode):
+                if mode == "fwd":
+                    for i_conn in range(self.options["n_in"]):
+                        d_residuals["V"] += d_inputs["I_in:{}".format(i_conn)]
+                    for i_conn in range(self.options["n_out"]):
+                        d_residuals["V"] -= d_inputs["I_out:{}".format(i_conn)]
+
+                if mode == "rev":
+                    for i_conn in range(self.options["n_in"]):
+                        d_inputs["I_in:{}".format(i_conn)] += d_residuals["V"]
+                    for i_conn in range(self.options["n_out"]):
+                        d_inputs["I_out:{}".format(i_conn)] -= d_residuals["V"]
+
+        class Circuit(om.Group):
+
+            def setup(self):
+                self.add_subsystem("n1", Node(n_in=1, n_out=2), promotes_inputs=[("I_in:0", "I_in")])
+                self.add_subsystem("n2", Node())  # leaving defaults
+
+                self.add_subsystem("R1", Resistor(R=100.0), promotes_inputs=[("V_out", "Vg")])
+                self.add_subsystem("R2", Resistor(R=10000.0))
+                self.add_subsystem("D1", Diode(), promotes_inputs=[("V_out", "Vg")])
+
+                self.connect("n1.V", ["R1.V_in", "R2.V_in"])
+                self.connect("R1.I", "n1.I_out:0")
+                self.connect("R2.I", "n1.I_out:1")
+
+                self.connect("n2.V", ["R2.V_out", "D1.V_in"])
+                self.connect("R2.I", "n2.I_in:0")
+                self.connect("D1.I", "n2.I_out:0")
+
+                self.nonlinear_solver = om.NewtonSolver()
+                self.linear_solver = om.ScipyKrylov()
+
+                self.nonlinear_solver.options["iprint"] = -1
+                self.nonlinear_solver.options["maxiter"] = 10
+                self.nonlinear_solver.options["solve_subsystems"] = True
+                self.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS()
+                self.nonlinear_solver.linesearch.options["maxiter"] = 10
+                self.nonlinear_solver.linesearch.options["iprint"] = -1
+
+        p = om.Problem()
+        model = p.model
+
+        model.add_subsystem("circuit", Circuit())
+
+        p.setup(force_alloc_complex=True)
+
+        p.set_val("circuit.I_in", 0.1)
+        p.set_val("circuit.Vg", 0.0)
+
+        # set some initial guesses
+        p.set_val("circuit.n1.V", 10.0)
+        p.set_val("circuit.n2.V", 1e-3)
+
+        p.run_model()
+
+        # sanity check: should sum to .1 Amps
+        assert_near_equal(p["circuit.R1.I"] + p["circuit.D1.I"], .1)
+
+        partials = force_check_partials(p, method='cs', step=1e-200, compact_print=True, out_stream=None)
+        assert_check_partials(partials)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Summary

Changed `check_partials` to use `run_apply_linear` when performing a matrix-vector product so that scaling is properly applied.

Also:
- changed local variable name from `under_CI` to a more accurate `force_check_partials`
- changed some tests that were throwing warnings due to use of `assertRaisesRegex` to use f-strings instead
- added the test case provided in the issue

### Related Issues

- Resolves #3072 

### Backwards incompatibilities

None

### New Dependencies

None
