### PR TITLE
Changed the minimum required version of Python from 3.7 to 3.8

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -75,8 +75,8 @@ jobs:
           # test oldest supported versions
           - NAME: Ubuntu Oldest
             OS: ubuntu-latest
-            PY: '3.7'
-            NUMPY: '1.21'
+            PY: '3.8'
+            NUMPY: '1.22'
             SCIPY: '1.7'
             OPENMPI: '4.0'
             MPI4PY: '3.0'

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ generator.  You can install everything needed for development by running:
 
 ## OpenMDAO Versions
 
-**OpenMDAO 3.x.y** represents the current, supported version. It requires Python 3.7
+**OpenMDAO 3.x.y** represents the current, supported version. It requires Python 3.8
 or later and is maintained [here][4]. To upgrade to the latest release, run:
 
     pip install --upgrade openmdao

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -932,19 +932,6 @@ class Problem(object):
         model = self.model
         comm = self.comm
 
-        if sys.version_info.minor < 8:
-            sv = sys.version_info
-            msg = f'OpenMDAO support for Python version {sv.major}.{sv.minor} will end soon.'
-            try:
-                from IPython import get_ipython
-                ip = get_ipython()
-                if ip is None or ip.config is None or 'IPKernelApp' not in ip.config:
-                    warn_deprecation(msg)
-            except ImportError:
-                warn_deprecation(msg)
-            except AttributeError:
-                warn_deprecation(msg)
-
         if not isinstance(self.model, Group):
             raise TypeError("The model for this Problem is of type "
                             f"'{self.model.__class__.__name__}'. "

--- a/openmdao/test_suite/tests/test_warnings.py
+++ b/openmdao/test_suite/tests/test_warnings.py
@@ -143,7 +143,6 @@ class TestWarnings(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.filterwarnings('error', category=om.OpenMDAOWarning)
-            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
 
             with self.assertRaises(Exception) as e:
                 p.setup()

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -5,10 +5,7 @@ A console script wrapper for multiple openmdao functions.
 import sys
 import os
 import argparse
-if sys.version_info.minor > 7:
-    import importlib.metadata as ilmd
-else:
-    ilmd = None
+import importlib.metadata as ilmd
 
 import re
 from openmdao import __version__ as version
@@ -660,7 +657,7 @@ def openmdao_cmd():
 
         if hasattr(options, 'executor'):
             options.executor(options, user_args)
-        elif options.dependency_versions is True and ilmd is not None:
+        elif options.dependency_versions is True:
             dep_versions = {}
             _get_deps(dep_versions, 'openmdao')
 

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -324,7 +324,6 @@ class TestModuleFunctions(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
             p.setup()
 
         p.run_model()
@@ -341,7 +340,6 @@ class TestModuleFunctions(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
             p.setup()
 
         p.run_model()
@@ -359,7 +357,6 @@ class TestModuleFunctions(unittest.TestCase):
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
-            warnings.filterwarnings("ignore", r'.*OpenMDAO support for Python version .* will end soon.*')
             p.setup()
 
         p.run_model()

--- a/setup.py
+++ b/setup.py
@@ -26,8 +26,8 @@ optional_dependencies = {
         'pyDOE3'
     ],
     'jax': [
-        'jax>=0.4.0; python_version>="3.8"',
-        'jaxlib>=0.4.0; python_version>="3.8"'
+        'jax>=0.4.0',
+        'jaxlib>=0.4.0'
     ],
     'notebooks': [
         'notebook',
@@ -74,7 +74,7 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Topic :: Scientific/Engineering',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
     ],
     keywords='optimization multidisciplinary multi-disciplinary analysis',
@@ -185,7 +185,7 @@ setup(
         ],
         'openmdao': ['*/tests/*.py', '*/*/tests/*.py', '*/*/*/tests/*.py']
     },
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         'networkx>=2.0',
         'numpy',


### PR DESCRIPTION
### Summary

Changed the minimum required version of Python from 3.7 to 3.8

- updated `python_requires` in `setup.py` to specify Python 3.8
- updated the `oldest` job in the tests workflow to use Python 3.8
- removed logic related to Python 3.7 and the imminent end of support for it

### Related Issues

- Resolves #3129

### Backwards incompatibilities

None

### New Dependencies

None
