### PR TITLE
linesearch is now a property of Solver.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -434,7 +434,7 @@ class Driver(object):
         Check for design variable values that exceed their bounds.
 
         This method's behavior is controlled by the OPENMDAO_INVALID_DESVAR environment variable,
-        which may take on values 'ignore', 'error', 'warn'.
+        which may take on values 'ignore', 'raise'', 'warn'.
         - 'ignore' : Proceed without checking desvar bounds.
         - 'warn' : Issue a warning if one or more desvar values exceed bounds.
         - 'raise' : Raise an exception if one or more desvar values exceed bounds.

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4818,7 +4818,7 @@ class System(object):
             if s._nonlinear_solver:
                 nl = s._nonlinear_solver
                 nl._iter_count = 0
-                if hasattr(nl, 'linesearch') and nl.linesearch:
+                if nl.linesearch:
                     nl.linesearch._iter_count = 0
 
     def get_reports_dir(self):

--- a/openmdao/recorders/recording_manager.py
+++ b/openmdao/recorders/recording_manager.py
@@ -156,7 +156,7 @@ def _get_all_requesters(problem):
         nl = system._nonlinear_solver
         if nl:
             yield nl
-            if hasattr(nl, 'linesearch') and nl.linesearch:
+            if nl.linesearch:
                 yield nl.linesearch
 
 
@@ -231,7 +231,7 @@ def record_model_options(problem, run_number):
             nl = system._nonlinear_solver
             if nl:
                 recorder.record_metadata_solver(nl, run_number)
-                if hasattr(nl, 'linesearch') and nl.linesearch:
+                if nl.linesearch:
                     recorder.record_metadata_solver(nl.linesearch, run_number)
 
             ln = system._linear_solver

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -76,7 +76,8 @@ class BroydenSolver(NonlinearSolver):
         self.linear_solver = None
 
         # Slot for linesearch
-        self.linesearch = BoundsEnforceLS()
+        self.supports['linesearch'] = True
+        self._linesearch = BoundsEnforceLS()
 
         self.cite = CITATION
 

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -46,7 +46,7 @@ class BroydenSolver(NonlinearSolver):
         Most recent Jacobian matrix.
     linear_solver : LinearSolver
         Linear solver to use for calculating inverse Jacobian.
-    linesearch : NonlinearSolver
+    _linesearch : NonlinearSolver
         Line search algorithm. Default is None for no line search.
     size : int
         Total length of the states being solved.

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -25,7 +25,7 @@ class NewtonSolver(NonlinearSolver):
     linear_solver : LinearSolver
         Linear solver to use to find the Newton search direction. The default
         is the parent system's linear solver.
-    linesearch : NonlinearSolver
+    _linesearch : NonlinearSolver
         Line search algorithm. Default is None for no line search.
     """
 

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -41,7 +41,8 @@ class NewtonSolver(NonlinearSolver):
         self.linear_solver = None
 
         # Slot for linesearch
-        self.linesearch = BoundsEnforceLS()
+        self.supports['linesearch'] = True
+        self._linesearch = BoundsEnforceLS()
 
     def _declare_options(self):
         """

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -710,7 +710,7 @@ class NonlinearSolver(Solver):
 
             with Recording(type(self).__name__, self._iter_count, self) as rec:
                 ls = self.linesearch
-                if stall_count == 3 and ls and ls.options['print_bound_enforce']:
+                if stall_count == 3 and ls and not ls.options['print_bound_enforce']:
 
                     self.linesearch.options['print_bound_enforce'] = True
 

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -198,6 +198,7 @@ class Solver(object):
         self.supports = OptionsDictionary(parent_name=self.msginfo)
         self.supports.declare('gradients', types=bool, default=False)
         self.supports.declare('implicit_components', types=bool, default=False)
+        self.supports.declare('linesearch', types=bool, default=False)
 
         self._declare_options()
         self.options.update(kwargs)
@@ -593,6 +594,19 @@ class NonlinearSolver(Solver):
                              desc='If True, the states are cached after a successful solve and '
                                   'used to restart the solver in the case of a failed solve.')
 
+    @property
+    def linesearch(self):
+        if not self.supports['linesearch']:
+            return None
+        else:
+            return self._linesearch
+
+    @linesearch.setter
+    def linesearch(self, ls):
+        if not self.supports['linesearch']:
+            raise AttributeError(f'{self.msginfo}: This solver does not support a linesearch.')
+        self._linesearch = ls
+
     def _setup_solvers(self, system, depth):
         """
         Assign system instance, set depth, and optionally perform setup.
@@ -688,7 +702,8 @@ class NonlinearSolver(Solver):
 
             with Recording(type(self).__name__, self._iter_count, self) as rec:
 
-                if stall_count == 3 and not self.linesearch.options['print_bound_enforce']:
+                if stall_count == 3 and self.linesearch is not None and \
+                    not self.linesearch.options['print_bound_enforce']:
 
                     self.linesearch.options['print_bound_enforce'] = True
 

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -596,6 +596,14 @@ class NonlinearSolver(Solver):
 
     @property
     def linesearch(self):
+        """
+        Get the linesearch solver associated with this solver.
+
+        Returns
+        -------
+        NonlinearSolver or None
+            The linesearch associated with this solver, or None if it does not support one.
+        """
         if not self.supports['linesearch']:
             return None
         else:
@@ -701,9 +709,8 @@ class NonlinearSolver(Solver):
                 force_one_iteration = False
 
             with Recording(type(self).__name__, self._iter_count, self) as rec:
-
-                if stall_count == 3 and self.linesearch is not None and \
-                    not self.linesearch.options['print_bound_enforce']:
+                ls = self.linesearch
+                if stall_count == 3 and ls and ls.options['print_bound_enforce']:
 
                     self.linesearch.options['print_bound_enforce'] = True
 

--- a/openmdao/solvers/tests/test_solver_features.py
+++ b/openmdao/solvers/tests/test_solver_features.py
@@ -219,6 +219,33 @@ class TestSolverFeatures(unittest.TestCase):
 
         prob.run_model()
 
+    def test_linesearch_property(self):
+        import openmdao.api as om
+
+        ns = om.NewtonSolver()
+        bs = om.BroydenSolver()
+        nlbgs = om.NonlinearBlockGS()
+        nlbj = om.NonlinearBlockJac()
+
+        for solver in [ns, bs, nlbgs, nlbj]:
+            with self.subTest(msg=solver.msginfo):
+                if solver in (ns, bs):
+                    self.assertIsInstance(solver.linesearch, om.BoundsEnforceLS)
+                else:
+                    self.assertIsNone(solver.linesearch)
+
+                new_ls = om.ArmijoGoldsteinLS()
+
+                if solver in (nlbgs, nlbj):
+                    with self.assertRaises(AttributeError) as e:
+                        solver.linesearch = new_ls
+                    expected = (f'{solver.msginfo}: This solver does not '
+                                'support a linesearch.')
+                    self.assertEqual(expected, str(e.exception))
+                else:
+                    solver.linesearch = new_ls
+                    self.assertIs(solver.linesearch, new_ls)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

Solver now has a `.supports['linesearch']` entry, which is only True for Newton and Broyden solvers.
The `.linesearch` property will return `None` for those Solvers which do not support it.
Assigning `.linesearch` to a Solver which doesn't support it now results in an error.

### Related Issues

- Resolves #2881 

### Backwards incompatibilities

None

### New Dependencies

None
