### PR TITLE
Bugs Related to Serialization

### DIFF
--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -68,7 +68,7 @@ class ExplicitComponent(Component):
         """
         new_jacvec_prod = getattr(self, 'compute_jacvec_product', None)
 
-        if self.matrix_free is _UNDEFINED:
+        if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('compute_jacvec_product', self, ExplicitComponent)
 
         if self.matrix_free:

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -76,7 +76,7 @@ class ImplicitComponent(Component):
         if self._has_solve_nl is _UNDEFINED:
             self._has_solve_nl = overrides_method('solve_nonlinear', self, ImplicitComponent)
 
-        if self.matrix_free is _UNDEFINED:
+        if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('apply_linear', self, ImplicitComponent)
 
         if self.matrix_free:

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -217,7 +217,11 @@ class Solver(object):
         str
             Info to prepend to messages.
         """
+        # Default initialization
         if self._system is None:
+            return type(self).__name__
+        # Following Dead Weakref
+        elif self._system() is None:
             return type(self).__name__
         return f"{type(self).__name__} in {self._system().msginfo}"
 
@@ -307,8 +311,13 @@ class Solver(object):
         depth : int
             depth of the current system (already incremented).
         """
+        # Default initialization
         if self._system is None:
             self._system = weakref.ref(system)
+        # Following Dead Weakref
+        elif self._system() is None:
+            self._system = weakref.ref(system)
+        # Assignment Mismatch
         elif self._system != weakref.ref(system):
             raise RuntimeError(f"{type(self).__name__} has already been assigned to "
                                f"{self._system().msginfo} and cannot also be assigned to "

--- a/openmdao/solvers/tests/test_solver_features.py
+++ b/openmdao/solvers/tests/test_solver_features.py
@@ -246,6 +246,24 @@ class TestSolverFeatures(unittest.TestCase):
                     solver.linesearch = new_ls
                     self.assertIs(solver.linesearch, new_ls)
 
+    def test_solver_broken_weakref(self):
+
+        prob = om.Problem()
+        sys = prob.model.add_subsystem('sellar', SellarDerivatives())
+
+        sys.nonlinear_solver =om.NewtonSolver(solve_subsystems=False)
+
+        # Simulate Broken Weakref
+        solver = sys.nonlinear_solver
+        solver._system = lambda: None
+
+        # Setup should still run with broken ref
+        prob.setup()
+
+        # Message info should still be readible
+        info = solver.msginfo
+        assert info == type(solver).__name__
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

My team and I have been developing a web application (based on plotly dash) that uses openmdao quite heavily in the backend. In order to pass objects between callbacks we need to serialize them and then de-serialize them. We're currently looking to upgrade from openmdao 3.17 to 3.30 and these are two fixes to issues we encountered related to serialized openmdao objects and passing them between processes. I know this probably isn't too common of a use case, but I'd appreciate if these changes could be accepted.

#### 1. weakref serialization
Serialization of a weakref breaks the reference. After a weakref is broken, it becomes a function that returns None. This is shown in the following code

```python
import weakref
import gc

class System:
    pass

system = System()
_system = weakref.ref(system)

# System is deleted and garbage collectes
del system
gc.collect()

# After this deletion and garbage collection _system() will return None
assert _system() == None
```

This case is not accounted for in the System._setup solvers function logic. The RuntimeError error will always be raised as `self._system()` is None, not `self._system`. 

```python
        if self._system is None:
            self._system = weakref.ref(system)
        elif self._system != weakref.ref(system):
            raise RuntimeError(f"{type(self).__name__} has already been assigned to "
                               f"{self._system().msginfo} and cannot also be assigned to "
                               f"{system.msginfo}.")
```

This was corrected as follows

```python
        # Default initialization
        if self._system is None:
            self._system = weakref.ref(system)
        # Following Dead Weakref
        elif self._system() is None:
            self._system = weakref.ref(system)
        # Assignment Mismatch
        elif self._system != weakref.ref(system):
            raise RuntimeError(f"{type(self).__name__} has already been assigned to "
                               f"{self._system().msginfo} and cannot also be assigned to "
                               f"{system.msginfo}.")
```

#### 2. self.matrix_free is _UNDEFINED

The `is` function can be a little finicky when working with multiprocessing and passing an object between processes. We found instances where the object would be created in one process, then passed to another and `self.matrix_free is _UNDEFINED` would return `False` but `self.matrix_free == _UNDEFINED` would return `True`. This is because the `_UNDEFINED` class it's referencing is a class from another process (thus making `is` `False`) but they are equivalent (thus making `==` `True`). This therefor broke the configure stack for us.

I've made the change in `ExplicitComponent` and `ImplicitComponent` `_configure` to fix this.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
