### PR TITLE
Added `set_reports_dir` to openmdao.api.

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -121,7 +121,7 @@ from openmdao.utils.jax_utils import register_jax_component
 
 # Reports System
 from openmdao.utils.reports_system import register_report, unregister_report, get_reports_dir, \
-    list_reports, clear_reports
+    list_reports, clear_reports, set_reports_dir
 
 import os
 

--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -94,12 +94,10 @@
     "\n",
     "If the user wishes to have the reports directory placed into a different directory other than the default current working directory, the user has two options for doing so.\n",
     "\n",
-    "First, this option can be set programmatically using the `set_reports_dir` function from `openmdao.api`.\n",
+    "1. This option can be set programmatically using the `set_reports_dir` function from `openmdao.api`.\n",
     "Note that this is a global OpenMDAO setting and therefore it cannot take different values for different processors if running multiple problems simultaneously under MPI.\n",
     "\n",
-    "The default value may be set using the environment variable `OPENMDAO_REPORTS_DIR` to the name of that directory. The directory does not have to exist beforehand. It will be created by the reporting system. As an example, if `OPENMDAO_REPORTS_DIR` is set to \"my_reports\", then, if the `Problem` name is `problem1`, then the reports will be written to the \"my_reports/problem1\" directory.\n",
-    "\n",
-    "Note that `OPENMDAO_REPORTS_DIR` is read during the import of openmdao, so setting `os.environ['OPENMDAO_REPORTS_DIR'] = './my_reports_dir' after OpenMDAO has been imported **will have no effect**."
+    "2. The default value may be set using the environment variable `OPENMDAO_REPORTS_DIR` to the name of that directory. The directory does not have to exist beforehand. It will be created by the reporting system. As an example, if `OPENMDAO_REPORTS_DIR` is set to \"my_reports\", then, if the `Problem` name is `problem1`, then the reports will be written to the \"my_reports/problem1\" directory.Note that `OPENMDAO_REPORTS_DIR` is read during the import of openmdao, so setting `os.environ['OPENMDAO_REPORTS_DIR'] = './my_reports_dir'` after OpenMDAO has been imported **will have no effect**."
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -92,8 +92,20 @@
    "source": [
     "## Setting the directory for the reports\n",
     "\n",
-    "If the user wishes to have the reports directory placed into a different directory other than the default current working directory, the user can set the environment variable, `OPENMDAO_REPORTS_DIR` to the name of that directory. The directory does not have to exist beforehand. It will be created by the reporting system. As an example, if `OPENMDAO_REPORTS_DIR` is set to \"my_reports\", then, if the `Problem` name is `problem1`, then the reports will be written to the \"my_reports/problem1\" directory.\n",
+    "If the user wishes to have the reports directory placed into a different directory other than the default current working directory, the user has two options for doing so.\n",
     "\n",
+    "First, this option can be set programmatically using the `set_reports_dir` function from `openmdao.api`.\n",
+    "Note that this is a global OpenMDAO setting and therefore it cannot take different values for different processors if running multiple problems simultaneously under MPI.\n",
+    "\n",
+    "The default value may be set using the environment variable `OPENMDAO_REPORTS_DIR` to the name of that directory. The directory does not have to exist beforehand. It will be created by the reporting system. As an example, if `OPENMDAO_REPORTS_DIR` is set to \"my_reports\", then, if the `Problem` name is `problem1`, then the reports will be written to the \"my_reports/problem1\" directory.\n",
+    "\n",
+    "Note that `OPENMDAO_REPORTS_DIR` is read during the import of openmdao, so setting `os.environ['OPENMDAO_REPORTS_DIR'] = './my_reports_dir' after OpenMDAO has been imported **will have no effect**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Support for subproblems\n",
     "\n",
     "The reporting system supports subproblems. For example, if a model has two Problems and they have the names `problem1` and `problem2`, the reporting system will put the reports into the subfolders, `problem1` and `problem2` under the top level reports directory, which defaults to `./reports` or is specified by the value of `OPENMDAO_REPORTS_DIR`.\n",

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -12,7 +12,7 @@ from openmdao.core.problem import _default_prob_name
 import openmdao.core.problem as probmod
 from openmdao.core.constants import _UNDEFINED
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.utils.reports_system import set_reports_dir, _reports_dir, register_report, \
+from openmdao.utils.reports_system import _reports_dir, register_report, \
     list_reports, clear_reports, _reset_reports_dir, activate_report, _reports_registry
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_no_warning
@@ -49,7 +49,7 @@ class TestReportsSystem(unittest.TestCase):
         # But we need to remember whether it was set so we can restore it
         self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
         clear_reports()
-        set_reports_dir(_reports_dir)
+        om.set_reports_dir(_reports_dir)
 
         self.count = 0
 
@@ -60,7 +60,7 @@ class TestReportsSystem(unittest.TestCase):
 
     def setup_and_run_simple_problem(self, driver=None, reports=_UNDEFINED, reports_dir=_UNDEFINED):
         if reports_dir is not _UNDEFINED:
-            set_reports_dir(reports_dir)
+            om.set_reports_dir(reports_dir)
 
         prob = om.Problem(reports=reports)
         model = prob.model
@@ -87,7 +87,7 @@ class TestReportsSystem(unittest.TestCase):
 
     def setup_problem_w_errors(self, prob_name, driver=None, reports=_UNDEFINED, reports_dir=_UNDEFINED):
         if reports_dir is not _UNDEFINED:
-            set_reports_dir(reports_dir)
+            om.set_reports_dir(reports_dir)
 
         prob = om.Problem(reports=reports, name=prob_name)
         model = prob.model
@@ -579,7 +579,7 @@ class TestReportsSystemMPI(unittest.TestCase):
         # But we need to remember whether it was set so we can restore it
         self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
         clear_reports()
-        set_reports_dir(_reports_dir)
+        om.set_reports_dir(_reports_dir)
 
         self.count = 0  # used to keep a count of reports generated
 


### PR DESCRIPTION
### Summary

The `set_reports_dir` function was in reports_dir but should be part of `openmdao.api`.
This PR adds it to the public facing API and explains its use in the documentation.

### Related Issues

- Resolves #3134 

### Backwards incompatibilities

None

### New Dependencies

None
