### PR TITLE
Fix an MPI hang caused when one proc needs a complex linear vector and the others don't.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -1093,6 +1093,16 @@ class Group(System):
 
         vectypes = ('nonlinear', 'linear') if self._use_derivatives else ('nonlinear',)
 
+        # If any proc's local systems need a complex vector, then all procs need it.
+        if self.comm.size > 1:
+            all_nl_alloc_complex = self.comm.allgather(nl_alloc_complex)
+            if np.any(all_nl_alloc_complex):
+                nl_alloc_complex = True
+
+            all_ln_alloc_complex = self.comm.allgather(ln_alloc_complex)
+            if np.any(all_ln_alloc_complex):
+                ln_alloc_complex = True
+
         for vec_name in vectypes:
             if vec_name == 'nonlinear':
                 alloc_complex = nl_alloc_complex


### PR DESCRIPTION
…

### Summary

Fix an MPI hang caused when one proc needs a complex linear vector and the others don't. The complex allocation is handled by traversing the model and looking for solver configurations that need the nonlinear or linear vectors to be complex.  In this case, a solver on one proc needed the vector to be complex, but that wasn't communicated to the other procs, so they allocated a real Petsc vector, which caused the hang.  

The solution is to allgather the flags and set them to True if any rank is True.

### Related Issues

- Resolves #3139

### Backwards incompatibilities

None

### New Dependencies

None
