### PR TITLE
Fixed deprecated assertEquals

### DIFF
--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -833,7 +833,7 @@ class TestExecComp(unittest.TestCase):
         model.add_subsystem('comp', comp)
         p.setup()
 
-        self.assertEquals(len(comp._declared_partials_patterns), 0)
+        self.assertEqual(len(comp._declared_partials_patterns), 0)
 
         # run with has_diag_partials=True
         p = om.Problem()


### PR DESCRIPTION
### Summary

Smallest PR ever..  `assertEquals` is deprecated and removed in Python 3.12

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
