### PR TITLE
Fixed bug in deprecated `list_problem_vars()` function

### DIFF
--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -22,7 +22,7 @@ from openmdao.components.exec_comp import _expr_dict, _temporary_expr_dict
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_warning
 from openmdao.utils.general_utils import env_truthy
 from openmdao.utils.testing_utils import force_check_partials
-from openmdao.utils.om_warnings import OMDeprecationWarning, SetupWarning
+from openmdao.utils.om_warnings import SetupWarning
 
 _ufunc_test_data = {
     'min': {
@@ -1975,7 +1975,8 @@ class TestExecCompParameterized(unittest.TestCase):
 
             for comp in cpd:
                 for (var, wrt) in cpd[comp]:
-                    np.testing.assert_almost_equal(cpd[comp][var, wrt]['abs error'][0], 0, decimal=4)
+                    np.testing.assert_almost_equal(cpd[comp][var, wrt]['abs error'][0], 0, decimal=4,
+                                                   verbose=True, err_msg=f"{test_data['args']=}")
 
 
 if __name__ == "__main__":

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2030,13 +2030,13 @@ class Problem(object):
         """
         warn_deprecation(msg='Method `list_problem_vars` has been renamed `list_driver_vars`.\n'
                          'Please update your code to use list_driver_vars to avoid this warning.')
-        self.list_driver_vars(show_promoted_name=show_promoted_name,
-                              print_arrays=print_arrays,
-                              driver_scaling=driver_scaling,
-                              desvar_opts=desvar_opts,
-                              cons_opts=cons_opts,
-                              objs_opts=objs_opts,
-                              out_stream=out_stream)
+        return self.list_driver_vars(show_promoted_name=show_promoted_name,
+                                     print_arrays=print_arrays,
+                                     driver_scaling=driver_scaling,
+                                     desvar_opts=desvar_opts,
+                                     cons_opts=cons_opts,
+                                     objs_opts=objs_opts,
+                                     out_stream=out_stream)
 
     def list_driver_vars(self,
                          show_promoted_name=True,

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -17,9 +17,8 @@ from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.groups.parallel_groups import FanInGrouped
 
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.utils.general_utils import run_driver, printoptions
-from openmdao.utils.om_warnings import OMDeprecationWarning
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.general_utils import run_driver
 from openmdao.utils.testing_utils import use_tempdirs
 
 from openmdao.utils.mpi import MPI
@@ -1639,14 +1638,6 @@ class TestDOEDriverListVars(unittest.TestCase):
         self.assertIn('x     -1   0', output)
         self.assertIn('y     3    0', output)
         self.assertIn('f_xy  59   0', output)
-
-        expected_warning = 'Method `list_problem_vars` has been ' \
-                           'renamed `list_driver_vars`.\nPlease update ' \
-                           'your code to use list_driver_vars to avoid ' \
-                           'this warning.'
-
-        with assert_warning(OMDeprecationWarning, expected_warning):
-            prob.list_problem_vars()
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")


### PR DESCRIPTION
### Summary

- Fixed the deprecated `list_problem_vars()` function so it returns the value from `list_driver_vars()`
- Added a test to check the return value from the deprecated `list_problem_vars()` function

Also:
- Updated the assert in `test_exec_comp_jac` to display the randomized input arguments in the error message

### Related Issues

- Resolves #3148 
- Resolves #3146

### Backwards incompatibilities

None

### New Dependencies

None
