### PR TITLE
Fixed the temporarily broken search functionality in the docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 ]
 docs = [
     "ipyparallel",
-    "jupyter-book",
+    "jupyter-book==0.14",
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",


### PR DESCRIPTION
### Summary

This will restore the ability to search the docs.

I tried to bring all the `jupyter-book` dependencies up to current versions, but even after removing our theme and search customizations it did not work without errors.  The best results in the short term are what we were getting by pinning `jupyter-book==0.14`


### Related Issues

- Resolves #3169

### Backwards incompatibilities

None

### New Dependencies

None
