### PR TITLE
Updated ExternalCodeComp to handle path separators in the executable name

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ To install all the optional dependencies:
 This allows you to install **OpenMDAO** from a local copy of the source code.
 
     git clone http://github.com/OpenMDAO/OpenMDAO
-    pip install OpenMDAO
+    cd OpenMDAO
+    pip install .
 
 If you would like to make changes to **OpenMDAO** it is recommended you
 install it in *[editable][16]* mode (i.e., development mode) by adding the `-e`

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -195,7 +195,8 @@ class ExternalCodeDelegate(object):
         comp = self._comp
 
         if isinstance(command, str):
-            program_to_execute = re.findall(r"^([\w\-]+)", command)[0]
+            # parse for the first word, which may contain dashes and path separators
+            program_to_execute = re.findall(r"^([\w\-\/]+)", command)[0]
         else:
             program_to_execute = command[0]
 

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -196,7 +196,7 @@ class ExternalCodeDelegate(object):
 
         if isinstance(command, str):
             # parse for the first word, which may contain dashes and path separators
-            program_to_execute = re.findall(r"^([\w\-\/]+)", command)[0]
+            program_to_execute = re.findall(r"^([\w\-\/\:]+)", command)[0]
         else:
             program_to_execute = command[0]
 

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -278,7 +278,8 @@ class ParaboloidExternalCodeComp(om.ExternalCodeComp):
         #     sys.executable, 'extcode_paraboloid.py', self.input_file, self.output_file
         # ]
 
-        self.options['command'] = ('python extcode_paraboloid.py {} {}').format(self.input_file, self.output_file)
+        self.options['command'] = ('{} extcode_paraboloid.py {} {}').format(
+                                   sys.executable, self.input_file, self.output_file)
 
     def compute(self, inputs, outputs):
         x = inputs['x'].item()


### PR DESCRIPTION
### Summary

This fixes a couple of issues experienced by a new user as reported in #3171.

- Changed the README instructions for installing from a cloned repo to prevent a user from accidentally installing from pypi instead due to case sensitivity
- Changed the `ParaboloidExternalCodeComp` used in testing to use `sys.executable` to handle the case where the `python` command has a different name, e.g. `python3`
- Updated the logic in `ExternalCodeDelegate` so it can parse a command pathname that includes path separators, including the Windows colon


### Related Issues

- Resolves #3171, #3172

### Backwards incompatibilities

None

### New Dependencies

None
