### PR TITLE
Updated ExternalCodeComp to handle a period in the executable pathname

### DIFF
--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -196,7 +196,7 @@ class ExternalCodeDelegate(object):
 
         if isinstance(command, str):
             # parse for the first word, which may contain dashes and path separators
-            program_to_execute = re.findall(r"^([\w\-\/\:]+)", command)[0]
+            program_to_execute = re.findall(r"^([\w\-\/\:\.]+)", command)[0]
         else:
             program_to_execute = command[0]
 


### PR DESCRIPTION
### Summary

This is a follow up to PR #3173

An external command path could have periods, e.g.  _~/.conda/envs/OM/python3.10_, so we handle that as well.

### Related Issues

- Resolves #3172

### Backwards incompatibilities

None

### New Dependencies

None
