### PR TITLE
Issue #3177 fix: Added ability to force `assert_near_equal` to use absolute error.

### DIFF
--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2747,10 +2747,10 @@ class TestSqliteRecorder(unittest.TestCase):
         obj = case.get_objectives()
 
         assert_near_equal(obj, {'f_xy': -27.33333333}, tolerance=1e-8)
-        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=8.1e-8)
+        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=8.1e-8, tol_type='abs')
 
         if Version(scipy_version) < Version("1.11"):
-            assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=8.1e-8)
+            assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=8.1e-8, tol_type='abs')
         else:
             self.assertEqual(con, {})
 
@@ -3121,7 +3121,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         # get_val can convert your result's units if desired
         const_K = case.get_val("con1", units='K')
 
-        assert_near_equal(const, -1.68550507e-10, 1e-3, atol=1e-8)
+        assert_near_equal(const, -1.68550507e-10, 1e-3, tol_type='abs')
         assert_near_equal(const_K, 273.15, 1e-3)
 
         # list_outputs will list your model's outputs and return a list of them too
@@ -3135,7 +3135,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         assert_near_equal(objectives['obj'], 3.18339395, 1e-4)
         assert_near_equal(design_vars['x'], 0., 1e-4)
-        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-4, atol=1e-8)
+        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-4, tol_type='abs')
 
     def test_feature_driver_recording_options(self):
 
@@ -3635,8 +3635,8 @@ class TestFeatureAdvancedExample(unittest.TestCase):
         assert_near_equal(objectives['obj'], 3.18339395, 1e-8)
         assert_near_equal(design_vars['x'], 0., 1e-8)
         assert_near_equal(design_vars['z'], [1.97763888, 1.25035459e-15], 1e-8)
-        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-8, atol=1e-8)
-        assert_near_equal(constraints['con2'], -20.24472223, 1e-8, atol=1e-8)
+        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-8, tol_type='abs')
+        assert_near_equal(constraints['con2'], -20.24472223, 1e-8, tol_type='abs')
 
     def test_feature_problem_recorder(self):
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2747,10 +2747,10 @@ class TestSqliteRecorder(unittest.TestCase):
         obj = case.get_objectives()
 
         assert_near_equal(obj, {'f_xy': -27.33333333}, tolerance=1e-8)
-        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8)
+        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=1e-7)
 
         if Version(scipy_version) < Version("1.11"):
-            assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8)
+            assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=1e-7)
         else:
             self.assertEqual(con, {})
 
@@ -3121,7 +3121,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         # get_val can convert your result's units if desired
         const_K = case.get_val("con1", units='K')
 
-        assert_near_equal(const, -1.68550507e-10, 1e-3)
+        assert_near_equal(const, -1.68550507e-10, 1e-3, atol=1e-8)
         assert_near_equal(const_K, 273.15, 1e-3)
 
         # list_outputs will list your model's outputs and return a list of them too
@@ -3135,7 +3135,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         assert_near_equal(objectives['obj'], 3.18339395, 1e-4)
         assert_near_equal(design_vars['x'], 0., 1e-4)
-        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-4)
+        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-4, atol=1e-8)
 
     def test_feature_driver_recording_options(self):
 
@@ -3635,8 +3635,8 @@ class TestFeatureAdvancedExample(unittest.TestCase):
         assert_near_equal(objectives['obj'], 3.18339395, 1e-8)
         assert_near_equal(design_vars['x'], 0., 1e-8)
         assert_near_equal(design_vars['z'], [1.97763888, 1.25035459e-15], 1e-8)
-        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-8)
-        assert_near_equal(constraints['con2'], -20.24472223, 1e-8)
+        assert_near_equal(constraints['con1'], -1.68550507e-10, 1e-8, atol=1e-8)
+        assert_near_equal(constraints['con2'], -20.24472223, 1e-8, atol=1e-8)
 
     def test_feature_problem_recorder(self):
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -2747,10 +2747,10 @@ class TestSqliteRecorder(unittest.TestCase):
         obj = case.get_objectives()
 
         assert_near_equal(obj, {'f_xy': -27.33333333}, tolerance=1e-8)
-        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=1e-7)
+        assert_near_equal(dvs, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=8.1e-8)
 
         if Version(scipy_version) < Version("1.11"):
-            assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=1e-7)
+            assert_near_equal(con, {'x': 6.66666669, 'y': -7.33333338}, tolerance=1e-8, atol=8.1e-8)
         else:
             self.assertEqual(con, {})
 

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -575,7 +575,7 @@ def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
 
             if atol:
                 if abs(error) > atol:
-                    raise ValueError('actual %s, desired %s, rel error %s, absolute tolerance %s'
+                    raise ValueError('actual %s, desired %s, abs error %s, abs tolerance %s'
                                      % (actual, desired, error, atol))
             elif abs(error) > tolerance:
                 if actual.size < 10 and desired.size < 10:

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -432,7 +432,8 @@ def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
         The value expected.
     tolerance : float
         Maximum relative error ``(actual - desired) / desired``.
-
+    atol : float
+        Maximum absolute error ``(actual - desired)``.
     Returns
     -------
     float

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -434,6 +434,7 @@ def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
         Maximum relative error ``(actual - desired) / desired``.
     atol : float
         Maximum absolute error ``(actual - desired)``.
+
     Returns
     -------
     float

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -415,7 +415,7 @@ def assert_no_dict_jacobians(system, include_self=True, recurse=True):
         raise AssertionError('\n'.join(parts))
 
 
-def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
+def assert_near_equal(actual, desired, tolerance=1e-15, tol_type='rel'):
     """
     Check relative error.
 
@@ -431,9 +431,12 @@ def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
     desired : float, array-like, dict
         The value expected.
     tolerance : float
-        Maximum relative error ``(actual - desired) / desired``.
-    atol : float
-        Maximum absolute error ``(actual - desired)``.
+        Maximum relative or absolute error.
+        For relative tolerance: ``(actual - desired) / desired``.
+        For absolute  tolerance: ``(actual - desired)``.
+    tol_type : {'rel', 'abs'}
+        Type of error to use: 'rel' for relative error, 'abs' for absolute error.
+        Default is set to 'rel'.
 
     Returns
     -------
@@ -502,7 +505,7 @@ def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
 
         for key in actual_keys:
             try:
-                new_error = assert_near_equal(actual[key], desired[key], tolerance, atol)
+                new_error = assert_near_equal(actual[key], desired[key], tolerance, tol_type)
                 error = max(error, new_error)
             except ValueError as exception:
                 msg = '{}: '.format(key) + str(exception)
@@ -566,28 +569,22 @@ def assert_near_equal(actual, desired, tolerance=1e-15, atol=None):
                 else:
                     raise ValueError('actual and desired values have non-matching nan'
                                      ' values')
-            if np.linalg.norm(desired) == 0:
-                error = np.linalg.norm(actual)
-            elif atol:
+            if np.linalg.norm(desired) == 0 or tol_type == 'abs':
                 error = np.linalg.norm(actual - desired)
             else:
                 error = np.linalg.norm(actual - desired) / np.linalg.norm(desired)
 
-            if atol:
-                if abs(error) > atol:
-                    raise ValueError('actual %s, desired %s, abs error %s, abs tolerance %s'
-                                     % (actual, desired, error, atol))
-            elif abs(error) > tolerance:
+            if abs(error) > tolerance:
                 if actual.size < 10 and desired.size < 10:
-                    raise ValueError('actual %s, desired %s, rel error %s, tolerance %s'
-                                     % (actual, desired, error, tolerance))
+                    raise ValueError('actual %s, desired %s, %s error %s, tolerance %s'
+                                     % (actual, desired, tol_type, error, tolerance))
                 else:
                     raise ValueError('arrays do not match, rel error %.3e > tol (%.3e)' %
                                      (error, tolerance))
     elif isinstance(actual, tuple) and isinstance(desired, tuple):
         error = 0.0
         for act, des in zip(actual, desired):
-            new_error = assert_near_equal(act, des, tolerance, atol)
+            new_error = assert_near_equal(act, des, tolerance, tol_type)
             error = max(error, new_error)
     else:
         raise ValueError(


### PR DESCRIPTION
### Summary

Added a`tol_type` parameter to assert_near_equal to allow users to force it to use absolute error when the nominal value is small but nonzero.  Also made the necessary changes to the tests in `test_sqlite_recorder.py` so that they used absolute tolerance as well.

It passes all the previously failing test cases within `test_sqlite_recorder.py`:

```
batuhansahin@227-3 OpenMDAO % testflo openmdao/recorders/tests/test_sqlite_recorder.py -n 1

..........................................................................S...S..

OK

Passed:  79
Failed:  0
Skipped: 2


Ran 81 tests using 1 processes
Wall clock time:   00:00:8.52
```

### Related Issues

- Resolves #3177 

### Backwards incompatibilities

None

### New Dependencies

None
