### PR TITLE
Warning in AddSubtractComp for duplicate input names

### DIFF
--- a/openmdao/components/add_subtract_comp.py
+++ b/openmdao/components/add_subtract_comp.py
@@ -7,6 +7,7 @@ import numpy as np
 from scipy import sparse as sp
 
 from openmdao.core.explicitcomponent import ExplicitComponent
+from openmdao.utils.om_warnings import issue_warning
 
 
 class AddSubtractComp(ExplicitComponent):
@@ -172,6 +173,10 @@ class AddSubtractComp(ExplicitComponent):
         elif len(scaling_factors) != len(input_names):
             raise ValueError(self.msginfo + ': Scaling factors list needs to be same length '
                              'as input names')
+
+        if len(input_names) != len(set(input_names)):
+            issue_warning(f"Duplicate inputs are connected to '{output_name}'. This will "
+                          "double count the same value, which may cause unexpected behavior.")
 
         if length == 1:
             shape = (vec_size,)

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -516,7 +516,7 @@ class TestDuplicateWarning(unittest.TestCase):
 
     def test_no_warning(self):
         """
-        Tests that no warning is issued when there are no duplicate inputs
+        Tests if no warning is issued when there are no duplicate inputs
         """
         comp = om.AddSubtractComp()
         input_names = ["f1", "f2", "f3", "f4", "f5"]

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -3,7 +3,8 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.om_warnings import OpenMDAOWarning
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_warning, assert_no_warning
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -497,6 +498,35 @@ class TestFeature(unittest.TestCase):
         expected_i = np.array([[100, 200, 300], [0, -1, -2]]).T
         assert_near_equal(p.get_val('totalforcecomp.total_force', units='kN'), expected_i)
 
+
+class TestDuplicateWarning(unittest.TestCase):
+
+    def test_if_warning(self):
+        """
+        Tests if a warning is issued when duplicate inputs are used
+        """
+        comp = om.AddSubtractComp()
+        input_names = ["f1", "f2", "f2", "f1", "f3"]
+        output_name = "f"
+        msg = f"Duplicate inputs are connected to '{output_name}'. This will " \
+              "double count the same value, which may cause unexpected behavior."
+        
+        with assert_warning(OpenMDAOWarning, msg, True):
+            comp.add_equation(output_name, input_names=input_names)
+
+    def test_no_warning(self):
+        """
+        Tests that no warning is issued when there are no duplicate inputs
+        """
+        comp = om.AddSubtractComp()
+        input_names = ["f1", "f2", "f3", "f4", "f5"]
+        output_name = "f"
+        msg = f"Duplicate inputs are connected to '{output_name}'. This will " \
+              "double count the same value, which may cause unexpected behavior."
+        
+        with assert_no_warning(OpenMDAOWarning, msg):
+            comp.add_equation(output_name, input_names=input_names)
+    
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
### Summary

Added a warning when an input is connected to the same equation multiple times, since this double-counts the value. Also added a new unit test which makes sure that the warning is only issued when duplicate inputs are in the input names.

### Related Issues

- Resolves #3182 

### Backwards incompatibilities

None

### New Dependencies

None
