### PR TITLE
Gave user explicit access to the subproblem in SubModelComp

### DIFF
--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -157,6 +157,18 @@ class SubmodelComp(ExplicitComponent):
         """
         return name.replace('.', ':')
 
+    @property
+    def problem(self):
+        """
+        Allows user read-only access to the sub-problem.
+
+        Returns
+        -------
+        <Problem>
+            Instantiated problem used to run the model.
+        """
+        return self._subprob
+
     def add_input(self, prom_in, name=None, **kwargs):
         """
         Add input to model before or after setup.

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -160,7 +160,7 @@ class SubmodelComp(ExplicitComponent):
     @property
     def problem(self):
         """
-        Allows user read-only access to the sub-problem.
+        Allow user read-only access to the sub-problem.
 
         Returns
         -------

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -422,6 +422,18 @@ class TestSubmodelComp(unittest.TestCase):
         totals = p.check_totals(method='cs')
         assert_check_totals(totals, atol=1e-11, rtol=1e-11)
 
+    def test_problem_property(self):
+        """Tests the problem property of SubmodelComp"""
+        p = om.Problem()
+        submodel = om.SubmodelComp(problem=p)
+        subprob = submodel.problem
+
+        self.assertIsInstance(subprob, om.Problem) # make sure it returns a problem
+        self.assertEqual(subprob, p) # make sure it returns correct problem
+
+        with self.assertRaises(AttributeError): # make sure it cannot be assigned
+            submodel.problem = om.Problem()
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestSubmodelCompMPI(unittest.TestCase):


### PR DESCRIPTION
### Summary

Created a new `problem` property which gives the user read-only access to the sub-problem. Added tests within the test suite that makes sure that the problem cannot be reassigned, and that the problem is indeed the sub-problem within the SubmodelComp.

### Related Issues

- Resolves #3183

### Backwards incompatibilities

None

### New Dependencies

None
