### PR TITLE
Fix for a SubmodelComp indexing issue that was preventing data from being copied properly from the outer model to the inner model.

### DIFF
--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -4,7 +4,7 @@ from collections import defaultdict, Counter
 from openmdao.core.constants import _SetupStatus, INF_BOUND
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.total_jac import _TotalJacInfo
-from openmdao.utils.general_utils import pattern_filter
+from openmdao.utils.general_utils import pattern_filter, vprint
 from openmdao.utils.reports_system import clear_reports
 from openmdao.utils.mpi import MPI, FakeComm
 from openmdao.utils.coloring import compute_total_coloring, ColoringMeta
@@ -261,7 +261,8 @@ class SubmodelComp(ExplicitComponent):
 
         # store indep vars by promoted name, excluding _auto_ivc vars because later we'll
         # add the inputs connected to _auto_ivc vars as indep vars (because that's how the user
-        # would expect them to be named)
+        # would expect them to be named).  Note that not all indep_vars will be visible outside
+        # of this component.
         self.indep_vars = {}
         for src, meta in abs2meta.items():
             if src.startswith('_auto_ivc.'):
@@ -272,16 +273,16 @@ class SubmodelComp(ExplicitComponent):
                     meta = abs2meta_local[src]  # get local metadata if we have it
                 self.indep_vars[prom] = (src, meta)
 
-        # add any inputs connected to _auto_ivc vars as indep vars
+        # add any inputs connected to indep vars as indep vars.  Their name will be the
+        # promoted name of the input that connects to the actual indep var.
         for prom in prom2abs_in:
             src = p.model.get_source(prom)
-            if not src.startswith('_auto_ivc.'):
-                continue
             if src in abs2meta_local:
                 meta = abs2meta_local[src]  # get local metadata if we have it
             else:
                 meta = abs2meta[src]
-            self.indep_vars[prom] = (src, meta)
+            if 'openmdao:indep_var' in meta['tags']:
+                self.indep_vars[prom] = (src, meta)
 
         self._submodel_inputs = {}
         self._submodel_outputs = {}
@@ -373,8 +374,6 @@ class SubmodelComp(ExplicitComponent):
         of_metadata, wrt_metadata, _ = p.model._get_totals_metadata(driver=p.driver,
                                                                     of=ofs, wrt=wrts)
 
-        self._setup_transfer_idxs(of_metadata, wrt_metadata)
-
         if len(inputs) == 0 or len(outputs) == 0:
             return
 
@@ -424,6 +423,18 @@ class SubmodelComp(ExplicitComponent):
                                       wrt=self._to_outer_input(wrt),
                                       rows=nzrows, cols=nzcols)
 
+    def _setup_vectors(self, root_vectors):
+        """
+        Compute all vectors for all vec names and assign excluded variables lists.
+
+        Parameters
+        ----------
+        root_vectors : dict of dict of Vector
+            Root vectors: first key is 'input', 'output', or 'residual'; second key is vec_name.
+        """
+        super()._setup_vectors(root_vectors)
+        self._setup_transfer_idxs()
+
     def _set_complex_step_mode(self, active):
         super()._set_complex_step_mode(active)
         self._subprob.set_complex_step_mode(active)
@@ -447,10 +458,10 @@ class SubmodelComp(ExplicitComponent):
         p = self._subprob
 
         # set our inputs and outputs into the submodel
-        p.model._outputs.set_val(self._inputs.asarray(), idxs=self._input_xfer_idxs())
+        p.model._outputs.set_val(inputs.asarray(), idxs=self._input_xfer_idxs())
 
         inner_idxs = self._output_xfer_idxs()
-        p.model._outputs.set_val(self._outputs.asarray(), idxs=inner_idxs)
+        p.model._outputs.set_val(outputs.asarray(), idxs=inner_idxs)
 
         if self._do_opt:
             p.run_driver()
@@ -493,7 +504,7 @@ class SubmodelComp(ExplicitComponent):
                 partials[(self._to_outer_output(of), self._to_outer_input(wrt))] = \
                     tots[of, wrt][nzrows, nzcols].ravel()
 
-    def _setup_transfer_idxs(self, of_metadata, wrt_metadata):
+    def _setup_transfer_idxs(self):
         """
         Set up the transfer indices for input and output variables.
 
@@ -509,10 +520,13 @@ class SubmodelComp(ExplicitComponent):
 
         full_shape = (rng[1],) if full_inner_map else (0,)
 
+        # map outer name of inputs to their inner promoted name
+        input_map = {v[0]: k for k, v in self._submodel_inputs.items()}
+
         # get ranges for subodel outputs corresponding to our inputs
         inp_ranges = []
-        for inner_prom in self._submodel_inputs:
-            src, _ = self.indep_vars[inner_prom]
+        for inner_prom in self._inputs:
+            src, _ = self.indep_vars[input_map[inner_prom]]
             inp_ranges.append(full_inner_map[src])
 
         # get ranges for submodel outputs corresponding to our outputs

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -4,7 +4,7 @@ from collections import defaultdict, Counter
 from openmdao.core.constants import _SetupStatus, INF_BOUND
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.total_jac import _TotalJacInfo
-from openmdao.utils.general_utils import pattern_filter, vprint
+from openmdao.utils.general_utils import pattern_filter
 from openmdao.utils.reports_system import clear_reports
 from openmdao.utils.mpi import MPI, FakeComm
 from openmdao.utils.coloring import compute_total_coloring, ColoringMeta

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -164,7 +164,9 @@ class TestSubmodelComp(unittest.TestCase):
         p = om.Problem()
         model = om.Group()
 
-        model.add_subsystem('sub', om.ExecComp('z = x1**2 + x2**2 + x3**2'), promotes=['*'])
+        model.add_subsystem('sub', om.ExecComp(['z = foo**2 + bar**2 + baz**2',
+                                                'out = bgd - xyz*foo + baz',
+                                                'result = -foo*bgd + bar*xyz']), promotes=['*'])
         subprob = om.Problem()
         subprob.model.add_subsystem('submodel', model, promotes=['*'])
         comp = om.SubmodelComp(problem=subprob, inputs=['x*'], outputs=['*'])
@@ -172,9 +174,11 @@ class TestSubmodelComp(unittest.TestCase):
         p.model.add_subsystem('comp', comp, promotes_inputs=['*'], promotes_outputs=['*'])
         p.setup()
 
-        p.set_val('x1', 1)
-        p.set_val('x2', 2)
-        p.set_val('x3', 3)
+        p.set_val('foo', 1)
+        p.set_val('bar', 2)
+        p.set_val('baz', 3)
+        p.set_val('bgd', 4)
+        p.set_val('xyz', 5)
 
         p.run_model()
 
@@ -184,10 +188,12 @@ class TestSubmodelComp(unittest.TestCase):
         inputs = {inputs[i][0]: inputs[i][1]['val'] for i in range(len(inputs))}
         outputs = {outputs[i][0]: outputs[i][1]['val'] for i in range(len(outputs))}
 
-        assert_near_equal(inputs['x1'], 1)
-        assert_near_equal(inputs['x2'], 2)
-        assert_near_equal(inputs['x3'], 3)
+        assert_near_equal(inputs['foo'], 1)
+        assert_near_equal(inputs['bar'], 2)
+        assert_near_equal(inputs['baz'], 3)
         assert_near_equal(outputs['z'], 14)
+
+        assert_check_partials(p.check_partials(out_stream=None), atol=2e-6)
 
     def test_add_io_before_setup(self):
         p = om.Problem()
@@ -221,7 +227,7 @@ class TestSubmodelComp(unittest.TestCase):
         p.setup(force_alloc_complex=True)
 
         p.run_model()
-        cpd = p.check_partials(method='cs', out_stream=None)
+        assert_check_partials(p.check_partials(out_stream=None))
 
         assert_near_equal(p.get_val('z'), 1.0)
 
@@ -280,7 +286,7 @@ class TestSubmodelComp(unittest.TestCase):
         p.set_val('theta', np.pi)
 
         p.run_model()
-        cpd = p.check_partials(method='cs', out_stream=None)
+        assert_check_partials(p.check_partials(method='cs', out_stream=None))
 
         assert_near_equal(p.get_val('z'), 1)
 
@@ -441,8 +447,7 @@ class TestSubmodelCompMPI(unittest.TestCase):
 
         p.setup(force_alloc_complex=True)
         p.run_model()
-        cpd = p.check_partials(method='cs', out_stream=None)
-        assert_check_partials(cpd)
+        assert_check_partials(p.check_partials(method='cs', out_stream=None))
 
 
 class IncompleteRelevanceGroup(om.Group):
@@ -601,6 +606,69 @@ class TestSubmodelOpt(unittest.TestCase):
         self.assertEqual(cm.exception.args[0],
                          "'submodel' <class SubmodelComp>: Error calling compute_partials(), Can't compute partial "
                          "derivatives of a SubmodelComp with an internal optimizer.")
+
+
+
+
+def build_submodel(compute_x=False):
+    p = om.Problem()
+    supmodel = om.Group()
+    supmodel.add_subsystem('supComp', om.ExecComp('diameter = r * theta'),
+                            promotes_inputs=['*'],
+                            promotes_outputs=['*', ('diameter', 'aircraft:fuselage:diameter')])
+
+    subprob1 = om.Problem()
+    submodel1 = subprob1.model.add_subsystem('submodel1', om.Group(), promotes=['*'])
+
+    if compute_x:
+        submodel1.add_subsystem('x', om.ExecComp('x = diameter * 2 * r * theta'), promotes=['*', ('diameter', 'aircraft:fuselage:diameter')])
+    submodel1.add_subsystem('y', om.ExecComp('y = mass * donkey_kong'), promotes=['*', ('mass', 'dynamic:mission:mass'), ('donkey_kong', 'aircraft:engine:donkey_kong')])
+
+
+    p.model.add_subsystem('supModel', supmodel, promotes_inputs=['*'],
+                            promotes_outputs=['*'])
+
+
+    submodel = om.SubmodelComp(problem=subprob1, inputs=['*'], outputs=['*'], do_coloring=False)
+    p.model.add_subsystem('sub1', submodel,
+                            promotes_inputs=['*'],
+                            promotes_outputs=['*'])
+
+    p.model.set_input_defaults('r', 1.25)
+    p.model.set_input_defaults('theta', np.pi)
+
+    p.setup(force_alloc_complex=True)
+
+    p.set_val('r', 1.25)
+    p.set_val('theta', 0.5)
+    p.set_val('dynamic:mission:mass', 2.0)
+    p.set_val('aircraft:engine:donkey_kong', 3.0)
+    p.set_val('aircraft:fuselage:diameter', 3.5)
+
+    return p
+
+
+
+class TestSubModelBug(unittest.TestCase):
+
+    def test_submodel_bug(self):
+        p = build_submodel(compute_x=False)
+
+        p.run_model()
+
+        p.model.sub1.show_interface()
+
+        assert_near_equal(p.get_val('y'), 2.0 * 3.0)
+
+
+    def test_submodel_bug_fails(self):
+        p = build_submodel(compute_x=True)
+
+        p.run_model()
+
+        p.model.sub1.show_interface()
+
+        assert_near_equal(p.get_val('y'), 2.0 * 3.0)
 
 
 if __name__ == '__main__':

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -656,8 +656,6 @@ class TestSubModelBug(unittest.TestCase):
 
         p.run_model()
 
-        p.model.sub1.show_interface()
-
         assert_near_equal(p.get_val('y'), 2.0 * 3.0)
 
 
@@ -665,8 +663,6 @@ class TestSubModelBug(unittest.TestCase):
         p = build_submodel(compute_x=True)
 
         p.run_model()
-
-        p.model.sub1.show_interface()
 
         assert_near_equal(p.get_val('y'), 2.0 * 3.0)
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1445,3 +1445,27 @@ def get_rev_conns(conns):
         else:
             rev[src] = [tgt]
     return rev
+
+
+def vprint(it, end='\n', getter=None, file=None):
+    """
+    Iterate over the given iterator and print each item separated by end.
+
+    Parameters
+    ----------
+    it : iter
+        Iterator to be printed.
+    end : str
+        String written after each item.
+    getter : function or None
+        If not None, only print the part of each item returned by getter(item).
+    file : file-like or None
+        File to write to.  If None, use sys.stdout.
+    """
+    if file is None:
+        file = sys.stdout
+
+    for val in it:
+        if getter is not None:
+            val = getter(val)
+        print(val, end=end, file=file)


### PR DESCRIPTION
### Summary

This fixes the test case included in issue #3186.

An MPI related issue with SubmodelComp was discovered during this work.  That issue will be fixed in a later PR.

### Related Issues

- Resolves #3186

### Backwards incompatibilities

None

### New Dependencies

None
