### PR TITLE
Addressed vulnerability in dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ docs = [
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",
+    "idna>=3.7",
 ]
 doe = [
     "pyDOE3",
@@ -60,6 +61,7 @@ jax = [
 notebooks = [
     "ipympl",
     "notebook",
+    "idna>=3.7",
 ]
 test = [
     "aiounittest",


### PR DESCRIPTION
### Summary

Updated `[docs]` and `[notebook]` dependencies to require `idna>=3.7`.

### Related Issues

- Resolves #3193

### Backwards incompatibilities

None

### New Dependencies

None
