### PR TITLE
Fix pyOptSparse `hotstart_file` `@property` method

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -306,7 +306,7 @@ class pyOptSparseDriver(Driver):
         """
         warn_deprecation("The 'hotstart_file' attribute is deprecated. "
                          "Use the 'hotstart_file' option instead.")
-        return self.options['hist_file']
+        return self.options['hotstart_file']
 
     @hotstart_file.setter
     def hotstart_file(self, file_name):

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2816,7 +2816,7 @@ class TestPyoptSparse(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             driver.hist_file = filename
         with assert_warning(OMDeprecationWarning, msg):
-            driver.hist_file
+            self.assertEqual(driver.hist_file, filename)
         self.assertEqual(driver.options['hist_file'], filename)
 
         prob.setup()
@@ -2833,7 +2833,7 @@ class TestPyoptSparse(unittest.TestCase):
         with assert_warning(OMDeprecationWarning, msg):
             driver.hotstart_file = filename
         with assert_warning(OMDeprecationWarning, msg):
-            driver.hotstart_file
+            self.assertEqual(driver.hotstart_file, filename)
         self.assertEqual(driver.options['hotstart_file'], filename)
 
         prob.setup()


### PR DESCRIPTION
### Summary

The pyOptSparse hot start and history file attributes were switched to options. To maintain backward compatibility, `@property` methods were added that reference the option. However, the `hotstart_file` property method (presumably accidentally) references the `hist_file` option instead of the `hotstart_file` option. This PR fixes that.

### Backwards incompatibilities

None

### New Dependencies

None
