### PR TITLE
Updated Audit and Test workflows to use `setup-miniconda@v3`

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.11
           conda-version: "*"

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
           conda-version: "*"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -189,12 +189,11 @@ jobs:
           git fetch --prune --unshallow --tags
 
       - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
           conda-version: "*"
-          channels: conda-forge,defaults
-          channel-priority: true
+          channels: conda-forge
 
       - name: Install OpenMDAO
         run: |


### PR DESCRIPTION
### Summary

Updated Audit and Test workflows to use `setup-miniconda@v3`

Specifically [v3.04](https://github.com/conda-incubator/setup-miniconda/releases/tag/v3.0.4) fixes the MacOS issue:

> Fixes
https://github.com/conda-incubator/setup-miniconda/pull/345 Fix running on macOS 13 on Intel since the runners no longer provide miniconda by default.


### Related Issues

- Resolves #3209

### Backwards incompatibilities

None

### New Dependencies

None
