### PR TITLE
Added input fix to outputs

### DIFF
--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -529,13 +529,10 @@ class SubmodelComp(ExplicitComponent):
             src, _ = self.indep_vars[input_map[inner_prom]]
             inp_ranges.append(full_inner_map[src])
 
-        # map outer name of outputs to their inner promoted name
-        output_map = {v[0]: k for k, v in self._submodel_outputs.items()}
-
         # get ranges for submodel outputs corresponding to our outputs
         out_ranges = []
-        for inner_prom in self._outputs:
-            out_ranges.append(full_inner_map[prom2abs[output_map[inner_prom]][0]])
+        for inner_prom in self._submodel_outputs:
+            out_ranges.append(full_inner_map[prom2abs[inner_prom][0]])
 
         self._input_xfer_idxs = ranges2indexer(inp_ranges, src_shape=full_shape)
         self._output_xfer_idxs = ranges2indexer(out_ranges, src_shape=full_shape)

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -522,13 +522,15 @@ class SubmodelComp(ExplicitComponent):
 
         # map outer name of inputs to their inner promoted name
         input_map = {v[0]: k for k, v in self._submodel_inputs.items()}
-        output_map = {v[0]: k for k, v in self._submodel_outputs.items()}
 
         # get ranges for subodel outputs corresponding to our inputs
         inp_ranges = []
         for inner_prom in self._inputs:
             src, _ = self.indep_vars[input_map[inner_prom]]
             inp_ranges.append(full_inner_map[src])
+
+        # map outer name of outputs to their inner promoted name
+        output_map = {v[0]: k for k, v in self._submodel_outputs.items()}
 
         # get ranges for submodel outputs corresponding to our outputs
         out_ranges = []

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -522,6 +522,7 @@ class SubmodelComp(ExplicitComponent):
 
         # map outer name of inputs to their inner promoted name
         input_map = {v[0]: k for k, v in self._submodel_inputs.items()}
+        output_map = {v[0]: k for k, v in self._submodel_outputs.items()}
 
         # get ranges for subodel outputs corresponding to our inputs
         inp_ranges = []
@@ -531,8 +532,8 @@ class SubmodelComp(ExplicitComponent):
 
         # get ranges for submodel outputs corresponding to our outputs
         out_ranges = []
-        for inner_prom in self._submodel_outputs:
-            out_ranges.append(full_inner_map[prom2abs[inner_prom][0]])
+        for inner_prom in self._outputs:
+            out_ranges.append(full_inner_map[prom2abs[output_map[inner_prom]][0]])
 
         self._input_xfer_idxs = ranges2indexer(inp_ranges, src_shape=full_shape)
         self._output_xfer_idxs = ranges2indexer(out_ranges, src_shape=full_shape)

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -253,7 +253,7 @@ class pyOptSparseDriver(Driver):
                              desc='Title of this optimization run')
         self.options.declare('print_opt_prob', types=bool, default=False,
                              desc='Print the opt problem summary before running the optimization')
-        self.options.declare('print_results', types=bool, default=True,
+        self.options.declare('print_results', types=(bool,str), default=True,
                              desc='Print pyOpt results if True')
         self.options.declare('gradient_method', default='openmdao',
                              values={'openmdao', 'pyopt_fd', 'snopt_fd'},
@@ -646,6 +646,8 @@ class pyOptSparseDriver(Driver):
         # Print results
         if self.options['print_results']:
             if not MPI or model.comm.rank == 0:
+                if self.options['print_results'] == 'minimal':
+                    sol.minimal_print = True
                 print(sol)
 
         # Pull optimal parameters back into framework and re-run, so that


### PR DESCRIPTION
### Summary

Instead of just True/False, minimal will only print variables and
constraints that have a non-empty status (for example ones that
violate a bound)
This extends the acceptable values for print_result and automates setting the minimal_print value that is added here https://github.com/mdolab/pyoptsparse/pull/395
Even if the version of pyoptsparse a user has doesn't include this feature, it won't cause problems.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
Instead of just True/False, minimal will only print variables and
constraints that have a non-empty status (for example ones that
violate a bound)