### PR TITLE
Added ability to set print_results to "minimal"

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -253,7 +253,7 @@ class pyOptSparseDriver(Driver):
                              desc='Title of this optimization run')
         self.options.declare('print_opt_prob', types=bool, default=False,
                              desc='Print the opt problem summary before running the optimization')
-        self.options.declare('print_results', types=bool, default=True,
+        self.options.declare('print_results', types=(bool,str), default=True,
                              desc='Print pyOpt results if True')
         self.options.declare('gradient_method', default='openmdao',
                              values={'openmdao', 'pyopt_fd', 'snopt_fd'},
@@ -646,6 +646,8 @@ class pyOptSparseDriver(Driver):
         # Print results
         if self.options['print_results']:
             if not MPI or model.comm.rank == 0:
+                if self.options['print_results'] == 'minimal':
+                    sol.minimal_print = True
                 print(sol)
 
         # Pull optimal parameters back into framework and re-run, so that

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -253,7 +253,7 @@ class pyOptSparseDriver(Driver):
                              desc='Title of this optimization run')
         self.options.declare('print_opt_prob', types=bool, default=False,
                              desc='Print the opt problem summary before running the optimization')
-        self.options.declare('print_results', types=(bool,str), default=True,
+        self.options.declare('print_results', types=(bool, str), default=True,
                              desc='Print pyOpt results if True')
         self.options.declare('gradient_method', default='openmdao',
                              values={'openmdao', 'pyopt_fd', 'snopt_fd'},

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -647,8 +647,13 @@ class pyOptSparseDriver(Driver):
         if self.options['print_results']:
             if not MPI or model.comm.rank == 0:
                 if self.options['print_results'] == 'minimal':
-                    sol.minimal_print = True
-                print(sol)
+                    if hasattr(sol, 'summary_str'):
+                        print(sol.summary_str(minimal_print=True))
+                    else:
+                        print('minimal_print is not available for this solution')
+                        print(sol)
+                else:
+                    print(sol)
 
         # Pull optimal parameters back into framework and re-run, so that
         # framework is left in the right final state

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -658,9 +658,6 @@ class TestPyoptSparse(unittest.TestCase):
         prob.driver.options['print_results'] = 'minimal'
         prob.run_driver()
 
-        assert_near_equal(prob['x'], 30, 1e-6)
-        assert_near_equal(prob['y'], 0, 1e-6)
-
     def test_simple_array_comp2D(self):
 
         prob = om.Problem()

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -640,8 +640,6 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = OPTIMIZER
-        prob.driver.opt_settings['max_iter'] = 0
-        prob.driver.options['print_results'] = False
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
         model.add_design_var('y', lower=-50.0, upper=50.0)

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -623,6 +623,46 @@ class TestPyoptSparse(unittest.TestCase):
         assert_near_equal(prob['x'], 19.5, 1e-6)
         assert_near_equal(prob['y'], 5.5, 1e-6)
 
+    def test_minimal_print(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('x', 50.0)
+        model.set_input_defaults('y', 50.0)
+        model.set_input_defaults('z', 0)
+
+        parab = om.ExecComp('f_xy = (x-3.0)**2 + x*y + (y+4.0)**2 - 3.0 + z')
+
+        model.add_subsystem('comp', parab, promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x + y - 25.0'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = om.pyOptSparseDriver()
+        prob.driver.options['optimizer'] = OPTIMIZER
+        prob.driver.opt_settings['max_iter'] = 0
+        prob.driver.options['print_results'] = False
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_design_var('z', lower=-50.0, upper=0)
+        model.add_objective('f_xy')
+        model.add_constraint('c', lower=25)
+        model.add_constraint('x', upper=30)
+        model.add_constraint('y', upper=0)
+        model.add_constraint('z', upper=50)
+
+        prob.setup()
+        prob.driver.options['print_results'] = True
+        prob.run_driver()
+
+        prob.setup()
+        prob.driver.options['print_results'] = 'minimal'
+        prob.run_driver()
+
+        assert_near_equal(prob['x'], 30, 1e-6)
+        assert_near_equal(prob['y'], 0, 1e-6)
+
     def test_simple_array_comp2D(self):
 
         prob = om.Problem()


### PR DESCRIPTION
### Summary

Instead of just True/False, minimal will only print variables and constraints that have a non-empty status (for example ones that violate a bound)
This extends the acceptable values for print_result and automates setting the minimal_print value that is added here https://github.com/mdolab/pyoptsparse/pull/395
Even if the version of pyoptsparse a user has doesn't include this feature, it won't cause problems.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
