### PR TITLE
Updated `pyoptsparse_driver` to address change in `pyoptsparse v2.11.0`

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -83,7 +83,7 @@ python -m pip install --upgrade --pre jax jaxlib
 echo "============================================================="
 echo "Install latest PETSc"
 echo "============================================================="
-conda install mpi4py petsc petsc4py -q -y
+conda install mpi4py petsc!=3.21.1 petsc4py -q -y
 
 echo "============================================================="
 echo "Check MPI and PETSc installation"

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -283,7 +283,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: 'warning'
           message: |
-            Environment change detected on ${{ matrix.NAME }} build.
+            Environment change detected on `${{ matrix.NAME }}` build.
             Python, NumPy or SciPy was not the requested version:
             ```${{steps.env_info.outputs.errors}}```
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -295,7 +295,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ steps.run_tests.outcome }}
           message:
-            Unit testing failed on ${{ matrix.NAME }} build.
+            Unit testing failed on `${{ matrix.NAME }}` build.
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Slack doc build failure
@@ -305,7 +305,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ steps.build_docs.outcome }}
           message: |
-            Doc build failed on ${{ matrix.NAME }} build.
+            Doc build failed on `${{ matrix.NAME }}` build.
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Slack deprecation warnings
@@ -315,7 +315,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: 'warning'
           message: |
-            Deprecations were detected on ${{ matrix.NAME }} build.
+            Deprecations were detected on `${{ matrix.NAME }}` build.
             ```${{ steps.deprecations_report.outputs.summary }}```
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -11,11 +11,27 @@ on:
   workflow_dispatch:
 
    inputs:
+      run_name:
+        description: 'Name of workflow run as it will appear under Actions tab (optional):'
+        type: string
+        required: false
+        default: ''
+      job_name:
+        description: 'Select a job from the matrix to run (default: all jobs)'
+        type: choice
+        options:
+          - ''
+          - 'Ubuntu Latest'
+          - 'MacOS Latest'
+        required: false
+        default: ''
       debug_enabled:
-        type: boolean
         description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        type: boolean
         required: false
         default: false
+
+run-name:  ${{ inputs.run_name }}
 
 permissions: {}
 
@@ -35,6 +51,15 @@ jobs:
             PY: 3
             PETSc: 3
             SNOPT: 7.7
+            BUILD_DOCS: true
+
+          # test latest versions on macos
+          - NAME: MacOS Latest
+            OS: macos-13
+            PY: 3
+            PETSc: 3
+            SNOPT: 7.7
+            BUILD_DOCS: false
 
     runs-on: ${{ matrix.OS }}
 
@@ -56,6 +81,12 @@ jobs:
           echo "Initiated by: ${GITHUB_ACTOR}"
           echo "============================================================="
 
+      - name: Exit if this job was not selected
+        if: github.event_name == 'workflow_dispatch' &&  inputs.job_name != '' &&  inputs.job_name != matrix.NAME
+        uses: actions/github-script@v7
+        with:
+          script: core.setFailed('The ${{ matrix.NAME }} job was not included in the run, exiting...');
+
       - name: Create SSH key
         if: (matrix.SNOPT || matrix.BUILD_DOCS)
         env:
@@ -76,6 +107,11 @@ jobs:
           python-version: ${{ matrix.PY }}
           conda-version: "*"
           channels: conda-forge
+
+      - name: Install MacOS-specific dependencies
+        if: matrix.OS == 'macos-13'
+        run: |
+          conda install compilers swig
 
       - name: Install latest versions of [all] openmdao dependencies
         run: |
@@ -163,6 +199,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        with:
+          limit-access-to-actor: true
 
       - name: Run tests
         id: run_tests
@@ -178,6 +216,7 @@ jobs:
 
       - name: Build docs
         id: build_docs
+        if: matrix.BUILD_DOCS
         continue-on-error: true
         run: |
           export OPENMDAO_REPORTS=0
@@ -244,7 +283,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: 'warning'
           message: |
-            Environment change detected on `Latest` build.
+            Environment change detected on ${{ matrix.NAME }} build.
             Python, NumPy or SciPy was not the requested version:
             ```${{steps.env_info.outputs.errors}}```
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -256,7 +295,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ steps.run_tests.outcome }}
           message:
-            Unit testing failed on `Latest` build.
+            Unit testing failed on ${{ matrix.NAME }} build.
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Slack doc build failure
@@ -266,7 +305,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ steps.build_docs.outcome }}
           message: |
-            Doc build failed on `Latest` build.
+            Doc build failed on ${{ matrix.NAME }} build.
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Slack deprecation warnings
@@ -276,7 +315,7 @@ jobs:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: 'warning'
           message: |
-            Deprecations were detected on `Latest` build.
+            Deprecations were detected on ${{ matrix.NAME }} build.
             ```${{ steps.deprecations_report.outputs.summary }}```
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -32,6 +32,12 @@ on:
         required: false
         default: false
 
+      MacOS_ARM:
+        type: boolean
+        description: 'Include MacOS ARM in test matrix'
+        required: false
+        default: false
+
       Windows_Baseline:
         type: boolean
         description: 'Include Windows Baseline in test matrix'
@@ -79,15 +85,14 @@ jobs:
           # test baseline versions on Ubuntu
           - NAME: Ubuntu Baseline
             OS: ubuntu-latest
-            PY: '3.11'
+            PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.12'
-            PETSc: '3.18'
-            PYOPTSPARSE: 'v2.10.1'
+            SCIPY: '1.13'
+            PETSc: '3.20'
+            PYOPTSPARSE: 'v2.11.0'
             # PAROPT: true
             SNOPT: '7.7'
             OPTIONAL: '[all]'
-            JAX: '0.4.14'
             BANDIT: true
             PEP517: true
             TESTS: true
@@ -95,24 +100,38 @@ jobs:
 
           # test baseline versions on MacOS
           - NAME: MacOS Baseline
-            OS: macos-latest
-            PY: '3.11'
+            OS: macos-13
+            PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.12'
-            PETSc: '3.18'
-            # PYOPTSPARSE: 'v2.10.1'
+            SCIPY: '1.13'
+            PETSc: '3.20'
+            PYOPTSPARSE: 'v2.11.0'
+            # PAROPT: true
+            SNOPT: '7.7'
+            OPTIONAL: '[docs,doe,jax,notebooks,test]'
+            TESTS: true
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_Baseline }}
+
+          # test baseline versions on MacOS/ARM
+          - NAME: MacOS ARM
+            OS: macos-14
+            PY: '3.12'
+            NUMPY: '1.26'
+            SCIPY: '1.13'
+            PETSc: '3.20'
+            # PYOPTSPARSE: 'v2.11.0'
             # PAROPT: true
             # SNOPT: '7.7'
             OPTIONAL: '[all]'
             TESTS: true
-            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_Baseline }}
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_ARM }}
 
           # test minimal install
           - NAME: Ubuntu Minimal
             OS: ubuntu-latest
-            PY: '3.11'
+            PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.12'
+            SCIPY: '1.13'
             OPTIONAL: '[test]'
             TESTS: true
             EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.Ubuntu_Minimal }}
@@ -137,9 +156,9 @@ jobs:
             OS: ubuntu-latest
             PY: '3.11'
             NUMPY: '1.26'
-            SCIPY: '1.12'
-            PETSc: '3.18'
-            PYOPTSPARSE: 'v2.10.1'
+            SCIPY: '1.13'
+            PETSc: '3.19'
+            PYOPTSPARSE: 'v2.11.0'
             SNOPT: '7.7'
             OPTIONAL: '[all]'
             BUILD_DOCS: true
@@ -214,6 +233,11 @@ jobs:
           else
             python -m pip install .${{ matrix.OPTIONAL }}
           fi
+
+      - name: Install MacOS-specific dependencies
+        if: matrix.OS == 'macos-13'
+        run: |
+          conda install swig
 
       - name: Install PETSc
         if: matrix.PETSc
@@ -365,6 +389,8 @@ jobs:
       - name: Setup tmate session
         if: ${{ inputs.debug_enabled }}
         uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true
 
       - name: Run tests
         id: run_tests
@@ -551,10 +577,10 @@ jobs:
         include:
           # baseline versions
           - NAME: Windows Baseline
-            PY: '3.11'
-            NUMPY: '1.24'
-            SCIPY: '1.12'
-            PYOPTSPARSE: '2.10.1'
+            PY: '3.12'
+            NUMPY: '1.26'
+            SCIPY: '1.13'
+            PYOPTSPARSE: '2.11.0'
             BANDIT: true
             EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.Windows_Baseline }}
 
@@ -584,12 +610,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Fetch tags
-        run: |
-          git fetch --prune --unshallow --tags
-
       - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
           conda-version: "*"

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -675,7 +675,9 @@ class pyOptSparseDriver(Driver):
             if optimizer == 'IPOPT':
                 if exit_status not in {0, 1}:
                     self.fail = True
-            elif exit_status > 2:
+            else:
+                # exit status may be the empty string for optimizers that don't support it
+                if exit_status and exit_status > 2:
                 self.fail = True
 
         except KeyError:

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -678,7 +678,7 @@ class pyOptSparseDriver(Driver):
             else:
                 # exit status may be the empty string for optimizers that don't support it
                 if exit_status and exit_status > 2:
-                self.fail = True
+                    self.fail = True
 
         except KeyError:
             # optimizers other than pySNOPT may not populate this dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 ]
 docs = [
     "ipyparallel",
-    "jupyter-book==0.14",
+    "jupyter-book",
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 ]
 docs = [
     "ipyparallel",
-    "jupyter-book",
+    "jupyter-book==0.14",
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",


### PR DESCRIPTION
### Summary

Updated `pyoptsparse_driver` to address change in `pyoptsparse v2.11.0`
- the `exit_status` entry in the `optInform` dictionary may now be the empty string

Also updated the CI workflows:
- updated the `latest` workflow script to avoid PETSc 3.21.1, which has a [bug](https://gitlab.com/petsc/petsc/-/issues/1587) 
- added a MacOS 13 build to the `latest` workflow
- changed the MacOS Baseline build on the `test` workflow to use `macos-13` bacause `macos-latest` is now ARM
- added a MacOS ARM build to the `test` workflow
- updated the baseline versions of Python, NumPy, SciPy, PETSc and pyOptSparse in the `test` workflow

### Related Issues

- Resolves #3212 

### Backwards incompatibilities

None

### New Dependencies

None
