### PR TITLE
Added ability to handle reading case recorder files with class instances when the associated class cannot be imported

### DIFF
--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -29,7 +29,7 @@ from json import loads as json_loads
 from io import TextIOBase
 
 
-class _InstanceWithNoClassDefinition:
+class UknownType:
     """
     A class used by _RestrictedUnpickler.
 
@@ -64,7 +64,7 @@ class _RestrictedUnpicklerForCaseReader(pickle.Unpickler):
         # Returning this acts as a kind of flag to indicate that
         # the unpickler can't generate instances of classes whose class definition
         # is not available
-        return _InstanceWithNoClassDefinition
+        return UknownType
 
     def loads_and_return_errors(self):
         unpickled_contents = self.load()
@@ -88,7 +88,7 @@ def _loads_and_return_errors(s):
     for key in keys:
         try:
             isInstanceWithNoClassDefinition = isinstance(dictionary[key],
-                                                         _InstanceWithNoClassDefinition)
+                                                         UknownType)
             if isInstanceWithNoClassDefinition:
                 dictionary.undeclare(key)
         except RuntimeError:  # OptionDictionary item might not be set yet

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -29,7 +29,7 @@ from json import loads as json_loads
 from io import TextIOBase
 
 
-class UknownType:
+class UnknownType:
     """
     A class used by _RestrictedUnpickler.
 
@@ -64,7 +64,7 @@ class _RestrictedUnpicklerForCaseReader(pickle.Unpickler):
         # Returning this acts as a kind of flag to indicate that
         # the unpickler can't generate instances of classes whose class definition
         # is not available
-        return UknownType
+        return UnknownType
 
     def loads_and_return_errors(self):
         unpickled_contents = self.load()
@@ -81,18 +81,6 @@ def _loads_and_return_errors(s):
 
     # returns a tuple of the value and also error strings
     dictionary, error_string = _RestrictedUnpicklerForCaseReader(i).loads_and_return_errors()
-
-    # remove any InstanceWithNoClassDefinition classes
-    # Only want to return legit values in the OptionsDictionary
-    keys = [key for key, value in dictionary.items()]
-    for key in keys:
-        try:
-            isInstanceWithNoClassDefinition = isinstance(dictionary[key],
-                                                         UknownType)
-            if isInstanceWithNoClassDefinition:
-                dictionary.undeclare(key)
-        except RuntimeError:  # OptionDictionary item might not be set yet
-            pass
 
     return dictionary, error_string
 

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -49,17 +49,12 @@ class _RestrictedUnpicklerForCaseReader(pickle.Unpickler):
         self.error_strings = ''  # Used to document which classes are not available
 
     def find_class(self, module, name):
-        # Only allow classes from 'module'
-
-        module_available = importlib.util.find_spec(module) is not None
-        if module_available:  # module is available so do as normal
+        try:
             return super().find_class(module, name)
-
-        # If module not available...
-        # Save into the error_strings variable what was not available.
-        if self.error_strings:
-            self.error_strings += ', '
-        self.error_strings += f"global '{module}.{name}' is not available."
+        except ModuleNotFoundError as e:
+            if self.error_strings:
+                self.error_strings += ', '
+            self.error_strings += str(e)
 
         # Returning this acts as a kind of flag to indicate that
         # the unpickler can't generate instances of classes whose class definition

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import sys
+import types
 import unittest
 
 from io import StringIO
@@ -3054,6 +3055,89 @@ class TestSqliteCaseReader(unittest.TestCase):
         assert_near_equal(cons['exec.z'], con_vals['exec.z'])
         assert_near_equal(cons['ALIAS_TEST'], con_vals['ALIAS_TEST'])
         assert_near_equal(cons['con|with->scaling'], con_vals['con|with->scaling'])
+
+    def test_reading_non_importable_objects_in_system_options(self):
+        # A test to see if a case recorder file can read as much information
+        # as possible from the metadata, even if some cannot be read since the 
+        # recording was done with a module that is not available while doing the 
+        # reading of the case recorder file
+        
+        module_path = 'mymodule.py'  # the module file that will exist while recording but not reading
+        
+        def create_case_recording_file():
+            # Define the module content as a string
+            module_content = """
+class DummyClass(object):
+    pass
+            """
+            # Write the content to the file to create the module
+            with open(module_path, 'w') as file:
+                file.write(module_content)
+
+            # need to do this because the use_tempdirs decorator does not 
+            #  update the python path and so "." is not included and this 
+            #  module being created cannot be found
+            current_dir = os.getcwd()
+            if current_dir not in sys.path:
+                sys.path.append(current_dir)
+
+            # import the newly created module
+            import mymodule
+            
+            class ParaboloidWithDummyMetadata(om.ExplicitComponent):
+                def setup(self):
+                    self.add_input('x', val=0.0)
+                    self.add_input('y', val=0.0)
+                    self.add_output('f_xy', val=0.0)
+                def setup_partials(self):
+                    self.declare_partials('*', '*', method='fd')
+                def compute(self, inputs, outputs):
+                    x = inputs['x']
+                    y = inputs['y']
+                    outputs['f_xy'] = (x - 3.0)**2 + x * y + (y + 4.0)**2 - 3.0
+                def initialize(self):
+                    self.options.declare('dummy', types=mymodule.DummyClass, default=mymodule.DummyClass())
+           
+            prob = om.Problem()
+            recorder = om.SqliteRecorder('cases.sql')
+            prob.add_recorder(recorder)
+
+            prob.model.add_subsystem('parab_with_dummy_metadata', ParaboloidWithDummyMetadata(), 
+                                     promotes_inputs=['x', 'y'])
+            prob.model.add_subsystem('const', om.ExecComp('g = x + y'), promotes_inputs=['x', 'y'])
+            prob.model.set_input_defaults('x', 3.0)
+            prob.model.set_input_defaults('y', -4.0)
+            prob.driver = om.ScipyOptimizeDriver()
+            prob.driver.options['optimizer'] = 'COBYLA'
+            prob.model.add_design_var('x', lower=-50, upper=50)
+            prob.model.add_design_var('y', lower=-50, upper=50)
+            prob.model.add_objective('parab_with_dummy_metadata.f_xy')
+            prob.model.add_constraint('const.g', lower=0, upper=10.)
+            prob.setup()
+            prob.run_driver()
+            prob.record('final')
+            
+            prob.cleanup()
+            
+            # Really remove the module!
+            del sys.modules['mymodule']
+            os.remove(module_path)
+
+
+        create_case_recording_file()
+        
+        # check to see if the case file can be read even though one item in the
+        # metadata will not be able to be read because the definition of the class
+        # for the instance is not available since the module containing it was removed
+        
+        # need to check for warning being issued about not being able to read it
+        with assert_warning(RuntimeWarning, "While reading system options from case recorder, the following errors occurred: global 'mymodule.DummyClass' is not available."):
+            cr = om.CaseReader('cases.sql')
+            
+        # Check to see that all the other component options for the DummyClass a retrievable from the case recorder file
+        parab_component_options = cr._system_options['parab_with_dummy_metadata']['component_options']
+        component_options_names = [name for name in parab_component_options]
+        self.assertEqual(['always_opt', 'distributed', 'run_root_only'], sorted(component_options_names))
 
 
 @use_tempdirs

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3137,10 +3137,13 @@ class DummyClass(object):
         with assert_warning(RuntimeWarning, "While reading system options from case recorder, the following errors occurred: global 'mymodule.DummyClass' is not available."):
             cr = om.CaseReader('cases.sql')
             
-        # Check to see that all the other component options for the DummyClass a retrievable from the case recorder file
+        # Check to see that all the component options for the DummyClass are retrievable from the case recorder file
         parab_component_options = cr._system_options['parab_with_dummy_metadata']['component_options']
         component_options_names = [name for name in parab_component_options]
-        self.assertEqual(['always_opt', 'distributed', 'run_root_only'], sorted(component_options_names))
+        from openmdao.recorders.sqlite_reader import UnknownType
+        self.assertEqual(['always_opt', 'distributed', 'dummy', 'run_root_only'], 
+                         sorted(component_options_names))
+        self.assertTrue(isinstance(parab_component_options['dummy'], UnknownType))
 
 
 @use_tempdirs

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3134,7 +3134,7 @@ class DummyClass(object):
         # for the instance is not available since the module containing it was removed
         
         # need to check for warning being issued about not being able to read it
-        with assert_warning(RuntimeWarning, "While reading system options from case recorder, the following errors occurred: global 'mymodule.DummyClass' is not available."):
+        with assert_warning(RuntimeWarning, "While reading system options from case recorder, the following errors occurred: No module named 'mymodule'"):
             cr = om.CaseReader('cases.sql')
             
         # Check to see that all the component options for the DummyClass are retrievable from the case recorder file

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -3074,13 +3074,6 @@ class DummyClass(object):
             with open(module_path, 'w') as file:
                 file.write(module_content)
 
-            # need to do this because the use_tempdirs decorator does not 
-            #  update the python path and so "." is not included and this 
-            #  module being created cannot be found
-            current_dir = os.getcwd()
-            if current_dir not in sys.path:
-                sys.path.append(current_dir)
-
             # import the newly created module
             import mymodule
             
@@ -3123,9 +3116,19 @@ class DummyClass(object):
             del sys.modules['mymodule']
             os.remove(module_path)
 
+        # need to do this because the use_tempdirs decorator does not 
+        #  update the python path and so "." is not included and this 
+        #  module being created cannot be found
+        syspath_save = sys.path[:]
+        current_dir = os.getcwd()
+        if current_dir not in sys.path:
+            sys.path.append(current_dir)
 
-        create_case_recording_file()
-        
+        try:
+            create_case_recording_file()
+        finally:
+            sys.path = syspath_save
+
         # check to see if the case file can be read even though one item in the
         # metadata will not be able to be read because the definition of the class
         # for the instance is not available since the module containing it was removed


### PR DESCRIPTION
### Summary

Added ability to handle reading case recorder files with class instances when the associated class cannot be imported.

Designed to handle the following example scenario. 

A user does case recording on a computer where a module MyModule exists. An instance of that class is recorded in the component options metadata for a component in the model. 

This case recorder file is shared with another user that does not have access to that module. Currently if that second user reads the case recorder file, the reading of the file fails completely. Not data can be read from it. 

This PR solves this problem by skipping reading of that one class instance and reading everything else. 

### Related Issues

- Resolves #3205 

### Backwards incompatibilities

None

### New Dependencies

None
