### PR TITLE
Added `minimum` option to `KSComp`

### DIFF
--- a/openmdao/components/ks_comp.py
+++ b/openmdao/components/ks_comp.py
@@ -159,8 +159,12 @@ class KSComp(ExplicitComponent):
         self.options.declare('width', types=int, default=1, desc='Width of constraint vector.')
         self.options.declare('vec_size', types=int, default=1,
                              desc='The number of rows to independently aggregate.')
+        self.options.declare('minimum', types=bool, default=False,
+                             desc='Return the minimum instead of the maximum by multiplying both the inputs '
+                                  'and output by -1. It is not recommended to use both this option and the '
+                                  'lower_flag option (it will return the negative of the aggregated max.)')
         self.options.declare('lower_flag', types=bool, default=False,
-                             desc="Set to True to reverse sign of input constraints.")
+                             desc='Set to True to reverse sign of input constraints.')
         self.options.declare('rho', 50.0, desc="Constraint Aggregation Factor.")
         self.options.declare('upper', 0.0, desc="Upper bound for constraint, default is zero.")
         self.options.declare('add_constraint', types=bool, default=False,
@@ -229,8 +233,15 @@ class KSComp(ExplicitComponent):
         con_val = inputs['g'] - opt['upper']
         if opt['lower_flag']:
             con_val = -con_val
+        if opt['minimum']:
+            con_val = -con_val
 
-        outputs['KS'] = KSfunction.compute(con_val, opt['rho'])
+        ks_val = KSfunction.compute(con_val, opt['rho'])
+
+        if opt['minimum']:
+            ks_val = -ks_val
+
+        outputs['KS'] = ks_val
 
     def compute_partials(self, inputs, partials):
         """
@@ -244,10 +255,11 @@ class KSComp(ExplicitComponent):
             Sub-jac components written to partials[output_name, input_name].
         """
         opt = self.options
-        width = opt['width']
 
         con_val = inputs['g'] - opt['upper']
         if opt['lower_flag']:
+            con_val = -con_val
+        if opt['minimum']:
             con_val = -con_val
 
         derivs = KSfunction.derivatives(con_val, opt['rho'])[0]

--- a/openmdao/components/ks_comp.py
+++ b/openmdao/components/ks_comp.py
@@ -160,9 +160,10 @@ class KSComp(ExplicitComponent):
         self.options.declare('vec_size', types=int, default=1,
                              desc='The number of rows to independently aggregate.')
         self.options.declare('minimum', types=bool, default=False,
-                             desc='Return the minimum instead of the maximum by multiplying both the inputs '
-                                  'and output by -1. It is not recommended to use both this option and the '
-                                  'lower_flag option (it will return the negative of the aggregated max.)')
+                             desc='Return the minimum instead of the maximum by multiplying both '
+                                  'the inputs and output by -1. It is not recommended to use both '
+                                  'this option and the lower_flag option (it will return the '
+                                  'negative of the aggregated max.)')
         self.options.declare('lower_flag', types=bool, default=False,
                              desc='Set to True to reverse sign of input constraints.')
         self.options.declare('rho', 50.0, desc="Constraint Aggregation Factor.")

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -6,7 +6,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_stress import MultipointBeamGroup
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -320,6 +320,67 @@ class TestKSFunctionFeatures(unittest.TestCase):
 
         assert_near_equal(prob.get_val('ks.KS', indices=0), np.amax(prob.get_val('x')), tolerance=1e-8)
 
+    def test_minimum(self):
+
+        n = 10
+
+        model = om.Group()
+
+        model.add_subsystem('ks', om.KSComp(width=n, minimum=True), promotes_inputs=[('g', 'x')])
+        model.set_input_defaults('x', range(n))
+
+        prob = om.Problem(model=model)
+        prob.setup()
+        prob.run_model()
+
+        assert_near_equal(prob.get_val('ks.KS', indices=0), np.amin(prob.get_val('x')), tolerance=1e-8)
+
+    def test_minimum_partials(self):
+
+        n = 10
+
+        model = om.Group()
+
+        model.add_subsystem('ks', om.KSComp(width=n, minimum=True), promotes_inputs=[('g', 'x')])
+        model.set_input_defaults('x', range(n))
+
+        prob = om.Problem(model=model)
+        prob.setup(force_alloc_complex=True)
+        prob.run_model()
+
+        partials = force_check_partials(prob, includes=['ks'], out_stream=None, method="cs", step=1e-200)
+        assert_check_partials(partials)
+
+    def test_minimum_and_lower_flag(self):
+
+        n = 10
+
+        model = om.Group()
+
+        model.add_subsystem('ks', om.KSComp(width=n, minimum=True, lower_flag=True), promotes_inputs=[('g', 'x')])
+        model.set_input_defaults('x', range(n))
+
+        prob = om.Problem(model=model)
+        prob.setup()
+        prob.run_model()
+
+        assert_near_equal(prob.get_val('ks.KS', indices=0), -np.amax(prob.get_val('x')), tolerance=1e-8)
+
+    def test_minimum_and_lower_flag_partials(self):
+
+        n = 10
+
+        model = om.Group()
+
+        model.add_subsystem('ks', om.KSComp(width=n, minimum=True, lower_flag=True), promotes_inputs=[('g', 'x')])
+        model.set_input_defaults('x', range(n))
+
+        prob = om.Problem(model=model)
+        prob.setup(force_alloc_complex=True)
+        prob.run_model()
+
+        partials = force_check_partials(prob, includes=['ks'], out_stream=None, method="cs", step=1e-200)
+        assert_check_partials(partials)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### Summary

The existing `KSComp` has no option to compute the minimum of the input array, rather than the maximum. It does include the `lower_flag` option, but that returns the negative of the minimum instead of the actual minimum because it assumes the component is being used to compute a constraint with a limit of zero (where it doesn't matter that the output is negated).

Ideally, I think the `minimum` option should replace `lower_flag`, but this would break backward compatibility. Maybe it should have a warning if both `lower_flag` and `minimum` are specified? It works fine with both, but it's a weird thing to choose.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
