### PR TITLE
Updated tests for constrained differential evolution

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3327,7 +3327,7 @@ class System(object):
             and ref0.
         scaler : float or ndarray, optional
             Value to multiply the model value to get the scaled value for the driver. scaler
-            is second in precedence. adder and scaler are an alterantive to using ref
+            is second in precedence. adder and scaler are an alternative to using ref
             and ref0.
         units : str, optional
             Units to convert to before applying scaling.

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -835,13 +835,12 @@ class ScipyOptimizeDriver(Driver):
         if meta['linear']:
             grad = self._lincongrad_cache
         else:
-            if self._grad_cache is not None:
-                grad = self._grad_cache
-            else:
+            if self._grad_cache is None:
                 # _gradfunc has not been called, meaning gradients are not
                 # used for the objective but are needed for the constraints
-                grad = self._compute_totals(of=self._obj_and_nlcons, wrt=self._dvlist,
-                                            return_format=self._total_jac_format)
+                self._gradfunc(x_new)
+            grad = self._grad_cache
+
         grad_idx = self._con_idx[name] + idx
 
         # print("Constraint Gradient returned")

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1836,7 +1836,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
     def test_differential_evolution(self):
         # Source of example:
-        # https://scipy.github.io/devdocs/generated/scipy.optimize.dual_annealing.html
+        # https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html
         np.random.seed(6)
 
         size = 3  # size of the design variable
@@ -1935,11 +1935,12 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         self.assertFalse(failed, f"Optimization failed, result = \n{prob.driver.result}")
 
-        assert_near_equal(prob['x'], [0.96632622, 0.93367155], 1e-2)
-        assert_near_equal(prob['f'], 0.0011352416852625719, 1e-2)
+        assert_near_equal(prob['con'], 1.8999999, 1e-5)
+        assert_near_equal(prob['x'], [0.96632622, 0.93367155], 1e-3)
+        assert_near_equal(prob['f'], 0.0011352416852625719, 1e-3)
 
-    @unittest.skipUnless(ScipyVersion >= Version("1.4") and ScipyVersion < Version("1.12"),
-                         "scipy >= 1.4, < 1.12 is required.")
+    @unittest.skipUnless(ScipyVersion >= Version("1.4"),
+                         "scipy >= 1.4 is required.")
     def test_differential_evolution_constrained_nonlinear(self):
         # Source of example:
         # https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.differential_evolution.html
@@ -1957,10 +1958,10 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                             promotes=['*'])
 
         model.add_design_var('x', lower=0, upper=1)
-        model.add_constraint('con', upper=1.9, linear=False)
+        model.add_constraint('con', upper=1.9, linear=False, scaler=1e1)
         model.add_objective('f')
 
-        driver = om.ScipyOptimizeDriver(optimizer='differential_evolution', disp=False)
+        driver = om.ScipyOptimizeDriver(optimizer='differential_evolution', disp=True)
         driver.opt_settings['seed'] = 1
 
         prob = om.Problem(model, driver)
@@ -1969,8 +1970,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         self.assertFalse(failed, f"Optimization failed, result = \n{prob.driver.result}")
 
-        assert_near_equal(prob['x'], [0.96632622, 0.93367155], 1e-2)
-        assert_near_equal(prob['f'], 0.0011352416852625719, 1e-2)
+        assert_near_equal(prob['con'], 1.8999999, 1e-5)
+        assert_near_equal(prob['x'], [0.96632622, 0.93367155], 1e-3)
+        assert_near_equal(prob['f'], 0.0011352416852625719, 1e-3)
 
     @unittest.skipUnless(ScipyVersion >= Version("1.4"),
                          "scipy >= 1.4 is required.")

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1961,7 +1961,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_constraint('con', upper=1.9, linear=False, scaler=1e1)
         model.add_objective('f')
 
-        driver = om.ScipyOptimizeDriver(optimizer='differential_evolution', disp=True)
+        driver = om.ScipyOptimizeDriver(optimizer='differential_evolution', disp=False)
         driver.opt_settings['seed'] = 1
 
         prob = om.Problem(model, driver)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -1924,7 +1924,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
         model.add_subsystem('constraint_comp',
                             om.ExecComp('con = sum(x)', con={'shape': (1,)}, x={'shape': (size)}),
                             promotes=['*'])
-        model.add_constraint('con', upper=1.9, linear=True)
+        model.add_constraint('con', upper=1.9, scaler=2, linear=True)
 
         driver = om.ScipyOptimizeDriver(optimizer='differential_evolution', disp=False)
         driver.opt_settings['seed'] = 1
@@ -1958,7 +1958,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                             promotes=['*'])
 
         model.add_design_var('x', lower=0, upper=1)
-        model.add_constraint('con', upper=1.9, linear=False, scaler=1e1)
+        model.add_constraint('con', upper=1.9, scaler=2, linear=False)
         model.add_objective('f')
 
         driver = om.ScipyOptimizeDriver(optimizer='differential_evolution', disp=False)


### PR DESCRIPTION
### Summary

The constrained differential evolution test seems to be more sensitive to scaling for SciPy 1.12 and above.

A scaler was added to the constraint for tests using the rosenbrock example, so that it is better scaled and optimization is successful for both older and newer versions of SciPy.


### Related Issues

- Resolves #3196 

### Backwards incompatibilities

None

### New Dependencies

None
