### PR TITLE
a couple of fixes for 'om total_coloring' and 'om partial_coloring'

### DIFF
--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -236,7 +236,7 @@ class ColoringMeta(object):
             if self.show_summary:
                 self.coloring.summary()
             if self.show_sparsity:
-                self.coloring.display_bokeh()
+                self.coloring.display_bokeh(show=True)
 
     def __iter__(self):
         """
@@ -2899,17 +2899,18 @@ def _total_coloring_cmd(options, user_args):
                 coloring_info.orders = options.orders
             if options.num_jacs is not None:
                 coloring_info.num_full_jacs = options.num_jacs
+            if options.show_sparsity:
+                coloring_info.show_sparsity = options.show_sparsity
 
             with profiling('coloring_profile.out') if options.profile else do_nothing_context():
-                coloring = compute_total_coloring(prob,
+                coloring_info.coloring = compute_total_coloring(prob,
                                                   num_full_jacs=coloring_info.num_full_jacs,
                                                   tol=coloring_info.tol,
                                                   orders=coloring_info.orders,
                                                   setup=False, run_model=True, fname=outfile,
                                                   driver=prob.driver)
 
-            if coloring is not None:
-                coloring_info.display()
+            coloring_info.display()
         else:
             print("Derivatives are turned off.  Cannot compute simul coloring.")
 
@@ -3011,7 +3012,7 @@ def _partial_coloring_cmd(options, user_args):
             print('\n')
 
         if options.show_sparsity and not coloring._meta.get('show_sparsity'):
-            coloring.display()
+            coloring.display_bokeh(show=True)
             print('\n')
 
         if not coloring._meta.get('show_summary'):

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -2903,12 +2903,11 @@ def _total_coloring_cmd(options, user_args):
                 coloring_info.show_sparsity = options.show_sparsity
 
             with profiling('coloring_profile.out') if options.profile else do_nothing_context():
-                coloring_info.coloring = compute_total_coloring(prob,
-                                                  num_full_jacs=coloring_info.num_full_jacs,
-                                                  tol=coloring_info.tol,
-                                                  orders=coloring_info.orders,
-                                                  setup=False, run_model=True, fname=outfile,
-                                                  driver=prob.driver)
+                coloring_info.coloring = \
+                    compute_total_coloring(prob, num_full_jacs=coloring_info.num_full_jacs,
+                                           tol=coloring_info.tol, orders=coloring_info.orders,
+                                           setup=False, run_model=True, fname=outfile,
+                                           driver=prob.driver)
 
             coloring_info.display()
         else:


### PR DESCRIPTION
### Summary

The command line tool to display total coloring wasn't generating any display even if --view was used. Also, the partial coloring command line tool was using the old matplotlib display so I switched it over to use the newer bokeh one.

### Backwards incompatibilities

None

### New Dependencies

None
