### PR TITLE
Added `usedforsecurity=False` flag to hashlib.md5 uses for FIPS-enabled systems.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6104,7 +6104,13 @@ class System(object):
         for key in sorted(self._conn_global_abs_in2out):
             data.append(self._conn_global_abs_in2out[key])
 
-        return hashlib.md5(str(data).encode()).hexdigest()  # nosec: content not sensitive
+        try:
+            hash = hashlib.md5(str(data).encode(),
+                               usedforsecurity=False).hexdigest() # nosec: content not sensitive
+        except TypeError:
+            hash = hashlib.md5(str(data).encode()).hexdigest() # nosec: content not sensitive
+
+        return hash
 
     def _get_full_dist_shape(self, abs_name, local_shape):
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6106,9 +6106,9 @@ class System(object):
 
         try:
             hash = hashlib.md5(str(data).encode(),
-                               usedforsecurity=False).hexdigest() # nosec: content not sensitive
+                               usedforsecurity=False).hexdigest()  # nosec: content not sensitive
         except TypeError:
-            hash = hashlib.md5(str(data).encode()).hexdigest() # nosec: content not sensitive
+            hash = hashlib.md5(str(data).encode()).hexdigest()  # nosec: content not sensitive
 
         return hash
 

--- a/openmdao/surrogate_models/kriging.py
+++ b/openmdao/surrogate_models/kriging.py
@@ -121,7 +121,10 @@ class KrigingSurrogate(SurrogateModel):
         cache = self.options['training_cache']
 
         if cache:
-            data_hash = md5()  # nosec: hashed content not sensitive
+            try:
+                data_hash = md5(usedforsecurity=False)  # nosec: hashed content not sensitive
+            except TypeError:
+                data_hash = md5()  # nosec: hashed content not sensitive
             data_hash.update(x.flatten())
             data_hash.update(y.flatten())
             training_data_hash = data_hash.hexdigest()


### PR DESCRIPTION
### Summary

Users of Linux systems with FIPS (Federal Information Processing Standard) enabled were unable to use OpenMDAO features which called hashlib.md5.  The argument `usedforsecurity=False` allows this code to operate, but is only available in Python >= 3.9.

This change adds the `usedforsecurity=False` to `hashlib.md5` calls.
WIth Python 3.8 this will fall back to the previous method without the argument, so FIPS systems will need to use Python 3.9 or later.

### Related Issues

- Resolves #3236

### Backwards incompatibilities

None

### New Dependencies

None
