### PR TITLE
Fix for SubmodelComp indexing bug.

### DIFF
--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -275,10 +275,7 @@ class SubmodelComp(ExplicitComponent):
 
         p.final_setup()
 
-        nproc = p.comm.size
-
         abs2meta_out = p.model._var_allprocs_abs2meta['output']
-        abs2meta_in = p.model._var_allprocs_abs2meta['input']
         abs2meta_local = p.model._var_abs2meta['output']
         prom2abs_in = p.model._var_allprocs_prom2abs_list['input']
         prom2abs_out = p.model._var_allprocs_prom2abs_list['output']

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -1,16 +1,15 @@
 """Define the SubmodelComp class for evaluating OpenMDAO systems within components."""
-from collections import defaultdict, Counter
 
-from openmdao.core.constants import _SetupStatus, INF_BOUND
+import numpy as np
+
+from openmdao.core.constants import _SetupStatus
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.total_jac import _TotalJacInfo
 from openmdao.utils.general_utils import pattern_filter
 from openmdao.utils.reports_system import clear_reports
 from openmdao.utils.mpi import MPI, FakeComm
 from openmdao.utils.coloring import compute_total_coloring, ColoringMeta
-from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.utils.indexer import ranges2indexer
-from openmdao.utils.iter_utils import size2range_iter, meta2item_iter
 from openmdao.utils.relevance import get_relevance
 
 
@@ -75,9 +74,9 @@ class SubmodelComp(ExplicitComponent):
     _subprob : <Problem>
         Instantiated problem used to run the model.
     _submodel_inputs : dict
-        Mapping of inner promoted input names to outer input names and kwargs.
+        Mapping of inner promoted input names to outer input names.
     _submodel_outputs : dict
-        Mapping of inner promoted output names to outer output names and kwargs.
+        Mapping of inner promoted output names to outer output names.
     _static_submodel_inputs : dict
         Mapping of inner promoted input names to outer input names and kwargs that is populated
         outside of setup. These must be bookkept separately from submodel inputs added during setup
@@ -88,12 +87,16 @@ class SubmodelComp(ExplicitComponent):
         because setup can be called multiple times and the submodel outputs dict is reset each time.
     _sub_coloring_info : ColoringMeta
         The coloring information for the submodel.
-    _input_xfer_idxs : ndarray
+    _ins2sub_outs_idxs : ndarray
         Index array that maps our input array into parts of the output array of the submodel.
-    _output_xfer_idxs : ndarray
-        Index array that maps our output array into parts of the output array of the submodel.
+    _sub_outs_idxs : ndarray
+        Index array that maps parts of the output array of the submodel into our output array.
     _zero_partials : set
         Set of (output, input) pairs that should have zero partials.
+    _totjacinfo : _TotalJacInfo or None
+        Object that computes the total jacobian for the submodel.
+    _do_opt : bool
+        True if the submodel has an optimizer.
     """
 
     def __init__(self, problem, inputs=None, outputs=None, reports=False, **kwargs):
@@ -110,8 +113,8 @@ class SubmodelComp(ExplicitComponent):
 
         self._submodel_inputs = {}
         self._submodel_outputs = {}
-        self._input_xfer_idxs = None
-        self._output_xfer_idxs = None
+        self._ins2sub_outs_idxs = None
+        self._sub_outs_idxs = None
         self._zero_partials = set()
 
         self._static_submodel_inputs = {
@@ -126,7 +129,7 @@ class SubmodelComp(ExplicitComponent):
         Declare options.
         """
         super()._declare_options()
-        self.options.declare('do_coloring', types=bool, default=True,
+        self.options.declare('do_coloring', types=bool, default=False,
                              desc='If True, attempt to compute a total coloring for the submodel.')
 
     def _add_static_input(self, inner_prom_name_or_pattern, outer_name=None, **kwargs):
@@ -135,11 +138,15 @@ class SubmodelComp(ExplicitComponent):
     def _add_static_output(self, inner_prom_name_or_pattern, outer_name=None, **kwargs):
         self._static_submodel_outputs[inner_prom_name_or_pattern] = (outer_name, kwargs)
 
-    def _to_outer_output(self, inner_name):
-        return self._submodel_outputs[inner_name][0]
+    def _to_outer_output(self, inner_name, absolute=False):
+        if absolute:
+            return self.pathname + '.' + self._submodel_outputs[inner_name]
+        return self._submodel_outputs[inner_name]
 
-    def _to_outer_input(self, inner_name):
-        return self._submodel_inputs[inner_name][0]
+    def _to_outer_input(self, inner_name, absolute=False):
+        if absolute:
+            return self.pathname + '.' + self._submodel_inputs[inner_name]
+        return self._submodel_inputs[inner_name]
 
     def _make_valid_name(self, name):
         """
@@ -191,18 +198,21 @@ class SubmodelComp(ExplicitComponent):
             raise NameError(f"Can't add input using wildcard '{prom_in}' during setup. "
                             "Use add_static_input outside of setup instead.")
 
-        # if we get here, our internal setup() is complete, so we can add the input to the
-        # submodel immediately.
-
-        if name is None:
-            name = self._make_valid_name(prom_in)
-
-        self._submodel_inputs[prom_in] = (name, kwargs)
+        # if we get here, our internal setup() is complete, so we can add the input immediately.
 
         if self._problem_meta['setup_status'] > _SetupStatus.POST_CONFIGURE:
             raise Exception('Cannot call add_input after configure.')
 
-        super().add_input(name, **kwargs)
+        if prom_in not in self.indep_vars:
+            raise NameError(f"'{prom_in}' is not an independent variable in the submodel or an "
+                            "unconnected input variable.")
+
+        if name is None:
+            name = self._make_valid_name(prom_in)
+
+        self._submodel_inputs[prom_in] = name
+
+        super().add_input(name, **self._get_input_kwargs(prom_in, kwargs))
 
     def add_output(self, prom_out, name=None, **kwargs):
         """
@@ -232,12 +242,12 @@ class SubmodelComp(ExplicitComponent):
         if name is None:
             name = self._make_valid_name(prom_out)
 
-        self._submodel_outputs[prom_out] = (name, kwargs)
+        self._submodel_outputs[prom_out] = name
 
         if self._problem_meta['setup_status'] > _SetupStatus.POST_CONFIGURE:
             raise Exception('Cannot call add_output after configure.')
 
-        super().add_output(name, **kwargs)
+        super().add_output(name, **self._get_output_kwargs(prom_out, kwargs))
 
     def setup(self):
         """
@@ -265,25 +275,29 @@ class SubmodelComp(ExplicitComponent):
 
         p.final_setup()
 
-        abs2meta = p.model._var_allprocs_abs2meta['output']
+        nproc = p.comm.size
+
+        abs2meta_out = p.model._var_allprocs_abs2meta['output']
+        abs2meta_in = p.model._var_allprocs_abs2meta['input']
         abs2meta_local = p.model._var_abs2meta['output']
         prom2abs_in = p.model._var_allprocs_prom2abs_list['input']
         prom2abs_out = p.model._var_allprocs_prom2abs_list['output']
         abs2prom_out = p.model._var_allprocs_abs2prom['output']
 
-        # store indep vars by promoted name, excluding _auto_ivc vars because later we'll
-        # add the inputs connected to _auto_ivc vars as indep vars (because that's how the user
-        # would expect them to be named).  Note that not all indep_vars will be visible outside
-        # of this component.
-        self.indep_vars = {}
-        for src, meta in abs2meta.items():
+        # indep vars is a dict containing promoted names of all indep vars belonging to
+        # IndepVarComps in the submodel, along with all inputs connected to _auto_ivc vars.
+        # All SubmodelComp inputs must come from the indep_vars dict, because any other inputs
+        # in the submodel are dependent on other outputs and would be overwritten when the
+        # submodel runs, erasing any values set by the SubmodelComp.
+        self.indep_vars = indep_vars = {}
+        for src, meta in abs2meta_out.items():
             if src.startswith('_auto_ivc.'):
                 continue
             prom = abs2prom_out[src]
-            if prom not in self.indep_vars and 'openmdao:indep_var' in meta['tags']:
+            if prom not in indep_vars and 'openmdao:indep_var' in meta['tags']:
                 if src in abs2meta_local:
                     meta = abs2meta_local[src]  # get local metadata if we have it
-                self.indep_vars[prom] = (src, meta)
+                indep_vars[prom] = (src, meta)
 
         # add any inputs connected to auto_ivc vars as indep vars.  Their name will be the
         # promoted name of the input that connects to the actual indep var.
@@ -293,83 +307,133 @@ class SubmodelComp(ExplicitComponent):
                 if src in abs2meta_local:
                     meta = abs2meta_local[src]  # get local metadata if we have it
                 else:
-                    meta = abs2meta[src]
-                self.indep_vars[prom] = (src, meta)
+                    meta = abs2meta_out[src]
+                indep_vars[prom] = (src, meta)
 
-        self._submodel_inputs = {}
-        self._submodel_outputs = {}
-
+        submodel_inputs = {}
         for inner_prom, (outer_name, kwargs) in self._static_submodel_inputs.items():
+            # outer_name could still be None here
             if _is_glob(inner_prom):
-                found = False
-                for match in pattern_filter(inner_prom, self.indep_vars):
-                    self._submodel_inputs[match] = (match, kwargs.copy())
-                    found = True
-                if not found:
+                matches = list(pattern_filter(inner_prom, indep_vars))
+                if not matches:
                     raise NameError(f"Pattern '{inner_prom}' doesn't match any independent "
                                     "variables in the submodel.")
-            elif inner_prom in self.indep_vars:
-                self._submodel_inputs[inner_prom] = (outer_name, kwargs.copy())
+            elif inner_prom in indep_vars:
+                matches = [inner_prom]
             else:
                 raise NameError(f"'{inner_prom}' is not an independent variable in the submodel.")
 
+            for match in matches:
+                iname = self._make_valid_name(match if outer_name is None else outer_name)
+                submodel_inputs[match] = iname
+
+                super().add_input(iname, **self._get_input_kwargs(match, kwargs))
+
+                if 'val' in kwargs:  # val in kwargs overrides internal value
+                    self._subprob.set_val(match, kwargs['val'])
+
+        self._submodel_inputs = dict(sorted(submodel_inputs.items(), key=lambda x: x[0]))
+
+        submodel_outputs = {}
         for inner_prom, (outer_name, kwargs) in self._static_submodel_outputs.items():
+            # outer_name could still be None here
             if _is_glob(inner_prom):
-                found = False
+                matches = []
                 for match in pattern_filter(inner_prom, prom2abs_out):
                     if match.startswith('_auto_ivc.') or match in self._submodel_inputs:
                         continue
-                    self._submodel_outputs[match] = (match, kwargs.copy())
-                    found = True
-                if not found:
+                    matches.append(match)
+                if not matches:
                     raise NameError(f"Pattern '{inner_prom}' doesn't match any outputs in the "
                                     "submodel.")
             elif inner_prom in prom2abs_out:
-                self._submodel_outputs[inner_prom] = (outer_name, kwargs.copy())
+                matches = [inner_prom]
             else:
                 raise NameError(f"'{inner_prom}' is not an output in the submodel.")
 
-        for inner_prom, (outer_name, kwargs) in sorted(self._submodel_inputs.items(),
-                                                       key=lambda x: x[0]):
+            for match in matches:
+
+                oname = self._make_valid_name(match if outer_name is None else outer_name)
+                submodel_outputs[match] = oname
+
+                super().add_output(oname, **self._get_output_kwargs(match, kwargs))
+
+                if 'val' in kwargs:  # val in kwargs overrides internal value
+                    self._subprob.set_val(inner_prom, kwargs['val'])
+
+        self._submodel_outputs = dict(sorted(submodel_outputs.items(), key=lambda x: x[0]))
+
+    def _get_output_kwargs(self, prom, kwargs):
+        """
+        Get updated kwargs based on metadata from the submodel for the given promoted output.
+
+        Parameters
+        ----------
+        prom : str
+            Promoted name of the output.
+        kwargs : dict
+            Keyword arguments for the add_output call.
+
+        Returns
+        -------
+        dict
+            Updated kwargs.
+        """
+        prom2abs = self._subprob.model._var_allprocs_prom2abs_list['output']
+
+        try:
+            # look for local metadata first, in case it sets 'val'
+            meta = self._subprob.model._var_abs2meta['output'][prom2abs[prom][0]]
+        except KeyError:
             try:
-                _, meta = self.indep_vars[inner_prom]
+                # just use global metadata
+                meta = self._subprob.model._var_allprocs_abs2meta['output'][prom2abs[prom][0]]
             except KeyError:
-                raise KeyError(f"Independent variable '{inner_prom}' not found in model")
+                raise KeyError(f"Output '{prom}' not found in model")
 
-            final_kwargs = {n: v for n, v in meta.items() if n in _allowed_add_input_args}
-            final_kwargs.update(kwargs)
-            if outer_name is None:
-                outer_name = inner_prom
+        self._check_var_allowed(prom2abs[prom], meta)
 
-            outer_name = self._make_valid_name(outer_name)
-            self._submodel_inputs[inner_prom] = (outer_name, kwargs)  # in case outer_name was None
+        final_kwargs = {n: v for n, v in meta.items() if n in _allowed_add_output_args}
+        final_kwargs.update(kwargs)
+        return final_kwargs
 
-            super().add_input(outer_name, **final_kwargs)
-            if 'val' in kwargs:  # val in kwargs overrides internal value
-                self._subprob.set_val(inner_prom, kwargs['val'])
+    def _get_input_kwargs(self, prom, kwargs):
+        """
+        Get updated kwargs based on metadata from the submodel for the given promoted input.
 
-        for inner_prom, (outer_name, kwargs) in sorted(self._submodel_outputs.items(),
-                                                       key=lambda x: x[0]):
-            try:
-                # look for metadata locally first, then use allprocs data if we have to
-                meta = abs2meta_local[prom2abs_out[inner_prom][0]]
-            except KeyError:
-                try:
-                    meta = abs2meta[prom2abs_out[inner_prom][0]]
-                except KeyError:
-                    raise KeyError(f"Output '{inner_prom}' not found in model")
+        Parameters
+        ----------
+        prom : str
+            Promoted name of the input.
+        kwargs : dict
+            Keyword arguments for the add_input call.
 
-            final_kwargs = {n: v for n, v in meta.items() if n in _allowed_add_output_args}
-            final_kwargs.update(kwargs)
-            if outer_name is None:
-                outer_name = inner_prom
+        Returns
+        -------
+        dict
+            Updated kwargs.
+        """
+        src, meta = self.indep_vars[prom]
+        self._check_var_allowed(src, meta)
+        final_kwargs = {n: v for n, v in meta.items() if n in _allowed_add_input_args}
+        final_kwargs.update(kwargs)
+        return final_kwargs
 
-            outer_name = self._make_valid_name(outer_name)
-            self._submodel_outputs[inner_prom] = (outer_name, kwargs)  # in case outer_name was None
+    def _check_var_allowed(self, abs_name, meta):
+        """
+        Raise an exception if the variable is not allowed in a SubmodelComp.
 
-            super().add_output(outer_name, **final_kwargs)
-            if 'val' in kwargs:  # val in kwargs overrides internal value
-                self._subprob.set_val(inner_prom, kwargs['val'])
+        Parameters
+        ----------
+        abs_name : str
+            Absolute name of the variable.
+        meta : dict
+            Metadata for the variable.
+        """
+        if self._subprob.comm.size > 1:
+            if meta['distributed']:
+                raise RuntimeError(f"Variable '{abs_name}' is distributed, and  distributed "
+                                   "variables are not currently supported in SubmodelComp.")
 
     def setup_partials(self):
         """
@@ -400,7 +464,7 @@ class SubmodelComp(ExplicitComponent):
 
         # save the _TotJacInfo object so we can use it in future calls to compute_partials
         self._totjacinfo = _TotalJacInfo(p, of=self._submodel_outputs, wrt=self._submodel_inputs,
-                                         return_format='flat_dict',
+                                         return_format='flat_dict', get_remote=True,
                                          approx=p.model._owns_approx_jac,
                                          coloring_info=coloring_info,
                                          driver=False)
@@ -469,11 +533,11 @@ class SubmodelComp(ExplicitComponent):
         """
         p = self._subprob
 
-        # set our inputs and outputs into the submodel
-        p.model._outputs.set_val(inputs.asarray(), idxs=self._input_xfer_idxs())
-
-        inner_idxs = self._output_xfer_idxs()
-        p.model._outputs.set_val(outputs.asarray(), idxs=inner_idxs)
+        # set our inputs into the submodel outputs. We don't set into the submodel inputs
+        # because they are all connected to outputs which would overwrite our values when the
+        # submodel runs. So the only inputs we allow from outside are those that are connected to
+        # indep vars, which are outputs in the submodel that are not dependent on anything else.
+        p.model._outputs.set_val(inputs.asarray()[self._ins_idxs()], idxs=self._ins2sub_outs_idxs())
 
         if self._do_opt:
             p.run_driver()
@@ -481,7 +545,12 @@ class SubmodelComp(ExplicitComponent):
             p.run_model()
 
         # collect outputs from the submodel
-        self._outputs.set_val(p.model._outputs.asarray()[inner_idxs])
+        self._outputs.set_val(0.0)
+        self._outputs.set_val(p.model._outputs.asarray()[self._sub_outs_idxs()],
+                              idxs=self._outs_idxs())
+
+        if self.comm.size > 1:
+            self._outputs.set_val(self.comm.allreduce(self._outputs.asarray(), op=MPI.SUM))
 
     def compute_partials(self, inputs, partials):
         """
@@ -521,28 +590,36 @@ class SubmodelComp(ExplicitComponent):
         These map parts of our input and output arrays to the input and output arrays of the
         submodel.
         """
-        abs2meta = self._subprob.model._var_allprocs_abs2meta['output']
-        prom2abs = self._subprob.model._var_allprocs_prom2abs_list['output']
+        submod = self._subprob.model
+        sub_slices = submod._outputs.get_slice_dict()
+        slices = self._inputs.get_slice_dict()
+        prefix = self.pathname + '.'
 
-        full_inner_map = {}
-        for name, rng in size2range_iter(meta2item_iter(abs2meta.items(), 'size')):
-            full_inner_map[name] = rng
+        input_ranges = []
+        sub_out_ranges = []
+        for inner_prom, outer_name in self._submodel_inputs.items():
+            sub_src = submod.get_source(inner_prom)
+            if submod._owned_size(sub_src) > 0:
+                sub_slc = sub_slices[sub_src]
+                sub_out_ranges.append((sub_slc.start, sub_slc.stop))
+                slc = slices[prefix + outer_name]
+                input_ranges.append((slc.start, slc.stop))
 
-        full_shape = (rng[1],) if full_inner_map else (0,)
+        self._ins_idxs = ranges2indexer(input_ranges, src_shape=(len(self._inputs),))
+        self._ins2sub_outs_idxs = ranges2indexer(sub_out_ranges, src_shape=(len(submod._outputs),))
 
-        # map outer name of inputs to their inner promoted name
-        input_map = {v[0]: k for k, v in self._submodel_inputs.items()}
-
-        # get ranges for subodel outputs corresponding to our inputs
-        inp_ranges = []
-        for inner_prom in self._inputs:
-            src, _ = self.indep_vars[input_map[inner_prom]]
-            inp_ranges.append(full_inner_map[src])
-
-        # get ranges for submodel outputs corresponding to our outputs
+        prom2abs = submod._var_allprocs_prom2abs_list['output']
+        slices = self._outputs.get_slice_dict()
+        sub_out_ranges = []
         out_ranges = []
-        for inner_prom in self._submodel_outputs:
-            out_ranges.append(full_inner_map[prom2abs[inner_prom][0]])
 
-        self._input_xfer_idxs = ranges2indexer(inp_ranges, src_shape=full_shape)
-        self._output_xfer_idxs = ranges2indexer(out_ranges, src_shape=full_shape)
+        for inner_prom, outer_name in self._submodel_outputs.items():
+            sub_src = prom2abs[inner_prom][0]
+            if submod._owned_size(sub_src) > 0:
+                sub_slc = sub_slices[sub_src]
+                slc = slices[prefix + outer_name]
+                out_ranges.append((slc.start, slc.stop))
+                sub_out_ranges.append((sub_slc.start, sub_slc.stop))
+
+        self._outs_idxs = ranges2indexer(out_ranges, src_shape=(len(self._outputs),))
+        self._sub_outs_idxs = ranges2indexer(sub_out_ranges, src_shape=(len(submod._outputs),))

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -5,7 +5,7 @@ import openmdao.api as om
 from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, \
      assert_check_totals
-from openmdao.test_suite.groups.parallel_groups import FanIn, FanOut
+from openmdao.test_suite.groups.parallel_groups import FanInGrouped, FanOutGrouped
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -53,11 +53,13 @@ class TestSubmodelComp(unittest.TestCase):
                                promotes_inputs=['x', 'y'],
                                promotes_outputs=['z'])
 
-        p.model.add_subsystem('sub1', build_submodelcomp1(inputs=['r', 'theta'], outputs=['x']),
+        p.model.add_subsystem('sub1', build_submodelcomp1(inputs=['r', 'theta'], outputs=['x'],
+                              do_coloring=True),
                               promotes_inputs=['r','theta'],
                               promotes_outputs=['x'])
 
-        p.model.add_subsystem('sub2', build_submodelcomp2(inputs=['r', 'theta'], outputs=['y']),
+        p.model.add_subsystem('sub2', build_submodelcomp2(inputs=['r', 'theta'], outputs=['y'],
+                              do_coloring=True),
                               promotes_inputs=['r','theta'],
                               promotes_outputs=['y'])
 
@@ -82,8 +84,8 @@ class TestSubmodelComp(unittest.TestCase):
                             promotes_inputs=['x', 'y'],
                             promotes_outputs=['z'])
 
-        p.model.add_subsystem('sub1', build_submodelcomp1())
-        p.model.add_subsystem('sub2', build_submodelcomp2())
+        p.model.add_subsystem('sub1', build_submodelcomp1(do_coloring=True))
+        p.model.add_subsystem('sub2', build_submodelcomp2(do_coloring=True))
         p.model.add_subsystem('supModel', model, promotes_inputs=['x','y'], promotes_outputs=['z'])
 
         p.setup(force_alloc_complex=True)
@@ -103,7 +105,7 @@ class TestSubmodelComp(unittest.TestCase):
         subprob.model.add_subsystem('submodel', model)
         subcomp = om.SubmodelComp(problem=subprob,
                                   inputs=[('submodel.subsys.x', 'a'), ('submodel.subsys.y', 'b')],
-                                  outputs=[('submodel.subsys.z', 'c')])
+                                  outputs=[('submodel.subsys.z', 'c')], do_coloring=True)
 
         p.model.add_subsystem('subcomp', subcomp, promotes_inputs=['a', 'b'], promotes_outputs=['c'])
         p.setup()
@@ -139,7 +141,7 @@ class TestSubmodelComp(unittest.TestCase):
 
         comp = om.SubmodelComp(problem=subprob,
                                inputs=[('submodel.x1Comp.x', 'x'), ('submodel.x2Comp.x', 'y')],
-                               outputs=[('submodel.model.z', 'z')])
+                               outputs=[('submodel.model.z', 'z')], do_coloring=True)
 
         p.model.add_subsystem('comp', comp)
 
@@ -169,7 +171,7 @@ class TestSubmodelComp(unittest.TestCase):
                                                 'result = -foo*bgd + bar*xyz']), promotes=['*'])
         subprob = om.Problem()
         subprob.model.add_subsystem('submodel', model, promotes=['*'])
-        comp = om.SubmodelComp(problem=subprob, inputs=['x*'], outputs=['*'])
+        comp = om.SubmodelComp(problem=subprob, inputs=['x*'], outputs=['*'], do_coloring=True)
 
         p.model.add_subsystem('comp', comp, promotes_inputs=['*'], promotes_outputs=['*'])
         p.setup()
@@ -203,8 +205,8 @@ class TestSubmodelComp(unittest.TestCase):
                             promotes_inputs=['x', 'y'],
                             promotes_outputs=['z'])
 
-        comp1 = build_submodelcomp1(promote=False)
-        comp2 = build_submodelcomp2(promote=False)
+        comp1 = build_submodelcomp1(promote=False, do_coloring=True)
+        comp2 = build_submodelcomp2(promote=False, do_coloring=True)
 
         comp1.add_input('subComp1.r', name='r')
         comp1.add_input('subComp1.theta', name='theta')
@@ -240,7 +242,7 @@ class TestSubmodelComp(unittest.TestCase):
                                     promotes_outputs=['x'])
                 subprob = om.Problem(); subprob.model.add_subsystem('model', model)
                 subprob.model.promotes('model', any=['*'])
-                self.add_subsystem('submodel1', om.SubmodelComp(problem=subprob))
+                self.add_subsystem('submodel1', om.SubmodelComp(problem=subprob, do_coloring=True))
 
             def configure(self):
                 self._get_subsystem('submodel1').add_input('r')
@@ -257,7 +259,7 @@ class TestSubmodelComp(unittest.TestCase):
                                     promotes_outputs=['y'])
                 subprob = om.Problem(); subprob.model.add_subsystem('model', model)
                 subprob.model.promotes('model', any=['*'])
-                self.add_subsystem('submodel2', om.SubmodelComp(problem=subprob))
+                self.add_subsystem('submodel2', om.SubmodelComp(problem=subprob, do_coloring=True))
 
             def configure(self):
                 self._get_subsystem('submodel2').add_input('r')
@@ -298,8 +300,8 @@ class TestSubmodelComp(unittest.TestCase):
                             promotes_inputs=['x', 'y'],
                             promotes_outputs=['z'])
 
-        comp1 = build_submodelcomp1()
-        comp2 = build_submodelcomp2()
+        comp1 = build_submodelcomp1(do_coloring=True)
+        comp2 = build_submodelcomp2(do_coloring=True)
 
         comp1.add_input('psi')
 
@@ -328,7 +330,7 @@ class TestSubmodelComp(unittest.TestCase):
         subprob = om.Problem()
         subprob.model.add_subsystem('submodel', submodel, promotes=['*'])
 
-        comp = om.SubmodelComp(problem=subprob)
+        comp = om.SubmodelComp(problem=subprob, do_coloring=True)
         comp.add_input('z')
         comp.add_output('x')
 
@@ -362,7 +364,7 @@ class TestSubmodelComp(unittest.TestCase):
         subprob = om.Problem()
         subprob.model.add_subsystem('submodel', submodel, promotes=['*'])
 
-        comp = om.SubmodelComp(problem=subprob)
+        comp = om.SubmodelComp(problem=subprob, do_coloring=True)
         comp.add_input('z')
         comp.add_output('x')
 
@@ -375,7 +377,7 @@ class TestSubmodelComp(unittest.TestCase):
         p = om.Problem()
         subprob = om.Problem()
         subprob.model.add_subsystem('comp', om.ExecComp('x = r*cos(theta)'), promotes=['*'])
-        submodel = om.SubmodelComp(problem=subprob)
+        submodel = om.SubmodelComp(problem=subprob, do_coloring=True)
 
         submodel.add_input('r', name='new_r', val=20)
         submodel.add_input('theta', name='new_theta', val=0.5)
@@ -394,7 +396,7 @@ class TestSubmodelComp(unittest.TestCase):
         p = om.Problem()
         subprob = om.Problem()
         subprob.model.add_subsystem('comp', om.ExecComp('x = r*cos(theta)'), promotes=['*'])
-        submodel = om.SubmodelComp(problem=subprob)
+        submodel = om.SubmodelComp(problem=subprob, do_coloring=True)
 
         submodel.add_input('r', name='new_r', val=20)
         submodel.add_input('theta', name='new_theta', val=0.5)
@@ -410,7 +412,7 @@ class TestSubmodelComp(unittest.TestCase):
         p = om.Problem()
         subprob = om.Problem()
         subprob.model.add_subsystem('comp', om.ExecComp('x = r*cos(theta)'), promotes=['*'])
-        submodel = om.SubmodelComp(problem=subprob)
+        submodel = om.SubmodelComp(problem=subprob, do_coloring=True)
 
         submodel.add_input('r', name='new_r', val=20)
         submodel.add_input('theta', name='new_theta', val=0.5)
@@ -431,7 +433,7 @@ class TestSubmodelComp(unittest.TestCase):
     def test_problem_property(self):
         """Tests the problem property of SubmodelComp"""
         p = om.Problem()
-        submodel = om.SubmodelComp(problem=p)
+        submodel = om.SubmodelComp(problem=p, do_coloring=True)
         subprob = submodel.problem
 
         self.assertIsInstance(subprob, om.Problem) # make sure it returns a problem
@@ -452,14 +454,82 @@ class TestSubmodelCompMPI(unittest.TestCase):
 
         par = model.add_subsystem('par', om.ParallelGroup())
 
-        par.add_subsystem('subprob1', om.SubmodelComp(problem=om.Problem(model=FanOut()),
-                                                      inputs=['p.x'], outputs=['comp2.y', 'comp3.y']))
-        par.add_subsystem('subprob2', om.SubmodelComp(problem=om.Problem(model=FanIn()),
-                                                      inputs=['p1.x1', 'p2.x2'], outputs=['comp3.y']))
+        par.add_subsystem('subprob1', om.SubmodelComp(problem=om.Problem(model=FanOutGrouped()),
+                                                      inputs=['iv.x'], outputs=['c2.y', 'c3.y'],
+                                                      do_coloring=True))
+        par.add_subsystem('subprob2', om.SubmodelComp(problem=om.Problem(model=FanInGrouped()),
+                                                      inputs=['*'], outputs=['c3.y'],
+                                                      do_coloring=True))
 
         p.setup(force_alloc_complex=True)
         p.run_model()
         assert_check_partials(p.check_partials(method='cs', out_stream=None))
+
+    # @unittest.skip("Unskip this after vars under ParallelGroups work with SubmodelComp")
+    def test_submodel_with_parallel_group(self):
+        p = om.Problem()
+
+        model = p.model
+
+        G = model.add_subsystem('G', om.Group())
+
+        psub = om.Problem()
+        par = psub.model.add_subsystem('par', om.ParallelGroup())
+        par.add_subsystem('fanout1', FanOutGrouped())
+        par.add_subsystem('fanout2', FanOutGrouped())
+        G.add_subsystem('subprob1', om.SubmodelComp(problem=psub, inputs=['*'], outputs=['*'],
+                                                    do_coloring=False))
+
+        p.setup(force_alloc_complex=True)
+        p.run_model()
+
+        assert_near_equal(psub.get_val('par.fanout1.c2.y', get_remote=True), -6.0)
+        assert_near_equal(psub.get_val('par.fanout2.c2.y', get_remote=True), -6.0)
+        assert_near_equal(psub.get_val('par.fanout1.c3.y', get_remote=True), 15.0)
+        assert_near_equal(psub.get_val('par.fanout2.c3.y', get_remote=True), 15.0)
+
+        assert_check_partials(psub.check_partials(method='cs', show_only_incorrect=True)) #, out_stream=None))
+        assert_check_partials(p.check_partials(method='cs', show_only_incorrect=True)) #, out_stream=None))
+
+    @unittest.skip("Unskip this after distributed vars work with SubmodelComp")
+    def test_submodel_distrib(self):
+        p = om.Problem()
+
+        model = p.model
+
+        G = model.add_subsystem('G', om.Group())
+
+        size = 3
+        xstart = (np.arange(size) + 1.0) * 5.0
+        ystart = (np.arange(size) + 1.0) * 3.0
+
+        psub = om.Problem()
+        ivc = psub.model.add_subsystem('ivc', om.IndepVarComp('x', xstart))
+        ivc.add_output('y', ystart)
+
+        psub.model.add_subsystem('distcomp1', DistribCompDerivs(size=size))
+        psub.model.add_subsystem('distcomp2', DistribCompDerivs(size=size))
+        psub.model.connect('ivc.x', 'distcomp1.invec')
+        psub.model.connect('ivc.y', 'distcomp2.invec')
+        G.add_subsystem('subprob1', om.SubmodelComp(problem=psub, inputs=['*'], outputs=['*'],
+                                                    do_coloring=False))
+
+        p.setup(force_alloc_complex=True)
+        p.run_model()
+
+        if p.comm.rank == 0:
+            assert_near_equal(psub.get_val('distcomp1.outvec', get_remote=False), [10.0, 20.0])
+            assert_near_equal(psub.get_val('distcomp2.outvec', get_remote=False), [6.0, 12.0])
+        else:
+            assert_near_equal(psub.get_val('distcomp1.outvec', get_remote=False), [-45.0])
+            assert_near_equal(psub.get_val('distcomp2.outvec', get_remote=False), [-27.0])
+
+        assert_near_equal(psub.get_val('distcomp1.outvec', get_remote=True), [10.0, 20.0, -45.0])
+        assert_near_equal(psub.get_val('distcomp2.outvec', get_remote=True), [6.0, 12.0, -27.0])
+
+        assert_check_partials(psub.check_partials(method='cs', show_only_incorrect=False)) #, out_stream=None))
+
+        assert_check_partials(p.check_partials(method='cs', show_only_incorrect=False)) #, out_stream=None))
 
 
 class IncompleteRelevanceGroup(om.Group):
@@ -488,7 +558,8 @@ class TestSubmodelColoring(unittest.TestCase):
 
 
         model.add_subsystem('sub', om.SubmodelComp(problem=om.Problem(model=IncompleteRelevanceGroup(3)),
-                                                    inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y']))
+                                                    inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y'],
+                                                    do_coloring=True))
 
         p.setup(force_alloc_complex=True)
         p.run_model()
@@ -508,7 +579,8 @@ class TestSubmodelColoring(unittest.TestCase):
 
 
         model.add_subsystem('sub', om.SubmodelComp(problem=om.Problem(model=IncompleteRelevanceGroup(3)),
-                                                    inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y']))
+                                                    inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y'],
+                                                    do_coloring=True))
 
         p.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')
         p.driver.declare_coloring(show_summary=True)
@@ -549,9 +621,11 @@ class TestSubmodelColoringMultiSubmodelComps(unittest.TestCase):
         par = model.add_subsystem('par', om.ParallelGroup(), promotes=['*'])
 
         par.add_subsystem('sub1', om.SubmodelComp(problem=om.Problem(model=IncompleteRelevanceGroup(3)),
-                                                  inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y']))
+                                                  inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y'],
+                                                  do_coloring=True))
         par.add_subsystem('sub2', om.SubmodelComp(problem=om.Problem(model=IncompleteRelevanceGroup(3)),
-                                                  inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y']))
+                                                  inputs=['C1.x', 'C2.x'], outputs=['C3.y', 'C4.y', 'C5.y'],
+                                                  do_coloring=True))
 
         p.driver = om.ScipyOptimizeDriver(optimizer='SLSQP')
         p.driver.declare_coloring(show_summary=True)
@@ -620,9 +694,7 @@ class TestSubmodelOpt(unittest.TestCase):
                          "derivatives of a SubmodelComp with an internal optimizer.")
 
 
-
-
-def build_submodel(compute_x=False):
+def build_submodel(subsystem_name):
     p = om.Problem()
     supmodel = om.Group()
     supmodel.add_subsystem('supComp', om.ExecComp('diameter = r * theta'),
@@ -632,16 +704,17 @@ def build_submodel(compute_x=False):
     subprob1 = om.Problem()
     submodel1 = subprob1.model.add_subsystem('submodel1', om.Group(), promotes=['*'])
 
-    if compute_x:
-        submodel1.add_subsystem('x', om.ExecComp('x = diameter * 2 * r * theta'), promotes=['*', ('diameter', 'aircraft:fuselage:diameter')])
-    submodel1.add_subsystem('y', om.ExecComp('y = mass * donkey_kong'), promotes=['*', ('mass', 'dynamic:mission:mass'), ('donkey_kong', 'aircraft:engine:donkey_kong')])
-
+    submodel1.add_subsystem(subsystem_name, om.ExecComp('x = diameter * 2 * r * theta'),
+                            promotes=['*', ('diameter', 'aircraft:fuselage:diameter')])
+    submodel1.add_subsystem('b', om.ExecComp('y = mass * donkey_kong'),
+                            promotes=['*', ('mass', 'dynamic:mission:mass'),
+                                      ('donkey_kong', 'aircraft:engine:donkey_kong')])
 
     p.model.add_subsystem('supModel', supmodel, promotes_inputs=['*'],
                             promotes_outputs=['*'])
 
 
-    submodel = om.SubmodelComp(problem=subprob1, inputs=['*'], outputs=['*'], do_coloring=False)
+    submodel = om.SubmodelComp(problem=subprob1, inputs=['*'], outputs=['*'], do_coloring=True)
     p.model.add_subsystem('sub1', submodel,
                             promotes_inputs=['*'],
                             promotes_outputs=['*'])
@@ -660,23 +733,24 @@ def build_submodel(compute_x=False):
     return p
 
 
-
 class TestSubModelBug(unittest.TestCase):
 
-    def test_submodel_bug(self):
-        p = build_submodel(compute_x=False)
+    def test_submodel_bug1(self):
+        p = build_submodel(subsystem_name='a')
 
         p.run_model()
 
         assert_near_equal(p.get_val('y'), 2.0 * 3.0)
+        assert_check_partials(p.check_partials(method='cs', out_stream=None))
 
 
-    def test_submodel_bug_fails(self):
-        p = build_submodel(compute_x=True)
+    def test_submodel_bug2(self):
+        p = build_submodel(subsystem_name='c')
 
         p.run_model()
 
         assert_near_equal(p.get_val('y'), 2.0 * 3.0)
+        assert_check_partials(p.check_partials(method='cs', out_stream=None))
 
 
 if __name__ == '__main__':

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -465,7 +465,6 @@ class TestSubmodelCompMPI(unittest.TestCase):
         p.run_model()
         assert_check_partials(p.check_partials(method='cs', out_stream=None))
 
-    # @unittest.skip("Unskip this after vars under ParallelGroups work with SubmodelComp")
     def test_submodel_with_parallel_group(self):
         p = om.Problem()
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1554,7 +1554,7 @@ class Problem(object):
                     # prevent adding multiple approxs with same wrt (and confusing users with
                     # warnings)
                     if abs_key[1] not in added_wrts:
-                        approximations[fd_options['method']].add_approximation(abs_key, self.model,
+                        approximations[fd_options['method']].add_approximation(abs_key, comp,
                                                                                fd_options,
                                                                                vector=vector)
                         added_wrts.add(abs_key[1])

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3609,7 +3609,7 @@ class System(object):
             key = src_name
 
         meta['source'] = src_name
-        meta['distributed'] = \
+        meta['distributed'] = dist = \
             src_name in abs2meta_out and abs2meta_out[src_name]['distributed']
 
         if get_size:
@@ -3626,7 +3626,10 @@ class System(object):
                     indices = indices.shaped_instance()
                     meta['size'] = meta['global_size'] = indices.indexed_src_size
                 else:
-                    meta['size'] = sizes[owning_rank[src_name], abs2idx[src_name]]
+                    if dist:
+                        meta['size'] = sizes[self.comm.rank, abs2idx[src_name]]
+                    else:
+                        meta['size'] = sizes[owning_rank[src_name], abs2idx[src_name]]
                     meta['global_size'] = out_meta['global_size']
             else:
                 meta['size'] = meta['global_size'] = 0  # discrete var, don't know size
@@ -5004,7 +5007,7 @@ class System(object):
             if self._assembled_jac:
                 self._assembled_jac.set_complex_step_mode(active)
 
-        for sub in self.system_iter(include_self=False, recurse=True):
+        for sub in self._subsystems_myproc:
             sub._set_complex_step_mode(active)
 
     def cleanup(self):

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2395,7 +2395,7 @@ class TestFDRelative(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             prob.check_partials()
 
-        msg = "<model> <class Group>: Option 'directional' is not supported when 'step_calc' is set to 'rel_element.'"
+        msg = "'comp' <class FDComp>: Option 'directional' is not supported when 'step_calc' is set to 'rel_element.'"
         self.assertEqual(cm.exception.args[0], msg)
 
     def test_check_settings_on_comp(self):


### PR DESCRIPTION
### Summary

SubmodelComp outputs were not being properly copied to the outer model in some cases.

For now, variables exposed as inputs or outputs of a SubmodelComp are not allowed to be distributed.

### Related Issues

- Resolves #3200

### Backwards incompatibilities

The default value of the `do_coloring` option for SubmodelComp has been changed to False.

### New Dependencies

None
