### PR TITLE
Updates for NumPy 2.0 compatibility and testing

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -1,29 +1,10 @@
 # this script will populate a conda environment with the latest versions
 # (including pre-release versions) of all OpenMDAO dependencies
 
-conda upgrade -c conda-forge --all -y
-
 echo "============================================================="
 echo "Upgrade to latest pip"
 echo "============================================================="
 python -m pip install --upgrade pip
-
-echo "============================================================="
-echo "Install latest setuptools"
-echo "============================================================="
-python -m pip install --upgrade --pre setuptools
-
-echo "============================================================="
-echo "Install latest versions of NumPy/SciPy"
-echo "============================================================="
-python -m pip install --upgrade --pre numpy
-python -m pip install --upgrade --pre scipy
-
-# remember versions so we can check them later
-NUMPY_VER=`python -c "import numpy; print(numpy.__version__)"`
-SCIPY_VER=`python -c "import scipy; print(scipy.__version__)"`
-echo "NUMPY_VER=$NUMPY_VER" >> $GITHUB_ENV
-echo "SCIPY_VER=$SCIPY_VER" >> $GITHUB_ENV
 
 echo "============================================================="
 echo "Install latest versions of 'required' dependencies"
@@ -47,6 +28,11 @@ echo "============================================================="
 python -m pip install --upgrade --pre pyDOE3
 
 echo "============================================================="
+echo "Install latest versions of 'jax' dependencies"
+echo "============================================================="
+python -m pip install --upgrade --pre jax jaxlib
+
+echo "============================================================="
 echo "Install latest versions of 'notebooks' dependencies"
 echo "============================================================="
 python -m pip install --upgrade --pre notebook
@@ -68,10 +54,7 @@ python -m pip install --upgrade --pre pydocstyle
 python -m pip install --upgrade --pre testflo
 python -m pip install --upgrade --pre websockets
 python -m pip install --upgrade --pre aiounittest
-echo "the latest version of playwright (1.38.0) is pinned to"
-echo "greenlet 2.0.2 which does not build properly for python 3.12"
-echo "https://github.com/microsoft/playwright-python/issues/2096"
-python -m pip install --upgrade --pre playwright  || echo "Skipping playwright, no GUI testing!"
+python -m pip install --upgrade --pre playwright
 python -m pip install --upgrade --pre num2words
 
 echo "============================================================="
@@ -79,31 +62,6 @@ echo "Install latest versions of other optional packages"
 echo "============================================================="
 python -m pip install --upgrade --pre pyparsing psutil objgraph pyxdsm
 python -m pip install --upgrade --pre jax jaxlib
-
-echo "============================================================="
-echo "Install latest PETSc"
-echo "============================================================="
-conda install mpi4py petsc!=3.21.1 petsc4py -q -y
-
-echo "============================================================="
-echo "Check MPI and PETSc installation"
-echo "============================================================="
-export OMPI_MCA_rmaps_base_oversubscribe=1
-export OMPI_MCA_btl=^openib
-
-echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
-echo "OMPI_MCA_btl=^openib" >> $GITHUB_ENV
-
-echo "-----------------------"
-echo "Quick test of mpi4py:"
-mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
-echo "-----------------------"
-echo "Quick test of petsc4py:"
-mpirun -n 3 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; \
-                       import petsc4py; petsc4py.init(); \
-                       x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  \
-                       print(x.getArray())"
-echo "-----------------------"
 
 echo "============================================================="
 echo "Display conda environment"

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -177,9 +177,6 @@ jobs:
         run: |
           source .github/scripts/install_latest_deps.sh
 
-          echo "Install latest dev version of testflo for deprecations fix"
-          pip install git+https://github.com/OpenMDAO/testflo
-
       - name: Install pyOptSparse
         if: ${{ matrix.PYOPTSPARSE }}
         run: |

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -21,8 +21,10 @@ on:
         type: choice
         options:
           - ''
-          - 'Ubuntu Latest'
-          - 'MacOS Latest'
+          - 'Ubuntu Latest, NumPy<2'
+          - 'Ubuntu Latest, NumPy 2 (No PETSc/pyOptSparse)'
+          - 'MacOS Latest, NumPy<2'
+          - 'MacOS Latest, NumPy 2 (No PETSc/pyOptSparse)'
         required: false
         default: ''
       debug_enabled:
@@ -46,20 +48,36 @@ jobs:
       matrix:
         include:
           # test latest versions on ubuntu
-          - NAME: Ubuntu Latest
+          # Include PETSc/pyOptSparse, which require NumPy<2
+          - NAME: Ubuntu Latest, NumPy<2
             OS: ubuntu-latest
             PY: 3
-            PETSc: 3
-            SNOPT: 7.7
+            NUMPY: '<2'
+            PETSc: True
+            PYOPTSPARSE: true
+            SNOPT: true
             BUILD_DOCS: true
 
+          # test latest versions on ubuntu
+          # Exclude PETSc/pyOptSparse, which require NumPy<2
+          - NAME: Ubuntu Latest, NumPy 2 (No PETSc/pyOptSparse)
+            OS: ubuntu-latest
+            PY: 3
+
           # test latest versions on macos
-          - NAME: MacOS Latest
+          # Include PETSc/pyOptSparse, which require NumPy<2
+          - NAME: MacOS Latest, NumPy<2
             OS: macos-13
             PY: 3
-            PETSc: 3
-            SNOPT: 7.7
-            BUILD_DOCS: false
+            NUMPY: '<2'
+            PETSc: True
+            PYOPTSPARSE: true
+
+          # test latest versions on macos
+          # Exclude PETSc/pyOptSparse, which require NumPy<2
+          - NAME: MacOS Latest, NumPy 2 (No PETSc/pyOptSparse)
+            OS: macos-13
+            PY: 3
 
     runs-on: ${{ matrix.OS }}
 
@@ -113,11 +131,57 @@ jobs:
         run: |
           conda install compilers swig
 
+      - name: Install NumPy/SciPy
+        run: |
+          echo "============================================================="
+          echo "Install latest versions of NumPy/SciPy"
+          echo "============================================================="
+          python -m pip install --upgrade --pre "numpy${{ matrix.NUMPY }}"
+          python -m pip install --upgrade --pre scipy
+
+          # remember versions so we can check them later
+          NUMPY_VER=`python -c "import numpy; print(numpy.__version__)"`
+          SCIPY_VER=`python -c "import scipy; print(scipy.__version__)"`
+          echo "NUMPY_VER=$NUMPY_VER" >> $GITHUB_ENV
+          echo "SCIPY_VER=$SCIPY_VER" >> $GITHUB_ENV
+
+      - name: Install PETSc
+        if: ${{ matrix.PETSC }}
+        run: |
+          echo "============================================================="
+          echo "Install latest PETSc"
+          echo "============================================================="
+          conda install mpi4py petsc!=3.21.1 petsc4py -q -y
+
+          echo "============================================================="
+          echo "Check MPI and PETSc installation"
+          echo "============================================================="
+          export OMPI_MCA_rmaps_base_oversubscribe=1
+          export OMPI_MCA_btl=^openib
+
+          echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> $GITHUB_ENV
+          echo "OMPI_MCA_btl=^openib" >> $GITHUB_ENV
+
+          echo "-----------------------"
+          echo "Quick test of mpi4py:"
+          mpirun -n 3 python -c "from mpi4py import MPI; print(f'Rank: {MPI.COMM_WORLD.rank}')"
+          echo "-----------------------"
+          echo "Quick test of petsc4py:"
+          mpirun -n 3 python -c "import numpy; from mpi4py import MPI; comm = MPI.COMM_WORLD; \
+                              import petsc4py; petsc4py.init(); \
+                              x = petsc4py.PETSc.Vec().createWithArray(numpy.ones(5)*comm.rank, comm=comm);  \
+                              print(x.getArray())"
+          echo "-----------------------"
+
       - name: Install latest versions of [all] openmdao dependencies
         run: |
           source .github/scripts/install_latest_deps.sh
 
+          echo "Install latest dev version of testflo for deprecations fix"
+          pip install git+https://github.com/OpenMDAO/testflo
+
       - name: Install pyOptSparse
+        if: ${{ matrix.PYOPTSPARSE }}
         run: |
           echo "============================================================="
           echo "Define useful functions"
@@ -138,13 +202,15 @@ jobs:
           echo "============================================================="
           python -m pip install git+https://github.com/OpenMDAO/build_pyoptsparse
           BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
-          if [[ "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
+          if [[ "${{ matrix.SNOPT }}" ]]; then
+            if [[ "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
               echo "  > Secure copying SNOPT 7.7 over SSH"
               mkdir SNOPT
               scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT
               SNOPT="-s SNOPT/src"
-          else
+            else
               echo "SNOPT source is not available"
+            fi
           fi
           build_pyoptsparse $BRANCH $SNOPT
 
@@ -153,7 +219,20 @@ jobs:
           echo "============================================================="
           echo "Install OpenMDAO"
           echo "============================================================="
+          if [[ "${{ matrix.NUMPY }}" == "" ]]; then
+            sed -i.bak 's/numpy<2/numpy/g' pyproject.toml
+            grep numpy pyproject.toml
+          fi
           python -m pip install .
+
+      - name: Check NumPy 2.0 Compatibility
+        run: |
+          echo "============================================================="
+          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
+          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
+          echo "============================================================="
+          python -m pip install ruff
+          ruff check . --select NPY201
 
       - name: Display environment info
         id: env_info

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -203,10 +203,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Fetch tags
-        run: |
-          git fetch --prune --unshallow --tags
-
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -233,6 +229,15 @@ jobs:
           else
             python -m pip install .${{ matrix.OPTIONAL }}
           fi
+
+      - name: Check NumPy 2.0 Compatibility
+        run: |
+          echo "============================================================="
+          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
+          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
+          echo "============================================================="
+          python -m pip install ruff
+          ruff check . --select NPY201
 
       - name: Install MacOS-specific dependencies
         if: matrix.OS == 'macos-13'
@@ -485,6 +490,11 @@ jobs:
             echo "Install version of openssl compatible with hosting service"
             echo "============================================================="
             conda install -c conda-forge 'openssl=3.0'
+
+            echo "============================================================="
+            echo "Fetch tags to get docs version"
+            echo "============================================================="
+            git fetch --prune --unshallow --tags
 
             echo "============================================================="
             echo "Publish docs"

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -326,7 +326,7 @@ class InterpND(object):
             for i, p in enumerate(xi.T):
                 if np.isnan(p).any():
                     raise OutOfBoundsError("One of the requested xi contains a NaN",
-                                           i, np.NaN, self.grid[i][0], self.grid[i][-1])
+                                           i, np.nan, self.grid[i][0], self.grid[i][-1])
 
                 eps = 1e-14 * self.grid[i][-1]
                 if np.any(p < self.grid[i][0] - eps) or np.any(p > self.grid[i][-1] + eps):

--- a/openmdao/components/interp_util/interp_semi.py
+++ b/openmdao/components/interp_util/interp_semi.py
@@ -159,7 +159,7 @@ class InterpNDSemi(object):
             for i, p in enumerate(xi.T):
                 if np.isnan(p).any():
                     raise OutOfBoundsError("One of the requested xi contains a NaN",
-                                           i, np.NaN, self.grid[i][0], self.grid[i][-1])
+                                           i, np.nan, self.grid[i][0], self.grid[i][-1])
 
         if self._compute_d_dvalues:
             # If the table grid or values are component inputs, then we need to create a new table

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -11,6 +11,12 @@ import openmdao.api as om
 from openmdao.utils.assert_utils import assert_no_warning, assert_check_partials
 from openmdao.utils.testing_utils import use_tempdirs, force_check_partials
 
+try:
+    # The exceptions module is new in NumPy 1.25.  Older exceptions remain available
+    # through the main NumPy namespace for compatibility. (Until NumPy 2.0 release)
+    from numpy.exceptions import ComplexWarning
+except ModuleNotFoundError:
+    from numpy import ComplexWarning
 
 @use_tempdirs
 class TestBalanceComp(unittest.TestCase):
@@ -408,7 +414,7 @@ class TestBalanceComp(unittest.TestCase):
         prob.run_model()
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(action="error", category=np.ComplexWarning)
+            warnings.filterwarnings(action="error", category=ComplexWarning)
             cpd = force_check_partials(prob, out_stream=None, method='cs')
 
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -9,6 +9,13 @@ from openmdao.test_suite.components.sellar_feature import SellarIDF
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
+try:
+    # The exceptions module is new in NumPy 1.25.  Older exceptions remain available
+    # through the main NumPy namespace for compatibility. (Until NumPy 2.0 release)
+    from numpy.exceptions import ComplexWarning
+except ModuleNotFoundError:
+    from numpy import ComplexWarning
+
 
 class TestEQConstraintComp(unittest.TestCase):
 
@@ -352,7 +359,7 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.run_driver()
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(action="error", category=np.ComplexWarning)
+            warnings.filterwarnings(action="error", category=ComplexWarning)
             cpd = force_check_partials(prob, out_stream=None, method='cs')
 
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1119,8 +1119,16 @@ class Component(System):
                                  f'will raise an error.')
 
             if rows is not None:
-                rows = np.array(rows, dtype=INT_DTYPE, copy=False)
-                cols = np.array(cols, dtype=INT_DTYPE, copy=False)
+                # If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)`
+                # to allow a copy when needed (no behavior change in NumPy 1.x).
+                # For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html
+                # #adapting-to-changes-in-the-copy-keyword.
+                if np.__version__[0] == '2':
+                    rows = np.asarray(rows, dtype=INT_DTYPE)
+                    cols = np.asarray(cols, dtype=INT_DTYPE)
+                else:
+                    rows = np.array(rows, dtype=INT_DTYPE, copy=False)
+                    cols = np.array(cols, dtype=INT_DTYPE, copy=False)
 
                 # Check the length of rows and cols to catch this easy mistake and give a
                 # clear message.

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1119,16 +1119,8 @@ class Component(System):
                                  f'will raise an error.')
 
             if rows is not None:
-                # If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)`
-                # to allow a copy when needed (no behavior change in NumPy 1.x).
-                # For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html
-                # #adapting-to-changes-in-the-copy-keyword.
-                if np.__version__[0] == '2':
-                    rows = np.asarray(rows, dtype=INT_DTYPE)
-                    cols = np.asarray(cols, dtype=INT_DTYPE)
-                else:
-                    rows = np.array(rows, dtype=INT_DTYPE, copy=False)
-                    cols = np.array(cols, dtype=INT_DTYPE, copy=False)
+                rows = np.asarray(rows, dtype=INT_DTYPE)
+                cols = np.asarray(cols, dtype=INT_DTYPE)
 
                 # Check the length of rows and cols to catch this easy mistake and give a
                 # clear message.

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -22,7 +22,7 @@ from openmdao.utils.coloring import _compute_coloring, compute_total_coloring, C
 from openmdao.utils.mpi import MPI, multi_proc_exception_check
 from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 from openmdao.test_suite.tot_jac_builder import TotJacBuilder
-from openmdao.utils.general_utils import run_driver
+from openmdao.utils.general_utils import run_driver, printoptions
 
 import openmdao.test_suite
 
@@ -1328,7 +1328,8 @@ class SimulColoringVarOutputTestClass(unittest.TestCase):
 
         p.setup(check=False)
 
-        failed, output = run_driver(p)
+        with printoptions(legacy='1.21'):
+            failed, output = run_driver(p)
 
         self.assertFalse(failed, "Optimization failed.")
 

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -508,7 +508,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         prob['pc.c'] = 3.
 
         # Making sure that guess_nonlinear is called early enough to eradicate this.
-        prob['comp2.x'] = np.NaN
+        prob['comp2.x'] = np.nan
 
         prob.run_model()
         assert_near_equal(prob['comp2.x'], 3.)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -20,7 +20,7 @@ from openmdao.test_suite.components.sellar_feature import SellarMDA
 from openmdao.test_suite.components.simple_comps import NonSquareArrayComp
 from openmdao.test_suite.groups.sin_fitter import SineFitter
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
-from openmdao.utils.general_utils import run_driver
+from openmdao.utils.general_utils import run_driver, printoptions
 from openmdao.utils.testing_utils import set_env_vars_context, use_tempdirs
 from openmdao.utils.mpi import MPI
 
@@ -2096,8 +2096,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        with self.assertRaises(RuntimeError) as msg:
-            prob.run_driver()
+        with printoptions(legacy='1.21'):
+            with self.assertRaises(RuntimeError) as msg:
+                prob.run_driver()
 
         self.assertEqual(str(msg.exception),
                          "Design variables [('z', inds=[0])] have no impact on the constraints or objective.")
@@ -2154,8 +2155,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         msg = "Constraints or objectives [('parab.z', inds=[0])] cannot be impacted by the design variables of the problem."
 
-        with assert_warning(UserWarning, msg):
-            prob.run_driver()
+        with printoptions(legacy='1.21'):
+            with assert_warning(UserWarning, msg):
+                prob.run_driver()
 
     def test_singular_jac_desvars_multidim_indices_dv(self):
         expected_msg = "Design variables [('z', inds=[(0, 1, 0), (1, 0, 1), (1, 1, 0)])] " \
@@ -2188,16 +2190,17 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
                 prob.setup()
 
-                # run the optimization
-                if option == 'error':
-                    with self.assertRaises(RuntimeError) as ctx:
+                with printoptions(legacy='1.21'):
+                    # run the optimization
+                    if option == 'error':
+                        with self.assertRaises(RuntimeError) as ctx:
+                            prob.run_driver()
+                        self.assertEqual(str(ctx.exception), expected_msg)
+                    elif option == 'warn':
+                        with assert_warning(om.DerivativesWarning, expected_msg):
+                            prob.run_driver()
+                    else:
                         prob.run_driver()
-                    self.assertEqual(str(ctx.exception), expected_msg)
-                elif option == 'warn':
-                    with assert_warning(om.DerivativesWarning, expected_msg):
-                        prob.run_driver()
-                else:
-                    prob.run_driver()
 
     def test_singular_jac_error_desvars_multidim_indices_con(self):
         prob = om.Problem()
@@ -2226,8 +2229,9 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        with self.assertRaises(RuntimeError) as msg:
-            prob.run_driver()
+        with printoptions(legacy='1.21'):
+            with self.assertRaises(RuntimeError) as msg:
+                prob.run_driver()
 
         self.assertEqual(str(msg.exception),
                          "Constraints or objectives [('parab.f_z', inds=[(1, 1, 0)])] cannot be impacted by the design variables of the problem.")

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -12,6 +12,7 @@ from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJa
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
 from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.general_utils import printoptions
 from openmdao.utils.mpi import MPI
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -32,7 +33,7 @@ class NanComp(om.ExplicitComponent):
     def compute_partials(self, inputs, partials):
         """Intentionally incorrect derivative."""
         J = partials
-        J['y', 'x'] = np.NaN
+        J['y', 'x'] = np.nan
 
 
 class SingularComp(om.ImplicitComponent):
@@ -64,7 +65,7 @@ class NanComp2(om.ExplicitComponent):
     def compute_partials(self, inputs, partials):
         """Intentionally incorrect derivative."""
         J = partials
-        J['y', 'x'] = np.NaN
+        J['y', 'x'] = np.nan
         J['y2', 'x'] = 2.0
 
 class DupPartialsComp(om.ExplicitComponent):
@@ -260,8 +261,9 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         model.linear_solver = om.DirectSolver(assemble_jac=True)
 
-        with self.assertRaises(Exception) as cm:
-            prob.setup()
+        with printoptions(legacy='1.21'):
+            with self.assertRaises(Exception) as cm:
+                prob.setup()
 
         expected_msg = "'dupcomp' <class DupPartialsComp>: d(x)/d(c): declare_partials has been called with rows and cols that specify the following duplicate subjacobian entries: [(4, 11), (10, 2)]."
 

--- a/openmdao/utils/cs_safe.py
+++ b/openmdao/utils/cs_safe.py
@@ -20,7 +20,20 @@ def abs(x):
         Absolute value.
     """
     if isinstance(x, np.ndarray):
-        return x * np.sign(x)
+        # Changed in NumPy 2.0: Definition of complex sign changed to follow the Array API standard.
+        # 1.x: For complex inputs, the sign function returns sign(x.real) + 0j if x.real != 0
+        #      else sign(x.imag) + 0j.
+        # 2.0: For complex inputs, the sign function returns x / abs(x), and 0 if x==0.
+        if np.__version__[0] == '2' and np.any(np.iscomplex(x)):
+            # replicate NumPy 1.x behavior for complex arrays
+            z0_idx = x.real == 0
+            nz_idx = x.real != 0
+            signs = np.zeros(x.shape, dtype=complex)
+            signs[nz_idx] = np.sign(x[nz_idx]).real + 0j
+            signs[z0_idx] = np.sign(x[z0_idx].imag) + 0j
+            return x * signs
+        else:
+            return x * np.sign(x)
     elif x.real < 0.0:
         return -x
     return x

--- a/openmdao/utils/cs_safe.py
+++ b/openmdao/utils/cs_safe.py
@@ -4,6 +4,11 @@ collection of complex-step safe functions to replace standard numpy operations.
 
 import numpy as np
 
+if np.__version__[0] == '2':
+    NumPy2 = True
+else:
+    NumPy2 = False
+
 
 def abs(x):
     """
@@ -24,7 +29,7 @@ def abs(x):
         # 1.x: For complex inputs, the sign function returns sign(x.real) + 0j if x.real != 0
         #      else sign(x.imag) + 0j.
         # 2.0: For complex inputs, the sign function returns x / abs(x), and 0 if x==0.
-        if np.__version__[0] == '2' and np.any(np.iscomplex(x)):
+        if NumPy2 and np.any(np.iscomplex(x)):
             # replicate NumPy 1.x behavior for complex arrays
             z0_idx = x.real == 0
             nz_idx = x.real != 0


### PR DESCRIPTION
### Summary

- Updated the `Latest` workflow to test NumPy 2.0 pre-release separately (excluding PETSc and pyOptSparse)
- Added NumPy 2.0 compatibility check to the `Tests` workflow
- Fixed several NumPy 2.0 compatibility issues on The OpenMDAO codebase
  - Replaced `NaN` with `nan`
  - Updated `ComplexWarning` imports to use new location
  - Changed `array(copy=False)` to `asarray()`, which will not copy if the object is already a numpy array
  - Updated tests to handle change in the default print format
  - Updated the `cs_safe.abs()` method to preserve current numpy<2 logic for the `sign` operation

### Related Issues

- Resolves #3240

### Backwards incompatibilities

None

### New Dependencies

None
