### PR TITLE
fix for group set_val when using set_input_defaults

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5369,7 +5369,7 @@ class System(object):
         try:
             ginputs = self._group_inputs
         except AttributeError:
-            ginputs = {}  # could happen if top level system is not a Group
+            ginputs = {}  # could happen if this system is not a Group
 
         if post_setup:
             abs_names = name2abs_names(self, name)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5367,7 +5367,7 @@ class System(object):
         n_proms = 0  # if nonzero, name given was promoted input name w/o a matching prom output
 
         try:
-            ginputs = model._group_inputs
+            ginputs = self._group_inputs
         except AttributeError:
             ginputs = {}  # could happen if top level system is not a Group
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1615,6 +1615,20 @@ class TestGroup(unittest.TestCase):
 
         np.testing.assert_array_equal(p['x'], np.ones(5))
 
+    def test_set_input_defaults_set_val(self):
+        class MyGroup(om.Group):
+            def setup(self):
+                self.add_subsystem('ec1', om.ExecComp('y=x', x={'units': 'm'}), promotes_inputs=['x'])
+                self.add_subsystem('ec2', om.ExecComp('z=x**2', x={'units': 'ft'}), promotes_inputs=['x'])
+                self.set_input_defaults('x', val=1.0, units='m')
+
+        p = om.Problem(om.Group())
+        comp = p.model.add_subsystem('comp', MyGroup())
+        p.setup()
+        p.run_model()
+        comp.set_val('x', 3.5, units='m')
+        assert_near_equal(comp.get_val('x'), 3.5)
+
 
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestGroupMPISlice(unittest.TestCase):


### PR DESCRIPTION
### Summary

When calling set_val on a group, it was accessing the group input defaults for the model instead of the specified group.

### Related Issues

- Resolves #3246

### Backwards incompatibilities

None

### New Dependencies

None
