### PR TITLE
Fixed a NumPy 2.0 compatibility issue in the test suite

### DIFF
--- a/openmdao/test_suite/mpi_scaling.py
+++ b/openmdao/test_suite/mpi_scaling.py
@@ -67,7 +67,7 @@ class ExplicitSleepComp(om.ExplicitComponent):
     def compute_partials(self, inputs, partials):
         if debug: print(f"compute partials for {self.pathname}")
         self.sleep(self.compute_partials_delay)
-        val = np.eye(np.product(self.varshape, dtype=int))
+        val = np.eye(np.prod(self.varshape, dtype=int))
         for iname, oname in zip(self.inames, self.onames):
             partials[oname, iname] = val
 


### PR DESCRIPTION
### Summary

- Replaced call to `np.product()` with `np.prod()`

per [numpy-2-migration-guide](https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-migration-guide):
```
product       Use np.prod instead.
```

### Related Issues

- Resolves #3250

### Backwards incompatibilities

None

### New Dependencies

None
