### PR TITLE
Fixed error message when a component has an inconsistent set of variables across ranks.

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -343,7 +343,7 @@ class Component(System):
                 else:
                     varmsg = "Variables have not been declared in the same order on all ranks."
 
-                msg = (f"{self.msginfo}: {varmsg} A component must declare the same variables in "
+                msg = (f"{self.msginfo}: {varmsg} A component must declare all variables in "
                        "the same order on all ranks, even if the size of the variable is 0 on "
                        "some ranks.")
                 break

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -306,8 +306,48 @@ class Component(System):
         else:
             self._discrete_inputs = self._discrete_outputs = ()
 
+        if self.comm.size > 1:
+            # check that same variables are declared on all procs
+            vnames = (list(self._var_rel_names['output']), list(self._var_rel_names['input']))
+            allnames = self.comm.gather(vnames, root=0)
+            if self.comm.rank == 0:
+                outset, inset = vnames
+                msg = ''
+                for oset, iset in allnames:
+                    if iset != inset or oset != outset:
+                        msg = self._missing_vars_error(allnames)
+                        break
+                self.comm.bcast(msg, root=0)
+            else:
+                msg = self.comm.bcast(None, root=0)
+
+            if msg:
+                raise RuntimeError(msg)
+
         self._serial_idxs = None
         self._inconsistent_keys = set()
+
+    def _missing_vars_error(self, allnames):
+        msg = ''
+        outset, inset = allnames[0]
+        for rank, (olist, ilist) in enumerate(allnames):
+            if rank != 0 and (olist != outset or ilist != inset):
+                idiff = set(inset).symmetric_difference(ilist)
+                odiff = set(outset).symmetric_difference(olist)
+                if idiff or odiff:
+                    varnames = sorted(idiff | odiff)
+                    if len(varnames) == 1:
+                        varmsg = f"Variable '{varnames[0]}' exists on some ranks and not others."
+                    else:
+                        varmsg = f"Variables {varnames} exist on some ranks and not others."
+                else:
+                    varmsg = "Variables have not been declared in the same order on all ranks."
+
+                msg = (f"{self.msginfo}: {varmsg} A component must declare the same variables in "
+                       "the same order on all ranks, even if the size of the variable is 0 on "
+                       "some ranks.")
+                break
+        return msg
 
     @collect_errors
     def _setup_var_sizes(self):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6156,12 +6156,13 @@ class System(object):
             # to avoid a confusing KeyError
             return (0,)
         high_dims = shape[1:]
+        sz = shape_to_len(shape)
         with multi_proc_exception_check(self.comm):
             if high_dims:
                 high_size = shape_to_len(high_dims)
 
                 dim_size_match = bool(global_size % high_size == 0)
-                if dim_size_match is False:
+                if dim_size_match is False and sz > 0:
                     raise RuntimeError(f"{self.msginfo}: All but the first dimension of the "
                                        "shape's local parts in a distributed variable must match "
                                        f"across processes. For output '{abs_name}', local shape "

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -1140,6 +1140,89 @@ class TestDistribCheckMPI(unittest.TestCase):
         assert_near_equal(prob.get_val("parallel.sum1.sum", get_remote=True), 3.0)
         assert_near_equal(prob.get_val("parallel.sum2.sum", get_remote=True), 12.0)
 
+
+@unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+class TestCompDistVarErrors(unittest.TestCase):
+    """
+    When a component declares variables in different orders on different ranks
+    or declares variables on some ranks but not others.
+    """
+
+    N_PROCS = 4
+
+    def test_missing_vars(self):
+        class Comp1(om.ExplicitComponent):
+            def setup(self):
+                if self.comm.rank==0:
+                    self.add_output('a', np.zeros((2,3)), distributed=True)
+                elif self.comm.rank==1:
+                    self.add_output('a', np.zeros((1,3)), distributed=True)
+                else:
+                    self.add_output('a', np.zeros((0,3)), distributed=True)
+
+        class Comp2(om.ExplicitComponent):
+            def setup(self):
+                self.add_input('a', distributed=True, shape_by_conn=True)
+                if self.comm.rank==0:
+                    self.add_output('b', np.zeros(2), distributed=True)
+                    self.add_output('c', np.zeros(2), distributed=True)
+                else:
+                    self.add_output('b', np.zeros(0), distributed=True)
+
+        class Group1(om.Group):
+            def setup(self):
+                self.add_subsystem('comp1', Comp1(), promotes=['*'])
+                self.add_subsystem('comp2', Comp2(), promotes=['*'])
+
+        prob = om.Problem()
+        prob.model = Group1()
+
+        with self.assertRaises(Exception) as cm:
+            prob.setup(mode='rev')
+
+        self.assertEqual(str(cm.exception),
+                         "'comp2' <class Comp2>: Variable 'c' exists on some ranks and not others. "
+                         "A component must declare all variables in the same order on all ranks, "
+                         "even if the size of the variable is 0 on some ranks.")
+
+    def test_out_of_order_vars(self):
+        class Comp1(om.ExplicitComponent):
+            def setup(self):
+                if self.comm.rank==0:
+                    self.add_output('a', np.zeros((2,3)), distributed=True)
+                elif self.comm.rank==1:
+                    self.add_output('a', np.zeros((1,3)), distributed=True)
+                else:
+                    self.add_output('a', np.zeros((0,3)), distributed=True)
+
+        class Comp2(om.ExplicitComponent):
+            def setup(self):
+                self.add_input('a', distributed=True, shape_by_conn=True)
+                if self.comm.rank==0:
+                    self.add_output('b', np.zeros(2), distributed=True)
+                    self.add_output('c', np.zeros(2), distributed=True)
+                else:
+                    self.add_output('c', np.zeros(1), distributed=True)
+                    self.add_output('b', np.zeros(1), distributed=True)
+
+        class Group1(om.Group):
+            def setup(self):
+                self.add_subsystem('comp1', Comp1(), promotes=['*'])
+                self.add_subsystem('comp2', Comp2(), promotes=['*'])
+
+        prob = om.Problem()
+        prob.model = Group1()
+
+        with self.assertRaises(Exception) as cm:
+            prob.setup(mode='rev')
+
+        self.assertEqual(str(cm.exception),
+                         "'comp2' <class Comp2>: Variables have not been declared in the same "
+                         "order on all ranks. A component must declare all variables in the "
+                         "same order on all ranks, even if the size of the variable is 0 on some ranks.")
+
+
+
 if __name__ == '__main__':
     from openmdao.utils.mpi import mpirun_tests
     mpirun_tests()


### PR DESCRIPTION
### Summary

An incorrect error message was being generated when the framework was attempting to  compute distributed indices because there was no earlier check to prevent a component from having different variables on different ranks.

### Related Issues

- Resolves #3249

### Backwards incompatibilities

None

### New Dependencies

None
