### PR TITLE
Fix the sparkline plots in the optimization report - height was too small

### DIFF
--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -61,7 +61,7 @@ _plot_value_linewidth = 0.5
 _equality_constraint_dot_size = 3
 
 # overall image parameters and layout
-_sparkline_figsize = (3, .5)
+_sparkline_figsize = (3, 0.8)
 _scalar_visual_figsize = (2.0, .2)
 _plot_dpi = 150
 _plot_pad_inches = 0


### PR DESCRIPTION
The sparkline plots were given too little space vertically to be correctly drawn. This not only affected the display of the tick  marks, which is what the issue writer pointed out, but it also affected the entire plot being shown correctly.

### Summary

Provide more vertical space for sparkline plots in the optimization report.

### Related Issues

- Resolves #3243 

### Backwards incompatibilities

None

### New Dependencies

None
