### PR TITLE
Updated the test workflow to fail if a security issue is found

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -56,6 +56,7 @@ jobs:
             PETSc: True
             PYOPTSPARSE: true
             SNOPT: true
+            BANDIT: true
             BUILD_DOCS: true
 
           # test latest versions on ubuntu
@@ -353,6 +354,7 @@ jobs:
           grep '^0 unique deprecation warnings' $RPT_FILE
 
       - name: Scan for security issues
+        if: matrix.BANDIT
         id: bandit
         continue-on-error: true
         run: |

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -352,6 +352,27 @@ jobs:
 
           grep '^0 unique deprecation warnings' $RPT_FILE
 
+      - name: Scan for security issues
+        id: bandit
+        continue-on-error: true
+        run: |
+          python -m pip install bandit
+          echo "============================================================="
+          echo "Run bandit scan for high/medium severity issues"
+          echo "============================================================="
+          cd ${{ github.workspace }}
+          python -m bandit -c bandit.yml -ll -r openmdao
+
+      - name: Slack security issue
+        if: steps.bandit.outcome == 'failure'
+        uses: act10ns/slack@v2.0.0
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          status: 'warning'
+          message:
+            Security issue found on `${{ matrix.NAME }}` build.
+            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
       - name: Slack env change
         if: steps.env_info.outputs.errors != ''
         uses: act10ns/slack@v2.0.0

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -726,7 +726,6 @@ jobs:
       - name: Scan for security issues
         if: matrix.BANDIT
         id: bandit
-        continue-on-error: true
         run: |
           python -m pip install bandit
           echo "============================================================="
@@ -734,16 +733,6 @@ jobs:
           echo "============================================================="
           cd ${{ github.workspace }}
           python -m bandit -c bandit.yml -ll -r openmdao
-
-      - name: Slack security issue
-        if: steps.bandit.outcome == 'failure'
-        uses: act10ns/slack@v2.0.0
-        with:
-          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
-          status: ${{ steps.bandit.outcome }}
-          message:
-            Security issue found on `${{ matrix.NAME }}` build.
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
 
   coveralls:

--- a/.github/workflows/openmdao_update_poem.yml
+++ b/.github/workflows/openmdao_update_poem.yml
@@ -8,7 +8,7 @@ on:
     types: [ opened, reopened, closed ]
     branches: [ master ]
 
-# permissions: {}
+permissions: {}
 
 jobs:
 

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -440,7 +440,7 @@ class LambdaPickleWrapper(object):
             The state of this object.
         """
         self.__dict__.update(state)
-        self._func = eval(state['_func'])
+        self._func = eval(state['_func'])  # nosec
 
     def _getsrc(self):
         if self._src is None:


### PR DESCRIPTION
### Summary

- Updated the `test` workflow to fail if `bandit` finds a security issue (rather than sending a slack message)
- Added a `bandit` scan to the `latest` workflow that will not fail but will send a notification via slack
- Added the `# nosec` tag to an `eval` call used when unpickling a function 

### Related Issues

- Resolves #3260

### Backwards incompatibilities

None

### New Dependencies

None
