### PR TITLE
Fix relevance check for empty groups

### DIFF
--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -811,11 +811,11 @@ class Relevance(object):
         """
         if not self._active:
             return True
-        
-        if name not in self._sys2idx:
-            return False
 
-        return self._current_rel_sarray[self._sys2idx[name]]
+        try:
+            return self._current_rel_sarray[self._sys2idx[name]]
+        except KeyError:
+            return False
 
     def filter(self, systems, relevant=True):
         """

--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -796,7 +796,8 @@ class Relevance(object):
 
     def is_relevant_system(self, name):
         """
-        Return True if the given named system is relevant.
+        Return True if the given named system is relevant. Returns False if
+        system has no subsystems with outputs
 
         Parameters
         ----------
@@ -810,6 +811,9 @@ class Relevance(object):
         """
         if not self._active:
             return True
+        
+        if name not in self._sys2idx:
+            return False
 
         return self._current_rel_sarray[self._sys2idx[name]]
 

--- a/openmdao/utils/tests/test_relevance.py
+++ b/openmdao/utils/tests/test_relevance.py
@@ -61,3 +61,5 @@ class TestRelevanceEmptyGroups(unittest.TestCase):
 
         prob.setup()
         prob.run_driver()
+
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))

--- a/openmdao/utils/tests/test_relevance.py
+++ b/openmdao/utils/tests/test_relevance.py
@@ -59,7 +59,7 @@ class TestRelevanceEmptyGroups(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver()
 
-        prob.setup()
+        prob.setup(force_alloc_complex=True)
         prob.run_driver()
 
         assert_check_totals(prob.check_totals(method='cs', out_stream=None))

--- a/openmdao/utils/tests/test_relevance.py
+++ b/openmdao/utils/tests/test_relevance.py
@@ -43,3 +43,21 @@ class TestDerivsWithoutDVs(unittest.TestCase):
         prob.run_model()
         chk = prob.check_totals(of='b', wrt='a', show_only_incorrect=True)
         assert_check_totals(chk)
+
+class TestRelevanceEmptyGroups(unittest.TestCase):
+    def test_emptygroup(self):
+        '''Tests that relevance checks do not error if empty groups are present'''
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('empy_group', om.Group(), promotes=['*'])
+        grp2: om.Group = model.add_subsystem('non_empty_group', om.Group(), promotes=['*'])
+        grp2.add_subsystem('idv', om.IndepVarComp('x', val=1), promotes=['*'])
+        grp2.add_subsystem('comp', om.ExecComp('y=2*x**2'), promotes=['*'])
+        model.add_design_var('x')
+        model.add_objective('y')
+
+        prob.driver = om.ScipyOptimizeDriver()
+
+        prob.setup()
+        prob.run_driver()


### PR DESCRIPTION
### Summary

Relevancy checks currently fail if any empty groups are present. This is a bit of an edge case, but we sometimes have a few empty groups when various user set constraints\configurations aren't applied.

### Example
This code will fail in 3.32.1-dev

```python
import openmdao.api as om

prob = om.Problem()
model = prob.model

grp1: om.Group = model.add_subsystem('empy_group', om.Group(), promotes=['*'])
grp2: om.Group = model.add_subsystem('non_empty_group', om.Group(), promotes=['*'])
grp2.add_subsystem('idv', om.IndepVarComp('x', val=1), promotes=['*'])
grp2.add_subsystem('comp', om.ExecComp('y=2*x**2'), promotes=['*'])
model.add_design_var('x')
model.add_objective('y')

prob.driver = om.ScipyOptimizeDriver()

prob.setup()
prob.run_driver()
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
