### PR TITLE
Optimizers now keep track of design vars that impact linear constraints and nonlinear responses separately.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -14,7 +14,6 @@ from openmdao.core.total_jac import _TotalJacInfo
 from openmdao.core.constants import INT_DTYPE, _SetupStatus
 from openmdao.recorders.recording_manager import RecordingManager
 from openmdao.recorders.recording_iteration_stack import Recording
-from openmdao.utils.hooks import _setup_hooks
 from openmdao.utils.record_util import create_local_meta, check_path, has_match
 from openmdao.utils.general_utils import _src_name_iter
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -268,7 +268,6 @@ class Driver(object):
         self._designvars = None
         self._designvars_discrete = []
         self._cons = None
-        self._nl_cons = None
         self._objs = None
         self._responses = None
 
@@ -1092,7 +1091,6 @@ class Driver(object):
         """
         self._objs = objs = {}
         self._cons = cons = {}
-        self._nl_cons = nl_cons = {}
 
         self._responses = responses
         self._designvars = desvars
@@ -1104,8 +1102,6 @@ class Driver(object):
                 cons[name] = meta
                 if meta['linear']:
                     continue  # don't add to response size
-                else:
-                    nl_cons[name] = meta
             else:
                 objs[name] = meta
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -5093,13 +5093,22 @@ class Group(System):
         has_custom_derivs = False
         list_wrt = list(wrt) if wrt is not None else []
 
-        driver_wrt = list(driver._designvars)
         if wrt is None:
+            lincons = [d for d, meta in driver._cons.items() if meta['linear']]
+            if lincons:
+                if len(lincons) == len(driver._cons):  # all constraints are linear
+                    driver_wrt = list(driver._lin_dvs)
+                else:  # mixed linear and nonlinear constraints
+                    driver_wrt = list(driver._designvars)
+            else:
+                driver_wrt = list(driver._nl_dvs)
+
             wrt = driver_wrt
             if not wrt:
                 raise RuntimeError("No design variables were passed to compute_totals and "
                                    "the driver is not providing any.")
         else:
+            driver_wrt = list(driver._designvars)
             wrt_src_names = [m['source'] for m in driver._designvars.values()]
             if list_wrt != driver_wrt and list_wrt != wrt_src_names:
                 has_custom_derivs = True

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -282,7 +282,7 @@ class Problem(object):
 
         self.comm = comm
 
-        self._metadata = None
+        self._metadata = {'setup_status': _SetupStatus.PRE_SETUP}
         self._run_counter = -1
         self._rec_mgr = RecordingManager()
 
@@ -469,7 +469,7 @@ class Problem(object):
         bool
             True if the named system or variable is local to this process.
         """
-        if self._metadata is None:
+        if self._metadata['setup_status'] < _SetupStatus.POST_SETUP:
             raise RuntimeError(f"{self.msginfo}: is_local('{name}') was called before setup() "
                                "completed.")
 
@@ -652,9 +652,13 @@ class Problem(object):
                                ": Before calling `run_model`, the `setup` method must be called "
                                "if set_output_solver_options has been called.")
 
-        if self._mode is None:
-            raise RuntimeError(self.msginfo +
-                               ": The `setup` method must be called before `run_model`.")
+        if self._metadata['setup_status'] < _SetupStatus.POST_SETUP:
+            if self.model._order_set:
+                raise RuntimeError(f"{self.msginfo}: Cannot call set_order without calling setup "
+                                   "after")
+            else:
+                raise RuntimeError(self.msginfo +
+                                   ": The `setup` method must be called before `run_model`.")
 
         old_prefix = self._recording_iter.prefix
 
@@ -699,7 +703,7 @@ class Problem(object):
         model = self.model
         driver = self.driver
 
-        if self._mode is None:
+        if self._metadata['setup_status'] < _SetupStatus.POST_SETUP:
             raise RuntimeError(self.msginfo +
                                ": The `setup` method must be called before `run_driver`.")
 
@@ -1044,7 +1048,13 @@ class Problem(object):
         """
         driver = self.driver
 
-        response_size, desvar_size = driver._update_voi_meta(self.model)
+        responses = self.model.get_responses(recurse=True, use_prom_ivc=True)
+        designvars = self.model.get_design_vars(recurse=True, use_prom_ivc=True)
+
+        if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
+            self.model._final_setup()
+
+        response_size, desvar_size = driver._update_voi_meta(self.model, responses, designvars)
 
         # update mode if it's been set to 'auto'
         if self._orig_mode == 'auto':
@@ -1053,9 +1063,6 @@ class Problem(object):
             mode = self._orig_mode
 
         self._metadata['mode'] = mode
-
-        if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
-            self.model._final_setup()
 
         # If set_solver_print is called after an initial run, in a multi-run scenario,
         #  this part of _final_setup still needs to happen so that change takes effect

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1767,8 +1767,7 @@ class Problem(object):
             if not self.driver._responses:
                 raise RuntimeError("Driver is not providing any response variables "
                                    "for compute_totals.")
-            lcons = [n for n, meta in self.driver._cons.items()
-                     if ('linear' in meta and meta['linear'])]
+            lcons = [n for n, meta in self.driver._cons.items() if meta['linear']]
             if lcons:
                 # if driver has linear constraints, construct a full list of driver responses
                 # in order to avoid using any driver coloring that won't include the linear

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -11,15 +11,15 @@ import numpy as np
 import openmdao.api as om
 from openmdao.core.driver import Driver
 from openmdao.utils.units import convert_units
-from openmdao.utils.assert_utils import assert_near_equal, assert_warnings, assert_check_totals
-from openmdao.utils.general_utils import printoptions
+from openmdao.utils.assert_utils import assert_near_equal, assert_warnings, assert_check_totals, assert_no_warning
+from openmdao.utils.general_utils import printoptions, set_pyoptsparse_opt
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp, NonSquareArrayComp
 from openmdao.utils.om_warnings import OpenMDAOWarning
-
 from openmdao.utils.mpi import MPI
+from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -1122,6 +1122,47 @@ class TestDriverMPI(unittest.TestCase):
 
         assert_near_equal(x_star, 6.6666, tolerance=1.0E-3)
         assert_near_equal(y_star, -7.3333, tolerance=1.0E-3)
+
+
+class TestLinearOnlyDVs(unittest.TestCase):
+    def build_model(self, driver):
+
+        prob = om.Problem()
+        model = prob.model
+        prob.driver = driver
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = x - y + k'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=-50.0, upper=50.0)
+        model.add_design_var('k', lower=-1, upper=1)
+        model.add_objective('f_xy')
+        model.add_constraint('c', lower=15.0, linear=True)
+
+        prob.setup()
+        
+        return prob
+
+    def test_pyoptsparse(self):
+        OPTIMIZER = set_pyoptsparse_opt('SLSQP')[1]
+
+        driver = pyOptSparseDriver(optimizer=OPTIMIZER, print_results=False)
+        driver.opt_settings['ACC'] = 1e-9
+
+        prob = self.build_model(driver)
+        with assert_no_warning(category=om.DerivativesWarning):
+            prob.run_driver()
+
+    def test_scipy_opt(self):
+        driver = om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False)
+        prob = self.build_model(driver)
+        with assert_no_warning(category=om.DerivativesWarning):
+            prob.run_driver()
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -19,7 +19,7 @@ from openmdao.test_suite.components.sellar import SellarDerivatives
 from openmdao.test_suite.components.simple_comps import DoubleArrayComp, NonSquareArrayComp
 from openmdao.utils.om_warnings import OpenMDAOWarning
 from openmdao.utils.mpi import MPI
-from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver, pyoptsparse
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -1145,9 +1145,10 @@ class TestLinearOnlyDVs(unittest.TestCase):
         model.add_constraint('c', lower=15.0, linear=True)
 
         prob.setup()
-        
+
         return prob
 
+    @unittest.skipIf(pyoptsparse is None, "pyoptsparse is required.")
     def test_pyoptsparse(self):
         OPTIMIZER = set_pyoptsparse_opt('SLSQP')[1]
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -2044,9 +2044,10 @@ class TestProblem(unittest.TestCase):
         model = prob.model
         model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
 
-        msg = "Problem .*: 'x' Cannot call set_val before setup."
-        with self.assertRaisesRegex(RuntimeError, msg):
+        msg = "<class Group>: Called set_val(x, ...) before setup completes."
+        with self.assertRaises(RuntimeError) as cm:
             prob.set_val('x', 0.)
+        self.assertEqual(str(cm.exception), msg)
 
     def test_design_var_connected_to_output_as_input_err(self):
         prob = om.Problem(name='output_as_input_err')
@@ -2063,8 +2064,8 @@ class TestProblem(unittest.TestCase):
                                        promotes_inputs=['x'])
 
         c1.add_design_var('x', lower=0, upper=5)
-        prob.setup()
 
+        prob.setup()
         with self.assertRaises(Exception) as cm:
             prob.final_setup()
 

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -140,7 +140,10 @@ class _TotalJacInfo(object):
         self.initialize = True
         self.approx = approx
         self.coloring_info = coloring_info
-        self._linear_only_dvs = set(driver._lin_dvs).difference(driver._nl_dvs)
+        try:
+            self._linear_only_dvs = set(driver._lin_dvs).difference(driver._nl_dvs)
+        except AttributeError:
+            self._linear_only_dvs = set()
 
         orig_of = of
         orig_wrt = wrt

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -140,6 +140,7 @@ class _TotalJacInfo(object):
         self.initialize = True
         self.approx = approx
         self.coloring_info = coloring_info
+        self._linear_only_dvs = set(driver._lin_dvs).difference(driver._nl_dvs)
 
         orig_of = of
         orig_wrt = wrt
@@ -1637,7 +1638,9 @@ class _TotalJacInfo(object):
         if np.any(row):  # there's at least 1 col that's zero across all rows
             zero_cols = []
             for n, meta in self.input_meta['fwd'].items():
-
+                # don't flag zero cols for linear only dvs
+                if n in self._linear_only_dvs:
+                    continue
                 zero_idxs = self._get_zero_inds(meta, row)
 
                 if zero_idxs[0].size > 0:

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -153,12 +153,12 @@ class _TotalJacInfo(object):
         ofsize = sum(meta['global_size'] for meta in of_metadata.values())
         wrtsize = sum(meta['global_size'] for meta in wrt_metadata.values())
 
-        for meta in of_metadata.values():
-            if 'linear' in meta and meta['linear']:
-                has_lin_cons = True
-                break
-        else:
-            has_lin_cons = False
+        has_lin_cons = False
+        if driver and driver.supports['linear_constraints']:
+            for meta in of_metadata.values():
+                if 'linear' in meta and meta['linear']:
+                    has_lin_cons = True
+                    break
 
         if self._orig_mode == 'auto':
             if has_lin_cons:
@@ -177,9 +177,6 @@ class _TotalJacInfo(object):
         self._dist_driver_vars = driver._dist_driver_vars if driver else {}
 
         all_abs2meta_out = model._var_allprocs_abs2meta['output']
-
-        if not driver or not driver.supports['linear_constraints']:
-            has_lin_cons = False
 
         self.has_lin_cons = has_lin_cons
         self.dist_input_range_map = {}

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -178,8 +178,7 @@ class DOEDriver(Driver):
             self._quantities.append(name)
 
         # Add all constraints
-        con_meta = self._cons
-        for name, _ in con_meta.items():
+        for name, _ in self._cons.items():
             self._quantities.append(name)
 
         if MPI and self.options['run_parallel']:

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -945,7 +945,7 @@ class pyOptSparseDriver(Driver):
         use_approx = self._problem().model._owns_approx_of is not None
 
         # exclude linear cons
-        for con, conmeta in filter_by_meta(self._cons.items(), 'linear'):
+        for con, conmeta in filter_by_meta(self._cons.items(), 'linear', exclude=True):
             self._con_subjacs[con] = {}
             consrc = conmeta['source']
             for dv, dvmeta in self._designvars.items():

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -24,7 +24,7 @@ except Exception as err:
 
 from openmdao.core.constants import INT_DTYPE, _DEFAULT_REPORTS_DIR, _ReprClass
 from openmdao.core.analysis_error import AnalysisError
-from openmdao.core.driver import Driver, RecordingDebugging
+from openmdao.core.driver import Driver, RecordingDebugging, filter_by_meta
 from openmdao.core.group import Group
 from openmdao.utils.class_util import WeakMethodWrapper
 from openmdao.utils.mpi import FakeComm, MPI
@@ -948,10 +948,7 @@ class pyOptSparseDriver(Driver):
 
         use_approx = self._problem().model._owns_approx_of is not None
 
-        for con, conmeta in self._cons.items():
-            if conmeta['linear']:
-                continue  # skip linear constraints because they're not in the coloring
-
+        for con, conmeta in filter_by_meta(self._cons.items(), 'linear'):
             self._con_subjacs[con] = {}
             consrc = conmeta['source']
             for dv, dvmeta in self._designvars.items():

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -372,7 +372,7 @@ class pyOptSparseDriver(Driver):
         self._check_for_invalid_desvar_values()
         self._check_jac = self.options['singular_jac_behavior'] in ['error', 'warn']
 
-        linear_constraints = [key for (key, con) in self._cons.items() if con['linear']]
+        linear_constraints = [key for key, con in self._cons.items() if con['linear']]
 
         # Only need initial run if we have linear constraints or if we are using an optimizer that
         # doesn't perform one initially.
@@ -449,7 +449,7 @@ class pyOptSparseDriver(Driver):
         # # compute dynamic simul deriv coloring
         problem.get_total_coloring(self._coloring_info, run_model=not model_ran)
 
-        bad_resps = [n for n in model._relevance._no_dv_responses if n in self._cons]
+        bad_resps = [n for n in relevance._no_dv_responses if n in self._cons]
         bad_cons = [n for n, m in self._cons.items() if m['source'] in bad_resps]
 
         if bad_cons:

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -10,7 +10,6 @@ import sys
 import json
 import signal
 from packaging.version import Version
-from itertools import chain
 
 import numpy as np
 from scipy.sparse import coo_matrix
@@ -634,7 +633,7 @@ class pyOptSparseDriver(Driver):
         # Pull optimal parameters back into framework and re-run, so that
         # framework is left in the right final state
         dv_dict = sol.getDVs()
-        for name in chain(self._lin_dvs, self._nl_dvs):
+        for name in self._designvars:
             self.set_design_var(name, dv_dict[model._get_prom_name(name)])
 
         with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:

--- a/openmdao/drivers/tests/test_analysis_errors.py
+++ b/openmdao/drivers/tests/test_analysis_errors.py
@@ -52,7 +52,7 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
     })
 
     # invalid range chosen to be on the nominal path of the optimizer
-    invalid_range = defaultdict(lambda: {'x': (7.2, 10.2), 'y': (-50., -40.)})
+    invalid_range = defaultdict(lambda: {'x': (7.2, 10.2), 'y': (-50.0001, -40.)})
     invalid_range.update({
         'ParOpt': {'x': (4., 6.), 'y': (-4., -6.)},
     })

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -440,13 +440,13 @@ class TestPyoptSparse(unittest.TestCase):
         assert_near_equal(prob['x'], 7.16667, 1e-6)
         assert_near_equal(prob['y'], -7.833334, 1e-6)
 
-        self.assertEqual(prob.driver._quantities, ['f_xy'])
+        self.assertEqual(prob.driver._nl_responses, ['f_xy'])
 
         # make sure multiple driver runs don't grow the list of _quantities
-        quants = copy.copy(prob.driver._quantities)
+        quants = copy.copy(prob.driver._nl_responses)
         for i in range(5):
             prob.run_driver()
-            self.assertEqual(quants, prob.driver._quantities)
+            self.assertEqual(quants, prob.driver._nl_responses)
 
     def test_simple_paraboloid_equality(self):
 

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1135,8 +1135,7 @@ class BlockLinearSolver(LinearSolver):
             depth of the current system (already incremented).
         """
         super()._setup_solvers(system, depth)
-        if system._use_derivatives:
-            self._create_rhs_vec()
+        self._rhs_vec = None
 
     def _create_rhs_vec(self):
         system = self._system()
@@ -1146,6 +1145,9 @@ class BlockLinearSolver(LinearSolver):
             self._rhs_vec = system._doutputs.asarray(True)
 
     def _update_rhs_vec(self):
+        if self._rhs_vec is None:
+            self._create_rhs_vec()
+
         if self._mode == 'fwd':
             self._rhs_vec[:] = self._system()._dresiduals.asarray()
         else:

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1165,6 +1165,8 @@ class BlockLinearSolver(LinearSolver):
         active : bool
             Complex mode flag; set to True prior to commencing complex step.
         """
+        if self._rhs_vec is None:
+            self._create_rhs_vec()
         if active:
             self._rhs_vec = self._rhs_vec.astype(complex)
         else:

--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -322,6 +322,56 @@ class Relevance(object):
             yield (src, local, self._names2rel_array(rel_vars, self._var2idx),
                    self._names2rel_array(rel_systems, self._sys2idx))
 
+    def _is_var_relevant2arr(self, var, arr):
+        """
+        Return True if the given variable is relevant according to the given relevance array.
+
+        Parameters
+        ----------
+        var : str
+            Variable name.
+        arr : ndarray
+            Boolean relevance array.
+
+        Returns
+        -------
+        bool
+            True if the given variable is relevant.
+        """
+        return arr[self._var2idx[var]]
+
+    def _vars2rel_array(self, vars):
+        """
+        Return a relevance array for the given variables.
+
+        Parameters
+        ----------
+        vars : iter of str
+            Iterator over variable names.
+
+        Returns
+        -------
+        ndarray
+            Boolean relevance array.  True means name is relevant.
+        """
+        return self._names2rel_array(vars, self._var2idx)
+
+    def _sys2rel_array(self, systems):
+        """
+        Return a relevance array for the given systems.
+
+        Parameters
+        ----------
+        systems : iter of str
+            Iterator over system names.
+
+        Returns
+        -------
+        ndarray
+            Boolean relevance array.  True means name is relevant.
+        """
+        return self._names2rel_array(systems, self._sys2idx)
+
     def _names2rel_array(self, names, names2inds):
         """
         Return a relevance array for the given names.

--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -322,56 +322,6 @@ class Relevance(object):
             yield (src, local, self._names2rel_array(rel_vars, self._var2idx),
                    self._names2rel_array(rel_systems, self._sys2idx))
 
-    def _is_var_relevant2arr(self, var, arr):
-        """
-        Return True if the given variable is relevant according to the given relevance array.
-
-        Parameters
-        ----------
-        var : str
-            Variable name.
-        arr : ndarray
-            Boolean relevance array.
-
-        Returns
-        -------
-        bool
-            True if the given variable is relevant.
-        """
-        return arr[self._var2idx[var]]
-
-    def _vars2rel_array(self, vars):
-        """
-        Return a relevance array for the given variables.
-
-        Parameters
-        ----------
-        vars : iter of str
-            Iterator over variable names.
-
-        Returns
-        -------
-        ndarray
-            Boolean relevance array.  True means name is relevant.
-        """
-        return self._names2rel_array(vars, self._var2idx)
-
-    def _sys2rel_array(self, systems):
-        """
-        Return a relevance array for the given systems.
-
-        Parameters
-        ----------
-        systems : iter of str
-            Iterator over system names.
-
-        Returns
-        -------
-        ndarray
-            Boolean relevance array.  True means name is relevant.
-        """
-        return self._names2rel_array(systems, self._sys2idx)
-
     def _names2rel_array(self, names, names2inds):
         """
         Return a relevance array for the given names.

--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -527,8 +527,9 @@ class Relevance(object):
         found = set()
         for fsrc, farr in self._single_seed2relvars['fwd'].items():
             for rsrc, rarr in self._single_seed2relvars['rev'].items():
-                if (farr & rarr)[self._var2idx[fsrc]]:
-                    found.add(rsrc)
+                if rsrc not in found:
+                    if (farr & rarr)[self._var2idx[fsrc]]:
+                        found.add(rsrc)
 
         self._no_dv_responses = \
             [rsrc for rsrc in self._single_seed2relvars['rev'] if rsrc not in found]
@@ -1074,7 +1075,7 @@ class Relevance(object):
         responses : dict
             A dict of all responses from the model.
         """
-        # don't redo this if it's already been done
+        # don't redo this if it's already done
         if model._pre_components is not None:
             return
 

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -420,7 +420,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
 
         _compute_jac_view_info(totals, data, dv_vals, response_vals, coloring)
 
-        if lindata['oflabels']:
+        if lindata['oflabels'] and lindata['wrtlabels']:
             lin_response_vals = {n: full_response_vals[n] for n in lindata['oflabels']}
 
             if driver._total_jac_linear is None:

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -117,7 +117,7 @@ def _compute_jac_view_info(totals, data, dv_vals, response_vals, coloring):
 
     nonempty_submats = set()  # submats with any nonzero values
 
-    var_matrix = np.zeros((len(data['ofslices']), len(data['wrtslices'])))
+    var_matrix = np.zeros((len(response_vals), len(dv_vals)))
 
     matrix = np.abs(totals)
 
@@ -198,6 +198,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
     obj_table = []
 
     dv_vals = driver.get_design_var_values(get_remote=True)
+    lin_dv_vals = {n: v for n, v in dv_vals.items() if n in driver._lin_dvs}
     obj_vals = driver.get_objective_values(driver_scaling=True)
     con_vals = driver.get_constraint_values(driver_scaling=True)
 
@@ -402,7 +403,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
 
         data['linear'] = lindata = {}
         lindata['oflabels'] = [n for n, meta in driver._cons.items() if meta['linear']]
-        lindata['wrtlabels'] = data['wrtlabels']  # needs to mimic data structure
+        lindata['wrtlabels'] = [n for n in data['wrtlabels'] if n in driver._lin_dvs]
 
         # check for separation of linear constraints
         if lindata['oflabels']:
@@ -434,7 +435,7 @@ def view_driver_scaling(driver, outfile=_default_scaling_filename, show_browser=
             else:
                 lintotals = driver._total_jac_linear.J
 
-            _compute_jac_view_info(lintotals, lindata, dv_vals, lin_response_vals, None)
+            _compute_jac_view_info(lintotals, lindata, lin_dv_vals, lin_response_vals, None)
 
     if driver._problem().comm.rank == 0:
 

--- a/openmdao/visualization/scaling_viewer/scaling_table.html
+++ b/openmdao/visualization/scaling_viewer/scaling_table.html
@@ -638,7 +638,7 @@ function startup() {
                 .append("svg")
                 .classed("heatmap", true);
 
-            heatmap(data.linear.oflabels, data.wrtlabels, data.linear.var_mat_list, "#linear-jac", true);
+            heatmap(data.linear.oflabels, data.linear.wrtlabels, data.linear.var_mat_list, "#linear-jac", true);
         }
         else {
             d3.select("#varjac-button").html("responses wrt DVs");


### PR DESCRIPTION
### Summary

The warning seen in issue #3221 no longer appears if the design variable in question is one that only impacts linear constraints.

Also, in pyOptSparseDriver, the linear and nonlinear total jacobians now only contain the appropriate design variables.  This was not done in ScipyOptimizeDriver because, unlike pyoptsparse, it doesn't keep track of different jacobians internally.

The scaling viewer was also updated so that the linear jacobian now only contains design variables that impact the linear constraints.

### Related Issues

- Resolves #3221

### Backwards incompatibilities

None

### New Dependencies

None
