### PR TITLE
Fix for test_scaffold test that doesn't clean up site-packages installs on some machines

### DIFF
--- a/openmdao/utils/tests/test_scaffold.py
+++ b/openmdao/utils/tests/test_scaffold.py
@@ -86,6 +86,7 @@ class TestScaffold(unittest.TestCase):
 
             # install it
             check_call(['pip', 'install', '-q', '--no-cache-dir', '--no-deps', '.'])  # nosec: trusted input
+            os.chdir(startdir) 
 
             try:
                 modname = _camel_case_split(cname)


### PR DESCRIPTION
On some machines the test_scaffold:TestScaffold.test_packages script did not uninstall packages installed in site-packages. This fixes that issue.

### Related Issues

- Resolves #3278 

### Backwards incompatibilities

None

### New Dependencies

None
