### PR TITLE
Try Except for Report Dir removal

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -356,7 +356,11 @@ class Problem(object):
         reports_dirpath = pathlib.Path(get_reports_dir()).joinpath(f'{self._name}')
         if self.comm.rank == 0:
             if os.path.isdir(reports_dirpath):
-                shutil.rmtree(reports_dirpath)
+                try:
+                    shutil.rmtree(reports_dirpath)
+                except FileNotFoundError:
+                    # Folder already removed by another proccess
+                    pass
 
         # register hooks for any reports
         activate_reports(self._reports, self)


### PR DESCRIPTION
### Summary

We use pytest xdist for unit testing which is a parallel processing extension to pytest. Currently the default behavior of Problem is to delete the reports dir even if `reports=False` in the init call. This can lead to some test starting on different processors/threads simultaneously trying to clear the reports directory. 

This PR adds a try except around this so that tests don't fail if this occurs

```python
            if os.path.isdir(reports_dirpath):
                try:
                    shutil.rmtree(reports_dirpath)
                except FileNotFoundError:
                    # Folder already removed by another proccess
                    pass
```


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
