### PR TITLE
Removed 2.0.0 pin from pydocstyle dependency requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ test = [
     "parameterized",
     "playwright>=1.20",
     "pycodestyle>=2.4.0",
-    "pydocstyle==2.0.0",
+    "pydocstyle>=2.0.0",
     "testflo>=1.3.6",
     "websockets>8",
 ]


### PR DESCRIPTION
### Summary

Removed the 2.0.0 version pin from pydocstyle, allowing the newest version to be installed.

This enables running the PEP257 check, which was previously being skipped due to version 2.0.0 being incompatible with current versions of Python.

### Related Issues

- Resolves #3285 

### Backwards incompatibilities

None

### New Dependencies

None
