### PR TITLE
Prob.load_case discrete input fix

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -2380,7 +2380,7 @@ class Problem(object):
                         except KeyError:
                             # Var may be discrete
                             varmeta = abs2meta_disc_in[abs_name]
-                        if varmeta['distributed'] and model.comm.size > 1:
+                        if varmeta.get('distributed') and model.comm.size > 1:
                             sizes = model._var_sizes['input'][:, abs2idx[abs_name]]
                             model.set_val(abs_name, scatter_dist_to_local(val, model.comm, sizes))
                         else:

--- a/openmdao/recorders/tests/test_load_case.py
+++ b/openmdao/recorders/tests/test_load_case.py
@@ -232,6 +232,9 @@ class TestLoadCase(unittest.TestCase):
             def compute(self, inputs, outputs, d_ins, d_outs):
                 super().compute(inputs, outputs)
 
+            def compute_partials(self, inputs, outputs, d_ins):
+                super().compute_partials(inputs, outputs)
+
 
         # Setup the optimization 
         prob = om.Problem() 

--- a/openmdao/recorders/tests/test_load_case.py
+++ b/openmdao/recorders/tests/test_load_case.py
@@ -223,7 +223,7 @@ class TestLoadCase(unittest.TestCase):
 
             def setup(self):
                 super().setup()
-                self.add_discrete_output('disc_in', val='in')
+                self.add_discrete_input('disc_in', val='in')
                 self.add_discrete_output('disc_out', val='out')
                 self.add_design_var('x', lower=-50, upper=50)
                 self.add_design_var('y', lower=-50, upper=50)
@@ -241,6 +241,8 @@ class TestLoadCase(unittest.TestCase):
         prob.driver.options['optimizer'] = 'SLSQP'
 
         # Setup Recorder
+        prob.model.recording_options['record_inputs'] = True
+        prob.model.recording_options['record_outputs'] = True
         recorder = om.SqliteRecorder('cases.sql')
         prob.add_recorder(recorder)
 


### PR DESCRIPTION
### Summary

I missed an edge case for discrete inputs in #3284. This fixes it by alignining the `if` statement for inputs on line 2383 to the one for outputs on line 2425.

### Related Issues

- Resolves #3282

### Backwards incompatibilities

None

### New Dependencies

None
