### PR TITLE
Updated a couple of tests to pass the NumPy 2.x compatibility check

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -223,15 +223,6 @@ jobs:
           fi
           python -m pip install .
 
-      - name: Check NumPy 2.0 Compatibility
-        run: |
-          echo "============================================================="
-          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
-          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
-          echo "============================================================="
-          python -m pip install ruff
-          ruff check . --select NPY201
-
       - name: Display environment info
         id: env_info
         if: always()
@@ -374,6 +365,15 @@ jobs:
           message:
             Security issue found on `${{ matrix.NAME }}` build.
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Check NumPy 2.0 Compatibility
+        run: |
+          echo "============================================================="
+          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
+          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
+          echo "============================================================="
+          python -m pip install ruff
+          ruff check . --select NPY201
 
       - name: Slack env change
         if: steps.env_info.outputs.errors != ''

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -230,15 +230,6 @@ jobs:
             python -m pip install .${{ matrix.OPTIONAL }}
           fi
 
-      - name: Check NumPy 2.0 Compatibility
-        run: |
-          echo "============================================================="
-          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
-          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
-          echo "============================================================="
-          python -m pip install ruff
-          ruff check . --select NPY201
-
       - name: Install MacOS-specific dependencies
         if: matrix.OS == 'macos-13'
         run: |
@@ -516,6 +507,15 @@ jobs:
           echo "============================================================="
           cd $GITHUB_WORKSPACE
           python -m bandit -c bandit.yml -ll -r openmdao
+
+      - name: Check NumPy 2.0 Compatibility
+        run: |
+          echo "============================================================="
+          echo "Check OpenMDAO code for NumPy 2.0 compatibility"
+          echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
+          echo "============================================================="
+          python -m pip install ruff
+          ruff check . --select NPY201
 
       - name: Slack env change
         if: steps.env_info.outputs.errors != ''

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -16,7 +16,7 @@ try:
     # through the main NumPy namespace for compatibility. (Until NumPy 2.0 release)
     from numpy.exceptions import ComplexWarning
 except ModuleNotFoundError:
-    from numpy import ComplexWarning
+    from numpy import ComplexWarning  # noqa: NPY201
 
 @use_tempdirs
 class TestBalanceComp(unittest.TestCase):

--- a/openmdao/components/tests/test_balance_comp.py
+++ b/openmdao/components/tests/test_balance_comp.py
@@ -414,7 +414,7 @@ class TestBalanceComp(unittest.TestCase):
         prob.run_model()
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(action="error", category=ComplexWarning)
+            warnings.filterwarnings(action="error", category=ComplexWarning)  # noqa: NPY201
             cpd = force_check_partials(prob, out_stream=None, method='cs')
 
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -359,7 +359,7 @@ class TestEQConstraintComp(unittest.TestCase):
         prob.run_driver()
 
         with warnings.catch_warnings():
-            warnings.filterwarnings(action="error", category=ComplexWarning)
+            warnings.filterwarnings(action="error", category=ComplexWarning)  # noqa: NPY201
             cpd = force_check_partials(prob, out_stream=None, method='cs')
 
         assert_check_partials(cpd, atol=1e-10, rtol=1e-10)

--- a/openmdao/components/tests/test_eq_constraint_comp.py
+++ b/openmdao/components/tests/test_eq_constraint_comp.py
@@ -14,7 +14,7 @@ try:
     # through the main NumPy namespace for compatibility. (Until NumPy 2.0 release)
     from numpy.exceptions import ComplexWarning
 except ModuleNotFoundError:
-    from numpy import ComplexWarning
+    from numpy import ComplexWarning  # noqa: NPY201
 
 
 class TestEQConstraintComp(unittest.TestCase):


### PR DESCRIPTION
### Summary

- added `# noqa: NPY201` flag to a couple of tests that use the ComplexWarning class so they won't fail the riff NPY021 check
- move the ruff NPY021 check to later in the test workflows, after the rest of the tests have been run

### Related Issues

- Resolves #3290 

### Backwards incompatibilities

None

### New Dependencies

None
