### PR TITLE
Fixed path to SNOPT output file in analysis error documentation

### DIFF
--- a/openmdao/docs/openmdao_book/advanced_user_guide/analysis_errors/analysis_error.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/analysis_errors/analysis_error.ipynb
@@ -375,7 +375,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with open(\"SNOPT_print.out\", encoding=\"utf-8\", errors='ignore') as f:\n",
+    "with open(prob.get_outputs_dir() / \"SNOPT_print.out\", encoding=\"utf-8\", errors='ignore') as f:\n",
     "    SNOPT_history = f.read()\n",
     "beg = SNOPT_history.find(\"   Itns Major Minor\")\n",
     "end = SNOPT_history.find(\"Problem name\", beg)\n",
@@ -403,7 +403,7 @@
    "metadata": {},
    "source": [
     "```{Note}\n",
-    "Not all optimizers will respond as nicely to an AnalysisError as the two demonstrated here (`IPOPT` and `SNOPT`).  Some optimizers may fail to navigate around the bad region and find a solution at all.  Other may find an incorrect solution.  It is important to understand the capabilities of your chosen optimizer when working with a model that may raise an AnlysisError.\n",
+    "Not all optimizers will respond as nicely to an AnalysisError as the two demonstrated here (`IPOPT` and `SNOPT`).  Some optimizers may fail to navigate around the bad region and find a solution at all.  Other may find an incorrect solution.  It is important to understand the capabilities of your chosen optimizer when working with a model that may raise an AnalysisError.\n",
     "```\n"
    ]
   }


### PR DESCRIPTION
### Summary

Fixed path to SNOPT output file in analysis error documentation

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
