### PR TITLE
fix for case when no objective is declared and all constraints are linear

### DIFF
--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -786,6 +786,9 @@ class Relevance(object):
         self._current_rel_varray = self._get_rel_array(self._seed_var_map,
                                                        self._single_seed2relvars,
                                                        fwd_seeds, rev_seeds)
+        if self._current_rel_varray.size == 0:
+            self._active = False
+
         self._current_rel_sarray = self._get_rel_array(self._seed_sys_map,
                                                        self._single_seed2relsys,
                                                        fwd_seeds, rev_seeds)


### PR DESCRIPTION
### Summary

Added handling in the Relevance class for the special case when no objective was declared and all constraints were linear.  This situation resulted in an empty seed array that couldn't be indexed into without raising an IndexError.

### Related Issues

- Resolves #3310

### Backwards incompatibilities

None

### New Dependencies

None
