### PR TITLE
Added `openmdao clean` command line utility and `openmdao.api.clean_outputs` function.

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -62,6 +62,7 @@ from openmdao.surrogate_models.surrogate_model import SurrogateModel, \
 
 from openmdao.utils.coloring import display_coloring
 from openmdao.utils.indexer import slicer, indexer
+from openmdao.utils.file_utils import clean_outputs
 from openmdao.utils.find_cite import print_citations
 from openmdao.utils.spline_distributions import cell_centered
 from openmdao.utils.spline_distributions import sine_distribution

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1034,6 +1034,10 @@ class Problem(object):
                     pass
         self._metadata['reports_dir'] = self.get_reports_dir(force=False)
 
+        # Touch the .openmdao_out file for the output directory to make it easily identifiable.
+        if not MPI or (self.comm is not None and self.comm.rank == 0):
+            open(self.get_outputs_dir() / '.openmdao_out', 'w').close()
+            
         try:
             model._setup(model_comm, self._metadata)
         finally:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1025,7 +1025,7 @@ class Problem(object):
         # Start setup by deleting any existing reports so that the files
         # that are in that directory are all from this run and not a previous run
         reports_dirpath = self.get_reports_dir(force=False)
-        if self.comm.rank == 0:
+        if not MPI or (self.comm is not None and self.comm.rank == 0):
             if os.path.isdir(reports_dirpath):
                 try:
                     shutil.rmtree(reports_dirpath)
@@ -1037,7 +1037,7 @@ class Problem(object):
         # Touch the .openmdao_out file for the output directory to make it easily identifiable.
         if not MPI or (self.comm is not None and self.comm.rank == 0):
             open(self.get_outputs_dir() / '.openmdao_out', 'w').close()
-            
+
         try:
             model._setup(model_comm, self._metadata)
         finally:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1034,7 +1034,7 @@ class Problem(object):
                     pass
         self._metadata['reports_dir'] = self.get_reports_dir(force=False)
 
-        # Touch the .openmdao_out file for the output directory to make it easily identifiable.
+        # Touch the .openmdao_out file for the output directory to ease identification.
         if not MPI or (self.comm is not None and self.comm.rank == 0):
             open(self.get_outputs_dir() / '.openmdao_out', 'w').close()
 

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -185,6 +185,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(om-command-clean)=\n",
+    "### openmdao clean\n",
+    "\n",
+    "OpenMDAO creates an output directory for each problem it runs. This directory contains recording files, optimizer output files, derivative coloring information (if generated), and reports (if generated).\n",
+    "The `openmdao clean` command recurse through the given path and remove any OpenMDAO output directories found.\n",
+    "\n",
+    "OpenMDAO output directories are identified by the presence of an `.openmdao_out` file, which is automatically added upon their creation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!openmdao clean --help"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "(om-command-n2)=\n",
     "### openmdao n2\n",
     "\n",

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -189,7 +189,7 @@
     "### openmdao clean\n",
     "\n",
     "OpenMDAO creates an output directory for each problem it runs. This directory contains recording files, optimizer output files, derivative coloring information (if generated), and reports (if generated).\n",
-    "The `openmdao clean` command recurse through the given path and remove any OpenMDAO output directories found.\n",
+    "The `openmdao clean` command recurses through the given path and remove any OpenMDAO output directories found.\n",
     "\n",
     "OpenMDAO output directories are identified by the presence of an `.openmdao_out` file, which is automatically added upon their creation."
    ]

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -1,7 +1,8 @@
 """
 Utilities for working with files.
 """
-
+from collections.abc import Iterable
+from itertools import chain
 from multiprocessing import Value
 import sys
 import os
@@ -10,6 +11,10 @@ import types
 from fnmatch import fnmatch
 from os.path import join, basename, dirname, isfile, split, splitext, abspath
 import pathlib
+import shutil
+
+import openmdao
+from openmdao.utils.om_warnings import issue_warning
 
 
 def get_module_path(fpath):
@@ -217,7 +222,7 @@ def fname2mod_name(fname):
                   ';', ':', '"', "'", '<', '>', '?', '/', '\\', '|']
 
     if not fname.endswith('.py'):
-        raise ValueError(f"'{s}' does not end with '.py'")
+        raise ValueError(f"'{fname}' does not end with '.py'")
 
     s = os.path.basename(fname).rsplit('.', 1)[0]
 
@@ -439,6 +444,10 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
     The resulting outputs directory will be nested where each problem's output directory
     contains its own output files and subdirectories as well as any subproblems.
 
+    This directory also will include a .openmdao_outputs hidden file that
+    marks this directory as being created by OpenMDAO. This makes identifying the
+    directory during cleanup more reliable.
+
     Parameters
     ----------
     obj : Problem or System or Solver or None
@@ -451,7 +460,6 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
     from openmdao.core.problem import Problem
     from openmdao.core.system import System
     from openmdao.solvers.solver import Solver
-    from openmdao.core.constants import _SetupStatus
 
     if isinstance(obj, Problem):
         prob_meta = obj._metadata
@@ -481,3 +489,117 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
         dirpath.mkdir(parents=True, exist_ok=True)
 
     return dirpath
+
+
+def _is_openmdao_output_dir(directory):
+    """
+    Check if a directory is an OpenMDAO output directory.
+
+    Parameters
+    ----------
+    directory : str or Path
+        The directory to check.
+
+    Returns
+    -------
+    bool
+        True if the directory is an OpenMDAO output directory, False otherwise.
+    """
+    directory = pathlib.Path(directory)
+    return directory.is_dir() and directory.name.endswith('_out') \
+        and (directory / '.openmdao_out').exists()
+
+
+def _find_openmdao_output_dirs(paths, recurse):
+    """
+    Find all OpenMDAO output directories in the given path.
+
+    Parameters
+    ----------
+    paths : str or Path or Iterable
+        The path to search for OpenMDAO output directories.
+    recurse : bool
+        If True, search recursively.
+
+    Returns
+    -------
+    list
+        A list of OpenMDAO output directories.
+    """
+    if isinstance(paths, (str, pathlib.Path)):
+        paths = [paths]
+    elif not isinstance(paths, Iterable):
+        raise ValueError("The 'paths' parameter must be a string, Path, or an iterable of them.")
+
+    openmdao_dirs = []
+    for path in paths:
+        path = pathlib.Path(path)
+        if not path.is_dir():
+            continue
+
+        for root, dirs, _ in os.walk(path):
+            # Use a copy of the dirs list to avoid modifying it while iterating
+            if _is_openmdao_output_dir(root):
+                openmdao_dirs.append(pathlib.Path(root))
+            for d in dirs[:]:
+                dir_path = pathlib.Path(root) / d
+                if _is_openmdao_output_dir(dir_path):
+                    openmdao_dirs.append(dir_path)
+                    dirs.remove(d)  # Do not recurse into OpenMDAO output directories
+            if not recurse:
+                break
+    return openmdao_dirs
+
+
+def clean_outputs(obj='.', recurse=False, prompt=True, dryrun=False):
+    """
+    Remove output directories created by OpenMDAO.
+
+    A directory is determined to be an OpenMDAO output directory if its name
+    ends in `_out` and it contains the file `.openmdao_out`.
+
+    Parameters
+    ----------
+    obj : Problem or System or Solver or str or Path
+        The problem or system or solver whose output file should be removed.
+    recurse : bool
+        If True, and if obj is a string or Path, recurse into it
+        finding and removing OpenMDAO output directories along the way.
+        This option is ignored if obj is a Problem, System, or Solver.
+    prompt : bool
+        If True, prompt the user to confirm directories to be removed.
+        This option is ignored if obj is a Problem, System, or Solver.
+    dryrun : bool
+        If True, report which directories would be removed without actually removing them.
+    """
+    output_dirs = []
+
+    if isinstance(obj, (str, pathlib.Path)):
+        output_dirs = _find_openmdao_output_dirs(obj, recurse)
+    elif hasattr(obj, 'get_outputs_dir'):
+        output_dir = obj.get_outputs_dir()
+        prompt = False
+        if output_dir and _is_openmdao_output_dir(output_dir):
+            output_dirs.append(pathlib.Path(output_dir))
+
+    if not output_dirs:
+        print('No OpenMDAO output directories found.')
+        return
+    else:
+        print(f'Found {len(output_dirs)} OpenMDAO output directories:')
+
+    for dir_path in sorted(output_dirs):
+        print(f"  {dir_path}")
+
+    if dryrun:
+        print(f'Would remove {len(output_dirs)} output directories (dryrun = True).')
+        return
+    if prompt:
+        response = input(f"Do you want to remove {len(output_dirs)} output "
+                         "directories? [y/N] ").strip().lower()
+        if response != 'y':
+            return
+    for dir_path in sorted(output_dirs):
+        shutil.rmtree(dir_path)
+
+    print(f"Removed {len(output_dirs)} OpenMDAO output directories.")

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -588,18 +588,19 @@ def clean_outputs(obj='.', recurse=False, prompt=True, dryrun=False):
     else:
         print(f'Found {len(output_dirs)} OpenMDAO output directories:')
 
+    removed_count = 0
     for dir_path in sorted(output_dirs):
-        print(f"  {dir_path}")
+        if dryrun:
+            print(f'Would remove {dir_path} (dryrun = True).')
+        elif prompt:
+            response = input(f"Remove {dir_path}? [y/N] ").strip().lower()
+            if response == 'y':
+                shutil.rmtree(dir_path)
+                print(f'Removed {dir_path}')
+                removed_count += 1
+        else:
+            shutil.rmtree(dir_path)
+            print(f'Removed {dir_path}')
+            removed_count += 1
 
-    if dryrun:
-        print(f'Would remove {len(output_dirs)} output directories (dryrun = True).')
-        return
-    if prompt:
-        response = input(f"Do you want to remove {len(output_dirs)} output "
-                         "directories? [y/N] ").strip().lower()
-        if response != 'y':
-            return
-    for dir_path in sorted(output_dirs):
-        shutil.rmtree(dir_path)
-
-    print(f"Removed {len(output_dirs)} OpenMDAO output directories.")
+    print(f'Removed {removed_count} OpenMDAO output directories.')

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -291,8 +291,8 @@ def _clean_setup_parser(parser):
         The parser we're adding options to.
     """
     parser.add_argument('path', nargs='*', default='.',
-                        help='Path(s) from which OpenMDAO output directories should be remove.')
-    parser.add_argument('-f', '--force', action='store_true', dest='force',
+                        help='Path(s) from which OpenMDAO output directories should be removed.')
+    parser.add_argument('-f', '--noprompt', action='store_false', dest='prompt',
                         help='Remove output directories without confirmation.')
     parser.add_argument('-n', '--norecurse', action='store_true', dest='no_recurse',
                         help='Do not recurse into subdirectories to find directories to remove.')
@@ -311,7 +311,7 @@ def _clean_cmd(options, user_args):
     user_args : list of str
         Args to be passed to the user script.
     """
-    clean_outputs(options.path, recurse=not options.no_recurse, prompt=not options.force,
+    clean_outputs(options.path, recurse=not options.no_recurse, prompt=options.prompt,
                   dryrun=options.dryrun)
 
 

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -49,6 +49,7 @@ from openmdao.devtools.iprof_mem import _mem_prof_exec, _mem_prof_setup_parser, 
     _mempost_exec, _mempost_setup_parser
 from openmdao.error_checking.check_config import _check_config_cmd, _check_config_setup_parser
 from openmdao.utils.mpi import MPI
+from openmdao.utils.file_utils import clean_outputs
 from openmdao.utils.find_cite import print_citations
 from openmdao.utils.code_utils import _calltree_setup_parser, _calltree_exec
 from openmdao.utils.coloring import _total_coloring_setup_parser, _total_coloring_cmd, \
@@ -278,6 +279,40 @@ def _tree_setup_parser(parser):
                         help="Display input and output sizes.")
     parser.add_argument('--approx', action='store_true', dest='show_approx',
                         help="Show which components compute approximations.")
+
+
+def _clean_setup_parser(parser):
+    """
+    Set up the openmdao subparser for the 'openmdao clean' command.
+
+    Parameters
+    ----------
+    parser : argparse subparser
+        The parser we're adding options to.
+    """
+    parser.add_argument('path', nargs='*', default='.',
+                        help='Path(s) from which OpenMDAO output directories should be remove.')
+    parser.add_argument('-f', '--force', action='store_true', dest='force',
+                        help='Remove output directories without confirmation.')
+    parser.add_argument('-n', '--norecurse', action='store_true', dest='no_recurse',
+                        help='Do not recurse into subdirectories to find directories to remove.')
+    parser.add_argument('-d', '--dryrun', action='store_true', dest='dryrun',
+                        help='Highlight directories to be removed but do not actually remove them.')
+
+
+def _clean_cmd(options, user_args):
+    """
+    Return the post_setup hook function for 'openmdao summary'.
+
+    Parameters
+    ----------
+    options : argparse Namespace
+        Command line options.
+    user_args : list of str
+        Args to be passed to the user script.
+    """
+    clean_outputs(options.path, recurse=not options.no_recurse, prompt=not options.force,
+                  dryrun=options.dryrun)
 
 
 def _get_tree_filter(attrs, vecvars):
@@ -531,6 +566,7 @@ _command_map = {
     'check': (_check_config_setup_parser, _check_config_cmd,
               'Perform a number of configuration checks on the problem.'),
     'cite': (_cite_setup_parser, _cite_cmd, 'Print citations referenced by the problem.'),
+    'clean': (_clean_setup_parser, _clean_cmd, 'Remove OpenMDAO output directories.'),
     'comm_info': (_comm_info_setup_parser, _comm_info_cmd,
                   'Print MPI communicator info for systems.'),
     'compute_entry_points': (_compute_entry_points_setup_parser, _compute_entry_points_exec,

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -249,7 +249,6 @@ def set_env_vars_context(**kwargs):
         for k, v in kwargs.items():
             saved[k] = os.environ.get(k)
             os.environ[k] = v  # will raise exception if v is not a string
-
         yield
 
     finally:

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -125,18 +125,21 @@ class CmdlineTestCase(unittest.TestCase):
     def test_clean(self):
         import openmdao.api as om
 
-        p1 = om.Problem(name='foo')
+        p1 = om.Problem()
         p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
         p1.setup()
         p1.run_model()
 
-        p2 = om.Problem(name='bar')
+        p2 = om.Problem()
         p2.model.add_subsystem('exec', om.ExecComp('z = a * b'))
         p2.setup()
         p2.run_model()
 
-        self.assertIn('foo_out', os.listdir(os.getcwd()))
-        self.assertIn('bar_out', os.listdir(os.getcwd()))
+        p1_outdir = p1.get_outputs_dir()
+        p2_outdir = p2.get_outputs_dir()
+
+        self.assertIn(str(p1_outdir), os.listdir(os.getcwd()))
+        self.assertIn(str(p2_outdir), os.listdir(os.getcwd()))
 
         proc = subprocess.Popen('openmdao clean -f'.split(),  # nosec: trusted input
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -146,8 +149,8 @@ class CmdlineTestCase(unittest.TestCase):
             proc.kill()
             outs, errs = proc.communicate()
 
-        self.assertNotIn('foo_out', os.listdir(os.getcwd()))
-        self.assertNotIn('bar_out', os.listdir(os.getcwd()))
+        self.assertNotIn(str(p1_outdir), os.listdir(os.getcwd()))
+        self.assertNotIn(str(p2_outdir), os.listdir(os.getcwd()))
 
     def test_n2_err(self):
         # command should raise exception but still produce an n2 html file

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -109,6 +109,7 @@ class TestCleanOutputs(unittest.TestCase):
         self.assertNotIn('foo_out', os.listdir(os.getcwd()))
         self.assertNotIn('bar_out', os.listdir(os.getcwd()))
 
+    @unittest.skipIf(sys.version_info  < (3, 9, 0))
     def test_specify_non_output_dir_prompt(self):
 
         for recurse in (True, False):

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -109,7 +109,7 @@ class TestCleanOutputs(unittest.TestCase):
         self.assertNotIn('foo_out', os.listdir(os.getcwd()))
         self.assertNotIn('bar_out', os.listdir(os.getcwd()))
 
-    @unittest.skipIf(sys.version_info  < (3, 9, 0))
+    @unittest.skipIf(sys.version_info  < (3, 9, 0), 'Requires Python 3.9.0 or later.')
     def test_specify_non_output_dir_prompt(self):
 
         for recurse in (True, False):

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -1,0 +1,154 @@
+import unittest
+
+from contextlib import redirect_stdout, contextmanager
+import io
+import os
+import sys
+
+import openmdao.api as om
+from openmdao.utils.testing_utils import use_tempdirs
+
+
+@contextmanager
+def _replace_stdin(target):
+    orig = sys.stdin
+    sys.stdin = target
+    yield
+    sys.stdin = orig
+
+
+@use_tempdirs
+class TestCleanOutputs(unittest.TestCase):
+
+    def test_specify_prob(self):
+
+        p1 = om.Problem(name='foo')
+        p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
+        p1.setup()
+        p1.run_model()
+
+        p2 = om.Problem(name='bar')
+        p2.model.add_subsystem('exec', om.ExecComp('z = a * b'))
+        p2.setup()
+        p2.run_model()
+
+        # First Test that a dryrun on p1 works as expected.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(p1, dryrun=True)
+
+        expected = ('Found 1 OpenMDAO output directories:\n'
+                    '  foo_out\n'
+                    'Would remove 1 output directories (dryrun = True).\n')
+        
+        self.assertIn(expected, ss.getvalue())
+
+        # Now actually do it.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(p1)
+
+        self.assertNotIn('foo_out', os.listdir(os.getcwd()))
+        self.assertIn('bar_out', os.listdir(os.getcwd()))
+
+        # Now specify p2 with the output directory.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(p2)
+        
+        self.assertNotIn('bar_out', os.listdir(os.getcwd()))
+
+    def test_specify_non_output_dir_no_prompt(self):
+
+        p1 = om.Problem(name='foo')
+        p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
+        p1.setup()
+        p1.run_model()
+
+        p2 = om.Problem(name='bar')
+        p2.model.add_subsystem('exec', om.ExecComp('z = a * b'))
+        p2.setup()
+        p2.run_model()
+
+        # First Test that a dryrun on p1 works as expected.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs('.', dryrun=True)
+
+        print(ss.getvalue())
+
+        expected = ('Found 2 OpenMDAO output directories:\n'
+                    '  bar_out\n'
+                    '  foo_out\n'
+                    'Would remove 2 output directories (dryrun = True).')
+        
+        self.assertIn(expected, ss.getvalue())
+
+        # Test that no specified path gives the same result.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(dryrun=True)
+
+        expected = ('Found 2 OpenMDAO output directories:\n'
+                    '  bar_out\n'
+                    '  foo_out\n'
+                    'Would remove 2 output directories (dryrun = True).')
+        
+        self.assertIn(expected, ss.getvalue())
+
+        # Now remove the files
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(prompt=False)
+        
+        expected = ('Found 2 OpenMDAO output directories:\n'
+                    '  bar_out\n'
+                    '  foo_out\n'
+                    'Removed 2 OpenMDAO output directories.\n')
+        
+        self.assertIn(expected, ss.getvalue())
+
+        self.assertNotIn('foo_out', os.listdir(os.getcwd()))
+        self.assertNotIn('bar_out', os.listdir(os.getcwd()))
+
+    def test_specify_non_output_dir_prompt(self):
+
+        for recurse in (True, False):
+            with self.subTest(f'{recurse=}'):
+                p1 = om.Problem()
+                p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
+                p1.setup()
+                p1.run_model()
+
+                p2 = om.Problem()
+                p2.model.add_subsystem('exec', om.ExecComp('z = a * b'))
+                p2.setup()
+                p2.run_model()
+
+                # First, respond in the negative
+                ss = io.StringIO()
+                with redirect_stdout(ss):
+                    with _replace_stdin(io.StringIO('n')):
+                        om.clean_outputs(recurse=recurse)
+                
+                if recurse:
+                    expected = ('Found 2 OpenMDAO output directories:\n')
+                    self.assertIn(expected, ss.getvalue())
+
+                    outdirs = [d for d in os.listdir(os.getcwd()) if d.endswith('_out')]           
+                    self.assertEqual(len(outdirs), 2)
+
+                    # Respond in the positive to actually remove them.
+                    ss = io.StringIO()
+                    with redirect_stdout(ss):
+                        with _replace_stdin(io.StringIO('y')):
+                            om.clean_outputs()
+
+                    expected = ('Removed 2 OpenMDAO output directories.\n')
+                    
+                    self.assertIn(expected, ss.getvalue())
+
+                    outdirs = [d for d in os.listdir(os.getcwd()) if d.endswith('_out')]           
+                    self.assertEqual(len(outdirs), 0)
+                else:
+                    print(ss.getvalue())


### PR DESCRIPTION
### Summary

Added the ability to recursively find and remove OpenMDAO output directories to keep users filesystems from getting cluttered.

### Related Issues

- Resolves #3317 

### Backwards incompatibilities

None

### New Dependencies

None
