### PR TITLE
Addressed a couple of issues that were causing the 'latest' test workflow to fail

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -53,7 +53,7 @@ jobs:
             OS: ubuntu-latest
             PY: 3
             NUMPY: '<2'
-            PETSc: True
+            PETSc: true
             PYOPTSPARSE: true
             SNOPT: true
             BANDIT: true
@@ -71,7 +71,7 @@ jobs:
             OS: macos-13
             PY: 3
             NUMPY: '<2'
-            PETSc: True
+            PETSc: true
             PYOPTSPARSE: true
 
           # test latest versions on macos
@@ -152,7 +152,12 @@ jobs:
           echo "============================================================="
           echo "Install latest PETSc"
           echo "============================================================="
-          conda install mpi4py petsc!=3.21.1 petsc4py -q -y
+          if [[ "${{ matrix.NUMPY }}" == "<2" ]]; then
+            conda install mpich mpi4py=3 petsc4py=3.21.2 -q -y
+          else
+            conda install mpich mpi4py=3 petsc4py -q -y
+          fi
+
 
           echo "============================================================="
           echo "Check MPI and PETSc installation"

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -153,9 +153,9 @@ jobs:
           echo "Install latest PETSc"
           echo "============================================================="
           if [[ "${{ matrix.NUMPY }}" == "<2" ]]; then
-            conda install mpich mpi4py=3 petsc4py=3.21.2 -q -y
+            conda install mpich mpi4py petsc4py=3.21.2 -q -y
           else
-            conda install mpich mpi4py=3 petsc4py -q -y
+            conda install mpich mpi4py petsc4py -q -y
           fi
 
 

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -517,6 +517,7 @@ class LintTestCase(unittest.TestCase):
 
     def test_docstrings(self):
         failures = {}
+
         # Loop over directories
         for dirpath in sorted(directories):
 
@@ -596,12 +597,17 @@ class LintTestCase(unittest.TestCase):
             msg = '\n'
             count = 0
             for key in failures:
+                # numpydoc 1.8.0rc2 introduces a bug that causes this decorator to fail the YD01 check
+                # (https://github.com/numpy/numpydoc/pull/541)
+                if key == 'openmdao.utils.options_dictionary.OptionsDictionary.temporary':
+                    failures[key].remove('YD01: No Yields section found')
                 msg += f'{key}\n'
                 count += len(failures[key])
                 for failure in failures[key]:
                     msg += f'    {failure}\n'
-            msg += f'Found {count} issues in docstrings'
-            self.fail(msg)
+            if count:
+                msg += f'Found {count} issues in docstrings'
+                self.fail(msg)
 
 
 if __name__ == '__main__':

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -600,7 +600,10 @@ class LintTestCase(unittest.TestCase):
                 # numpydoc 1.8.0rc2 introduces a bug that causes this decorator to fail the YD01 check
                 # (https://github.com/numpy/numpydoc/pull/541)
                 if key == 'openmdao.utils.options_dictionary.OptionsDictionary.temporary':
-                    failures[key].remove('YD01: No Yields section found')
+                    try:
+                        failures[key].remove('YD01: No Yields section found')
+                    except ValueError:
+                        pass
                 msg += f'{key}\n'
                 count += len(failures[key])
                 for failure in failures[key]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ classifiers = [
 ]
 dependencies = [
     "networkx>=2.0",
-    "numpy<2",
+    "numpy",
     "packaging",
     "requests",
     "scipy",


### PR DESCRIPTION
### Summary

Addressed a couple of issues that were causing the `latest` test workflow to fail.

- `petsc4py` versions after 3.21.2 causes an error on MacOS
- `numpydoc` 1.8.0rc2 introduces a bug that causes an `OptionsDictionary` decorator to fail the `YD01` check

Also, removed the `numpy<2` requirement from `pyproject.toml`, since OpenMDAO itself has no issues with NumPy 2.x

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
