### PR TITLE
added better error msg when a distributed variable is part of an invalid connection or is unconnected

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -200,6 +200,8 @@ class Group(System):
         within this group, keyed by active response.  These determine if contributions
         from all ranks will be added together to get the correct input values when derivatives
         in the larger model are being solved using reverse mode.
+    _bad_conn_vars : set
+        Set of variables involved in invalid connections.
     """
 
     def __init__(self, **kwargs):
@@ -229,6 +231,7 @@ class Group(System):
         self._post_components = None
         self._iterated_components = None
         self._fd_rev_xfer_correction_dist = {}
+        self._bad_conn_vars = None
 
         # TODO: we cannot set the solvers with property setters at the moment
         # because our lint check thinks that we are defining new attributes
@@ -1385,7 +1388,7 @@ class Group(System):
 
         self._resolve_src_indices()
 
-        if self.comm.size > 1:
+        if self.comm.size > 1 and not self._bad_conn_vars:
             abs2idx = self._var_allprocs_abs2idx
             all_abs2meta = self._var_allprocs_abs2meta
             all_abs2meta_in = all_abs2meta['input']
@@ -2109,6 +2112,8 @@ class Group(System):
         abs2meta = self._var_abs2meta['input']
         allprocs_abs2meta_in = self._var_allprocs_abs2meta['input']
 
+        self._bad_conn_vars = set()
+
         # Add explicit connections (only ones declared by this group)
         for prom_in, (prom_out, src_indices, flat) in self._manual_connections.items():
 
@@ -2125,6 +2130,8 @@ class Group(System):
                     msg = f"{self.msginfo}: Attempted to connect from '{prom_out}' to " + \
                           f"'{prom_in}', but '{prom_out}' doesn't exist. Perhaps you meant " + \
                           f"to connect to one of the following outputs: {guesses}."
+
+                self._bad_conn_vars.update((prom_in, prom_out))
                 self._collect_error(msg)
                 continue
 
@@ -2139,6 +2146,8 @@ class Group(System):
                     msg = f"{self.msginfo}: Attempted to connect from '{prom_out}' to " + \
                           f"'{prom_in}', but '{prom_in}' doesn't exist. Perhaps you meant " + \
                           f"to connect to one of the following inputs: {guesses}."
+
+                self._bad_conn_vars.update((prom_in, prom_out))
                 self._collect_error(msg)
                 continue
 
@@ -2155,6 +2164,7 @@ class Group(System):
                     self._collect_error(
                         f"{self.msginfo}: Output and input are in the same System for connection "
                         f"from '{prom_out}' to '{prom_in}'.")
+                    self._bad_conn_vars.update((prom_in, prom_out))
                     continue
 
                 if src_indices is not None:
@@ -2164,6 +2174,7 @@ class Group(System):
                             f"{self.msginfo}: Setting of 'src_indices' along with 'shape_by_conn', "
                             f"'copy_shape', or 'compute_shape' for variable '{abs_in}' "
                             "is unsupported.")
+                        self._bad_conn_vars.update((prom_in, prom_out))
                         continue
 
                     if abs_in in abs2meta:
@@ -2179,6 +2190,7 @@ class Group(System):
                                 self._collect_error(
                                     f"When connecting from '{prom_out}' to '{prom_in}': {exc}",
                                     exc_type=type_exc, tback=tb, ident=(abs_out, abs_in))
+                                self._bad_conn_vars.update((prom_in, prom_out))
                                 continue
 
                         meta = abs2meta[abs_in]
@@ -2193,6 +2205,7 @@ class Group(System):
                         f"{self.msginfo}: Input '{abs_in}' cannot be connected to '{abs_out}' "
                         f"because it's already connected to '{abs_in2out[abs_in]}'.",
                         ident=(abs_out, abs_in))
+                    self._bad_conn_vars.update((prom_in, prom_out))
                     continue
 
                 abs_in2out[abs_in] = abs_out
@@ -2573,7 +2586,7 @@ class Group(System):
                                                                **meta2node_data(all_abs2meta_in[n]))
                                                 graph.add_edge(n, name, multi=False)
                                                 break
-                            if fail:
+                            if fail and name not in self._bad_conn_vars:
                                 self._collect_error(
                                     f"{self.msginfo}: 'shape_by_conn' was set for "
                                     f"unconnected variable '{name}'.")
@@ -4450,14 +4463,15 @@ class Group(System):
         auto_conns = {}
 
         for tgt in all_abs2meta:
-            if tgt in conns:
+            if tgt in conns or tgt in self._bad_conn_vars:
                 continue
 
             all_meta = all_abs2meta[tgt]
             if all_meta['distributed']:
                 # OpenMDAO currently can't create an automatic IndepVarComp for inputs on
                 # distributed components.
-                raise RuntimeError(f'Distributed component input "{tgt}" requires an IndepVarComp.')
+                if tgt not in self._bad_conn_vars:
+                    raise RuntimeError(f'Distributed component input "{tgt}" is not connected.')
 
             prom = abs2prom[tgt]
             if prom in prom2auto:


### PR DESCRIPTION

### Summary

The error message no longer erroneously says that the distributed input must be connected to an IndepVarComp output, and it distinguishes between an unconnected input and an input that has been connected to a nonexistent output.
 
### Related Issues

- Resolves #3312

### Backwards incompatibilities

None

### New Dependencies

None
