### PR TITLE
Added code linting with Ruff to the test workflow

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -68,7 +68,7 @@ jobs:
           # test latest versions on macos
           # Include PETSc/pyOptSparse, which require NumPy<2
           - NAME: MacOS Latest, NumPy<2
-            OS: macos-latest
+            OS: macos-13
             PY: 3
             NUMPY: '<2'
             PETSc: true
@@ -77,7 +77,7 @@ jobs:
           # test latest versions on macos
           # Exclude PETSc/pyOptSparse, which require NumPy<2
           - NAME: MacOS Latest, NumPy 2 (No PETSc/pyOptSparse)
-            OS: macos-latest
+            OS: macos-13
             PY: 3
 
     runs-on: ${{ matrix.OS }}
@@ -127,17 +127,10 @@ jobs:
           conda-version: "*"
           channels: conda-forge
 
-      - name: Install compilers
+      - name: Install MacOS-specific dependencies
         if: matrix.OS == 'macos-13'
         run: |
-          if [[ "${{ matrix.BREW }}" ]]; then
-            brew install swig meson
-            if [[ "${{ matrix.OS }}" == "macos-latest" ]]; then
-              ln -s /opt/homebrew/bin/gfortran-13 /opt/homebrew/bin/gfortran
-            fi
-          else
-            conda install compilers cython swig -q -y
-          fi
+          conda install compilers swig
 
       - name: Install NumPy/SciPy
         run: |
@@ -221,7 +214,7 @@ jobs:
               echo "SNOPT source is not available"
             fi
           fi
-          build_pyoptsparse -v $BRANCH $SNOPT
+          build_pyoptsparse $BRANCH $SNOPT
 
       - name: Install OpenMDAO
         run: |
@@ -291,7 +284,7 @@ jobs:
           cd $HOME
           RPT_FILE=`pwd`/deprecations.txt
           echo "RPT_FILE=$RPT_FILE" >> $GITHUB_ENV
-          testflo -n 1 openmdao --pre_announce --timeout=240 --deprecations_report=$RPT_FILE --exclude=test_warnings_filters
+          testflo -n 1 openmdao --timeout=240 --deprecations_report=$RPT_FILE --exclude=test_warnings_filters
 
       - name: Build docs
         id: build_docs

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -68,7 +68,7 @@ jobs:
           # test latest versions on macos
           # Include PETSc/pyOptSparse, which require NumPy<2
           - NAME: MacOS Latest, NumPy<2
-            OS: macos-13
+            OS: macos-latest
             PY: 3
             NUMPY: '<2'
             PETSc: true
@@ -77,7 +77,7 @@ jobs:
           # test latest versions on macos
           # Exclude PETSc/pyOptSparse, which require NumPy<2
           - NAME: MacOS Latest, NumPy 2 (No PETSc/pyOptSparse)
-            OS: macos-13
+            OS: macos-latest
             PY: 3
 
     runs-on: ${{ matrix.OS }}
@@ -127,10 +127,17 @@ jobs:
           conda-version: "*"
           channels: conda-forge
 
-      - name: Install MacOS-specific dependencies
+      - name: Install compilers
         if: matrix.OS == 'macos-13'
         run: |
-          conda install compilers swig
+          if [[ "${{ matrix.BREW }}" ]]; then
+            brew install swig meson
+            if [[ "${{ matrix.OS }}" == "macos-latest" ]]; then
+              ln -s /opt/homebrew/bin/gfortran-13 /opt/homebrew/bin/gfortran
+            fi
+          else
+            conda install compilers cython swig -q -y
+          fi
 
       - name: Install NumPy/SciPy
         run: |
@@ -157,7 +164,6 @@ jobs:
           else
             conda install mpich mpi4py petsc4py -q -y
           fi
-
 
           echo "============================================================="
           echo "Check MPI and PETSc installation"
@@ -215,7 +221,7 @@ jobs:
               echo "SNOPT source is not available"
             fi
           fi
-          build_pyoptsparse $BRANCH $SNOPT
+          build_pyoptsparse -v $BRANCH $SNOPT
 
       - name: Install OpenMDAO
         run: |
@@ -285,7 +291,7 @@ jobs:
           cd $HOME
           RPT_FILE=`pwd`/deprecations.txt
           echo "RPT_FILE=$RPT_FILE" >> $GITHUB_ENV
-          testflo -n 1 openmdao --timeout=240 --deprecations_report=$RPT_FILE --exclude=test_warnings_filters
+          testflo -n 1 openmdao --pre_announce --timeout=240 --deprecations_report=$RPT_FILE --exclude=test_warnings_filters
 
       - name: Build docs
         id: build_docs

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -517,6 +517,14 @@ jobs:
           python -m pip install ruff
           ruff check . --select NPY201
 
+      - name: Perform linting with Ruff
+        run: |
+          echo "============================================================="
+          echo "Lint OpenMDAO code per settings in pyproject.toml"
+          echo "============================================================="
+          python -m pip install ruff
+          ruff check . --config pyproject.toml
+
       - name: Slack env change
         if: steps.env_info.outputs.errors != ''
         uses: act10ns/slack@v2.0.0

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -518,6 +518,7 @@ jobs:
           ruff check . --select NPY201
 
       - name: Perform linting with Ruff
+        if: ${{ matrix.NAME == 'Ubuntu Baseline' }}
         run: |
           echo "============================================================="
           echo "Lint OpenMDAO code per settings in pyproject.toml"

--- a/benchmark/benchmark_manycomps.py
+++ b/benchmark/benchmark_manycomps.py
@@ -2,7 +2,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.test_suite.build4test import DynComp, create_dyncomps
+from openmdao.test_suite.build4test import create_dyncomps
 
 
 class BM(unittest.TestCase):

--- a/benchmark/benchmark_manyvars.py
+++ b/benchmark/benchmark_manyvars.py
@@ -2,7 +2,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.test_suite.build4test import DynComp, create_dyncomps
+from openmdao.test_suite.build4test import DynComp
 
 
 def _build_comp(np, no, ns=0):

--- a/benchmark/benchmark_multipoint.py
+++ b/benchmark/benchmark_multipoint.py
@@ -1,4 +1,3 @@
-import time
 import unittest
 
 import numpy as np

--- a/benchmark/benchmark_trees.py
+++ b/benchmark/benchmark_trees.py
@@ -2,7 +2,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.test_suite.build4test import DynComp, create_dyncomps, make_subtree
+from openmdao.test_suite.build4test import make_subtree
 
 
 class BM(unittest.TestCase):

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -1,7 +1,6 @@
 """Base class used to define the interface for derivative approximation schemes."""
 import time
 from collections import defaultdict
-from itertools import repeat
 import numpy as np
 
 from openmdao.core.constants import INT_DTYPE

--- a/openmdao/approximation_schemes/complex_step.py
+++ b/openmdao/approximation_schemes/complex_step.py
@@ -1,9 +1,5 @@
 """Complex Step derivative approximations."""
 
-from collections import defaultdict
-
-import numpy as np
-
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning
 from openmdao.approximation_schemes.approximation_scheme import ApproximationScheme
 

--- a/openmdao/code_review/test_lint_attributes.py
+++ b/openmdao/code_review/test_lint_attributes.py
@@ -184,8 +184,9 @@ class LintAttributesTestCase(unittest.TestCase):
                                             doc_varnames_re.findall(pc_doc_matches[0]) \
                                                 if(len(pc_doc_matches) == 1) else []
                                         if v in pc_doc_name_matches:
-                                            if(print_info): print(f"    Documented member `{v}` in "
-                                                                  f"base class `{pc.__name__}`")
+                                            if(print_info):
+                                                print(f"    Documented member `{v}` in "
+                                                      f"base class `{pc.__name__}`")
                                             break
                                 else:
                                     new_failures.append(
@@ -193,9 +194,9 @@ class LintAttributesTestCase(unittest.TestCase):
                                         'class or parent class docstrings')
                         else:  # no init section
                             if len(doc_matches) == 0: # no Attributes section
-                                if print_info: print(
-                                    f'    Skipping Class `{class_name}`... missing Attributes '
-                                    'and init')
+                                if print_info:
+                                    print(f'    Skipping Class `{class_name}`... '
+                                          'missing Attributes and init')
                             else:  # one Attributes section
                                 new_failures.append(
                                     'Attributes section in docstring but no __init__ function')

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -549,7 +549,7 @@ class LintTestCase(unittest.TestCase):
                         full_class_path = f'{module_name}.{class_name}'
                         try:
                             result = validate.validate(full_class_path)
-                        except:
+                        except Exception:
                             continue
 
                         failures.update(self._failure_dict(full_class_path, result))
@@ -568,7 +568,7 @@ class LintTestCase(unittest.TestCase):
                                 full_method_path = f'{module_name}.{class_name}.{method_name}'
                                 try:
                                     result = validate.validate(full_method_path)
-                                except:
+                                except Exception:
                                     continue
 
                                 failures.update(self._failure_dict(full_method_path, result))
@@ -586,7 +586,7 @@ class LintTestCase(unittest.TestCase):
                             full_function_path = f'{module_name}.{func_name}'
                             try:
                                 result = validate.validate(full_function_path)
-                            except:
+                            except Exception:
                                 continue
 
                             failures.update(self._failure_dict(full_function_path, result))

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -340,11 +340,9 @@ class LintTestCase(unittest.TestCase):
             # Check formatting
             for (name, typ, desc) in doc_returns:
                 if name_required and not name:
-                    new_failures.append('no detectable name for Return '
-                                        'value'.format(name))
+                    new_failures.append('no detectable name for Return value')
                 if desc == '':
-                    new_failures.append('no description given for Return '
-                                        '{0}'.format(name))
+                    new_failures.append(f'no description given for Return {name}')
 
         return new_failures
 

--- a/openmdao/code_review/test_lint_docstrings.py
+++ b/openmdao/code_review/test_lint_docstrings.py
@@ -324,7 +324,7 @@ class LintTestCase(unittest.TestCase):
             return []
 
         doc_returns = numpy_doc_string['Returns']
-        doc_yields = numpy_doc_string['Yields']
+        # doc_yields = numpy_doc_string['Yields']
 
         # TODO:  Enforce Yields in docs for contextmanagers
         if _is_context_manager(func):

--- a/openmdao/components/balance_comp.py
+++ b/openmdao/components/balance_comp.py
@@ -1,7 +1,6 @@
 """Define the BalanceComp class."""
 
 from types import FunctionType
-from numbers import Number
 
 import numpy as np
 

--- a/openmdao/components/eq_constraint_comp.py
+++ b/openmdao/components/eq_constraint_comp.py
@@ -1,6 +1,5 @@
 """Define the EQConstraintComp class."""
 
-from numbers import Number
 
 import numpy as np
 

--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -3,10 +3,9 @@ import re
 import time
 from itertools import product
 from contextlib import contextmanager
-from collections import defaultdict
 
 import numpy as np
-from numpy import ndarray, imag, complex128 as npcomplex
+from numpy import ndarray, imag
 
 from openmdao.core.system import _DEFAULT_COLORING_META
 from openmdao.utils.coloring import _ColSparsityJac, _compute_coloring

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -5,7 +5,6 @@ import traceback
 import numpy as np
 
 from openmdao.core.explicitcomponent import ExplicitComponent
-from openmdao.core.constants import INT_DTYPE
 import openmdao.func_api as omf
 from openmdao.components.func_comp_common import _check_var_name, _copy_with_ignore, _add_options, \
     jac_forward, jac_reverse, _get_tangents
@@ -27,7 +26,7 @@ if jax is not None:
         from jax import Array as JaxArray
     except ImportError:
         # versions of jax before 0.3.18 do not have the jax.Array base class
-        raise RuntimeError(f"An unsupported version of jax is installed. "
+        raise RuntimeError("An unsupported version of jax is installed. "
                            "OpenMDAO requires 'jax>=4.0' and 'jaxlib>=4.0'. "
                            "Try 'pip install openmdao[jax]' with Python>=3.8.")
 

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -13,7 +13,6 @@ from openmdao.utils.array_utils import shape_to_len
 try:
     import jax
     from jax import jit
-    import jax.numpy as jnp  # noqa: E402
     jax.config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
     _, err, tb = sys.exc_info()

--- a/openmdao/components/explicit_func_comp.py
+++ b/openmdao/components/explicit_func_comp.py
@@ -13,7 +13,7 @@ from openmdao.utils.array_utils import shape_to_len
 try:
     import jax
     from jax import jit
-    import jax.numpy as jnp
+    import jax.numpy as jnp  # noqa: E402
     jax.config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
     _, err, tb = sys.exc_info()

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -8,7 +8,7 @@ from shutil import which
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.implicitcomponent import ImplicitComponent
-from openmdao.utils.shell_proc import STDOUT, DEV_NULL, ShellProc  # noqa: E401
+from openmdao.utils.shell_proc import STDOUT, DEV_NULL, ShellProc  # noqa: F401
 
 
 class ExternalCodeDelegate(object):

--- a/openmdao/components/external_code_comp.py
+++ b/openmdao/components/external_code_comp.py
@@ -8,7 +8,7 @@ from shutil import which
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.implicitcomponent import ImplicitComponent
-from openmdao.utils.shell_proc import STDOUT, DEV_NULL, ShellProc
+from openmdao.utils.shell_proc import STDOUT, DEV_NULL, ShellProc  # noqa: E401
 
 
 class ExternalCodeDelegate(object):

--- a/openmdao/components/func_comp_common.py
+++ b/openmdao/components/func_comp_common.py
@@ -26,10 +26,6 @@ except Exception:
         traceback.print_tb(tb)
     jax = None
 
-from openmdao.utils.om_warnings import issue_warning
-from openmdao.vectors.vector import Vector
-from openmdao.core.constants import INT_DTYPE
-
 
 # regex to check for variable names.
 namecheck_rgx = re.compile('[_a-zA-Z][_a-zA-Z0-9]*')

--- a/openmdao/components/implicit_func_comp.py
+++ b/openmdao/components/implicit_func_comp.py
@@ -237,7 +237,7 @@ class ImplicitFuncComp(ImplicitComponent):
         func = self._apply_nonlinear_func
         # argnums specifies which position args are to be differentiated
         inames = list(func.get_input_names())
-        argnums = aa = [i for i, m in enumerate(func._inputs.values()) if 'is_option' not in m]
+        argnums = [i for i, m in enumerate(func._inputs.values()) if 'is_option' not in m]
         if len(argnums) == len(inames):
             argnums = None  # speedup if there are no static args
         osize = len(self._outputs)

--- a/openmdao/components/implicit_func_comp.py
+++ b/openmdao/components/implicit_func_comp.py
@@ -13,7 +13,7 @@ from openmdao.utils.array_utils import shape_to_len
 
 try:
     import jax
-    from jax import jit, jacfwd, jacrev  # noqa: E401
+    from jax import jit
     jax.config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
     _, err, tb = sys.exc_info()

--- a/openmdao/components/implicit_func_comp.py
+++ b/openmdao/components/implicit_func_comp.py
@@ -13,7 +13,7 @@ from openmdao.utils.array_utils import shape_to_len
 
 try:
     import jax
-    from jax import jit, jacfwd, jacrev
+    from jax import jit, jacfwd, jacrev  # noqa: E401
     jax.config.update("jax_enable_x64", True)  # jax by default uses 32 bit floats
 except Exception:
     _, err, tb = sys.exc_info()

--- a/openmdao/components/interp_util/interp_akima.py
+++ b/openmdao/components/interp_util/interp_akima.py
@@ -501,7 +501,6 @@ class InterpAkima(InterpAlgorithm):
 
         # Propagate derivatives from sub table.
         if subtable is not None and (self._compute_d_dx or self._compute_d_dvalues):
-            shape = dval3.shape
             cd_term = 0
 
             if self._compute_d_dx:
@@ -1559,12 +1558,6 @@ class Interp1DAkima(InterpAlgorithmFixed):
         idx_coeffs = idx_grid + 1
         needed = set(idx_coeffs)
         x = x.ravel()
-
-        # Complex Step
-        if self.values.dtype == complex:
-            dtype = self.values.dtype
-        else:
-            dtype = x.dtype
 
         if self.vec_coeff is None:
             self.coeffs = set()

--- a/openmdao/components/interp_util/interp_bsplines.py
+++ b/openmdao/components/interp_util/interp_bsplines.py
@@ -2,7 +2,7 @@
 Interpolation usng simple B-splines.
 """
 import numpy as np
-from scipy.sparse import csc_matrix, csr_matrix
+from scipy.sparse import csr_matrix
 
 from openmdao.components.interp_util.interp_algorithm import InterpAlgorithm
 

--- a/openmdao/components/interp_util/interp_slinear.py
+++ b/openmdao/components/interp_util/interp_slinear.py
@@ -632,7 +632,6 @@ class Interp2DSlinear(InterpAlgorithmFixed):
         """
         x = x_vec[:, 0]
         y = x_vec[:, 1]
-        grid = self.grid
         vec_size = len(x)
         i_x, i_y = idx
 
@@ -971,7 +970,6 @@ class Interp3DSlinear(InterpAlgorithmFixed):
         x = x_vec[:, 0]
         y = x_vec[:, 1]
         z = x_vec[:, 2]
-        grid = self.grid
         vec_size = len(x)
         i_x, i_y, i_z = idx
 

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -12,9 +12,8 @@ import openmdao.api as om
 from openmdao.components.interp_util.interp import InterpND, SPLINE_METHODS, TABLE_METHODS
 from openmdao.components.interp_util.interp_semi import InterpNDSemi
 from openmdao.components.interp_util.outofbounds_error import OutOfBoundsError
-from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, assert_warning, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
-from openmdao.utils.om_warnings import OMDeprecationWarning
 
 def rel_error(actual, computed):
     return np.linalg.norm(actual - computed) / np.linalg.norm(actual)
@@ -260,7 +259,7 @@ class TestInterpNDSemiPython(unittest.TestCase):
             values = X + Y
             grid = np.array([X, Y]).T
             with self.assertRaises(ValueError) as cm:
-                interp = InterpNDSemi(grid, values, method=method)
+                InterpNDSemi(grid, values, method=method)
 
             msg = 'There are {} points in a data dimension, but method'.format(k)
             self.assertTrue(str(cm.exception).startswith(msg))
@@ -297,19 +296,19 @@ class TestInterpNDSemiPython(unittest.TestCase):
         values = values.ravel()
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpNDSemi(grid, values, method='junk')
+            InterpNDSemi(grid, values, method='junk')
 
         msg = ('Interpolation method "junk" is not defined. Valid methods are')
         self.assertTrue(cm.exception.args[0].startswith(msg))
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpNDSemi(grid, values, method=points)
+            InterpNDSemi(grid, values, method=points)
 
         msg = ("Argument 'method' should be a string.")
         self.assertTrue(cm.exception.args[0].startswith(msg))
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpNDSemi(grid, values[:-1], method='slinear')
+            InterpNDSemi(grid, values[:-1], method='slinear')
 
         msg = ('There are 2016 point arrays, but 2015 values.')
         self.assertEqual(cm.exception.args[0], msg)
@@ -317,13 +316,13 @@ class TestInterpNDSemiPython(unittest.TestCase):
         badgrid = deepcopy(grid)
         badgrid[0][0] = -6.0
         with self.assertRaises(ValueError) as cm:
-            interp = InterpNDSemi(badgrid, values, method='slinear')
+            InterpNDSemi(badgrid, values, method='slinear')
 
         msg = ('The points in dimension 0 must be strictly ascending.')
         self.assertEqual(cm.exception.args[0], msg)
 
         with self.assertRaises(KeyError) as cm:
-            interp = InterpNDSemi(grid, values, method='slinear', bad_arg=1)
+            InterpNDSemi(grid, values, method='slinear', bad_arg=1)
 
         msg = ("Option 'bad_arg' cannot be set because it has not been declared.")
         self.assertTrue(cm.exception.args[0].endswith(msg))
@@ -435,7 +434,7 @@ class TestInterpNDPython(unittest.TestCase):
             values = X + Y
             #self.assertRaises(ValueError, InterpND, points, values, method)
             with self.assertRaises(ValueError) as cm:
-                interp = InterpND(method=method, points=points, values=values)
+                InterpND(method=method, points=points, values=values)
 
             msg = 'There are {} points in a data dimension, but method'.format(k)
             self.assertTrue(str(cm.exception).startswith(msg))
@@ -471,7 +470,7 @@ class TestInterpNDPython(unittest.TestCase):
         gradient = np.array(df(*test_pt))
         tol = 1e-1
         for method in self.interp_methods:
-            k = self.interp_configs[method]
+            self.interp_configs[method]
             if method == 'slinear':
                 tol = 2
             interp = InterpND(method=method, points=points, values=values,
@@ -745,19 +744,19 @@ class TestInterpNDPython(unittest.TestCase):
         points, values = self._get_sample_4d_large()
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='junk', points=points, values=values.tolist())
+            InterpND(method='junk', points=points, values=values.tolist())
 
         msg = ('Interpolation method "junk" is not defined. Valid methods are')
         self.assertTrue(str(cm.exception).startswith(msg))
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method=points, points=points, values=values.tolist())
+            InterpND(method=points, points=points, values=values.tolist())
 
         msg = ("Argument 'method' should be a string.")
         self.assertTrue(str(cm.exception).startswith(msg))
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='slinear', points=points, values=values.tolist()[1])
+            InterpND(method='slinear', points=points, values=values.tolist()[1])
 
         msg = ('There are 4 point arrays, but values has 3 dimensions')
         self.assertEqual(str(cm.exception), msg)
@@ -765,37 +764,36 @@ class TestInterpNDPython(unittest.TestCase):
         badpoints = deepcopy(points)
         badpoints[0][0] = 55.0
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='slinear', points=badpoints, values=values.tolist())
+            InterpND(method='slinear', points=badpoints, values=values.tolist())
 
         msg = ('The points in dimension 0 must be strictly ascending')
         self.assertEqual(str(cm.exception), msg)
 
         badpoints[0] = np.vstack((np.arange(6), np.arange(6)))
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='slinear', points=badpoints, values=values.tolist())
+            InterpND(method='slinear', points=badpoints, values=values.tolist())
 
         msg = ('The points in dimension 0 must be 1-dimensional')
         self.assertEqual(str(cm.exception), msg)
 
         badpoints[0] = (np.arange(4))
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='slinear', points=badpoints, values=values.tolist())
+            InterpND(method='slinear', points=badpoints, values=values.tolist())
 
         msg = ('There are 4 points and 6 values in dimension 0')
         self.assertEqual(str(cm.exception), msg)
 
         badvalues = np.array(values, dtype=complex)
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='scipy_slinear', points=badpoints, values=badvalues.tolist())
+            InterpND(method='scipy_slinear', points=badpoints, values=badvalues.tolist())
 
         msg = ("Interpolation method 'scipy_slinear' does not support complex points or values.")
         self.assertEqual(str(cm.exception), msg)
 
-        interp = InterpND(method='slinear', points=points, values=values.tolist())
-        x = [0.5, 0, 0.5, 0.9]
+        InterpND(method='slinear', points=points, values=values.tolist())
 
         with self.assertRaises(KeyError) as cm:
-            interp = InterpND(method='slinear', points=points, values=values.tolist(), bad_arg=1)
+            InterpND(method='slinear', points=points, values=values.tolist(), bad_arg=1)
 
         msg = ("\"InterpLinear: Option 'bad_arg' cannot be set because it has not been declared.")
         self.assertTrue(str(cm.exception).startswith(msg))
@@ -803,13 +801,13 @@ class TestInterpNDPython(unittest.TestCase):
         # Bspline not supported for tables.
         points, values, func, df = self. _get_sample_2d()
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='bsplines', points=points, values=values)
+            InterpND(method='bsplines', points=points, values=values)
 
         msg = "Method 'bsplines' is not supported for table interpolation."
         self.assertTrue(str(cm.exception).startswith(msg))
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='bsplines', points=points)
+            InterpND(method='bsplines', points=points)
 
         msg = "Either 'values' or 'x_interp' must be specified."
         self.assertTrue(str(cm.exception).startswith(msg))
@@ -861,7 +859,7 @@ class TestInterpNDPython(unittest.TestCase):
                 self.options.declare('interp', None)
 
             def setup(self):
-                method = self.options['interp']
+                self.options['interp']
 
                 self.add_input('p1', p1)
                 self.add_input('p2', p2)
@@ -915,13 +913,13 @@ class TestInterpNDFixedPython(unittest.TestCase):
         f = 2.0 * np.array([0, 1, 2])
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='1D-akima', points=p, values=f)
+            InterpND(method='1D-akima', points=p, values=f)
 
         msg = "There are 3 points in a data dimension, but method '1D-akima' requires at least 4 points per dimension."
         self.assertTrue(str(cm.exception).startswith(msg))
 
         with self.assertRaises(ValueError) as cm:
-            interp = InterpND(method='3D-slinear', points=p, values=f)
+            InterpND(method='3D-slinear', points=p, values=f)
 
         msg = "There are 1 dimensions, but method '3D-slinear' only works with a fixed table dimension of 3."
         self.assertTrue(str(cm.exception).startswith(msg))

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -20,7 +20,7 @@ def rel_error(actual, computed):
 
 scipy_gte_019 = True
 try:
-    from scipy.interpolate._bsplines import make_interp_spline
+    from scipy.interpolate._bsplines import make_interp_spline  # noqa: F401
 except ImportError:
     scipy_gte_019 = False
 

--- a/openmdao/components/interp_util/tests/test_interp_nd.py
+++ b/openmdao/components/interp_util/tests/test_interp_nd.py
@@ -75,7 +75,7 @@ class InterpNDStandaloneFeatureTestcase(unittest.TestCase):
 
     def test_interp_spline_bsplines(self):
 
-        xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])
+        # xcp = np.array([1.0, 2.0, 4.0, 6.0, 10.0, 12.0])
         ycp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])
         n = 50
         x = np.linspace(1.0, 12.0, n)

--- a/openmdao/components/linear_system_comp.py
+++ b/openmdao/components/linear_system_comp.py
@@ -54,7 +54,6 @@ class LinearSystemComp(ImplicitComponent):
 
         self._lup = []
         shape = (vec_size, size) if vec_size > 1 else (size, )
-        shape_A = (vec_size_A, size, size) if vec_size_A > 1 else (size, size)
 
         init_A = np.eye(size)
         if vec_size_A > 1:

--- a/openmdao/components/submodel_comp.py
+++ b/openmdao/components/submodel_comp.py
@@ -1,7 +1,5 @@
 """Define the SubmodelComp class for evaluating OpenMDAO systems within components."""
 
-import numpy as np
-
 from openmdao.core.constants import _SetupStatus
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.total_jac import _TotalJacInfo

--- a/openmdao/components/tests/test_add_subtract_comp.py
+++ b/openmdao/components/tests/test_add_subtract_comp.py
@@ -472,7 +472,6 @@ class TestFeature(unittest.TestCase):
         n = 3
 
         p = om.Problem()
-        model = p.model
 
         # Construct an adder/subtracter here. create a relationship through the add_equation method
         adder = om.AddSubtractComp()

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -10,8 +10,6 @@ from numpy.testing import assert_almost_equal
 import scipy
 from io import StringIO
 
-from packaging.version import Version
-
 try:
     from parameterized import parameterized
 except ImportError:
@@ -20,7 +18,6 @@ except ImportError:
 import openmdao.api as om
 from openmdao.components.exec_comp import _expr_dict, _temporary_expr_dict
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_warning
-from openmdao.utils.general_utils import env_truthy
 from openmdao.utils.testing_utils import force_check_partials
 from openmdao.utils.om_warnings import SetupWarning
 
@@ -440,9 +437,9 @@ class TestExecComp(unittest.TestCase):
     def test_units_varname_novalue(self):
         prob = om.Problem()
         prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
-        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+units+1.',
-                                                        x={'val': 2.0, 'units': 'm'},
-                                                        y={'units': 'm'}))
+        prob.model.add_subsystem('C1', om.ExecComp('y=x+units+1.',
+                                                   x={'val': 2.0, 'units': 'm'},
+                                                   y={'units': 'm'}))
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(NameError) as cm:
@@ -483,9 +480,9 @@ class TestExecComp(unittest.TestCase):
     def test_conflicting_units(self):
         prob = om.Problem()
         prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
-        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+z+1.', units='m',
-                                                        x={'val': 2.0, 'units': 'km'},
-                                                        z=2.0))
+        prob.model.add_subsystem('C1', om.ExecComp('y=x+z+1.', units='m',
+                                                   x={'val': 2.0, 'units': 'km'},
+                                                   z=2.0))
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(RuntimeError) as cm:
@@ -943,10 +940,10 @@ class TestExecComp(unittest.TestCase):
 
     def test_tags(self):
         prob = om.Problem(model=om.Group())
-        C1 = prob.model.add_subsystem('C1', om.ExecComp('y=x+z+1.',
-                                                        x={'val': 1.0, 'units': 'm', 'tags': 'tagx'},
-                                                        y={'units': 'm', 'tags': ['tagy','tagq']},
-                                                        z={'val': 2.0, 'tags': 'tagz'}))
+        prob.model.add_subsystem('C1', om.ExecComp('y=x+z+1.',
+                                                   x={'val': 1.0, 'units': 'm', 'tags': 'tagx'},
+                                                   y={'units': 'm', 'tags': ['tagy','tagq']},
+                                                   z={'val': 2.0, 'tags': 'tagz'}))
 
         prob.setup(check=False)
 
@@ -1166,7 +1163,7 @@ class TestExecComp(unittest.TestCase):
         prob.run_model()
 
         stream = StringIO()
-        outputs = prob.model.list_outputs(residuals=True, residuals_tol=1e-5, out_stream=stream)
+        prob.model.list_outputs(residuals=True, residuals_tol=1e-5, out_stream=stream)
 
         text = stream.getvalue()
         self.assertTrue("balance" in text)
@@ -1489,7 +1486,7 @@ class TestFunctionRegistration(unittest.TestCase):
 
         om.ExecComp.register("myfunc", lambda x: x * x, complex_safe=True)
         p = om.Problem()
-        comp = p.model.add_subsystem("comp", om.ExecComp("y = 2 * myfunc(x)"))
+        p.model.add_subsystem("comp", om.ExecComp("y = 2 * myfunc(x)"))
 
         p.setup()
         p.run_model()
@@ -1558,7 +1555,7 @@ class TestFunctionRegistration(unittest.TestCase):
             size = 10
             om.ExecComp.register('area', lambda x: x**2, complex_safe=False)
             p = om.Problem()
-            comp = p.model.add_subsystem('comp', om.ExecComp('area_square = area(x)', shape=size))
+            p.model.add_subsystem('comp', om.ExecComp('area_square = area(x)', shape=size))
             p.setup()
             p['comp.x'] = 3.
             # calling run_model should NOT raise an exception
@@ -1566,7 +1563,7 @@ class TestFunctionRegistration(unittest.TestCase):
             assert_near_equal(p['comp.area_square'], np.ones(size) * 9., 1e-6)
 
             with self.assertRaises(Exception) as cm:
-                data = force_check_partials(p, out_stream=None)
+                force_check_partials(p, out_stream=None)
             self.assertEqual(cm.exception.args[0],
                              "'comp' <class ExecComp>: expression contains functions ['area'] that are not complex safe. To fix this, call declare_partials('*', ['x'], method='fd') on this component prior to setup.")
 
@@ -1620,7 +1617,7 @@ class TestFunctionRegistration(unittest.TestCase):
             assert_near_equal(p['comp.out2'], np.ones(size) * 21., 1e-6)
 
             with self.assertRaises(Exception) as cm:
-                data = force_check_partials(p, out_stream=None, step=1e-7)
+                force_check_partials(p, out_stream=None, step=1e-7)
             self.assertEqual(cm.exception.args[0],
                              "'comp' <class ExecComp>: expression contains functions ['unsafe'] that are not complex safe. To fix this, call declare_partials('*', ['z'], method='fd') on this component prior to setup.")
 
@@ -1722,7 +1719,7 @@ class TestFunctionRegistration(unittest.TestCase):
             # have to use regex to handle differences in numpy print formats for shape
             msg = "'comp' <class ExecComp>: Error occurred evaluating 'y = double\(x\) \* 3\.':\n" \
                   "could not broadcast input array from shape \(10.*\) into shape \(8.*\)"
-            with self.assertRaisesRegex(Exception, msg) as cm:
+            with self.assertRaisesRegex(Exception, msg):
                 p.run_model()
 
     def test_shape_by_conn_bug_has_diag_partials_bug(self):
@@ -1932,7 +1929,7 @@ class TestExecCompParameterized(unittest.TestCase):
         if 'check_val' not in test_data:
             try:
                 force_check_partials(prob, out_stream=None)
-            except TypeError as e:
+            except TypeError:
                 print(f, 'does not support complex-step differentiation')
 
     @parameterized.expand(itertools.product([

--- a/openmdao/components/tests/test_explicit_func_comp.py
+++ b/openmdao/components/tests/test_explicit_func_comp.py
@@ -1,5 +1,4 @@
 import unittest
-import math
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -7,7 +6,7 @@ from io import StringIO
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_check_totals
-from openmdao.utils.cs_safe import abs, arctan2
+from openmdao.utils.cs_safe import abs
 import openmdao.func_api as omf
 from openmdao.utils.coloring import compute_total_coloring
 
@@ -364,7 +363,7 @@ class TestFuncCompWrapped(unittest.TestCase):
 
         prob = om.Problem()
         prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0, units='cm'))
-        C1 = prob.model.add_subsystem('C1', om.ExplicitFuncComp(f))
+        prob.model.add_subsystem('C1', om.ExplicitFuncComp(f))
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(Exception) as cm:
@@ -384,7 +383,7 @@ class TestFuncCompWrapped(unittest.TestCase):
 
         prob = om.Problem()
         prob.model.add_subsystem('indep', om.IndepVarComp('x', 100.0))
-        C1 = prob.model.add_subsystem('C1', om.ExplicitFuncComp(f))
+        prob.model.add_subsystem('C1', om.ExplicitFuncComp(f))
         prob.model.connect('indep.x', 'C1.x')
 
         with self.assertRaises(Exception) as cm:
@@ -601,7 +600,6 @@ class TestFuncCompWrapped(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(of=['comp.x', 'comp.y', 'comp.z'], wrt=['comp.a', 'comp.b', 'comp.c'], return_format='flat_dict')
-        Jcomp = prob.model.comp._jacobian._subjacs_info
 
         assert_near_equal(J['comp.x', 'comp.a'], np.diag(np.arange(1,4,dtype=float)*2.), 0.00001)
         assert_near_equal(J['comp.x', 'comp.b'], np.zeros((3,3)), 0.00001)
@@ -619,7 +617,6 @@ class TestFuncCompWrapped(unittest.TestCase):
         prob.run_model()
 
         J = prob.compute_totals(['comp.x', 'comp.y', 'comp.z'], wrt=['comp.a', 'comp.b', 'comp.c'], return_format='flat_dict')
-        Jcomp = prob.model.comp._jacobian._subjacs_info
 
         assert_near_equal(J['comp.x', 'comp.a'], np.diag(np.arange(1,4,dtype=float)*2.), 0.00001)
         assert_near_equal(J['comp.x', 'comp.b'], np.zeros((3,3)), 0.00001)
@@ -832,7 +829,7 @@ class TestFuncCompWrapped(unittest.TestCase):
         prob.run_model()
 
         stream = StringIO()
-        outputs = prob.model.list_outputs(residuals=True, residuals_tol=1e-5, out_stream=stream)
+        prob.model.list_outputs(residuals=True, residuals_tol=1e-5, out_stream=stream)
 
         text = stream.getvalue()
         self.assertTrue("balance" in text)

--- a/openmdao/components/tests/test_explicit_func_comp.py
+++ b/openmdao/components/tests/test_explicit_func_comp.py
@@ -13,7 +13,6 @@ from openmdao.utils.coloring import compute_total_coloring
 
 try:
     import jax
-    import jax.numpy as jnp
 except ImportError:
     jax = None
 
@@ -1050,7 +1049,7 @@ class TestJax(unittest.TestCase):
         p.run_model()
         J = p.compute_totals(of=['comp.x'], wrt=['comp.a', 'comp.b', 'comp.c'])
 
-        I = np.eye(np.prod(shape, dtype=int))
+        I = np.eye(np.prod(shape, dtype=int))  # noqa: E741
         assert_near_equal(J['comp.x', 'comp.a'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.b'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.c'], I * 3.)
@@ -1227,7 +1226,7 @@ class TestJaxNumpy(unittest.TestCase):
 
         J = p.compute_totals(of=['comp.x'], wrt=['comp.a', 'comp.b', 'comp.c'])
 
-        I = np.eye(np.prod(shape)) if shape else np.eye(1)
+        I = np.eye(np.prod(shape)) if shape else np.eye(1)  # noqa: E741
         assert_near_equal(J['comp.x', 'comp.a'], I * p['comp.b'].ravel() * np.cos(p['comp.a']).ravel(), tolerance=1e-7)
         assert_near_equal(J['comp.x', 'comp.b'], I * np.sin(p['comp.a']).ravel(), tolerance=1e-7)
         assert_near_equal(J['comp.x', 'comp.c'], I * 3., tolerance=1e-7)
@@ -1272,7 +1271,7 @@ class TestJax2retvals(unittest.TestCase):
         p.run_model()
         J = p.compute_totals(of=['comp.x', 'comp.y'], wrt=['comp.a', 'comp.b', 'comp.c'])
 
-        I = np.eye(np.prod(shape)) if shape else np.eye(1)
+        I = np.eye(np.prod(shape)) if shape else np.eye(1)  # noqa: E741
         assert_near_equal(J['comp.x', 'comp.a'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.b'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.c'], I * 3.)
@@ -1329,7 +1328,7 @@ class TestJaxNonDifferentiableArgs(unittest.TestCase):
         p.run_model()
         J = p.compute_totals(of=['comp.x', 'comp.y'], wrt=['comp.a', 'comp.b', 'comp.c'])
 
-        I = np.eye(3)
+        I = np.eye(3)  # noqa: E741
         assert_near_equal(J['comp.x', 'comp.a'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.b'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.c'], I * 3.)
@@ -1375,7 +1374,7 @@ class TestJax2retvalsColoring(unittest.TestCase):
         p.run_model()
         J = p.compute_totals(of=['comp.x', 'comp.y'], wrt=['comp.a', 'comp.b', 'comp.c'])
 
-        I = np.eye(np.prod(shape)) if shape else np.eye(1)
+        I = np.eye(np.prod(shape)) if shape else np.eye(1)  # noqa: E741
         assert_near_equal(J['comp.x', 'comp.a'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.b'], I * 2.)
         assert_near_equal(J['comp.x', 'comp.c'], I * 3.)

--- a/openmdao/components/tests/test_external_code_comp.py
+++ b/openmdao/components/tests/test_external_code_comp.py
@@ -10,7 +10,7 @@ from scipy.optimize import fsolve
 import openmdao.api as om
 from openmdao.components.external_code_comp import STDOUT
 
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal
 
 DIRECTORY = os.path.dirname((os.path.abspath(__file__)))
 

--- a/openmdao/components/tests/test_implicit_func_comp.py
+++ b/openmdao/components/tests/test_implicit_func_comp.py
@@ -1,8 +1,6 @@
 import unittest
-import math
 
 import numpy as np
-from scipy.optimize import newton
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_check_totals

--- a/openmdao/components/tests/test_implicit_func_comp.py
+++ b/openmdao/components/tests/test_implicit_func_comp.py
@@ -9,7 +9,6 @@ from openmdao.core.tests.test_partial_color import _check_partial_matrix
 
 try:
     import jax
-    import jax.numpy as jnp
 except ImportError:
     jax = None
 

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -565,7 +565,7 @@ class TestMultipleErrors(unittest.TestCase):
                          "Conflicting vec_size=10 specified for vector 'x', "
                          "which has already been defined with vec_size=1.")
 
-    def test_x_vec_size_mismatch(self):
+    def test_x_vec_shape_mismatch(self):
         mvp = om.MatrixVectorProductComp()
 
         with self.assertRaises(ValueError) as ctx:

--- a/openmdao/components/tests/test_meta_model_semi_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_semi_structured_comp.py
@@ -368,7 +368,7 @@ class TestMetaModelSemiStructured(unittest.TestCase):
         model.add_subsystem('comp', comp)
 
         msg = "Size mismatch: training data for 'f' is length 3, but" + \
-            f" data for 'x' is length 4."
+              " data for 'x' is length 4."
         with self.assertRaisesRegex(ValueError, msg):
             prob.setup()
 
@@ -516,7 +516,7 @@ class TestMetaModelSemiStructured(unittest.TestCase):
 
         # we can verify all gradients by checking against finite-difference
         chk = prob.check_totals(of='comp.f', wrt=['tab.k', 'comp.p1', 'comp.p2', 'comp.p3'],
-                                   method='cs', out_stream=None);
+                                method='cs', out_stream=None)
         assert_check_totals(chk, atol=1e-10, rtol=1e-10)
 
     def test_detect_local_extrapolation(self):
@@ -564,8 +564,6 @@ class TestMetaModelSemiStructured(unittest.TestCase):
             assert_near_equal(prob.get_val('interp.f'), expected, 1e-3)
 
     def test_lagrange3_edge_extrapolation_detection_bug(self):
-        import itertools
-
         import numpy as np
         import openmdao.api as om
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -22,8 +22,7 @@ except ImportError:
 # check that pyoptsparse is installed
 # if it is, try to use SNOPT but fall back to SLSQP
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
-if OPTIMIZER:
-    pass
+
 
 x = np.array([-0.97727788, -0.15135721, -0.10321885,  0.40015721,  0.4105985,
                0.95008842,  0.97873798,  1.76405235,  1.86755799,  2.2408932 ])

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -1128,11 +1128,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         model = om.Group()
         ivc = om.IndepVarComp()
 
-        mapdata = SampleMap()
-
-        params = mapdata.param_data
-        outs = mapdata.output_data
-
         ivc.add_output('x', np.array([.33]))
 
         ivc.add_output('f_train', np.array([.3, .7, .5, .6, .3, .4, .2]))
@@ -1207,10 +1202,6 @@ class TestMetaModelStructuredPython(unittest.TestCase):
     def test_training_gradient_unsupported(self):
         # If using a fixed table method
         model = om.Group()
-        mapdata = SampleMap()
-
-        params = mapdata.param_data
-        outs = mapdata.output_data
 
         comp = om.MetaModelStructuredComp(training_data_gradients=True, extrapolate=True,
                                           method='1D-akima', vec_size=1)
@@ -1232,10 +1223,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
 
     def test_vectorized_1D_akima(self):
         model = om.Group()
-        mapdata = SampleMap()
 
-        params = mapdata.param_data
-        outs = mapdata.output_data
         nn = 2
 
         comp = om.MetaModelStructuredComp(extrapolate=True,

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -15,7 +15,7 @@ from openmdao.utils.testing_utils import use_tempdirs, force_check_partials
 
 scipy_gte_019 = True
 try:
-    from scipy.interpolate._bsplines import make_interp_spline
+    from scipy.interpolate._bsplines import make_interp_spline  # noqa: F401
 except ImportError:
     scipy_gte_019 = False
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -2,7 +2,6 @@
 Unit tests for the structured metamodel component.
 """
 import unittest
-import inspect
 
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -24,7 +23,7 @@ except ImportError:
 # if it is, try to use SNOPT but fall back to SLSQP
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
 if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+    pass
 
 x = np.array([-0.97727788, -0.15135721, -0.10321885,  0.40015721,  0.4105985,
                0.95008842,  0.97873798,  1.76405235,  1.86755799,  2.2408932 ])
@@ -628,7 +627,7 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         prob.run_model()
 
         chk = prob.check_totals(of='comp.f', wrt=['tab.k', 'comp.p1', 'comp.p2', 'comp.p3'],
-                                method='cs', out_stream=None);
+                                method='cs', out_stream=None)
         assert_check_totals(chk, atol=1e-10, rtol=1e-10)
 
     def test_training_gradient_setup_called_twice(self):
@@ -1462,8 +1461,7 @@ class TestMetaModelStructuredCompFeature(unittest.TestCase):
         force_check_partials(prob, compact_print=True)
 
     def test_error_messages_scalar_only(self):
-        prob = om.Problem()
-        model = prob.model
+        om.Problem()
 
         comp = om.MetaModelStructuredComp(training_data_gradients=True,
                                           method='slinear', vec_size=3)

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -236,9 +236,9 @@ class MultiFiMetaModelTestCase(unittest.TestCase):
         mm.options['train_y2_fi2'] = [4.0, 4.1, 4.3, 4.4, 4.5 ,4.6]
 
         prob.run_model()
-        expected_xtrain=[np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]),
-                         np.array([[1.1, 2.1], [2.1, 2.2], [3.1, 2.3],
-                                   [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])]
+        # expected_xtrain=[np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]]),
+        #                 np.array([[1.1, 2.1], [2.1, 2.2], [3.1, 2.3],
+        #                           [1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])]
         expected_y1train=[np.array([[0.0], [0.1], [0.2]]),
                           np.array([[3.0], [3.1], [3.3], [3.4], [3.5], [3.6]])]
         expected_y2train=[np.array([[4.0], [4.0], [4.0]]),

--- a/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
+++ b/openmdao/components/tests/test_multifi_meta_model_unstructured_comp.py
@@ -2,7 +2,7 @@ import numpy as np
 import unittest
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class MockSurrogate(om.MultiFiSurrogateModel):

--- a/openmdao/components/tests/test_spline_comp.py
+++ b/openmdao/components/tests/test_spline_comp.py
@@ -10,7 +10,6 @@ from openmdao.components.spline_comp import SPLINE_METHODS
 from openmdao.utils.assert_utils import assert_check_partials, assert_near_equal
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.spline_distributions import cell_centered, sine_distribution
-from openmdao.components.interp_util.interp import InterpND
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -353,7 +352,6 @@ class SplineCompTestCase(unittest.TestCase):
         x = np.linspace(1.0, 12.0, n)
 
         prob = om.Problem()
-        model = prob.model
 
         # Set options specific to akima
         akima_option = {'delta_x': 0.1, 'eps': 1e-30}
@@ -430,7 +428,6 @@ class SplineCompFeatureTestCase(unittest.TestCase):
 
         x_cp = np.linspace(0., 1., 6)
         y_cp = np.array([5.0, 12.0, 14.0, 16.0, 21.0, 29.0])
-        n = 20
         x = om.sine_distribution(20, start=0, end=1, phase=np.pi)
 
         prob = om.Problem()
@@ -459,7 +456,6 @@ class SplineCompFeatureTestCase(unittest.TestCase):
         x = np.linspace(1.0, 12.0, n)
 
         prob = om.Problem()
-        model = prob.model
 
         # Set options specific to akima
         akima_option = {'delta_x': 0.1, 'eps': 1e-30}
@@ -477,7 +473,6 @@ class SplineCompFeatureTestCase(unittest.TestCase):
     def test_bspline_options(self):
 
         prob = om.Problem()
-        model = prob.model
 
         n_cp = 80
         n_point = 160
@@ -527,7 +522,6 @@ class SplineCompFeatureTestCase(unittest.TestCase):
     def test_bsplines_2to3doc(self):
 
         prob = om.Problem()
-        model = prob.model
 
         n_cp = 5
         n_point = 10

--- a/openmdao/components/tests/test_submodel_comp.py
+++ b/openmdao/components/tests/test_submodel_comp.py
@@ -6,6 +6,7 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, \
      assert_check_totals
 from openmdao.test_suite.groups.parallel_groups import FanInGrouped, FanOutGrouped
+from openmdao.test_suite.components.distributed_components import DistribCompDerivs
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -240,7 +241,8 @@ class TestSubmodelComp(unittest.TestCase):
                 comp = om.ExecComp('x = r*cos(theta)')
                 model.add_subsystem('comp', comp, promotes_inputs=['r', 'theta'],
                                     promotes_outputs=['x'])
-                subprob = om.Problem(); subprob.model.add_subsystem('model', model)
+                subprob = om.Problem()
+                subprob.model.add_subsystem('model', model)
                 subprob.model.promotes('model', any=['*'])
                 self.add_subsystem('submodel1', om.SubmodelComp(problem=subprob, do_coloring=True))
 
@@ -257,7 +259,8 @@ class TestSubmodelComp(unittest.TestCase):
                 comp = om.ExecComp('y = r*sin(theta)')
                 model.add_subsystem('comp', comp, promotes_inputs=['r', 'theta'],
                                     promotes_outputs=['y'])
-                subprob = om.Problem(); subprob.model.add_subsystem('model', model)
+                subprob = om.Problem()
+                subprob.model.add_subsystem('model', model)
                 subprob.model.promotes('model', any=['*'])
                 self.add_subsystem('submodel2', om.SubmodelComp(problem=subprob, do_coloring=True))
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2,7 +2,6 @@
 
 import sys
 import types
-from types import LambdaType
 from collections import defaultdict
 from collections.abc import Iterable
 from itertools import product
@@ -17,9 +16,8 @@ from openmdao.core.system import System, _supported_methods, _DEFAULT_COLORING_M
 from openmdao.core.constants import INT_DTYPE
 from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
 from openmdao.utils.array_utils import shape_to_len
-from openmdao.utils.class_util import overrides_method
 from openmdao.utils.units import simplify_unit
-from openmdao.utils.name_maps import abs_key_iter, abs_key2rel_key, rel_name2abs_name
+from openmdao.utils.name_maps import abs_key_iter, abs_key2rel_key
 from openmdao.utils.mpi import MPI
 from openmdao.utils.general_utils import format_as_float_or_array, ensure_compatible, \
     find_matches, make_set, inconsistent_across_procs
@@ -194,7 +192,6 @@ class Component(System):
                 self._num_par_fd = 1
 
         self.comm = comm
-        nprocs = comm.size
 
         # Clear out old variable information so that we can call setup on the component.
         self._var_rel_names = {'input': [], 'output': []}

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -66,8 +66,6 @@ class ExplicitComponent(Component):
         """
         Configure this system to assign children settings and detect if matrix_free.
         """
-        new_jacvec_prod = getattr(self, 'compute_jacvec_product', None)
-
         if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('compute_jacvec_product', self, ExplicitComponent)
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -25,9 +25,9 @@ from openmdao.solvers.linear.linear_runonce import LinearRunOnce
 from openmdao.solvers.linear.direct import DirectSolver
 from openmdao.utils.array_utils import array_connection_compatible, _flatten_src_indices, \
     shape_to_len, ValueRepeater
-from openmdao.utils.general_utils import common_subpath, all_ancestors, \
+from openmdao.utils.general_utils import common_subpath, \
     convert_src_inds, shape2tuple, get_connection_owner, ensure_compatible, \
-    meta2src_iter, get_rev_conns, _contains_all
+    meta2src_iter, get_rev_conns
 from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismatch, _find_unit, \
     _is_unitless, simplify_unit
 from openmdao.utils.graph_utils import get_out_of_order_nodes
@@ -2641,7 +2641,6 @@ class Group(System):
 
         knowns = {n for n, d in graph.nodes(data=True) if d['shape'] is not None}
         all_knowns = knowns.copy()
-        all_resolved = set()
 
         nodes = graph.nodes
         edges = graph.edges
@@ -3100,7 +3099,7 @@ class Group(System):
         if src_indices is None:
             prominfo = None
             if flat_src_indices is not None or src_shape is not None:
-                issue_warning(f"ignored flat_src_indices and/or src_shape because"
+                issue_warning("ignored flat_src_indices and/or src_shape because"
                               " src_indices was not specified.", prefix=self.msginfo,
                               category=UnusedOptionWarning)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -21,9 +21,9 @@ import scipy.sparse as sparse
 
 from openmdao.core.constants import _SetupStatus
 from openmdao.core.component import Component
-from openmdao.core.driver import Driver, record_iteration, SaveOptResult
+from openmdao.core.driver import Driver, record_iteration
 from openmdao.core.explicitcomponent import ExplicitComponent
-from openmdao.core.system import System, _OptStatus
+from openmdao.core.system import System
 from openmdao.core.group import Group
 from openmdao.core.total_jac import _TotalJacInfo
 from openmdao.core.constants import _DEFAULT_OUT_STREAM, _UNDEFINED
@@ -1605,7 +1605,7 @@ class Problem(object):
                     # one.
                     if _wrt in local_opts and local_opts[_wrt]['directional']:
                         if i == 0:  # only do this on the first iteration
-                            deriv[f'J_fwd'] = np.atleast_2d(np.sum(deriv['J_fwd'], axis=1)).T
+                            deriv['J_fwd'] = np.atleast_2d(np.sum(deriv['J_fwd'], axis=1)).T
 
                         if comp.matrix_free:
                             if i == 0:  # only do this on the first iteration
@@ -2632,7 +2632,7 @@ class Problem(object):
                     out_stream = sys.stdout
                 hr = '-' * len(header)
                 print(f'{hr}\n{header}\n{hr}', file=out_stream)
-                print(f'None found', file=out_stream)
+                print('None found', file=out_stream)
 
         return problem_indep_vars
 
@@ -3147,7 +3147,7 @@ def _assemble_derivative_data(derivative_data, rel_error_tol, abs_error_tol, out
             num_col_meta = {'format': num_format}
 
             if totals:
-                title = f"Total Derivatives"
+                title = "Total Derivatives"
             else:
                 title = f"{sys_type}: {sys_class_name} '{sys_name}'"
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5427,9 +5427,9 @@ class System(object):
                         elif tunits is not None:
                             value = model.convert_from_units(src, value, tunits)
                         else:
-                            msg = f"A value with no units has been specified for input " + \
+                            msg = "A value with no units has been specified for input " + \
                                   f"'{name}', but the source ('{src}') has units '{sunits}'. " + \
-                                  f"No unit checking can be done."
+                                  "No unit checking can be done."
                             issue_warning(msg, prefix=self.msginfo, category=UnitsWarning)
                 else:
                     if gunits is None:

--- a/openmdao/core/tests/test_add_var.py
+++ b/openmdao/core/tests/test_add_var.py
@@ -4,8 +4,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.utils.om_warnings import OMDeprecationWarning
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class CompAddWithDefault(om.ExplicitComponent):

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -108,8 +108,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
 
         prob.setup()
         prob.run_model()
-        J = prob.compute_totals(of=['parab.f_xy'], wrt=['px.x', 'py.y'])
-        # print(J)
+        prob.compute_totals(of=['parab.f_xy'], wrt=['px.x', 'py.y'])
 
         # 1. run_model; 2. step x; 3. step y
         self.assertEqual(model.parab.count, 3)

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -7,8 +7,6 @@ from packaging.version import Version
 import numpy as np
 from scipy import __version__ as scipy_version
 
-ScipyVersion = Version(scipy_version)
-
 import openmdao.api as om
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArray, TestImplCompArrayDense
 from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -31,6 +29,8 @@ try:
 except ImportError:
     vector_class = om.DefaultVector
     PETScVector = None
+
+ScipyVersion = Version(scipy_version)
 
 # check that pyoptsparse is installed
 # if it is, try to use SNOPT but fall back to SLSQP

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -36,9 +36,6 @@ except ImportError:
 # if it is, try to use SNOPT but fall back to SLSQP
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
 
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
-
 
 @use_tempdirs
 class TestGroupFiniteDifference(unittest.TestCase):

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -36,6 +36,9 @@ except ImportError:
 # if it is, try to use SNOPT but fall back to SLSQP
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
 
+if OPTIMIZER:
+    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
+
 
 @use_tempdirs
 class TestGroupFiniteDifference(unittest.TestCase):

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -1977,7 +1977,7 @@ class TestComponentComplexStep(unittest.TestCase):
 
         prob = om.Problem()
         model = prob.model
-        comp = model.add_subsystem('comp', BadSparsityComp())
+        model.add_subsystem('comp', BadSparsityComp())
 
         prob.setup(check=False, mode='fwd')
         prob.set_solver_print(level=0)
@@ -2361,7 +2361,6 @@ class TestFDRelative(unittest.TestCase):
                 self.add_output('y', np.ones((nn, )))
 
             def setup_partials(self):
-                nn = self.options['vec_size']
                 self.set_check_partial_options('x_element', method='fd', step_calc='rel_element', directional=True)
 
             def compute(self, inputs, outputs):
@@ -2620,7 +2619,7 @@ class CheckTotalsIndices(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
-        check = prob.check_totals(compact_print=True)
+        prob.check_totals(compact_print=True)
 
 
 def _setup_1ivc_fdgroupwithpar_1sink(size=7):

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -27,7 +27,7 @@ def _test_func_name(func, num, param):
         for item in p:
             try:
                 arg = item.__name__
-            except:
+            except Exception:
                 arg = str(item)
             args.append(arg)
     return func.__name__ + '_' + '_'.join(args)

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -1,13 +1,10 @@
 import unittest
-import time
 from collections.abc import Iterable
 
 import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
-from openmdao.utils.array_utils import evenly_distrib_idxs, take_nth
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 try:
     from parameterized import parameterized

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1234,7 +1234,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(stream.getvalue().count('n/a'), 25)
         self.assertEqual(stream.getvalue().count('rev'), 15)
         self.assertEqual(stream.getvalue().count('Component'), 2)
-        self.assertEqual(len([l for l in stream.getvalue().splitlines() if l.startswith('| ')]), 12) # counts rows (including headers)
+        self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 12) # counts rows (including headers)
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=False)
@@ -1320,7 +1320,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         self.assertEqual(stream.getvalue().count('n/a'), 10)
         self.assertEqual(stream.getvalue().count('rev'), 15)
         self.assertEqual(stream.getvalue().count('Component'), 2)
-        self.assertEqual(len([l for l in stream.getvalue().splitlines() if l.startswith('| ')]), 8)
+        self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 8)
 
         stream = StringIO()
         partials_data = prob.check_partials(out_stream=stream, compact_print=False)

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -15,7 +15,6 @@ from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayMatV
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 from openmdao.test_suite.components.array_comp import ArrayComp
-from openmdao.test_suite.scripts.circle_opt import CircleOpt
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning, \
      assert_check_partials
 from openmdao.utils.om_warnings import DerivativesWarning, OMInvalidCheckDerivativesOptionsWarning
@@ -1458,7 +1457,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         assert_check_partials(data, atol=1.0E-8, rtol=1.0E-8)
 
         stream = StringIO()
-        J = prob.check_partials(out_stream=stream, compact_print=True)
+        prob.check_partials(out_stream=stream, compact_print=True)
         output = stream.getvalue()
         self.assertTrue("(d)'x1'" in output)
         self.assertTrue("(d)'x2'" in output)
@@ -1570,7 +1569,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob = om.Problem()
         model = prob.model
-        mycomp = model.add_subsystem('mycomp', ArrayCompMatrixFree(), promotes=['*'])
+        model.add_subsystem('mycomp', ArrayCompMatrixFree(), promotes=['*'])
 
         np.random.seed(1)
 
@@ -1632,7 +1631,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob = om.Problem()
         model = prob.model
-        mycomp = model.add_subsystem('mycomp', ArrayCompMatrixFree(), promotes=['*'])
+        model.add_subsystem('mycomp', ArrayCompMatrixFree(), promotes=['*'])
 
         np.random.seed(1)
 
@@ -1707,13 +1706,13 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         prob = om.Problem()
         model = prob.model
-        mycomp = model.add_subsystem('mycomp', ArrayCompMatrixFree(), promotes=['*'])
+        model.add_subsystem('mycomp', ArrayCompMatrixFree(), promotes=['*'])
 
         prob.setup()
         prob.run_model()
 
         with self.assertRaises(ValueError) as cm:
-            J = prob.check_partials(method='fd', out_stream=None)
+            prob.check_partials(method='fd', out_stream=None)
 
         msg = "'mycomp' <class ArrayCompMatrixFree>: For matrix free components, directional should be set to True for all inputs."
         self.assertEqual(str(cm.exception), msg)
@@ -1836,7 +1835,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.setup()
 
         stream = StringIO()
-        data = prob.check_partials(out_stream=stream)
+        prob.check_partials(out_stream=stream)
         lines = stream.getvalue().splitlines()
 
         self.assertTrue("Relative Error (Jfor - Jfd) / Jfor : 1." in lines[10])
@@ -1959,7 +1958,7 @@ class TestCheckPartialsDistribDirectional(unittest.TestCase):
         prob.setup(force_alloc_complex=True, mode='rev')
         prob.run_model()
         # this test passes if this call doesn't raise an exception
-        partials = prob.check_partials(compact_print=True, method='cs')
+        prob.check_partials(compact_print=True, method='cs')
 
 
 class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
@@ -2322,7 +2321,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        data = prob.check_partials(out_stream=None, compact_print=True)
+        prob.check_partials(out_stream=None, compact_print=True)
 
     def test_set_step_on_comp(self):
 
@@ -2406,9 +2405,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        stream = StringIO()
-        prob.check_partials(form='central', compact_print=True, out_stream=stream)
-        contents = stream.getvalue()
+        prob.check_partials(form='central', compact_print=True)
 
     def test_set_step_calc_global(self):
 
@@ -2500,12 +2497,12 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
         prob = om.Problem()
         model = prob.model
-        mycomp = model.add_subsystem('mycomp', ArrayComp(), promotes=['*'])
+        model.add_subsystem('mycomp', ArrayComp(), promotes=['*'])
 
         prob.setup()
         prob.run_model()
 
-        data = prob.check_partials()
+        prob.check_partials()
 
     def test_directional_matrix_free(self):
 
@@ -2564,7 +2561,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        data = prob.check_partials()
+        prob.check_partials()
 
     def test_directional_sparse_deriv(self):
 
@@ -2743,7 +2740,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_single_fd_step_fwd(self):
         p = self.setup_model()
         stream = StringIO()
-        J = p.check_partials(step=[1e-6], out_stream=stream)
+        p.check_partials(step=[1e-6], out_stream=stream)
         contents = stream.getvalue()
         ncomps = 2
         nderivs = ncomps * 2
@@ -2759,7 +2756,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_single_fd_step_compact(self):
         p = self.setup_model()
         stream = StringIO()
-        J = p.check_partials(step=[1e-6], compact_print=True, out_stream=stream)
+        p.check_partials(step=[1e-6], compact_print=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
@@ -2779,7 +2776,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_single_cs_step_compact(self):
         p = self.setup_model()
         stream = StringIO()
-        J = p.check_partials(method='cs', step=[1e-30], compact_print=True, out_stream=stream)
+        p.check_partials(method='cs', step=[1e-30], compact_print=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
@@ -2799,7 +2796,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_multi_fd_steps(self):
         p = self.setup_model()
         stream = StringIO()
-        J = p.check_partials(step=[1e-6, 1e-7], out_stream=stream)
+        p.check_partials(step=[1e-6, 1e-7], out_stream=stream)
         contents = stream.getvalue()
         ncomps = 2
         nderivs = ncomps * 2
@@ -2813,7 +2810,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_multi_fd_steps_compact(self):
         p = self.setup_model()
         stream = StringIO()
-        J = p.check_partials(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
+        p.check_partials(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
@@ -2833,7 +2830,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_multi_cs_steps_compact(self):
         p = self.setup_model()
         stream = StringIO()
-        J = p.check_partials(method='cs', step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
+        p.check_partials(method='cs', step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
@@ -2853,7 +2850,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def test_multi_fd_steps_compact_directional(self):
         p = self.setup_model(directional=True)
         stream = StringIO()
-        J = p.check_partials(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
+        p.check_partials(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -133,7 +133,7 @@ class TestProblemComputeTotalsGetRemoteFalse(unittest.TestCase):
         p.setup(mode=mode)
         p.run_model()
 
-        dv_vals = p.driver.get_design_var_values(get_remote=False)
+        p.driver.get_design_var_values(get_remote=False)
 
         # Compute totals and check the length of the gradient array on each proc
         J = p.compute_totals(get_remote=False)
@@ -179,7 +179,7 @@ class TestProblemComputeTotalsGetRemoteFalse(unittest.TestCase):
         p.setup(mode=mode)
         p.run_model()
 
-        dv_vals = p.driver.get_design_var_values(get_remote=False)
+        p.driver.get_design_var_values(get_remote=False)
 
         # Compute totals and check the length of the gradient array on each proc
         J = p.compute_totals(get_remote=False)
@@ -431,8 +431,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # Test compact_print output
         compact_stream = StringIO()
-        compact_totals = prob.check_totals(method='fd', out_stream=compact_stream,
-            compact_print=True)
+        prob.check_totals(method='fd', out_stream=compact_stream, compact_print=True)
 
         compact_lines = compact_stream.getvalue().splitlines()
 
@@ -465,7 +464,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # check derivatives with complex step and a larger step size.
         stream = StringIO()
-        totals = prob.check_totals(method='fd', show_progress=True, out_stream=stream)
+        prob.check_totals(method='fd', show_progress=True, out_stream=stream)
 
         lines = stream.getvalue().splitlines()
         self.assertTrue("1/3: Checking derivatives with respect to: 'd1.x [2]' ..." in lines[0])
@@ -476,7 +475,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # Check to make sure nothing is going to output
         stream = StringIO()
-        totals = prob.check_totals(method='fd', show_progress=False, out_stream=stream)
+        prob.check_totals(method='fd', show_progress=False, out_stream=stream)
 
         lines = stream.getvalue()
         self.assertFalse("Checking derivatives with respect to" in lines)
@@ -1284,8 +1283,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(totals['a3', 'widths']['abs error'][0], 0.0, 1e-6)
         assert_near_equal(totals['a4', 'widths']['abs error'][0], 0.0, 1e-6)
 
-        l = prob.list_driver_vars(show_promoted_name=True, print_arrays=False,
-                                  cons_opts=['indices', 'alias'])
+        prob.list_driver_vars(show_promoted_name=True, print_arrays=False,
+                              cons_opts=['indices', 'alias'])
 
         # Rev mode
 
@@ -1309,7 +1308,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.setup(mode='rev')
 
-        result = prob.run_driver()
+        prob.run_driver()
 
         totals = prob.check_totals(out_stream=None)
 
@@ -1926,7 +1925,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         for c in  [m.comp5, m.comp6, m.comp7, m.comp8]:
             c.nsolve_linear = 0
 
-        J = prob.compute_totals()
+        prob.compute_totals()
 
         nsolves = [c.nsolve_linear for c in [m.comp5, m.comp6, m.comp7, m.comp8]]
         # Coloring requires 2 linear solves, mixing all dependencies, so each comp gets
@@ -1951,7 +1950,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         for c in  [m.comp5, m.comp6, m.comp7, m.comp8]:
             c.nsolve_linear = 0
 
-        J = prob.compute_totals()
+        prob.compute_totals()
 
         nsolves = [c.nsolve_linear for c in [m.comp5, m.comp6, m.comp7, m.comp8]]
         # Coloring requires 2 linear solves, mixing all dependencies, so each comp gets
@@ -1992,7 +1991,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         for c in  [m.comp1, m.comp2, m.comp3, m.comp4]:
             c.nsolve_linear = 0
 
-        J = prob.compute_totals()
+        prob.compute_totals()
 
         nsolves = [c.nsolve_linear for c in [m.comp1, m.comp2, m.comp3, m.comp4]]
         # coloring requires 2 rev solves, which combine all dependencies, so each
@@ -2016,7 +2015,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         for c in  [m.comp1, m.comp2, m.comp3, m.comp4]:
             c.nsolve_linear = 0
 
-        J = prob.compute_totals()
+        prob.compute_totals()
 
         nsolves = [c.nsolve_linear for c in [m.comp1, m.comp2, m.comp3, m.comp4]]
         # coloring requires 2 rev solves, which combine all dependencies, so each
@@ -2054,7 +2053,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.setup(mode='fwd')
         p.run_model()
         stream = StringIO()
-        J = p.check_totals(step=[1e-6], out_stream=stream)
+        p.check_totals(step=[1e-6], out_stream=stream)
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
@@ -2070,7 +2069,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.setup(mode='rev')
         p.run_model()
         stream = StringIO()
-        J = p.check_totals(step=[1e-6], out_stream=stream)
+        p.check_totals(step=[1e-6], out_stream=stream)
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
@@ -2088,7 +2087,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 p.setup(mode=mode)
                 p.run_model()
                 stream = StringIO()
-                J = p.check_totals(step=[1e-6], compact_print=True, out_stream=stream)
+                p.check_totals(step=[1e-6], compact_print=True, out_stream=stream)
                 contents = stream.getvalue()
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 0)
@@ -2102,7 +2101,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 p.setup(mode=mode, force_alloc_complex=True)
                 p.run_model()
                 stream = StringIO()
-                J = p.check_totals(method='cs', step=1e-30, compact_print=True, out_stream=stream)
+                p.check_totals(method='cs', step=1e-30, compact_print=True, out_stream=stream)
                 contents = stream.getvalue()
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 0)
@@ -2114,7 +2113,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.setup(mode='fwd')
         p.run_model()
         stream = StringIO()
-        J = p.check_totals(step=[1e-6, 1e-7], out_stream=stream)
+        p.check_totals(step=[1e-6, 1e-7], out_stream=stream)
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
@@ -2128,7 +2127,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.setup(mode='fwd')
         p.run_model()
         stream = StringIO()
-        J = p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
+        p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Full Model:"), 3)
         self.assertEqual(contents.count("Fd Magnitude:"), 6)
@@ -2141,7 +2140,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.setup(mode='rev')
         p.run_model()
         stream = StringIO()
-        J = p.check_totals(step=[1e-6, 1e-7], out_stream=stream)
+        p.check_totals(step=[1e-6, 1e-7], out_stream=stream)
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
@@ -2155,7 +2154,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.setup(mode='rev')
         p.run_model()
         stream = StringIO()
-        J = p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
+        p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Full Model:"), 6)
         self.assertEqual(contents.count("Fd Magnitude:"), 12)
@@ -2170,7 +2169,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 p.setup(mode=mode)
                 p.run_model()
                 stream = StringIO()
-                J = p.check_totals(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
+                p.check_totals(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
                 contents = stream.getvalue()
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
@@ -2184,7 +2183,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 p.setup(mode=mode, force_alloc_complex=True)
                 p.run_model()
                 stream = StringIO()
-                J = p.check_totals(method='cs', step=[1e-20, 1e-30], compact_print=True, out_stream=stream)
+                p.check_totals(method='cs', step=[1e-20, 1e-30], compact_print=True, out_stream=stream)
                 contents = stream.getvalue()
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
@@ -2205,7 +2204,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                     p.setup(mode=mode)
                     p.run_model()
                     stream = StringIO()
-                    J = p.check_totals(step=[1e-6, 1e-7], compact_print=True, directional=True, out_stream=stream)
+                    p.check_totals(step=[1e-6, 1e-7], compact_print=True, directional=True, out_stream=stream)
                     contents = stream.getvalue()
                     self.assertEqual(contents.count("step"), 1)
                     # check number of rows/cols

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -39,6 +39,8 @@ except ImportError:
 
 # check that pyoptsparse is installed
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
+if OPTIMIZER:
+    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 
 class CounterGroup(om.Group):

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -534,7 +534,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
 
         try:
             OPT('SLSQP')
-        except:
+        except Exception:
             raise unittest.SkipTest("This test requires pyoptsparse SLSQP.")
 
         p_color = run_opt(pyOptSparseDriver, 'auto', optimizer='SLSQP', print_results=False,
@@ -653,7 +653,7 @@ class SimulColoringPyoptSparseRevTestCase(unittest.TestCase):
 
         try:
             OPT('SLSQP')
-        except:
+        except Exception:
             raise unittest.SkipTest("This test requires pyoptsparse SLSQP.")
 
         p_color = run_opt(pyOptSparseDriver, 'rev', optimizer='SLSQP', print_results=False,
@@ -685,7 +685,7 @@ class SimulColoringPyoptSparseRevTestCase(unittest.TestCase):
 
         try:
             OPT('SLSQP')
-        except:
+        except Exception:
             raise unittest.SkipTest("This test requires pyoptsparse SLSQP.")
 
         # run w/o coloring
@@ -739,7 +739,7 @@ class SimulColoringPyoptSparseRevTestCase(unittest.TestCase):
 
         try:
             OPT('SLSQP')
-        except:
+        except Exception:
             raise unittest.SkipTest("This test requires pyoptsparse SLSQP.")
 
         p = run_opt(pyOptSparseDriver, 'auto', optimizer='SLSQP', print_results=False, con_alias=True)
@@ -1132,7 +1132,7 @@ def _test_func_name(func, num, param):
     for p in param.args:
         try:
             arg = p.__name__
-        except:
+        except Exception:
             arg = str(p)
         args.append(arg)
     return func.__name__ + '_'.join(args)

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -469,7 +469,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         SIZE = 0
         p = om.Problem()
 
-        arctan_yox = p.model.add_subsystem('arctan_yox', DynamicPartialsComp(SIZE))
+        p.model.add_subsystem('arctan_yox', DynamicPartialsComp(SIZE))
 
         p.driver = om.ScipyOptimizeDriver()
         p.driver.options['optimizer'] = 'SLSQP'
@@ -510,7 +510,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
         SIZE = 0
         p = om.Problem()
 
-        arctan_yox = p.model.add_subsystem('arctan_yox', DynamicPartialsComp(SIZE))
+        p.model.add_subsystem('arctan_yox', DynamicPartialsComp(SIZE))
 
         p.driver = om.ScipyOptimizeDriver()
         p.driver.options['optimizer'] = 'SLSQP'
@@ -580,7 +580,7 @@ class SimulColoringPyoptSparseTestCase(unittest.TestCase):
     @unittest.skipUnless(OPTIMIZER == 'SNOPT', "This test requires SNOPT.")
     def test_print_options_total_with_coloring_rev(self):
         # first, run w/o coloring
-        p = run_opt(pyOptSparseDriver, 'rev', optimizer='SNOPT', print_results=False)
+        run_opt(pyOptSparseDriver, 'rev', optimizer='SNOPT', print_results=False)
         p_color = run_opt(pyOptSparseDriver, 'rev', optimizer='SNOPT', print_results=False,
                           dynamic_total_coloring=True, debug_print=['totals'])
 
@@ -772,7 +772,7 @@ class SimulColoringScipyTestCase(unittest.TestCase):
         coloring = p_color_fwd.driver._coloring_info.coloring
 
         with self.assertRaises(Exception) as context:
-            p_color = run_opt(om.ScipyOptimizeDriver, 'rev', color_info=coloring, optimizer='SLSQP', disp=False)
+            run_opt(om.ScipyOptimizeDriver, 'rev', color_info=coloring, optimizer='SLSQP', disp=False)
         self.assertEqual(str(context.exception),
                          "Simultaneous coloring does forward solves but mode has been set to 'rev'")
 
@@ -1097,7 +1097,7 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
         coloring = p_color_rev.driver._coloring_info.coloring
 
         with self.assertRaises(Exception) as context:
-            p_color = run_opt(om.ScipyOptimizeDriver, 'fwd', color_info=coloring, optimizer='SLSQP', disp=False)
+            run_opt(om.ScipyOptimizeDriver, 'fwd', color_info=coloring, optimizer='SLSQP', disp=False)
         self.assertEqual(str(context.exception),
                          "Simultaneous coloring does reverse solves but mode has been set to 'fwd'")
 
@@ -1121,8 +1121,8 @@ class SimulColoringRevScipyTestCase(unittest.TestCase):
 
     def test_dynamic_total_coloring_no_derivs(self):
         with self.assertRaises(Exception) as context:
-            p_color = run_opt(om.ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False,
-                              dynamic_total_coloring=True, derivs=False)
+            run_opt(om.ScipyOptimizeDriver, 'rev', optimizer='SLSQP', disp=False,
+                    dynamic_total_coloring=True, derivs=False)
         self.assertEqual(str(context.exception),
                          "Derivative support has been turned off but compute_totals was called.")
 
@@ -1532,7 +1532,7 @@ class SimulColoringConfigCheckTestCase(unittest.TestCase):
         with open('_bad_format_', 'w') as f:
             f.write('asdfas asdfasdf;lkjasdflkjas df sadf;jasdf;lkja')
         with self.assertRaises(RuntimeError) as ctx:
-            c = Coloring.load('_bad_format_')
+            Coloring.load('_bad_format_')
 
         self.assertEqual(ctx.exception.args[0], "File '_bad_format_' is not a valid coloring file.")
 
@@ -1542,7 +1542,7 @@ class SimulColoringConfigCheckTestCase(unittest.TestCase):
             pickle.dump(s, f)
 
         with self.assertRaises(RuntimeError) as ctx:
-            c = Coloring.load('_bad_pickle_')
+            Coloring.load('_bad_pickle_')
 
         self.assertEqual(ctx.exception.args[0], "File '_bad_pickle_' is not a valid coloring file.")
 

--- a/openmdao/core/tests/test_coloring.py
+++ b/openmdao/core/tests/test_coloring.py
@@ -39,8 +39,6 @@ except ImportError:
 
 # check that pyoptsparse is installed
 OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT')
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 
 class CounterGroup(om.Group):

--- a/openmdao/core/tests/test_component_io_independence_from_prob.py
+++ b/openmdao/core/tests/test_component_io_independence_from_prob.py
@@ -1,5 +1,4 @@
 import unittest
-import numpy as np
 import openmdao.api as om
 import gc
 

--- a/openmdao/core/tests/test_compute_jacvec_prod.py
+++ b/openmdao/core/tests/test_compute_jacvec_prod.py
@@ -1,14 +1,9 @@
 
-import sys
 import unittest
 
 import numpy as np
 
 import openmdao.api as om
-from openmdao.core.driver import Driver
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.test_suite.components.paraboloid import Paraboloid
-from openmdao.test_suite.components.sellar import SellarDerivatives
 
 
 def get_comp(size):
@@ -140,9 +135,9 @@ class TestPComputeJacvecProd(unittest.TestCase):
         comp = model.add_subsystem('comp', om.IndepVarComp('x', val=np.zeros(size - 1)))
         comp.add_output('inp', val=0.0)
 
-        C1 = model.add_subsystem('C1', get_comp(size))
-        C2 = model.add_subsystem('C2', get_comp(size))
-        C3 = model.add_subsystem('C3', get_comp(size))
+        model.add_subsystem('C1', get_comp(size))
+        model.add_subsystem('C2', get_comp(size))
+        model.add_subsystem('C3', get_comp(size))
 
         model.connect('comp.x', ['C1.x', 'C2.x', 'C3.x'])
         model.connect('comp.inp', 'C1.inp')
@@ -154,7 +149,7 @@ class TestPComputeJacvecProd(unittest.TestCase):
     def _build_cjv_model(self, size, mode):
         p = om.Problem()
 
-        comp = p.model.add_subsystem('comp', SubProbComp(input_size=size, num_nodes=3, mode=mode))
+        p.model.add_subsystem('comp', SubProbComp(input_size=size, num_nodes=3, mode=mode))
 
         p.setup(mode=mode)
 

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -56,7 +56,7 @@ class TestConnections(unittest.TestCase):
     def test_pull_size_from_source(self):
         raise unittest.SkipTest("setting input size based on src size not supported yet")
 
-        class Src(ExplicitComponent):
+        class Src(om.ExplicitComponent):
 
             def setup(self):
 
@@ -70,7 +70,7 @@ class TestConnections(unittest.TestCase):
                 outputs['y1'] = x * np.array([1.0, 2.0, 3.0])
                 outputs['y2'] = x * np.array([1.0, 2.0, 3.0])
 
-        class Tgt(ExplicitComponent):
+        class Tgt(om.ExplicitComponent):
 
             def setup(self):
 
@@ -102,7 +102,7 @@ class TestConnections(unittest.TestCase):
     def test_pull_size_from_source_with_indices(self):
         raise unittest.SkipTest("setting input size based on src size not supported yet")
 
-        class Src(ExplicitComponent):
+        class Src(om.ExplicitComponent):
 
             def setup(self):
 
@@ -120,7 +120,7 @@ class TestConnections(unittest.TestCase):
                 outputs['y2'] = x * np.array([1.0, 2.0, 3.0])
                 outputs['y3'] = x * 4.0
 
-        class Tgt(ExplicitComponent):
+        class Tgt(om.ExplicitComponent):
 
             def setup(self):
 

--- a/openmdao/core/tests/test_cp_rev_matrix_free_dist.py
+++ b/openmdao/core/tests/test_cp_rev_matrix_free_dist.py
@@ -4,7 +4,6 @@ left the test because it checks the format of the printed values from check part
 """
 import unittest
 from io import StringIO
-import re
 
 import numpy as np
 

--- a/openmdao/core/tests/test_deriv_transfers.py
+++ b/openmdao/core/tests/test_deriv_transfers.py
@@ -210,9 +210,6 @@ class TestParallelGroups(unittest.TestCase):
         model = prob.model
         size = 3
 
-        sizes = [2, 1]
-        rank = prob.comm.rank
-
         if not auto:
             model.add_subsystem('indep', om.IndepVarComp('x', np.ones(size)), promotes=['x'])
 
@@ -363,8 +360,6 @@ class TestParallelGroups(unittest.TestCase):
         model = prob.model
         size = 3
 
-        sizes = [2, 1]
-        rank = prob.comm.rank
         model.add_subsystem('indep', om.IndepVarComp('x', np.ones(size)))
         par = model.add_subsystem('par', om.ParallelGroup())
         par.add_subsystem('C1', om.ExecComp('y = 3 * x', x=np.zeros(size), y=np.zeros(size)))

--- a/openmdao/core/tests/test_deriv_transfers.py
+++ b/openmdao/core/tests/test_deriv_transfers.py
@@ -31,7 +31,7 @@ def _test_func_name(func, num, param):
         for item in p:
             try:
                 arg = item.__name__
-            except:
+            except Exception:
                 arg = str(item)
             args.append(arg)
     return func.__name__ + '_' + '_'.join(args)

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -616,20 +616,6 @@ class TestConstraintOnModel(unittest.TestCase):
             prob.model.add_design_var('x', lower=0.0, upper=['a', 'b'],
                                       ref0=-100.0, ref=100)
 
-    def test_constraint_invalid_name(self):
-
-        prob = om.Problem()
-
-        prob.model = SellarDerivatives()
-        prob.model.nonlinear_solver = om.NonlinearBlockGS()
-
-        with self.assertRaises(TypeError) as context:
-            prob.model.add_constraint(42, lower=-100, upper=100, ref0=-100.0,
-                                      ref=100)
-
-        self.assertEqual(str(context.exception), '<class SellarDerivatives>: The name argument should '
-                                                 'be a string, got 42')
-
     def test_constraint_invalid_lower(self):
 
         prob = om.Problem()

--- a/openmdao/core/tests/test_direct_nondistrib_comp.py
+++ b/openmdao/core/tests/test_direct_nondistrib_comp.py
@@ -1,6 +1,5 @@
 import unittest
 
-import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_check_partials

--- a/openmdao/core/tests/test_direct_nondistrib_comp.py
+++ b/openmdao/core/tests/test_direct_nondistrib_comp.py
@@ -40,7 +40,6 @@ class QuadraticComp(om.ImplicitComponent):
     def linearize(self, inputs, outputs, partials):
         a = inputs['a']
         b = inputs['b']
-        c = inputs['c']
         x = outputs['x']
 
         partials['x', 'a'] = x ** 2

--- a/openmdao/core/tests/test_discrete.py
+++ b/openmdao/core/tests/test_discrete.py
@@ -1,6 +1,5 @@
 """ Unit tests for discrete variables."""
 
-import sys
 import unittest
 import copy
 
@@ -588,7 +587,7 @@ class DiscreteTestCase(unittest.TestCase):
         indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_output('x', 1.0)
 
-        comp = model.add_subsystem('comp', CompDiscWDerivs())
+        model.add_subsystem('comp', CompDiscWDerivs())
         model.connect('indep.x', 'comp.x')
 
         model.add_design_var('indep.x')
@@ -608,8 +607,8 @@ class DiscreteTestCase(unittest.TestCase):
         indep = model.add_subsystem('indep', om.IndepVarComp())
         indep.add_output('x', 1.0)
 
-        comp = model.add_subsystem('comp', CompDiscWDerivsImplicit(), promotes=['N'])
-        sink = model.add_subsystem('sink', MixedCompDiscIn(1.0))
+        model.add_subsystem('comp', CompDiscWDerivsImplicit(), promotes=['N'])
+        model.add_subsystem('sink', MixedCompDiscIn(1.0))
         model.connect('indep.x', 'comp.y2_actual')
         model.connect('comp.Nout', 'sink.x')
 
@@ -635,7 +634,7 @@ class DiscreteTestCase(unittest.TestCase):
 
         G = model.add_subsystem('G', om.Group(), promotes_inputs=['x'])
 
-        G1 = G.add_subsystem('G1', InternalDiscreteGroup(), promotes_inputs=['x'], promotes_outputs=['y'])
+        G.add_subsystem('G1', InternalDiscreteGroup(), promotes_inputs=['x'], promotes_outputs=['y'])
 
         G2 = G.add_subsystem('G2', om.Group(), promotes_inputs=['x'])
         G2.add_subsystem('C2_1', om.ExecComp('y=3*x'), promotes_inputs=['x'])
@@ -659,7 +658,7 @@ class DiscreteTestCase(unittest.TestCase):
         self.assertEqual(prob['C4.y'], 16.0)
 
         with self.assertRaises(Exception) as ctx:
-            J = prob.compute_totals()
+            prob.compute_totals()
         self.assertEqual(str(ctx.exception),
                          "Total derivative of 'C3.y' with respect to 'x' depends upon discrete output variables ['G.G1.C1.y'].")
 

--- a/openmdao/core/tests/test_discrete_mpi.py
+++ b/openmdao/core/tests/test_discrete_mpi.py
@@ -1,16 +1,9 @@
 """ Unit tests for the problem interface."""
 
-import sys
 import unittest
-import warnings
 
-import numpy as np
-
-from openmdao.api import Problem, IndepVarComp, NonlinearBlockGS, ScipyOptimizeDriver, \
-    ExecComp, Group, NewtonSolver, ImplicitComponent, ScipyKrylov, ExplicitComponent, ParallelGroup
+from openmdao.api import Problem, IndepVarComp, ParallelGroup
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.test_suite.components.paraboloid import Paraboloid
-from openmdao.test_suite.components.sellar import SellarDerivatives
 
 from openmdao.utils.mpi import MPI
 
@@ -19,7 +12,7 @@ try:
 except ImportError:
     PETScVector = None
 
-from openmdao.core.tests.test_discrete import ModCompEx, ModCompIm, DiscretePromTestCase, PathCompEx
+from openmdao.core.tests.test_discrete import ModCompEx, ModCompIm, DiscretePromTestCase
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_distrib_adder.py
+++ b/openmdao/core/tests/test_distrib_adder.py
@@ -1,9 +1,7 @@
-import os
-
 import unittest
 import numpy as np
 
-from openmdao.api import ExplicitComponent, Problem, Group, IndepVarComp, slicer
+from openmdao.api import ExplicitComponent, Problem, IndepVarComp, slicer
 
 from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.utils.mpi import MPI

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -2472,8 +2472,8 @@ class TestDistribBugs(unittest.TestCase):
             Jname = 'J_fwd' if 'J_fwd' in val else 'J_rev'
             idx = 0 if 'J_fwd' in val else 1
             try:
-                analytic = val[Jname]
-                fd = val['J_fd']
+                val[Jname]  # analytic
+                val['J_fd']  # FD
             except Exception as err:
                 self.fail(f"For key {key}: {err}")
             try:

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -2191,7 +2191,7 @@ class TestBugs(unittest.TestCase):
                 outputs['func'] += np.sum(inputs['state'])
 
         prob = om.Problem()
-        dvs = prob.model.add_subsystem('dvs',DVS())
+        prob.model.add_subsystem('dvs', DVS())
         prob.model.add_subsystem('solver', SolverComp())
         prob.model.connect('dvs.state','solver.state')
         prob.model.add_design_var('dvs.state', indices=[0,2])
@@ -2595,14 +2595,14 @@ class TestDistribBugs(unittest.TestCase):
 
     def test_check_err(self):
         with self.assertRaises(RuntimeError) as cm:
-            prob = self.get_problem(Distrib_DerivsErr)
+            self.get_problem(Distrib_DerivsErr)
 
         msg = "'D1' <class Distrib_DerivsErr>: component has defined partial ('out_nd', 'in_dist') which is a non-distributed output wrt a distributed input. This is only supported using the matrix free API."
         self.assertEqual(str(cm.exception), msg)
 
     def test_fd_check_err(self):
         with self.assertRaises(RuntimeError) as cm:
-            prob = self.get_problem(Distrib_DerivsFD, mode='fwd')
+            self.get_problem(Distrib_DerivsFD, mode='fwd')
 
         msg = "'D1' <class Distrib_DerivsFD>: component has defined partial ('out_nd', 'in_dist') which is a non-distributed output wrt a distributed input. This is only supported using the matrix free API."
         self.assertEqual(str(cm.exception), msg)
@@ -2631,7 +2631,7 @@ class TestDistribBugs(unittest.TestCase):
 
         prob.run_driver()
 
-        desvar = prob.driver.get_design_var_values()
+        prob.driver.get_design_var_values()
         con = prob.driver.get_constraint_values()
 
         assert_near_equal(con['f_xy'], 24.0)

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -285,7 +285,7 @@ def _test_func_name(func, num, param):
     for p in param.args:
         try:
             arg = p.__name__
-        except:
+        except Exception:
             arg = str(p)
         args.append(arg)
     return func.__name__ + '_' + '_'.join(args)
@@ -870,13 +870,13 @@ class MPITests2(unittest.TestCase):
 
         assert_check_totals(prob.check_totals(method='fd', out_stream=None), rtol=1e-5)
 
-    def test_distrib_voi_group_fd2(self):
+    def test_distrib_voi_group_fd2_fwd(self):
         prob = _setup_ivc_subivc_dist_parab_sum()
         prob.setup(mode='fwd', force_alloc_complex=True)
         prob.run_model()
         assert_check_totals(prob.check_totals(method='fd', out_stream=None))
 
-    def test_distrib_voi_group_fd2(self):
+    def test_distrib_voi_group_fd2_rev(self):
         prob = _setup_ivc_subivc_dist_parab_sum()
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -261,13 +261,13 @@ class DistributedListVarsTest(unittest.TestCase):
 
         stream = StringIO()
         with multi_proc_exception_check(prob.comm):
-            vars = sorted(prob.model.list_vars(val=True,
-                                               units=True,
-                                               shape=True,
-                                               prom_name=False,
-                                               print_arrays=True,
-                                               all_procs=True,
-                                               out_stream=stream))
+            prob.model.list_vars(val=True,
+                                 units=True,
+                                 shape=True,
+                                 prom_name=False,
+                                 print_arrays=True,
+                                 all_procs=True,
+                                 out_stream=stream)
 
             expected = [
                 "8 Variables(s) in 'model'",

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -279,7 +279,7 @@ class NOMPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
 
@@ -426,7 +426,7 @@ class MPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribCompSimple(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
 
@@ -637,7 +637,7 @@ class MPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
 
@@ -658,9 +658,9 @@ class MPITests(unittest.TestCase):
         p = om.Problem()
 
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribInputComp(arr_size=size))
-        C3 = top.add_subsystem("C3", om.ExecComp("y=x", x=np.zeros(size*commsize),
+        top.add_subsystem("C3", om.ExecComp("y=x", x=np.zeros(size*commsize),
                                                  y=np.zeros(size*commsize)))
 
         comm = p.comm
@@ -689,8 +689,8 @@ class MPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
-        C2 = top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
         C3 = top.add_subsystem("C3", DistribGatherComp(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.invec')
@@ -755,7 +755,7 @@ class MPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
         C2 = top.add_subsystem("C2", DistribOverlappingInputComp(arr_size=size, local_size=local_size))
         top.connect('C1.outvec', 'C2.invec', src_indices=np.arange(start, end, dtype=int))
         p.setup()
@@ -793,8 +793,8 @@ class MPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
-        C2 = top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
         C3 = top.add_subsystem("C3", NonDistribGatherComp(size=size))
         top.connect('C1.outvec', 'C2.invec')
         top.connect('C2.outvec', 'C3.invec', om.slicer[:])

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -129,9 +129,6 @@ class DistribOverlappingInputComp(om.ExplicitComponent):
         """ component declares the local sizes and sets initial values
         for all distributed inputs and outputs"""
 
-        comm = self.comm
-        rank = comm.rank
-
         arr_size = self.options['arr_size']
         local_size = self.options['local_size']
 
@@ -450,8 +447,8 @@ class MPITests(unittest.TestCase):
 
         p = om.Problem()
         top = p.model
-        C1 = top.add_subsystem("C1", InOutArrayComp(arr_size=size))
-        C2 = top.add_subsystem("C2", DistribCompWithDerivs(arr_size=size))
+        top.add_subsystem("C1", InOutArrayComp(arr_size=size))
+        top.add_subsystem("C2", DistribCompWithDerivs(arr_size=size))
         top.connect('C1.outvec', 'C2.invec')
 
         p.setup()
@@ -474,8 +471,8 @@ class MPITests(unittest.TestCase):
 
         class Model(om.Group):
             def setup(self):
-                C1 = self.add_subsystem("C1", InOutArrayComp(arr_size=size))
-                C2 = self.add_subsystem("C2", DistribCompSimple(arr_size=size))
+                self.add_subsystem("C1", InOutArrayComp(arr_size=size))
+                self.add_subsystem("C2", DistribCompSimple(arr_size=size))
                 self.connect('C1.outvec', 'C2.invec')
 
             def configure(self):
@@ -817,7 +814,7 @@ class MPITests(unittest.TestCase):
         size = 2
 
         prob = om.Problem()
-        C2 = prob.model.add_subsystem("C", DistribCompSimple(arr_size=size))
+        prob.model.add_subsystem("C", DistribCompSimple(arr_size=size))
 
         with self.assertRaises(RuntimeError) as context:
             prob.setup()
@@ -871,8 +868,8 @@ class ProbRemoteTests(unittest.TestCase):
         top.connect('P.invec1', 'par.C1.invec')
         top.connect('P.invec2', 'par.C2.invec')
 
-        C1 = par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
-        C2 = par.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
+        par.add_subsystem("C1", DistribInputDistribOutputComp(arr_size=size))
+        par.add_subsystem("C2", DistribInputDistribOutputComp(arr_size=size))
 
         p.setup()
 
@@ -962,7 +959,7 @@ class ProbRemoteTests(unittest.TestCase):
         top.connect('P.invec', 'C1.invec')
         top.connect('P.disc_in', 'C1.disc_in')
 
-        C1 = top.add_subsystem("C1", DistribInputDistribOutputDiscreteComp(arr_size=size))
+        top.add_subsystem("C1", DistribInputDistribOutputDiscreteComp(arr_size=size))
         p.setup()
 
         # Conclude setup but don't run model.

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -184,7 +184,7 @@ class TestDriver(unittest.TestCase):
         model = prob.model
 
         model.add_subsystem('px', om.IndepVarComp(name="x", val=np.ones((2, ))))
-        comp = model.add_subsystem('comp', DoubleArrayComp())
+        model.add_subsystem('comp', DoubleArrayComp())
         model.connect('px.x', 'comp.x1')
 
         model.add_design_var('px.x', ref=np.array([.1, 1e-6]))
@@ -793,7 +793,7 @@ class TestDriver(unittest.TestCase):
         prob.set_val('sub.x', 50.)
         prob.set_val('sub.y', 50.)
 
-        result = prob.run_driver()
+        prob.run_driver()
 
         assert_near_equal(prob['sub.x'], 6.66666667, 1e-6)
         assert_near_equal(prob['sub.y'], -7.3333333, 1e-6)
@@ -1073,7 +1073,7 @@ class TestDriverMPI(unittest.TestCase):
 
         p = om.Problem()
 
-        pg = p.model.add_subsystem('par_group', ParModel())
+        p.model.add_subsystem('par_group', ParModel())
         p.model.add_subsystem('obj', om.ExecComp('f = y0 + y1'))
 
         p.model.connect('par_group.g0.comp.y', 'obj.y0')

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -31,7 +31,7 @@ class TestAdder(unittest.TestCase):
         prob = om.Problem()
         prob.model = om.Group()
 
-        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp('in', np.ones(10)), promotes=['*'])
+        prob.model.add_subsystem('indeps', om.IndepVarComp('in', np.ones(10)), promotes=['*'])
 
         prob.model.add_subsystem('L2norm', L2())
         prob.model.connect('in', ['L2norm.vec'])
@@ -543,7 +543,7 @@ class TestDynShapes(unittest.TestCase):
         # now put the DynShapeGroupSeries in a cycle (sink.y2 feeds back into Gdyn.C1.x2). Sizes are known
         # at both ends of the model (the IVC and at the sink)
         p = om.Problem()
-        indep = p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
+        p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
         p.model.add_subsystem('Gdyn', DynShapeGroupSeries(3,2, DynShapeComp))
         p.model.add_subsystem('sink', om.ExecComp('y1, y2 = x1*2, x2*2',
                                                   x1=np.ones((2,3)),
@@ -591,7 +591,7 @@ class TestDynShapes(unittest.TestCase):
         # now put the DynShapeGroupSeries in a cycle (sink.y2 feeds back into Gdyn.C1.x2), but here,
         # sink.y2 is unsized, so no var in the '2' loop can get resolved.
         p = om.Problem(name='cycle_unresolved')
-        indep = p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
+        p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
         p.model.add_subsystem('Gdyn', DynShapeGroupSeries(3,2, DynShapeComp))
         p.model.add_subsystem('sink', om.ExecComp('y1, y2 = x1*2, x2*2',
                                                   x1={'shape_by_conn': True, 'copy_shape': 'y1'},
@@ -614,7 +614,7 @@ class TestDynShapes(unittest.TestCase):
 
     def test_bad_copy_shape_name(self):
         p = om.Problem(name='bad_copy_shape_name')
-        indep = p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
+        p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
         p.model.add_subsystem('sink', om.ExecComp('y1 = x1*2',
                                                   x1={'shape_by_conn': True, 'copy_shape': 'y1'},
                                                   y1={'shape_by_conn': True, 'copy_shape': 'x11'}))
@@ -629,7 +629,7 @@ class TestDynShapes(unittest.TestCase):
 
     def test_unconnected_var_dyn_shape(self):
         p = om.Problem(name='unconnected_var_dyn_shape')
-        indep = p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
+        p.model.add_subsystem('indep', om.IndepVarComp('x1', val=np.ones((2,3))))
         p.model.add_subsystem('sink', om.ExecComp('y1 = x1*2',
                                                   x1={'shape_by_conn': True, 'copy_shape': 'y1'},
                                                   y1={'shape_by_conn': True}))
@@ -654,8 +654,8 @@ class TestDistribDynShapes(unittest.TestCase):
         indep.add_output('x1', shape_by_conn=True)
 
         par = p.model.add_subsystem('par', om.ParallelGroup())
-        G1 = par.add_subsystem('G1', DynShapeGroupSeries(2,1, DistribDynShapeComp))
-        G2 = par.add_subsystem('G2', DynShapeGroupSeries(2,1, DistribDynShapeComp))
+        par.add_subsystem('G1', DynShapeGroupSeries(2,1, DistribDynShapeComp))
+        par.add_subsystem('G2', DynShapeGroupSeries(2,1, DistribDynShapeComp))
 
         # 'sink' has a defined shape and dyn shapes propagate in reverse from there.
         p.model.add_subsystem('sink', om.ExecComp(['y1=x1+x2'], shape=(8,)))
@@ -980,10 +980,10 @@ class TestDynShapesWithInputConns(unittest.TestCase):
     def test_shape_from_conn_input(self):
         prob = om.Problem()
         sub = prob.model.add_subsystem('sub', om.Group())
-        comp1 = sub.add_subsystem('comp1', om.ExecComp('y=3*x', x={'shape_by_conn': True}, y={'copy_shape': 'x'}),
-                                  promotes_inputs=['x'])
-        comp2 = sub.add_subsystem('comp2', om.ExecComp('y=3*x', x=np.ones(2), y=np.zeros(2)),
-                                  promotes_inputs=['x'])
+        sub.add_subsystem('comp1', om.ExecComp('y=3*x', x={'shape_by_conn': True}, y={'copy_shape': 'x'}),
+                          promotes_inputs=['x'])
+        sub.add_subsystem('comp2', om.ExecComp('y=3*x', x=np.ones(2), y=np.zeros(2)),
+                          promotes_inputs=['x'])
 
         prob.setup()
 
@@ -996,12 +996,12 @@ class TestDynShapesWithInputConns(unittest.TestCase):
     def test_shape_from_conn_input_mismatch(self):
         prob = om.Problem(name='shape_from_conn_input_mismatch')
         sub = prob.model.add_subsystem('sub', om.Group())
-        comp1 = sub.add_subsystem('comp1', om.ExecComp('y=3*x', x={'shape_by_conn': True}, y={'copy_shape': 'x'}),
-                                  promotes_inputs=['x'])
-        comp2 = sub.add_subsystem('comp2', om.ExecComp('y=3*x', x=np.ones(2), y=np.zeros(2)),
-                                  promotes_inputs=['x'])
-        comp3 = sub.add_subsystem('comp3', om.ExecComp('y=3*x', x=np.ones(3), y=np.zeros(3)),
-                                  promotes_inputs=['x'])
+        sub.add_subsystem('comp1', om.ExecComp('y=3*x', x={'shape_by_conn': True}, y={'copy_shape': 'x'}),
+                          promotes_inputs=['x'])
+        sub.add_subsystem('comp2', om.ExecComp('y=3*x', x=np.ones(2), y=np.zeros(2)),
+                          promotes_inputs=['x'])
+        sub.add_subsystem('comp3', om.ExecComp('y=3*x', x=np.ones(3), y=np.zeros(3)),
+                          promotes_inputs=['x'])
 
         with self.assertRaises(Exception) as cm:
             prob.setup()
@@ -1015,10 +1015,10 @@ class TestDynShapesWithInputConns(unittest.TestCase):
     def test_shape_from_conn_input_mismatch_group_inputs(self):
         prob = om.Problem(name='shape_from_conn_input_mismatch_group_inputs')
         sub = prob.model.add_subsystem('sub', om.Group())
-        comp1 = sub.add_subsystem('comp1', om.ExecComp('y=3*x', x={'shape_by_conn': True}, y={'copy_shape': 'x'}),
-                                  promotes_inputs=['x'])
-        comp2 = sub.add_subsystem('comp2', om.ExecComp('y=3*x', x=np.ones(2), y=np.zeros(2)),
-                                  promotes_inputs=['x'])
+        sub.add_subsystem('comp1', om.ExecComp('y=3*x', x={'shape_by_conn': True}, y={'copy_shape': 'x'}),
+                          promotes_inputs=['x'])
+        sub.add_subsystem('comp2', om.ExecComp('y=3*x', x=np.ones(2), y=np.zeros(2)),
+                          promotes_inputs=['x'])
 
         sub.set_input_defaults('x', src_shape=(3, ))
 

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -1,7 +1,5 @@
 """Simple example demonstrating how to implement an explicit component."""
 
-import sys
-
 from io import StringIO
 import unittest
 

--- a/openmdao/core/tests/test_feature_cache_linear_solution.py
+++ b/openmdao/core/tests/test_feature_cache_linear_solution.py
@@ -51,7 +51,6 @@ class CacheLinearTestCase(unittest.TestCase):
             def linearize(self, inputs, outputs, partials):
                 a = inputs['a'][0]
                 b = inputs['b'][0]
-                c = inputs['c'][0]
                 x = outputs['states'][0]
                 y = outputs['states'][1]
 

--- a/openmdao/core/tests/test_func_api.py
+++ b/openmdao/core/tests/test_func_api.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 
 import openmdao.func_api as omf
-from openmdao.utils.assert_utils import assert_warning, assert_no_warning
+from openmdao.utils.assert_utils import assert_no_warning
 
 try:
     import jax
@@ -318,7 +318,7 @@ class TestFuncAPI(unittest.TestCase):
                 .add_outputs(x={}, y={'shape': (3,3)})
                 .declare_partials(of='*', wrt='*', method='jax'))
         with self.assertRaises(Exception) as cm:
-            outvar_meta = list(f.get_output_meta())
+            f.get_output_meta()
 
         msg = "shape from metadata for return value 'y' of (3, 3) doesn't match computed shape of (3, 2)."
         self.assertEqual(cm.exception.args[0], msg)

--- a/openmdao/core/tests/test_func_api.py
+++ b/openmdao/core/tests/test_func_api.py
@@ -249,7 +249,7 @@ class TestFuncAPI(unittest.TestCase):
             return x, y
 
         with self.assertRaises(Exception) as cm:
-            f = (omf.wrap(func)
+            f = (omf.wrap(func)  # noqa: F841
                  .declare_partials(of='x', wrt=['a', 'b'], method='jax')
                  .declare_partials(of='y', wrt=['a', 'b'], method='fd'))
 
@@ -264,7 +264,7 @@ class TestFuncAPI(unittest.TestCase):
             return x, y
 
         with self.assertRaises(Exception) as cm:
-            f = (omf.wrap(func)
+            f = (omf.wrap(func)  # noqa: F841
                  .declare_partials(of='y', wrt=['a', 'b'], method='fd')
                  .declare_partials(of='x', wrt=['a', 'b'], method='jax'))
 
@@ -277,14 +277,14 @@ class TestFuncAPI(unittest.TestCase):
             y = a / b
             return x, y
 
-        f = (omf.wrap(func)
+        f = (omf.wrap(func)  # noqa: F841
              .declare_coloring(wrt='*', method='cs'))
 
         meta = f.get_declare_coloring()
         self.assertEqual(meta, {'wrt': '*', 'method': 'cs'})
 
         with self.assertRaises(Exception) as cm:
-            f2 = (omf.wrap(func)
+            f2 = (omf.wrap(func)  # noqa: F841
                     .declare_coloring(wrt='a', method='cs')
                     .declare_coloring(wrt='b', method='cs'))
 
@@ -481,7 +481,7 @@ class TestFuncAPI(unittest.TestCase):
 
     def test_return_names(self):
         def func(a):
-            b = a + 1
+            b = a + 1  # noqa: F841
             # no return statement
 
         f = omf.wrap(func)
@@ -489,5 +489,3 @@ class TestFuncAPI(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-
-

--- a/openmdao/core/tests/test_getset_vars.py
+++ b/openmdao/core/tests/test_getset_vars.py
@@ -477,7 +477,7 @@ class ParTestCase(unittest.TestCase):
         G = p.model.add_subsystem('G', om.ParallelGroup())
 
         a = G.add_subsystem('a', CompA())
-        b = G.add_subsystem('b', CompB())
+        G.add_subsystem('b', CompB())
 
         G.connect('a.y', 'b.y', src_indices=[-1])
 

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -2752,7 +2752,8 @@ class TestGroupAddInput(unittest.TestCase):
                                             promotes_inputs=['x'])
 
         g3 = g1.add_subsystem("G3", om.Group(), promotes_inputs=['x'])
-        if diff_vals: val = 2.0
+        if diff_vals:
+            val = 2.0
         g3.add_subsystem("C3", om.ExecComp("y = 4. * x",
                                             x={'val': val, 'units': units1},
                                             y={'val': 1.0, 'units': units1}),
@@ -2765,7 +2766,8 @@ class TestGroupAddInput(unittest.TestCase):
         par = model.add_subsystem("par", om.ParallelGroup(), promotes_inputs=['x'])
 
         g4 = par.add_subsystem("G4", om.Group(), promotes_inputs=['x'])
-        if diff_vals: val = 3.0
+        if diff_vals:
+            val = 3.0
         g4.add_subsystem("C5", om.ExecComp("y = 6. * x",
                                             x={'val': val, 'units': units2},
                                             y={'val': 1.0, 'units': units2}),
@@ -2776,7 +2778,8 @@ class TestGroupAddInput(unittest.TestCase):
                                             promotes_inputs=['x'])
 
         g5 = par.add_subsystem("G5", om.Group(), promotes_inputs=['x'])
-        if diff_vals: val = 4.0
+        if diff_vals:
+            val = 4.0
         g5.add_subsystem("C7", om.ExecComp("y = 8. * x",
                                             x={'val': val, 'units': units1},
                                             y={'val': 1.0, 'units': units1}),

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -3,7 +3,6 @@ Unit tests for Group.
 """
 import itertools
 import unittest
-from collections import defaultdict
 
 import numpy as np
 
@@ -17,7 +16,7 @@ from openmdao.test_suite.components.sellar import SellarDis2
 from openmdao.utils.mpi import MPI
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning
 from openmdao.utils.logger_utils import TestLogger
-from openmdao.utils.om_warnings import PromotionWarning, OMDeprecationWarning
+from openmdao.utils.om_warnings import PromotionWarning
 from openmdao.utils.name_maps import name2abs_names
 from openmdao.utils.testing_utils import set_env_vars_context
 
@@ -207,10 +206,10 @@ class TestGroup(unittest.TestCase):
         g1 = p.model.add_subsystem('g1', om.Group())
         g2 = g1.add_subsystem('g2', om.Group(), promotes=['g3.c1.x'])  # make g2 disappear using promotes
         g3 = g2.add_subsystem('g3', om.Group())
-        c1 = g3.add_subsystem('c1', om.ExecComp('y=2.*x', x=2.))
+        g3.add_subsystem('c1', om.ExecComp('y=2.*x', x=2.))
 
         g3_ = g1.add_subsystem('g3', om.Group(), promotes=['x'])  # second g3, but directly under g1
-        c1_ = g3_.add_subsystem('c1', om.ExecComp('y=3.*x', x=3.), promotes=['x'])
+        g3_.add_subsystem('c1', om.ExecComp('y=3.*x', x=3.), promotes=['x'])
 
         with self.assertRaises(Exception) as cm:
             p.setup()
@@ -225,10 +224,10 @@ class TestGroup(unittest.TestCase):
         g1 = p.model.add_subsystem('g1', om.Group())
         g2 = g1.add_subsystem('g2', om.Group(), promotes=['g3.c1.y'])  # make g2 disappear using promotes
         g3 = g2.add_subsystem('g3', om.Group())
-        c1 = g3.add_subsystem('c1', om.ExecComp('y=2.*x', x=2.))
+        g3.add_subsystem('c1', om.ExecComp('y=2.*x', x=2.))
 
         g3_ = g1.add_subsystem('g3', om.Group(), promotes=['y'])  # second g3, but directly under g1
-        c1_ = g3_.add_subsystem('c1', om.ExecComp('y=3.*x', x=3.), promotes=['y'])
+        g3_.add_subsystem('c1', om.ExecComp('y=3.*x', x=3.), promotes=['y'])
 
         with self.assertRaises(Exception) as cm:
             p.setup()
@@ -1087,7 +1086,7 @@ class TestGroup(unittest.TestCase):
 
     def test_empty_group(self):
         p = om.Problem()
-        g1 = p.model.add_subsystem('G1', om.Group(), promotes=['*'])
+        p.model.add_subsystem('G1', om.Group(), promotes=['*'])
 
         p.setup()
 
@@ -3111,7 +3110,7 @@ class MultComp(om.ExplicitComponent):
 
         out_list = [o for _, _, o in self.mults]
         if len(all_outs) < len(out_list):
-            raise RuntimeError(f"Some outputs appear more than once.")
+            raise RuntimeError("Some outputs appear more than once.")
 
         for inp, _, out in self.mults:
             self.add_input(inp, val=self.inits.get(inp, 1.))
@@ -3899,8 +3898,8 @@ class TestFeatureConfigure(unittest.TestCase):
                 self.set_input_defaults('x', val=99.)
 
         p = om.Problem(model=ConfigGroup())
-        C1 = p.model.add_subsystem('C1', om.ExecComp('y=2*x'), promotes_inputs=['x'])
-        C2 = p.model.add_subsystem('C2', om.ExecComp('y=3*x'), promotes_inputs=['x'])
+        p.model.add_subsystem('C1', om.ExecComp('y=2*x'), promotes_inputs=['x'])
+        p.model.add_subsystem('C2', om.ExecComp('y=3*x'), promotes_inputs=['x'])
 
         p.setup()
         self.assertEqual(p['x'], 99.)
@@ -4045,7 +4044,7 @@ class TestFeatureConfigure(unittest.TestCase):
                 self.add_subsystem('comp', MyComp())
 
             def configure(self):
-                meta = self.comp.get_io_metadata('output', includes='y')
+                self.comp.get_io_metadata('output', includes='y')
 
         p = om.Problem()
         p.model.add_subsystem("G", MyGroup())
@@ -4167,7 +4166,7 @@ class TestNaturalNaming(unittest.TestCase):
         g2 = g1.add_subsystem('g2', om.Group(), promotes=['*'])
         g3 = g2.add_subsystem('g3', om.Group())
         g4 = g3.add_subsystem('g4', om.Group(), promotes=['*'])
-        c1 = g4.add_subsystem('c1', om.ExecComp('y=2.0*x', x=7., y=9.), promotes=['x','y'])
+        g4.add_subsystem('c1', om.ExecComp('y=2.0*x', x=7., y=9.), promotes=['x','y'])
         p.setup()
 
         full_in = 'g1.g2.g3.g4.c1.x'
@@ -4244,13 +4243,13 @@ class TestNaturalNamingMPI(unittest.TestCase):
         g2 = g1.add_subsystem('g2', om.Group(), promotes=['*'])
         g3 = g2.add_subsystem('g3', om.Group())
         g4 = g3.add_subsystem('g4', om.Group(), promotes=['*'])
-        c1 = g4.add_subsystem('c1', om.ExecComp('y=2.0*x', x=7., y=9.), promotes=['x','y'])
+        g4.add_subsystem('c1', om.ExecComp('y=2.0*x', x=7., y=9.), promotes=['x','y'])
 
         g1a = par.add_subsystem('g1a', om.Group())
         g2a = g1a.add_subsystem('g2', om.Group(), promotes=['*'])
         g3a = g2a.add_subsystem('g3', om.Group())
         g4a = g3a.add_subsystem('g4', om.Group(), promotes=['*'])
-        c1 = g4a.add_subsystem('c1', om.ExecComp('y=2.0*x', x=7., y=9.), promotes=['x','y'])
+        g4a.add_subsystem('c1', om.ExecComp('y=2.0*x', x=7., y=9.), promotes=['x','y'])
 
         p.setup()
 

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -51,7 +51,6 @@ class QuadraticLinearize(QuadraticComp):
     def linearize(self, inputs, outputs, partials):
         a = inputs['a']
         b = inputs['b']
-        c = inputs['c']
         x = outputs['x']
 
         partials['x', 'a'] = x ** 2
@@ -83,7 +82,6 @@ class QuadraticJacVec(QuadraticComp):
                      d_inputs, d_outputs, d_residuals, mode):
         a = inputs['a']
         b = inputs['b']
-        c = inputs['c']
         x = outputs['x']
         if mode == 'fwd':
             if 'x' in d_residuals:

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -1,5 +1,4 @@
 """Simple example demonstrating how to implement an implicit component."""
-import sys
 import unittest
 
 from io import StringIO
@@ -391,9 +390,9 @@ class ImplicitCompTestCase(unittest.TestCase):
         self.prob.run_model()
 
         stream = StringIO()
-        states = self.prob.model.list_outputs(explicit=False, residuals=True,
-                                              prom_name=True, hierarchical=True,
-                                              out_stream=stream)
+        self.prob.model.list_outputs(explicit=False, residuals=True,
+                                     prom_name=True, hierarchical=True,
+                                     out_stream=stream)
 
         text = stream.getvalue()
         self.assertEqual(text.count('comp1.x'), 1)
@@ -533,7 +532,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
             def linearize(self, inputs, outputs, partials):
                 a = inputs['a']
                 b = inputs['b']
-                c = inputs['c']
+
                 x = outputs['x']
 
                 partials['x', 'a'] = x ** 2
@@ -610,7 +609,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
             def linearize(self, inputs, outputs, partials):
                 a = inputs['a']
                 b = inputs['b']
-                c = inputs['c']
+
                 x = outputs['x']
 
                 partials['x', 'a'] = x ** 2
@@ -663,7 +662,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
             def linearize(self, inputs, outputs, partials):
                 a = inputs['a']
                 b = inputs['b']
-                c = inputs['c']
+
                 x = outputs['x']
 
                 partials['x', 'a'] = x ** 2
@@ -845,7 +844,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
             def linearize(self, inputs, outputs, partials):
                 a = inputs['a']
                 b = inputs['b']
-                c = inputs['c']
+
                 x = outputs['x']
 
                 partials['x', 'a'] = x ** 2

--- a/openmdao/core/tests/test_indep_var_comp.py
+++ b/openmdao/core/tests/test_indep_var_comp.py
@@ -167,7 +167,7 @@ class TestIndepVarComp(unittest.TestCase):
 
     def test_invalid_tags(self):
         with self.assertRaises(TypeError) as cm:
-            comp = om.IndepVarComp('indep_var', tags=99)
+            om.IndepVarComp('indep_var', tags=99)
 
         self.assertEqual(str(cm.exception),
             "IndepVarComp: Value (99) of option 'tags' has type 'int', "

--- a/openmdao/core/tests/test_leaks.py
+++ b/openmdao/core/tests/test_leaks.py
@@ -1,19 +1,9 @@
 
 import unittest
-import gc
-from contextlib import contextmanager
-from types import FunctionType, MethodType, CoroutineType, GeneratorType, FrameType
-from collections import defaultdict
 from io import StringIO
 
 import openmdao.api as om
 from openmdao.core.tests.test_coloring import run_opt
-from openmdao.core.system import System
-from openmdao.vectors.vector import Vector
-from openmdao.solvers.solver import Solver
-from openmdao.core.driver import Driver
-from openmdao.jacobians.jacobian import Jacobian
-from openmdao.approximation_schemes.approximation_scheme import ApproximationScheme
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.devtools.memory import check_iter_leaks, list_iter_leaks
 from openmdao.utils.testing_utils import use_tempdirs

--- a/openmdao/core/tests/test_masking.py
+++ b/openmdao/core/tests/test_masking.py
@@ -2,8 +2,8 @@ import unittest
 import numpy as np
 from numpy.testing import assert_almost_equal
 
-from openmdao.api import Problem, Group, IndepVarComp, DirectSolver, NewtonSolver, \
-    ScipyKrylov, LinearRunOnce, LinearBlockGS
+from openmdao.api import Problem, IndepVarComp, DirectSolver, NewtonSolver, \
+    ScipyKrylov, LinearBlockGS
 
 from openmdao.test_suite.components.double_sellar import DoubleSellar, DoubleSellarImplicit
 

--- a/openmdao/core/tests/test_mpi_coloring_bug.py
+++ b/openmdao/core/tests/test_mpi_coloring_bug.py
@@ -12,9 +12,6 @@ from openmdao.utils.testing_utils import use_tempdirs
 # check that pyoptsparse is installed
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
-
 
 class TrajDesignParameterOptionsDictionary(om.OptionsDictionary):
 

--- a/openmdao/core/tests/test_mwe_matmat.py
+++ b/openmdao/core/tests/test_mwe_matmat.py
@@ -1,9 +1,5 @@
-import unittest
 
 from openmdao.api import ExplicitComponent
-from openmdao.api import Problem, IndepVarComp
-
-from openmdao.utils.mpi import MPI
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -247,20 +247,21 @@ class DecoupledTestCase(unittest.TestCase):
         root = prob.model
         root.linear_solver = om.LinearBlockGS()
 
-        Indep1 = root.add_subsystem('Indep1', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        Indep2 = root.add_subsystem('Indep2', om.IndepVarComp('x', np.arange(asize+2, dtype=float)+1.0))
+        root.add_subsystem('Indep1', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        root.add_subsystem('Indep2', om.IndepVarComp('x', np.arange(asize+2, dtype=float)+1.0))
+
         G1 = root.add_subsystem('G1', om.ParallelGroup())
         G1.linear_solver = om.LinearBlockGS()
 
-        c1 = G1.add_subsystem('c1', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
-                                                x=np.zeros(asize), y=np.zeros(asize)))
-        c2 = G1.add_subsystem('c2', om.ExecComp('y = x[:%d] * 2.0' % asize,
-                                                x=np.zeros(asize+2), y=np.zeros(asize)))
+        G1.add_subsystem('c1', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                           x=np.zeros(asize), y=np.zeros(asize)))
+        G1.add_subsystem('c2', om.ExecComp('y = x[:%d] * 2.0' % asize,
+                                           x=np.zeros(asize+2), y=np.zeros(asize)))
 
-        Con1 = root.add_subsystem('Con1', om.ExecComp('y = x * 5.0',
-                                                      x=np.zeros(asize), y=np.zeros(asize)))
-        Con2 = root.add_subsystem('Con2', om.ExecComp('y = x * 4.0',
-                                                      x=np.zeros(asize), y=np.zeros(asize)))
+        root.add_subsystem('Con1', om.ExecComp('y = x * 5.0',
+                                               x=np.zeros(asize), y=np.zeros(asize)))
+        root.add_subsystem('Con2', om.ExecComp('y = x * 4.0',
+                                               x=np.zeros(asize), y=np.zeros(asize)))
         root.connect('Indep1.x', 'G1.c1.x')
         root.connect('Indep2.x', 'G1.c2.x')
         root.connect('G1.c1.y', 'Con1.x')
@@ -361,18 +362,19 @@ class IndicesTestCase(unittest.TestCase):
         root = prob.model
         root.linear_solver = om.LinearBlockGS()
 
-        p = root.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        root.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+
         G1 = root.add_subsystem('G1', om.ParallelGroup())
         G1.linear_solver = om.LinearBlockGS()
 
-        c2 = G1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
-                                                x=np.zeros(asize), y=np.zeros(asize)))
-        c3 = G1.add_subsystem('c3', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
-                                                x=np.zeros(asize), y=np.zeros(asize)))
-        c4 = root.add_subsystem('c4', om.ExecComp('y = x * 4.0',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
-        c5 = root.add_subsystem('c5', om.ExecComp('y = x * 5.0',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
+        G1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
+                                           x=np.zeros(asize), y=np.zeros(asize)))
+        G1.add_subsystem('c3', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                           x=np.zeros(asize), y=np.zeros(asize)))
+        root.add_subsystem('c4', om.ExecComp('y = x * 4.0',
+                                             x=np.zeros(asize), y=np.zeros(asize)))
+        root.add_subsystem('c5', om.ExecComp('y = x * 5.0',
+                                             x=np.zeros(asize), y=np.zeros(asize)))
 
         prob.model.add_design_var('p.x', indices=[1, 2])
         prob.model.add_constraint('c4.y', upper=0.0, indices=[1], parallel_deriv_color='par_resp')
@@ -426,17 +428,17 @@ class IndicesTestCase2(unittest.TestCase):
         par2 = G1.add_subsystem('par2', om.Group())
         par2.linear_solver = om.LinearBlockGS()
 
-        p1 = par1.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
-        p2 = par2.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+10.0))
+        par1.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+1.0))
+        par2.add_subsystem('p', om.IndepVarComp('x', np.arange(asize, dtype=float)+10.0))
 
-        c2 = par1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
-        c3 = par2.add_subsystem('c3', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
-        c4 = par1.add_subsystem('c4', om.ExecComp('y = x * 4.0',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
-        c5 = par2.add_subsystem('c5', om.ExecComp('y = x * 5.0',
-                                                  x=np.zeros(asize), y=np.zeros(asize)))
+        par1.add_subsystem('c2', om.ExecComp('y = x * 2.0',
+                                             x=np.zeros(asize), y=np.zeros(asize)))
+        par2.add_subsystem('c3', om.ExecComp('y = ones(3).T*x.dot(arange(3.,6.))',
+                                             x=np.zeros(asize), y=np.zeros(asize)))
+        par1.add_subsystem('c4', om.ExecComp('y = x * 4.0',
+                                             x=np.zeros(asize), y=np.zeros(asize)))
+        par2.add_subsystem('c5', om.ExecComp('y = x * 5.0',
+                                             x=np.zeros(asize), y=np.zeros(asize)))
 
         prob.model.add_design_var('G1.par1.p.x', indices=[1, 2])
         prob.model.add_design_var('G1.par2.p.x', indices=[1, 2])
@@ -593,7 +595,7 @@ class PartialDependGroup(om.Group):
     def setup(self):
         size = 4
 
-        Comp1 = self.add_subsystem('Comp1', SumComp(size))
+        self.add_subsystem('Comp1', SumComp(size))
         pargroup = self.add_subsystem('ParallelGroup1', om.ParallelGroup())
 
         self.set_input_defaults('Comp1.x', val=np.arange(size, dtype=float)+1.0)
@@ -604,8 +606,8 @@ class PartialDependGroup(om.Group):
         pargroup.linear_solver.options['iprint'] = -1
 
         delay = .1
-        Con1 = pargroup.add_subsystem('Con1', SlowComp(delay=delay, size=2, mult=2.0))
-        Con2 = pargroup.add_subsystem('Con2', SlowComp(delay=delay, size=2, mult=-3.0))
+        pargroup.add_subsystem('Con1', SlowComp(delay=delay, size=2, mult=2.0))
+        pargroup.add_subsystem('Con2', SlowComp(delay=delay, size=2, mult=-3.0))
 
         self.connect('Comp1.y', 'ParallelGroup1.Con1.x')
         self.connect('Comp1.y', 'ParallelGroup1.Con2.x')
@@ -701,24 +703,25 @@ class CleanupTestCase(unittest.TestCase):
         root.linear_solver = om.LinearBlockGS()
         root.linear_solver.options['err_on_non_converge'] = True
 
-        inputs = root.add_subsystem("inputs", om.IndepVarComp("x", 1.0))
+        root.add_subsystem("inputs", om.IndepVarComp("x", 1.0))
+
         G1 = root.add_subsystem("G1", om.Group())
-        dparam = G1.add_subsystem("dparam", om.ExecComp("y = .5*x"))
-        G1_inputs = G1.add_subsystem("inputs", om.IndepVarComp("x", 1.5))
-        start = G1.add_subsystem("start", om.ExecComp("y = .7*x"))
-        timecomp = G1.add_subsystem("time", om.ExecComp("y = -.2*x"))
+        G1.add_subsystem("dparam", om.ExecComp("y = .5*x"))
+        G1.add_subsystem("inputs", om.IndepVarComp("x", 1.5))
+        G1.add_subsystem("start", om.ExecComp("y = .7*x"))
+        G1.add_subsystem("time", om.ExecComp("y = -.2*x"))
 
         G2 = G1.add_subsystem("G2", om.Group())
-        stage_step = G2.add_subsystem("stage_step",
-                                      om.ExecComp("y = -0.1*x + .5*x2 - .4*x3 + .9*x4"))
-        ode = G2.add_subsystem("ode", om.ExecComp("y = .8*x - .6*x2"))
-        dummy = G2.add_subsystem("dummy", om.IndepVarComp("x", 1.3))
+        G2.add_subsystem("stage_step",
+                         om.ExecComp("y = -0.1*x + .5*x2 - .4*x3 + .9*x4"))
+        G2.add_subsystem("ode", om.ExecComp("y = .8*x - .6*x2"))
+        G2.add_subsystem("dummy", om.IndepVarComp("x", 1.3))
 
-        step = G1.add_subsystem("step", om.ExecComp("y = -.2*x + .4*x2 - .4*x3"))
-        output = G1.add_subsystem("output", om.ExecComp("y = .6*x"))
+        G1.add_subsystem("step", om.ExecComp("y = -.2*x + .4*x2 - .4*x3"))
+        G1.add_subsystem("output", om.ExecComp("y = .6*x"))
 
-        con = root.add_subsystem("con", om.ExecComp("y = .2 * x"))
-        obj = root.add_subsystem("obj", om.ExecComp("y = .3 * x"))
+        root.add_subsystem("con", om.ExecComp("y = .2 * x"))
+        root.add_subsystem("obj", om.ExecComp("y = .3 * x"))
 
         root.connect("inputs.x", "G1.dparam.x")
 
@@ -744,13 +747,13 @@ class CleanupTestCase(unittest.TestCase):
         p.run_model()
 
         # test will fail if this fails to converge
-        J = p.compute_totals(['con.y', 'obj.y'],
-                             ['inputs.x'], return_format='dict')
+        p.compute_totals(['con.y', 'obj.y'],
+                         ['inputs.x'], return_format='dict')
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class CheckParallelDerivColoringEfficiency(unittest.TestCase):
-    # these tests check that redudant calls to compute_jacvec_product
+    # these tests check that redundant calls to compute_jacvec_product
     # are not performed when running parallel derivatives
     # ref issue 1405
 
@@ -771,7 +774,6 @@ class CheckParallelDerivColoringEfficiency(unittest.TestCase):
                 self.add_output('y2', shape=size)
 
             def compute(self, inputs, outputs):
-                waittime = self.options['time']
                 size = self.options['size']
                 outputs['y'] = np.linspace(3, 10, size) * inputs['x']
                 outputs['y2'] = np.linspace(2, 4, size) * inputs['x']
@@ -969,7 +971,7 @@ class LinearGroup(om.Group):
         self.options.declare("b", desc="y-intercept")
 
     def setup(self):
-        ivc = self.add_subsystem("ivc", om.IndepVarComp("x", val=0.0), promotes=["*"])
+        self.add_subsystem("ivc", om.IndepVarComp("x", val=0.0), promotes=["*"])
         self.add_subsystem("eval", LinearComp(a=self.options["a"], b=self.options["b"]), promotes=["*"])
         # Make x a dv for the linear equation
         self.add_design_var("x", lower=-100.0, upper=100.0)

--- a/openmdao/core/tests/test_parallel_fd.py
+++ b/openmdao/core/tests/test_parallel_fd.py
@@ -2,7 +2,6 @@
 import itertools
 import numpy as np
 import unittest
-TestCase = unittest.TestCase
 
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
@@ -101,7 +100,7 @@ def setup_diamond_model(par_fds, size, method, par_fd_at):
     return prob
 
 
-class SerialSimpleFDTestCase(TestCase):
+class SerialSimpleFDTestCase(unittest.TestCase):
 
     def test_serial_fd(self):
         size = 15
@@ -123,7 +122,7 @@ class SerialSimpleFDTestCase(TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-class ParallelSimpleFDTestCase2(TestCase):
+class ParallelSimpleFDTestCase2(unittest.TestCase):
 
     N_PROCS = 2
 
@@ -149,7 +148,7 @@ class ParallelSimpleFDTestCase2(TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-class ParallelFDTestCase5(TestCase):
+class ParallelFDTestCase5(unittest.TestCase):
 
     N_PROCS = 5
 
@@ -172,7 +171,7 @@ class ParallelFDTestCase5(TestCase):
         assert_near_equal(J['C1.y']['P1.x'], np.eye(size)*mult, 1e-6)
 
 
-class SerialDiamondFDTestCase(TestCase):
+class SerialDiamondFDTestCase(unittest.TestCase):
 
     def test_diamond_fd_totals(self):
         size = 15
@@ -198,7 +197,7 @@ class SerialDiamondFDTestCase(TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-class ParallelDiamondFDTestCase(TestCase):
+class ParallelDiamondFDTestCase(unittest.TestCase):
 
     N_PROCS = 4
 
@@ -256,7 +255,7 @@ def _test_func_name(func, num, param):
     for p in param.args:
         try:
             arg = p.__name__
-        except:
+        except Exception:
             arg = str(p)
         args.append(arg)
     return func.__name__ + '_' + '_'.join(args)

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -61,9 +61,6 @@ class TestParallelGroups(unittest.TestCase):
     def test_fan_out_grouped(self, solv_tup, nlsolver):
         prob = om.Problem(FanOutGrouped())
 
-        of=['c2.y', "c3.y"]
-        wrt=['iv.x']
-
         solver, jactype = solv_tup
 
         prob.model.linear_solver = solver()
@@ -309,9 +306,6 @@ class TestParallelGroupsMPI2(TestParallelGroups):
 
         model.connect('sub.c2.y', 'c2.x')
         model.connect('sub.c3.y', 'c3.x')
-
-        of=['c2.y', "c3.y"]
-        wrt=['iv.x']
 
         prob.setup(check=False, mode='fwd')
         prob.set_solver_print(level=0)
@@ -843,8 +837,8 @@ class TestSingleRankRunWithBcast(unittest.TestCase):
         par.add_subsystem('C1', BcastComp())
         par.add_subsystem('C2', BcastComp())
 
-        model.connect('indep.x', f'par.C1.x')
-        model.connect('indep.x', f'par.C2.x')
+        model.connect('indep.x', 'par.C1.x')
+        model.connect('indep.x', 'par.C2.x')
 
         # add component that uses outputs from parallel components
         model.add_subsystem('dummy_comp', DoubleComp())

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -47,7 +47,7 @@ def _test_func_name(func, num, param):
         for item in p:
             try:
                 arg = item.__name__
-            except:
+            except Exception:
                 arg = str(item)
             args.append(arg)
     return func.__name__ + '_' + '_'.join(args)
@@ -267,7 +267,7 @@ class TestParallelGroupsMPI2(TestParallelGroups):
 
     def test_zero_shape(self):
         raise unittest.SkipTest("zero shapes not fully supported yet")
-        class MultComp(ExplicitComponent):
+        class MultComp(om.ExplicitComponent):
             def __init__(self, mult):
                 self.mult = mult
                 super().__init__()

--- a/openmdao/core/tests/test_parallel_src_indices.py
+++ b/openmdao/core/tests/test_parallel_src_indices.py
@@ -1,10 +1,9 @@
 import unittest
 import numpy as np
 from openmdao.utils.mpi import MPI
-import traceback
 
 from openmdao.api import Problem
-from openmdao.api import ExplicitComponent, IndepVarComp
+from openmdao.api import ExplicitComponent
 from openmdao.api import NonlinearRunOnce, LinearRunOnce
 
 try:

--- a/openmdao/core/tests/test_partial_color.py
+++ b/openmdao/core/tests/test_partial_color.py
@@ -358,7 +358,7 @@ def _test_func_name(func, num, param):
     for p in param.args:
         try:
             arg = p.__name__
-        except:
+        except Exception:
             arg = str(p)
         args.append(arg)
     return func.__name__ + '_' + '_'.join(args)

--- a/openmdao/core/tests/test_partial_color.py
+++ b/openmdao/core/tests/test_partial_color.py
@@ -19,16 +19,14 @@ try:
 except ImportError:
     jax = None
 
-from openmdao.api import Problem, Group, IndepVarComp, ImplicitComponent, ExecComp, \
-    ExplicitComponent, NonlinearBlockGS, ScipyOptimizeDriver, NewtonSolver, DirectSolver, \
-        ImplicitFuncComp, slicer
+from openmdao.api import Problem, Group, IndepVarComp, ImplicitComponent, ExplicitComponent, \
+    NonlinearBlockGS, ScipyOptimizeDriver, NewtonSolver, DirectSolver, ImplicitFuncComp
 import openmdao.func_api as omf
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.utils.array_utils import evenly_distrib_idxs, rand_sparsity
+from openmdao.utils.assert_utils import assert_warning
+from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.utils.mpi import MPI
-from openmdao.utils.coloring import compute_total_coloring, Coloring
+from openmdao.utils.coloring import compute_total_coloring
 
-from openmdao.test_suite.components.simple_comps import DoubleArrayComp, NonSquareArrayComp
 
 try:
     from openmdao.parallel_api import PETScVector
@@ -692,8 +690,8 @@ class TestColoringSemitotals(unittest.TestCase):
         model.add_subsystem('indeps', indeps)
         sub = model.add_subsystem('sub', CounterGroup())
         sub.declare_coloring('*', method=method)
-        comp = sub.add_subsystem('comp', SparseCompExplicit(sparsity, method, isplit=isplit, osplit=osplit,
-                                                            sparse_partials=sparse_partials))
+        sub.add_subsystem('comp', SparseCompExplicit(sparsity, method, isplit=isplit, osplit=osplit,
+                                                     sparse_partials=sparse_partials))
 
         for conn in conns:
             model.connect(*conn)
@@ -708,10 +706,10 @@ class TestColoringSemitotals(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        derivs = prob.driver._compute_totals()  # this is when the dynamic coloring update happens
+        prob.driver._compute_totals()  # this is when the dynamic coloring update happens
 
         start_nruns = sub._nruns
-        derivs = prob.driver._compute_totals()
+        prob.driver._compute_totals()
         _check_partial_matrix(sub, sub._jacobian._subjacs_info, sparsity, method)
         self.assertEqual(sub._nruns - start_nruns, 10)
 
@@ -777,7 +775,7 @@ class TestColoringSemitotals(unittest.TestCase):
         prob.run_model()
 
         start_nruns = comp._nruns
-        derivs = prob.driver._compute_totals()
+        prob.driver._compute_totals()
 
         nruns = comp._nruns - start_nruns
         self.assertEqual(nruns, 10)
@@ -793,8 +791,8 @@ class TestColoringSemitotals(unittest.TestCase):
         model.add_subsystem('indeps', indeps)
         sub = model.add_subsystem('sub', CounterGroup())
         sub.declare_coloring('*', method='fd')
-        comp = sub.add_subsystem('comp', SparseCompExplicit(sparsity, 'fd', isplit=1, osplit=1,
-                                                            sparse_partials=False))
+        sub.add_subsystem('comp', SparseCompExplicit(sparsity, 'fd', isplit=1, osplit=1,
+                                                     sparse_partials=False))
         for conn in conns:
             model.connect(*conn)
 
@@ -974,7 +972,7 @@ class TestColoring(unittest.TestCase):
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 
         model.add_subsystem('indeps', indeps)
-        comp = model.add_subsystem('comp', SparseCompExplicit(sparsity, method, isplit=isplit, osplit=2))
+        model.add_subsystem('comp', SparseCompExplicit(sparsity, method, isplit=isplit, osplit=2))
         model.connect('indeps.x0', 'comp.x0')
         model.connect('indeps.x1', 'comp.x1')
         model.declare_coloring('*', method=method, step=1e-6 if method=='fd' else None)
@@ -1026,7 +1024,7 @@ class TestColoring(unittest.TestCase):
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 
         model.add_subsystem('indeps', indeps)
-        comp = model.add_subsystem('comp', SparseCompExplicit(sparsity, 'cs', isplit=isplit, osplit=2))
+        model.add_subsystem('comp', SparseCompExplicit(sparsity, 'cs', isplit=isplit, osplit=2))
         model.connect('indeps.x0', 'comp.x0')
         model.connect('indeps.x1', 'comp.x1')
 
@@ -1079,7 +1077,7 @@ class TestColoring(unittest.TestCase):
 
         model.nonlinear_solver = NonlinearBlockGS()
         model.add_subsystem('indeps', indeps)
-        comp = model.add_subsystem('comp', SparseCompImplicit(sparsity, method, isplit=isplit, osplit=2))
+        model.add_subsystem('comp', SparseCompImplicit(sparsity, method, isplit=isplit, osplit=2))
         model.connect('indeps.x0', 'comp.x0')
         model.connect('indeps.x1', 'comp.x1')
 
@@ -1131,9 +1129,9 @@ class TestColoring(unittest.TestCase):
         indeps, conns = setup_indeps(isplit, mask.shape[1], 'indeps', 'comp')
 
         model.add_subsystem('indeps', indeps)
-        comp = model.add_subsystem('comp', SparseCompExplicit(sparsity, method,
-                                                              isplit=isplit, osplit=2,
-                                                              sparse_partials=sparse_partials))
+        model.add_subsystem('comp', SparseCompExplicit(sparsity, method,
+                                                       isplit=isplit, osplit=2,
+                                                       sparse_partials=sparse_partials))
 
         model.connect('indeps.x0', 'comp.x0')
         model.connect('indeps.x1', 'comp.x1')

--- a/openmdao/core/tests/test_pre_post_iter.py
+++ b/openmdao/core/tests/test_pre_post_iter.py
@@ -309,7 +309,7 @@ class TestPrePostIter(unittest.TestCase):
         coloring_info.coloring = None
         coloring_info.dynamic = True
 
-        J = prob.compute_totals(of=['iter2.y', 'iter3.y'], wrt=['iter1.x3'], coloring_info=coloring_info)
+        prob.compute_totals(of=['iter2.y', 'iter3.y'], wrt=['iter1.x3'], coloring_info=coloring_info)
 
         data = prob.check_totals(of=['iter2.y', 'iter3.y'], wrt=['iter1.x3'], out_stream=None)
         assert_check_totals(data)

--- a/openmdao/core/tests/test_prob_remote.py
+++ b/openmdao/core/tests/test_prob_remote.py
@@ -7,8 +7,6 @@ import openmdao.api as om
 from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.utils.general_utils import set_pyoptsparse_opt
-from openmdao.proc_allocators.default_allocator import DefaultAllocator
-from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.utils.assert_utils import assert_near_equal
 
 
@@ -21,8 +19,6 @@ if MPI:
 
 # check that pyoptsparse is installed. if it is, try to use SLSQP.
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -330,8 +326,8 @@ class ProbRemote4TestCase(unittest.TestCase):
         p1.add_design_var('x', lower=-50.0, upper=50.0)
 
         par = model.add_subsystem('par', om.ParallelGroup())
-        c1 = par.add_subsystem('C1', om.ExecComp('y = x*x'))
-        c2 = par.add_subsystem('C2', om.ExecComp('y = x*x'))
+        par.add_subsystem('C1', om.ExecComp('y = x*x'))
+        par.add_subsystem('C2', om.ExecComp('y = x*x'))
 
         model.add_subsystem('obj', om.ExecComp('o = a + b + 2.'))
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1750,7 +1750,7 @@ class TestProblem(unittest.TestCase):
         strout = StringIO()
         sys.stdout = strout
         try:
-            l = prob.list_driver_vars(print_arrays=True,
+            dv = prob.list_driver_vars(print_arrays=True,
                                        desvar_opts=['lower', 'upper', 'ref', 'ref0',
                                                     'indices', 'adder', 'scaler',
                                                     'parallel_deriv_color',
@@ -1775,37 +1775,37 @@ class TestProblem(unittest.TestCase):
         self.assertRegex(output[13], r'^\s+array+\(+\[[0-9., e+-]+\]+\)')
 
         # design vars
-        self.assertEqual(l['design_vars'][0][1]['name'], 'z')
-        self.assertEqual(l['design_vars'][0][1]['size'], 2)
-        assert(all(l['design_vars'][0][1]['val'] == prob.get_val('z')))
-        self.assertEqual(l['design_vars'][0][1]['scaler'], None)
-        self.assertEqual(l['design_vars'][0][1]['adder'], None)
+        self.assertEqual(dv['design_vars'][0][1]['name'], 'z')
+        self.assertEqual(dv['design_vars'][0][1]['size'], 2)
+        assert(all(dv['design_vars'][0][1]['val'] == prob.get_val('z')))
+        self.assertEqual(dv['design_vars'][0][1]['scaler'], None)
+        self.assertEqual(dv['design_vars'][0][1]['adder'], None)
 
-        self.assertEqual(l['design_vars'][1][1]['name'], 'x')
-        self.assertEqual(l['design_vars'][1][1]['size'], 1)
-        assert(all(l['design_vars'][1][1]['val'] == prob.get_val('x')))
-        self.assertEqual(l['design_vars'][1][1]['scaler'], None)
-        self.assertEqual(l['design_vars'][1][1]['adder'], None)
+        self.assertEqual(dv['design_vars'][1][1]['name'], 'x')
+        self.assertEqual(dv['design_vars'][1][1]['size'], 1)
+        assert(all(dv['design_vars'][1][1]['val'] == prob.get_val('x')))
+        self.assertEqual(dv['design_vars'][1][1]['scaler'], None)
+        self.assertEqual(dv['design_vars'][1][1]['adder'], None)
 
         # constraints
-        self.assertEqual(l['constraints'][0][1]['name'], 'con1')
-        self.assertEqual(l['constraints'][0][1]['size'], 1)
-        assert(all(l['constraints'][0][1]['val'] == prob.get_val('con1')))
-        self.assertEqual(l['constraints'][0][1]['scaler'], None)
-        self.assertEqual(l['constraints'][0][1]['adder'], None)
+        self.assertEqual(dv['constraints'][0][1]['name'], 'con1')
+        self.assertEqual(dv['constraints'][0][1]['size'], 1)
+        assert(all(dv['constraints'][0][1]['val'] == prob.get_val('con1')))
+        self.assertEqual(dv['constraints'][0][1]['scaler'], None)
+        self.assertEqual(dv['constraints'][0][1]['adder'], None)
 
-        self.assertEqual(l['constraints'][1][1]['name'], 'con2')
-        self.assertEqual(l['constraints'][1][1]['size'], 1)
-        assert(all(l['constraints'][1][1]['val'] == prob.get_val('con2')))
-        self.assertEqual(l['constraints'][1][1]['scaler'], None)
-        self.assertEqual(l['constraints'][1][1]['adder'], None)
+        self.assertEqual(dv['constraints'][1][1]['name'], 'con2')
+        self.assertEqual(dv['constraints'][1][1]['size'], 1)
+        assert(all(dv['constraints'][1][1]['val'] == prob.get_val('con2')))
+        self.assertEqual(dv['constraints'][1][1]['scaler'], None)
+        self.assertEqual(dv['constraints'][1][1]['adder'], None)
 
         # objectives
-        self.assertEqual(l['objectives'][0][1]['name'], 'obj')
-        self.assertEqual(l['objectives'][0][1]['size'], 1)
-        assert(all(l['objectives'][0][1]['val'] == prob.get_val('obj')))
-        self.assertEqual(l['objectives'][0][1]['scaler'], None)
-        self.assertEqual(l['objectives'][0][1]['adder'], None)
+        self.assertEqual(dv['objectives'][0][1]['name'], 'obj')
+        self.assertEqual(dv['objectives'][0][1]['size'], 1)
+        assert(all(dv['objectives'][0][1]['val'] == prob.get_val('obj')))
+        self.assertEqual(dv['objectives'][0][1]['scaler'], None)
+        self.assertEqual(dv['objectives'][0][1]['adder'], None)
 
     def test_list_problem_vars_deprecated(self):
         model = SellarDerivatives()

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -445,12 +445,12 @@ class TestProblem(unittest.TestCase):
             seed_names = wrt
             result_names = of
             rvec = prob.model._vectors['output']['linear']
-            prob.model._vectors['residual']['linear']
+            # lvec = prob.model._vectors['residual']['linear']
         else:
             seed_names = of
             result_names = wrt
             rvec = prob.model._vectors['residual']['linear']
-            prob.model._vectors['output']['linear']
+            # lvec = prob.model._vectors['output']['linear']
 
         J = prob.compute_totals(of, wrt, return_format='array')
 
@@ -1763,7 +1763,7 @@ class TestProblem(unittest.TestCase):
                                                    'indices', 'adder', 'scaler',
                                                    'parallel_deriv_color',
                                                    'cache_linear_solution'],
-                                   )
+                                       )
         finally:
             sys.stdout = stdout
         output = strout.getvalue().split('\n')

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -181,7 +181,7 @@ class TestProblem(unittest.TestCase):
         prob.run_model()
 
         with self.assertRaises(KeyError) as cm:
-            totals = prob.compute_totals(of='comp.f_xy', wrt="p1.x, p2.y")
+            prob.compute_totals(of='comp.f_xy', wrt="p1.x, p2.y")
         self.assertEqual(str(cm.exception), "'p1.x, p2.y'")
 
     def test_compute_totals_cleanup(self):
@@ -445,12 +445,12 @@ class TestProblem(unittest.TestCase):
             seed_names = wrt
             result_names = of
             rvec = prob.model._vectors['output']['linear']
-            lvec = prob.model._vectors['residual']['linear']
+            prob.model._vectors['residual']['linear']
         else:
             seed_names = of
             result_names = wrt
             rvec = prob.model._vectors['residual']['linear']
-            lvec = prob.model._vectors['output']['linear']
+            prob.model._vectors['output']['linear']
 
         J = prob.compute_totals(of, wrt, return_format='array')
 
@@ -1074,7 +1074,7 @@ class TestProblem(unittest.TestCase):
         # using the promoted name of the inputs will raise an exception because the two promoted
         # inputs have different units and set_input_defaults was not called to disambiguate.
         with self.assertRaises(RuntimeError) as cm:
-            x = prob['G1.x']
+            prob['G1.x']
 
         msg = "<model> <class Group>: The following inputs, ['G1.C1.x', 'G1.C2.x'], promoted to 'G1.x', are connected but their metadata entries ['units'] differ. Call <group>.set_input_defaults('x', units=?), where <group> is the Group named 'G1' to remove the ambiguity."
         self.assertEqual(cm.exception.args[0], msg)

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -1,7 +1,5 @@
 
-import sys
 import unittest
-from io import StringIO
 
 from openmdao.api import ParallelGroup, Problem, IndepVarComp, ExecComp, PETScVector
 from openmdao.devtools.debug import comm_info
@@ -112,7 +110,7 @@ class ProcTestCase3(unittest.TestCase):
 
     def test_4_subs_with_mins(self):
         try:
-            p = _build_model(nsubs=4, min_procs=[1,2,2,1])
+            _build_model(nsubs=4, min_procs=[1,2,2,1])
         except Exception as err:
             self.assertEqual(str(err), "'par' <class ParallelGroup>: MPI process allocation failed: can't meet min_procs required because the sum of the min procs required exceeds the procs allocated and the min procs required is > 1 for the following subsystems: ['C1', 'C2']")
         else:
@@ -183,7 +181,7 @@ class ProcTestCase6(unittest.TestCase):
 
     def test_3_subs_over_max(self):
         try:
-            p = _build_model(nsubs=3, max_procs=[1, 2, 2])
+            _build_model(nsubs=3, max_procs=[1, 2, 2])
         except Exception as err:
             self.assertEqual(str(err), "'par' <class ParallelGroup>: too many MPI procs allocated. Comm is size 6 but can only use 5.")
         else:

--- a/openmdao/core/tests/test_proc_alloc.py
+++ b/openmdao/core/tests/test_proc_alloc.py
@@ -9,7 +9,7 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 try:
     from openmdao.api import PETScVector
-except:
+except Exception:
     PETScVector = None
 
 

--- a/openmdao/core/tests/test_renamed_resids.py
+++ b/openmdao/core/tests/test_renamed_resids.py
@@ -263,39 +263,39 @@ class ResidNamingTestCase(unittest.TestCase):
 
     def test_size_mismatch(self):
         with self.assertRaises(Exception) as cm:
-            prob = self._build_model(MyCompSizeMismatch)
+            self._build_model(MyCompSizeMismatch)
 
         self.assertEqual(cm.exception.args[0], "'MyComp' <class MyCompSizeMismatch>: The number of residuals (3) doesn't match number of outputs (2).  If any residuals are added using 'add_residuals', their total size must match the total size of the outputs.")
 
     def test_ref_shape_mismatch(self):
         with self.assertRaises(Exception) as cm:
-            prob = self._build_model(MyCompShapeMismatch)
+            self._build_model(MyCompShapeMismatch)
 
         self.assertEqual(cm.exception.args[0], "'MyComp' <class MyCompShapeMismatch>: When adding residual 'res1', expected shape (1,) but got shape (1, 2) for argument 'ref'.")
 
     def test_bad_unit(self):
         with self.assertRaises(Exception) as cm:
-            prob = self._build_model(MyCompBadUnits)
+            self._build_model(MyCompBadUnits)
 
         self.assertEqual(cm.exception.args[0], "'MyComp' <class MyCompBadUnits>: The units 'foobar/baz' are invalid.")
 
     def test_unit_mismatch(self):
         with self.assertRaises(Exception) as cm:
-            prob = self._build_model(MyCompUnitsMismatch)
+            self._build_model(MyCompUnitsMismatch)
 
         self.assertEqual(cm.exception.args[0], "'MyComp' <class MyCompUnitsMismatch>: residual units 'inch' for residual 'res1' != output res_units 'ft' for output 'Re'.")
 
     def test_ref_mismatch(self):
         with self.assertRaises(Exception) as cm:
-            prob = self._build_model(MyCompRefMismatch)
+            self._build_model(MyCompRefMismatch)
 
         self.assertEqual(cm.exception.args[0], "'MyComp' <class MyCompRefMismatch>: (4.0 != 3.0), 'ref' for residual 'res1' != 'res_ref' for output 'Re'.")
 
     def test_ref_mismatch_default_no_exception(self):
-        prob = self._build_model(MyCompRefMismatchDefault)
+        self._build_model(MyCompRefMismatchDefault)
 
     def test_ref_mismatch_default2_no_exception(self):
-        prob = self._build_model(MyCompRefMismatchDefault2)
+        self._build_model(MyCompRefMismatchDefault2)
 
     def test_analytic(self):
         prob = self._build_model(MyCompAnalytic)

--- a/openmdao/core/tests/test_run_root_only.py
+++ b/openmdao/core/tests/test_run_root_only.py
@@ -316,7 +316,7 @@ class TestRunRootOnlyErrors(unittest.TestCase):
         p.setup()
         with self.assertRaises(Exception) as cm:
             p.run_model()
-        self.assertEqual(cm.exception.args[0], f"'comp' <class MyComp>: Can't set 'run_root_only' option when a component has distributed variables.")
+        self.assertEqual(cm.exception.args[0], "'comp' <class MyComp>: Can't set 'run_root_only' option when a component has distributed variables.")
 
     def test_parallel_fd_err(self):
         class MyComp(om.ExplicitComponent):
@@ -336,7 +336,7 @@ class TestRunRootOnlyErrors(unittest.TestCase):
         p.setup()
         with self.assertRaises(Exception) as cm:
             p.run_model()
-        self.assertEqual(cm.exception.args[0], f"'comp' <class MyComp>: Can't set 'run_root_only' option when using parallel FD.")
+        self.assertEqual(cm.exception.args[0], "'comp' <class MyComp>: Can't set 'run_root_only' option when using parallel FD.")
 
     def test_parallel_deriv_color(self):
         class MyComp(om.ExplicitComponent):
@@ -358,6 +358,6 @@ class TestRunRootOnlyErrors(unittest.TestCase):
         p.setup(mode='rev')
         with self.assertRaises(Exception) as cm:
             p.run_model()
-        self.assertEqual(cm.exception.args[0], f"'comp' <class MyComp>: Can't set 'run_root_only' option when using parallel_deriv_color.")
+        self.assertEqual(cm.exception.args[0], "'comp' <class MyComp>: Can't set 'run_root_only' option when using parallel_deriv_color.")
 
 

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -1213,9 +1213,7 @@ class MyComp(om.ExplicitComponent):
                            [1.0, 6.0, -2.3, 1.0],
                            [7.0, 5.0, 1.1, 2.2],
                            [-3.0, 2.0, 6.8, -1.5]
-                           ])
-        np.repeat(np.arange(4), 4)
-        np.tile(np.arange(4), 4)
+                          ])
 
         self.declare_partials(of='x3_u_u', wrt='x2_u_u', val=self.J[0, 0])
         self.declare_partials(of='x3_u_u', wrt='x2_u_s', val=self.J[0, 1])
@@ -1237,8 +1235,7 @@ class MyComp(om.ExplicitComponent):
         self.declare_partials(of='x3_s_s', wrt='x2_s_u', val=self.J[3, 2])
         self.declare_partials(of='x3_s_s', wrt='x2_s_s', val=self.J[3, 3])
 
-    def compute(self, inputs, outputs, discrete_inputs=None,
-                discrete_outputs=None):
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
 
         outputs['x3_u_u'] = self.J[0, 0] * inputs['x2_u_u'] + self.J[0, 1] * inputs['x2_u_s'] + self.J[0, 2] * inputs['x2_s_u'] + self.J[0, 3] * inputs['x2_s_s']
         outputs['x3_u_s'] = self.J[1, 0] * inputs['x2_u_u'] + self.J[1, 1] * inputs['x2_u_s'] + self.J[1, 2] * inputs['x2_s_u'] + self.J[1, 3] * inputs['x2_s_s']

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -1492,7 +1492,7 @@ class TestResidualScaling(unittest.TestCase):
                 deltaV = inputs["V_in"] - inputs["V_out"]
                 Is = self.options["Is"]
                 Vt = self.options["Vt"]
-                I = Is * np.exp(deltaV / Vt)
+                I = Is * np.exp(deltaV / Vt)  # noqa: E741, allow "ambiguous" name I for current
 
                 J["I", "V_in"] = I / Vt
                 J["I", "V_out"] = -I / Vt

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -6,7 +6,6 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.core.driver import Driver
-from openmdao.utils.testing_utils import use_tempdirs
 
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayDense
@@ -900,7 +899,7 @@ class TestScaling(unittest.TestCase):
 
         model.add_subsystem('p1', om.IndepVarComp('x1', 1.0))
         model.add_subsystem('p2', om.IndepVarComp('x2', 1.0))
-        comp = model.add_subsystem('comp', ScalingExample1())
+        model.add_subsystem('comp', ScalingExample1())
         model.connect('p1.x1', 'comp.x1')
         model.connect('p2.x2', 'comp.x2')
 
@@ -922,7 +921,7 @@ class TestScaling(unittest.TestCase):
 
         model.add_subsystem('p1', om.IndepVarComp('x1', 1.0))
         model.add_subsystem('p2', om.IndepVarComp('x2', 1.0))
-        comp = model.add_subsystem('comp', ScalingExample2())
+        model.add_subsystem('comp', ScalingExample2())
         model.connect('p1.x1', 'comp.x1')
         model.connect('p2.x2', 'comp.x2')
 
@@ -944,7 +943,7 @@ class TestScaling(unittest.TestCase):
 
         model.add_subsystem('p1', om.IndepVarComp('x1', 1.0))
         model.add_subsystem('p2', om.IndepVarComp('x2', 1.0))
-        comp = model.add_subsystem('comp', ScalingExample3())
+        model.add_subsystem('comp', ScalingExample3())
         model.connect('p1.x1', 'comp.x1')
         model.connect('p2.x2', 'comp.x2')
 
@@ -965,7 +964,7 @@ class TestScaling(unittest.TestCase):
         model = prob.model
 
         model.add_subsystem('p', om.IndepVarComp('x', np.ones((2))))
-        comp = model.add_subsystem('comp', ScalingExampleVector())
+        model.add_subsystem('comp', ScalingExampleVector())
         model.connect('p.x', 'comp.x')
 
         prob.setup()
@@ -1215,8 +1214,8 @@ class MyComp(om.ExplicitComponent):
                            [7.0, 5.0, 1.1, 2.2],
                            [-3.0, 2.0, 6.8, -1.5]
                            ])
-        rows = np.repeat(np.arange(4), 4)
-        cols = np.tile(np.arange(4), 4)
+        np.repeat(np.arange(4), 4)
+        np.tile(np.arange(4), 4)
 
         self.declare_partials(of='x3_u_u', wrt='x2_u_u', val=self.J[0, 0])
         self.declare_partials(of='x3_u_u', wrt='x2_u_s', val=self.J[0, 1])
@@ -1314,7 +1313,7 @@ class TestScalingOverhaul(unittest.TestCase):
         inputs_comp.add_output('ox1_s_s', val=1.0)
 
         model.add_subsystem('p', inputs_comp)
-        mycomp = model.add_subsystem('comp', MyComp())
+        model.add_subsystem('comp', MyComp())
 
         model.connect('p.x1_u_u', 'comp.x2_u_u')
         model.connect('p.x1_u_s', 'comp.x2_u_s')
@@ -1412,7 +1411,7 @@ class TestScalingOverhaul(unittest.TestCase):
         inputs_comp.add_output('x1_u', val=1.0)
 
         model.add_subsystem('p', inputs_comp)
-        mycomp = model.add_subsystem('comp', MyImplicitComp())
+        model.add_subsystem('comp', MyImplicitComp())
 
         model.connect('p.x1_u', 'comp.x2_u')
 

--- a/openmdao/core/tests/test_simple_impl_comp.py
+++ b/openmdao/core/tests/test_simple_impl_comp.py
@@ -1,6 +1,4 @@
-import numpy as np
 import unittest
-import scipy.sparse.linalg
 
 from openmdao.api import Problem, ImplicitComponent, Group
 from openmdao.api import LinearBlockGS

--- a/openmdao/core/tests/test_src_indices.py
+++ b/openmdao/core/tests/test_src_indices.py
@@ -2,8 +2,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
-from openmdao.utils.om_warnings import  OMDeprecationWarning
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_totals
 
 class Inner(om.Group):
     def setup(self):
@@ -23,7 +22,7 @@ class SrcIndicesTestCase(unittest.TestCase):
     def test_one_nesting(self):
         prob = om.Problem()
         model = prob.model
-        comp = model.add_subsystem('src', om.ExecComp('y=3*x', x=np.zeros((7)), y=np.zeros((7))))
+        model.add_subsystem('src', om.ExecComp('y=3*x', x=np.zeros((7)), y=np.zeros((7))))
         model.add_subsystem('outer', Outer())
         model.connect('src.y', 'outer.desvar_x', src_indices=[2, 4], flat_src_indices=True)
         prob.setup()
@@ -50,7 +49,7 @@ class SrcIndicesTestCase(unittest.TestCase):
 
         g1 = p.model.add_subsystem('g1', om.Group())
         # c2 is vectorized calculations
-        c2 = g1.add_subsystem('c2', om.ExecComp('z = a * y', shape=(4,)))
+        g1.add_subsystem('c2', om.ExecComp('z = a * y', shape=(4,)))
 
         # The ultimate source of a and y may be scalar, or have some other arbitrary shape
         g1.promotes('c2', inputs=['a'], src_indices=[0, 0, 0, 0], src_shape=(1,))
@@ -83,11 +82,11 @@ class SrcIndicesTestCase(unittest.TestCase):
 
         g1 = p.model.add_subsystem('g1', om.Group(), promotes_inputs=['b'])
         # c1 contains scalar calculations
-        c1 = g1.add_subsystem('c1', om.ExecComp('y = a0 + b', shape=(1,)),
-                              promotes_inputs=[('a0', 'a'), 'b'], promotes_outputs=['y'])
+        g1.add_subsystem('c1', om.ExecComp('y = a0 + b', shape=(1,)),
+                         promotes_inputs=[('a0', 'a'), 'b'], promotes_outputs=['y'])
         g2 = g1.add_subsystem('g2', om.Group())
         # c2 is vectorized calculations
-        c2 = g2.add_subsystem('c2', om.ExecComp('z = a * y', shape=(4,)), promotes_inputs=['a', 'y'])
+        g2.add_subsystem('c2', om.ExecComp('z = a * y', shape=(4,)), promotes_inputs=['a', 'y'])
 
         g1.promotes('g2', inputs=['y'], src_indices=[0, 0, 0, 0], src_shape=(1,))
         g1.promotes('g2', inputs=['a'], src_indices=[0, 0, 0, 0], src_shape=(1,))
@@ -127,12 +126,12 @@ class SrcIndicesTestCase(unittest.TestCase):
 
         g1 = p.model.add_subsystem('g1', om.Group(), promotes_inputs=['b'])
         # c1 contains scalar calculations
-        c1 = g1.add_subsystem('c1', om.ExecComp('y = a0 + b', shape=(1,)),
-                              promotes_inputs=[('a0', 'a'), 'b'], promotes_outputs=['y'])
+        g1.add_subsystem('c1', om.ExecComp('y = a0 + b', shape=(1,)),
+                         promotes_inputs=[('a0', 'a'), 'b'], promotes_outputs=['y'])
 
         g2 = g1.add_subsystem('g2', om.Group())
         # c2 is vectorized calculations
-        c2 = g2.add_subsystem('c2',  om.ExecComp('z = a * y', shape=(4,)), promotes_inputs=['a', 'y'])
+        g2.add_subsystem('c2',  om.ExecComp('z = a * y', shape=(4,)), promotes_inputs=['a', 'y'])
 
         g1.promotes('g2', inputs=['a'], src_indices=[0, 0, 0, 0], src_shape=(1,))
         g1.promotes('g2', inputs=['y'], src_indices=[0, 0, 0, 0], src_shape=(1,))

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -209,7 +209,7 @@ class TestSystem(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             prob.model.list_inputs(return_format=dict)
 
-        msg = f"Invalid value (<class 'dict'>) for return_format, " \
+        msg = "Invalid value (<class 'dict'>) for return_format, " \
               "must be a string value of 'list' or 'dict'"
 
         self.assertEqual(str(cm.exception), msg)
@@ -217,7 +217,7 @@ class TestSystem(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             prob.model.list_outputs(return_format='dct')
 
-        msg = f"Invalid value ('dct') for return_format, " \
+        msg = "Invalid value ('dct') for return_format, " \
               "must be a string value of 'list' or 'dict'"
 
         self.assertEqual(str(cm.exception), msg)

--- a/openmdao/core/tests/test_system_set_solver_bounds_scaling_options.py
+++ b/openmdao/core/tests/test_system_set_solver_bounds_scaling_options.py
@@ -227,7 +227,7 @@ class TestSystemSetSolverOutputOptions(unittest.TestCase):
         prob.model.set_output_solver_options(name='comp.y1', ref=4)
         msg = "Problem .*: Before calling `run_model`, the `setup` method must be called if " \
               "set_output_solver_options has been called."
-        with self.assertRaisesRegex(RuntimeError, msg) as cm:
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.run_model()
 
         # also make sure it doesn't raise an error if done correctly with an additional call
@@ -246,7 +246,7 @@ class TestSystemSetSolverOutputOptions(unittest.TestCase):
         prob = Problem()
         model = prob.model
         # ScalingExample3 sets values for ref, res_ref, ref0, lower, and upper
-        comp = model.add_subsystem('comp', ScalingExample3())
+        model.add_subsystem('comp', ScalingExample3())
 
         # override all those values
         model.set_output_solver_options(name='comp.y1',
@@ -273,7 +273,7 @@ class TestSystemSetSolverOutputOptions(unittest.TestCase):
         prob.model.set_output_solver_options(name='lscomp.x', ref=5)
         msg = "Problem .*: Before calling `run_driver`, the `setup` method must be called if " \
               "set_output_solver_options has been called."
-        with self.assertRaisesRegex(RuntimeError, msg) as cm:
+        with self.assertRaisesRegex(RuntimeError, msg):
             prob.run_driver()
 
     def test_set_output_solver_options_vector_values(self):

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -476,11 +476,11 @@ def trace_dump(fname='trace_dump', skip=(), flush=True):
                 if 'self' in frame.f_locals:
                     try:
                         pname = frame.f_locals['self'].msginfo
-                    except:
+                    except Exception:
                         pass
                     try:
                         commsize = frame.f_locals['self'].comm.size
-                    except:
+                    except Exception:
                         pass
                 if pname is not None:
                     if not stack or pname != stack[-1][0]:
@@ -498,11 +498,11 @@ def trace_dump(fname='trace_dump', skip=(), flush=True):
                 if 'self' in frame.f_locals:
                     try:
                         pname = frame.f_locals['self'].msginfo
-                    except:
+                    except Exception:
                         pass
                     try:
                         commsize = frame.f_locals['self'].comm.size
-                    except:
+                    except Exception:
                         pass
                 print('   ' * len(stack), '<--', frame.f_code.co_name, "%s:%d" %
                       (frame.f_code.co_filename, frame.f_code.co_firstlineno),
@@ -804,7 +804,7 @@ def show_dist_var_conns(group, rev=False, out_stream=_DEFAULT_OUT_STREAM):
                             orstr = str(sorted_ranks)
                             if len(sorted_ranks) > 3:
                                 for j, r in enumerate(sorted_ranks):
-                                    if j == 0 or r - val == 1:
+                                    if j == 0 or r - val == 1:  # noqa: F821, val initialized below
                                         val = r
                                     else:
                                         break
@@ -818,7 +818,7 @@ def show_dist_var_conns(group, rev=False, out_stream=_DEFAULT_OUT_STREAM):
                             irstr = str(sorted(iranks))
                             if len(sorted_ranks) > 3:
                                 for j, r in enumerate(sorted_ranks):
-                                    if j == 0 or r - val == 1:
+                                    if j == 0 or r - val == 1:  # noqa: F821, val initialized below
                                         val = r
                                     else:
                                         break

--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -2,7 +2,6 @@
 
 
 import sys
-import pathlib
 from io import StringIO
 
 import numpy as np
@@ -11,7 +10,6 @@ from collections import Counter
 
 from openmdao.core.constants import _SetupStatus, _DEFAULT_OUT_STREAM
 from openmdao.utils.mpi import MPI
-from openmdao.utils.om_warnings import issue_warning, MPIWarning
 from openmdao.utils.reports_system import register_report
 from openmdao.utils.file_utils import text2html, _load_and_exec
 from openmdao.utils.rangemapper import RangeMapper
@@ -121,7 +119,6 @@ def tree(top, show_solvers=True, show_jacs=True, show_colors=True, show_approx=T
         indent = '    ' * (depth + tab)
         cprint(indent, end='')
 
-        info = ''
         if isinstance(s, Group):
             cprint("%s " % type(s).__name__, color=Fore.GREEN + Style.BRIGHT)
             cprint("%s" % s.name)
@@ -680,7 +677,8 @@ def show_dist_var_conns(group, rev=False, out_stream=_DEFAULT_OUT_STREAM):
         out_stream = sys.stdout
 
     if out_stream is None:
-        printer = lambda *args, **kwargs: None
+        def printer(*args, **kwargs):
+            return None
     else:
         printer = print
 

--- a/openmdao/devtools/iprof_mem.py
+++ b/openmdao/devtools/iprof_mem.py
@@ -1,16 +1,13 @@
 
 import sys
 import os
-import argparse
 import time
 import gc
 from importlib import import_module
-from collections import defaultdict
 from os.path import abspath, isfile, dirname, join
 from contextlib import contextmanager
 
-from openmdao.devtools.iprof_utils import find_qualified_name, func_group, \
-     _collect_methods, _setup_func_group, _get_methods, _Options
+from openmdao.devtools.iprof_utils import find_qualified_name, _Options
 from openmdao.utils.mpi import MPI
 from openmdao.devtools.debug import _get_color_printer
 
@@ -289,9 +286,7 @@ def postprocess_memtrace_tree(fname, min_mem=1.0, show_colors=True, rank=0, stre
     cprint, Fore, Back, Style = _get_color_printer(stream, show_colors, rank=rank)
 
     info = {}
-    cache = {}
 
-    top = None
     stack = []
     path_stack = []
     qual_cache = {}
@@ -399,9 +394,7 @@ def postprocess_memtrace_flat(fname, min_mem=1.0, show_colors=True, rank=0, stre
     cprint, Fore, Back, Style = _get_color_printer(stream, show_colors, rank=rank)
 
     info = {}
-    cache = {}
 
-    top = None
     stack = []
     qual_cache = {}
     maxmem = 0.0

--- a/openmdao/devtools/iprof_utils.py
+++ b/openmdao/devtools/iprof_utils.py
@@ -1,6 +1,4 @@
 
-import os
-import sys
 import ast
 
 from inspect import getmembers
@@ -108,7 +106,6 @@ def _setup_func_group():
 
     from openmdao.core.system import System
     from openmdao.core.group import Group
-    from openmdao.core.component import Component
     from openmdao.core.explicitcomponent import ExplicitComponent
     from openmdao.core.problem import Problem
     from openmdao.core.driver import Driver
@@ -119,7 +116,6 @@ def _setup_func_group():
     from openmdao.jacobians.jacobian import Jacobian
     from openmdao.matrices.matrix import Matrix
     from openmdao.vectors.default_vector import DefaultVector, DefaultTransfer
-    from openmdao.approximation_schemes.approximation_scheme import ApproximationScheme
 
     for class_ in [System, ExplicitComponent, Problem, Driver, _TotalJacInfo, Solver, LinearSolver,
                    NewtonSolver, Jacobian, Matrix, DefaultVector, DefaultTransfer, Group]:

--- a/openmdao/devtools/iprof_utils.py
+++ b/openmdao/devtools/iprof_utils.py
@@ -229,8 +229,8 @@ def _setup_func_group():
     })
 
     try:
-        from mpi4py import MPI
-        from petsc4py import PETSc
+        from mpi4py import MPI      # noqa: F401
+        from petsc4py import PETSc  # noqa: F401
         from openmdao.vectors.petsc_vector import PETScVector, PETScTransfer
 
         #TODO: this needs work.  Still lots of MPI calls not covered here...

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -2,15 +2,11 @@
 import os
 import sys
 from timeit import default_timer as etime
-import argparse
-import json
 import atexit
 from collections import defaultdict
-from itertools import chain
 
 from openmdao.utils.mpi import MPI
 
-from openmdao.utils.webview import webview
 from openmdao.devtools.iprof_utils import func_group, find_qualified_name, _collect_methods, \
      _setup_func_group, _get_methods, _Options
 

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -271,11 +271,13 @@ def _process_profile(flist):
     """
 
     nfiles = len(flist)
-    top_nodes = []
-    top_totals = []
 
     if nfiles == 1:
         return _process_1_profile(flist[0])
+
+    tot_names = []
+    top_nodes = []
+    top_totals = []
 
     for fname in sorted(flist):
         ext = os.path.splitext(fname)[1]
@@ -283,7 +285,7 @@ def _process_profile(flist):
             int(ext.lstrip('.'))
             dec = ext
             tot_names.append('$total' + dec)
-        except:
+        except Exception:
             dec = None
 
         nodes, tots = _process_1_profile(fname)
@@ -307,7 +309,6 @@ def _process_profile(flist):
     tree_nodes['$total'] = grand_total
 
     totals = {}
-    tot_names = []
     for i, tot in enumerate(top_totals):
         tot_names.append('$total.%d' % i)
         for name, tots in tot.items():

--- a/openmdao/devtools/iprofile_app/iprofile_app.py
+++ b/openmdao/devtools/iprofile_app/iprofile_app.py
@@ -55,7 +55,8 @@ def _stratify(call_data, sortby='time'):
     """
     depth_groups = []
     node_list = []  # all nodes in a single list
-    depthfunc=lambda d: d['depth']
+    def depthfunc(d):
+        return d['depth']
     for key, group in groupby(sorted(call_data.values(), key=depthfunc), key=depthfunc):
         # now further group each group by parent, then sort those in descending order
         # by 'sortby'
@@ -66,7 +67,6 @@ def _stratify(call_data, sortby='time'):
 
     max_depth = len(depth_groups)
     delta_y = 1.0 / max_depth
-    y = 0
     max_x = call_data['$total'][sortby]
 
     for depth, pardict in enumerate(depth_groups):
@@ -223,7 +223,7 @@ else:
             print("starting server on port %d" % options.port)
 
             serve_thread = _startThread(tornado.ioloop.IOLoop.current().start)
-            launch_thread = _startThread(lambda: _launch_browser(options.port))
+            _startThread(lambda: _launch_browser(options.port))
 
             while serve_thread.is_alive():
                 serve_thread.join(timeout=1)

--- a/openmdao/devtools/scripts/memplot.py
+++ b/openmdao/devtools/scripts/memplot.py
@@ -4,11 +4,8 @@ vs. time, with highligting of a specified function.
 """
 
 if __name__ == '__main__':
-    import sys
     import argparse
     import matplotlib.pyplot as plt
-    import numpy as np
-    from collections import defaultdict
 
     parser = argparse.ArgumentParser()
     parser.add_argument('-f', '--func', action='store', dest='func',

--- a/openmdao/devtools/tests/test_iprof_mem.py
+++ b/openmdao/devtools/tests/test_iprof_mem.py
@@ -71,8 +71,8 @@ class TestCmdlineMemory(unittest.TestCase):
         try:
             output = subprocess.check_output(cmd).decode('utf-8', 'ignore')
         except subprocess.CalledProcessError as err:
-            msg = "Running command '{}' failed. " + \
-                  "Output was: \n{}".format(cmd, err.output.decode('utf-8'))
+            msg = f"Running command '{cmd}' failed. " + \
+                  f"Output was: \n{err.output.decode('utf-8')}")
             self.fail(msg)
 
     def test_mem(self):

--- a/openmdao/devtools/tests/test_iprof_mem.py
+++ b/openmdao/devtools/tests/test_iprof_mem.py
@@ -1,8 +1,6 @@
 import unittest
 
-import types
 import os
-import sys
 import tempfile
 import shutil
 import subprocess

--- a/openmdao/devtools/tests/test_iprof_mem.py
+++ b/openmdao/devtools/tests/test_iprof_mem.py
@@ -69,11 +69,10 @@ class TestCmdlineMemory(unittest.TestCase):
 
     def _run_command(self, cmd):
         try:
-            output = subprocess.check_output(cmd).decode('utf-8', 'ignore')
+            subprocess.check_output(cmd).decode('utf-8', 'ignore')
         except subprocess.CalledProcessError as err:
-            msg = f"Running command '{cmd}' failed. " + \
-                  f"Output was: \n{err.output.decode('utf-8')}")
-            self.fail(msg)
+            self.fail(f"Running command '{cmd}' failed. " + \
+                      f"Output was: \n{err.output.decode('utf-8')}")
 
     def test_mem(self):
         self._run_command(['openmdao', 'mem', self.tstfile])

--- a/openmdao/devtools/tests/test_iprof_mem.py
+++ b/openmdao/devtools/tests/test_iprof_mem.py
@@ -51,7 +51,7 @@ class TestProfileMemory(unittest.TestCase):
 class TestCmdlineMemory(unittest.TestCase):
     def setUp(self):
         try:
-            import psutil
+            import psutil  # noqa: F401
         except ImportError:
             raise unittest.SkipTest("psutil is not installed")
 

--- a/openmdao/devtools/wingproj.py
+++ b/openmdao/devtools/wingproj.py
@@ -6,7 +6,6 @@ import os.path
 from os.path import exists, abspath, dirname, join
 import sys
 import fnmatch
-import logging
 from subprocess import Popen
 from configparser import ConfigParser
 from optparse import OptionParser
@@ -163,7 +162,7 @@ def run_wing():
     try:
         print("wing command: ", ' '.join(cmd))
         Popen(cmd, env=env)
-    except Exception as err:
+    except Exception:
         print("Failed to run command '%s'." % ' '.join(cmd))
 
 if __name__ == '__main__':

--- a/openmdao/devtools/wingproj.py
+++ b/openmdao/devtools/wingproj.py
@@ -64,13 +64,13 @@ def _find_wing():
         try:
             locs = [os.path.join(tdir, p, 'bin') for p in
                     fnmatch.filter(os.listdir(tdir), r'Wing IDE ?.?')]
-        except:
+        except Exception:
             locs = []
         tdir = r'C:\Program Files'
         try:
             locs.extend([os.path.join(tdir, p, 'bin') for p in
                          fnmatch.filter(os.listdir(tdir), r'Wing IDE ?.?')])
-        except:
+        except Exception:
             pass
     elif sys.platform == 'darwin':
         wname = 'wing'
@@ -89,7 +89,7 @@ def _find_wing():
     for path in all_locs:
         try:
             matches = fnmatch.filter(os.listdir(path), wname)
-        except:
+        except Exception:
             continue
         if matches:
             return os.path.join(path, sorted(matches)[-1])

--- a/openmdao/docs/openmdao_book/other/paraboloid.py
+++ b/openmdao/docs/openmdao_book/other/paraboloid.py
@@ -20,4 +20,4 @@ prob.set_val('paraboloid.x', 3.0)
 prob.set_val('paraboloid.y', -4.0)
 
 # run the optimization
-prob.run_driver();
+prob.run_driver()

--- a/openmdao/docs/openmdao_book/other_useful_docs/multipoint_beam_opt.py
+++ b/openmdao/docs/openmdao_book/other_useful_docs/multipoint_beam_opt.py
@@ -2,7 +2,6 @@
 import numpy as np
 
 import openmdao.api as om
-from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
 try:

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -11,7 +11,7 @@ except ImportError:
             raise unittest.SkipTest("tests require the 'playwright' and 'aiounittest' packages.")
 else:
     os.system("playwright install")
-    from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs
+    from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs  # noqa: E401
 
 
 if __name__ == "__main__":

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -3,8 +3,8 @@ import unittest
 import os
 
 try:
-    import playwright
-    import aiounittest
+    import playwright   # noqa: F401
+    import aiounittest  # noqa: F401
 except ImportError:
     class TestOpenMDAOJupyterBookDocs(unittest.TestCase):
         def test_jupyter_book_docs(self):

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -11,7 +11,7 @@ except ImportError:
             raise unittest.SkipTest("tests require the 'playwright' and 'aiounittest' packages.")
 else:
     os.system("playwright install")
-    from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs  # noqa: E401
+    from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs  # noqa: F401
 
 
 if __name__ == "__main__":

--- a/openmdao/docs/openmdao_book/theory_manual/sequence_diagrams/scaling_basic_compute_totals_direct.py
+++ b/openmdao/docs/openmdao_book/theory_manual/sequence_diagrams/scaling_basic_compute_totals_direct.py
@@ -3,7 +3,6 @@ Figure built manually in SVG.
 
 Note, these require the svgwrite package (and optionally, the svglib package to convert to pdf).
 """
-import subprocess
 
 from svgwrite import Drawing
 

--- a/openmdao/docs/openmdao_book/theory_manual/sequence_diagrams/scaling_basic_compute_totals_gmres.py
+++ b/openmdao/docs/openmdao_book/theory_manual/sequence_diagrams/scaling_basic_compute_totals_gmres.py
@@ -3,8 +3,6 @@ Figure built manually in SVG.
 
 Note, these require the svgwrite package (and optionally, the svglib package to convert to pdf).
 """
-import subprocess
-
 from svgwrite import Drawing
 
 filename = 'scaling_compute_totals_gmres.svg'

--- a/openmdao/docs/openmdao_book/theory_manual/sequence_diagrams/scaling_basic_run_model.py
+++ b/openmdao/docs/openmdao_book/theory_manual/sequence_diagrams/scaling_basic_run_model.py
@@ -3,8 +3,6 @@ Figure built manually in SVG.
 
 Note, these require the svgwrite package (and optionally, the svglib package to convert to pdf).
 """
-import subprocess
-
 from svgwrite import Drawing
 
 filename = 'scaling_run_model.svg'

--- a/openmdao/docs/upload_doc_version.py
+++ b/openmdao/docs/upload_doc_version.py
@@ -11,7 +11,7 @@ def get_tag_info():
     # using a pattern to only grab tags that are in version format "X.Y.Z"
     git_versions = subprocess.Popen(['git', 'tag', '-l', '*.*.*'],  # nosec: trusted input
                                     stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    cmd_out, cmd_err = git_versions.communicate()
+    cmd_out, _ = git_versions.communicate()
 
     cmd_out = cmd_out.decode('utf8')
     # take the output of git tag -l *.*.*, and split it from one string into a list.
@@ -29,7 +29,7 @@ def get_tag_info():
 
     cmd = subprocess.Popen(['git', 'rev-list', '-1', latest_tag, '-s'],  # nosec: trusted input
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    cmd_out, cmd_err = cmd.communicate()
+    cmd_out, _ = cmd.communicate()
 
     cmd_out = cmd_out.decode('utf8')
     commit_id = cmd_out.strip()
@@ -43,7 +43,7 @@ def get_commit_info():
     """
     git_commit = subprocess.Popen(['git', 'show', '--pretty=oneline', '-s'],  # nosec: trusted input
                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    cmd_out, cmd_err = git_commit.communicate()
+    cmd_out, _ = git_commit.communicate()
 
     cmd_out = cmd_out.decode('utf8')
     commit_id = cmd_out.split()[0]
@@ -104,7 +104,7 @@ def upload_doc_version(source_dir, destination, *args):
 
     try:
         subprocess.run(cmd, shell=True, check=True)  # nosec: trusted input
-    except:
+    except Exception:
         raise Exception('Doc transfer failed.')
     else:
         print("Uploaded documentation for", name if rel else "latest")

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -263,7 +263,6 @@ class DifferentialEvolutionDriver(Driver):
             Failure flag; True if failed to converge, False is successful.
         """
         self.result.reset()
-        model = self._problem().model
         ga = self._ga
 
         pop_size = self.options['pop_size']

--- a/openmdao/drivers/doe_driver.py
+++ b/openmdao/drivers/doe_driver.py
@@ -216,7 +216,7 @@ class DOEDriver(Driver):
                 if msg:
                     raise ValueError(msg)
 
-        with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
+        with RecordingDebugging(self._get_name(), self.iter_count, self):
             try:
                 self._run_solve_nonlinear()
                 metadata['success'] = 1

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -700,6 +700,7 @@ class GeneticAlgorithm(object):
 
         # Main Loop
         nfit = 0
+
         for generation in range(max_gen + 1):
             old_gen = copy.deepcopy(new_gen)
             x_pop = self.decode(old_gen, vlb, vub, bits)
@@ -766,9 +767,9 @@ class GeneticAlgorithm(object):
                 # previous generation.
                 if elite and generation > 0:
                     max_index = np.argmax(fitness[:, 0])
-                    old_gen[max_index] = min_gen
-                    x_pop[max_index] = min_x
-                    fitness[max_index, 0] = min_fit
+                    old_gen[max_index] = min_gen        # noqa: F821, min_gen initialized below
+                    x_pop[max_index] = min_x            # noqa: F821, min_x initialized below
+                    fitness[max_index, 0] = min_fit     # noqa: F821, min_fit initialized below
 
                 # Find best performing point in this generation.
                 min_fit = np.min(fitness)

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -700,7 +700,6 @@ class GeneticAlgorithm(object):
 
         # Main Loop
         nfit = 0
-
         for generation in range(max_gen + 1):
             old_gen = copy.deepcopy(new_gen)
             x_pop = self.decode(old_gen, vlb, vub, bits)
@@ -774,7 +773,7 @@ class GeneticAlgorithm(object):
                 # Find best performing point in this generation.
                 min_fit = np.min(fitness)
                 min_index = np.argmin(fitness)
-                # min_gen = old_gen[min_index]
+                min_gen = old_gen[min_index]  # noqa: F841, used above
                 min_x = x_pop[min_index]
 
                 if min_fit < fopt:

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -773,7 +773,7 @@ class GeneticAlgorithm(object):
                 # Find best performing point in this generation.
                 min_fit = np.min(fitness)
                 min_index = np.argmin(fitness)
-                min_gen = old_gen[min_index]
+                # min_gen = old_gen[min_index]
                 min_x = x_pop[min_index]
 
                 if min_fit < fopt:

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -5,7 +5,6 @@ pyoptsparse is based on pyOpt, which is an object-oriented framework for
 formulating and solving nonlinear constrained optimization problems, with
 additional MPI capability.
 """
-import pathlib
 import sys
 import json
 import signal
@@ -22,7 +21,7 @@ except ImportError:
 except Exception as err:
     pyoptsparse = err
 
-from openmdao.core.constants import INT_DTYPE, _DEFAULT_REPORTS_DIR, _ReprClass
+from openmdao.core.constants import _DEFAULT_REPORTS_DIR, _ReprClass
 from openmdao.core.analysis_error import AnalysisError
 from openmdao.core.driver import Driver, RecordingDebugging, filter_by_meta
 from openmdao.core.group import Group
@@ -523,7 +522,7 @@ class pyOptSparseDriver(Driver):
             _tmp = __import__('pyoptsparse', globals(), locals(), [optimizer], 0)
             opt = getattr(_tmp, optimizer)()
 
-        except Exception as err:
+        except Exception:
             # Change whatever pyopt gives us to an ImportError, give it a readable message,
             # but raise with the original traceback.
             msg = "Optimizer %s is not available in this installation." % optimizer
@@ -600,7 +599,7 @@ class pyOptSparseDriver(Driver):
                           storeHistory=self.options['hist_file'],
                           hotStart=self.options['hotstart_file'])
 
-        except Exception as c:
+        except Exception:
             if self._exc_info is None:
                 raise
 

--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -626,7 +626,7 @@ class ScipyOptimizeDriver(Driver):
 
             self._update_design_vars(x_new)
 
-            with RecordingDebugging(self._get_name(), self.iter_count, self) as rec:
+            with RecordingDebugging(self._get_name(), self.iter_count, self):
                 self.iter_count += 1
                 with model._relevance.nonlinear_active('iter'):
                     self._run_solve_nonlinear()
@@ -638,7 +638,7 @@ class ScipyOptimizeDriver(Driver):
 
             self._con_cache = self.get_constraint_values()
 
-        except Exception as msg:
+        except Exception:
             if self._exc_info is None:  # only record the first one
                 self._exc_info = sys.exc_info()
             return 0

--- a/openmdao/drivers/tests/test_analysis_errors.py
+++ b/openmdao/drivers/tests/test_analysis_errors.py
@@ -10,8 +10,6 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs, parameterized_name, require_pyoptsparse
 from openmdao.test_suite.components.paraboloid_invalid_region import Paraboloid
 
-from openmdao.utils.mpi import MPI
-
 try:
     from parameterized import parameterized
 except ImportError:
@@ -148,7 +146,6 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
                                    f"Found {errs} {func} errors in CONMIN.out, expected {err_count}")
 
         elif optimizer == 'IPOPT':
-            output_dir = prob.get_outputs_dir()
             with open(f"{prob.get_outputs_dir()}/IPOPT.out", encoding="utf-8") as f:
                 IPOPT_history = f.read()
 

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -17,7 +17,7 @@ from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar_feature import SellarMDA
 
 from openmdao.utils.general_utils import run_driver
-from openmdao.utils.testing_utils import use_tempdirs, set_env_vars_context
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 from openmdao.utils.mpi import MPI
 try:
@@ -395,9 +395,9 @@ class TestDifferentialEvolution(unittest.TestCase):
             prob.final_setup()
 
         # A value of None for lower and upper is changed to +/- INF_BOUND in add_design_var()
-        if lower == None:
+        if lower is None:
             lower = -INF_BOUND
-        if upper == None:
+        if upper is None:
             upper = INF_BOUND
 
         msg = ("Invalid bounds for design variable 'x'. When using "
@@ -648,10 +648,10 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
     def test_driver_supports(self):
         prob = om.Problem()
 
-        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
+        prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
 
         # setup the optimization
-        driver = prob.driver = om.DifferentialEvolutionDriver()
+        prob.driver = om.DifferentialEvolutionDriver()
 
         with self.assertRaises(KeyError) as raises_msg:
             prob.driver.supports['equality_constraints'] = False
@@ -848,9 +848,9 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
             prob.final_setup()
 
         # A value of None for lower and upper is changed to +/- INF_BOUND in add_constraint()
-        if lower == None:
+        if lower is None:
             lower = -INF_BOUND
-        if upper == None:
+        if upper is None:
             upper = INF_BOUND
 
         msg = ("Invalid bounds for constraint 'const.g'. "
@@ -956,9 +956,6 @@ class D1(om.ExplicitComponent):
             outputs['y1'] = 28.0 - 0.2*y2 + x
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
-        y2 = inputs['y2']
-        x = inputs['x']
-
         partials['y1', 'y2'] = -0.2
         if self.comm.rank == 1:
             partials['y1', 'x'] = 2.0
@@ -978,7 +975,7 @@ class D2(om.ExplicitComponent):
         y1 = inputs['y1']
 
         if self.comm.rank == 1:
-            outputs['y2'] = y2 = y1**.5 - 3
+            outputs['y2'] = y1**.5 - 3
         else:
             outputs['y2'] = y1**.5 + 7
 

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -591,9 +591,6 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
     def tearDown(self):
         del os.environ['DifferentialEvolutionDriver_seed']  # clean up environment
 
-    def tearDown(self):
-        del os.environ['DifferentialEvolutionDriver_seed']  # clean up environment
-
     def test_constrained_with_penalty(self):
         class Cylinder(om.ExplicitComponent):
             def setup(self):

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1271,7 +1271,6 @@ class TestDOEDriver(unittest.TestCase):
         prob.cleanup()
 
         cr = om.CaseReader("cases.sql")
-        cases = cr.list_cases('problem', out_stream=None)
 
         case = cr.get_case('end')
         inputs = case.inputs
@@ -2190,7 +2189,7 @@ class TestParallelDOE2proc(unittest.TestCase):
 
         # Test for missing metadata db file error
         try:
-            cr_test = om.CaseReader(filename, metadata_filename='nonexistant_filename')
+            om.CaseReader(filename, metadata_filename='nonexistant_filename')
             found_metadata = True
         except IOError:
             found_metadata = False

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -1600,43 +1600,6 @@ class TestDOEDriverListVars(unittest.TestCase):
         prob.run_driver()
         prob.cleanup()
 
-        prob.list_driver_vars()
-
-
-@use_tempdirs
-class TestDOEDriverListVars(unittest.TestCase):
-
-    def test_list_driver_vars(self):
-        # this passes if no exception is raised
-
-        prob = om.Problem()
-        model = prob.model
-
-        # Add independent variables
-        indeps = model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
-        indeps.add_discrete_output('x', 4)
-        indeps.add_discrete_output('y', 3)
-
-        # Add components
-        model.add_subsystem('parab', ParaboloidDiscrete(), promotes=['*'])
-
-        # Specify design variable range and objective
-        model.add_design_var('x')
-        model.add_design_var('y')
-        model.add_objective('f_xy')
-
-        samples = [[('x', 5), ('y', 1)],
-                   [('x', 3), ('y', 6)],
-                   [('x', -1), ('y', 3)],
-        ]
-
-        # Setup driver for 3 cases at a time
-        prob.driver = om.DOEDriver(om.ListGenerator(samples))
-
-        prob.setup(derivatives=False)
-        prob.run_driver()
-        prob.cleanup()
-
         f = StringIO()
         prob.list_driver_vars(out_stream=f)
         output = f.getvalue()

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -18,7 +18,7 @@ from openmdao.test_suite.components.sellar_feature import SellarMDA
 from openmdao.test_suite.components.three_bar_truss import ThreeBarTruss
 
 from openmdao.utils.general_utils import run_driver
-from openmdao.utils.testing_utils import use_tempdirs, set_env_vars_context
+from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 try:
     from parameterized import parameterized
@@ -541,9 +541,9 @@ class TestSimpleGA(unittest.TestCase):
             prob.final_setup()
 
         # A value of None for lower and upper is changed to +/- INF_BOUND in add_design_var()
-        if lower == None:
+        if lower is None:
             lower = -INF_BOUND
-        if upper == None:
+        if upper is None:
             upper = INF_BOUND
 
         msg = ("Invalid bounds for design variable 'x'. When using "
@@ -828,10 +828,10 @@ class TestConstrainedSimpleGA(unittest.TestCase):
 
         prob = om.Problem()
 
-        indeps = prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
+        prob.model.add_subsystem('indeps', om.IndepVarComp(), promotes=['*'])
 
         # setup the optimization
-        driver = prob.driver = om.SimpleGADriver()
+        prob.driver = om.SimpleGADriver()
 
         with self.assertRaises(KeyError) as raises_msg:
             prob.driver.supports['equality_constraints'] = False
@@ -1038,9 +1038,9 @@ class TestConstrainedSimpleGA(unittest.TestCase):
             prob.final_setup()
 
         # A value of None for lower and upper is changed to +/- INF_BOUND in add_constraint()
-        if lower == None:
+        if lower is None:
             lower = -INF_BOUND
-        if upper == None:
+        if upper is None:
             upper = INF_BOUND
 
         msg = ("Invalid bounds for constraint 'const.g'. "
@@ -1251,9 +1251,6 @@ class D1(om.ExplicitComponent):
             outputs['y1'] = 28.0 - 0.2*y2 + x
 
     def compute_partials(self, inputs, partials, discrete_inputs=None):
-        y2 = inputs['y2']
-        x = inputs['x']
-
         partials['y1', 'y2'] = -0.2
         if self.comm.rank == 1:
             partials['y1', 'x'] = 2.0
@@ -1273,7 +1270,7 @@ class D2(om.ExplicitComponent):
         y1 = inputs['y1']
 
         if self.comm.rank == 1:
-            outputs['y2'] = y2 = y1**.5 - 3
+            outputs['y2'] = y1**.5 - 3
         else:
             outputs['y2'] = y1**.5 + 7
 

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -16,7 +16,7 @@ from openmdao.test_suite.components.paraboloid_problem import ParaboloidProblem
 from openmdao.test_suite.components.paraboloid_distributed import DistParab
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
-from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver 
+from openmdao.utils.general_utils import set_pyoptsparse_opt, run_driver
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.om_warnings import OMDeprecationWarning
 from openmdao.utils.mpi import MPI
@@ -2375,9 +2375,12 @@ class TestPyoptSparse(unittest.TestCase):
         p.model.add_objective('exec.y', index=50)
         p.model.add_constraint('exec.z', indices=[0], equals=25)
 
-        msg = "Constraint 'exec.z' already exists. Use the 'alias' argument to apply a second constraint"
-        with self.assertRaises(RuntimeError) as msg:
+        with self.assertRaises(RuntimeError) as ctx:
             p.model.add_constraint('exec.z', indices=[-1], lower=20)
+
+        self.assertEqual(str(ctx.exception),
+                         "<class Group>: Constraint 'exec.z' already exists. "
+                         "Use the 'alias' argument to apply a second constraint")
 
     def test_obj_and_con_same_var_different_indices(self):
 
@@ -2572,7 +2575,6 @@ class TestPyoptSparse(unittest.TestCase):
         prob.setup(force_alloc_complex=True)
         prob.run_model()
 
-        desvar = prob.driver.get_design_var_values()
         con = prob.driver.get_constraint_values()
 
         assert_near_equal(con['a1'], 24.0)
@@ -3254,7 +3256,6 @@ class TestPyoptSparseSnoptFeature(unittest.TestCase):
         import signal
 
         prob = om.Problem()
-        model = prob.model
 
         prob.driver = om.pyOptSparseDriver()
         prob.driver.options['optimizer'] = "SNOPT"

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -226,14 +226,11 @@ class TestMPIScatter(unittest.TestCase):
 
         prob.run_driver()
 
-        desvar = prob.driver.get_design_var_values()
         con = prob.driver.get_constraint_values()
         obj = prob.driver.get_objective_values()
 
         assert_near_equal(obj['f_sum'], 0.0, 2e-6)
-        assert_near_equal(con['f_xy'],
-                          np.zeros(7),
-                          1e-5)
+        assert_near_equal(con['f_xy'], np.zeros(7), 1e-5)
 
     @require_pyoptsparse('ParOpt')
     def test_paropt_distcomp(self):
@@ -266,14 +263,11 @@ class TestMPIScatter(unittest.TestCase):
 
         prob.run_driver()
 
-        desvar = prob.driver.get_design_var_values()
         con = prob.driver.get_constraint_values()
         obj = prob.driver.get_objective_values()
 
         assert_near_equal(obj['sum.f_sum'], 0.0, 4e-6)
-        assert_near_equal(con['parab.f_xy'],
-                          np.zeros(7),
-                          1e-5)
+        assert_near_equal(con['parab.f_xy'], np.zeros(7), 1e-5)
 
 
 @require_pyoptsparse(OPTIMIZER)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -156,7 +156,6 @@ class TestMPIScatter(unittest.TestCase):
 
         prob.run_driver()
 
-        desvar = prob.driver.get_design_var_values()
         con = prob.driver.get_constraint_values()
         obj = prob.driver.get_objective_values()
 
@@ -1650,7 +1649,7 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=False)
 
-        failed = not prob.run_driver().success
+        prob.run_driver()
 
         assert_near_equal(prob['z'][0], 1.9776, 1e-3)
         assert_near_equal(prob['z'][1], 0.0, 1e-3)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -9,8 +9,6 @@ from packaging.version import Version
 import numpy as np
 from scipy import __version__ as scipy_version
 
-ScipyVersion = Version(scipy_version)
-
 import openmdao.api as om
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense, TestExplCompArraySparse, TestExplCompArrayJacVec
 from openmdao.test_suite.components.paraboloid import Paraboloid
@@ -31,6 +29,10 @@ try:
 except ImportError:
     vector_class = om.DefaultVector
     PETScVector = None
+
+
+ScipyVersion = Version(scipy_version)
+
 
 def rosenbrock(x):
     x_0 = x[:-1]

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -49,21 +49,11 @@ class TestCheckConfig(unittest.TestCase):
         p.setup(check=['cycles', 'out_of_order'], logger=testlogger)
         p.final_setup()
 
-        expected_info = (
-            "The following groups contain cycles:\n"
-            "   Group '' has the following cycles: [['C1', 'C2', 'C4']]\n"
-        )
-
-        expected_warning = (
-            "The following systems are executed out-of-order:\n"
-            "   System 'C3' executes out-of-order with respect to its source systems ['C4']\n"
-        )
-
-        msg = '\n'.join(testlogger._msgs['info'])
         testlogger.find_in('info', "The following groups contain cycles:")
         testlogger.find_in('info', "   Group '' has the following cycles:")
         testlogger.find_in('info', "      ['C1', 'C2', 'C4']")
-        testlogger.find_in('warning', expected_warning)
+        testlogger.find_in('warning', "The following systems are executed out-of-order:\n"
+            "   System 'C3' executes out-of-order with respect to its source systems ['C4']\n")
 
     def test_parallel_group_order(self):
         prob = om.Problem()

--- a/openmdao/error_checking/tests/test_check_solvers.py
+++ b/openmdao/error_checking/tests/test_check_solvers.py
@@ -1,7 +1,7 @@
 
 import unittest
 
-from openmdao.api import Problem, Group, IndepVarComp, ImplicitComponent, ExecComp, \
+from openmdao.api import Problem, Group, IndepVarComp, ExecComp, \
     LinearBlockGS, NonlinearBlockGS, DirectSolver
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.test_suite.components.sellar import StateConnection
@@ -221,9 +221,9 @@ class TestCheckSolvers(unittest.TestCase):
         prob = Problem()
         model = prob.model
 
-        C1 = model.add_subsystem("C1", ExecComp('y=2.0*x'))
-        C2 = model.add_subsystem("C2", ExecComp('y=2.0*x'))
-        C3 = model.add_subsystem("C3", ExecComp('y=2.0*x'))
+        model.add_subsystem("C1", ExecComp('y=2.0*x'))
+        model.add_subsystem("C2", ExecComp('y=2.0*x'))
+        model.add_subsystem("C3", ExecComp('y=2.0*x'))
 
         model.connect('C1.y','C2.x')
         model.connect('C2.y','C3.x')
@@ -247,9 +247,9 @@ class TestCheckSolvers(unittest.TestCase):
         prob = Problem()
         model = prob.model
 
-        C1 = model.add_subsystem("C1", ExecComp('y=2.0*x'))
-        C2 = model.add_subsystem("C2", ExecComp('y=2.0*x'))
-        C3 = model.add_subsystem("C3", ExecComp('y=2.0*x'))
+        model.add_subsystem("C1", ExecComp('y=2.0*x'))
+        model.add_subsystem("C2", ExecComp('y=2.0*x'))
+        model.add_subsystem("C3", ExecComp('y=2.0*x'))
 
         model.connect('C1.y','C2.x')
         model.connect('C2.y','C3.x')
@@ -274,9 +274,9 @@ class TestCheckSolvers(unittest.TestCase):
         model = prob.model
 
         G1 = model.add_subsystem("G1", Group())
-        C1 = G1.add_subsystem("C1", ExecComp('y=2.0*x'))
-        C2 = G1.add_subsystem("C2", ExecComp('y=2.0*x'))
-        C3 = G1.add_subsystem("C3", ExecComp('y=2.0*x'))
+        G1.add_subsystem("C1", ExecComp('y=2.0*x'))
+        G1.add_subsystem("C2", ExecComp('y=2.0*x'))
+        G1.add_subsystem("C3", ExecComp('y=2.0*x'))
 
         G1.connect('C1.y','C2.x')
         G1.connect('C2.y','C3.x')

--- a/openmdao/jacobians/jacobian.py
+++ b/openmdao/jacobians/jacobian.py
@@ -7,9 +7,7 @@ from scipy.sparse import issparse
 
 from openmdao.core.constants import INT_DTYPE
 from openmdao.utils.name_maps import key2abs_key
-from openmdao.utils.array_utils import sparse_subinds
 from openmdao.matrices.matrix import sparse_types
-from openmdao.vectors.vector import _full_slice
 
 SUBJAC_META_DEFAULTS = {
     'rows': None,

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -98,7 +98,7 @@ class MyExplicitComp2(ExplicitComponent):
 
     def compute_partials(self, inputs, partials):
         w = inputs['w']
-        z = inputs['z']
+
         jac = self._jac_type(np.array([[
             2.0*w[0] - 10.0,
             2.0*w[1] + 2.0,

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -220,7 +220,7 @@ def _test_func_name(func, num, param):
     for p in param.args:
         try:
             arg = p.__name__
-        except:
+        except Exception:
             arg = str(p)
         args.append(arg)
     return 'test_jacobian_src_indices_' + '_'.join(args)

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -1,7 +1,6 @@
 """ Test the Jacobian objects."""
 
 import itertools
-import sys
 import unittest
 
 import numpy as np
@@ -445,7 +444,7 @@ class TestJacobian(unittest.TestCase):
         sub1 = sup.add_subsystem('sub1', Group(), promotes=['*'])
         sub2 = sup.add_subsystem('sub2', Group(), promotes=['*'])
 
-        d1 = sub1.add_subsystem('d1', TwoSellarDis1(), promotes=['x', 'z', 'y1', 'y2'])
+        sub1.add_subsystem('d1', TwoSellarDis1(), promotes=['x', 'z', 'y1', 'y2'])
         sub2.add_subsystem('d2', TwoSellarDis2(), promotes=['z', 'y1', 'y2'])
 
         model.add_subsystem('con_cmp1', ExecComp('con1 = 3.16 - y1[0] - y1[1]', y1=np.array([0.0, 0.0])),
@@ -467,7 +466,7 @@ class TestJacobian(unittest.TestCase):
         wrt = ['x', 'z']
 
         # Make sure we don't get a size mismatch.
-        derivs = prob.compute_totals(of=of, wrt=wrt)
+        prob.compute_totals(of=of, wrt=wrt)
 
     def test_assembled_jac_bad_key(self):
         # this test fails if AssembledJacobian._update sets in_start with 'output' instead of 'input'
@@ -475,8 +474,8 @@ class TestJacobian(unittest.TestCase):
         prob.model = Group(assembled_jac_type='dense')
         prob.model.add_subsystem('indep', IndepVarComp('x', 1.0))
         prob.model.add_subsystem('C1', ExecComp('c=a*2.0+b', a=0., b=0., c=0.))
-        c2 = prob.model.add_subsystem('C2', ExecComp('d=a*2.0+b+c', a=0., b=0., c=0., d=0.))
-        c3 = prob.model.add_subsystem('C3', ExecComp('ee=a*2.0', a=0., ee=0.))
+        prob.model.add_subsystem('C2', ExecComp('d=a*2.0+b+c', a=0., b=0., c=0., d=0.))
+        prob.model.add_subsystem('C3', ExecComp('ee=a*2.0', a=0., ee=0.))
 
         prob.model.nonlinear_solver = NewtonSolver(solve_subsystems=False)
         prob.model.linear_solver = DirectSolver(assemble_jac=True)
@@ -774,12 +773,12 @@ class TestJacobian(unittest.TestCase):
 
         msg = 'Variable name pair \("{}", "{}"\) must first be declared.'
         with self.assertRaisesRegex(KeyError, msg.format('y', 'x')):
-            J = prob.compute_totals(of=['comp.y'], wrt=['p1.x'])
+            prob.compute_totals(of=['comp.y'], wrt=['p1.x'])
 
     def test_one_src_2_tgts_with_src_indices_densejac(self):
         size = 4
         prob = Problem(model=Group(assembled_jac_type='dense'))
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)))
+        prob.model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)))
 
         G1 = prob.model.add_subsystem('G1', Group())
         G1.add_subsystem('C1', ExecComp('z=2.0*y+3.0*x', x=np.zeros(size//2), y=np.zeros(size//2),
@@ -803,7 +802,7 @@ class TestJacobian(unittest.TestCase):
     def test_one_src_2_tgts_csc_error(self):
         size = 10
         prob = Problem()
-        indeps = prob.model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)))
+        prob.model.add_subsystem('indeps', IndepVarComp('x', np.ones(size)))
 
         G1 = prob.model.add_subsystem('G1', Group())
         G1.add_subsystem('C1', ExecComp('z=2.0*y+3.0*x', x=np.zeros(size), y=np.zeros(size),
@@ -994,8 +993,6 @@ class TestJacobian(unittest.TestCase):
         for i, sz in enumerate(comp.wrtsizes):
             p[f'comp.x{i}'] = np.random.random(sz)
         p.run_model()
-        ofs = [f'comp.y{i}' for i in range(len(comp.ofsizes))]
-        wrts = [f'comp.x{i}' for i in range(len(comp.wrtsizes))]
         p.check_partials(out_stream=None, show_only_incorrect=True)
         p.model.comp._jacobian.set_col(p.model.comp, 5, comp.sparsity[:, 5] * 99)
 
@@ -1095,7 +1092,7 @@ class OverlappingPartialsTestCase(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        J = p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
+        p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
         np.testing.assert_almost_equal(p.model._assembled_jac._int_mtx._matrix.toarray(),
                                        np.array([[-1.,  0.,  0.],
                                                  [ 0., -1.,  0.],
@@ -1115,7 +1112,7 @@ class OverlappingPartialsTestCase(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        J = p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
+        p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
         np.testing.assert_almost_equal(p.model._assembled_jac._int_mtx._matrix,
                                        np.array([[-1.,  0.,  0.],
                                                  [ 0., -1.,  0.],
@@ -1133,7 +1130,7 @@ class OverlappingPartialsTestCase(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        J = p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
+        p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
         np.testing.assert_almost_equal(p.model._assembled_jac._int_mtx._matrix.toarray(),
                                        np.array([[-1.,  0.,  0.,  0.],
                                                  [ 0., -1.,  0.,  0.],
@@ -1152,7 +1149,7 @@ class OverlappingPartialsTestCase(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        J = p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
+        p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
         np.testing.assert_almost_equal(p.model._assembled_jac._int_mtx._matrix.toarray(),
                                        np.array([[-1.,  0.,  0.,  0.],
                                                  [ 0., -1.,  0.,  0.],
@@ -1171,7 +1168,7 @@ class OverlappingPartialsTestCase(unittest.TestCase):
         p.setup()
         p.run_model()
 
-        J = p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
+        p.compute_totals(of=['C1.z'], wrt=['indeps.x'], return_format='array')
         np.testing.assert_almost_equal(p.model._assembled_jac._int_mtx._matrix.toarray(),
                                        np.array([[-1.,  0.,  9.,  8.],
                                                  [ 0., -1.,  5., 10.],

--- a/openmdao/matrices/coo_matrix.py
+++ b/openmdao/matrices/coo_matrix.py
@@ -1,9 +1,8 @@
 """Define the COOmatrix class."""
 import numpy as np
 from numpy import ndarray
-from scipy.sparse import coo_matrix, csc_matrix
+from scipy.sparse import coo_matrix
 
-from collections import OrderedDict
 
 from openmdao.core.constants import INT_DTYPE
 from openmdao.matrices.matrix import Matrix, _compute_index_map

--- a/openmdao/matrices/csc_matrix.py
+++ b/openmdao/matrices/csc_matrix.py
@@ -1,6 +1,5 @@
 """Define the CSCmatrix class."""
 
-import numpy as np
 from scipy.sparse import csc_matrix
 
 from openmdao.matrices.coo_matrix import COOMatrix

--- a/openmdao/matrices/csr_matrix.py
+++ b/openmdao/matrices/csr_matrix.py
@@ -1,5 +1,4 @@
 """Define the CSRmatrix class."""
-from scipy.sparse import coo_matrix
 
 from openmdao.matrices.coo_matrix import COOMatrix
 

--- a/openmdao/proc_allocators/default_allocator.py
+++ b/openmdao/proc_allocators/default_allocator.py
@@ -1,5 +1,4 @@
 """Define the DefaultAllocator class."""
-import warnings
 
 import numpy as np
 

--- a/openmdao/proc_allocators/default_allocator.py
+++ b/openmdao/proc_allocators/default_allocator.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from openmdao.proc_allocators.proc_allocator import ProcAllocator, ProcAllocationError
-from openmdao.utils.mpi import MPI
+from openmdao.proc_allocators.proc_allocator import ProcAllocator, ProcAllocationError  # noqa: E401
+from openmdao.utils.mpi import MPI  # noqa: E401
 
 
 class DefaultAllocator(ProcAllocator):

--- a/openmdao/proc_allocators/default_allocator.py
+++ b/openmdao/proc_allocators/default_allocator.py
@@ -2,8 +2,8 @@
 
 import numpy as np
 
-from openmdao.proc_allocators.proc_allocator import ProcAllocator, ProcAllocationError  # noqa: E401
-from openmdao.utils.mpi import MPI  # noqa: E401
+from openmdao.proc_allocators.proc_allocator import ProcAllocator, ProcAllocationError  # noqa: F401
+from openmdao.utils.mpi import MPI  # noqa: F401
 
 
 class DefaultAllocator(ProcAllocator):

--- a/openmdao/recorders/recording_iteration_stack.py
+++ b/openmdao/recorders/recording_iteration_stack.py
@@ -1,8 +1,6 @@
 """Management of iteration stack for recording."""
 import weakref
 
-from openmdao.utils.mpi import MPI
-
 _norec_funcs = frozenset(['_run_apply', '_compute_totals'])
 
 

--- a/openmdao/recorders/sqlite_reader.py
+++ b/openmdao/recorders/sqlite_reader.py
@@ -1,11 +1,9 @@
 """
 Definition of the SqliteCaseReader.
 """
-import importlib
 import sqlite3
 from collections import OrderedDict
 
-import os
 import sys
 import numpy as np
 import io

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -207,7 +207,7 @@ class SqliteRecorder(CaseRecorder):
                         print("Note: Metadata is being recorded separately as "
                               f"{metadata_filepath}.")
                         try:
-                            rc = os.remove(metadata_filepath)
+                            os.remove(metadata_filepath)
                             issue_warning("The existing case recorder metadata file, "
                                           f"{metadata_filepath}, is being overwritten.",
                                           category=UserWarning)

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -298,7 +298,7 @@ class DistributedRecorderTest(unittest.TestCase):
         prob = om.Problem()
         model = prob.model
 
-        geom = model.add_subsystem('tcomp', TopComp())
+        model.add_subsystem('tcomp', TopComp())
 
         model.add_design_var('tcomp.theta_c2_C', lower=-20., upper=20., indices=range(2, 9))
         model.add_constraint('tcomp.c_ae', lower=0.e0,)

--- a/openmdao/recorders/tests/test_list_vars.py
+++ b/openmdao/recorders/tests/test_list_vars.py
@@ -27,7 +27,7 @@ class ListVarsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             case.list_inputs(return_format=dict)
 
-        msg = f"Invalid value (<class 'dict'>) for return_format, " \
+        msg = "Invalid value (<class 'dict'>) for return_format, " \
               "must be a string value of 'list' or 'dict'"
 
         self.assertEqual(str(cm.exception), msg)
@@ -35,7 +35,7 @@ class ListVarsTest(unittest.TestCase):
         with self.assertRaises(ValueError) as cm:
             case.list_outputs(return_format='dct')
 
-        msg = f"Invalid value ('dct') for return_format, " \
+        msg = "Invalid value ('dct') for return_format, " \
               "must be a string value of 'list' or 'dict'"
 
         self.assertEqual(str(cm.exception), msg)

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -34,8 +34,6 @@ from openmdao.utils.testing_utils import use_tempdirs
 
 # check that pyoptsparse is installed
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
 
 def count_keys(d):
@@ -523,7 +521,7 @@ class TestSqliteCaseReader(unittest.TestCase):
                                                        linear_solver=om.ScipyKrylov,
                                                        mda_nonlinear_solver=om.NonlinearBlockGS)
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP', print_results=False)
+        driver = prob.driver = om.pyOptSparseDriver(optimizer='SLSQP', print_results=False)
         driver.recording_options['record_desvars'] = True
         driver.recording_options['record_objectives'] = True
         driver.recording_options['record_constraints'] = True

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2,7 +2,6 @@
 
 import sys
 import os
-import sys
 import unittest
 
 from io import StringIO
@@ -2844,7 +2843,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         ]
 
         stream = StringIO()
-        cases = cr.list_cases(out_stream=stream)
+        cr.list_cases(out_stream=stream)
         text = stream.getvalue().split('\n')
         for i, line in enumerate(expected_cases):
             self.assertEqual(text[i], line)
@@ -2875,7 +2874,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         self.assertTrue(str(cm.exception), "Invalid output stream specified for 'out_stream'.")
 
         stream = StringIO()
-        cases = cr.list_sources(out_stream=stream)
+        cr.list_sources(out_stream=stream)
         text = stream.getvalue().split('\n')
         for i, line in enumerate(expected_sources):
             self.assertEqual(text[i], line)
@@ -2905,7 +2904,7 @@ class TestSqliteCaseReader(unittest.TestCase):
         ]
 
         stream = StringIO()
-        cases = cr.list_source_vars('driver', out_stream=stream)
+        cr.list_source_vars('driver', out_stream=stream)
         text = sorted(stream.getvalue().split('\n'), reverse=True)
         for i, line in enumerate(expected_cases):
             self.assertEqual(text[i], line)
@@ -3912,10 +3911,10 @@ class TestSqliteCaseReaderLegacy(unittest.TestCase):
         cr = om.CaseReader(filename)
 
         with assert_warning(UserWarning, 'System options not recorded.'):
-            options = cr.list_model_options()
+            cr.list_model_options()
 
         with assert_warning(UserWarning, 'Solver options not recorded.'):
-            options = cr.list_solver_options()
+            cr.list_solver_options()
 
         # The case reader should handle a v11 database that had a
         # different separator for runs in the model option keys

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -27,7 +27,7 @@ from openmdao.recorders.tests.sqlite_recorder_test_utils import assertMetadataRe
 
 from openmdao.recorders.tests.recorder_test_utils import run_driver
 from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays, \
-    assert_warning, assert_no_warning
+    assert_no_warning
 from openmdao.utils.general_utils import determine_adder_scaler
 from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
 from openmdao.utils.om_warnings import OMDeprecationWarning
@@ -412,7 +412,7 @@ class TestSqliteRecorder(unittest.TestCase):
     def test_double_run_driver_option_overwrite(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = om.ScipyOptimizeDriver(disp=False, tol=1e-9)
+        prob.driver = om.ScipyOptimizeDriver(disp=False, tol=1e-9)
 
         prob.model.add_recorder(self.recorder)
 
@@ -513,7 +513,7 @@ class TestSqliteRecorder(unittest.TestCase):
     def test_double_run_model_option_overwrite(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = om.ScipyOptimizeDriver(disp=False, tol=1e-9)
+        prob.driver = om.ScipyOptimizeDriver(disp=False, tol=1e-9)
 
         prob.model.add_recorder(self.recorder)
 
@@ -3093,7 +3093,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         model.add_constraint('con2', upper=0.0)
 
         # setup the optimization
-        driver = prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=False)
+        prob.driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9, disp=False)
 
         # Create a recorder variable
         recorder = om.SqliteRecorder('cases.sql')
@@ -3107,8 +3107,7 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
 
         # Instantiate your CaseReader
         cr = om.CaseReader("cases.sql")
-        # Isolate "problem" as your source
-        driver_cases = cr.list_cases('problem')
+
         # Get the first case from the recorder
         case = cr.get_case('after_run_driver')
 
@@ -3516,8 +3515,6 @@ class TestFeatureSqliteRecorder(unittest.TestCase):
         prob.set_val('test_sys.x', np.random.rand(vec_size))
 
         prob.run_driver()
-
-        y0 = prob.get_val('test_sys.y')
 
         test_sys.options['vec_size'] = 10
 

--- a/openmdao/recorders/tests/test_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_sqlite_recorder.py
@@ -37,9 +37,6 @@ from openmdao.utils.general_utils import set_pyoptsparse_opt
 
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
-
 
 class Cycle(om.Group):
 
@@ -362,7 +359,7 @@ class TestSqliteRecorder(unittest.TestCase):
     def test_simple_driver_recording_pyoptsparse(self):
         prob = ParaboloidProblem()
 
-        driver = prob.driver = pyOptSparseDriver(optimizer='SLSQP')
+        driver = prob.driver = om.pyOptSparseDriver(optimizer='SLSQP')
         driver.options['print_results'] = False
         driver.opt_settings['ACC'] = 1e-9
 

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -103,9 +103,9 @@ def format_singular_error(system, matrix):
             try:
                 u, _, _ = np.linalg.svd(matrix)
 
-            except Exception as err:
+            except Exception:
                 msg = f"Jacobian in '{system.pathname}' is not full rank, but OpenMDAO was " + \
-                    "not able to determine which rows or columns."
+                      "not able to determine which rows or columns."
                 return msg
 
             # Nonzero elements in the left singular vector show the rows that contribute strongly to
@@ -318,7 +318,7 @@ class DirectSolver(LinearSolver):
             elif isinstance(matrix, csc_matrix):
                 try:
                     self._lu = scipy.sparse.linalg.splu(matrix)
-                except RuntimeError as err:
+                except RuntimeError:
                     raise RuntimeError(format_singular_error(system, matrix))
 
             elif isinstance(matrix, np.ndarray):  # dense
@@ -328,11 +328,11 @@ class DirectSolver(LinearSolver):
                         warnings.simplefilter('error', RuntimeWarning)
                     try:
                         self._lup = scipy.linalg.lu_factor(matrix)
-                    except RuntimeWarning as err:
+                    except RuntimeWarning:
                         raise RuntimeError(format_singular_error(system, matrix))
 
                     # NaN in matrix.
-                    except ValueError as err:
+                    except ValueError:
                         raise RuntimeError(format_nan_error(system, matrix))
 
             # Note: calling scipy.sparse.linalg.splu on a COO actually transposes
@@ -357,11 +357,11 @@ class DirectSolver(LinearSolver):
                 try:
                     self._lup = scipy.linalg.lu_factor(mtx)
 
-                except RuntimeWarning as err:
+                except RuntimeWarning:
                     raise RuntimeError(format_singular_error(system, mtx))
 
                 # NaN in matrix.
-                except ValueError as err:
+                except ValueError:
                     raise RuntimeError(format_nan_error(system, mtx))
 
         if self._lin_rhs_checker is not None:
@@ -399,17 +399,17 @@ class DirectSolver(LinearSolver):
                         warnings.simplefilter('error', RuntimeWarning)
                     try:
                         inv_jac = scipy.linalg.inv(matrix)
-                    except RuntimeWarning as err:
+                    except RuntimeWarning:
                         raise RuntimeError(format_singular_error(system, matrix))
 
                     # NaN in matrix.
-                    except ValueError as err:
+                    except ValueError:
                         raise RuntimeError(format_nan_error(system, matrix))
 
             elif isinstance(matrix, csc_matrix):
                 try:
                     inv_jac = scipy.sparse.linalg.inv(matrix)
-                except RuntimeError as err:
+                except RuntimeError:
                     raise RuntimeError(format_singular_error(system, matrix))
 
                 # to prevent broadcasting errors later, make sure inv_jac is 2D
@@ -435,11 +435,11 @@ class DirectSolver(LinearSolver):
                 try:
                     inv_jac = scipy.linalg.inv(mtx)
 
-                except RuntimeWarning as err:
+                except RuntimeWarning:
                     raise RuntimeError(format_singular_error(system, mtx))
 
                 # NaN in matrix.
-                except ValueError as err:
+                except ValueError:
                     raise RuntimeError(format_nan_error(system, mtx))
 
         return inv_jac

--- a/openmdao/solvers/linear/linear_block_gs.py
+++ b/openmdao/solvers/linear/linear_block_gs.py
@@ -1,9 +1,7 @@
 """Define the LinearBlockGS class."""
 
-import sys
 import numpy as np
 
-from openmdao.core.constants import _UNDEFINED
 from openmdao.solvers.solver import BlockLinearSolver
 
 

--- a/openmdao/solvers/linear/linear_rhs_checker.py
+++ b/openmdao/solvers/linear/linear_rhs_checker.py
@@ -4,7 +4,6 @@ Define the LinearRHSChecker class.
 LinearRHSChecker manages caching of solutions and right-hand sides for linear solves.
 """
 
-import os
 from collections import deque
 import atexit
 

--- a/openmdao/solvers/linear/petsc_ksp.py
+++ b/openmdao/solvers/linear/petsc_ksp.py
@@ -1,8 +1,6 @@
 """LinearSolver that uses PetSC KSP to solve for a system's derivatives."""
 
 import numpy as np
-import os
-import sys
 
 from openmdao.solvers.solver import LinearSolver
 from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -906,10 +906,10 @@ class TestDirectSolver(LinearSolverTests.LinearSolverTestCase):
         prob.run_model()
 
         with self.assertRaises(RuntimeError) as cm:
-            jac = prob.compute_totals(of=['x', 'y', 'z'], wrt=['a'])
+            prob.compute_totals(of=['x', 'y', 'z'], wrt=['a'])
 
         expected = "Jacobian in '' is not full rank, but OpenMDAO was not " + \
-                    "able to determine which rows or columns."
+                   "able to determine which rows or columns."
 
         self.assertEqual(expected, str(cm.exception))
 

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -157,8 +157,8 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         # It takes 6 iterations without Aitken.
         aitken.options['maxiter'] = 4
 
-        sub = model.add_subsystem('sub', SellarDerivatives(nonlinear_solver=om.NonlinearRunOnce(),
-                                                           linear_solver=aitken))
+        model.add_subsystem('sub', SellarDerivatives(nonlinear_solver=om.NonlinearRunOnce(),
+                                                     linear_solver=aitken))
         model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
 
         prob.setup(mode='fwd')
@@ -178,8 +178,8 @@ class TestBGSSolver(LinearSolverTests.LinearSolverTestCase):
         # It takes 6 iterations without Aitken.
         aitken.options['maxiter'] = 4
 
-        sub = model.add_subsystem('sub', SellarDerivatives(nonlinear_solver=om.NonlinearRunOnce(),
-                                                           linear_solver=aitken))
+        model.add_subsystem('sub', SellarDerivatives(nonlinear_solver=om.NonlinearRunOnce(),
+                                                     linear_solver=aitken))
         model.nonlinear_solver = om.NewtonSolver(solve_subsystems=True)
 
         prob.setup(mode='rev')
@@ -475,25 +475,25 @@ class TestRecursiveApplyFix(unittest.TestCase):
     def test_matrix_free_explicit_fwd(self):
         prob, comp = execute_model1('fwd')
         comp._comp_jvp_count = 0
-        J = prob.compute_totals()
+        prob.compute_totals()
         self.assertEqual(comp._comp_jvp_count, 1)
 
     def test_matrix_free_explicit_rev(self):
         prob, comp = execute_model1('rev')
         comp._comp_jvp_count = 0
-        J = prob.compute_totals()
+        prob.compute_totals()
         self.assertEqual(comp._comp_jvp_count, 1)
 
     def test_matrix_free_explicit2_fwd(self):
         prob, comp = execute_model2('fwd')
         comp._comp_jvp_count = 0
-        J = prob.compute_totals()
+        prob.compute_totals()
         self.assertEqual(comp._comp_jvp_count, 1)
 
     def test_matrix_free_explicit2_rev(self):
         prob, comp = execute_model2('rev')
         comp._comp_jvp_count = 0
-        J = prob.compute_totals()
+        prob.compute_totals()
         self.assertEqual(comp._comp_jvp_count, 1)
 
 
@@ -679,7 +679,7 @@ class Coupled(om.Group):
 def create_model_with_post_not_in_a_group(maxiter):
     model = om.Group()
 
-    ivc = model.add_subsystem('ivc', om.IndepVarComp('x'))
+    model.add_subsystem('ivc', om.IndepVarComp('x'))
 
     coupling = model.add_subsystem('coupling', Coupled(), promotes=['*'])
     coupling.nonlinear_solver = om.NonlinearBlockGS(maxiter=maxiter)
@@ -697,7 +697,7 @@ def create_model_with_post_not_in_a_group(maxiter):
 def create_model_with_scenario(maxiter):
     model = om.Group()
 
-    ivc = model.add_subsystem('ivc', om.IndepVarComp('x'))
+    model.add_subsystem('ivc', om.IndepVarComp('x'))
 
     scenario = model.add_subsystem('scenario', om.Group(), promotes=['*'])
     coupling = scenario.add_subsystem('coupling', Coupled(), promotes=['*'])
@@ -719,29 +719,30 @@ class UserTestCase(unittest.TestCase):
         prob = om.Problem(create_model_with_scenario(1))
         prob.setup(mode='fwd')
         prob.run_model()
-        totals = prob.compute_totals('post.comp4.z','ivc.x')
+        prob.compute_totals('post.comp4.z','ivc.x')
         self.assertEqual(prob.model._get_subsystem('scenario.post.comp4').count, 1)
 
     def test_with_scenario_rev(self):
         prob = om.Problem(create_model_with_scenario(1))
         prob.setup(mode='rev')
         prob.run_model()
-        totals = prob.compute_totals('post.comp4.z','ivc.x')
+        prob.compute_totals('post.comp4.z','ivc.x')
         self.assertEqual(prob.model._get_subsystem('scenario.post.comp4').count, 1)
 
     def test_post_not_in_group_fwd(self):
         prob = om.Problem(create_model_with_post_not_in_a_group(10))
         prob.setup(mode='fwd')
         prob.run_model()
-        totals = prob.compute_totals('comp4.z','ivc.x')
+        prob.compute_totals('comp4.z','ivc.x')
         self.assertEqual(prob.model._get_subsystem('comp4').count, 1)
 
     def test_post_not_in_group_rev(self):
         prob = om.Problem(create_model_with_post_not_in_a_group(10))
         prob.setup(mode='rev')
         prob.run_model()
-        totals = prob.compute_totals('comp4.z','ivc.x')
+        prob.compute_totals('comp4.z','ivc.x')
         self.assertEqual(prob.model._get_subsystem('comp4').count, 1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/solvers/linear/tests/test_linear_block_gs.py
+++ b/openmdao/solvers/linear/tests/test_linear_block_gs.py
@@ -16,7 +16,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.mpi import MPI
 try:
     from openmdao.api import PETScVector
-except:
+except Exception:
     PETScVector = None
 
 

--- a/openmdao/solvers/linear/tests/test_petsc_ksp.py
+++ b/openmdao/solvers/linear/tests/test_petsc_ksp.py
@@ -187,7 +187,7 @@ class TestPETScKrylov(unittest.TestCase):
         """Solve implicit system with PETScKrylov using a preconditioner."""
 
         group = TestImplicitGroup(lnSolverClass=om.PETScKrylov)
-        precon = group.linear_solver.precon = om.DirectSolver(assemble_jac=False)
+        group.linear_solver.precon = om.DirectSolver(assemble_jac=False)
         group.linear_solver.options['precon_side'] = 'left'
         group.linear_solver.options['ksp_type'] = 'richardson'
 
@@ -219,7 +219,7 @@ class TestPETScKrylov(unittest.TestCase):
         assert_near_equal(output, group.expected_solution, 3e-15)
 
         # test the direct solver and make sure KSP correctly recurses for _linearize
-        precon = group.linear_solver.precon = om.DirectSolver(assemble_jac=False)
+        group.linear_solver.precon = om.DirectSolver(assemble_jac=False)
         group.linear_solver.options['precon_side'] = 'left'
         group.linear_solver.options['ksp_type'] = 'richardson'
 
@@ -310,9 +310,9 @@ class TestPETScKrylov(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
         # Should take less iterations when starting from previous solution.
@@ -336,9 +336,9 @@ class TestPETScKrylov(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
         # Should take less iterations when starting from previous solution.
@@ -375,7 +375,7 @@ class TestPETScKrylov(unittest.TestCase):
         prob.run_model()
 
         with self.assertRaises(RuntimeError) as cm:
-            J = prob.compute_totals(of=['obj'], wrt=['z'])
+            prob.compute_totals(of=['obj'], wrt=['z'])
 
         msg = 'PETScKrylov in <model> <class Group>: PETScKrylov solver is not supported under complex step.'
         self.assertEqual(str(cm.exception), msg)
@@ -485,7 +485,7 @@ class TestPETScKrylovSolverFeature(unittest.TestCase):
         of = ['obj']
 
         with self.assertRaises(om.AnalysisError) as cm:
-            J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+            prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
         msg = "Solver 'LN: PETScKrylov' on system '' failed to converge in 4 iterations."
         self.assertEqual(str(cm.exception), msg)

--- a/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
+++ b/openmdao/solvers/linear/tests/test_scipy_iter_solver.py
@@ -157,9 +157,9 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
         # Should take less iterations when starting from previous solution.
@@ -190,9 +190,9 @@ class TestScipyKrylov(LinearSolverTests.LinearSolverTestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount1 = prob.model.linear_solver._iter_count
-        J = prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        prob.driver._compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
         icount2 = prob.model.linear_solver._iter_count
 
         # Should take less iterations when starting from previous solution.
@@ -293,7 +293,7 @@ class TestScipyKrylovFeature(unittest.TestCase):
         of = ['obj']
 
         with self.assertRaises(om.AnalysisError) as cm:
-            J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+            prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
 
         msg = "Solver 'LN: SCIPY' on system '' failed to converge in 3 iterations."
         self.assertEqual(str(cm.exception), msg)
@@ -394,7 +394,7 @@ class TestCaching(unittest.TestCase):
         prob.set_val('ivc.x', .3)
         prob.run_model()
 
-        J = prob.compute_totals()
+        prob.compute_totals()
 
         self.assertEqual(G.linear_solver._lin_rhs_checker._stats['parhits'], 1)
 

--- a/openmdao/solvers/linear/tests/test_user_defined.py
+++ b/openmdao/solvers/linear/tests/test_user_defined.py
@@ -7,6 +7,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.array_utils import evenly_distrib_idxs
+from openmdao.utils.mpi import MPI
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -46,6 +47,7 @@ class DistribStateImplicit(om.ImplicitComponent):
 
         local_sum = np.zeros(1)
         local_sum[0] = np.sum(o['states'])
+        tmp = np.zeros(1)
 
         r['out_var'] = o['out_var'] - tmp[0]
 
@@ -221,6 +223,7 @@ class TestUserDefinedSolver(unittest.TestCase):
 
                 local_sum = np.zeros(1)
                 local_sum[0] = np.sum(o['states'])
+                tmp = np.zeros(1)
 
                 r['out_var'] = o['out_var'] - tmp[0]
 

--- a/openmdao/solvers/linear/tests/test_user_defined.py
+++ b/openmdao/solvers/linear/tests/test_user_defined.py
@@ -46,7 +46,6 @@ class DistribStateImplicit(om.ImplicitComponent):
 
         local_sum = np.zeros(1)
         local_sum[0] = np.sum(o['states'])
-        global_sum = np.zeros(1)
 
         r['out_var'] = o['out_var'] - tmp[0]
 
@@ -164,7 +163,7 @@ class TestUserDefinedSolver(unittest.TestCase):
 
         p.setup(mode='rev', check=False)
         p.run_model()
-        jac = p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
+        p.compute_totals(of=['out_var'], wrt=['a'], return_format='dict')
 
     def test_method_default(self):
         # Uses `solve_linear` by default
@@ -222,7 +221,6 @@ class TestUserDefinedSolver(unittest.TestCase):
 
                 local_sum = np.zeros(1)
                 local_sum[0] = np.sum(o['states'])
-                global_sum = np.zeros(1)
 
                 r['out_var'] = o['out_var'] - tmp[0]
 

--- a/openmdao/solvers/linesearch/tests/test_backtracking.py
+++ b/openmdao/solvers/linesearch/tests/test_backtracking.py
@@ -1,7 +1,6 @@
 """ Test for the Backtracking Line Search"""
 
 import sys
-import os
 import unittest
 from math import atan
 
@@ -10,7 +9,6 @@ from io import StringIO
 import numpy as np
 
 import openmdao.api as om
-from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.implicit_newton_linesearch \
     import ImplCompTwoStates, ImplCompTwoStatesArrays
 from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2withDerivatives
@@ -445,7 +443,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
             assert_near_equal(top['comp.z'][ind], [1.5], 1e-8)
 
         with printoptions(precision=3):
-            msg = (f"'comp.z' exceeds lower bounds\n  Val: [1.333 1.333 1.333]\n  Lower: [1.5 1.5 1.5]\n")
+            msg = ("'comp.z' exceeds lower bounds\n  Val: [1.333 1.333 1.333]\n  Lower: [1.5 1.5 1.5]\n")
             with assert_warning(om.SolverWarning, msg):
                 top.run_model()
 
@@ -456,7 +454,7 @@ class TestBoundsEnforceLSArrayBounds(unittest.TestCase):
         top['comp.z'] = 2.4
 
         with printoptions(precision=3):
-            msg = (f"'comp.z' exceeds upper bounds\n  Val: [2.667 2.667 2.667]\n  Upper: [2.6  2.5  2.65]\n")
+            msg = ("'comp.z' exceeds upper bounds\n  Val: [2.667 2.667 2.667]\n  Upper: [2.6  2.5  2.65]\n")
             with assert_warning(om.SolverWarning, msg):
                 top.run_model()
 
@@ -742,7 +740,7 @@ class TestArmijoGoldsteinLSArrayBounds(unittest.TestCase):
 
         model.nonlinear_solver.options['solve_subsystems'] = True
         model.nonlinear_solver.options['max_sub_solves'] = 4
-        ls = model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
+        model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='vector')
 
         prob.set_solver_print(level=0)
 
@@ -784,7 +782,6 @@ class CompAtan(om.ImplicitComponent):
         residuals['y'] = (33.0 * atan(y-20.0))**2 + x
 
     def linearize(self, inputs, outputs, jacobian):
-        x = inputs['x'].item()
         y = outputs['y'].item()
 
         jacobian['y', 'y'] = 2178.0*atan(y-20.0) / (y**2 - 40.0*y + 401.0)
@@ -1035,7 +1032,7 @@ class TestFeatureLineSearch(unittest.TestCase):
         top.model.nonlinear_solver.options['maxiter'] = 10
         top.model.linear_solver = om.ScipyKrylov()
 
-        ls = top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='scalar')
+        top.model.nonlinear_solver.linesearch = om.ArmijoGoldsteinLS(bound_enforcement='scalar')
 
         top.setup()
         top.set_val('x', np.array([2., 2, 2]).reshape(3, 1))

--- a/openmdao/solvers/nonlinear/broyden.py
+++ b/openmdao/solvers/nonlinear/broyden.py
@@ -10,7 +10,6 @@ from openmdao.solvers.linesearch.backtracking import BoundsEnforceLS
 from openmdao.solvers.solver import NonlinearSolver
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.om_warnings import issue_warning, SetupWarning
-from openmdao.utils.mpi import MPI
 
 
 CITATION = """@ARTICLE{

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -1,12 +1,8 @@
 """Define the NewtonSolver class."""
 
-
-import numpy as np
-
 from openmdao.solvers.linesearch.backtracking import BoundsEnforceLS
 from openmdao.solvers.solver import NonlinearSolver
 from openmdao.recorders.recording_iteration_stack import Recording
-from openmdao.utils.mpi import MPI
 
 
 class NewtonSolver(NonlinearSolver):

--- a/openmdao/solvers/nonlinear/newton.py
+++ b/openmdao/solvers/nonlinear/newton.py
@@ -146,7 +146,7 @@ class NewtonSolver(NonlinearSolver):
         bool
             Flag for indicating child linerization
         """
-        return (self.options['solve_subsystems'] and not system.under_complex_step
+        return (self.options['solve_subsystems'] and not self._system().under_complex_step
                 and self._iter_count <= self.options['max_sub_solves'])
 
     def _linearize(self):

--- a/openmdao/solvers/nonlinear/nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/nonlinear_block_gs.py
@@ -3,7 +3,6 @@
 import numpy as np
 
 from openmdao.solvers.solver import NonlinearSolver
-from openmdao.utils.mpi import MPI
 
 
 class NonlinearBlockGS(NonlinearSolver):

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -1,6 +1,5 @@
 """Test the Broyden nonlinear solver. """
 
-import os
 import unittest
 
 import numpy as np
@@ -13,13 +12,11 @@ from openmdao.test_suite.components.sellar import SellarStateConnection, SellarD
      SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.scripts.circuit_analysis import Circuit
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning
-from openmdao.utils.array_utils import evenly_distrib_idxs
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
 except ImportError:
     PETScVector = None
-from openmdao.utils.mpi import MPI
 
 
 class VectorEquation(om.ImplicitComponent):
@@ -70,8 +67,6 @@ class MixedEquation(om.ImplicitComponent):
         residuals['x45'] = res[3:]
 
     def linearize(self, inputs, outputs, jacobian):
-        c = inputs['c']
-        x = np.empty((5, ))
         x12 = outputs['x12']
         x3 = outputs['x3']
         x45 = outputs['x45']
@@ -184,8 +179,8 @@ class TestBryoden(unittest.TestCase):
         # Test top level Sellar (i.e., not grouped).
 
         prob = om.Problem()
-        model = prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
-                                                   linear_solver=om.LinearRunOnce())
+        prob.model = SellarStateConnection(nonlinear_solver=om.BroydenSolver(),
+                                           linear_solver=om.LinearRunOnce())
 
         prob.setup()
 

--- a/openmdao/solvers/nonlinear/tests/test_newton.py
+++ b/openmdao/solvers/nonlinear/tests/test_newton.py
@@ -1,7 +1,6 @@
 """Test the Newton nonlinear solver. """
 
 import unittest
-import warnings
 
 import numpy as np
 

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
@@ -5,7 +5,6 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.double_sellar import DoubleSellar
 from openmdao.test_suite.components.sellar import SellarDerivatives, \
     SellarDis1withDerivatives, SellarDis2withDerivatives, \
@@ -340,8 +339,6 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.setup()
 
-        y1_0 = prob.get_val('y1')
-        y2_0 = prob.get_val('y2')
         model.nonlinear_solver.options['use_aitken'] = True
         model.nonlinear_solver.options['aitken_initial_factor'] = 0.33
         model.nonlinear_solver.options['maxiter'] = 1
@@ -370,8 +367,6 @@ class TestNLBGaussSeidel(unittest.TestCase):
 
         prob.setup()
 
-        y1_0 = prob.get_val('y1')
-        y2_0 = prob.get_val('y2')
         model.nonlinear_solver.options['use_aitken'] = True
         model.nonlinear_solver.options['aitken_min_factor'] = 1.2
         model.nonlinear_solver.options['maxiter'] = 1

--- a/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
+++ b/openmdao/solvers/nonlinear/tests/test_nonlinear_block_gs.py
@@ -14,7 +14,7 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
 try:
     from openmdao.api import PETScVector
-except:
+except Exception:
     PETScVector = None
 
 

--- a/openmdao/solvers/tests/test_output_cache.py
+++ b/openmdao/solvers/tests/test_output_cache.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning
 
 
 class SubComp1(om.ExplicitComponent):

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -1,7 +1,6 @@
 """Tests the `debug_print` option for Nonlinear solvers."""
 
 import os
-import re
 import sys
 import shutil
 import tempfile
@@ -33,7 +32,6 @@ nonlinear_solvers = [
 
 class TestNonlinearSolvers(unittest.TestCase):
     def setUp(self):
-        import re
         import os
         from tempfile import mkdtemp
 

--- a/openmdao/solvers/tests/test_solver_features.py
+++ b/openmdao/solvers/tests/test_solver_features.py
@@ -129,11 +129,11 @@ class TestSolverFeatures(unittest.TestCase):
 
         prob.setup()
 
-        msg = (f"Your model has stalled three times and may be violating the bounds. "
-                f"In the future, turn on print_bound_enforce in your solver options "
-                f"here: \nnonlinear_solver.linesearch.options"
-                f"['print_bound_enforce']=True. "
-                f"\nThe bound(s) being violated now are:\n")
+        msg = ("Your model has stalled three times and may be violating the bounds. "
+               "In the future, turn on print_bound_enforce in your solver options "
+               "here: \nnonlinear_solver.linesearch.options"
+               "['print_bound_enforce']=True. "
+               "\nThe bound(s) being violated now are:\n")
         with assert_warning(UserWarning, msg):
             prob.run_model()
 
@@ -166,11 +166,11 @@ class TestSolverFeatures(unittest.TestCase):
 
         prob.setup()
 
-        msg = (f"Your model has stalled three times and may be violating the bounds. "
-                f"In the future, turn on print_bound_enforce in your solver options "
-                f"here: \nbalance_group.nonlinear_solver.linesearch.options"
-                f"['print_bound_enforce']=True. "
-                f"\nThe bound(s) being violated now are:\n")
+        msg = ("Your model has stalled three times and may be violating the bounds. "
+               "In the future, turn on print_bound_enforce in your solver options "
+               "here: \nbalance_group.nonlinear_solver.linesearch.options"
+               "['print_bound_enforce']=True. "
+               "\nThe bound(s) being violated now are:\n")
 
         with assert_warning(UserWarning, msg):
             prob.run_model()

--- a/openmdao/solvers/tests/test_solver_iprint.py
+++ b/openmdao/solvers/tests/test_solver_iprint.py
@@ -2,7 +2,6 @@
 
 import os
 from io import StringIO
-import re
 import sys
 import unittest
 

--- a/openmdao/solvers/tests/test_solver_parametric_suite.py
+++ b/openmdao/solvers/tests/test_solver_parametric_suite.py
@@ -3,7 +3,6 @@
 import numpy as np
 import unittest
 
-from openmdao.core.group import Group
 from openmdao.core.problem import Problem
 from openmdao.core.implicitcomponent import ImplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal

--- a/openmdao/surrogate_models/tests/test_map.py
+++ b/openmdao/surrogate_models/tests/test_map.py
@@ -1,4 +1,4 @@
-from openmdao.api import Group, Problem, MetaModelUnStructuredComp, NearestNeighbor
+from openmdao.api import Problem, MetaModelUnStructuredComp, NearestNeighbor
 from openmdao.utils.assert_utils import assert_near_equal
 
 import numpy as np

--- a/openmdao/surrogate_models/tests/test_multifi_cokriging.py
+++ b/openmdao/surrogate_models/tests/test_multifi_cokriging.py
@@ -15,10 +15,12 @@ class CoKrigingSurrogateTest(unittest.TestCase):
         # A matching test using the OpenMDAO surrogate class is below (test_1d_2fi_cokriging).
 
         # high fidelity model
-        fe = lambda x: ((x * 6 - 2) ** 2) * np.sin((x * 6 - 2) * 2)
+        def fe(x):
+            return (x * 6 - 2) ** 2 * np.sin((x * 6 - 2) * 2)
 
         # low fidelity model
-        fc = lambda x: 0.5 * fe(x) + (x - 0.5) * 10. - 5
+        def fc(x):
+            return 0.5 * fe(x) + (x - 0.5) * 10.0 - 5
 
         # Xe: DOE for expensive code (nested in Xc)
         # Xc: DOE for cheap code

--- a/openmdao/surrogate_models/tests/test_multifi_cokriging.py
+++ b/openmdao/surrogate_models/tests/test_multifi_cokriging.py
@@ -112,13 +112,13 @@ class CoKrigingSurrogateTest(unittest.TestCase):
 
         # Test with theta setting instead of estimation
         krig2 = MultiFiCoKrigingSurrogate(theta=[0.1])
-        krig1.train(x, y)
+        krig2.train(x, y)
 
         mu, sigma = krig1.predict([-2., 0.])
         assert_near_equal(mu, [[branin(x[0])]], 1e-5)
-        assert_near_equal(sigma, [[0.]], 1e-5)
+        assert_near_equal(sigma, [[0.]], 1e-4)
 
-        mu, sigma = krig1.predict([5., 5.])
+        mu, sigma = krig2.predict([5., 5.])
         assert_near_equal(mu, [[22]], 1)
         assert_near_equal(sigma, [[13]], 1)
 

--- a/openmdao/surrogate_models/tests/test_response_surface.py
+++ b/openmdao/surrogate_models/tests/test_response_surface.py
@@ -1,6 +1,7 @@
 # pylint: disable-msg=C0111,C0103
 
-import unittest, itertools
+import unittest
+import itertools
 
 
 from numpy import array, linspace, sin, cos, pi

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -10,8 +10,6 @@ from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.indepvarcomp import IndepVarComp
 
-from openmdao.utils.mpi import MPI
-
 
 class DynComp(ExplicitComponent):
     """

--- a/openmdao/test_suite/components/branin.py
+++ b/openmdao/test_suite/components/branin.py
@@ -125,8 +125,8 @@ class BraninDiscrete(om.ExplicitComponent):
         b = 5.1/(4.0*np.pi**2)
         c = 5.0/np.pi
         d = 6.0
-        e = 10.0
-        f = 1.0/(8.0*np.pi)
+        # e = 10.0
+        # f = 1.0/(8.0*np.pi)
 
         partials['f', 'x1'] = 2.0*a*(x1 - b*x0**2 + c*x0 - d)
         #partials['f', 'x0'] = 2.0*a*(x1 - b*x0**2 + c*x0 - d)*(-2.*b*x0 + c) - e*(1.-f)*np.sin(x0)

--- a/openmdao/test_suite/components/distributed_components.py
+++ b/openmdao/test_suite/components/distributed_components.py
@@ -6,7 +6,6 @@ Components that are used in multiple places for testing distributed components.
 import numpy as np
 import openmdao.api as om
 
-from openmdao.utils.mpi import MPI
 from openmdao.utils.array_utils import evenly_distrib_idxs
 
 

--- a/openmdao/test_suite/components/exec_comp_for_test.py
+++ b/openmdao/test_suite/components/exec_comp_for_test.py
@@ -1,10 +1,9 @@
 
 import time
-import os
 
 from openmdao.components.exec_comp import ExecComp
 from openmdao.core.analysis_error import AnalysisError
-from openmdao.utils.mpi import MPI
+
 
 class ExecComp4Test(ExecComp):
     """

--- a/openmdao/test_suite/components/expl_comp_array.py
+++ b/openmdao/test_suite/components/expl_comp_array.py
@@ -1,6 +1,5 @@
 """Define the explicit test component (array)."""
 import numpy as np
-import scipy.sparse
 
 import openmdao.api as om
 

--- a/openmdao/test_suite/components/expl_comp_simple.py
+++ b/openmdao/test_suite/components/expl_comp_simple.py
@@ -1,5 +1,4 @@
 """Define the explicit test component (simple)."""
-import scipy.sparse
 
 from openmdao.core.explicitcomponent import ExplicitComponent
 

--- a/openmdao/test_suite/components/impl_comp_array.py
+++ b/openmdao/test_suite/components/impl_comp_array.py
@@ -1,7 +1,6 @@
 """Define the implicit test component (array)."""
 
 import numpy as np
-import scipy.sparse
 
 import openmdao.api as om
 

--- a/openmdao/test_suite/components/implicit_newton_linesearch.py
+++ b/openmdao/test_suite/components/implicit_newton_linesearch.py
@@ -2,7 +2,6 @@
 from math import exp
 
 import numpy as np
-import unittest
 
 import openmdao.api as om
 

--- a/openmdao/test_suite/components/paraboloid_distributed.py
+++ b/openmdao/test_suite/components/paraboloid_distributed.py
@@ -121,7 +121,6 @@ class DistParabDeprecated(om.ExplicitComponent):
         rank = comm.rank
 
         sizes, offsets = evenly_distrib_idxs(comm.size, arr_size)
-        start = offsets[rank]
         io_size = sizes[rank]
         self.offset = offsets[rank]
 

--- a/openmdao/test_suite/components/paraboloid_distributed.py
+++ b/openmdao/test_suite/components/paraboloid_distributed.py
@@ -27,7 +27,6 @@ class DistParab(om.ExplicitComponent):
         rank = comm.rank
 
         sizes, offsets = evenly_distrib_idxs(comm.size, arr_size)
-        start = offsets[rank]
         io_size = sizes[rank]
         self.offset = offsets[rank]
 
@@ -125,7 +124,6 @@ class DistParabDeprecated(om.ExplicitComponent):
         start = offsets[rank]
         io_size = sizes[rank]
         self.offset = offsets[rank]
-        end = start + io_size
 
         # src_indices will be computed automatically
         self.add_input('x', val=np.ones(io_size), distributed=True)

--- a/openmdao/test_suite/components/quad_implicit.py
+++ b/openmdao/test_suite/components/quad_implicit.py
@@ -36,7 +36,6 @@ class QuadraticComp(om.ImplicitComponent):
     def linearize(self, inputs, outputs, partials):
         a = inputs['a']
         b = inputs['b']
-        c = inputs['c']
         x = outputs['x']
 
         partials['x', 'a'] = x ** 2

--- a/openmdao/test_suite/components/sellar_feature.py
+++ b/openmdao/test_suite/components/sellar_feature.py
@@ -250,10 +250,12 @@ class SellarMDALinearSolver(om.Group):
     def setup(self):
 
         cycle = self.add_subsystem('cycle', om.Group(), promotes=['*'])
-        d1 = cycle.add_subsystem('d1', SellarDis1(), promotes_inputs=['x', 'z', 'y2'],
-                                 promotes_outputs=['y1'])
-        d2 = cycle.add_subsystem('d2', SellarDis2(), promotes_inputs=['z', 'y1'],
-                                 promotes_outputs=['y2'])
+        cycle.add_subsystem('d1', SellarDis1(), 
+                            promotes_inputs=['x', 'z', 'y2'],
+                            promotes_outputs=['y1'])
+        cycle.add_subsystem('d2', SellarDis2(), 
+                            promotes_inputs=['z', 'y1'],
+                            promotes_outputs=['y2'])
 
         self.set_input_defaults('x', 1.0)
         self.set_input_defaults('z', np.array([5.0, 2.0]))
@@ -355,8 +357,8 @@ class SellarNoDerivativesCS(om.Group):
         self.add_subsystem('pz', om.IndepVarComp('z', np.array([5.0, 2.0])), promotes=['z'])
 
         cycle = self.add_subsystem('cycle', om.Group(), promotes=['x', 'z', 'y1', 'y2'])
-        d1 = cycle.add_subsystem('d1', SellarDis1CS(), promotes=['x', 'z', 'y1', 'y2'])
-        d2 = cycle.add_subsystem('d2', SellarDis2CS(), promotes=['z', 'y1', 'y2'])
+        cycle.add_subsystem('d1', SellarDis1CS(), promotes=['x', 'z', 'y1', 'y2'])
+        cycle.add_subsystem('d2', SellarDis2CS(), promotes=['z', 'y1', 'y2'])
 
         self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)',
                                                   z=np.array([0.0, 0.0]), x=0.0),

--- a/openmdao/test_suite/components/three_bar_truss.py
+++ b/openmdao/test_suite/components/three_bar_truss.py
@@ -219,7 +219,7 @@ class ThreeBarTrussVector(om.ExplicitComponent):
         rho = np.zeros((3, ))
         try:
             rho[0] = self.rho[mat[0]]
-        except:
+        except Exception:
             pass
         rho[1] = self.rho[mat[1]]
         rho[2] = self.rho[mat[2]]

--- a/openmdao/test_suite/groups/parallel_groups.py
+++ b/openmdao/test_suite/groups/parallel_groups.py
@@ -106,8 +106,8 @@ class FanInGrouped2(om.Group):
     def __init__(self):
         super().__init__()
 
-        p1 = self.add_subsystem('p1', om.IndepVarComp('x', 1.0))
-        p2 = self.add_subsystem('p2', om.IndepVarComp('x', 1.0))
+        self.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+        self.add_subsystem('p2', om.IndepVarComp('x', 1.0))
 
         self.sub = self.add_subsystem('sub', om.ParallelGroup())
         self.sub.add_subsystem('c1', om.ExecComp(['y=-2.0*x']))

--- a/openmdao/test_suite/matrices/ml2np.py
+++ b/openmdao/test_suite/matrices/ml2np.py
@@ -33,7 +33,8 @@ def matlab2npy(mlfile):
 
 
 if __name__ == '__main__':
-    import sys, os
+    import sys
+    import os
 
     a = matlab2npy(sys.argv[1])
     base = os.path.splitext(sys.argv[1])[0]

--- a/openmdao/test_suite/mpi_scaling.py
+++ b/openmdao/test_suite/mpi_scaling.py
@@ -4,7 +4,6 @@ from itertools import repeat
 import numpy as np
 import openmdao.api as om
 from openmdao.utils.general_utils import shape2tuple, env_truthy
-from openmdao.utils.mpi import MPI
 
 
 debug = env_truthy('OM_DEBUG')
@@ -42,7 +41,7 @@ class ExplicitSleepComp(om.ExplicitComponent):
                 elif isinstance(v, np.ndarray):
                     self.varshape = v.shape
                 else:
-                    raise TypeError(f"ExplicitSleepComp doesn't work with discrete variables.")
+                    raise TypeError("ExplicitSleepComp doesn't work with discrete variables.")
 
     def setup(self):
         self.inames = []
@@ -174,7 +173,6 @@ def make_group(ncomps, nvars, delays, proc_groups, max_procs, nliters=2, liniter
 
 if __name__ == '__main__':
     import sys
-    from openmdao.utils.assert_utils import assert_check_totals
     from time import perf_counter
 
     start = perf_counter()

--- a/openmdao/test_suite/scripts/circuit_analysis.py
+++ b/openmdao/test_suite/scripts/circuit_analysis.py
@@ -1,9 +1,6 @@
-import unittest
-
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
 
 
 class Resistor(om.ExplicitComponent):

--- a/openmdao/test_suite/scripts/multipoint_beam_opt.py
+++ b/openmdao/test_suite/scripts/multipoint_beam_opt.py
@@ -2,7 +2,6 @@
 import numpy as np
 
 import openmdao.api as om
-from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
 try:

--- a/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
+++ b/openmdao/test_suite/test_examples/basic_opt_paraboloid.py
@@ -1,7 +1,6 @@
 import unittest
 
 from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.test_suite.components.paraboloid import Paraboloid
 
 
 class BasicOptParaboloid(unittest.TestCase):

--- a/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/components/local_stiffness_matrix_comp.py
@@ -26,7 +26,7 @@ class LocalStiffnessMatrixComp(om.ExplicitComponent):
         coeffs[3, :] = [6 * L0, 2 * L0 ** 2, -6 * L0, 4 * L0 ** 2]
         coeffs *= E / L0 ** 3
 
-        self.mtx = mtx = np.zeros((num_elements, 4, 4, num_elements))
+        self.mtx = np.zeros((num_elements, 4, 4, num_elements))
         for ind in range(num_elements):
             self.mtx[ind, :, :, ind] = coeffs
 

--- a/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/multipoint_beam_stress.py
@@ -69,7 +69,7 @@ class MultipointBeamGroup(om.Group):
         E = self.options['E']
         L = self.options['L']
         b = self.options['b']
-        volume = self.options['volume']
+        # volume = self.options['volume']
         max_bending = self.options['max_bending']
         num_elements = self.options['num_elements']
         num_nodes = num_elements + 1

--- a/openmdao/test_suite/test_examples/test_circuit_analysis.py
+++ b/openmdao/test_suite/test_examples/test_circuit_analysis.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 import unittest
 
 import openmdao.api as om

--- a/openmdao/test_suite/tests/test_auto_ivc_api_conversion.py
+++ b/openmdao/test_suite/tests/test_auto_ivc_api_conversion.py
@@ -63,7 +63,7 @@ class TestConversionGuideDoc(unittest.TestCase):
 
         prob.setup()
 
-        x = prob.get_val('x')
+        prob.get_val('x')
         prob.set_val('y', 15.0)
 
     def test_constrained(self):

--- a/openmdao/test_suite/tot_jac_builder.py
+++ b/openmdao/test_suite/tot_jac_builder.py
@@ -2,10 +2,8 @@
 A tool to make it easier to investigate coloring of jacobians with different sparsity structures.
 """
 
-import sys
 import numpy as np
 
-from openmdao.utils.general_utils import printoptions
 from openmdao.utils.coloring import _compute_coloring
 
 class TotJacBuilder(object):
@@ -15,9 +13,8 @@ class TotJacBuilder(object):
 
     def add_random_points(self, npoints):
         nrows, ncols = self.J.shape
-        count = 0
 
-        zro = self.J == False
+        zro = self.J is False
         flat = self.J[zro].flatten()
         flat[:npoints] = True
         np.random.shuffle(flat)
@@ -117,9 +114,6 @@ class TotJacBuilder(object):
         else:
             nrows, ncols = (100, 50)
             builder = TotJacBuilder(nrows, ncols)
-
-        J = builder.J
-        shape = J.shape
 
         # dense rows
         for row in range(n_dense_rows):

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -4,10 +4,8 @@ Utils for dealing with arrays.
 import sys
 from itertools import product
 import hashlib
-from math import isclose
 
 import numpy as np
-from numpy.linalg import norm
 
 from scipy.sparse import coo_matrix
 

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -2,7 +2,6 @@
 Functions for making assertions about OpenMDAO Systems.
 """
 
-from math import isnan
 from fnmatch import fnmatch
 import warnings
 import unittest

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -21,8 +21,8 @@ import numpy as np
 from scipy.sparse import coo_matrix, csc_matrix, csr_matrix
 
 from openmdao.core.constants import INT_DTYPE, _DEFAULT_OUT_STREAM
-from openmdao.utils.general_utils import _src_name_iter, _src_or_alias_item_iter, \
-    _convert_auto_ivc_to_conn_name, pattern_filter
+from openmdao.utils.general_utils import _src_name_iter, _convert_auto_ivc_to_conn_name, \
+    pattern_filter
 import openmdao.utils.hooks as hooks
 from openmdao.utils.file_utils import _load_and_exec
 from openmdao.utils.om_warnings import issue_warning, OMDeprecationWarning, DerivativesWarning
@@ -1286,8 +1286,8 @@ class Coloring(object):
                 print('</pre>\n', file=out_stream)
 
         if html:
-            out_stream.write(f'</body>\n'
-                             f'</html>')
+            out_stream.write('</body>\n'
+                             '</html>')
 
         if has_overlap:
             raise RuntimeError("Internal coloring bug: jacobian has entries where fwd and rev "
@@ -2997,7 +2997,6 @@ def _partial_coloring_cmd(options, user_args):
         Args to be passed to the user script.
 
     """
-    from openmdao.core.problem import Problem
     from openmdao.core.component import Component
     from openmdao.devtools.debug import profiling
     from openmdao.utils.general_utils import do_nothing_context

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -10,7 +10,6 @@ import pickle
 import sys
 import tempfile
 import traceback
-import pathlib
 import webbrowser
 from itertools import combinations, groupby
 from contextlib import contextmanager

--- a/openmdao/utils/entry_points.py
+++ b/openmdao/utils/entry_points.py
@@ -12,7 +12,6 @@ from inspect import getmembers, isclass
 import textwrap
 
 from openmdao.utils.file_utils import package_iter, get_module_path, _iter_entry_points
-from openmdao.utils.om_warnings import issue_warning
 
 from openmdao.core.component import Component
 from openmdao.core.explicitcomponent import ExplicitComponent

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -10,6 +10,8 @@ from fnmatch import fnmatch
 from os.path import join, basename, dirname, isfile, split, splitext, abspath
 import pathlib
 
+from openmdao.utils.om_warnings import issue_warning
+
 
 def get_module_path(fpath):
     """
@@ -216,7 +218,7 @@ def fname2mod_name(fname):
                   ';', ':', '"', "'", '<', '>', '?', '/', '\\', '|']
 
     if not fname.endswith('.py'):
-        raise ValueError(f"'{s}' does not end with '.py'")
+        raise ValueError(f"'{fname}' does not end with '.py'")
 
     s = os.path.basename(fname).rsplit('.', 1)[0]
 

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -2,7 +2,6 @@
 Utilities for working with files.
 """
 
-from multiprocessing import Value
 import sys
 import os
 import importlib
@@ -451,7 +450,6 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
     from openmdao.core.problem import Problem
     from openmdao.core.system import System
     from openmdao.solvers.solver import Solver
-    from openmdao.core.constants import _SetupStatus
 
     if isinstance(obj, Problem):
         prob_meta = obj._metadata

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1187,7 +1187,7 @@ def wing_dbg():
         new = sys.path[:] + [os.environ['WINGHOME']]
         sys.path = new
         try:
-            import wingdbstub
+            import wingdbstub  # noqa: E401
         finally:
             sys.path = save
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1187,7 +1187,7 @@ def wing_dbg():
         new = sys.path[:] + [os.environ['WINGHOME']]
         sys.path = new
         try:
-            import wingdbstub  # noqa: E401
+            import wingdbstub  # noqa: F401
         finally:
             sys.path = save
 

--- a/openmdao/utils/hooks.py
+++ b/openmdao/utils/hooks.py
@@ -7,8 +7,6 @@ import warnings
 import weakref
 from inspect import getmro
 
-from openmdao.utils.om_warnings import issue_warning
-
 
 # global dict of hooks
 # {class_name: { inst_id: {fname: [pre_hooks, post_hooks]}}}

--- a/openmdao/utils/indexer.py
+++ b/openmdao/utils/indexer.py
@@ -1132,7 +1132,7 @@ class ShapedMultiIndexer(Indexer):
             The index array into a flat array.
         """
         if self._src_shape is None:
-            raise ValueError(f"Can't determine extent of array because source shape is not known.")
+            raise ValueError("Can't determine extent of array because source shape is not known.")
 
         idxs = np.arange(shape_to_len(self._src_shape), dtype=np.int32).reshape(self._src_shape)
 
@@ -1243,7 +1243,7 @@ class MultiIndexer(ShapedMultiIndexer):
             self._shaped_inst = ShapedMultiIndexer(tuple(idxer.shaped_instance()()
                                                          for idxer in self._idx_list),
                                                    flat_src=self._flat_src)
-        except Exception as err:
+        except Exception:
             self._shaped_inst = None
         else:
             self._shaped_inst.set_src_shape(self._src_shape)

--- a/openmdao/utils/jax_utils.py
+++ b/openmdao/utils/jax_utils.py
@@ -1,7 +1,6 @@
 """
 Utilities for the use of jax in combination with OpenMDAO.
 """
-from collections.abc import Callable
 
 try:
     import jax

--- a/openmdao/utils/mpi.py
+++ b/openmdao/utils/mpi.py
@@ -31,14 +31,14 @@ def _redirect_streams(to_fd):
     try:
         original_stdout_fd = sys.stdout.fileno()
         sys.stdout.close()
-    except (AttributeError, io.UnsupportedOperation) as err:
+    except (AttributeError, io.UnsupportedOperation):
         with open(os.devnull) as devnull:
             original_stdout_fd = devnull.fileno()
 
     try:
         original_stderr_fd = sys.stderr.fileno()
         sys.stderr.close()
-    except (AttributeError, io.UnsupportedOperation) as err:
+    except (AttributeError, io.UnsupportedOperation):
         with open(os.devnull) as devnull:
             original_stderr_fd = devnull.fileno()
 

--- a/openmdao/utils/numba.py
+++ b/openmdao/utils/numba.py
@@ -5,8 +5,8 @@ If numba is not available, this module provides a dummy jit decorator that simpl
 original function.
 """
 try:
-    import numba
-    from numba import *
+    import numba         # noqa: F401
+    from numba import *  # noqa: F403
 except ImportError:
     numba = None
     prange = range

--- a/openmdao/utils/rangemapper.py
+++ b/openmdao/utils/rangemapper.py
@@ -2,8 +2,6 @@
 A collection of classes for mapping indices to variable names and vice versa.
 """
 
-from openmdao.utils.array_utils import shape_to_len
-
 
 # default size of array for which we use a FlatRangeMapper instead of a RangeTree
 MAX_FLAT_RANGE_SIZE = 10000

--- a/openmdao/utils/relevance.py
+++ b/openmdao/utils/relevance.py
@@ -4,7 +4,6 @@ Class definitions for Relevance and related classes.
 
 from contextlib import contextmanager
 from collections import defaultdict
-import atexit
 
 import numpy as np
 

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -4,6 +4,7 @@ Utility functions related to the reporting system which generates reports by def
 
 import os
 import inspect
+import pathlib
 from itertools import chain
 
 from openmdao.core.constants import _UNDEFINED

--- a/openmdao/utils/reports_system.py
+++ b/openmdao/utils/reports_system.py
@@ -2,12 +2,9 @@
 Utility functions related to the reporting system which generates reports by default for all runs.
 """
 
-from collections import namedtuple
 import os
 import inspect
 from itertools import chain
-
-from numpy import isin
 
 from openmdao.core.constants import _UNDEFINED
 from openmdao.utils.hooks import _register_hook, _unregister_hook
@@ -655,7 +652,7 @@ def _add_dir_to_tree(dirpath, lines, explevel, level, to_match):
             lines.append('</li>')
             return
 
-    lines.append(f'<ul>')
+    lines.append('<ul>')
 
     for f in chain(files, sorted(directories)):
         path = os.path.join(dirpath, f)

--- a/openmdao/utils/scaffold.py
+++ b/openmdao/utils/scaffold.py
@@ -152,7 +152,7 @@ def _scaffold_exec(options, user_args):
                 os.mkdir(pkg_name)
                 os.chdir(pkg_name)
 
-                with open('__init__.py', 'w') as f:
+                with open('__init__.py', 'w'):
                     pass
 
                 if base == 'command':
@@ -164,7 +164,7 @@ def _scaffold_exec(options, user_args):
                 os.chdir('test')
 
                 # make test dir a package as well
-                with open('__init__.py', 'w') as f:
+                with open('__init__.py', 'w'):
                     pass
 
                 _write_template(testfile, 'test', class_name=options.class_name)

--- a/openmdao/utils/shell_proc.py
+++ b/openmdao/utils/shell_proc.py
@@ -259,9 +259,9 @@ class ShellProc(subprocess.Popen):
         if return_code:
             if return_code > 0:
                 try:
-                    err_msg = os.strerror(return_code)
+                    error_msg = os.strerror(return_code)
                 except OverflowError:
-                    err_msg = "Process exited with unknown return code {}".format(return_code)
+                    error_msg = "Process exited with unknown return code {}".format(return_code)
             elif sys.platform != 'win32':
                 sig = -return_code
                 if sig < signal.NSIG:

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -4,12 +4,10 @@ import functools
 import builtins
 import os
 import re
-import sys
 from itertools import zip_longest
 from contextlib import contextmanager
 
 import numpy as np
-from scipy.sparse import coo_matrix
 
 try:
     from parameterized import parameterized

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -115,8 +115,8 @@ class CmdlineTestCase(unittest.TestCase):
         # check the expected output at all.  The underlying functions that implement the
         # commands should be tested seperately.
         try:
-            output = subprocess.check_output(cmd.split(),
-                                             stderr=subprocess.STDOUT)  # nosec: trusted input
+            subprocess.check_output(cmd.split(),
+                                    stderr=subprocess.STDOUT)  # nosec: trusted input
         except subprocess.CalledProcessError as err:
             self.fail(f"Command '{cmd}' failed.  Return code: {err.returncode}: "
                       f"Output was: \n{err.output.decode('utf-8')}")
@@ -176,7 +176,7 @@ class CmdlineTestfuncTestCase(unittest.TestCase):
         # check the expected output at all.  The underlying functions that implement the
         # commands should be tested seperately.
         try:
-            output = subprocess.check_output(cmd.split())  # nosec: trusted input
+            subprocess.check_output(cmd.split())  # nosec: trusted input
         except subprocess.CalledProcessError as err:
             self.fail(f"Command '{cmd}' failed.  Return code: {err.returncode} "
                       f"Output was: \n{err.output.decode('utf-8')}")

--- a/openmdao/utils/tests/test_code_utils.py
+++ b/openmdao/utils/tests/test_code_utils.py
@@ -22,36 +22,36 @@ class TestCodeUtils(unittest.TestCase):
 class TestLambdaPickleWrapper(unittest.TestCase):
 
     def test_init(self):
-        func = lambda x: x + 1
+        func = lambda x: x + 1  # noqa
         wrapper = LambdaPickleWrapper(func)
         self.assertEqual(wrapper._func, func)
 
     def test_call(self):
-        func = lambda x: x + 1
+        func = lambda x: x + 1  # noqa
         wrapper = LambdaPickleWrapper(func)
         self.assertEqual(wrapper(1), 2)
 
     def test_getstate(self):
-        func = lambda x: x + 1
+        func = lambda x: x + 1  # noqa
         wrapper = LambdaPickleWrapper(func)
         state = wrapper.__getstate__()
         self.assertEqual(state['_func'], wrapper._getsrc())
 
     def test_setstate(self):
-        func = lambda x: x + 1
+        func = lambda x: x + 1  # noqa
         wrapper = LambdaPickleWrapper(func)
         state = {'_func': 'lambda x: x + 2', '_src': None}
         wrapper.__setstate__(state)
         self.assertEqual(wrapper(1), 3)
 
     def test_getsrc(self):
-        func = lambda x: x + 1
+        func = lambda x: x + 1  # noqa
         wrapper = LambdaPickleWrapper(func)
         src = wrapper._getsrc()
         self.assertEqual(src, 'lambda x: x + 1')
 
     def test_pickle(self):
-        func = lambda x: x + 1
+        func = lambda x: x + 1  # noqa
         wrapper = LambdaPickleWrapper(func)
         pkl = pickle.dumps(wrapper)
         wrapper2 = pickle.loads(pkl)

--- a/openmdao/utils/tests/test_entry_points.py
+++ b/openmdao/utils/tests/test_entry_points.py
@@ -6,13 +6,6 @@ from openmdao.utils.entry_points import list_installed, _filtered_ep_iter, _allo
     compute_entry_points, _epgroup_bases, split_ep
 from openmdao.utils.assert_utils import assert_no_warning
 
-from openmdao.api import Group, SurrogateModel
-from openmdao.core.component import Component
-from openmdao.core.driver import Driver
-from openmdao.solvers.solver import LinearSolver, NonlinearSolver
-from openmdao.recorders.case_recorder import CaseRecorder
-from openmdao.recorders.base_case_reader import BaseCaseReader
-
 
 _ep_bases = tuple(_epgroup_bases)
 
@@ -27,7 +20,7 @@ def _is_ep_class(c):
 class TestEntryPoints(unittest.TestCase):
 
     def test_list_installed(self):
-        dct = list_installed()
+        list_installed()
 
     # test that all entry points are loadable and result in the correct type
     def test_ep_load(self):

--- a/openmdao/utils/tests/test_entry_points.py
+++ b/openmdao/utils/tests/test_entry_points.py
@@ -13,7 +13,7 @@ _ep_bases = tuple(_epgroup_bases)
 def _is_ep_class(c):
     try:
         return issubclass(c, _ep_bases)
-    except:
+    except Exception:
         return False
 
 
@@ -29,13 +29,6 @@ class TestEntryPoints(unittest.TestCase):
     # test if all relevant classes have been registered as entry points
     def test_ep_registered(self):
         skip = set(['openmdao.surrogate_models.surrogate_model:MultiFiSurrogateModel'])
-
-        # if mpi4py isn't installed, then the pyopstsparse_driver import will fail
-        try:
-            import mpi4py
-            from pyoptsparse import Optimization
-        except ImportError:
-            skip.add('openmdao.drivers.pyoptsparse_driver:pyOptSparseDriver')
 
         # collect declared entry points for openmdao
         registered_eps = {}

--- a/openmdao/utils/tests/test_file_wrap.py
+++ b/openmdao/utils/tests/test_file_wrap.py
@@ -763,7 +763,7 @@ class FileParserFeature(unittest.TestCase):
         parser.mark_anchor("LOAD CASE")
         var = parser.transfer_var(1, 4)
 
-        from numpy import isnan, isinf
+        from numpy import isnan
         self.assertEqual(isnan(var), True)
 
     def test_parse_string(self):

--- a/openmdao/utils/tests/test_find_citations.py
+++ b/openmdao/utils/tests/test_find_citations.py
@@ -25,7 +25,7 @@ class TestFindCite(unittest.TestCase):
         p.model.nonlinear_solver.cite = "foobar nonlinear_solver"
         p.model.linear_solver.cite = "foobar linear_solver"
 
-        indeps = p.model.add_subsystem('indeps', IndepVarComp('x', 10), promotes=['*'])
+        p.model.add_subsystem('indeps', IndepVarComp('x', 10), promotes=['*'])
 
         ec = p.model.add_subsystem('ec', MyImplComp(), promotes=['*'])
         ec.nonlinear_solver = NewtonSolver()
@@ -144,7 +144,7 @@ class TestFindCitePar(unittest.TestCase):
         p.model.nonlinear_solver.cite = "foobar nonlinear_solver"
         p.model.linear_solver.cite = "foobar linear_solver"
 
-        indeps = p.model.add_subsystem('indeps', IndepVarComp('x', 10), promotes=['*'])
+        p.model.add_subsystem('indeps', IndepVarComp('x', 10), promotes=['*'])
 
         par = p.model.add_subsystem('par', ParallelGroup(), promotes=['*'])
 

--- a/openmdao/utils/tests/test_hooks.py
+++ b/openmdao/utils/tests/test_hooks.py
@@ -245,8 +245,6 @@ class HooksTestCase(unittest.TestCase):
 
         hooks._unregister_hook('setup', 'Problem')
 
-        msg = "No hook found for method 'final_setup' for class 'Problem' and instance 'None'."
-
         hooks._unregister_hook('run_model', 'Problem')
         prob.calls = []
 
@@ -307,7 +305,7 @@ class HooksTestCase(unittest.TestCase):
 
         of=['comp.f_xy']
         wrt=['p1.x', 'p2.y']
-        J = prob.compute_totals(of=of, wrt=wrt, return_format='array')
+        prob.compute_totals(of=of, wrt=wrt, return_format='array')
         self.assertEqual(len(prob.calls), 2)
         self.assertEqual(prob.calls[0],  ('pre_totals', (), {'of': ['comp.f_xy'], 'wrt': ['p1.x', 'p2.y'], 'return_format': 'array'}))
         self.assertEqual(prob.calls[1],  ('post_totals', (), {'of': ['comp.f_xy'], 'wrt': ['p1.x', 'p2.y'], 'return_format': 'array'}))

--- a/openmdao/utils/tests/test_indexer.py
+++ b/openmdao/utils/tests/test_indexer.py
@@ -148,7 +148,7 @@ class IndexerTestCase(unittest.TestCase):
         assert_equal(src[ind.shaped_array()], np.array([5,3,7,9]))
         assert_equal(ind.shaped_instance()(), np.array([5,3,7,9]))
 
-    def test_neg_arr(self):
+    def test_neg_arr2(self):
         ind = indexer[[-1, -3, -5]]
         src = np.arange(10)
 

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -342,7 +342,7 @@ test       **Required**  ['a', 'b']         N/A                    Test integer 
             self.dict['test2'] = None
         # Should only generate warning first time
         with assert_no_warning(OMDeprecationWarning, msg):
-            option = self.dict['test2']
+            self.dict['test2']
 
     def test_deprecated_tuple_option(self):
         msg = 'Option "test1" is deprecated. Use "foo" instead.'

--- a/openmdao/utils/tests/test_options_dictionary_feature.py
+++ b/openmdao/utils/tests/test_options_dictionary_feature.py
@@ -122,7 +122,7 @@ class TestOptionsDictionary(unittest.TestCase):
                 outputs['y'] = 2 * inputs['x']
 
         try:
-            comp = VectorDoublingComp(size=5)
+            VectorDoublingComp(size=5)
         except Exception as err:
             self.assertEqual(str(err), "Option 'size' with value 5 must be an even number.")
 

--- a/openmdao/utils/tests/test_rangemapper.py
+++ b/openmdao/utils/tests/test_rangemapper.py
@@ -1,7 +1,6 @@
 import unittest
 
-from openmdao.utils.assert_utils import assert_near_equal
-from openmdao.utils.rangemapper import RangeMapper, RangeTree, FlatRangeMapper, MAX_FLAT_RANGE_SIZE
+from openmdao.utils.rangemapper import RangeMapper, RangeTree, FlatRangeMapper
 
 
 _data = {

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -239,7 +239,7 @@ class TestReportsSystem(unittest.TestCase):
     def test_report_generation_on_error(self):
         prob_name = 'error_problem'
         try:
-            prob = self.setup_problem_w_errors(prob_name)
+            self.setup_problem_w_errors(prob_name)
         except Exception as err:
             # get the path to the problem subdirectory
             problem_reports_dir = pathlib.Path(f'{prob_name}_out/reports')
@@ -612,7 +612,7 @@ class TestReportsSystem(unittest.TestCase):
 
         problem_reports_dir = subprob.get_reports_dir()
         self.assertFalse(problem_reports_dir.is_dir(),
-                         f'The problem2 report dir was found but should not exist.')
+                         'The problem2 report dir was found but should not exist.')
         path = pathlib.Path(problem_reports_dir).joinpath(self.n2_filename)
         self.assertFalse(path.is_file(),
                          f'The problem2 n2 report file, {str(path)}, was found but should not exist.')
@@ -635,7 +635,7 @@ class TestReportsSystem(unittest.TestCase):
     @hooks_active
     def test_report_generation_extra_compute_totals_from_scaling_report(self):
         clear_reports()
-        from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver, pyoptsparse
+        from openmdao.drivers.pyoptsparse_driver import pyoptsparse
         if pyoptsparse is None:
             raise unittest.SkipTest("pyoptsparse is required.")
         prob = self.setup_and_run_simple_problem(driver=om.pyOptSparseDriver(optimizer='SLSQP'),

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -31,9 +31,6 @@ except ImportError:
 
 OPT, OPTIMIZER = set_pyoptsparse_opt('SLSQP')
 
-if OPTIMIZER:
-    from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
-
 
 @use_tempdirs
 class TestReportsSystem(unittest.TestCase):
@@ -258,7 +255,7 @@ class TestReportsSystem(unittest.TestCase):
     @unittest.skipUnless(OPTIMIZER, "This test requires pyOptSparseDriver.")
     def test_report_generation_basic_pyoptsparse(self):
         # Just to try a different driver
-        prob = self.setup_and_run_simple_problem(driver=pyOptSparseDriver(optimizer='SLSQP'))
+        prob = self.setup_and_run_simple_problem(driver=om.pyOptSparseDriver(optimizer='SLSQP'))
 
         # get the path to the problem subdirectory
         problem_reports_dir = prob.get_reports_dir()

--- a/openmdao/utils/tests/test_scaffold.py
+++ b/openmdao/utils/tests/test_scaffold.py
@@ -2,7 +2,7 @@
 import unittest
 import os
 import importlib
-from subprocess import check_call
+from subprocess import CalledProcessError, check_call
 
 from openmdao.utils.scaffold import _camel_case_split, _write_template
 from openmdao.utils.testing_utils import use_tempdirs
@@ -85,7 +85,7 @@ class TestScaffold(unittest.TestCase):
 
             # install it
             check_call(['pip', 'install', '-q', '--no-cache-dir', '--no-deps', '.'])  # nosec: trusted input
-            os.chdir(startdir) 
+            os.chdir(startdir)
 
             try:
                 modname = _camel_case_split(cname)

--- a/openmdao/utils/tests/test_scaffold.py
+++ b/openmdao/utils/tests/test_scaffold.py
@@ -4,7 +4,6 @@ import os
 import importlib
 from subprocess import check_call
 
-import openmdao.api as om
 from openmdao.utils.scaffold import _camel_case_split, _write_template
 from openmdao.utils.testing_utils import use_tempdirs
 
@@ -94,7 +93,7 @@ class TestScaffold(unittest.TestCase):
                 # try to instantiate it
                 mod = importlib.import_module('.'.join((pkgname, modname)))
                 klass = getattr(mod, tgtname)
-                instance = klass(*args)
+                klass(*args)
 
             finally:
 

--- a/openmdao/utils/tests/test_testing_utils.py
+++ b/openmdao/utils/tests/test_testing_utils.py
@@ -12,7 +12,7 @@ class TestMissingImports(unittest.TestCase):
     def test_missing_imports_cm(self):
         with self.assertRaises(ImportError) as e:
             with MissingImports('pyoptsparse'):
-                import pyoptsparse  # noqa: F401
+                import pyoptsparse  # noqa
 
         msg = "No module named pyoptsparse due to missing import pyoptsparse."
 
@@ -21,37 +21,39 @@ class TestMissingImports(unittest.TestCase):
     def test_missing_imports(self):
 
         with MissingImports('pyoptsparse'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
     def test_missing_imports_docs(self):
 
         with MissingImports('IPython'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
         with MissingImports('matplotlib'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
         with MissingImports('numpydoc'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
     def test_missing_imports_notebooks(self):
 
         with MissingImports('notebook'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
     def test_missing_imports_visualization(self):
+
         with MissingImports('bokeh'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
     def test_missing_imports_testing(self):
+
         with MissingImports('parameterized'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
         with MissingImports('pycodestyle'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
         with MissingImports('testflo'):
-            import openmdao.api as om  # noqa: F401
+            import openmdao.api as om  # noqa
 
 
 class TestPrimitives(unittest.TestCase):

--- a/openmdao/utils/tests/test_testing_utils.py
+++ b/openmdao/utils/tests/test_testing_utils.py
@@ -12,7 +12,7 @@ class TestMissingImports(unittest.TestCase):
     def test_missing_imports_cm(self):
         with self.assertRaises(ImportError) as e:
             with MissingImports('pyoptsparse'):
-                import pyoptsparse  # noqa: E401
+                import pyoptsparse  # noqa: F401
 
         msg = "No module named pyoptsparse due to missing import pyoptsparse."
 
@@ -21,37 +21,37 @@ class TestMissingImports(unittest.TestCase):
     def test_missing_imports(self):
 
         with MissingImports('pyoptsparse'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
     def test_missing_imports_docs(self):
 
         with MissingImports('IPython'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
         with MissingImports('matplotlib'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
         with MissingImports('numpydoc'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
     def test_missing_imports_notebooks(self):
 
         with MissingImports('notebook'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
     def test_missing_imports_visualization(self):
         with MissingImports('bokeh'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
     def test_missing_imports_testing(self):
         with MissingImports('parameterized'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
         with MissingImports('pycodestyle'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
         with MissingImports('testflo'):
-            import openmdao.api as om  # noqa: E401
+            import openmdao.api as om  # noqa: F401
 
 
 class TestPrimitives(unittest.TestCase):
@@ -210,4 +210,3 @@ class TestSNumEqual(unittest.TestCase):
         # Test with strings that contain multiple numbers outside the tolerance
         self.assertFalse(snum_equal("abc123.0001def456.0001", "abc123.0002def456.0002", atol=1e-6))
         self.assertFalse(snum_equal("abc123.0001def456.0001", "abc123.0002def456.0002", rtol=1e-6))
-

--- a/openmdao/utils/tests/test_testing_utils.py
+++ b/openmdao/utils/tests/test_testing_utils.py
@@ -12,7 +12,7 @@ class TestMissingImports(unittest.TestCase):
     def test_missing_imports_cm(self):
         with self.assertRaises(ImportError) as e:
             with MissingImports('pyoptsparse'):
-                import pyoptsparse
+                import pyoptsparse  # noqa: E401
 
         msg = "No module named pyoptsparse due to missing import pyoptsparse."
 
@@ -21,37 +21,37 @@ class TestMissingImports(unittest.TestCase):
     def test_missing_imports(self):
 
         with MissingImports('pyoptsparse'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
     def test_missing_imports_docs(self):
 
         with MissingImports('IPython'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
         with MissingImports('matplotlib'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
         with MissingImports('numpydoc'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
     def test_missing_imports_notebooks(self):
 
         with MissingImports('notebook'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
     def test_missing_imports_visualization(self):
         with MissingImports('bokeh'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
     def test_missing_imports_testing(self):
         with MissingImports('parameterized'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
         with MissingImports('pycodestyle'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
         with MissingImports('testflo'):
-            import openmdao.api as om
+            import openmdao.api as om  # noqa: E401
 
 
 class TestPrimitives(unittest.TestCase):

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -7,8 +7,7 @@ import warnings
 import openmdao.api as om
 from openmdao.utils.units import NumberDict, PhysicalUnit, _find_unit, import_library, \
     add_unit, add_offset_unit, unit_conversion, simplify_unit
-from openmdao.utils.assert_utils import assert_warning, assert_near_equal
-from openmdao.utils.om_warnings import OMDeprecationWarning
+from openmdao.utils.assert_utils import assert_near_equal
 
 
 class TestNumberDict(unittest.TestCase):

--- a/openmdao/utils/tests/test_vartable.py
+++ b/openmdao/utils/tests/test_vartable.py
@@ -1,7 +1,6 @@
 import sys
 import unittest
 
-import numpy as np
 from io import StringIO
 
 import openmdao.api as om

--- a/openmdao/vectors/default_transfer.py
+++ b/openmdao/vectors/default_transfer.py
@@ -7,7 +7,6 @@ import numpy as np
 from openmdao.core.constants import INT_DTYPE
 from openmdao.vectors.transfer import Transfer
 from openmdao.utils.array_utils import _global2local_offsets
-from openmdao.utils.mpi import MPI
 
 
 def _fill(arr, indices_iter):

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -11,7 +11,7 @@ if use_mpi is False:
     PETScTransfer = None
 else:
     try:
-        import petsc4py
+        import petsc4py  # noqa: F401
         from petsc4py import PETSc
     except ImportError:
         PETSc = None

--- a/openmdao/vectors/tests/test_vector.py
+++ b/openmdao/vectors/tests/test_vector.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI, multi_proc_exception_check
 
 try:
@@ -224,9 +224,9 @@ class TestPETScVector3Proc(unittest.TestCase):
         model.add_subsystem('des_vars', comp)
 
         sub = model.add_subsystem('pp', om.ParallelGroup())
-        c1 = sub.add_subsystem('calc1', om.ExecComp('y = 2.0*x', x=np.ones((3, )), y=np.ones((3, ))))
-        c2 = sub.add_subsystem('calc2', om.ExecComp('y = 5.0*x', x=np.ones((3, )), y=np.ones((3, ))))
-        c3 = sub.add_subsystem('calc3', om.ExecComp('y = 7.0*x', x=np.ones((3, )), y=np.ones((3, ))))
+        sub.add_subsystem('calc1', om.ExecComp('y = 2.0*x', x=np.ones((3, )), y=np.ones((3, ))))
+        sub.add_subsystem('calc2', om.ExecComp('y = 5.0*x', x=np.ones((3, )), y=np.ones((3, ))))
+        sub.add_subsystem('calc3', om.ExecComp('y = 7.0*x', x=np.ones((3, )), y=np.ones((3, ))))
 
         model.connect('des_vars.v1', 'pp.calc1.x')
         model.connect('des_vars.v1', 'pp.calc2.x')
@@ -246,7 +246,7 @@ class TestPETScVector3Proc(unittest.TestCase):
             assert_near_equal(norm_val, 89.61584681293817, 1e-10)
 
         with multi_proc_exception_check(prob.comm):
-            J = prob.compute_totals(of=['pp.calc1.y', 'pp.calc2.y', 'pp.calc3.y'], wrt=['des_vars.v1'])
+            prob.compute_totals(of=['pp.calc1.y', 'pp.calc2.y', 'pp.calc3.y'], wrt=['des_vars.v1'])
 
         with multi_proc_exception_check(prob.comm):
             vec = prob.model._vectors['output']['linear']

--- a/openmdao/visualization/case_viewer/case_viewer.py
+++ b/openmdao/visualization/case_viewer/case_viewer.py
@@ -481,7 +481,6 @@ class CaseViewer(object):
         if axis.lower() not in ('x', 'y'):
             raise ValueError(f'Unknown axis: {axis}')
 
-        src = self._widgets['source_select'].value
         cases = self._widgets['cases_list'].options
 
         if not cases:
@@ -522,7 +521,6 @@ class CaseViewer(object):
             if axis.lower() not in ('x', 'y'):
                 raise ValueError(f'Unknown axis: {axis}')
 
-            src = self._widgets['source_select'].value
             cases = self._widgets['cases_list'].options
 
             if not cases:
@@ -532,7 +530,6 @@ class CaseViewer(object):
 
             w_var_select = self._widgets[f'{axis}_select']
             var_filter = self._widgets[f'{axis}_filter'].value
-            var_select = w_var_select.value
             var_type = self._widgets[f'{axis}_var_type'].value
 
             if var_type == 'optimization':
@@ -943,7 +940,7 @@ class CaseViewer(object):
         """
         with self._widgets['debug_output']:
             cr = self._case_reader
-            src = self._widgets['source_select'].value
+            self._widgets['source_select'].value
             cases = self._widgets['cases_list'].options
             x_var = self._widgets['x_select'].value
             y_var = self._widgets['y_select'].value

--- a/openmdao/visualization/case_viewer/case_viewer.py
+++ b/openmdao/visualization/case_viewer/case_viewer.py
@@ -306,7 +306,7 @@ class CaseViewer(object):
         if get_ipython() is None:
             raise RuntimeError('CaseViewer must be run from within a Jupyter notebook.')
         try:
-            import ipympl
+            import ipympl  # noqa: F401
         except ImportError:
             raise RuntimeError('CaseViewer requires ipympl')
 

--- a/openmdao/visualization/connection_viewer/viewconns.py
+++ b/openmdao/visualization/connection_viewer/viewconns.py
@@ -1,7 +1,6 @@
 
 """Define a function to view connections."""
 import os
-import pathlib
 import json
 from itertools import chain
 from collections import defaultdict
@@ -14,9 +13,7 @@ except ImportError:
     IFrame = display = None
 
 from openmdao.core.problem import Problem
-from openmdao.utils.units import convert_units
 from openmdao.utils.mpi import MPI
-from openmdao.utils.webview import webview
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.notebook_utils import notebook, colab
 from openmdao.utils.om_warnings import issue_warning

--- a/openmdao/visualization/dyn_shape_plot.py
+++ b/openmdao/visualization/dyn_shape_plot.py
@@ -1,7 +1,5 @@
 """Functions for plotting the dynamic shapes dependency graph."""
 
-import os
-import sys
 import networkx as nx
 
 from openmdao.core.problem import Problem

--- a/openmdao/visualization/graph_viewer.py
+++ b/openmdao/visualization/graph_viewer.py
@@ -12,7 +12,6 @@ import networkx as nx
 
 from openmdao.solvers.nonlinear.nonlinear_runonce import NonlinearRunOnce
 from openmdao.solvers.linear.linear_runonce import LinearRunOnce
-from openmdao.utils.om_warnings import issue_warning
 from openmdao.utils.general_utils import all_ancestors
 from openmdao.utils.file_utils import _load_and_exec
 import openmdao.utils.hooks as hooks
@@ -572,7 +571,7 @@ def write_graph(G, prog='dot', display=True, outfile='graph.html'):
         The graph that was written.
     """
     if pydot is None:
-        raise RuntimeError(f"write_graph requires pydot.  Install pydot using "
+        raise RuntimeError("write_graph requires pydot.  Install pydot using "
                            "'pip install pydot'. Note that pydot requires graphviz, which is a "
                            "non-Python application.\nIt can be installed at the system level "
                            "or via a package manager like conda.")

--- a/openmdao/visualization/htmlpp.py
+++ b/openmdao/visualization/htmlpp.py
@@ -237,7 +237,7 @@ class HtmlPreprocessor():
         for found_directive in matches:
 
             full_match = found_directive.group(0)
-            comment_start = found_directive.group(1)
+            # comment_start = found_directive.group(1)
             keyword = found_directive.group(2)
             arg = found_directive.group(3)
 

--- a/openmdao/visualization/htmlpp.py
+++ b/openmdao/visualization/htmlpp.py
@@ -270,7 +270,7 @@ class HtmlPreprocessor():
                 # Recursively insert a CSS file which may also have hpp directives
                 new_content = '<style type="text/css">\n' + \
                               self.parse_contents(self.load_file(arg, rlvl=rlvl,
-                                                  allow_dup=flags['dup']), rlvl) + f'\n</style>'
+                                                  allow_dup=flags['dup']), rlvl) + '\n</style>'
 
             elif keyword == 'bin2b64':
                 new_content = self.load_file(arg, binary=True, allow_dup=flags['dup'], rlvl=rlvl)

--- a/openmdao/visualization/inputs_report/inputs_report.py
+++ b/openmdao/visualization/inputs_report/inputs_report.py
@@ -1,7 +1,6 @@
 """
 A Viewer for OpenMDAO inputs.
 """
-import pathlib
 import functools
 
 import numpy as np

--- a/openmdao/visualization/inputs_report/inputs_report.py
+++ b/openmdao/visualization/inputs_report/inputs_report.py
@@ -5,11 +5,6 @@ import functools
 
 import numpy as np
 
-try:
-    from IPython.display import IFrame, display, HTML
-except ImportError:
-    IFrame = display = None
-
 from openmdao.core.problem import Problem
 from openmdao.utils.mpi import MPI
 from openmdao.utils.general_utils import printoptions

--- a/openmdao/visualization/inputs_report/tests/test_inputs_report.py
+++ b/openmdao/visualization/inputs_report/tests/test_inputs_report.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.test_suite.components.double_sellar import DoubleSellar
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.visualization.inputs_report.inputs_report import inputs_report
 
@@ -105,7 +105,6 @@ class TestInputReportsMPI(unittest.TestCase):
                 self.options.declare('n0')
 
             def setup(self):
-                n0 = self.options['n0']
                 self.add_input('x', shape_by_conn=True, distributed=True)
                 self.add_output('x_sum', shape=1)
 

--- a/openmdao/visualization/meta_model_viewer/meta_model_visualization.py
+++ b/openmdao/visualization/meta_model_viewer/meta_model_visualization.py
@@ -746,7 +746,7 @@ class MetaModelVisualization(object):
 
         # Normalize so each dimension spans [0, 1]
         points = np.divide(points, self.limit_range)
-        dist_limit = np.linalg.norm(self.dist_range * self.limit_range)
+        # dist_limit = np.linalg.norm(self.dist_range * self.limit_range)
         scaled_x0 = np.divide(self.input_point_list, self.limit_range)
 
         # Query the nearest neighbors tree for the closest points to the scaled x0 array
@@ -811,7 +811,7 @@ class MetaModelVisualization(object):
 
         # Normalize so each dimension spans [0, 1]
         points = np.divide(points, self.limit_range)
-        dist_limit = np.linalg.norm(self.dist_range * self.limit_range)
+        np.linalg.norm(self.dist_range * self.limit_range)
         scaled_x0 = np.divide(self.input_point_list, self.limit_range)
 
         # Query the nearest neighbors tree for the closest points to the scaled x0 array

--- a/openmdao/visualization/meta_model_viewer/meta_model_visualization.py
+++ b/openmdao/visualization/meta_model_viewer/meta_model_visualization.py
@@ -811,7 +811,7 @@ class MetaModelVisualization(object):
 
         # Normalize so each dimension spans [0, 1]
         points = np.divide(points, self.limit_range)
-        np.linalg.norm(self.dist_range * self.limit_range)
+        # dist_limit = np.linalg.norm(self.dist_range * self.limit_range)
         scaled_x0 = np.divide(self.input_point_list, self.limit_range)
 
         # Query the nearest neighbors tree for the closest points to the scaled x0 array

--- a/openmdao/visualization/meta_model_viewer/tests/test_semi_struct.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_semi_struct.py
@@ -69,7 +69,7 @@ class SemistructuredMetaModelCompTests(unittest.TestCase):
         prob.setup(force_alloc_complex=True)
         prob.run_model()
 
-        viz = MetaModelVisualization(interp)
+        MetaModelVisualization(interp)
 
 
 if __name__ == '__main__':

--- a/openmdao/visualization/meta_model_viewer/tests/test_structured.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_structured.py
@@ -343,12 +343,12 @@ class StructuredMetaModelCompTests(unittest.TestCase):
         adjusted_points.input_point_list = [6.632653061224477, 3.36734693877551]
         adjusted_points.dist_range = 0.5
 
-        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')
-        right_plot = adjusted_points._right_plot()
+        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')  # noqa
+        right_plot = adjusted_points._right_plot()  # noqa
         right_transparency = adjusted_points.right_alphas
 
-        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')
-        bottom_plot = adjusted_points._bottom_plot()
+        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')  # noqa
+        bottom_plot = adjusted_points._bottom_plot()  # noqa
         bottom_transparency = adjusted_points.bottom_alphas
 
 
@@ -360,10 +360,10 @@ class StructuredMetaModelCompTests(unittest.TestCase):
         adjusted_points = MetaModelVisualization(self.mm)
         adjusted_points.input_point_list = [6.632653061224477, 3.36734693877551]
 
-        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')
+        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')  # noqa
         right_plot = adjusted_points._right_plot()
 
-        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')
+        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')  # noqa
         bottom_plot = adjusted_points._bottom_plot()
 
 

--- a/openmdao/visualization/meta_model_viewer/tests/test_structured.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_structured.py
@@ -343,12 +343,12 @@ class StructuredMetaModelCompTests(unittest.TestCase):
         adjusted_points.input_point_list = [6.632653061224477, 3.36734693877551]
         adjusted_points.dist_range = 0.5
 
-        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')  # noqa
-        right_plot = adjusted_points._right_plot()  # noqa
+        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')  # noqa: F841 unused
+        right_plot = adjusted_points._right_plot()  # noqa: F841 unused
         right_transparency = adjusted_points.right_alphas
 
-        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')  # noqa
-        bottom_plot = adjusted_points._bottom_plot()  # noqa
+        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')  # noqa: F841 unused
+        bottom_plot = adjusted_points._bottom_plot()  # noqa: F841 unused
         bottom_transparency = adjusted_points.bottom_alphas
 
 
@@ -360,11 +360,11 @@ class StructuredMetaModelCompTests(unittest.TestCase):
         adjusted_points = MetaModelVisualization(self.mm)
         adjusted_points.input_point_list = [6.632653061224477, 3.36734693877551]
 
-        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')  # noqa
-        right_plot = adjusted_points._right_plot()
+        right_points = adjusted_points._structured_training_points(compute_distance=True, source='right')  # noqa: F841 unused
+        right_plot = adjusted_points._right_plot()  # noqa: F841 unused
 
-        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')  # noqa
-        bottom_plot = adjusted_points._bottom_plot()
+        bottom_points = adjusted_points._structured_training_points(compute_distance=True, source='bottom')  # noqa: F841 unused
+        bottom_plot = adjusted_points._bottom_plot()  # noqa: F841 unused
 
 
         self.assertTrue(len(adjusted_points.right_alphas) == 10)

--- a/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
@@ -74,7 +74,7 @@ class UnstructuredMetaModelCompTests(unittest.TestCase):
         prob.setup()
 
         with self.assertRaises(Exception) as context:
-            viz = MetaModelVisualization(interp)
+            MetaModelVisualization(interp)
 
         msg = "No training data present for one or more parameters"
         self.assertTrue(msg in str(context.exception))
@@ -102,7 +102,7 @@ class UnstructuredMetaModelCompTests(unittest.TestCase):
         prob.setup()
 
         with self.assertRaises(Exception) as context:
-            viz = MetaModelVisualization(interp)
+            MetaModelVisualization(interp)
 
         msg = 'Must have more than one input value'
         self.assertTrue(msg in str(context.exception))

--- a/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
@@ -288,12 +288,12 @@ class UnstructuredMetaModelCompTests(unittest.TestCase):
                                         1.28254220e-01, 1.05787985e-01, 1.01550282e-01, 8.44650788e-02,
                                         6.39578812e-02, 3.34477398e-02, 1.97405267e-02, 6.40957590e-04])
 
-        right_points = adjusted_points._unstructured_training_points(compute_distance=True, source='right')  # noqa
-        right_plot = adjusted_points._right_plot()  # noqa
+        right_points = adjusted_points._unstructured_training_points(compute_distance=True, source='right')  # noqa (unused)
+        right_plot = adjusted_points._right_plot()  # noqa (unused)
         right_transparency = adjusted_points.right_alphas
 
-        bottom_points = adjusted_points._unstructured_training_points(compute_distance=True, source='bottom')  # noqa
-        bottom_plot = adjusted_points._bottom_plot()  # noqa
+        bottom_points = adjusted_points._unstructured_training_points(compute_distance=True, source='bottom')  # noqa (unused)
+        bottom_plot = adjusted_points._bottom_plot()  # noqa (unused)
         bottom_transparency = adjusted_points.bottom_alphas
 
         assert_near_equal(right_transparency, known_points_right, 1.1e-02)

--- a/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
+++ b/openmdao/visualization/meta_model_viewer/tests/test_unstruct.py
@@ -288,12 +288,12 @@ class UnstructuredMetaModelCompTests(unittest.TestCase):
                                         1.28254220e-01, 1.05787985e-01, 1.01550282e-01, 8.44650788e-02,
                                         6.39578812e-02, 3.34477398e-02, 1.97405267e-02, 6.40957590e-04])
 
-        right_points = adjusted_points._unstructured_training_points(compute_distance=True, source='right')
-        right_plot = adjusted_points._right_plot()
+        right_points = adjusted_points._unstructured_training_points(compute_distance=True, source='right')  # noqa
+        right_plot = adjusted_points._right_plot()  # noqa
         right_transparency = adjusted_points.right_alphas
 
-        bottom_points = adjusted_points._unstructured_training_points(compute_distance=True, source='bottom')
-        bottom_plot = adjusted_points._bottom_plot()
+        bottom_points = adjusted_points._unstructured_training_points(compute_distance=True, source='bottom')  # noqa
+        bottom_plot = adjusted_points._bottom_plot()  # noqa
         bottom_transparency = adjusted_points.bottom_alphas
 
         assert_near_equal(right_transparency, known_points_right, 1.1e-02)

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -2,7 +2,6 @@
 import inspect
 import os
 import sys
-import pathlib
 from operator import itemgetter
 
 import networkx as nx

--- a/openmdao/visualization/n2_viewer/tests/create_generic_model.py
+++ b/openmdao/visualization/n2_viewer/tests/create_generic_model.py
@@ -1,7 +1,7 @@
 from openmdao.visualization.htmlpp import HtmlPreprocessor
 from num2words import num2words
 import os
-import inspect 
+import inspect
 import sys
 
 default_output_filename = 'gen_diag.html' if len(sys.argv) < 2 else sys.argv[1]
@@ -47,7 +47,7 @@ for x in range (1,3):
                 'type': 'output',
                 'val': 1111 * z + 20 * y + x
             }
-            ch1.append(newchild3) 
+            ch1.append(newchild3)
 
 model_data['connections_list'] = (
     { 'src': 'grp_one.child_one.output_1_1', 'tgt': 'grp_one.child_two.input_2_1'},
@@ -55,7 +55,7 @@ model_data['connections_list'] = (
     { 'src': 'grp_one.child_three.output_3_1', 'tgt': 'grp_two.child_four.input_4_1'},
     { 'src': 'grp_one.child_one.output_1_2', 'tgt': 'grp_two.child_two.input_2_1'},
     { 'src': 'grp_two.child_two.output_2_1', 'tgt': 'grp_one.child_two.input_2_1'},
-    
+
 )
 
 # pretty = json.dumps(model_data, indent=2)
@@ -71,7 +71,7 @@ html_vars = {
     'model_data': model_data
 }
 
-import openmdao
+import openmdao  # noqa: E402
 openmdao_dir = os.path.dirname(inspect.getfile(openmdao))
 vis_dir = os.path.join(openmdao_dir, "visualization/n2_viewer")
 

--- a/openmdao/visualization/n2_viewer/tests/create_generic_model.py
+++ b/openmdao/visualization/n2_viewer/tests/create_generic_model.py
@@ -1,6 +1,5 @@
 from openmdao.visualization.htmlpp import HtmlPreprocessor
 from num2words import num2words
-import json
 import os
 import inspect 
 import sys

--- a/openmdao/visualization/n2_viewer/tests/gen_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/gen_gui_test.py
@@ -252,7 +252,7 @@ class gen_gui_test_case(_GuiTestCase):
                     await self.page.wait_for_selector(nth_selector, state='attached',
                                                       timeout=max_time)
                     found = True
-                except:
+                except Exception:
                     num_tries += 1
 
             num_tries = 0
@@ -263,7 +263,7 @@ class gen_gui_test_case(_GuiTestCase):
                     await self.page.wait_for_selector(nth_selector, state='detached',
                                                       timeout=max_time)
                     found = True
-                except:
+                except Exception:
                     num_tries += 1
 
         else:
@@ -275,7 +275,7 @@ class gen_gui_test_case(_GuiTestCase):
                     await self.page.wait_for_selector(nth_selector, state='detached',
                                                       timeout=max_time)
                     found = True
-                except:
+                except Exception:
                     num_tries += 1
 
         hndl_list = await self.page.query_selector_all(selector)

--- a/openmdao/visualization/n2_viewer/tests/gui_test_models/bug_arrow.py
+++ b/openmdao/visualization/n2_viewer/tests/gui_test_models/bug_arrow.py
@@ -1,6 +1,4 @@
 
-import numpy as np
-
 from openmdao.api import Group, ExplicitComponent, IndepVarComp
 
 

--- a/openmdao/visualization/n2_viewer/tests/gui_test_models/circuit.py
+++ b/openmdao/visualization/n2_viewer/tests/gui_test_models/circuit.py
@@ -50,7 +50,7 @@ class Diode(om.ExplicitComponent):
         deltaV = inputs['V_in'] - inputs['V_out']
         Is = self.options['Is']
         Vt = self.options['Vt']
-        I = Is * np.exp(deltaV / Vt)
+        I = Is * np.exp(deltaV / Vt)  # noqa: E741, allow ambiguous variable name 'I'
 
         J['I', 'V_in'] = I/Vt
         J['I', 'V_out'] = -I/Vt

--- a/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
+++ b/openmdao/visualization/n2_viewer/tests/n2_gui_test.py
@@ -830,7 +830,7 @@ class n2_gui_test_case(_GuiTestCase):
                     await self.page.wait_for_selector(nth_selector, state='attached',
                                                       timeout=max_time)
                     found = True
-                except:
+                except Exception:
                     num_tries += 1
 
             num_tries = 0
@@ -841,7 +841,7 @@ class n2_gui_test_case(_GuiTestCase):
                     await self.page.wait_for_selector(nth_selector, state='detached',
                                                       timeout=max_time)
                     found = True
-                except:
+                except Exception:
                     num_tries += 1
 
         else:
@@ -853,7 +853,7 @@ class n2_gui_test_case(_GuiTestCase):
                     await self.page.wait_for_selector(nth_selector, state='detached',
                                                       timeout=max_time)
                     found = True
-                except:
+                except Exception:
                     num_tries += 1
 
         hndl_list = await self.page.query_selector_all(selector)

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -10,8 +10,8 @@ except ImportError:
             raise unittest.SkipTest("tests require the 'playwright' package.")
 else:
     os.system("playwright install")
-    from .n2_gui_test import n2_gui_test_case
-    from .gen_gui_test import gen_gui_test_case
+    from .n2_gui_test import n2_gui_test_case  # noqa: E401
+    from .gen_gui_test import gen_gui_test_case  # noqa: E401
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -3,15 +3,15 @@ import unittest
 import os
 
 try:
-    import playwright
+    import playwright  # noqa: F401
 except ImportError:
     class TestOpenMDAOn2GUI(unittest.TestCase):
         def test_n2_gui(self):
             raise unittest.SkipTest("tests require the 'playwright' package.")
 else:
     os.system("playwright install")
-    from .n2_gui_test import n2_gui_test_case  # noqa: E401
-    from .gen_gui_test import gen_gui_test_case  # noqa: E401
+    from .n2_gui_test import n2_gui_test_case  # noqa: F401
+    from .gen_gui_test import gen_gui_test_case  # noqa: F401
 
 if __name__ == "__main__":
     unittest.main()

--- a/openmdao/visualization/n2_viewer/tests/test_parallel_n2.py
+++ b/openmdao/visualization/n2_viewer/tests/test_parallel_n2.py
@@ -3,7 +3,6 @@
 import os
 import unittest
 import openmdao.api as om
-from openmdao.visualization.n2_viewer.n2_viewer import n2
 from openmdao.utils.mpi import MPI
 
 try:
@@ -39,7 +38,7 @@ class Top(om.Group):
     def setup(self):
 
         indep_var = self.add_subsystem('indep_var', om.IndepVarComp())
-        myc = self.add_subsystem('myComp', myComp())
+        self.add_subsystem('myComp', myComp())
 
         indep_var.add_output('x1', 2.0)
 

--- a/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
+++ b/openmdao/visualization/n2_viewer/tests/test_viewmodeldata.py
@@ -8,9 +8,6 @@ import types
 import base64
 import zlib
 
-from shutil import rmtree
-from tempfile import mkdtemp
-
 import numpy as np
 
 import openmdao.api as om
@@ -101,7 +98,7 @@ class TestViewerData(unittest.TestCase):
                     val = np.asarray(tree[key])
                     try:
                         assert_near_equal(expected_val, val, tolerance=val_tol)
-                    except Exception as e:
+                    except Exception:
                         raise AssertionError(f'{_path + [key]} did not match to expected value')
 
         for i, key in enumerate(expected_tree.keys()):

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -1,5 +1,4 @@
 import os
-import pathlib
 import unittest
 
 import numpy as np
@@ -134,7 +133,7 @@ class TestOptimizationReport(unittest.TestCase):
             else:
                 try:
                     value = int(value)
-                except ValueError as err:
+                except ValueError:
                     pass
             return value
 

--- a/openmdao/visualization/options_widget.py
+++ b/openmdao/visualization/options_widget.py
@@ -152,7 +152,7 @@ class OptionsWidget(object):
 
             types = option['types']
 
-            if types == list:
+            if isinstance(types, list):
                 _widgets.append(widgets.Textarea(
                     description=name,
                     tooltip=desc,

--- a/openmdao/visualization/options_widget.py
+++ b/openmdao/visualization/options_widget.py
@@ -4,13 +4,11 @@ A widget-based representation of OptionsDictionary for use in Jupyter notebooks.
 
 try:
     import ipywidgets as widgets
-    from ipywidgets import DOMWidget, register
-    from ipywidgets import interact, Layout
+    from ipywidgets import Layout
     from IPython.display import display
 except Exception:
     widgets = None
 
-from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.om_warnings import issue_warning
 
 

--- a/openmdao/visualization/scaling_viewer/scaling_report.py
+++ b/openmdao/visualization/scaling_viewer/scaling_report.py
@@ -3,13 +3,11 @@
 import os
 import json
 import functools
-import pathlib
 
 import numpy as np
 
 from openmdao.core.constants import _SetupStatus, INF_BOUND
 import openmdao.utils.hooks as hooks
-from openmdao.utils.mpi import MPI
 from openmdao.utils.webview import webview
 from openmdao.utils.general_utils import default_noraise
 from openmdao.utils.file_utils import _load_and_exec

--- a/openmdao/visualization/tables/table_builder.py
+++ b/openmdao/visualization/tables/table_builder.py
@@ -6,7 +6,6 @@ import sys
 import os
 import json
 import textwrap
-from collections import namedtuple
 from itertools import zip_longest, chain
 from html import escape
 from dataclasses import dataclass
@@ -103,7 +102,7 @@ class TableBuilder(object):
         if headers in ('keys', 'firstrow'):
             rows, headers = self._to_rows(rows, headers)
         elif isinstance(headers, str):
-            raise RuntimeError(f"If 'headers' is a string, it must be one of ['keys', 'firstrow'].")
+            raise RuntimeError("If 'headers' is a string, it must be one of ['keys', 'firstrow'].")
 
         self._raw_rows = []
         for row in rows:
@@ -873,7 +872,6 @@ class TextTableBuilder(TableBuilder):
         """
         header_lines = []
         data_lines = []
-        sep = self.data_row_line.sep
         row_cells = None
         row_list = list(self._stringified_row_iter())
         if row_list:

--- a/openmdao/visualization/tables/tests/test_tables.py
+++ b/openmdao/visualization/tables/tests/test_tables.py
@@ -269,8 +269,8 @@ Col0  Col1  Col2
     def test_basic_tabulator(self):
         # for now, just check that it doesn't crash
         headers = ['Strings', 'Floats', 'Something else']
-        table = generate_table(self.table_row_iter('str', 'float', None),
-                               tablefmt='tabulator', headers=headers)
+        generate_table(self.table_row_iter('str', 'float', None),
+                       tablefmt='tabulator', headers=headers)
 
     def test_embedded_newline(self):
         cells = [

--- a/openmdao/visualization/tables/tests/test_tables.py
+++ b/openmdao/visualization/tables/tests/test_tables.py
@@ -3,7 +3,6 @@ import numpy as np
 import math
 from html.parser import HTMLParser
 
-import openmdao.api as om
 from openmdao.visualization.tables.table_builder import generate_table
 from openmdao.utils.testing_utils import use_tempdirs
 
@@ -272,7 +271,6 @@ Col0  Col1  Col2
         headers = ['Strings', 'Floats', 'Something else']
         table = generate_table(self.table_row_iter('str', 'float', None),
                                tablefmt='tabulator', headers=headers)
-        tstr = str(table)
 
     def test_embedded_newline(self):
         cells = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,13 @@ line-ending = "lf"
 convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore `F401` (import violations) in api files.
+# Ignore `F401` (unused import) in api files.
 "api.py" = ["F401"]
 "parallel_api.py" = ["F401"]
+"__init__.py" = ["F401"]
+# Ignore all directories named `tests`.
+"**/tests/**" = ["E","F"]
+# Ignore files in the test suite.
+"**/test_suite/**" = ["E","F"]
+# Allow variable name I for current
+"**/extcode_resistor.py" = ["E741"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,3 +185,8 @@ line-ending = "lf"
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+# Ignore `E402` (import violations) in api files.
+"api.py" = ["E402"]
+"parallel_api.py" = ["E402"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,3 +176,12 @@ path = "openmdao/__init__.py"
 include = [
     "/openmdao",
 ]
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.format]
+line-ending = "lf"
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,8 +191,6 @@ convention = "numpy"
 "api.py" = ["F401"]
 "parallel_api.py" = ["F401"]
 "__init__.py" = ["F401"]
-# Ignore all directories named `tests`.
-"**/tests/**" = ["E","F"]
 # Ignore files in the test suite.
 "**/test_suite/**" = ["E","F"]
 # Allow variable name I for current

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,6 +187,6 @@ line-ending = "lf"
 convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
-# Ignore `E402` (import violations) in api files.
-"api.py" = ["E402"]
-"parallel_api.py" = ["E402"]
+# Ignore `F401` (import violations) in api files.
+"api.py" = ["F401"]
+"parallel_api.py" = ["F401"]


### PR DESCRIPTION
### Summary

A new step has been added to the test workflow (on the 'Ubuntu Baseline' build) that performs linting on the OpenMDAO code base using [Ruff](https://docs.astral.sh/ruff/).  Ruff settings have been added to `pyproject.toml`.

I ran the Ruff [linter](https://docs.astral.sh/ruff/linter/) on the code and addressed a number of issues that it identified.

- removed unused imports
- removed unused variables
  - commented some assignments that were unused but may be useful as documentation
- removed the `f` prefix from strings that didn't need to be f-strings
- replaced a couple occurrences of `==` with `is`
- added Exception to bare excepts
- added # noqa flag where it seemed warranted
- renamed some tests that had the same name as other tests and were masking them

Also:

- fixed a number of issues uncovered in the tests (e.g. not asserting error message)

Note: This is a lot of changes and it's possible that something will slip through that was not covered in unit tests, although I did also run the integrated tests for Aviary, CADRE, Dymos and pyCycle against this branch.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
