### PR TITLE
Addressed a NumPy 2.1 deprecated keyword argument

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -4407,7 +4407,7 @@ class Group(System):
 
                     if val is not value:
                         if val.shape:
-                            val = np.reshape(value, newshape=val.shape)
+                            val = np.reshape(value, val.shape)
                         else:
                             val = value
 


### PR DESCRIPTION
### Summary

Removed deprecated `newshape` keyword from an invocation of the NumPy `reshape` function.

This keyword will be [deprecated as of NumPy 2.1](https://numpy.org/devdocs/reference/generated/numpy.reshape.html).

Removing the keyword and making it a positional argument is backward and forward compatible.


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
