### PR TITLE
Updated test workflow to trigger pycycle tests

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -124,7 +124,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
-          conda-version: "*"
           channels: conda-forge
 
       - name: Install MacOS-specific dependencies
@@ -377,6 +376,7 @@ jobs:
           echo "See: https://numpy.org/devdocs/numpy_2_0_migration_guide.html"
           echo "============================================================="
           python -m pip install ruff
+          cd ${{ github.workspace }}
           ruff check . --select NPY201
 
       - name: Slack env change

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -87,7 +87,7 @@ jobs:
             OS: ubuntu-latest
             PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.13'
+            SCIPY: '1.14'
             PETSc: '3.20'
             PYOPTSPARSE: 'v2.11.0'
             # PAROPT: true
@@ -117,7 +117,7 @@ jobs:
             OS: macos-14
             PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.13'
+            SCIPY: '1.14'
             PETSc: '3.20'
             # PYOPTSPARSE: 'v2.11.0'
             # PAROPT: true
@@ -131,7 +131,7 @@ jobs:
             OS: ubuntu-latest
             PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.13'
+            SCIPY: '1.14'
             OPTIONAL: '[test]'
             TESTS: true
             EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.Ubuntu_Minimal }}
@@ -207,7 +207,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
-          conda-version: "*"
           channels: conda-forge
 
       - name: Install OpenMDAO
@@ -330,7 +329,7 @@ jobs:
               echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
             fi
 
-            build_pyoptsparse $BRANCH $PAROPT $SNOPT
+            build_pyoptsparse -v $BRANCH $PAROPT $SNOPT
           fi
 
       - name: Install optional dependencies
@@ -633,7 +632,6 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
-          conda-version: "*"
           channels: conda-forge
 
       - name: Install OpenDMAO
@@ -755,14 +753,30 @@ jobs:
         parallel-finished: true
 
 
-  dymos_tests:
-    name: Run Dymos Tests
+  related_tests:
+    name: Run Dymos & pyCycle Tests
     needs: [tests, windows_tests]
     runs-on: ubuntu-latest
+
     steps:
     - uses: benc-uk/workflow-dispatch@v1
       with:
         workflow: Dymos Tests
         repo: ${{ github.repository_owner }}/dymos
+        token: ${{ secrets.ACCESS_TOKEN }}
+      if: github.event_name == 'push'
+
+    - uses: benc-uk/workflow-dispatch@v1
+      with:
+        workflow: pyCycle Tests
+        repo: ${{ github.repository_owner }}/pycycle
+        inputs: >
+          {
+            "run_name": "Test Latest OpenMDAO Development Version",
+            "Ubuntu_Baseline": false,
+            "MacOS_Baseline": false,
+            "Windows_Baseline": false,
+            "OpenMDAO_Dev": true
+           }
         token: ${{ secrets.ACCESS_TOKEN }}
       if: github.event_name == 'push'


### PR DESCRIPTION
### Summary

Updated test workflow to trigger pycycle tests in addition to dymos tests when there is a push to the OpenMDAO master branch.

This PR should not be merged until the related [pyCycle PR](https://github.com/OpenMDAO/pyCycle/pull/56) is merged.

Also, some additional workflow tweaks were made including updating the baseline to use scipy 1.14

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
