### PR TITLE
Updated `openmdao clean`

### DIFF
--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -191,7 +191,12 @@
     "OpenMDAO creates an output directory for each problem it runs. This directory contains recording files, optimizer output files, derivative coloring information (if generated), and reports (if generated).\n",
     "The `openmdao clean` command recurses through the given path and remove any OpenMDAO output directories found.\n",
     "\n",
-    "OpenMDAO output directories are identified by the presence of an `.openmdao_out` file, which is automatically added upon their creation."
+    "OpenMDAO output directories are identified by the presence of an `.openmdao_out` file, which is automatically added upon their creation.\n",
+    "\n",
+    "One note regarding the `pattern` argument. This pattern provides the glob pattern which the directory names must match to be cleaned.\n",
+    "By default, this is `'*_out'`. This pattern will be applied regardless of the depth of recursion. On the other hand, providing a glob\n",
+    "pattern to the command such as `openmdao clean *_out` will only clean directories whose name matches `'*_out'` in the current working directory.\n",
+    "To prevent expansion of the wildcard pattern, surround the argument of pattern with quotes: `--pattern=\"foo*_out\"`."
    ]
   },
   {

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -578,7 +578,12 @@ def clean_outputs(obj='.', recurse=False, prompt=True, pattern='*_out', dryrun=F
     output_dirs = []
 
     if isinstance(obj, (str, pathlib.Path)):
+        # A single pathname or path object was given.
         output_dirs = _find_openmdao_output_dirs(obj, pattern, recurse)
+    elif isinstance(obj, (Iterable,)):
+        # Multiple paths given
+        for dirname in obj:
+            output_dirs.extend(_find_openmdao_output_dirs(dirname, pattern, recurse))
     elif hasattr(obj, 'get_outputs_dir'):
         output_dir = obj.get_outputs_dir()
         prompt = False

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -503,11 +503,10 @@ def _is_openmdao_output_dir(directory):
         True if the directory is an OpenMDAO output directory, False otherwise.
     """
     directory = pathlib.Path(directory)
-    return directory.is_dir() and directory.name.endswith('_out') \
-        and (directory / '.openmdao_out').exists()
+    return directory.is_dir() and (directory / '.openmdao_out').exists()
 
 
-def _find_openmdao_output_dirs(paths, recurse):
+def _find_openmdao_output_dirs(paths, pattern='*_out', recurse=False):
     """
     Find all OpenMDAO output directories in the given path.
 
@@ -515,6 +514,8 @@ def _find_openmdao_output_dirs(paths, recurse):
     ----------
     paths : str or Path or Iterable
         The path to search for OpenMDAO output directories.
+    pattern : str
+        A glob pattern that the output directories are required to match.
     recurse : bool
         If True, search recursively.
 
@@ -536,19 +537,21 @@ def _find_openmdao_output_dirs(paths, recurse):
 
         for root, dirs, _ in os.walk(path):
             # Use a copy of the dirs list to avoid modifying it while iterating
-            if _is_openmdao_output_dir(root):
-                openmdao_dirs.append(pathlib.Path(root))
+            root_path = pathlib.Path(root)
+            if _is_openmdao_output_dir(root) and fnmatch(root_path.name, pattern):
+                openmdao_dirs.append(root_path)
             for d in dirs[:]:
                 dir_path = pathlib.Path(root) / d
                 if _is_openmdao_output_dir(dir_path):
-                    openmdao_dirs.append(dir_path)
+                    if fnmatch(dir_path.name, pattern):
+                        openmdao_dirs.append(dir_path)
                     dirs.remove(d)  # Do not recurse into OpenMDAO output directories
             if not recurse:
                 break
     return openmdao_dirs
 
 
-def clean_outputs(obj='.', recurse=False, prompt=True, dryrun=False):
+def clean_outputs(obj='.', recurse=False, prompt=True, pattern='*_out', dryrun=False):
     """
     Remove output directories created by OpenMDAO.
 
@@ -566,13 +569,16 @@ def clean_outputs(obj='.', recurse=False, prompt=True, dryrun=False):
     prompt : bool
         If True, prompt the user to confirm directories to be removed.
         This option is ignored if obj is a Problem, System, or Solver.
+    pattern : str
+        A glob pattern used for matching directories. This is "*_out" by default,
+        but users may specify it to only remove select output directories.
     dryrun : bool
         If True, report which directories would be removed without actually removing them.
     """
     output_dirs = []
 
     if isinstance(obj, (str, pathlib.Path)):
-        output_dirs = _find_openmdao_output_dirs(obj, recurse)
+        output_dirs = _find_openmdao_output_dirs(obj, pattern, recurse)
     elif hasattr(obj, 'get_outputs_dir'):
         output_dir = obj.get_outputs_dir()
         prompt = False

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -570,8 +570,7 @@ def clean_outputs(obj='.', recurse=False, prompt=True, pattern='*_out', dryrun=F
         If True, prompt the user to confirm directories to be removed.
         This option is ignored if obj is a Problem, System, or Solver.
     pattern : str
-        A glob pattern used for matching directories. This is "*_out" by default,
-        but users may specify it to only remove select output directories.
+        A glob pattern used for matching directories.
     dryrun : bool
         If True, report which directories would be removed without actually removing them.
     """

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -298,6 +298,8 @@ def _clean_setup_parser(parser):
                         help='Do not recurse into subdirectories to find directories to remove.')
     parser.add_argument('-d', '--dryrun', action='store_true', dest='dryrun',
                         help='Highlight directories to be removed but do not actually remove them.')
+    parser.add_argument('-p', '--pattern', action='store', dest='pattern', default='*_out',
+                        help="Directory name glob pattern to match.")
 
 
 def _clean_cmd(options, user_args):
@@ -312,7 +314,7 @@ def _clean_cmd(options, user_args):
         Args to be passed to the user script.
     """
     clean_outputs(options.path, recurse=not options.no_recurse, prompt=options.prompt,
-                  dryrun=options.dryrun)
+                  pattern=options.pattern, dryrun=options.dryrun)
 
 
 def _get_tree_filter(attrs, vecvars):

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -299,7 +299,10 @@ def _clean_setup_parser(parser):
     parser.add_argument('-d', '--dryrun', action='store_true', dest='dryrun',
                         help='Highlight directories to be removed but do not actually remove them.')
     parser.add_argument('-p', '--pattern', action='store', dest='pattern', default='*_out',
-                        help="Directory name glob pattern to match.")
+                        help='Only directories whose name matches this glob pattern will be '
+                        'removed. This glob pattern applies to directory names found when '
+                        'recursing through the given paths. Surround this argument with quotation '
+                        'marks to prevent the OS from interpreting the glob pattern.')
 
 
 def _clean_cmd(options, user_args):

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -223,7 +223,7 @@ class TestCleanOutputs(unittest.TestCase):
             om.clean_outputs('.', pattern='*', dryrun=True, recurse=True)
 
         expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove baz_out/foo_out2 (dryrun = True).',
+                    'Would remove baz_out/foo_out (dryrun = True).',
                     'Would remove baz_out/bar_out (dryrun = True).',
                     'Removed 0 OpenMDAO output directories.')
         
@@ -256,6 +256,40 @@ class TestCleanOutputs(unittest.TestCase):
             om.clean_outputs('.', dryrun=True, recurse=False)
 
         expected = ('No OpenMDAO output directories found.',)
+
+        try:
+            for expected_str in expected:
+                self.assertIn(expected_str, ss.getvalue())
+        finally:
+            shutil.rmtree('baz_out')
+
+    def test_multiple_paths(self):
+
+        p1 = om.Problem(name='foo')
+        p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
+        p1.setup()
+        p1.run_model()
+
+        p2 = om.Problem(name='bar')
+        p2.model.add_subsystem('exec', om.ExecComp('z = a * b'))
+        p2.setup()
+        p2.run_model()
+
+        # Make another non-openmdao outut directory to test recursion.
+        pathlib.Path('baz_out').mkdir(exist_ok=True)
+        shutil.move('foo_out', 'baz_out')
+        shutil.move('bar_out', 'baz_out')
+
+        # First Test that a dryrun on p1 works as expected.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(('baz_out/foo_out', 'baz_out/bar_out'),
+                             dryrun=True, recurse=False)
+
+        expected = ('Found 2 OpenMDAO output directories:',
+                    'Would remove baz_out/foo_out (dryrun = True).',
+                    'Would remove baz_out/bar_out (dryrun = True).',
+                    'Removed 0 OpenMDAO output directories.')
 
         try:
             for expected_str in expected:

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -11,10 +11,14 @@ import sys
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.core.problem import _clear_problem_names
 
 
 @use_tempdirs
 class TestCleanOutputs(unittest.TestCase):
+
+    def setUp(self):
+        _clear_problem_names()
 
     def test_specify_prob(self):
 
@@ -264,7 +268,6 @@ class TestCleanOutputs(unittest.TestCase):
             shutil.rmtree('baz_out')
 
     def test_multiple_paths(self):
-
         p1 = om.Problem(name='foo')
         p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
         p1.setup()

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -227,8 +227,8 @@ class TestCleanOutputs(unittest.TestCase):
             om.clean_outputs('.', pattern='*', dryrun=True, recurse=True)
 
         expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove baz_out/foo_out (dryrun = True).',
-                    'Would remove baz_out/bar_out (dryrun = True).',
+                    f'Would remove baz_out{os.sep}foo_out (dryrun = True).',
+                    f'Would remove baz_out{os.sep}bar_out (dryrun = True).',
                     'Removed 0 OpenMDAO output directories.')
         
         try:
@@ -290,8 +290,8 @@ class TestCleanOutputs(unittest.TestCase):
                              dryrun=True, recurse=False)
 
         expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove baz_out/foo_out (dryrun = True).',
-                    'Would remove baz_out/bar_out (dryrun = True).',
+                    f'Would remove baz_out{os.sep}foo_out (dryrun = True).',
+                    f'Would remove baz_out{os.sep}bar_out (dryrun = True).',
                     'Removed 0 OpenMDAO output directories.')
 
         try:


### PR DESCRIPTION
### Summary

OpenMDAO clean now 
- supports a pattern to match directory names.
- allows multiple paths to be provided for removal.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
