### PR TITLE
Remove references to conda in the docs

### DIFF
--- a/openmdao/docs/openmdao_book/getting_started/getting_started.ipynb
+++ b/openmdao/docs/openmdao_book/getting_started/getting_started.ipynb
@@ -8,7 +8,7 @@
     "\n",
     "Installation Instructions:\n",
     "\n",
-    "From your python environment (we recommend [Anaconda](https://www.anaconda.com/distribution)), just type:\n",
+    "From your python environment, just type:\n",
     "\n",
     "``` bash\n",
     "pip install 'openmdao[all]'\n",
@@ -55,12 +55,7 @@
    "source": [
     "## Parallel Processing with MPI\n",
     "\n",
-    "OpenMDAO enables parallel processing via [MPI](https://www.mcs.anl.gov/research/projects/mpi/) and [PETSc](https://petsc.org). The easiest way to install support for these is to use `conda`:\n",
-    "\n",
-    "    conda create -n OpenMDAO python=3\n",
-    "    conda activate OpenMDAO\n",
-    "    conda install -c conda-forge mpi4py petsc4py\n",
-    "    pip install openmdao[all]\n",
+    "OpenMDAO enables parallel processing via [MPI](https://www.mcs.anl.gov/research/projects/mpi/) and [PETSc](https://petsc.org). This requires a few pre-requisites that can be installed with your package manager of choice: `mpi4py` and `petsc4py`.\n",
     "    \n",
     "For Windows users, installing `PETSc` can be more difficult as [described on the PETSc web site](https://petsc.org/main/install/windows/).  Probably the quickest way to get up and running with MPI on Windows is to use\n",
     "[Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/). WSL integration with [Visual Studio Code](https://code.visualstudio.com/) provides a nearly seamless development environment on Windows."

--- a/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/ci_testing.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/developer_docs/ci_testing.ipynb
@@ -20,7 +20,7 @@
     "\n",
     "Finally, this workflow includes one job specifically for building the documentation with [Jupyter Book](https://jupyterbook.org/en/stable/intro.html).  If there are any warnings or errors during the build process, they will be listed in the workflow output under the \"Display doc build reports\" header.\n",
     "\n",
-    "This workflow can be a handy reference for how to use [conda](https://docs.conda.io/en/latest/) to build an OpenMDAO environment with all the optional dependencies. In particular you can see how to install MPI support with PETSc and how to install [pyOptSparse](https://github.com/mdolab/pyoptsparse) using the [build_pyoptsparse](https://github.com/OpenMDAO/build_pyoptsparse) utility.\n",
+    "This workflow can be a handy reference for how to build an OpenMDAO environment with all the optional dependencies. In particular you can see how to install MPI support with PETSc and how to install [pyOptSparse](https://github.com/mdolab/pyoptsparse) using the [build_pyoptsparse](https://github.com/OpenMDAO/build_pyoptsparse) utility.\n",
     "\n",
     "## OpenMDAO Audit workflow\n",
     "\n",


### PR DESCRIPTION
### Summary

Licensing issues with conda have led to some confusion among users.  Since it is not required as a pre-requisite for OpenMDAO, we are removing those references from the docs to avoid confusion.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
