### PR TITLE
A couple of things to cut down on the number of outfiles directories left lying around after running tests

### DIFF
--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1808,16 +1808,6 @@ def setup_sparsity(mask):
 class TestFunctionRegistrationColoring(unittest.TestCase):
     def setUp(self):
         np.random.seed(11)
-        self.startdir = os.getcwd()
-        self.tempdir = tempfile.mkdtemp(prefix=self.__class__.__name__ + '_')
-        os.chdir(self.tempdir)
-
-    def tearDown(self):
-        os.chdir(self.startdir)
-        try:
-            shutil.rmtree(self.tempdir)
-        except OSError:
-            pass
 
     def test_manual_coloring(self):
         with _temporary_expr_dict():

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -55,7 +55,7 @@ from openmdao.utils.general_utils import pad_name, LocalRangeIterable, \
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation, \
     OMInvalidCheckDerivativesOptionsWarning
 import openmdao.utils.coloring as coloring_mod
-from openmdao.utils.file_utils import _get_outputs_dir
+from openmdao.utils.file_utils import _get_outputs_dir, get_work_dir
 from openmdao.visualization.tables.table_builder import generate_table
 
 try:
@@ -290,7 +290,7 @@ class Problem(object):
         # General options
         self.options = OptionsDictionary(parent_name=type(self).__name__)
         self.options.declare('coloring_dir', types=str,
-                             default=os.path.join(os.getcwd(), 'coloring_files'),
+                             default=os.path.join(get_work_dir(), 'coloring_files'),
                              desc='Directory containing coloring files (if any) for this Problem.')
         self.options.declare('group_by_pre_opt_post', types=bool,
                              default=False,

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -55,7 +55,7 @@ from openmdao.utils.general_utils import pad_name, LocalRangeIterable, \
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation, \
     OMInvalidCheckDerivativesOptionsWarning
 import openmdao.utils.coloring as coloring_mod
-from openmdao.utils.file_utils import _get_outputs_dir, get_work_dir
+from openmdao.utils.file_utils import _get_outputs_dir
 from openmdao.visualization.tables.table_builder import generate_table
 
 try:
@@ -290,7 +290,7 @@ class Problem(object):
         # General options
         self.options = OptionsDictionary(parent_name=type(self).__name__)
         self.options.declare('coloring_dir', types=str,
-                             default=os.path.join(get_work_dir(), 'coloring_files'),
+                             default=os.path.join(os.getcwd(), 'coloring_files'),
                              desc='Directory containing coloring files (if any) for this Problem.')
         self.options.declare('group_by_pre_opt_post', types=bool,
                              default=False,

--- a/openmdao/core/tests/test_partial_color.py
+++ b/openmdao/core/tests/test_partial_color.py
@@ -1,6 +1,4 @@
-import os
-import tempfile
-import shutil
+
 import unittest
 import itertools
 from fnmatch import fnmatchcase

--- a/openmdao/core/tests/test_partial_color.py
+++ b/openmdao/core/tests/test_partial_color.py
@@ -8,7 +8,6 @@ from fnmatch import fnmatchcase
 import numpy as np
 from scipy.sparse import coo_matrix
 
-
 try:
     import jax
     import jax.numpy as jnp
@@ -344,7 +343,7 @@ _BIGMASK = np.array(
      [0, 1, 1, 0, 1, 1, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1]]
 )
 
-
+@use_tempdirs
 class TestColoringExplicit(unittest.TestCase):
     def setUp(self):
         np.random.seed(11)
@@ -1478,7 +1477,6 @@ class TestStaticColoring(unittest.TestCase):
                 model.add_subsystem('indeps', indeps)
                 comp = model.add_subsystem('comp', SparseCompExplicit(sparsity, method,
                                                                     isplit=isplit, osplit=2))
-                # model.declare_coloring('*', method=method)
                 model.connect('indeps.x0', 'comp.x0')
                 model.connect('indeps.x1', 'comp.x1')
 
@@ -1534,24 +1532,6 @@ class TestStaticColoring(unittest.TestCase):
 @use_tempdirs
 class TestStaticColoringParallelCS(unittest.TestCase):
     N_PROCS = 2
-
-    def setUp(self):
-        np.random.seed(11)
-        self.startdir = os.getcwd()
-        if MPI.COMM_WORLD.rank == 0:
-            self.tempdir = tempfile.mkdtemp(prefix=self.__class__.__name__ + '_')
-            MPI.COMM_WORLD.bcast(self.tempdir, root=0)
-        else:
-            self.tempdir = MPI.COMM_WORLD.bcast(None, root=0)
-        os.chdir(self.tempdir)
-
-    def tearDown(self):
-        os.chdir(self.startdir)
-        if MPI.COMM_WORLD.rank == 0:
-            try:
-                shutil.rmtree(self.tempdir)
-            except OSError:
-                pass
 
     # semi-total coloring feature disabled.
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -19,6 +19,7 @@ import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.file_utils import get_work_dir
 from openmdao.utils.tests.test_hooks import hooks_active
 
 try:
@@ -2134,7 +2135,7 @@ class TestProblem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path('prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(get_work_dir(), 'prob_name_out', 'subdir')), str(d))
 
     def test_duplicate_prob_name(self):
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1,5 +1,6 @@
 """ Unit tests for the problem interface."""
 
+import os
 import pathlib
 import sys
 import unittest
@@ -19,7 +20,6 @@ import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.file_utils import get_work_dir
 from openmdao.utils.tests.test_hooks import hooks_active
 
 try:
@@ -2135,7 +2135,7 @@ class TestProblem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path(get_work_dir(), 'prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(os.getcwd(), 'prob_name_out', 'subdir')), str(d))
 
     def test_duplicate_prob_name(self):
 

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -20,6 +20,7 @@ import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.file_utils import get_work_dir
 from openmdao.utils.tests.test_hooks import hooks_active
 
 try:
@@ -2135,7 +2136,7 @@ class TestProblem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path(os.getcwd(), 'prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(get_work_dir(), 'prob_name_out', 'subdir')), str(d))
 
     def test_duplicate_prob_name(self):
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -7,6 +7,7 @@ import numpy as np
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.file_utils import get_work_dir
 
 
 @use_tempdirs
@@ -691,7 +692,7 @@ class TestSystem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path('test_prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(get_work_dir(), 'test_prob_name_out', 'subdir')), str(d))
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -8,6 +8,7 @@ import numpy as np
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.file_utils import get_work_dir
 
 
 @use_tempdirs
@@ -692,7 +693,7 @@ class TestSystem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path(os.getcwd(), 'test_prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(get_work_dir(), 'test_prob_name_out', 'subdir')), str(d))
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -1,13 +1,13 @@
 """ Unit tests for the system interface."""
 
 import unittest
+import os
 
 import numpy as np
 
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.file_utils import get_work_dir
 
 
 @use_tempdirs
@@ -692,7 +692,7 @@ class TestSystem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path(get_work_dir(), 'test_prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(os.getcwd(), 'test_prob_name_out', 'subdir')), str(d))
 
 
 if __name__ == "__main__":

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -9,6 +9,7 @@ from openmdao.utils.mpi import MPI
 
 from openmdao.devtools.iprof_utils import func_group, find_qualified_name, _collect_methods, \
      _setup_func_group, _get_methods, _Options
+from openmdao.utils.file_utils import get_work_dir
 
 
 def _prof_node(fpath, parts):
@@ -43,7 +44,7 @@ def _setup(options, finalize=True):
     if _profile_setup:
         raise RuntimeError("profiling is already set up.")
 
-    _profile_prefix = os.path.join(os.getcwd(), 'iprof')
+    _profile_prefix = os.path.join(get_work_dir(), 'iprof')
     _profile_setup = True
 
     methods = _get_methods(options, default='openmdao')

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -9,7 +9,6 @@ from openmdao.utils.mpi import MPI
 
 from openmdao.devtools.iprof_utils import func_group, find_qualified_name, _collect_methods, \
      _setup_func_group, _get_methods, _Options
-from openmdao.utils.file_utils import get_work_dir
 
 
 def _prof_node(fpath, parts):
@@ -44,7 +43,7 @@ def _setup(options, finalize=True):
     if _profile_setup:
         raise RuntimeError("profiling is already set up.")
 
-    _profile_prefix = os.path.join(get_work_dir(), 'iprof')
+    _profile_prefix = os.path.join(os.getcwd(), 'iprof')
     _profile_setup = True
 
     methods = _get_methods(options, default='openmdao')

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -11,6 +11,7 @@ from openmdao.test_suite.components.sellar import SellarDis1, SellarDis2
 from openmdao.error_checking.check_config import get_sccs_topo
 from openmdao.utils.assert_utils import assert_warning, assert_no_warning
 from openmdao.utils.logger_utils import TestLogger
+from openmdao.utils.testing_utils import use_tempdirs
 
 
 class MyComp(om.ExecComp):
@@ -211,8 +212,8 @@ class TestCheckConfig(unittest.TestCase):
         p.final_setup()
 
         expected_info = (
-            "The following groups contain cycles:", 
-            "   Group '' has the following cycles:", 
+            "The following groups contain cycles:",
+            "   Group '' has the following cycles:",
             "      ['G1', 'C4']"
         )
 
@@ -361,8 +362,8 @@ class TestCheckConfig(unittest.TestCase):
         p.final_setup()
 
         expected_info = (
-            "The following groups contain cycles:", 
-            "   Group 'G1' has the following cycles:", 
+            "The following groups contain cycles:",
+            "   Group 'G1' has the following cycles:",
             "      ['C13', 'C12', 'C11']",
             "      ['C23', 'C22', 'C21']",
             "      ['C3', 'C2', 'C1']"
@@ -550,25 +551,11 @@ class TestCheckConfig(unittest.TestCase):
         testlogger.find_in('warning', msg4)
         testlogger.find_in('warning', msg5)
 
-
+@use_tempdirs
 class TestRecorderCheckConfig(unittest.TestCase):
 
     def setUp(self):
-        self.orig_dir = os.getcwd()
-        self.temp_dir = mkdtemp()
-        os.chdir(self.temp_dir)
-
-        self.filename = os.path.join(self.temp_dir, "sqlite_test")
-        self.recorder = om.SqliteRecorder(self.filename)
-
-    def tearDown(self):
-        os.chdir(self.orig_dir)
-        try:
-            rmtree(self.temp_dir)
-        except OSError as e:
-            # If directory already deleted, keep going
-            if e.errno not in (errno.ENOENT, errno.EACCES, errno.EPERM):
-                raise e
+        self.recorder = om.SqliteRecorder("sqlite_test")
 
     def test_check_no_recorder_set(self):
         p = om.Problem()

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -12,6 +12,7 @@ from openmdao.utils.mpi import MPI
 import openmdao.api as om
 
 from openmdao.utils.array_utils import evenly_distrib_idxs
+from openmdao.utils.file_utils import get_work_dir
 from openmdao.recorders.tests.sqlite_recorder_test_utils import \
     assertDriverIterDataRecorded, assertProblemDataRecorded
 from openmdao.recorders.tests.recorder_test_utils import run_driver
@@ -407,7 +408,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
         def run_parallel():
             # process cases.sql in parallel
-            cr = om.CaseReader('test_record_on_one_proc_out/cases.sql')
+            cr = om.CaseReader(os.path.join(get_work_dir(), 'test_record_on_one_proc_out/cases.sql'))
 
             cases = cr.list_cases()
             self.assertEqual(len(cases), 9)

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -12,7 +12,6 @@ from openmdao.utils.mpi import MPI
 import openmdao.api as om
 
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.utils.file_utils import get_work_dir
 from openmdao.recorders.tests.sqlite_recorder_test_utils import \
     assertDriverIterDataRecorded, assertProblemDataRecorded
 from openmdao.recorders.tests.recorder_test_utils import run_driver
@@ -408,7 +407,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
         def run_parallel():
             # process cases.sql in parallel
-            cr = om.CaseReader(os.path.join(get_work_dir(), 'test_record_on_one_proc_out/cases.sql'))
+            cr = om.CaseReader('test_record_on_one_proc_out/cases.sql')
 
             cases = cr.list_cases()
             self.assertEqual(len(cases), 9)

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -15,7 +15,7 @@ import openmdao.api as om
 from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
 from openmdao.utils.general_utils import run_model, printoptions
-from openmdao.utils.assert_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs
 
 try:
     from parameterized import parameterized

--- a/openmdao/solvers/tests/test_solver_debug_print.py
+++ b/openmdao/solvers/tests/test_solver_debug_print.py
@@ -14,8 +14,8 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.scripts.circuit_analysis import Circuit
 
-from openmdao.utils.general_utils import run_model
-from openmdao.utils.general_utils import printoptions
+from openmdao.utils.general_utils import run_model, printoptions
+from openmdao.utils.assert_utils import use_tempdirs
 
 try:
     from parameterized import parameterized
@@ -29,16 +29,11 @@ nonlinear_solvers = [
     om.BroydenSolver
 ]
 
-
+@use_tempdirs
 class TestNonlinearSolvers(unittest.TestCase):
     def setUp(self):
         import os
         from tempfile import mkdtemp
-
-        # perform test in temporary directory
-        self.startdir = os.getcwd()
-        self.tempdir = mkdtemp(prefix='test_solver')
-        os.chdir(self.tempdir)
 
         # iteration coordinate, file name and variable data are common for all tests
         coord = 'rank0:root._solve_nonlinear|0|NLRunOnce|0|circuit._solve_nonlinear|0'
@@ -69,17 +64,6 @@ class TestNonlinearSolvers(unittest.TestCase):
             " 'circuit.n2.V': array([ 0.001+0.j])}",
             ""
         ])
-
-    def tearDown(self):
-        import os
-        from shutil import rmtree
-
-        # clean up the temporary directory
-        os.chdir(self.startdir)
-        try:
-            rmtree(self.tempdir)
-        except OSError:
-            pass
 
     @parameterized.expand([
         [solver.__name__, solver] for solver in nonlinear_solvers
@@ -209,27 +193,13 @@ class TestNonlinearSolvers(unittest.TestCase):
         # Should be empty since solver debugging printing was turned off
         self.assertEqual(output, '')
 
-
+@use_tempdirs
 class TestNonlinearSolversIsolated(unittest.TestCase):
     """
     This test needs to run isolated to preclude interactions in the underlying
     `warnings` module that is used to raise the singular entry error.
     """
     ISOLATED = True
-
-    def setUp(self):
-        # perform test in temporary directory
-        self.startdir = os.getcwd()
-        self.tempdir = tempfile.mkdtemp(prefix='test_solver')
-        os.chdir(self.tempdir)
-
-    def tearDown(self):
-        # clean up the temporary directory
-        os.chdir(self.startdir)
-        try:
-            shutil.rmtree(self.tempdir)
-        except OSError:
-            pass
 
     def test_debug_after_raised_error(self):
         prob = om.Problem()

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -237,17 +237,21 @@ def _calltree_exec(options, user_args):
     func_name = parts[-1]
     modpath = '.'.join(parts[:-2])
 
+    old_syspath = sys.path[:]
     sys.path.append(os.getcwd())
 
-    mod = importlib.import_module(modpath)
-    klass = getattr(mod, class_name)
+    try:
+        mod = importlib.import_module(modpath)
+        klass = getattr(mod, class_name)
 
-    stream_map = {'stdout': sys.stdout, 'stderr': sys.stderr}
-    stream = stream_map.get(options.outfile)
-    if stream is None:
-        stream = open(options.outfile, 'w')
+        stream_map = {'stdout': sys.stdout, 'stderr': sys.stderr}
+        stream = stream_map.get(options.outfile)
+        if stream is None:
+            stream = open(options.outfile, 'w')
 
-    get_nested_calls(klass, func_name, stream)
+        get_nested_calls(klass, func_name, stream)
+    finally:
+        sys.path = old_syspath
 
 
 def _target_iter(targets):

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -433,22 +433,6 @@ def image2html(imagefile, title='', alt=''):
 """
 
 
-def get_work_dir():
-    """
-    Return either os.getcwd() or the value of the OPENMDAO_WORKDIR environment variable.
-
-    Returns
-    -------
-    str
-        The working directory.
-    """
-    workdir = os.environ.get('OPENMDAO_WORKDIR', '')
-    if workdir:
-        return workdir
-
-    return os.getcwd()
-
-
 def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
     """
     Return a pathlib.Path for the outputs directory related to the given problem or system.
@@ -465,10 +449,11 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
     ----------
     obj : Problem or System or Solver or None
         The problem or system or Solver from which we are opening a file.
+    subdirs : str
+        Additional subdirectories under the top level directory for the relevant problem. Each
+        subdir is passed as a separate positional argument.
     mkdir : bool
         If True, force the creation of this directory.
-    subdirs : str
-        Additional subdirectories under the top level directory for the relevant problem.
     """
     from openmdao.core.problem import Problem
     from openmdao.core.system import System
@@ -495,15 +480,14 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
 
     prob_pathname = prob_meta['pathname']
 
-    outspath = pathlib.Path(get_work_dir()) / pathlib.Path(*[f'{p}_out'
-                                                             for p in prob_pathname.split('/')])
-    dirpath = outspath / pathlib.Path(*subdirs)
+    outs_dir = pathlib.Path(*[f'{p}_out' for p in prob_pathname.split('/')])
+    dirpath = outs_dir / pathlib.Path(*subdirs)
 
     if not dirpath.is_dir() and comm.rank == 0 and mkdir:
         dirpath.mkdir(parents=True, exist_ok=True)
         # Touch the .openmdao_out file for the output directory to ease identification.
-        if not (outspath / '.openmdao_out').exists():
-            open(outspath / '.openmdao_out', 'w').close()
+        if not (outs_dir / '.openmdao_out').exists():
+            open(outs_dir / '.openmdao_out', 'w').close()
 
     return dirpath
 

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -433,6 +433,22 @@ def image2html(imagefile, title='', alt=''):
 """
 
 
+def get_work_dir():
+    """
+    Return either os.getcwd() or the value of the OPENMDAO_WORKDIR environment variable.
+
+    Returns
+    -------
+    str
+        The working directory.
+    """
+    workdir = os.environ.get('OPENMDAO_WORKDIR', '')
+    if workdir:
+        return workdir
+
+    return os.getcwd()
+
+
 def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
     """
     Return a pathlib.Path for the outputs directory related to the given problem or system.
@@ -480,7 +496,8 @@ def _get_outputs_dir(obj=None, *subdirs, mkdir=True):
 
     prob_pathname = prob_meta['pathname']
 
-    outs_dir = pathlib.Path(*[f'{p}_out' for p in prob_pathname.split('/')])
+    outs_dir = pathlib.Path(get_work_dir()) / pathlib.Path(*[f'{p}_out'
+                                                             for p in prob_pathname.split('/')])
     dirpath = outs_dir / pathlib.Path(*subdirs)
 
     if not dirpath.is_dir() and comm.rank == 0 and mkdir:

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -16,7 +16,6 @@ except ImportError:
     parameterized = None
 
 from openmdao.utils.general_utils import env_truthy, env_none
-from openmdao.utils.file_utils import get_work_dir
 
 
 def _new_setup(self):
@@ -25,7 +24,6 @@ def _new_setup(self):
 
     from openmdao.utils.mpi import MPI, multi_proc_exception_check
     self.startdir = os.getcwd()
-    self.workdir = os.environ.get('OPENMDAO_WORKDIR', '')
 
     if MPI is None:
         self.tempdir = tempfile.mkdtemp(prefix='testdir-')
@@ -36,9 +34,6 @@ def _new_setup(self):
         self.tempdir = MPI.COMM_WORLD.bcast(None, root=0)
 
     os.chdir(self.tempdir)
-    # on mac tempdir is a symlink which messes some things up, so
-    # use resolve to get the real directory path
-    os.environ['OPENMDAO_WORKDIR'] = str(Path(self.tempdir).resolve())
     if hasattr(self, 'original_setUp'):
         if MPI is not None and MPI.COMM_WORLD.size > 1:
             with multi_proc_exception_check(MPI.COMM_WORLD):
@@ -60,10 +55,6 @@ def _new_teardown(self):
             self.original_tearDown()
 
     os.chdir(self.startdir)
-    if self.workdir:
-        os.environ['OPENMDAO_WORKDIR'] = self.workdir
-    elif os.environ['OPENMDAO_WORKDIR'] == self.tempdir:
-        del os.environ['OPENMDAO_WORKDIR']
 
     if MPI is None:
         rank = 0

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -6,6 +6,7 @@ import os
 import re
 from itertools import zip_longest
 from contextlib import contextmanager
+from pathlib import Path
 
 import numpy as np
 
@@ -15,6 +16,7 @@ except ImportError:
     parameterized = None
 
 from openmdao.utils.general_utils import env_truthy, env_none
+from openmdao.utils.file_utils import get_work_dir
 
 
 def _new_setup(self):
@@ -23,6 +25,8 @@ def _new_setup(self):
 
     from openmdao.utils.mpi import MPI, multi_proc_exception_check
     self.startdir = os.getcwd()
+    self.workdir = os.environ.get('OPENMDAO_WORKDIR', '')
+
     if MPI is None:
         self.tempdir = tempfile.mkdtemp(prefix='testdir-')
     elif MPI.COMM_WORLD.rank == 0:
@@ -32,6 +36,9 @@ def _new_setup(self):
         self.tempdir = MPI.COMM_WORLD.bcast(None, root=0)
 
     os.chdir(self.tempdir)
+    # on mac tempdir is a symlink which messes some things up, so
+    # use resolve to get the real directory path
+    os.environ['OPENMDAO_WORKDIR'] = str(Path(self.tempdir).resolve())
     if hasattr(self, 'original_setUp'):
         if MPI is not None and MPI.COMM_WORLD.size > 1:
             with multi_proc_exception_check(MPI.COMM_WORLD):
@@ -53,6 +60,10 @@ def _new_teardown(self):
             self.original_tearDown()
 
     os.chdir(self.startdir)
+    if self.workdir:
+        os.environ['OPENMDAO_WORKDIR'] = self.workdir
+    elif os.environ['OPENMDAO_WORKDIR'] == self.tempdir:
+        del os.environ['OPENMDAO_WORKDIR']
 
     if MPI is None:
         rank = 0

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -6,7 +6,6 @@ import os
 import re
 from itertools import zip_longest
 from contextlib import contextmanager
-from pathlib import Path
 
 import numpy as np
 
@@ -64,10 +63,11 @@ def _new_teardown(self):
         rank = MPI.COMM_WORLD.rank
 
     if rank == 0:
-        try:
-            shutil.rmtree(self.tempdir)
-        except OSError:
-            pass
+        if not os.environ.get('OPENMDAO_KEEPDIRS'):
+            try:
+                shutil.rmtree(self.tempdir)
+            except OSError:
+                pass
 
 
 def use_tempdirs(cls):

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -135,12 +135,12 @@ class CmdlineTestCase(unittest.TestCase):
         p2.setup()
         p2.run_model()
 
-        p1_outdir = p1.get_outputs_dir()
-        p2_outdir = p2.get_outputs_dir()
+        p1_outdir = os.path.basename(str(p1.get_outputs_dir()))
+        p2_outdir = os.path.basename(str(p2.get_outputs_dir()))
 
-        subdirs = [os.path.abspath(p) for p in os.listdir(os.getcwd())]
-        self.assertIn(str(p1_outdir), subdirs)
-        self.assertIn(str(p2_outdir), subdirs)
+        subdirs = os.listdir(os.getcwd())
+        self.assertIn(p1_outdir, subdirs)
+        self.assertIn(p2_outdir, subdirs)
 
         proc = subprocess.Popen('openmdao clean -f'.split(),  # nosec: trusted input
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -150,9 +150,9 @@ class CmdlineTestCase(unittest.TestCase):
             proc.kill()
             outs, errs = proc.communicate()
 
-        subdirs = [os.path.abspath(p) for p in os.listdir(os.getcwd())]
-        self.assertNotIn(str(p1_outdir), subdirs)
-        self.assertNotIn(str(p2_outdir), subdirs)
+        subdirs = os.listdir(os.getcwd())
+        self.assertNotIn(p1_outdir, subdirs)
+        self.assertNotIn(p2_outdir, subdirs)
 
     def test_n2_err(self):
         # command should raise exception but still produce an n2 html file

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -138,8 +138,9 @@ class CmdlineTestCase(unittest.TestCase):
         p1_outdir = p1.get_outputs_dir()
         p2_outdir = p2.get_outputs_dir()
 
-        self.assertIn(str(p1_outdir), os.listdir(os.getcwd()))
-        self.assertIn(str(p2_outdir), os.listdir(os.getcwd()))
+        subdirs = [os.path.abspath(p) for p in os.listdir(os.getcwd())]
+        self.assertIn(str(p1_outdir), subdirs)
+        self.assertIn(str(p2_outdir), subdirs)
 
         proc = subprocess.Popen('openmdao clean -f'.split(),  # nosec: trusted input
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -149,8 +150,9 @@ class CmdlineTestCase(unittest.TestCase):
             proc.kill()
             outs, errs = proc.communicate()
 
-        self.assertNotIn(str(p1_outdir), os.listdir(os.getcwd()))
-        self.assertNotIn(str(p2_outdir), os.listdir(os.getcwd()))
+        subdirs = [os.path.abspath(p) for p in os.listdir(os.getcwd())]
+        self.assertNotIn(str(p1_outdir), subdirs)
+        self.assertNotIn(str(p2_outdir), subdirs)
 
     def test_n2_err(self):
         # command should raise exception but still produce an n2 html file

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -11,6 +11,7 @@ import sys
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.file_utils import get_work_dir
 from openmdao.core.problem import _clear_problem_names
 from openmdao.utils.reports_system import clear_reports
 
@@ -61,14 +62,14 @@ class TestCleanOutputs(unittest.TestCase):
         with redirect_stdout(ss):
             om.clean_outputs(p1)
 
-        self.assertEqual(len(os.listdir('.')), 1)
+        self.assertEqual(len(os.listdir(get_work_dir())), 1)
 
         # Now specify p2 with the output directory.
         ss = io.StringIO()
         with redirect_stdout(ss):
             om.clean_outputs(p2)
 
-        self.assertEqual(len(os.listdir('.')), 0)
+        self.assertEqual(len(os.listdir(get_work_dir())), 0)
 
     def test_specify_non_output_dir_no_prompt(self):
 
@@ -84,44 +85,49 @@ class TestCleanOutputs(unittest.TestCase):
 
         # First Test that a dryrun on '.' works as expected.
         ss = io.StringIO()
-        with redirect_stdout(ss):
-            om.clean_outputs('.', dryrun=True)
+        cwd = os.getcwd()
+        os.chdir(get_work_dir())
+        try:
+            with redirect_stdout(ss):
+                om.clean_outputs('.', dryrun=True)
 
-        expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove bar_out (dryrun = True).',
-                    'Would remove foo_out (dryrun = True).',
-                    'Removed 0 OpenMDAO output directories.')
+            expected = ('Found 2 OpenMDAO output directories:',
+                        'Would remove bar_out (dryrun = True).',
+                        'Would remove foo_out (dryrun = True).',
+                        'Removed 0 OpenMDAO output directories.')
 
-        for expected_str in expected:
-            self.assertIn(expected_str, ss.getvalue())
+            for expected_str in expected:
+                self.assertIn(expected_str, ss.getvalue())
 
-        # Test that no specified path gives the same result.
-        ss = io.StringIO()
-        with redirect_stdout(ss):
-            om.clean_outputs(dryrun=True)
+            # Test that no specified path gives the same result.
+            ss = io.StringIO()
+            with redirect_stdout(ss):
+                om.clean_outputs(dryrun=True)
 
-        expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove bar_out (dryrun = True).',
-                    'Would remove foo_out (dryrun = True).',
-                    'Removed 0 OpenMDAO output directories.')
+            expected = ('Found 2 OpenMDAO output directories:',
+                        'Would remove bar_out (dryrun = True).',
+                        'Would remove foo_out (dryrun = True).',
+                        'Removed 0 OpenMDAO output directories.')
 
-        for expected_str in expected:
-            self.assertIn(expected_str, ss.getvalue())
+            for expected_str in expected:
+                self.assertIn(expected_str, ss.getvalue())
 
-        # Now remove the files
-        ss = io.StringIO()
-        with redirect_stdout(ss):
-            om.clean_outputs(prompt=False)
+            # Now remove the files
+            ss = io.StringIO()
+            with redirect_stdout(ss):
+                om.clean_outputs(prompt=False)
 
-        expected = ('Found 2 OpenMDAO output directories:\n'
-                    'Removed bar_out\n'
-                    'Removed foo_out\n'
-                    'Removed 2 OpenMDAO output directories.\n')
+            expected = ('Found 2 OpenMDAO output directories:\n'
+                        'Removed bar_out\n'
+                        'Removed foo_out\n'
+                        'Removed 2 OpenMDAO output directories.\n')
 
-        self.assertIn(expected, ss.getvalue())
+            self.assertIn(expected, ss.getvalue())
 
-        self.assertNotIn('foo_out', os.listdir('.'))
-        self.assertNotIn('bar_out', os.listdir('.'))
+            self.assertNotIn('foo_out', os.listdir('.'))
+            self.assertNotIn('bar_out', os.listdir('.'))
+        finally:
+            os.chdir(cwd)
 
     @unittest.skipIf(sys.version_info  < (3, 9, 0), 'Requires Python 3.9.0 or later.')
     def test_specify_non_output_dir_prompt(self):

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -11,7 +11,6 @@ import sys
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.file_utils import get_work_dir
 from openmdao.core.problem import _clear_problem_names
 from openmdao.utils.reports_system import clear_reports
 
@@ -62,14 +61,14 @@ class TestCleanOutputs(unittest.TestCase):
         with redirect_stdout(ss):
             om.clean_outputs(p1)
 
-        self.assertEqual(len(os.listdir(get_work_dir())), 1)
+        self.assertEqual(len(os.listdir('.')), 1)
 
         # Now specify p2 with the output directory.
         ss = io.StringIO()
         with redirect_stdout(ss):
             om.clean_outputs(p2)
 
-        self.assertEqual(len(os.listdir(get_work_dir())), 0)
+        self.assertEqual(len(os.listdir('.')), 0)
 
     def test_specify_non_output_dir_no_prompt(self):
 
@@ -85,49 +84,44 @@ class TestCleanOutputs(unittest.TestCase):
 
         # First Test that a dryrun on '.' works as expected.
         ss = io.StringIO()
-        cwd = os.getcwd()
-        os.chdir(get_work_dir())
-        try:
-            with redirect_stdout(ss):
-                om.clean_outputs('.', dryrun=True)
+        with redirect_stdout(ss):
+            om.clean_outputs('.', dryrun=True)
 
-            expected = ('Found 2 OpenMDAO output directories:',
-                        'Would remove bar_out (dryrun = True).',
-                        'Would remove foo_out (dryrun = True).',
-                        'Removed 0 OpenMDAO output directories.')
+        expected = ('Found 2 OpenMDAO output directories:',
+                    'Would remove bar_out (dryrun = True).',
+                    'Would remove foo_out (dryrun = True).',
+                    'Removed 0 OpenMDAO output directories.')
 
-            for expected_str in expected:
-                self.assertIn(expected_str, ss.getvalue())
+        for expected_str in expected:
+            self.assertIn(expected_str, ss.getvalue())
 
-            # Test that no specified path gives the same result.
-            ss = io.StringIO()
-            with redirect_stdout(ss):
-                om.clean_outputs(dryrun=True)
+        # Test that no specified path gives the same result.
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(dryrun=True)
 
-            expected = ('Found 2 OpenMDAO output directories:',
-                        'Would remove bar_out (dryrun = True).',
-                        'Would remove foo_out (dryrun = True).',
-                        'Removed 0 OpenMDAO output directories.')
+        expected = ('Found 2 OpenMDAO output directories:',
+                    'Would remove bar_out (dryrun = True).',
+                    'Would remove foo_out (dryrun = True).',
+                    'Removed 0 OpenMDAO output directories.')
 
-            for expected_str in expected:
-                self.assertIn(expected_str, ss.getvalue())
+        for expected_str in expected:
+            self.assertIn(expected_str, ss.getvalue())
 
-            # Now remove the files
-            ss = io.StringIO()
-            with redirect_stdout(ss):
-                om.clean_outputs(prompt=False)
+        # Now remove the files
+        ss = io.StringIO()
+        with redirect_stdout(ss):
+            om.clean_outputs(prompt=False)
 
-            expected = ('Found 2 OpenMDAO output directories:\n'
-                        'Removed bar_out\n'
-                        'Removed foo_out\n'
-                        'Removed 2 OpenMDAO output directories.\n')
+        expected = ('Found 2 OpenMDAO output directories:\n'
+                    'Removed bar_out\n'
+                    'Removed foo_out\n'
+                    'Removed 2 OpenMDAO output directories.\n')
 
-            self.assertIn(expected, ss.getvalue())
+        self.assertIn(expected, ss.getvalue())
 
-            self.assertNotIn('foo_out', os.listdir(os.getcwd()))
-            self.assertNotIn('bar_out', os.listdir(os.getcwd()))
-        finally:
-            os.chdir(cwd)
+        self.assertNotIn('foo_out', os.listdir('.'))
+        self.assertNotIn('bar_out', os.listdir('.'))
 
     @unittest.skipIf(sys.version_info  < (3, 9, 0), 'Requires Python 3.9.0 or later.')
     def test_specify_non_output_dir_prompt(self):

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -11,14 +11,28 @@ import sys
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.file_utils import get_work_dir
 from openmdao.core.problem import _clear_problem_names
+from openmdao.utils.reports_system import clear_reports
 
 
 @use_tempdirs
 class TestCleanOutputs(unittest.TestCase):
 
     def setUp(self):
-        _clear_problem_names()
+        # set things to a known initial state for all the test runs
+        _clear_problem_names()  # need to reset these to simulate separate runs
+        os.environ.pop('OPENMDAO_REPORTS', None)
+        # We need to remove the TESTFLO_RUNNING environment variable for these tests to run.
+        # The reports code checks to see if TESTFLO_RUNNING is set and will not do anything if set
+        # But we need to remember whether it was set so we can restore it
+        self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
+        clear_reports()
+
+    def tearDown(self):
+        # restore what was there before running the test
+        if self.testflo_running is not None:
+            os.environ['TESTFLO_RUNNING'] = self.testflo_running
 
     def test_specify_prob(self):
 
@@ -39,7 +53,7 @@ class TestCleanOutputs(unittest.TestCase):
 
         expected1 = 'Removed 0 OpenMDAO output directories.\n'
         expected2 = 'Would remove'
-        
+
         self.assertIn(expected1, ss.getvalue())
         self.assertIn(expected2, ss.getvalue())
 
@@ -48,14 +62,14 @@ class TestCleanOutputs(unittest.TestCase):
         with redirect_stdout(ss):
             om.clean_outputs(p1)
 
-        self.assertEqual(len(os.listdir(os.getcwd())), 1)
+        self.assertEqual(len(os.listdir(get_work_dir())), 1)
 
         # Now specify p2 with the output directory.
         ss = io.StringIO()
         with redirect_stdout(ss):
             om.clean_outputs(p2)
-        
-        self.assertEqual(len(os.listdir(os.getcwd())), 0)
+
+        self.assertEqual(len(os.listdir(get_work_dir())), 0)
 
     def test_specify_non_output_dir_no_prompt(self):
 
@@ -69,46 +83,51 @@ class TestCleanOutputs(unittest.TestCase):
         p2.setup()
         p2.run_model()
 
-        # First Test that a dryrun on p1 works as expected.
+        # First Test that a dryrun on '.' works as expected.
         ss = io.StringIO()
-        with redirect_stdout(ss):
-            om.clean_outputs('.', dryrun=True)
+        cwd = os.getcwd()
+        os.chdir(get_work_dir())
+        try:
+            with redirect_stdout(ss):
+                om.clean_outputs('.', dryrun=True)
 
-        expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove bar_out (dryrun = True).',
-                    'Would remove foo_out (dryrun = True).',
-                    'Removed 0 OpenMDAO output directories.')
-        
-        for expected_str in expected:
-            self.assertIn(expected_str, ss.getvalue())
+            expected = ('Found 2 OpenMDAO output directories:',
+                        'Would remove bar_out (dryrun = True).',
+                        'Would remove foo_out (dryrun = True).',
+                        'Removed 0 OpenMDAO output directories.')
 
-        # Test that no specified path gives the same result.
-        ss = io.StringIO()
-        with redirect_stdout(ss):
-            om.clean_outputs(dryrun=True)
+            for expected_str in expected:
+                self.assertIn(expected_str, ss.getvalue())
 
-        expected = ('Found 2 OpenMDAO output directories:',
-                    'Would remove bar_out (dryrun = True).',
-                    'Would remove foo_out (dryrun = True).',
-                    'Removed 0 OpenMDAO output directories.')
-        
-        for expected_str in expected:
-            self.assertIn(expected_str, ss.getvalue())
+            # Test that no specified path gives the same result.
+            ss = io.StringIO()
+            with redirect_stdout(ss):
+                om.clean_outputs(dryrun=True)
 
-        # Now remove the files
-        ss = io.StringIO()
-        with redirect_stdout(ss):
-            om.clean_outputs(prompt=False)
-        
-        expected = ('Found 2 OpenMDAO output directories:\n'
-                    'Removed bar_out\n'
-                    'Removed foo_out\n'
-                    'Removed 2 OpenMDAO output directories.\n')
-        
-        self.assertIn(expected, ss.getvalue())
+            expected = ('Found 2 OpenMDAO output directories:',
+                        'Would remove bar_out (dryrun = True).',
+                        'Would remove foo_out (dryrun = True).',
+                        'Removed 0 OpenMDAO output directories.')
 
-        self.assertNotIn('foo_out', os.listdir(os.getcwd()))
-        self.assertNotIn('bar_out', os.listdir(os.getcwd()))
+            for expected_str in expected:
+                self.assertIn(expected_str, ss.getvalue())
+
+            # Now remove the files
+            ss = io.StringIO()
+            with redirect_stdout(ss):
+                om.clean_outputs(prompt=False)
+
+            expected = ('Found 2 OpenMDAO output directories:\n'
+                        'Removed bar_out\n'
+                        'Removed foo_out\n'
+                        'Removed 2 OpenMDAO output directories.\n')
+
+            self.assertIn(expected, ss.getvalue())
+
+            self.assertNotIn('foo_out', os.listdir(os.getcwd()))
+            self.assertNotIn('bar_out', os.listdir(os.getcwd()))
+        finally:
+            os.chdir(cwd)
 
     @unittest.skipIf(sys.version_info  < (3, 9, 0), 'Requires Python 3.9.0 or later.')
     def test_specify_non_output_dir_prompt(self):
@@ -141,7 +160,7 @@ class TestCleanOutputs(unittest.TestCase):
                     expected = ('Found 2 OpenMDAO output directories:\n')
                     self.assertIn(expected, ss.getvalue())
 
-                    outdirs = [d for d in os.listdir('temp') if d.endswith('_out')]           
+                    outdirs = [d for d in os.listdir('temp') if d.endswith('_out')]
                     self.assertEqual(len(outdirs), 2)
 
                     # Respond in the positive to actually remove them.
@@ -151,14 +170,14 @@ class TestCleanOutputs(unittest.TestCase):
                             om.clean_outputs(recurse=recurse)
 
                     expected = ('Removed 2 OpenMDAO output directories.\n')
-                    
+
                     self.assertIn(expected, ss.getvalue())
 
-                    outdirs = [d for d in os.listdir('temp') if d.endswith('_out')]           
+                    outdirs = [d for d in os.listdir('temp') if d.endswith('_out')]
                     self.assertEqual(len(outdirs), 0)
                 else:
                     self.assertIn('No OpenMDAO output directories found.', ss.getvalue())
-                
+
                 shutil.rmtree('temp')
 
     def test_pattern(self):
@@ -184,7 +203,7 @@ class TestCleanOutputs(unittest.TestCase):
         expected = ('Found 1 OpenMDAO output directories:',
                     'Would remove foo_out (dryrun = True).',
                     'Removed 0 OpenMDAO output directories.')
-        
+
         for expected_str in expected:
             self.assertIn(expected_str, ss.getvalue())
 
@@ -197,7 +216,7 @@ class TestCleanOutputs(unittest.TestCase):
                     'Would remove foo_out (dryrun = True).',
                     'Would remove bar_out (dryrun = True).',
                     'Removed 0 OpenMDAO output directories.')
-        
+
         try:
             for expected_str in expected:
                 self.assertIn(expected_str, ss.getvalue())
@@ -230,7 +249,7 @@ class TestCleanOutputs(unittest.TestCase):
                     f'Would remove baz_out{os.sep}foo_out (dryrun = True).',
                     f'Would remove baz_out{os.sep}bar_out (dryrun = True).',
                     'Removed 0 OpenMDAO output directories.')
-        
+
         try:
             for expected_str in expected:
                 self.assertIn(expected_str, ss.getvalue())
@@ -268,17 +287,17 @@ class TestCleanOutputs(unittest.TestCase):
             shutil.rmtree('baz_out')
 
     def test_multiple_paths(self):
-        p1 = om.Problem(name='foo')
+        p1 = om.Problem(name='foo', reports=['summary'])
         p1.model.add_subsystem('exec', om.ExecComp('y = a + b'))
         p1.setup()
         p1.run_model()
 
-        p2 = om.Problem(name='bar')
+        p2 = om.Problem(name='bar', reports=['summary'])
         p2.model.add_subsystem('exec', om.ExecComp('z = a * b'))
         p2.setup()
         p2.run_model()
 
-        # Make another non-openmdao outut directory to test recursion.
+        # Make another non-openmdao output directory to test recursion.
         pathlib.Path('baz_out').mkdir(exist_ok=True)
         shutil.move('foo_out', 'baz_out')
         shutil.move('bar_out', 'baz_out')

--- a/openmdao/utils/tests/test_file_wrap.py
+++ b/openmdao/utils/tests/test_file_wrap.py
@@ -9,6 +9,7 @@ import shutil
 import unittest
 
 from openmdao.utils.assert_utils import assert_near_equal, assert_equal_arrays
+from openmdao.utils.testing_utils import use_tempdirs
 
 import numpy
 from numpy import array, isnan, isinf
@@ -24,23 +25,13 @@ DIRECTORY = os.path.dirname((os.path.abspath(__file__)))
 
 
 @unittest.skipUnless(pyparsing is not None, "Test requires pyparsing to be installed. (pip install pyparsing).")
+@use_tempdirs
 class TestCase(unittest.TestCase):
     """ Test file wrapping functions. """
 
     def setUp(self):
         self.templatename = 'template.dat'
         self.filename = 'filename.dat'
-        self.startdir = os.getcwd()
-        self.tempdir = tempfile.mkdtemp(prefix='omdao-')
-        os.chdir(self.tempdir)
-
-    def tearDown(self):
-        os.chdir(self.startdir)
-        if not os.environ.get('OPENMDAO_KEEPDIRS', False):
-            try:
-                shutil.rmtree(self.tempdir)
-            except OSError:
-                pass
 
     def test_templated_input(self):
         template = '\n'.join([

--- a/openmdao/utils/tests/test_shell_proc.py
+++ b/openmdao/utils/tests/test_shell_proc.py
@@ -3,28 +3,15 @@ import unittest
 
 import logging
 import os.path
-import shutil
 import signal
 import sys
-import tempfile
 
 from openmdao.utils.shell_proc import call, check_call, CalledProcessError, ShellProc
+from openmdao.utils.testing_utils import use_tempdirs
 
-
+@use_tempdirs
 class TestCase(unittest.TestCase):
     """ Test ShellProc functions. """
-
-    def setUp(self):
-        self.startdir = os.getcwd()
-        self.tempdir = tempfile.mkdtemp(prefix='test_shellproc-')
-        os.chdir(self.tempdir)
-
-    def tearDown(self):
-        os.chdir(self.startdir)
-        try:
-            shutil.rmtree(self.tempdir)
-        except OSError:
-            pass
 
     def test_call(self):
         logging.debug('')


### PR DESCRIPTION
### Summary

- a problem's outfiles directory is created now only if it's necessary (for reports or coloring files, or a direct call to _get_outputs_dir with mkdir=True)
- added an OPENMDAO_WORKDIR environment variable (defaults to os.cwd() if not set) that acts as the parent directory to the problem outfiles directory.  Updated the '@use_tempfiles' decorator to set OPENMDAO_WORKDIR to the temp directory so any problem outfiles dirs will be put there and then deleted along with the temp directory after the test runs.

After doing these two things, I no longer get any leftover outfiles directories after running testflo on openmdao.  Before I was getting > 500.


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
