### PR TITLE
Fixed a bug in testing utils

### DIFF
--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -61,8 +61,6 @@ def _new_teardown(self):
     os.chdir(self.startdir)
     if self.workdir:
         os.environ['OPENMDAO_WORKDIR'] = self.workdir
-    elif os.environ.get('OPENMDAO_WORKDIR') == self.tempdir:
-        del os.environ['OPENMDAO_WORKDIR']
 
     if MPI is None:
         rank = 0

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -61,7 +61,7 @@ def _new_teardown(self):
     os.chdir(self.startdir)
     if self.workdir:
         os.environ['OPENMDAO_WORKDIR'] = self.workdir
-    elif os.environ['OPENMDAO_WORKDIR'] == self.tempdir:
+    elif os.environ.get('OPENMDAO_WORKDIR') == self.tempdir:
         del os.environ['OPENMDAO_WORKDIR']
 
     if MPI is None:


### PR DESCRIPTION
### Summary

The following code can result in an error when OPENMDAO_WORKDIR is not set:
```
    if self.workdir:
        os.environ['OPENMDAO_WORKDIR'] = self.workdir
    elif os.environ['OPENMDAO_WORKDIR'] == self.tempdir:
        del os.environ['OPENMDAO_WORKDIR']
```

Since NOT self.workdir is only True if the environment variable has not been set, the elif part of this statement is incorrect and can result in an error, e.g.:
```
test_ex_brachistochrone.py:TestBrachistochroneExample.test_ex_brachistochrone_shooting_radau_uncompressed  ... FAIL (00:00:10.67, 431 MB)
/home/swryan/dev/OpenMDAO/openmdao/utils/coloring.py:395: DerivativesWarning:Coloring was deactivated.  Improvement of 0.0% was less than min allowed (5.0%).
/home/swryan/dev/OpenMDAO/openmdao/core/total_jac.py:1646: DerivativesWarning:Constraints or objectives [('traj0.phases.phase0->path_constraint->y', inds=[(0, 0)])] cannot be impacted by the design variables of the problem.
/home/swryan/dev/OpenMDAO/openmdao/core/group.py:1109: DerivativesWarning:Constraints or objectives [ode_eval.control_interp.control_rates:theta_rate2] cannot be impacted by the design variables of the problem because no partials were defined for them in their parent component(s).

Traceback (most recent call last):
  File "/home/swryan/dev/OpenMDAO/openmdao/utils/testing_utils.py", line 64, in _new_teardown
    elif os.environ['OPENMDAO_WORKDIR'] == self.tempdir:
         ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "<frozen os>", line 714, in __getitem__
KeyError: 'OPENMDAO_WORKDIR'
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
