### PR TITLE
Changed the N2 to display "Jacobian" when hovering over an input-to-output "connection" within a component, instead of "Connections"

### DIFF
--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -336,7 +336,8 @@ class NodeConnectionInfo extends NodeInfo {
             newRow.append('td').html(conn.tgt);
         }
 
-        let title = 'Connections';
+        let title = (color == "black") ? "Jacobian" : "Connections";
+
         if ( ! (cell.srcObj.isLeaf() || cell.tgtObj.isLeaf()) ) {
             title += ` from ${cell.srcObj.path} to ${cell.tgtObj.path}`;
         }

--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -313,7 +313,7 @@ class NodeConnectionInfo extends NodeInfo {
     /**
      * Load the NodeInfo window with connection information for an off-diagonal cell.
      * Within a component, this NodeInfo window will have the title "Jacobian {input} --> {output}."
-     * For true connections between components, the window title is "Connections {input} --> {output}."
+     * For true connections between components, the window title is "Connections {source} --> {target}."
      * @param {Object} event Reference to the event that triggered the function.
      * @param {MatrixCell} cell Reference to the cell that was hovered.
      * @param {String} color The color of the title bar.

--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -312,6 +312,8 @@ class NodeConnectionInfo extends NodeInfo {
 
     /**
      * Load the NodeInfo window with connection information for an off-diagonal cell.
+     * Within a component, this NodeInfo window will have the title "Jacobian {input} --> {output}."
+     * For true connections between components, the window title is "Connections {input} --> {output}."
      * @param {Object} event Reference to the event that triggered the function.
      * @param {MatrixCell} cell Reference to the cell that was hovered.
      * @param {String} color The color of the title bar.

--- a/openmdao/visualization/n2_viewer/gen/NodeInfo.js
+++ b/openmdao/visualization/n2_viewer/gen/NodeInfo.js
@@ -336,7 +336,7 @@ class NodeConnectionInfo extends NodeInfo {
             newRow.append('td').html(conn.tgt);
         }
 
-        let title = (color == "black") ? "Jacobian" : "Connections";
+        let title = (color == OmStyle.color.declaredPartial) ? "Jacobian" : "Connections";
 
         if ( ! (cell.srcObj.isLeaf() || cell.tgtObj.isLeaf()) ) {
             title += ` from ${cell.srcObj.path} to ${cell.tgtObj.path}`;


### PR DESCRIPTION
### Summary

N2 Diagram now labels the popup window "Jacobian" rather than "Connections" when the user has info enabled and mouses-over a jacobian element within a component..

### Related Issues

- Resolves #3342 

### Backwards incompatibilities

None

### New Dependencies

None
