### PR TITLE
Changed header text from white to black in optimization report

### DIFF
--- a/openmdao/visualization/opt_report/opt_report_template.html
+++ b/openmdao/visualization/opt_report/opt_report_template.html
@@ -20,7 +20,7 @@ row using color -->
 
     th {{
       background-color: SlateGray;
-      color: white;
+      color: black;
       }}
 
     th, td {{


### PR DESCRIPTION
### Summary

Changed header text from white to black in optimization report.

![image](https://github.com/user-attachments/assets/83e414b1-1e6b-4237-a4e4-1ec3201332f5)


### Related Issues

- Resolves #3288

### Backwards incompatibilities

None

### New Dependencies

None
