### PR TITLE
Added promoted name to error message when distributed input is not connected

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -4475,7 +4475,10 @@ class Group(System):
                 # OpenMDAO currently can't create an automatic IndepVarComp for inputs on
                 # distributed components.
                 if tgt not in self._bad_conn_vars:
-                    raise RuntimeError(f'Distributed component input "{tgt}" is not connected.')
+                    prom_name = abs2prom[tgt]
+                    promoted_as = f', promoted as "{prom_name}",' if prom_name != tgt else ''
+                    raise RuntimeError(f'Distributed component input "{tgt}"'
+                                       f'{promoted_as} is not connected.')
 
             prom = abs2prom[tgt]
             if prom in prom2auto:

--- a/openmdao/core/tests/test_distribcomp.py
+++ b/openmdao/core/tests/test_distribcomp.py
@@ -816,6 +816,18 @@ class MPITests(unittest.TestCase):
         err_msg = str(context.exception).split(':')[-1]
         self.assertEqual(err_msg, 'Distributed component input "C.invec" is not connected.')
 
+    def test_auto_ivc_error_promoted(self):
+        size = 2
+
+        prob = om.Problem()
+        prob.model.add_subsystem("C", DistribCompSimple(arr_size=size), promotes=['*'])
+
+        with self.assertRaises(RuntimeError) as context:
+            prob.setup()
+
+        err_msg = str(context.exception).split(':')[-1]
+        self.assertEqual(err_msg, 'Distributed component input "C.invec", promoted as "invec", is not connected.')
+
     def test_bad_distrib_connect(self):
         class Adder(om.ExplicitComponent):
             def setup(self):


### PR DESCRIPTION
### Summary

Added promoted name to error message when distributed input is not connected.

### Related Issues

- Resolves #3180

### Backwards incompatibilities

None

### New Dependencies

None
