### PR TITLE
Added docs for OPENMDAO_WORKDIR environment variable.

### DIFF
--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -90,14 +90,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "(reports_system:directory)=\n",
     "## Setting the directory for the reports\n",
     "\n",
-    "If the user wishes to have the reports directory placed into a different directory other than the default current working directory, the user has two options for doing so.\n",
+    "As of OpenMDAO 3.35.0, reports are placed within a \"reports\" directory under the problem's output directory.\n",
+    "By default, this directory is `f'{problem_name}_out'` in the current working directory.\n",
     "\n",
-    "1. This option can be set programmatically using the `set_reports_dir` function from `openmdao.api`.\n",
-    "Note that this is a global OpenMDAO setting and therefore it cannot take different values for different processors if running multiple problems simultaneously under MPI.\n",
+    "These directories are separated to ensure that data from multiple OpenMDAO executions does not collide.\n",
+    "A side-effect of this is that a users disk space can become cluttered with output files over time.\n",
+    "There are two ways to address this:\n",
     "\n",
-    "2. The default value may be set using the environment variable `OPENMDAO_REPORTS_DIR` to the name of that directory. The directory does not have to exist beforehand. It will be created by the reporting system. As an example, if `OPENMDAO_REPORTS_DIR` is set to \"my_reports\", then, if the `Problem` name is `problem1`, then the reports will be written to the \"my_reports/problem1\" directory.Note that `OPENMDAO_REPORTS_DIR` is read during the import of openmdao, so setting `os.environ['OPENMDAO_REPORTS_DIR'] = './my_reports_dir'` after OpenMDAO has been imported **will have no effect**."
+    "1. The user has the option of setting a common output directory for ALL problems using the `OPENMDAO_WORKDIR` environment variable. Thus there is a single directory that contains all OpenMDAO output data.\n",
+    "\n",
+    "2. The [openmdao clean](om-command-clean) or `openmdao.api.clean_outputs` function can be used to remove these directories.\n"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/other_useful_docs/environment_vars.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/environment_vars.ipynb
@@ -48,10 +48,16 @@
     "| OPENMDAO_INVALID_DESVAR_BEHAVIOR | Specifies default driver behavior if the initial design variables are out of bounds. | [Paraboloid](examples_paraboloid:specifying_initial_values) |\n",
     "| OPENMDAO_REPORTS | May be boolean-like or the names of the desired reports to be generated. | [Reports](features:reports:report_system:controlling_reporting_using_an_environment_variable) |\n",
     "| OPENMDAO_USE_MPI | Set to True to force an exception when MPI is needed but mpi4py is unavailable. | [Controlling MPI](features:debugging:controlling_mpi) |\n",
+    "| OPENMDAO_WORKDIR | Top-level directory for OpenMDAO outputs. Defaults to current working directory if not set. | [Reports System](reports_system:directory) |\n",
     "| USE_PROC_FILES | Set to True to cause stdout/err from each MPI process to be written to `[rank].out`. | [Controlling MPI](features:debugging:controlling_mpi) |\n",
     "| OMPI_MCA_rmaps_base_oversubscribe | Set to '1' to fix **there are not enough slots available in the system** issue for some versions of MPI. | [Controlling MPI](features:debugging:controlling_mpi) |\n",
     "| OMPI_MCA_btl=self,tcp | Set to 'self,tcp' to fix **A system call failed during shared memory initialization that should not have...** error in some version of MPI | [Controlling MPI](features:debugging:controlling_mpi) |\n"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
### Summary

Updated documentation to include the setting of the OPENMDAO_WORKDIR environment variable.
Also updated environment variable and report documentation that included the now removed `set_reports_dir` and `OPENMDAO_REPORTS_DIR` environment variable.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
