### PR TITLE
Remove --with-deps argument from playwright install

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -56,6 +56,8 @@ python -m pip install --upgrade --pre websockets
 python -m pip install --upgrade --pre aiounittest
 python -m pip install --upgrade --pre playwright
 python -m pip install --upgrade --pre num2words
+echo "pre-install playwright dependencies to avoid warning messages"
+playwright install --with-deps || true
 
 echo "============================================================="
 echo "Install latest versions of other optional packages"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -341,6 +341,9 @@ jobs:
           conda install graphviz
           python -m pip install pyparsing psutil objgraph pyxdsm pydot
 
+          echo "Pre-install playwright dependencies to avoid warning messages"
+          playwright install --with-deps || true
+
       - name: Display environment info
         id: env_info
         continue-on-error: true

--- a/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
+++ b/openmdao/docs/openmdao_book/tests/test_jupyter_gui_test.py
@@ -10,7 +10,7 @@ except ImportError:
         def test_jupyter_book_docs(self):
             raise unittest.SkipTest("tests require the 'playwright' and 'aiounittest' packages.")
 else:
-    os.system("playwright install --with-deps")
+    os.system("playwright install")
     from .jupyter_gui_test import TestOpenMDAOJupyterBookDocs  # noqa: F401
 
 

--- a/openmdao/visualization/n2_viewer/tests/test_gui.py
+++ b/openmdao/visualization/n2_viewer/tests/test_gui.py
@@ -9,7 +9,7 @@ except ImportError:
         def test_n2_gui(self):
             raise unittest.SkipTest("tests require the 'playwright' package.")
 else:
-    os.system("playwright install --with-deps")
+    os.system("playwright install")
     from .n2_gui_test import n2_gui_test_case  # noqa: F401
     from .gen_gui_test import gen_gui_test_case  # noqa: F401
 


### PR DESCRIPTION
### Summary

PR #3341 had  attempted to get rid of some warning messages coming from the playwright install command in some browser-based tests during CI testing by adding the `--with-deps` argument.  When tests are run on a user's system, this can result in being prompted for a root login to install those dependencies.  This is less desirable than just allowing the warning messages.

For the purposes of CI testing, playwright is pre-installed with dependencies to prevent the warning messages from cluttering the test log.


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
