### PR TITLE
Added access to the OpenMDAO command-line tools through `python -m openmdao`

### DIFF
--- a/openmdao/__main__.py
+++ b/openmdao/__main__.py
@@ -1,0 +1,10 @@
+"""
+Provide the OpenMDAO command line tool as 
+
+python -m openmdao 
+"""
+from openmdao.utils.om import openmdao_cmd
+
+
+if __name__ == '__main__':
+    openmdao_cmd()

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -24,8 +24,9 @@
    "source": [
     "# Command Line Tools\n",
     "\n",
-    "OpenMDAO has a number of command line tools that are available via the `openmdao`\n",
-    "command.\n",
+    "OpenMDAO has a number of command line tools that are available via the `openmdao` command.\n",
+    "These can also be accessed using the more pythonic `python -m openmdao` command.\n",
+    "These two commands are equivalent and will be used interchangably in this documentation.\n",
     "\n",
     "```{note}\n",
     "The `openmdao` sub-commands, as well as any other console scripts associated with OpenMDAO, will\n",
@@ -48,7 +49,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "openmdao -h\n",
+    "python -m openmdao -h\n",
     "```"
    ]
   },
@@ -62,7 +63,7 @@
    },
    "outputs": [],
    "source": [
-    "!openmdao -h"
+    "!python -m openmdao -h"
    ]
   },
   {
@@ -77,7 +78,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "openmdao n2 -h\n",
+    "python -m openmdao n2 -h\n",
     "```"
    ]
   },
@@ -91,7 +92,7 @@
    },
    "outputs": [],
    "source": [
-    "!openmdao n2 -h"
+    "!python -m openmdao n2 -h"
    ]
   },
   {

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -60,7 +60,7 @@ def _test_func_name(func, num, param):
 
 cmd_tests = [
     # tuple of (command line, dict of dependencies that might not be installed)
-    ('openmdao -h', {}),
+    ('python -m openmdao -h', {}),
     ('openmdao --help', {}),
     ('openmdao --view_reports {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao call_tree openmdao.components.exec_comp.ExecComp.setup', {}),
@@ -68,10 +68,11 @@ cmd_tests = [
     ('openmdao comm_info {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao cite {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao clean --dryrun {}'.format(scriptdir), {}),
+    ('python -m openmdao clean --dryrun {}'.format(scriptdir), {}),
     ('openmdao compute_entry_points openmdao', {}),
     ('openmdao graph --no-display {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
     ('openmdao graph --no-display --type=tree {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
-    ('openmdao graph --no-display --show-vars {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
+    ('python -m openmdao graph --no-display --show-vars {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
     ('openmdao graph --no-display --show-vars --no-recurse {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
     ('openmdao graph --no-display --group=circuit {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
     ('openmdao graph --no-display --group=circuit --show-vars {}'.format(os.path.join(scriptdir, 'circuit_analysis.py')), {'pydot': pydot, 'graphviz': graphviz}),
@@ -80,13 +81,13 @@ cmd_tests = [
         {'tornado': tornado}),
     ('openmdao iprof_totals {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao list_installed component command nl_solver lin_solver driver', {}),
-    ('openmdao list_installed component -d', {}),
+    ('python -m openmdao list_installed component -d', {}),
     ('openmdao list_pre_post {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao n2 --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao n2 --no_browser {} -- -f bar'.format(os.path.join(scriptdir, 'circle_coloring_needs_args.py')), {}),
     ('openmdao partial_coloring {}'.format(os.path.join(scriptdir, 'circle_coloring_dynpartials.py')), {}),
     ('openmdao scaffold -b ExplicitComponent -c Foo', {}),
-    ('openmdao scaffold -b ImplicitComponent -c Foo', {}),
+    ('python -m openmdao scaffold -b ImplicitComponent -c Foo', {}),
     ('openmdao scaffold -p blahpkg --cmd=hello', {}),
     ('openmdao scaling --no_browser {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
     ('openmdao summary {}'.format(os.path.join(scriptdir, 'circle_opt.py')), {}),
@@ -104,7 +105,6 @@ cmd_tests = [
     ('openmdao trace -m {}'.format(os.path.join(scriptdir, 'circle_opt.py')),
         {'psutil': psutil})
 ]
-
 
 @use_tempdirs
 class CmdlineTestCase(unittest.TestCase):
@@ -145,17 +145,21 @@ class CmdlineTestCase(unittest.TestCase):
         self.assertIn(p1_outdir, subdirs)
         self.assertIn(p2_outdir, subdirs)
 
-        proc = subprocess.Popen('openmdao clean -f'.split(),  # nosec: trusted input
-                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        try:
-            outs, errs = proc.communicate(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
-            outs, errs = proc.communicate()
+        for om_cmd in ('openmdao', 'python -m openmdao'):
 
-        subdirs = os.listdir(os.getcwd())
-        self.assertNotIn(p1_outdir, subdirs)
-        self.assertNotIn(p2_outdir, subdirs)
+            with self.subTest('Test using command line `{om_cmd}`'):
+
+                proc = subprocess.Popen('openmdao clean -f'.split(),  # nosec: trusted input
+                                        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                try:
+                    outs, errs = proc.communicate(timeout=10)
+                except subprocess.TimeoutExpired:
+                    proc.kill()
+                    outs, errs = proc.communicate()
+
+                subdirs = os.listdir(os.getcwd())
+                self.assertNotIn(p1_outdir, subdirs)
+                self.assertNotIn(p2_outdir, subdirs)
 
     def test_n2_err(self):
         # command should raise exception but still produce an n2 html file


### PR DESCRIPTION
### Summary

Adds the option of running the OpenMDAO command line tools using

```
python -m openmdao
```

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
