### PR TITLE
Updated oldest supported python version to 3.9

### DIFF
--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -47,9 +47,8 @@ jobs:
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
-          python-version: 3.11
-          conda-version: "*"
-          channels: conda-forge
+          python-version: 3.12
+          miniforge-version: latest
 
       - name: Install lxml
         if: matrix.OS == 'windows-latest'

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -124,7 +124,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
-          channels: conda-forge
+          miniforge-version: latest
 
       - name: Install MacOS-specific dependencies
         if: matrix.OS == 'macos-13'

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -139,13 +139,13 @@ jobs:
           # test oldest supported versions
           - NAME: Ubuntu Oldest
             OS: ubuntu-latest
-            PY: '3.8'
-            NUMPY: '1.22'
-            SCIPY: '1.7'
+            PY: '3.9'
+            NUMPY: '1.23'
+            SCIPY: '1.9'
             OPENMPI: '4.0'
             MPI4PY: '3.0'
             PETSc: '3.13'
-            PYOPTSPARSE: 'v1.2'
+            PYOPTSPARSE: 'v2.9.0'
             SNOPT: '7.2'
             OPTIONAL: '[all]'
             TESTS: true

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -211,6 +211,9 @@ jobs:
 
       - name: Install OpenMDAO
         run: |
+          echo "Make sure we are not using anaconda packages"
+          conda config --remove channels defaults
+
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip

--- a/openmdao/drivers/tests/test_analysis_errors.py
+++ b/openmdao/drivers/tests/test_analysis_errors.py
@@ -59,6 +59,7 @@ class TestPyoptSparseAnalysisErrors(unittest.TestCase):
     expected_result_eval_errors.update({
         'CONMIN': None,  # CONMIN does not provide a return code and will just give a bad answer
         'ParOpt': None,  # ParOpt does not provide a return code and will just give a bad answer
+        'SLSQP': None,   # SLSQP will sometimes fail on iterations and sometimes succeed...
     })
 
     expected_result_grad_errors = defaultdict(lambda: 0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "numpy>=2.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "OpenMDAO framework infrastructure"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "OpenMDAO Team", email = "openmdao@openmdao.org" },
 ]


### PR DESCRIPTION
### Summary

Updated oldest supported python version to 3.9

Also:
- Updated dependencies for `oldest` job in test workflow
- Changed audit and latest workflows to use miniforge
- Updated unreliable SLSQP test that was failing for some users
- Updated the `build-system` requirements to use NumPy 2.x so built wheels are forward and backward compatible, per the [NumPy recommendation](https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-abi-handling)

### Related Issues

- Resolves #3357

### Backwards incompatibilities

None

### New Dependencies

None
