### PR TITLE
POEM_96 Implementation: Minimization of Constraint Violation (SciPy Driver Only)

### DIFF
--- a/openmdao/drivers/scipy_optimizer.py
+++ b/openmdao/drivers/scipy_optimizer.py
@@ -461,7 +461,11 @@ class ScipyOptimizeDriver(Driver):
 
         # Hessian calculation method for optimizers, which require it
         if opt in _hessian_optimizers:
-            if 'hess' in self.opt_settings:
+            if self.options['minimize_constraint_violation']:
+                # USe BFGS for constraint violation minimization
+                from scipy.optimize import BFGS
+                hess = BFGS()
+            elif 'hess' in self.opt_settings:
                 hess = self.opt_settings.pop('hess')
             else:
                 # Defaults to BFGS, if not in opt_settings


### PR DESCRIPTION
### Summary

I've created a possible implementation for POEM_96 (https://github.com/OpenMDAO/POEMs/pull/194). I tried to make minimal changes to the overall codebase, so this approach adds a driver level option `minimize_constraint_violation` to activate this functionality. Currently this is only implemented for the SciPy driver as it's most relevant to SLSQP. Those running pyOptSparse with SNOPT or IPOPT already get a form of this build into those optimizers.

This proposal modified the `ScipyOptimizeDriver._objfunc` and `ScipyOptimizeDriver._gradfunc` functions directly to achieve this.

I'll add tests and updates to the docs if this approach is deemed reasonable. I've tested this in my teams main tool that runs OpenMDAO and found it works well and is quite useful. I can share some examples of using the feature in our tool over video call if you would like.

### Example Code
Here's a breif example to run the feature. When toggled on, the constraint violation is printed as the `Current function value` in the SciPy printout
```python
import openmdao.api as om

# Define a simple model
prob = om.Problem()
model = prob.model

# Design Vars
ivc: om.IndepVarComp = prob.model.add_subsystem('ivc', om.IndepVarComp(), promotes_outputs=['*'])
ivc.add_output('x', val=5.0)
ivc.add_design_var('x', lower=0.0, upper=10.0)

# Constraints
con = model.add_subsystem('comp', om.ExecComp('y = (x)**2'), promotes=['*'])
con.add_constraint('y', lower=1.25, upper=4.0)

con2 = model.add_subsystem('comp2', om.ExecComp('y2 = x+0.5'), promotes=['*'])
con2.add_constraint('y2', equals=2)

# Objective
model.add_subsystem('obj_comp', om.ExecComp('obj = (x-1)**2'), promotes=['*'])
model.add_objective('obj')

# Driver
prob.driver = om.ScipyOptimizeDriver()
prob.driver.options['optimizer'] = 'SLSQP'
prob.driver.options['minimize_constraint_violation'] = True  # Minimize constraint violations

# Setup the problem and run the optimization
prob.setup()
prob.run_driver()

# Print the final design variable and constraint values
print(f"Final design variable 'x': {prob['x']}")
print(f"Final constraint 'y': {prob['y']}")
print(f"Objective 'obj': {prob['obj']}")
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
