### PR TITLE
Removed deprecation warning for non-pythonic option names

### DIFF
--- a/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
@@ -154,6 +154,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Option Names\n",
+    "\n",
+    "An option name can be any valid string. It is recommended that you use clear concise names. It is also recommended that you restrict the characters to those permitted in valid python names so that they can be passed into the system's initialization arguments as arguments, but it is not required.\n",
+    "\n",
     "## Option Types\n",
     "\n",
     "Options are not limited to simple types like `int`. In the following example, the component takes a *Numpy* array as an option:"
@@ -557,6 +561,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Note that the option name must be a valid python name in order to use this `set` function. If your option has a name that is not valid in python (e.g., \"aircraft:propulsion:NUM_ENGINES\"), then you will have to set them individually with the dictionary interface.\n",
+    "\n",
     "## Setting options throughout a problem model (`Problem.model_options`)\n",
     "\n",
     "It is common for options to be passed down through a model tree from parent Group to child Group or Component.\n",
@@ -869,7 +875,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -883,7 +889,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.12.3"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/options/options.ipynb
@@ -156,7 +156,7 @@
    "source": [
     "## Option Names\n",
     "\n",
-    "An option name can be any valid string. It is recommended that you use clear concise names. It is also recommended that you restrict the characters to those permitted in valid python names so that they can be passed into the system's initialization arguments as arguments, but it is not required.\n",
+    "An option name can be any valid string. It is recommended that you use clear concise names. It is also recommended that you restrict the characters to those permitted in valid python names so that they can be passed into the system's initialization arguments, but it is not required.\n",
     "\n",
     "## Option Types\n",
     "\n",

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -1,16 +1,11 @@
 """Define the OptionsDictionary class."""
 import contextlib
-import re
 
 from openmdao.utils.om_warnings import warn_deprecation
 from openmdao.utils.notebook_utils import notebook
 from openmdao.visualization.tables.table_builder import generate_table
 
 from openmdao.core.constants import _UNDEFINED
-
-
-# regex to check for valid names.
-namecheck_rgx = re.compile('[a-zA-Z_][_a-zA-Z0-9]*')
 
 
 #
@@ -387,13 +382,6 @@ class OptionsDictionary(object):
             during __setitem__ and __getitem__.  If a tuple of the form (msg, new_name),
             display msg as with str, and forward any __setitem__/__getitem__ to new_name.
         """
-        match = namecheck_rgx.match(name)
-        if match is None or match.group() != name:
-            warn_deprecation(f"'{name}' is not a valid python name and will become an invalid "
-                             "option name in a future release. You can prevent this warning (and "
-                             "future exceptions) by declaring this option using a valid python "
-                             "name.")
-
         if values is not None and not isinstance(values, (set, list, tuple)):
             self._raise(f"In declaration of option '{name}', the 'values' arg must be of type None,"
                         f" list, or tuple - not {values}.", exc_type=TypeError)

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -386,11 +386,11 @@ test       **Required**  ['a', 'b']         N/A                    Test integer 
         expected_msg = "Can't find aliased option 'foo3' for deprecated option 'test3'."
         self.assertEqual(context.exception.args[0], expected_msg)
 
-    def test_bad_option_name(self):
+    def test_supported_option_name(self):
         opt = OptionsDictionary()
-        msg = "'foo:bar' is not a valid python name and will become an invalid option name in a future release. You can prevent this warning (and future exceptions) by declaring this option using a valid python name."
 
-        with assert_warning(OMDeprecationWarning, msg):
+        # We will continue to support ":" in option names.
+        with assert_no_warning(OMDeprecationWarning):
             opt.declare('foo:bar', 1.0)
 
     def test_context_manager(self):


### PR DESCRIPTION
### Summary

Remove deprecation warning for non-pythonic option names. We will continue to support them because they are widely used. Some clarification has been added to the docs to inform that some features of the system options will not work without pythonic names.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
