### PR TITLE
Fix confusing warning during `prob.setup(check=True)` when recorder is attached to problem

### DIFF
--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -463,6 +463,10 @@ def _check_missing_recorders(problem, logger):
     logger : object
         The object that manages logging output.
     """
+    # Look for a Problem recorder
+    if problem._rec_mgr._recorders:
+        return
+
     # Look for Driver recorder
     if problem.driver._rec_mgr._recorders:
         return

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -590,6 +590,17 @@ class TestRecorderCheckConfig(unittest.TestCase):
         expected_warning = "The Problem has no recorder of any kind attached"
         testlogger.find_in('warning', expected_warning)
 
+    def test_check_problem_recorder_set(self):
+        p = om.Problem()
+        p.add_recorder(self.recorder)
+
+        testlogger = TestLogger()
+        p.setup(check=True, logger=testlogger)
+        p.final_setup()
+
+        warnings = testlogger.get('warning')
+        self.assertEqual(len(warnings), 0)
+
     def test_check_driver_recorder_set(self):
         p = om.Problem()
         p.driver.add_recorder(self.recorder)


### PR DESCRIPTION
### Summary

This PR checks if a case recorder at the Problem level exists before issuing `WARNING: The Problem has no recorder of any kind attached` during `setup(check=True)`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None

### Example

Example script that will trigger the errant (IMHO) warning:

```python
import openmdao.api as om
from openmdao.test_suite.components.sellar_feature import SellarDerivatives

import numpy as np

model = SellarDerivatives()

model.nonlinear_solver = om.NonlinearBlockGS()
model.linear_solver = om.ScipyKrylov()


model.add_design_var('z', lower=np.array([-10.0, 0.0]),
                                               upper=np.array([10.0, 10.0]))
model.add_design_var('x', lower=0.0, upper=10.0)
model.add_objective('obj')
model.add_constraint('con1', upper=0.0)
model.add_constraint('con2', upper=0.0)

driver = om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-9)

prob = om.Problem(model, driver)

prob.add_recorder(om.SqliteRecorder("cases.sql"))

prob.recording_options['includes'] = []
prob.recording_options['record_objectives'] = True
prob.recording_options['record_constraints'] = True
prob.recording_options['record_desvars'] = True

prob.setup(check=True)
prob.run_driver()
```

When I run that with OpenMDAO 3.34.2 I get this output:

```
INFO: checking out_of_order
INFO: checking system
INFO: checking solvers
INFO: checking dup_inputs
INFO: checking missing_recorders
WARNING: The Problem has no recorder of any kind attached
INFO: checking unserializable_options
INFO: checking comp_has_no_outputs
INFO: checking auto_ivc_warnings
NL: NLBGS Converged in 8 iterations
NL: NLBGS Converged in 1 iterations
NL: NLBGS Converged in 9 iterations
NL: NLBGS Converged in 10 iterations
NL: NLBGS Converged in 10 iterations
NL: NLBGS Converged in 9 iterations
NL: NLBGS Converged in 6 iterations
Optimization terminated successfully    (Exit mode 0)
            Current function value: 3.183393951728078
            Iterations: 6
            Function evaluations: 6
            Gradient evaluations: 6
Optimization Complete
-----------------------------------
```

The warning is confusing to me since there is indeed a recorder attached.
