### PR TITLE
Added 'recordable_only' option to OptionsDictionary items method.

### DIFF
--- a/openmdao/core/tests/test_serialize.py
+++ b/openmdao/core/tests/test_serialize.py
@@ -27,6 +27,20 @@ class SerializeTestCase(unittest.TestCase):
 
         om.n2(p, show_browser=False)
 
+    def test_recordable_only(self):
+        p = om.Problem()
+
+        comp = p.model.add_subsystem('foo', BadOptionComp(bad=object()))
+
+        p.setup()
+        p.final_setup()
+
+        self.assertDictEqual(dict(comp.options.items(recordable_only=True)), {
+            'always_opt': False,
+            'distributed': False,
+            'run_root_only': False
+        })
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/utils/options_dictionary.py
+++ b/openmdao/utils/options_dictionary.py
@@ -548,9 +548,14 @@ class OptionsDictionary(object):
         else:
             self._raise(f"Option '{name}' is required but has not been set.")
 
-    def items(self):
+    def items(self, recordable_only=False):
         """
         Yield name and value of options.
+
+        Parameters
+        ----------
+        recordable_only : bool
+            If True, return only recordable options.
 
         Yields
         ------
@@ -560,10 +565,11 @@ class OptionsDictionary(object):
             Value of the option.
         """
         for key, val in self._dict.items():
-            try:
-                yield key, val['val']
-            except KeyError:
-                yield key, val['value']
+            if not recordable_only or val['recordable']:
+                try:
+                    yield key, val['val']
+                except KeyError:
+                    yield key, val['value']
 
     def _handle_deprecation(self, name, meta):
         """


### PR DESCRIPTION
### Summary

Added 'recordable_only' option to OptionsDictionary items method.

### Related Issues

- Resolves #3378 

### Backwards incompatibilities

None

### New Dependencies

None
