### PR TITLE
Update pyOptSparse citation

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -84,7 +84,7 @@ DEFAULT_OPT_SETTINGS['IPOPT'] = {
 }
 
 CITATIONS = """@article{Wu_pyoptsparse_2020,
-    author = {Neil Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
+    author = {Ella Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
      Joaquim R. R. A. Martins},
     title = {{pyOptSparse:} A {Python} framework for large-scale constrained
      nonlinear optimization of sparse systems},


### PR DESCRIPTION
### Summary

pyOptSparse citation is outdated, this PR updates it to reflect the [latest citation](https://joss.theoj.org/papers/10.21105/joss.02564).

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
