### PR TITLE
PSQP exit criteria

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -84,7 +84,7 @@ DEFAULT_OPT_SETTINGS['IPOPT'] = {
 }
 
 CITATIONS = """@article{Wu_pyoptsparse_2020,
-    author = {Neil Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
+    author = {Ella Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
      Joaquim R. R. A. Martins},
     title = {{pyOptSparse:} A {Python} framework for large-scale constrained
      nonlinear optimization of sparse systems},

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -84,7 +84,7 @@ DEFAULT_OPT_SETTINGS['IPOPT'] = {
 }
 
 CITATIONS = """@article{Wu_pyoptsparse_2020,
-    author = {Ella Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
+    author = {Neil Wu and Gaetan Kenway and Charles A. Mader and John Jasa and
      Joaquim R. R. A. Martins},
     title = {{pyOptSparse:} A {Python} framework for large-scale constrained
      nonlinear optimization of sparse systems},
@@ -651,6 +651,9 @@ class pyOptSparseDriver(Driver):
             # These are various failed statuses.
             if optimizer == 'IPOPT':
                 if exit_status not in {0, 1}:
+                    self.fail = True
+            elif optimizer == 'PSQP':
+                if exit_status not in {1, 2, 3, 4}:
                     self.fail = True
             else:
                 # exit status may be the empty string for optimizers that don't support it


### PR DESCRIPTION
### Summary

My understanding that any of the first 4 exit criteria of PSQP are acceptable (and maybe -6) and thus wouldn't constitute a failure

See https://github.com/mdolab/pyoptsparse/blob/bc021e4b76e2d6ff53c6c8312b39ef180be04b4c/pyoptsparse/pyPSQP/pyPSQP.py#L60
```python
        informs = {
            1: "Change in design variable was less than or equal to tolerance",
            2: "Change in objective function was less than or equal to tolerance",
            3: "Objective function less than or equal to tolerance",
            4: "Maximum constraint value is less than or equal to tolerance",
            11: "Maximum number of iterations exceeded",
            12: "Maximum number of function evaluations exceeded",
            13: "Maximum number of gradient evaluations exceeded",
            -6: "Termination criterion not satisfied, but obtained point is acceptable",
            -7: "Positive directional derivative in line search",
            -8: "Interpolation error in line search",
            -10: "Optimization failed",
        }
```


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
