### PR TITLE
BugFix: OpenMDAO Summary Report with discrete inputs

### DIFF
--- a/openmdao/devtools/debug.py
+++ b/openmdao/devtools/debug.py
@@ -333,7 +333,7 @@ def config_summary(problem, stream=sys.stdout):
         printer()
         conns = model._conn_global_abs_in2out
         printer("Total connections: %d   Total transfer data size: %d" %
-                (len(conns), sum(meta['input'][n]['size'] for n in conns)))
+                (len(conns), sum(meta['input'][n]['size'] for n in conns if n in meta['input'])))
 
     printer()
     printer("Driver type: %s" % problem.driver.__class__.__name__)


### PR DESCRIPTION
### Summary

The OpenMDAO summary report will crash halfway if there are any discrete variables. This is a quick fix. I think this will however ignore the contributions of the discretes to the transfer size, so feel free to disregard this PR and make a more appropriate fix. This will will prevent the `KeyError`

```  File "C:\Users\...\site-packages\openmdao\devtools\debug.py", line 339, in <genexpr>
    (len(conns), sum(meta['input'][n]['size'] for n in conns)))
KeyError: 'mydisceretevar'  
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
