### PR TITLE
Updated code & test workflow for Python 3.13 compatibility

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -18,6 +18,8 @@ echo "Install latest versions of 'docs' dependencies"
 echo "============================================================="
 python -m pip install --upgrade --pre matplotlib
 python -m pip install --upgrade --pre numpydoc
+echo "*** ipykernel 7.x seems to be broken at the moment"
+python -m pip install 'ipykernel<7'
 python -m pip install --upgrade --pre jupyter-book
 python -m pip install --upgrade --pre sphinx-sitemap
 python -m pip install --upgrade --pre ipyparallel

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -48,10 +48,10 @@ jobs:
       matrix:
         include:
           # test latest versions on ubuntu
-          # Include PETSc/pyOptSparse, which require NumPy<2
+          # Include pyOptSparse, which requires NumPy<2
           - NAME: Ubuntu Latest, NumPy<2
             OS: ubuntu-latest
-            PY: 3
+            PY: '3.12'
             NUMPY: '<2'
             PETSc: true
             PYOPTSPARSE: true
@@ -60,25 +60,31 @@ jobs:
             BUILD_DOCS: true
 
           # test latest versions on ubuntu
-          # Exclude PETSc/pyOptSparse, which require NumPy<2
-          - NAME: Ubuntu Latest, NumPy 2 (No PETSc/pyOptSparse)
+          # Exclude pyOptSparse, which requires NumPy<2
+          # NumPy>=2.1 is required with Python 3.13
+          - NAME: Ubuntu Latest, NumPy 2 (No pyOptSparse)
             OS: ubuntu-latest
-            PY: 3
+            PY: '3.13'
+            NUMPY: '>=2.1'
+            PETSc: true
 
           # test latest versions on macos
-          # Include PETSc/pyOptSparse, which require NumPy<2
+          # Include pyOptSparse, which requires NumPy<2
           - NAME: MacOS Latest, NumPy<2
             OS: macos-13
-            PY: 3
+            PY: '3.12'
             NUMPY: '<2'
             PETSc: true
             PYOPTSPARSE: true
 
           # test latest versions on macos
-          # Exclude PETSc/pyOptSparse, which require NumPy<2
-          - NAME: MacOS Latest, NumPy 2 (No PETSc/pyOptSparse)
+          # Exclude pyOptSparse, which require NumPy<2
+          # NumPy>=2.1 is required with Python 3.13
+          - NAME: MacOS Latest, NumPy 2 (No pyOptSparse)
             OS: macos-13
-            PY: 3
+            PY: '3.13'
+            NUMPY: '>=2.1'
+            PETSc: true
 
     runs-on: ${{ matrix.OS }}
 

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -140,12 +140,12 @@ jobs:
           - NAME: Ubuntu Oldest
             OS: ubuntu-latest
             PY: '3.9'
-            NUMPY: '1.23'
+            NUMPY: '1.24'
             SCIPY: '1.9'
             OPENMPI: '4.0'
             MPI4PY: '3.0'
             PETSc: '3.13'
-            PYOPTSPARSE: 'v2.9.0'
+            PYOPTSPARSE: 'v2.10.2'
             SNOPT: '7.2'
             OPTIONAL: '[all]'
             TESTS: true
@@ -647,9 +647,9 @@ jobs:
           python -m pip install --upgrade pip
 
           echo "============================================================="
-          echo "Install lxml for Windows (No Python 3.11 version on pypi)"
+          echo "Install mkl 2024.1.0 (test failure with 2024.2.2)"
           echo "============================================================="
-          conda install lxml
+          conda install mkl=2024.1.0
 
           echo "============================================================="
           echo "Install OpenMDAO"

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2999,11 +2999,12 @@ class Group(System):
                     # out_shape != in_shape is allowed if there's no ambiguity in storage order
                     if (in_shape is None or out_shape is None or
                             not array_connection_compatible(in_shape, out_shape)):
-                        self._collect_error(
-                            f"{self.msginfo}: The source and target shapes do not match or "
-                            f"are ambiguous for the connection '{abs_out}' to '{abs_in}'. "
-                            f"The source shape is {out_shape} "
-                            f"but the target shape is {in_shape}.", ident=(abs_out, abs_in))
+                        with np.printoptions(legacy='1.21'):
+                            self._collect_error(
+                                f"{self.msginfo}: The source and target shapes do not match or "
+                                f"are ambiguous for the connection '{abs_out}' to '{abs_in}'. "
+                                f"The source shape is {out_shape} "
+                                f"but the target shape is {in_shape}.", ident=(abs_out, abs_in))
                         continue
 
                 elif src_indices is not None:

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -484,8 +484,8 @@ class _TotalJacInfo(object):
                     start = end
 
             if full_j_srcs:
-                full_src_inds = np.hstack(full_j_srcs)
-                full_tgt_inds = np.hstack(full_j_tgts)
+                full_src_inds = np.hstack(full_j_srcs, dtype=INT_DTYPE)
+                full_tgt_inds = np.hstack(full_j_tgts, dtype=INT_DTYPE)
             else:
                 full_src_inds = np.zeros(0, dtype=INT_DTYPE)
                 full_tgt_inds = np.zeros(0, dtype=INT_DTYPE)

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/explicit_func_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/explicit_func_comp.ipynb
@@ -365,7 +365,7 @@
    "source": [
     "## Using jax to Compute Partial Derivatives\n",
     "\n",
-    "If the function used to instantiate the ExplicitFuncComp declares partials or coloring that use `method='jax'`, or if the component's `use_jax` option is set, then the jax AD package will be used to compute all of the component's derivatives.  Currently it's not possible to mix jax with finite difference methods ('cs' and 'fd') in the same component.\n",
+    "If the function used to instantiate the ExplicitFuncComp declares partials or coloring that use `method='jax'`, or if the component's `derivs_method` option is set to `jax`, then the jax AD package will be used to compute all of the component's derivatives.  Currently it's not possible to mix jax with finite difference methods ('cs' and 'fd') in the same component.\n",
     "\n",
     "Note that `jax` is not an OpenMDAO dependency, so you'll have to install it manually.\n",
     "\n",

--- a/openmdao/docs/openmdao_book/features/building_blocks/components/implicit_func_comp.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/components/implicit_func_comp.ipynb
@@ -277,7 +277,7 @@
    "source": [
     "## Using jax to Compute Partial Derivatives\n",
     "\n",
-    "If the function used to instantiate the ExplicitFuncComp declares partials or coloring that use `method='jax'`, or if the component's `use_jax` option is set, then the jax AD package will be used to compute all of the component's derivatives.  Currently it's not possible to mix jax with finite difference methods ('cs' and 'fd') in the same component.\n",
+    "If the function used to instantiate the ExplicitFuncComp declares partials or coloring that use `method='jax'`, or if the component's `derivs_method` option is set to `jax`, then the jax AD package will be used to compute all of the component's derivatives.  Currently it's not possible to mix jax with finite difference methods ('cs' and 'fd') in the same component.\n",
     "\n",
     "Note that `jax` is an optional OpenMDAO dependency, but you can install it manually.\n",
     "\n",


### PR DESCRIPTION
### Summary

Updated code & latest test workflow for Python 3.13 compatibility

Also:
- updated FuncComp docs for change in option name from `use_jax` to `deriv_method`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
