### PR TITLE
Fixed error when using set_input_defaults with a different but acceptable default value shape.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -4493,7 +4493,9 @@ class Group(System):
                             if src_indices._flat_src:
                                 val.ravel()[src_indices.flat()] = value.flat
                             else:
-                                val[src_indices()] = value
+                                # Squeeze out singleton dimensions so that we can assign
+                                # values of different shapes when the storage order is unambiguous.
+                                np.squeeze(val[src_indices()])[...] = np.squeeze(value)
                         except Exception as err:
                             src = self._conn_global_abs_in2out[tgt]
                             msg = f"{self.msginfo}: The source indices " + \

--- a/openmdao/core/tests/test_connections.py
+++ b/openmdao/core/tests/test_connections.py
@@ -562,6 +562,38 @@ class TestAutoIVCAllowableShapeMismatch(unittest.TestCase):
         assert_near_equal(a, np.array([5., 10., 15.]))
         assert_near_equal(b, np.array([5., 10., 15.]))
 
+    def test_src_shape_allowable_shape_mismatch(self):
+
+        p = om.Problem()
+
+        c1 = p.model.add_subsystem('c1', om.ExecComp())
+        c2 = p.model.add_subsystem('c2', om.ExecComp())
+
+        # c1 takes a flat 3-vector
+        # c2 takes a column vector
+        c1.add_expr('a = 5.0 * x1', a=dict(shape=(3,)), x1=dict(shape=(3,)))
+        c2.add_expr('b = 5.0 * x2', b=dict(shape=(3,)), x2=dict(shape=(3, 1)))
+
+        # x1 takes the first index of the first dimension and whatever the remaining dimensions are
+        p.model.promotes('c1', inputs=[('x1', 'x')], src_indices=om.slicer[[0], ...])
+        # x2 takes the second index of the first dimension and whatever the remaining dimensions are
+        p.model.promotes('c2', inputs=[('x2', 'x')], src_indices=om.slicer[[1], ...])
+
+        # The source shape from the auto ivc is two column vectors (2, 3, 1)
+        p.model.set_input_defaults('x',
+                                   src_shape=(2, 3, 1),
+                                   val=np.reshape([1., 2., 3., 4., 5., 6.], (2, 3, 1)))
+
+        p.setup()
+
+        p.run_model()
+
+        a = p.get_val('c1.a')
+        b = p.get_val('c2.b')
+
+        assert_near_equal(a, 5 * np.array([1., 2., 3.]))
+        assert_near_equal(b, 5 * np.array([4., 5., 6.]))
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestConnectionsDistrib(unittest.TestCase):


### PR DESCRIPTION
### Summary

AutoIVC allows two inputs to be connected to the same AutoIVC output with different shapes
as long as the storage order is unambiguously the same. However, when assigning default
values to these AutoIVC outputs, OpenMDAO isn't applying this logic and it results in an error.

This fix applies the same numpy.squeeze functionality that checks of the shapes are compatible
to the assignment of a default value to avoid indexing errors that are unnecessarily strict.

### Related Issues

- Resolves #3390 
- Resolves #3381 

### Backwards incompatibilities

None

### New Dependencies

None
