### PR TITLE
Fixed docstring for InterpND extrapolate option

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -20,7 +20,7 @@ python -m pip install --upgrade --pre matplotlib
 python -m pip install --upgrade --pre numpydoc
 echo "*** ipykernel 7.x seems to be broken at the moment"
 python -m pip install 'ipykernel<7'
-python -m pip install --upgrade --pre jupyter-book
+python -m pip install --upgrade --pre 'jupyter-book<2'
 python -m pip install --upgrade --pre sphinx-sitemap
 python -m pip install --upgrade --pre ipyparallel
 

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -49,6 +49,8 @@ jobs:
         with:
           python-version: 3.12
           miniforge-version: latest
+          conda-remove-defaults: true
+          channels: conda-forge
 
       - name: Install lxml
         if: matrix.OS == 'windows-latest'

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -131,6 +131,8 @@ jobs:
         with:
           python-version: ${{ matrix.PY }}
           miniforge-version: latest
+          conda-remove-defaults: true
+          channels: conda-forge
 
       - name: Install MacOS-specific dependencies
         if: matrix.OS == 'macos-13'

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -207,13 +207,11 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: ${{ matrix.PY }}
+          conda-remove-defaults: true
           channels: conda-forge
 
       - name: Install OpenMDAO
         run: |
-          echo "Make sure we are not using anaconda packages"
-          conda config --remove channels defaults
-
           conda install numpy=${{ matrix.NUMPY }} scipy=${{ matrix.SCIPY }} -q -y
 
           python -m pip install --upgrade pip
@@ -639,6 +637,7 @@ jobs:
         with:
           python-version: ${{ matrix.PY }}
           channels: conda-forge
+          conda-remove-defaults: true
 
       - name: Install OpenDMAO
         run: |

--- a/openmdao/components/interp_util/interp.py
+++ b/openmdao/components/interp_util/interp.py
@@ -81,7 +81,7 @@ class InterpND(object):
     extrapolate : bool
         If False, when interpolated values are requested outside of the domain of the input
         data, a ValueError is raised. If True, then the methods are allowed to extrapolate.
-        Default is True (raise an exception).
+        Default is False (raise an exception).
     num_cp : None or int
         Optional. When specified, use a linear distribution of num_cp control points. If you
         are using 'bsplines' as the method, then num_cp must be set instead of points.
@@ -99,7 +99,6 @@ class InterpND(object):
     extrapolate : bool
         If False, when interpolated values are requested outside of the domain of the input data,
         a ValueError is raised. If True, then the methods are allowed to extrapolate.
-        Default is True.
     grid : tuple
         Collection of points that determine the regular grid.
     table : <InterpTable>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 ]
 docs = [
     "ipyparallel",
-    "jupyter-book==0.14",
+    "jupyter-book<2",
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",


### PR DESCRIPTION
### Summary

Fixed docstring for InterpND extrapolate option

Also:
- changed the `jupyter-book` dependency to be `<2` due to significant [changes](https://executablebooks.org/en/latest/blog/2024-05-20-jupyter-book-myst/) in 2.0
- changed the github workflows to use the `conda-remove-defaults` option to `setup-miniconda`

### Related Issues

- Resolves #3395

### Backwards incompatibilities

None

### New Dependencies

None
