### PR TITLE
A couple of performance fixes.

### DIFF
--- a/benchmark/benchmark_manycomps.py
+++ b/benchmark/benchmark_manycomps.py
@@ -2,7 +2,7 @@
 import unittest
 
 import openmdao.api as om
-from openmdao.test_suite.build4test import create_dyncomps
+from openmdao.test_suite.build4test import create_dyncomps, build_test_model
 
 
 class BM(unittest.TestCase):
@@ -25,3 +25,12 @@ class BM(unittest.TestCase):
         create_dyncomps(p.model, 1000, 10, 10, 5)
         p.setup()
         p.final_setup()
+
+    def benchmark_3K_compute_totals(self):
+        p = om.Problem(build_test_model(3000, 4, 4, 3, 13, 1))
+        p.driver = om.ScipyOptimizeDriver()
+        p.setup()
+        p.run_model()
+
+        for i in range(10):
+            p.compute_totals()

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2130,7 +2130,7 @@ class Group(System):
         parent_conns : dict
             Dictionary of connections passed down from parent group.
         """
-        global_abs_in2out = self._conn_global_abs_in2out = {}
+        global_abs_in2out = defaultdict(set)
 
         allprocs_prom2abs_list_in = self._var_allprocs_prom2abs_list['input']
         allprocs_prom2abs_list_out = self._var_allprocs_prom2abs_list['output']
@@ -2151,7 +2151,7 @@ class Group(System):
         if parent_conns is not None:
             for abs_in, abs_out in parent_conns.items():
                 if abs_in.startswith(prefix) and abs_out.startswith(prefix):
-                    global_abs_in2out[abs_in] = abs_out
+                    global_abs_in2out[abs_in].add(abs_out)
 
                     in_subsys, _, _ = abs_in[path_len:].partition('.')
                     out_subsys, _, _ = abs_out[path_len:].partition('.')
@@ -2171,7 +2171,7 @@ class Group(System):
                 out_subsys, _, _ = abs_out[path_len:].partition('.')
                 for abs_in in allprocs_prom2abs_list_in[prom_name]:
                     in_subsys, _, _ = abs_in[path_len:].partition('.')
-                    global_abs_in2out[abs_in] = abs_out
+                    global_abs_in2out[abs_in].add(abs_out)
                     if out_subsys == in_subsys:
                         in_subsys, _, _ = abs_in[path_len:].partition('.')
                         out_subsys, _, _ = abs_out[path_len:].partition('.')
@@ -2296,31 +2296,23 @@ class Group(System):
 
         # Compute global_abs_in2out by first adding this group's contributions,
         # then adding contributions from systems above/below, then allgathering.
-        conn_list = list(global_abs_in2out.items())
-        conn_list.extend(abs_in2out.items())
-        global_abs_in2out.update(abs_in2out)
+        for tgt, src in abs_in2out.items():
+            global_abs_in2out[tgt].add(src)
 
         for subgroup in self._subgroups_myproc:
             if subgroup.name in new_conns:
                 subgroup._setup_global_connections(parent_conns=new_conns[subgroup.name])
             else:
                 subgroup._setup_global_connections()
-            global_abs_in2out.update(subgroup._conn_global_abs_in2out)
-            conn_list.extend(subgroup._conn_global_abs_in2out.items())
+            for tgt, src in subgroup._conn_global_abs_in2out.items():
+                global_abs_in2out[tgt].add(src)
 
-        if len(conn_list) > len(global_abs_in2out):
-            dupes = [n for n, val in Counter(tgt for tgt, _ in conn_list).items() if val > 1]
-            dup_info = defaultdict(set)
-            for tgt, src in conn_list:
-                for dup in dupes:
-                    if tgt == dup:
-                        dup_info[tgt].add(src)
-            dup_info = [(n, srcs) for n, srcs in dup_info.items() if len(srcs) > 1]
-            if dup_info:
-                dup = ["%s from %s" % (tgt, sorted(srcs)) for tgt, srcs in dup_info]
-                dupstr = ', '.join(dup)
-                self._collect_error(f"{self.msginfo}: The following inputs have multiple "
-                                    f"connections: {dupstr}.", ident=dupstr)
+        dup_info = [(n, srcs) for n, srcs in global_abs_in2out.items() if len(srcs) > 1]
+        if dup_info:
+            dup = ["%s from %s" % (tgt, sorted(srcs)) for tgt, srcs in dup_info]
+            dupstr = ', '.join(dup)
+            self._collect_error(f"{self.msginfo}: The following inputs have multiple "
+                                f"connections: {dupstr}.", ident=dupstr)
 
         if self.comm.size > 1 and self._mpi_proc_allocator.parallel:
             # If running in parallel, allgather
@@ -2332,12 +2324,16 @@ class Group(System):
 
             all_src_ind_ins = set()
             for myproc_global_abs_in2out, src_ind_ins in gathered:
-                global_abs_in2out.update(myproc_global_abs_in2out)
+                for tgt, srcs in myproc_global_abs_in2out.items():
+                    global_abs_in2out[tgt].update(srcs)
                 all_src_ind_ins.update(src_ind_ins)
             src_ind_inputs = all_src_ind_ins
 
         for inp in src_ind_inputs:
             allprocs_abs2meta_in[inp]['has_src_indices'] = True
+
+        self._conn_global_abs_in2out = {name: srcs.pop()
+                                        for name, srcs in global_abs_in2out.items()}
 
     def get_indep_vars(self, local):
         """

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -6,8 +6,6 @@ from openmdao.jacobians.jacobian import Jacobian
 from openmdao.core.constants import INT_DTYPE
 
 
-# import line_profiler
-
 class DictionaryJacobian(Jacobian):
     """
     No global <Jacobian>; use dictionary of user-supplied sub-Jacobians.
@@ -111,7 +109,6 @@ class DictionaryJacobian(Jacobian):
 
         return self._iter_keys
 
-    # @line_profiler.profile
     def _apply(self, system, d_inputs, d_outputs, d_residuals, mode):
         """
         Compute matrix-vector product.

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -6,6 +6,8 @@ from openmdao.jacobians.jacobian import Jacobian
 from openmdao.core.constants import INT_DTYPE
 
 
+# import line_profiler
+
 class DictionaryJacobian(Jacobian):
     """
     No global <Jacobian>; use dictionary of user-supplied sub-Jacobians.
@@ -109,6 +111,7 @@ class DictionaryJacobian(Jacobian):
 
         return self._iter_keys
 
+    # @line_profiler.profile
     def _apply(self, system, d_inputs, d_outputs, d_residuals, mode):
         """
         Compute matrix-vector product.

--- a/openmdao/jax/tests/test_jax.py
+++ b/openmdao/jax/tests/test_jax.py
@@ -74,7 +74,7 @@ class TestJax(unittest.TestCase):
         ksmin = ks_min(x, rho=1.E6)
         npmin = np.min(x)
 
-        assert_near_equal(ksmin, npmin, tolerance=1.0E-6)
+        assert_near_equal(ksmin, npmin, tolerance=2.0E-5)
 
 
 if __name__ == '__main__':

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1217,9 +1217,9 @@ class BlockLinearSolver(LinearSolver):
         Parameters
         ----------
         slv_vars : set, None, or _UNDEFINED
-            First variable set.
+            First variable set, from the current solver.
         sys_vars : set, None, or _UNDEFINED
-            Second variable set.
+            Second variable set, from above.
 
         Returns
         -------
@@ -1228,8 +1228,11 @@ class BlockLinearSolver(LinearSolver):
         """
         if sys_vars is None or slv_vars is None:
             return None
-        if slv_vars is _UNDEFINED:
+        if slv_vars is _UNDEFINED or not slv_vars:
             return sys_vars
+        if not sys_vars:
+            return slv_vars
+
         return sys_vars.union(slv_vars)
 
     def _run_apply(self, init=False):
@@ -1300,8 +1303,15 @@ class BlockLinearSolver(LinearSolver):
         scope_in : set, None, or _UNDEFINED
             Inputs relevant to possible lower level calls to _apply_linear on Components.
         """
-        self._scope_out = scope_out
-        self._scope_in = scope_in
+        if scope_out is _UNDEFINED or scope_out is None:
+            self._scope_out = scope_out
+        else:
+            self._scope_out = scope_out.intersection(self._system()._var_abs2meta['output'])
+
+        if scope_in is _UNDEFINED or scope_in is None:
+            self._scope_in = scope_in
+        else:
+            self._scope_in = scope_in.intersection(self._system()._var_abs2meta['input'])
 
     def solve(self, mode, rel_systems=None):
         """

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -254,10 +254,11 @@ if __name__ == '__main__':
 
     class SubGroup(Group):
         def setup(self):
-            create_dyncomps(self, num_comps, 2, 2, 2, var_factory=FloatFactory(vec_size))
-            cname = f"C{num_comps-1}"
-            self.add_objective(f"{cname}.o0")
-            self.add_constraint(f"{cname}.o1", lower=0.0)
+            create_dyncomps(self, num_comps, 2, 2, 2,
+                            var_factory=lambda: np.zeros(vec_size))
+            cname = "C%d"%(num_comps-1)
+            self.add_objective("%s.o0" % cname)
+            self.add_constraint("%s.o1" % cname, lower=0.0)
 
 
     p = Problem()
@@ -273,11 +274,11 @@ if __name__ == '__main__':
 
     par = g.add_subsystem("par", ParallelGroup())
     for pt in range(pts):
-        ptname = f"G{pt}"
+        ptname = "G%d"%pt
         ptg = par.add_subsystem(ptname, SubGroup())
         #create_dyncomps(ptg, num_comps, 2, 2, 2,
                             #var_factory=lambda: np.zeros(vec_size))
-        g.connect("P.x", f"par.{ptname}.C0.i0")
+        g.connect("P.x", "par.%s.C0.i0" % ptname)
 
         #cname = ptname + '.' + "C%d"%(num_comps-1)
         #g.add_objective("par.%s.o0" % cname)

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -276,13 +276,7 @@ if __name__ == '__main__':
     for pt in range(pts):
         ptname = "G%d"%pt
         ptg = par.add_subsystem(ptname, SubGroup())
-        #create_dyncomps(ptg, num_comps, 2, 2, 2,
-                            #var_factory=lambda: np.zeros(vec_size))
         g.connect("P.x", "par.%s.C0.i0" % ptname)
-
-        #cname = ptname + '.' + "C%d"%(num_comps-1)
-        #g.add_objective("par.%s.o0" % cname)
-        #g.add_constraint("par.%s.o1" % cname, lower=0.0)
 
     p.setup()
     p.final_setup()

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -142,7 +142,7 @@ def create_dyncomps(parent, ncomps, ninputs, noutputs, nconns,
 
 def create_testcomps(ncomps, comp_factory):
     """
-    Yield ncomps instances of the given comp_factory.
+    Yield ncomps instances returned from the given component factory.
     """
     for i in range(ncomps):
         yield f"C{i}", comp_factory()
@@ -159,6 +159,24 @@ def connect_comps(model, complist, ninputs, noutputs):
 
 
 def recursive_split(parent, complist, nsplits, max_levels, level=0, path=None):
+    """
+    Add levels to the system tree while splitting up the current component list.
+
+    Parameters
+    ----------
+    parent : Group
+        The parent group.
+    complist : list
+        List of components to split up.
+    nsplits : int
+        Number of splits to make.
+    max_levels : int
+        Maximum number of levels in the system tree.
+    level : int
+        Current level in the system tree.
+    path : list or None
+        List of names of parents in the system tree.
+    """
     if path is None:
         path = []
 
@@ -184,6 +202,30 @@ def recursive_split(parent, complist, nsplits, max_levels, level=0, path=None):
 
 
 def build_test_model(ncomps, ninputs, noutputs, splits_per_group, max_levels, shape):
+    """
+    Create a test problem that has design vars and responses and can compute derivatives.
+
+    Parameters
+    ----------
+    ncomps : int
+        Number of components in the model.
+    ninputs : int
+        Number of inputs to each component.
+    noutputs : int
+        Number of outputs from each component.
+    splits_per_group : int
+        Each Group has sub-Groups added based on the number of splits of the current list
+        of components.
+    max_levels : int
+        Maximum number of levels in the system tree.
+    shape : tuple
+        Shape of the input and output variables.
+
+    Returns
+    -------
+    Group
+        The model.
+    """
     model = Group()
     complist = [[name, None, comp] for name, comp in
                 create_testcomps(ncomps, DynComp2Factory(ninputs, noutputs, 1.1,
@@ -198,13 +240,6 @@ def build_test_model(ncomps, ninputs, noutputs, splits_per_group, max_levels, sh
         for i in range(1, noutputs):
             model.add_constraint(f"{complist[-1][1]}.o{i}", lower=0.0)
     return model
-
-
-# create all test components
-# recursively split them into groups by nsplit
-# each split group is a subgroup of the parent group
-# must be at least 1 component per group
-# create connections between components (sequentially, from comp i to comp i+1)
 
 
 if __name__ == '__main__':

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -3,12 +3,31 @@ Various functions to make it easier to build test models.
 """
 
 import time
-import numpy
+import numpy as np
 
 from openmdao.core.group import Group
 from openmdao.core.parallel_group import ParallelGroup
 from openmdao.core.explicitcomponent import ExplicitComponent
 from openmdao.core.indepvarcomp import IndepVarComp
+from openmdao.utils.array_utils import evenly_distrib_idxs
+
+
+class FloatFactory(object):
+    def __init__(self, shape=()):
+        self.shape = shape
+        self.size = np.prod(shape) if shape else 1
+
+    def __call__(self, iotype, idx):
+        if self.shape:
+            if iotype == 'input':
+                return np.ones(self.shape)
+            else:
+                return np.zeros(self.shape)
+        else:
+            if iotype == 'input':
+                return float(1.0)
+            else:
+                return float(0.0)
 
 
 class DynComp(ExplicitComponent):
@@ -17,22 +36,21 @@ class DynComp(ExplicitComponent):
     """
     def __init__(self, ninputs, noutputs,
                  nl_sleep=0.001, ln_sleep=0.001,
-                 var_factory=float, vf_args=()):
+                 var_factory=FloatFactory()):
         super().__init__()
 
         self.ninputs = ninputs
         self.noutputs = noutputs
         self.var_factory = var_factory
-        self.vf_args = vf_args
         self.nl_sleep = nl_sleep
         self.ln_sleep = ln_sleep
 
     def setup(self):
         for i in range(self.ninputs):
-            self.add_input(f'i{i}', self.var_factory(*self.vf_args))
+            self.add_input(f'i{i}', self.var_factory('input', i))
 
         for i in range(self.noutputs):
-            self.add_output(f'o{i}', self.var_factory(*self.vf_args))
+            self.add_output(f'o{i}', self.var_factory('output', i))
 
     def compute(self, inputs, outputs):
         time.sleep(self.nl_sleep)
@@ -44,8 +62,68 @@ class DynComp(ExplicitComponent):
         time.sleep(self.ln_sleep)
 
 
+class DynCompFactory(object):
+    def __init__(self, ninputs=10, noutputs=10, nl_sleep=0.001, ln_sleep=0.001,
+                 var_factory=FloatFactory()):
+        self.ninputs = ninputs
+        self.noutputs = noutputs
+        self.var_factory = var_factory
+        self.nl_sleep = nl_sleep
+        self.ln_sleep = ln_sleep
+
+    def __call__(self):
+        return DynComp(self.ninputs, self.noutputs, self.nl_sleep, self.ln_sleep,
+                       self.var_factory)
+
+
+class DynComp2(ExplicitComponent):
+    """
+    A component with a settable number of params and outputs.
+    """
+    def __init__(self, ninputs, noutputs, mult, var_factory):
+        super().__init__()
+
+        self.ninputs = ninputs
+        self.noutputs = noutputs
+        self.mult = mult
+        self.var_factory = var_factory
+
+    def setup(self):
+        for i in range(self.ninputs):
+            self.add_input(f'i{i}', self.var_factory('input', i))
+
+        for i in range(self.noutputs):
+            self.add_output(f'o{i}', self.var_factory('output', i))
+
+        self.declare_partials('*', '*',
+                              rows=np.arange(self.var_factory.size),
+                              cols=np.arange(self.var_factory.size))
+
+    def compute(self, inputs, outputs):
+        outputs.set_val(inputs.asarray() * self.mult)
+
+    def compute_partials(self, inputs, partials):
+        for o in range(self.noutputs):
+            for i in range(self.ninputs):
+                if o == i:
+                    partials[f'o{o}', f'i{i}'] = self.mult
+
+
+class DynComp2Factory(object):
+    def __init__(self, ninputs=10, noutputs=10, mult=1.1, var_factory=FloatFactory()):
+        self.ninputs = ninputs
+        self.noutputs = noutputs
+        self.mult = mult
+        self.var_factory = var_factory
+
+    def __call__(self):
+        return DynComp2(self.ninputs, self.noutputs, self.mult, self.var_factory)
+
+
+
 def make_subtree(parent, nsubgroups, levels,
-                 ncomps, ninputs, noutputs, nconns, var_factory=float):
+                 ncomps, ninputs, noutputs, nconns, var_factory=FloatFactory(),
+                 comp_factory=DynCompFactory()):
     """Construct a system subtree under the given parent group."""
 
     if levels <= 0:
@@ -53,27 +131,94 @@ def make_subtree(parent, nsubgroups, levels,
 
     if levels == 1:  # add leaf nodes
         create_dyncomps(parent, ncomps, ninputs, noutputs, nconns,
-                        var_factory=var_factory)
+                        var_factory=var_factory, comp_factory=comp_factory)
     else:  # add more subgroup levels
         for i in range(nsubgroups):
-            g = parent.add_subsystem("G%d"%i, Group())
+            g = parent.add_subsystem(f"G{i}", Group())
             make_subtree(g, nsubgroups, levels-1,
                          ncomps, ninputs, noutputs, nconns,
-                         var_factory=var_factory)
+                         var_factory=var_factory, comp_factory=comp_factory)
 
 
-def create_dyncomps(parent, ncomps, ninputs, noutputs, nconns,
-                    var_factory=float):
-    """Create a specified number of DynComps with a specified number
+def create_dyncomps(parent, ncomps, nconns,
+                    var_factory=FloatFactory(), comp_factory=DynCompFactory()):
+    """
+    Create a specified number of comp_factory() components with a specified number
     of variables (ninputs and noutputs), and add them to the given parent
     and add the number of specified connections.
     """
     for i in range(ncomps):
-        parent.add_subsystem("C%d" % i, DynComp(ninputs, noutputs, var_factory=var_factory))
+        parent.add_subsystem(f"C{i}", comp_factory(var_factory=var_factory))
 
         if i > 0:
             for j in range(nconns):
-                parent.connect("C%d.o%d" % (i-1,j), "C%d.i%d" % (i, j))
+                parent.connect(f"C{i-1}.o{j}", f"C{i}.i{j}")
+
+
+def create_testcomps(ncomps, comp_factory):
+    """
+    Yield ncomps instances of the given comp_factory.
+    """
+    for i in range(ncomps):
+        yield f"C{i}", comp_factory()
+
+
+def connect_comps(model, complist, ninputs, noutputs):
+    """
+    Connect the components in complist.
+    """
+    for i in range(len(complist)):
+        if i > 0:
+            for j in range(min(noutputs, ninputs)):
+                model.connect(f"{complist[i-1][1]}.o{j}", f"{complist[i][1]}.i{j}")
+
+
+def recursive_split(parent, complist, nsplits, max_levels, level=0, path=None):
+    if path is None:
+        path = []
+
+    sizes, offsets = evenly_distrib_idxs(nsplits, len(complist))
+    subs = [complist[offset:offset + size] for size, offset in zip(sizes, offsets)]
+    for subcomps in subs:
+        if not subcomps:
+            continue
+
+        g = Group()
+        gname = subcomps[0][0].replace('C', f'G_{level}_')
+        parent.add_subsystem(gname, g)
+
+        # if leaf node, add comps
+        if level + 1 >= max_levels or len(subcomps) < nsplits:
+            for i, subcomp in enumerate(subcomps):
+                cname, _, comp = subcomp
+                # set the pathname for connections later
+                subcomp[1] = '.'.join(path + [gname, cname])
+                g.add_subsystem(cname, comp)
+        else:
+            recursive_split(g, subcomps, nsplits, max_levels, level + 1, path + [gname])
+
+
+def build_test_model(ncomps, ninputs, noutputs, splits_per_group, max_levels, var_factory):
+    model = Group()
+    complist = [[name, None, comp] for name, comp in
+                create_testcomps(ncomps, DynComp2Factory(ninputs, noutputs, 1.1, var_factory))]
+    recursive_split(model, complist, splits_per_group, max_levels)
+    connect_comps(model, complist, ninputs, noutputs)
+    for i in range(ninputs):
+        model.add_design_var(f"{complist[0][1]}.i{i}")
+    if noutputs > 0:
+        model.add_objective(f"{complist[-1][1]}.o0", index=0)
+    if noutputs > 1:
+        for i in range(1, noutputs):
+            model.add_constraint(f"{complist[-1][1]}.o{i}", lower=0.0)
+    return model
+
+
+# create all test components
+# recursively split them into groups by nsplit
+# each split group is a subgroup of the parent group
+# must be at least 1 component per group
+# create connections between components (sequentially, from comp i to comp i+1)
 
 
 if __name__ == '__main__':
@@ -88,11 +233,10 @@ if __name__ == '__main__':
 
     class SubGroup(Group):
         def setup(self):
-            create_dyncomps(self, num_comps, 2, 2, 2,
-                            var_factory=lambda: numpy.zeros(vec_size))
-            cname = "C%d"%(num_comps-1)
-            self.add_objective("%s.o0" % cname)
-            self.add_constraint("%s.o1" % cname, lower=0.0)
+            create_dyncomps(self, num_comps, 2, 2, 2, var_factory=FloatFactory(vec_size))
+            cname = f"C{num_comps-1}"
+            self.add_objective(f"{cname}.o0")
+            self.add_constraint(f"{cname}.o1", lower=0.0)
 
 
     p = Problem()
@@ -102,17 +246,17 @@ if __name__ == '__main__':
         from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov
         g.linear_solver = ScipyKrylov()
 
-    g.add_subsystem("P", IndepVarComp('x', numpy.ones(vec_size)))
+    g.add_subsystem("P", IndepVarComp('x', np.ones(vec_size)))
 
     g.add_design_var("P.x")
 
     par = g.add_subsystem("par", ParallelGroup())
     for pt in range(pts):
-        ptname = "G%d"%pt
+        ptname = f"G{pt}"
         ptg = par.add_subsystem(ptname, SubGroup())
         #create_dyncomps(ptg, num_comps, 2, 2, 2,
-                            #var_factory=lambda: numpy.zeros(vec_size))
-        g.connect("P.x", "par.%s.C0.i0" % ptname)
+                            #var_factory=lambda: np.zeros(vec_size))
+        g.connect("P.x", f"par.{ptname}.C0.i0")
 
         #cname = ptname + '.' + "C%d"%(num_comps-1)
         #g.add_objective("par.%s.o0" % cname)

--- a/openmdao/test_suite/build4test.py
+++ b/openmdao/test_suite/build4test.py
@@ -193,7 +193,7 @@ def build_test_model(ncomps, ninputs, noutputs, splits_per_group, max_levels, sh
     for i in range(ninputs):
         model.add_design_var(f"{complist[0][1]}.i{i}")
     if noutputs > 0:
-        model.add_objective(f"{complist[-1][1]}.o0", index=0)
+        model.add_objective(f"{complist[-1][1]}.o0", index=0, flat_indices=True)
     if noutputs > 1:
         for i in range(1, noutputs):
             model.add_constraint(f"{complist[-1][1]}.o{i}", lower=0.0)


### PR DESCRIPTION
### Summary

One fix was to decrease the size of the sets of variables being passed down the solver tree during block linear solves.  We were passing down variables that were coming from systems not related to the current solve and doing set operations on those sets of variables at every level of the solver tree, which scaled poorly.

The other fix was in the setup of connections, where the way we were detecting duplicate connections didn't scale well.

### Related Issues

- Resolves #3397

### Backwards incompatibilities

None

### New Dependencies

None
