### PR TITLE
Fixed the search function in the documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 ]
 docs = [
     "ipyparallel",
-    "jupyter-book<2",
+    "jupyter-book<1",
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ all = [
 ]
 docs = [
     "ipyparallel",
-    "jupyter-book<1",
+    "jupyter-book==0.14",
     "matplotlib",
     "numpydoc>=1.1",
     "sphinx-sitemap",


### PR DESCRIPTION
### Summary

Fixed the search function in the documentation by pinning `jupyter-book==0.14`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
