### PR TITLE
 Changed language in the 'check unconnected inputs' config check to avoid confusion

### DIFF
--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -305,7 +305,7 @@ def _check_hanging_inputs(problem, logger):
             unconns.append((prom_tgt, abs_tgt))
 
     if unconns:
-        msg = ["The following inputs are not connected:\n"]
+        msg = ["The following inputs are connected to Auto IVC variables:\n"]
         for prom_tgt, abs_tgt in sorted(unconns):
             msg.append(f'  {prom_tgt} ({abs_tgt})\n')
         logger.warning(''.join(msg))

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -305,7 +305,7 @@ def _check_hanging_inputs(problem, logger):
             unconns.append((prom_tgt, abs_tgt))
 
     if unconns:
-        msg = ["The following inputs are connected to Auto IVC variables:\n"]
+        msg = ["The following inputs are connected to Auto IVC output variables:\n"]
         for prom_tgt, abs_tgt in sorted(unconns):
             msg.append(f'  {prom_tgt} ({abs_tgt})\n')
         logger.warning(''.join(msg))

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -420,7 +420,7 @@ class TestCheckConfig(unittest.TestCase):
         prob.final_setup()
 
         expected_warning = (
-            "The following inputs are not connected:\n"
+            "The following inputs are connected to Auto IVC variables:\n"
             "  cycle.d1.y2 (cycle.d1.y2)\n"
             "  x (cycle.d1.x)\n"
             "  x (obj_cmp.x)\n"

--- a/openmdao/error_checking/tests/test_check_config.py
+++ b/openmdao/error_checking/tests/test_check_config.py
@@ -420,7 +420,7 @@ class TestCheckConfig(unittest.TestCase):
         prob.final_setup()
 
         expected_warning = (
-            "The following inputs are connected to Auto IVC variables:\n"
+            "The following inputs are connected to Auto IVC output variables:\n"
             "  cycle.d1.y2 (cycle.d1.y2)\n"
             "  x (cycle.d1.x)\n"
             "  x (obj_cmp.x)\n"


### PR DESCRIPTION
### Summary

 Changed language in the 'check unconnected inputs' config check to avoid confusion

### Related Issues

- Resolves #3320

### Backwards incompatibilities

None

### New Dependencies

None
