### PR TITLE
Suppress an annoying warning when recorder setup happens multiple times.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1136,6 +1136,8 @@ class Problem(object, metaclass=ProblemMetaclass):
             raise RuntimeError(f"{self.msginfo}: Cannot call set_order without calling setup after")
 
         # set up recording, including any new recorders since last setup
+        # TODO: We should be smarter and only setup the recording when new recorders have
+        # been added.
         if self._metadata['setup_status'] >= _SetupStatus.POST_SETUP:
             driver._setup_recording()
             self._setup_recording()

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -728,7 +728,8 @@ class SqliteRecorder(CaseRecorder):
                     m.execute("INSERT INTO driver_metadata(id, model_viewer_data) VALUES(?,?)",
                               (key, json_data))
             except sqlite3.IntegrityError:
-                print("Model viewer data has already been recorded for %s." % key)
+                # This recorder already has model data.
+                pass
 
     def record_metadata_system(self, system, run_number=None):
         """


### PR DESCRIPTION
### Summary

This just removes a warning during final_setup. Setup_recording is called every time final_setup is called, because new recorders may be added at anytime between calls to run_model or run_driver.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
