### PR TITLE
fix link in first_analysis.ipynb

### DIFF
--- a/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
+++ b/openmdao/docs/openmdao_book/basic_user_guide/single_disciplinary_optimization/first_analysis.ipynb
@@ -128,7 +128,7 @@
     "In the `setup` method you define the inputs and outputs of the component.\n",
     "In the `setup_partials` method in this case you also ask OpenMDAO to approximate all the partial\n",
     "derivatives (derivatives of outputs with respect to inputs)\n",
-    "using the `finite difference method <https://en.wikipedia.org/wiki/Finite_difference_method>`_.\n",
+    "using the [finite difference method](https://en.wikipedia.org/wiki/Finite_difference_method).\n",
     "\n",
     "```{Note}\n",
     "    One of OpenMDAO's most unique features is its support for analytic derivatives.\n",


### PR DESCRIPTION
### Summary

Fix broken Wikipedia link in `first_analysis.ipynb`

### Related Issues

None, but here is a related pull request:

https://github.com/OpenMDAO/OpenMDAO/pull/2680

### Backwards incompatibilities

None

### New Dependencies

None
