### PR TITLE
fix link in models_with_solvers_implicit.ipynb

### DIFF
--- a/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "source": [
     "```{important}\n",
-    "Since we've provided default values for the options, they won't be required arguments when instantiating `Resistor` or `Diode`. Check out the [Features](../../features/features.ipynb) section for more details on how to use [component options](../../features/core_features/working_with_components/options.ipynb).\n",
+    "Since we've provided default values for the options, they won't be required arguments when instantiating `Resistor` or `Diode`. Check out the [Features](../../features/features.ipynb) section for more details on how to use [component options](../../features/core_features/options/options.ipynb).\n",
     "```"
    ]
   },

--- a/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
+++ b/openmdao/docs/openmdao_book/advanced_user_guide/models_implicit_components/models_with_solvers_implicit.ipynb
@@ -115,7 +115,7 @@
    "metadata": {},
    "source": [
     "```{important}\n",
-    "Since we've provided default values for the options, they won't be required arguments when instantiating `Resistor` or `Diode`. Check out the [Features](../../features/features.ipynb) section for more details on how to use [component options] (../../features/core_features/working_with_components/options.ipynb).\n",
+    "Since we've provided default values for the options, they won't be required arguments when instantiating `Resistor` or `Diode`. Check out the [Features](../../features/features.ipynb) section for more details on how to use [component options](../../features/core_features/working_with_components/options.ipynb).\n",
     "```"
    ]
   },


### PR DESCRIPTION
### Summary

The markdown link had a space in it causing it to render incorrectly.

### Related Issues

https://github.com/OpenMDAO/OpenMDAO/pull/3414

### Backwards incompatibilities

None

### New Dependencies

None
