### PR TITLE
Fixed use of `{object} is _UNDEFINED` which is problematic under MPI.

### DIFF
--- a/openmdao/code_review/test_common_problems.py
+++ b/openmdao/code_review/test_common_problems.py
@@ -1,0 +1,40 @@
+import unittest
+import pathlib
+import re
+
+
+class TestCommonProblems(unittest.TestCase):
+
+    def test_undefined_comparison(self):
+        """
+        Testing `{object} is _UNDEFINED` should not be done because _UNDEFINED can have
+        a different address on different processors. Use `{object} == _UNDEFINED`
+        instead. 
+        """
+        # Root directory of the openmdao package
+        root_dir = pathlib.Path(__file__).parent.parent
+        error_messages = []
+        pattern = re.compile(r'\b(\w+)\s+is\s+_UNDEFINED\b')  # Precompile the regex
+
+        # Traverse all Python files in the openmdao directory
+        for file_path in root_dir.rglob('*.py'):
+
+            try:
+                content = file_path.read_text(encoding='utf-8')
+                for match in pattern.finditer(content):
+                    variable_name = match.group(1)
+                    line_number = content[:match.start()].count('\n') + 1
+                    error_messages.append(
+                        f"Found '{variable_name} is _UNDEFINED' in {file_path} at line {line_number}. "
+                        f"Please use '{variable_name} == _UNDEFINED' instead."
+                    )
+            except Exception as e:  # Catch encoding or I/O errors
+                error_messages.append(f"Error reading {file_path}: {e}")
+
+        # Raise assertion error if any violations are found
+        if error_messages:
+            self.fail("\n".join(error_messages))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -81,7 +81,7 @@ class ExplicitComponent(Component):
         """
         Configure this system to assign children settings and detect if matrix_free.
         """
-        if self.matrix_free is _UNDEFINED:
+        if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('compute_jacvec_product', self, ExplicitComponent)
 
     def _jac_wrt_iter(self, wrt_matches=None):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -315,7 +315,7 @@ class Group(System):
             Assumed shape of any connected source or higher level promoted input.
         """
         meta = {'prom': name, 'auto': False}
-        if val is _UNDEFINED:
+        if val == _UNDEFINED:
             src_shape = shape2tuple(src_shape)
         else:
             if src_shape is not None:
@@ -1886,7 +1886,7 @@ class Group(System):
                     if submeta['auto']:
                         continue
                     if key in submeta:
-                        if fullmeta[key] is _UNDEFINED:
+                        if fullmeta[key] == _UNDEFINED:
                             origin = submeta['path']
                             origin_prom = submeta['prom']
                             val = fullmeta[key] = submeta[key]

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -96,16 +96,16 @@ class ImplicitComponent(Component):
         """
         self._has_guess = overrides_method('guess_nonlinear', self, ImplicitComponent)
 
-        if self._has_linearize is _UNDEFINED:
+        if self._has_linearize == _UNDEFINED:
             self._has_linearize = overrides_method('linearize', self, ImplicitComponent)
 
-        if self._has_solve_nl is _UNDEFINED:
+        if self._has_solve_nl == _UNDEFINED:
             self._has_solve_nl = overrides_method('solve_nonlinear', self, ImplicitComponent)
 
-        if self._has_solve_linear is _UNDEFINED:
+        if self._has_solve_linear == _UNDEFINED:
             self._has_solve_linear = overrides_method('solve_linear', self, ImplicitComponent)
 
-        if self.matrix_free is _UNDEFINED:
+        if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('apply_linear', self, ImplicitComponent)
 
     def _apply_nonlinear(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -554,7 +554,7 @@ class Problem(object, metaclass=ProblemMetaclass):
             val = self.model.get_val(name, units=units, indices=indices, get_remote=get_remote,
                                      from_src=True)
 
-        if val is _UNDEFINED:
+        if val == _UNDEFINED:
             if get_remote:
                 raise KeyError(f'{self.msginfo}: Variable name "{name}" not found.')
             else:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1025,9 +1025,9 @@ class System(object, metaclass=SystemMetaclass):
         #   method and what were the existing bounds
         if are_new_bounds:
             # wipe out all the bounds and only use what is set by the arguments to this call
-            if lower is _UNDEFINED:
+            if lower == _UNDEFINED:
                 lower = None
-            if upper is _UNDEFINED:
+            if upper == _UNDEFINED:
                 upper = None
         else:
             lower = existing_dv_meta['lower']
@@ -1043,13 +1043,13 @@ class System(object, metaclass=SystemMetaclass):
 
         # Now figure out scaling
         if are_new_scaling:
-            if scaler is _UNDEFINED:
+            if scaler == _UNDEFINED:
                 scaler = None
-            if adder is _UNDEFINED:
+            if adder == _UNDEFINED:
                 adder = None
-            if ref is _UNDEFINED:
+            if ref == _UNDEFINED:
                 ref = None
-            if ref0 is _UNDEFINED:
+            if ref0 == _UNDEFINED:
                 ref0 = None
         else:
             scaler = existing_dv_meta['scaler']
@@ -1193,11 +1193,11 @@ class System(object, metaclass=SystemMetaclass):
         #   method and what were the existing bounds
         if are_new_bounds:
             # wipe the slate clean and only use what is set by the arguments to this call
-            if equals is _UNDEFINED:
+            if equals == _UNDEFINED:
                 equals = None
-            if lower is _UNDEFINED:
+            if lower == _UNDEFINED:
                 lower = None
-            if upper is _UNDEFINED:
+            if upper == _UNDEFINED:
                 upper = None
         else:
             equals = existing_cons_meta['equals']
@@ -1216,13 +1216,13 @@ class System(object, metaclass=SystemMetaclass):
 
         # Now figure out scaling
         if are_new_scaling:
-            if scaler is _UNDEFINED:
+            if scaler == _UNDEFINED:
                 scaler = None
-            if adder is _UNDEFINED:
+            if adder == _UNDEFINED:
                 adder = None
-            if ref is _UNDEFINED:
+            if ref == _UNDEFINED:
                 ref = None
-            if ref0 is _UNDEFINED:
+            if ref0 == _UNDEFINED:
                 ref0 = None
         else:
             scaler = existing_cons_meta['scaler']
@@ -1340,7 +1340,7 @@ class System(object, metaclass=SystemMetaclass):
             name = alias
 
         # At least one of the scaling parameters must be set or function does nothing
-        if scaler is _UNDEFINED and adder is _UNDEFINED and ref is _UNDEFINED and ref0 == \
+        if scaler == _UNDEFINED and adder == _UNDEFINED and ref == _UNDEFINED and ref0 == \
                 _UNDEFINED:
             raise RuntimeError(
                 'Must set a value for at least one argument in call to set_objective_options.')
@@ -1360,13 +1360,13 @@ class System(object, metaclass=SystemMetaclass):
 
         # Since one or more of these are being set by the incoming arguments, the
         #   ones that are not being set should be set to None since they will be re-computed below
-        if scaler is _UNDEFINED:
+        if scaler == _UNDEFINED:
             scaler = None
-        if adder is _UNDEFINED:
+        if adder == _UNDEFINED:
             adder = None
-        if ref is _UNDEFINED:
+        if ref == _UNDEFINED:
             ref = None
-        if ref0 is _UNDEFINED:
+        if ref0 == _UNDEFINED:
             ref0 = None
 
         # Convert ref/ref0 to ndarray/float as necessary
@@ -5326,7 +5326,7 @@ class System(object, metaclass=SystemMetaclass):
                 # TODO: could cache these offsets
                 offsets = np.zeros(sizes.size, dtype=INT_DTYPE)
                 offsets[1:] = np.cumsum(sizes[:-1])
-                if val is _UNDEFINED:
+                if val == _UNDEFINED:
                     loc_val = np.zeros(sizes[myrank])
                 else:
                     loc_val = np.ascontiguousarray(val)

--- a/openmdao/core/tests/test_constants.py
+++ b/openmdao/core/tests/test_constants.py
@@ -11,9 +11,9 @@ class Foo(object):
 class ConstantsTestCase(unittest.TestCase):
     def test_repr_copy(self):
         cp = copy.copy(_UNDEFINED)
-        self.assertTrue(cp is _UNDEFINED, "Constants don't match!")
+        self.assertTrue(cp == _UNDEFINED, "Constants don't match!")
 
     def test_repr_deepcopy(self):
         f = Foo()
         cpf = copy.deepcopy(f)
-        self.assertTrue(cpf.bar is _UNDEFINED, "Constants don't match!")
+        self.assertTrue(cpf.bar == _UNDEFINED, "Constants don't match!")

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -1231,7 +1231,7 @@ class BlockLinearSolver(LinearSolver):
         """
         if sys_vars is None or slv_vars is None:
             return None
-        if slv_vars is _UNDEFINED or not slv_vars:
+        if slv_vars == _UNDEFINED or not slv_vars:
             return sys_vars
         if not sys_vars:
             return slv_vars
@@ -1306,12 +1306,12 @@ class BlockLinearSolver(LinearSolver):
         scope_in : set, None, or _UNDEFINED
             Inputs relevant to possible lower level calls to _apply_linear on Components.
         """
-        if scope_out is _UNDEFINED or scope_out is None:
+        if scope_out == _UNDEFINED or scope_out is None:
             self._scope_out = scope_out
         else:
             self._scope_out = scope_out.intersection(self._system()._var_abs2meta['output'])
 
-        if scope_in is _UNDEFINED or scope_in is None:
+        if scope_in == _UNDEFINED or scope_in is None:
             self._scope_in = scope_in
         else:
             self._scope_in = scope_in.intersection(self._system()._var_abs2meta['input'])

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -153,7 +153,7 @@ def _serialize_single_option(option):
 
     val = option['val']
 
-    if val is _UNDEFINED:
+    if val == _UNDEFINED:
         return str(val)
 
     if sys.getsizeof(val) > _MAX_OPTION_SIZE:
@@ -360,7 +360,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
             driver_opt_settings = None
 
         # set default behavior for values flag
-        if values is _UNDEFINED:
+        if values == _UNDEFINED:
             values = (data_source._metadata is not None and
                       data_source._metadata['setup_status'] >= _SetupStatus.POST_FINAL_SETUP)
 
@@ -377,7 +377,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
             raise TypeError(msg)
 
         # set default behavio r for values flag
-        if values is _UNDEFINED:
+        if values == _UNDEFINED:
             values = (data_source._problem_meta is not None and
                       data_source._problem_meta['setup_status'] >= _SetupStatus.POST_FINAL_SETUP)
 
@@ -391,7 +391,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
         data_dict = cr.problem_metadata
 
         # set default behavior for values flag
-        if values is _UNDEFINED:
+        if values == _UNDEFINED:
             values = True
 
         def set_values(children, stack, case):


### PR DESCRIPTION
### Summary

The use of `{object} is _UNDEFINED` for some variable is problematic, because _UNDEFINED exists in different memory addresses on different procs. Equality should be used instead. This is counterintuitive for programmers not thinking about MPI implications, so a test was added to check for the presence of `== _UNDEFINED` in the code.

### Related Issues

- Resolves #3421

### Backwards incompatibilities

None

### New Dependencies

None
