### PR TITLE
Added `is_undefined` function for MPI-safe and array-compatible checks.

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -119,7 +119,7 @@ from openmdao.utils.om_warnings import issue_warning, reset_warnings, OpenMDAOWa
     OMInvalidCheckDerivativesOptionsWarning
 
 # Utils
-from openmdao.utils.general_utils import wing_dbg, env_truthy, om_dump
+from openmdao.utils.general_utils import wing_dbg, env_truthy, om_dump, is_undefined
 from openmdao.utils.array_utils import shape_to_len
 from openmdao.utils.jax_utils import register_jax_component
 

--- a/openmdao/code_review/test_common_problems.py
+++ b/openmdao/code_review/test_common_problems.py
@@ -1,0 +1,70 @@
+import unittest
+import ast
+from pathlib import Path
+
+
+class UndefinedComparisonVisitor(ast.NodeVisitor):
+    """
+    AST Visitor to find occurrences of 'is _UNDEFINED' in Python code.
+    """
+
+    def __init__(self, file_path):
+        self.file_path = file_path
+        self.issues = []
+
+    def visit_Compare(self, node):
+        """
+        Check for comparisons like `variable is _UNDEFINED`.
+        """
+        if isinstance(node.ops[0], ast.Is) and isinstance(node.comparators[0], ast.Name):
+            if node.comparators[0].id == "_UNDEFINED":
+                variable = getattr(node.left, 'id', 'unknown')
+                line_number = node.lineno
+                self.issues.append(
+                    f"Found '{variable} is _UNDEFINED' in {self.file_path} at line {line_number}. "
+                    f"Please use 'openmdao.utils.general_utils.is_undefined({variable}) == _UNDEFINED' instead."
+                )
+        self.generic_visit(node)
+
+
+def process_file(file_path):
+    """
+    Process a single Python file and check for improper use of 'is _UNDEFINED'.
+    """
+    local_errors = []
+    try:
+        # Read and parse the file into an AST
+        source = file_path.read_text(encoding='utf-8')
+        tree = ast.parse(source, filename=str(file_path))
+
+        # Visit the AST nodes
+        visitor = UndefinedComparisonVisitor(file_path)
+        visitor.visit(tree)
+
+        # Collect any issues found
+        local_errors.extend(visitor.issues)
+    except (SyntaxError, UnicodeDecodeError) as e:
+        local_errors.append(f"Error reading {file_path}: {e}")
+    return local_errors
+
+
+class TestUndefinedComparison(unittest.TestCase):
+    def test_undefined_comparison(self):
+        # Define the root directory of the openmdao package
+        root_dir = Path(__file__).parent.parent
+        if not root_dir.exists():
+            self.fail(f"Root directory '{root_dir}' does not exist.")
+
+        error_messages = []
+
+        # Iterate through all Python files in the directory
+        for file_path in root_dir.rglob('*.py'):
+            error_messages.extend(process_file(file_path))
+
+        # Raise assertion error if any violations are found
+        if error_messages:
+            self.fail("\n".join(error_messages))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1714,8 +1714,8 @@ class TestFunctionRegistration(unittest.TestCase):
             # compute runs and just report as an error during expression evaluation.
 
             # have to use regex to handle differences in numpy print formats for shape
-            msg = "'comp' <class ExecComp>: Error occurred evaluating 'y = double\(x\) \* 3\.':\n" \
-                  "could not broadcast input array from shape \(10.*\) into shape \(8.*\)"
+            msg = r"'comp' <class ExecComp>: Error occurred evaluating 'y = double\(x\) \* 3\.':\n" \
+                  r"could not broadcast input array from shape \(10.*\) into shape \(8.*\)"
             with self.assertRaisesRegex(Exception, msg):
                 p.run_model()
 

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -528,7 +528,7 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         #   happen with f or g first. The order those are evaluated comes from the keys of
         #   dict so no guarantee on the order except for Python 3.6 !
         msg = "'comp' <class MetaModelStructuredComp>: Error interpolating output '[f|g]' because input 'comp.z' was " \
-              "out of bounds \('.*', '.*'\) with value '9.0'"
+              r"out of bounds \('.*', '.*'\) with value '9.0'"
         with self.assertRaisesRegex(om.AnalysisError, msg):
             self.run_and_check_derivs(self.prob)
 

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -11,6 +11,7 @@ from openmdao.vectors.vector import _full_slice
 from openmdao.utils.class_util import overrides_method
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.core.constants import INT_DTYPE, _UNDEFINED
+from openmdao.utils.general_utils import is_undefined
 from openmdao.utils.jax_utils import jax, jit, ExplicitCompJaxify, \
     compute_partials as _jax_compute_partials, \
     compute_jacvec_product as _jax_compute_jacvec_product, ReturnChecker, _jax_register_pytree_class
@@ -81,7 +82,7 @@ class ExplicitComponent(Component):
         """
         Configure this system to assign children settings and detect if matrix_free.
         """
-        if self.matrix_free == _UNDEFINED:
+        if is_undefined(self.matrix_free):
             self.matrix_free = overrides_method('compute_jacvec_product', self, ExplicitComponent)
 
     def _jac_wrt_iter(self, wrt_matches=None):

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -81,7 +81,7 @@ class ExplicitComponent(Component):
         """
         Configure this system to assign children settings and detect if matrix_free.
         """
-        if self.matrix_free is _UNDEFINED:
+        if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('compute_jacvec_product', self, ExplicitComponent)
 
     def _jac_wrt_iter(self, wrt_matches=None):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -28,7 +28,7 @@ from openmdao.utils.array_utils import array_connection_compatible, _flatten_src
     shape_to_len, ValueRepeater
 from openmdao.utils.general_utils import common_subpath, \
     convert_src_inds, shape2tuple, get_connection_owner, ensure_compatible, \
-    meta2src_iter, get_rev_conns
+    meta2src_iter, get_rev_conns, is_undefined
 from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismatch, _find_unit, \
     _is_unitless, simplify_unit
 from openmdao.utils.graph_utils import get_out_of_order_nodes, get_sccs_topo
@@ -315,7 +315,7 @@ class Group(System):
             Assumed shape of any connected source or higher level promoted input.
         """
         meta = {'prom': name, 'auto': False}
-        if val is _UNDEFINED:
+        if is_undefined(val):
             src_shape = shape2tuple(src_shape)
         else:
             if src_shape is not None:
@@ -1886,7 +1886,7 @@ class Group(System):
                     if submeta['auto']:
                         continue
                     if key in submeta:
-                        if fullmeta[key] is _UNDEFINED:
+                        if is_undefined(fullmeta[key]):
                             origin = submeta['path']
                             origin_prom = submeta['prom']
                             val = fullmeta[key] = submeta[key]

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -11,7 +11,8 @@ from openmdao.vectors.vector import _full_slice
 from openmdao.recorders.recording_iteration_stack import Recording
 from openmdao.utils.class_util import overrides_method
 from openmdao.utils.array_utils import shape_to_len
-from openmdao.utils.general_utils import format_as_float_or_array, _subjac_meta2value
+from openmdao.utils.general_utils import format_as_float_or_array, _subjac_meta2value, \
+    is_undefined
 from openmdao.utils.units import simplify_unit
 from openmdao.utils.rangemapper import RangeMapper
 from openmdao.utils.om_warnings import issue_warning
@@ -96,16 +97,16 @@ class ImplicitComponent(Component):
         """
         self._has_guess = overrides_method('guess_nonlinear', self, ImplicitComponent)
 
-        if self._has_linearize is _UNDEFINED:
+        if is_undefined(self._has_linearize):
             self._has_linearize = overrides_method('linearize', self, ImplicitComponent)
 
-        if self._has_solve_nl is _UNDEFINED:
+        if is_undefined(self._has_solve_nl):
             self._has_solve_nl = overrides_method('solve_nonlinear', self, ImplicitComponent)
 
-        if self._has_solve_linear is _UNDEFINED:
+        if is_undefined(self._has_solve_linear):
             self._has_solve_linear = overrides_method('solve_linear', self, ImplicitComponent)
 
-        if self.matrix_free == _UNDEFINED:
+        if is_undefined(self.matrix_free):
             self.matrix_free = overrides_method('apply_linear', self, ImplicitComponent)
 
     def _apply_nonlinear(self):

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -105,7 +105,7 @@ class ImplicitComponent(Component):
         if self._has_solve_linear is _UNDEFINED:
             self._has_solve_linear = overrides_method('solve_linear', self, ImplicitComponent)
 
-        if self.matrix_free is _UNDEFINED:
+        if self.matrix_free == _UNDEFINED:
             self.matrix_free = overrides_method('apply_linear', self, ImplicitComponent)
 
     def _apply_nonlinear(self):

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -54,7 +54,7 @@ from openmdao.utils.reports_system import get_reports_to_activate, activate_repo
     clear_reports, _load_report_plugins
 from openmdao.utils.general_utils import pad_name, LocalRangeIterable, \
     _find_dict_meta, env_truthy, add_border, match_includes_excludes, inconsistent_across_procs, \
-    ProblemMetaclass
+    ProblemMetaclass, is_undefined
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation, \
     OMInvalidCheckDerivativesOptionsWarning
 import openmdao.utils.coloring as coloring_mod
@@ -543,7 +543,7 @@ class Problem(object, metaclass=ProblemMetaclass):
             abs_names = name2abs_names(self.model, name)
             if abs_names:
                 val = self.model._get_cached_val(name, abs_names, get_remote=get_remote)
-                if val is not _UNDEFINED:
+                if not is_undefined(val):
                     if indices is not None:
                         val = val[indices]
                     if units is not None:
@@ -554,7 +554,7 @@ class Problem(object, metaclass=ProblemMetaclass):
             val = self.model.get_val(name, units=units, indices=indices, get_remote=get_remote,
                                      from_src=True)
 
-        if val is _UNDEFINED:
+        if is_undefined(val):
             if get_remote:
                 raise KeyError(f'{self.msginfo}: Variable name "{name}" not found.')
             else:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1340,7 +1340,8 @@ class System(object, metaclass=SystemMetaclass):
             name = alias
 
         # At least one of the scaling parameters must be set or function does nothing
-        if is_undefined(scaler) and is_undefined(adder) and is_undefined(ref) and is_undefined(ref0):
+        if is_undefined(scaler) and is_undefined(adder) \
+            and is_undefined(ref) and is_undefined(ref0):
             raise RuntimeError(
                 'Must set a value for at least one argument in call to set_objective_options.')
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -36,7 +36,7 @@ import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.indexer import indexer
 from openmdao.utils.om_warnings import issue_warning, \
     DerivativesWarning, PromotionWarning, UnusedOptionWarning, UnitsWarning, warn_deprecation
-from openmdao.utils.general_utils import determine_adder_scaler, \
+from openmdao.utils.general_utils import determine_adder_scaler, is_undefined, \
     format_as_float_or_array, all_ancestors, match_prom_or_abs, \
     ensure_compatible, env_truthy, make_traceback, _is_slicer_op, _wrap_comm, _unwrap_comm, \
     _om_dump, SystemMetaclass
@@ -1025,9 +1025,9 @@ class System(object, metaclass=SystemMetaclass):
         #   method and what were the existing bounds
         if are_new_bounds:
             # wipe out all the bounds and only use what is set by the arguments to this call
-            if lower is _UNDEFINED:
+            if is_undefined(lower):
                 lower = None
-            if upper is _UNDEFINED:
+            if is_undefined(upper):
                 upper = None
         else:
             lower = existing_dv_meta['lower']
@@ -1043,13 +1043,13 @@ class System(object, metaclass=SystemMetaclass):
 
         # Now figure out scaling
         if are_new_scaling:
-            if scaler is _UNDEFINED:
+            if is_undefined(scaler):
                 scaler = None
-            if adder is _UNDEFINED:
+            if is_undefined(adder):
                 adder = None
-            if ref is _UNDEFINED:
+            if is_undefined(ref):
                 ref = None
-            if ref0 is _UNDEFINED:
+            if is_undefined(ref0):
                 ref0 = None
         else:
             scaler = existing_dv_meta['scaler']
@@ -1193,11 +1193,11 @@ class System(object, metaclass=SystemMetaclass):
         #   method and what were the existing bounds
         if are_new_bounds:
             # wipe the slate clean and only use what is set by the arguments to this call
-            if equals is _UNDEFINED:
+            if is_undefined(equals):
                 equals = None
-            if lower is _UNDEFINED:
+            if is_undefined(lower):
                 lower = None
-            if upper is _UNDEFINED:
+            if is_undefined(upper):
                 upper = None
         else:
             equals = existing_cons_meta['equals']
@@ -1216,13 +1216,13 @@ class System(object, metaclass=SystemMetaclass):
 
         # Now figure out scaling
         if are_new_scaling:
-            if scaler is _UNDEFINED:
+            if is_undefined(scaler):
                 scaler = None
-            if adder is _UNDEFINED:
+            if is_undefined(adder):
                 adder = None
-            if ref is _UNDEFINED:
+            if is_undefined(ref):
                 ref = None
-            if ref0 is _UNDEFINED:
+            if is_undefined(ref0):
                 ref0 = None
         else:
             scaler = existing_cons_meta['scaler']
@@ -1340,8 +1340,7 @@ class System(object, metaclass=SystemMetaclass):
             name = alias
 
         # At least one of the scaling parameters must be set or function does nothing
-        if scaler is _UNDEFINED and adder is _UNDEFINED and ref is _UNDEFINED and ref0 == \
-                _UNDEFINED:
+        if is_undefined(scaler) and is_undefined(adder) and is_undefined(ref) and is_undefined(ref0):
             raise RuntimeError(
                 'Must set a value for at least one argument in call to set_objective_options.')
 
@@ -1360,13 +1359,13 @@ class System(object, metaclass=SystemMetaclass):
 
         # Since one or more of these are being set by the incoming arguments, the
         #   ones that are not being set should be set to None since they will be re-computed below
-        if scaler is _UNDEFINED:
+        if is_undefined(scaler):
             scaler = None
-        if adder is _UNDEFINED:
+        if is_undefined(adder):
             adder = None
-        if ref is _UNDEFINED:
+        if is_undefined(ref):
             ref = None
-        if ref0 is _UNDEFINED:
+        if is_undefined(ref0):
             ref0 = None
 
         # Convert ref/ref0 to ndarray/float as necessary
@@ -5326,7 +5325,7 @@ class System(object, metaclass=SystemMetaclass):
                 # TODO: could cache these offsets
                 offsets = np.zeros(sizes.size, dtype=INT_DTYPE)
                 offsets[1:] = np.cumsum(sizes[:-1])
-                if val is _UNDEFINED:
+                if is_undefined(val):
                     loc_val = np.zeros(sizes[myrank])
                 else:
                     loc_val = np.ascontiguousarray(val)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1340,10 +1340,13 @@ class System(object, metaclass=SystemMetaclass):
             name = alias
 
         # At least one of the scaling parameters must be set or function does nothing
-        if is_undefined(scaler) and is_undefined(adder) \
-            and is_undefined(ref) and is_undefined(ref0):
+        if (is_undefined(scaler) and is_undefined(adder)
+            and is_undefined(ref) and is_undefined(ref0)
+        ):
             raise RuntimeError(
-                'Must set a value for at least one argument in call to set_objective_options.')
+                'Must set a value for at least one argument '
+                'in call to set_objective_options.'
+            )
 
         if self._static_mode and self._static_responses:
             responses = self._static_responses

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1340,8 +1340,11 @@ class System(object, metaclass=SystemMetaclass):
             name = alias
 
         # At least one of the scaling parameters must be set or function does nothing
-        if (is_undefined(scaler) and is_undefined(adder)
-            and is_undefined(ref) and is_undefined(ref0)
+        if (
+            is_undefined(scaler)
+            and is_undefined(adder)
+            and is_undefined(ref)
+            and is_undefined(ref0)
         ):
             raise RuntimeError(
                 'Must set a value for at least one argument '

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -1163,8 +1163,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        msg = "\nProblem .*: To enable complex step, specify 'force_alloc_complex=True' when calling " + \
-                "setup on the problem, e\.g\. 'problem\.setup\(force_alloc_complex=True\)'"
+        msg = r"\nProblem .*: To enable complex step, specify 'force_alloc_complex=True' when calling " + \
+                r"setup on the problem, e\.g\. 'problem\.setup\(force_alloc_complex=True\)'"
         with self.assertRaisesRegex(RuntimeError, msg):
             prob.check_totals(method='cs')
 

--- a/openmdao/core/tests/test_constants.py
+++ b/openmdao/core/tests/test_constants.py
@@ -1,6 +1,7 @@
 import unittest
 import copy
 from openmdao.core.constants import _UNDEFINED
+from openmdao.api import is_undefined
 
 
 class Foo(object):
@@ -11,9 +12,9 @@ class Foo(object):
 class ConstantsTestCase(unittest.TestCase):
     def test_repr_copy(self):
         cp = copy.copy(_UNDEFINED)
-        self.assertTrue(cp is _UNDEFINED, "Constants don't match!")
+        self.assertTrue(is_undefined(cp), "Constants don't match!")
 
     def test_repr_deepcopy(self):
         f = Foo()
         cpf = copy.deepcopy(f)
-        self.assertTrue(cpf.bar is _UNDEFINED, "Constants don't match!")
+        self.assertTrue(is_undefined(cpf.bar), "Constants don't match!")

--- a/openmdao/core/tests/test_parallel_groups.py
+++ b/openmdao/core/tests/test_parallel_groups.py
@@ -338,7 +338,7 @@ class TestParallelGroupsMPI2(TestParallelGroups):
         if MPI:
             msg = ("Problem .*: The `distributed_vector_class` argument must be a distributed vector "
                    "class like `PETScVector` when running in parallel under MPI but 'DefaultVector' "
-                   "was specified which is not distributed\.")
+                   r"was specified which is not distributed\.")
             with self.assertRaisesRegex(ValueError, msg):
                 prob.setup(check=False, mode='fwd', distributed_vector_class=om.DefaultVector)
         else:

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -603,7 +603,7 @@ class TestJacobian(unittest.TestCase):
         model = prob.model
         model.add_subsystem('comp', Comp1())
 
-        msg = "'comp' <class Comp1>: d\(y\)/d\(x\): declare_partials has been called with rows and cols, which" + \
+        msg = r"'comp' <class Comp1>: d\(y\)/d\(x\): declare_partials has been called with rows and cols, which" + \
               " should be arrays of equal length, but rows is length 2 while " + \
               "cols is length 1."
         with self.assertRaisesRegex(RuntimeError, msg):
@@ -613,7 +613,7 @@ class TestJacobian(unittest.TestCase):
         model = prob.model
         model.add_subsystem('comp', Comp2())
 
-        msg = "'comp' <class Comp2>: d\(y\)/d\(x\): declare_partials has been called with rows and cols, which" + \
+        msg = r"'comp' <class Comp2>: d\(y\)/d\(x\): declare_partials has been called with rows and cols, which" + \
             " should be arrays of equal length, but rows is length 1 while " + \
             "cols is length 2."
         with self.assertRaisesRegex(RuntimeError, msg):
@@ -772,7 +772,7 @@ class TestJacobian(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        msg = 'Variable name pair \("{}", "{}"\) must first be declared.'
+        msg = r'Variable name pair \("{}", "{}"\) must first be declared.'
         with self.assertRaisesRegex(KeyError, msg.format('y', 'x')):
             prob.compute_totals(of=['comp.y'], wrt=['p1.x'])
 
@@ -1035,7 +1035,7 @@ class TestJacobian(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        msg = "'comp' \<class MyComp\>: Error calling compute_partials\(\), DictionaryJacobian in 'comp' \<class MyComp\>: Sub-jacobian for key \('comp.y', 'comp.x'\) has the wrong shape \(\(3,\)\), expected \(\(2,\)\)."
+        msg = r"'comp' \<class MyComp\>: Error calling compute_partials\(\), DictionaryJacobian in 'comp' \<class MyComp\>: Sub-jacobian for key \('comp.y', 'comp.x'\) has the wrong shape \(\(3,\)\), expected \(\(2,\)\)."
         with self.assertRaisesRegex(ValueError, msg):
             prob.compute_totals(of=['comp.y'], wrt=['comp.x'])
 

--- a/openmdao/jacobians/tests/test_jacobian_features.py
+++ b/openmdao/jacobians/tests/test_jacobian_features.py
@@ -199,20 +199,20 @@ class TestJacobianFeatures(unittest.TestCase):
 
     @parameterized.expand([
         ({'of': 'f', 'wrt': 'z', 'val': np.ones((1, 5))},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): Expected 1x4 but val is 1x5"),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): Expected 1x4 but val is 1x5"),
         ({'of': 'f', 'wrt': 'z', 'rows': [0, -1, 4], 'cols': [0, 0, 0]},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): row indices must be non-negative"),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): row indices must be non-negative"),
         ({'of': 'f', 'wrt': 'z', 'rows': [0, 0, 0], 'cols': [0, -1, 4]},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): col indices must be non-negative"),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): col indices must be non-negative"),
         ({'of': 'f', 'wrt': 'z', 'rows': [0, 0], 'cols': [0, 4]},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): Expected 1x4 but declared at least 1x5"),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): Expected 1x4 but declared at least 1x5"),
         ({'of': 'f', 'wrt': 'z', 'rows': [0, 10]},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): If one of rows/cols is specified, then both must be specified."),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): If one of rows/cols is specified, then both must be specified."),
         ({'of': 'f', 'wrt': 'z', 'cols': [0, 10]},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): If one of rows/cols is specified, then both must be specified."),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): If one of rows/cols is specified, then both must be specified."),
         ({'of': 'f', 'wrt': 'z', 'rows': [0, 0, 0], 'cols': [0, 1, 3], 'val': [0, 1]},
-         "'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): If rows and cols are specified, val must be a scalar or have the same shape, "
-         "val: \(2L?,\), rows/cols: \(3L?,\)"),
+         r"'simple' <class SimpleCompKwarg>: d\(f\)/d\(z\): If rows and cols are specified, val must be a scalar or have the same shape, "
+         r"val: \(2L?,\), rows/cols: \(3L?,\)"),
     ])
     def test_bad_sizes(self, partials_kwargs, error_msg):
         # This tests various shape mismatches. Basic size mismatch is now tested earlier in the
@@ -230,10 +230,10 @@ class TestJacobianFeatures(unittest.TestCase):
         self.assertRegex(str(ex.exception), error_msg)
 
     @parameterized.expand([
-        ({'of': 'q', 'wrt': 'z'}, "'simple' <class SimpleCompKwarg>: " + 'No matches were found for of="q"'),
-        ({'of': 'f?', 'wrt': 'x'}, "'simple' <class SimpleCompKwarg>: " + 'No matches were found for of="f?"'),
-        ({'of': 'f', 'wrt': 'q'}, "'simple' <class SimpleCompKwarg>: " + 'No matches were found for wrt="q"'),
-        ({'of': 'f', 'wrt': 'x?'}, "'simple' <class SimpleCompKwarg>: " + 'No matches were found for wrt="x?"'),
+        ({'of': 'q', 'wrt': 'z'}, r"'simple' <class SimpleCompKwarg>: " + 'No matches were found for of="q"'),
+        ({'of': 'f?', 'wrt': 'x'}, r"'simple' <class SimpleCompKwarg>: " + 'No matches were found for of="f?"'),
+        ({'of': 'f', 'wrt': 'q'}, r"'simple' <class SimpleCompKwarg>: " + 'No matches were found for wrt="q"'),
+        ({'of': 'f', 'wrt': 'x?'}, r"'simple' <class SimpleCompKwarg>: " + 'No matches were found for wrt="x?"'),
     ])
     def test_bad_names(self, partials_kwargs, error_msg):
         comp = SimpleCompKwarg(partials_kwargs)

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -16,7 +16,7 @@ from openmdao.utils.mpi import MPI
 from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import create_local_meta, check_path
 from openmdao.utils.om_warnings import issue_warning, SolverWarning
-from openmdao.utils.general_utils import SolverMetaclass
+from openmdao.utils.general_utils import SolverMetaclass, is_undefined
 
 
 class SolverInfo(object):
@@ -1231,7 +1231,7 @@ class BlockLinearSolver(LinearSolver):
         """
         if sys_vars is None or slv_vars is None:
             return None
-        if slv_vars is _UNDEFINED or not slv_vars:
+        if is_undefined(slv_vars) or not slv_vars:
             return sys_vars
         if not sys_vars:
             return slv_vars
@@ -1306,12 +1306,12 @@ class BlockLinearSolver(LinearSolver):
         scope_in : set, None, or _UNDEFINED
             Inputs relevant to possible lower level calls to _apply_linear on Components.
         """
-        if scope_out is _UNDEFINED or scope_out is None:
+        if is_undefined(scope_out) or scope_out is None:
             self._scope_out = scope_out
         else:
             self._scope_out = scope_out.intersection(self._system()._var_abs2meta['output'])
 
-        if scope_in is _UNDEFINED or scope_in is None:
+        if is_undefined(scope_in) or scope_in is None:
             self._scope_in = scope_in
         else:
             self._scope_in = scope_in.intersection(self._system()._var_abs2meta['input'])

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1083,6 +1083,7 @@ def convert_src_inds(parent_src_inds, parent_src_shape, my_src_inds, my_src_shap
     else:
         return parent_src_inds.shaped_array(flat=False).reshape(my_src_shape)[my_src_inds()]
 
+
 def is_undefined(obj):
     """
     Returns True if the object is _UNDEFINED.
@@ -1104,6 +1105,7 @@ def is_undefined(obj):
     if isinstance(obj, Iterable):
         return False
     return obj == _UNDEFINED
+
 
 def shape2tuple(shape):
     """

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable
 
 import numpy as np
 
-from openmdao.core.constants import INF_BOUND
+from openmdao.core.constants import INF_BOUND, _UNDEFINED
 from openmdao.utils.array_utils import shape_to_len
 
 
@@ -1083,6 +1083,27 @@ def convert_src_inds(parent_src_inds, parent_src_shape, my_src_inds, my_src_shap
     else:
         return parent_src_inds.shaped_array(flat=False).reshape(my_src_shape)[my_src_inds()]
 
+def is_undefined(obj):
+    """
+    Returns True if the object is _UNDEFINED.
+
+    This function should be used instead of `{obj} is _UNDEFINED`, which
+    is not reliable across processes. The use of `{obj} == _UNDEFINED` will
+    fail if `obj` is an array.
+
+    Parameters
+    ----------
+    obj : any
+        Any python object.
+
+    Returns
+    -------
+    bool
+        True if the obj is not an array, and obj == _UNDEFINED.
+    """
+    if isinstance(obj, Iterable):
+        return False
+    return obj == _UNDEFINED
 
 def shape2tuple(shape):
     """

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1086,7 +1086,7 @@ def convert_src_inds(parent_src_inds, parent_src_shape, my_src_inds, my_src_shap
 
 def is_undefined(obj):
     """
-    Returns True if the object is _UNDEFINED.
+    Return True if the object is _UNDEFINED.
 
     This function should be used instead of `{obj} is _UNDEFINED`, which
     is not reliable across processes. The use of `{obj} == _UNDEFINED` will

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -56,7 +56,7 @@ counter = 0
 
 def _test_func_name(func, num, param):
     # test name is the command with spaces, colons and backslashes replaced by underscore
-    return func.__name__ + '_' + re.sub('[ \\:\\\]', '_', param.args[0])
+    return func.__name__ + '_' + re.sub(r'[ \\:\\\]', '_', param.args[0])
 
 cmd_tests = [
     # tuple of (command line, dict of dependencies that might not be installed)

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -56,7 +56,7 @@ counter = 0
 
 def _test_func_name(func, num, param):
     # test name is the command with spaces, colons and backslashes replaced by underscore
-    return func.__name__ + '_' + re.sub(r'[ \\:\\\]', '_', param.args[0])
+    return func.__name__ + '_' + re.sub(r'[ \:\\]', '_', param.args[0])
 
 cmd_tests = [
     # tuple of (command line, dict of dependencies that might not be installed)

--- a/openmdao/utils/tests/test_options_dictionary.py
+++ b/openmdao/utils/tests/test_options_dictionary.py
@@ -276,8 +276,8 @@ test       **Required**  ['a', 'b']         N/A                    Test integer 
         with self.assertRaises(ValueError) as context:
             self.dict['test'] = object()
 
-        expected_msg = ("Value \(<object object at 0x[0-9A-Fa-f]+>\) of option 'test' is not one of \[<object object at 0x[0-9A-Fa-f]+>,"
-                        " <object object at 0x[0-9A-Fa-f]+>\].")
+        expected_msg = (r"Value \(<object object at 0x[0-9A-Fa-f]+>\) of option 'test' is not one of \[<object object at 0x[0-9A-Fa-f]+>,"
+                        r" <object object at 0x[0-9A-Fa-f]+>\].")
         self.assertRegex(str(context.exception), expected_msg)
 
     def test_read_only(self):

--- a/openmdao/visualization/n2_viewer/n2_viewer.py
+++ b/openmdao/visualization/n2_viewer/n2_viewer.py
@@ -24,7 +24,7 @@ from openmdao.recorders.case_reader import CaseReader
 from openmdao.solvers.nonlinear.newton import NewtonSolver
 from openmdao.utils.array_utils import convert_ndarray_to_support_nans_in_json
 from openmdao.utils.class_util import overrides_method
-from openmdao.utils.general_utils import default_noraise
+from openmdao.utils.general_utils import default_noraise, is_undefined
 from openmdao.utils.mpi import MPI
 from openmdao.utils.notebook_utils import notebook, display, HTML, IFrame, colab
 from openmdao.utils.om_warnings import issue_warning
@@ -153,7 +153,7 @@ def _serialize_single_option(option):
 
     val = option['val']
 
-    if val is _UNDEFINED:
+    if is_undefined(val):
         return str(val)
 
     if sys.getsizeof(val) > _MAX_OPTION_SIZE:
@@ -360,7 +360,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
             driver_opt_settings = None
 
         # set default behavior for values flag
-        if values is _UNDEFINED:
+        if is_undefined(values):
             values = (data_source._metadata is not None and
                       data_source._metadata['setup_status'] >= _SetupStatus.POST_FINAL_SETUP)
 
@@ -377,7 +377,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
             raise TypeError(msg)
 
         # set default behavio r for values flag
-        if values is _UNDEFINED:
+        if is_undefined(values):
             values = (data_source._problem_meta is not None and
                       data_source._problem_meta['setup_status'] >= _SetupStatus.POST_FINAL_SETUP)
 
@@ -391,7 +391,7 @@ def _get_viewer_data(data_source, values=_UNDEFINED, case_id=None):
         data_dict = cr.problem_metadata
 
         # set default behavior for values flag
-        if values is _UNDEFINED:
+        if is_undefined(values):
             values = True
 
         def set_values(children, stack, case):


### PR DESCRIPTION
### Summary

Testing `{obj} is _UNDEFINED` is not safe in an MPI context, because the object is likely to have a different
id across different processes.  A blanket replacement of `{obj} == _UNDEFINED` is not valid, because
{obj} might be an array and thus trigger the `any()/all()` exception.

A new `is_undefined` method is added to get around these issues.
A new test is added to the code base to ensure that no instances of `{obj} is _UNDEFINED` are found.

In the process of doing this, the new test revealed deprecation warnings related to the use of non-raw
strings for regex comparisons when backslashes were involved.  These have been replaced.

### Related Issues

- Resolves #3421

### Backwards incompatibilities

None

### New Dependencies

None
