### PR TITLE
Modified assert_check_partials to use numpy.assert_allclose

### DIFF
--- a/openmdao/components/tests/test_cross_product_comp.py
+++ b/openmdao/components/tests/test_cross_product_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -55,12 +55,7 @@ class TestCrossProductCompNx3(unittest.TestCase):
 
     def test_partials(self):
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 class TestCrossProductCompNx3x1(unittest.TestCase):
 
@@ -110,12 +105,7 @@ class TestCrossProductCompNx3x1(unittest.TestCase):
 
     def test_partials(self):
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 class TestCrossProductCompNonVectorized(unittest.TestCase):
 
@@ -163,12 +153,7 @@ class TestCrossProductCompNonVectorized(unittest.TestCase):
 
     def test_partials(self):
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestUnits(unittest.TestCase):
@@ -214,12 +199,7 @@ class TestUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleUnits(unittest.TestCase):
@@ -277,12 +257,7 @@ class TestMultipleUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleConfigure(unittest.TestCase):
@@ -342,12 +317,7 @@ class TestMultipleConfigure(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleCommonA(unittest.TestCase):
@@ -403,12 +373,7 @@ class TestMultipleCommonA(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleCommonB(unittest.TestCase):
@@ -464,12 +429,7 @@ class TestMultipleCommonB(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleErrors(unittest.TestCase):

--- a/openmdao/components/tests/test_dot_product_comp.py
+++ b/openmdao/components/tests/test_dot_product_comp.py
@@ -6,7 +6,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -51,12 +51,7 @@ class TestDotProductCompNx3(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestDotProductCompNx4(unittest.TestCase):
@@ -98,12 +93,7 @@ class TestDotProductCompNx4(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestUnits(unittest.TestCase):
@@ -149,12 +139,7 @@ class TestUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleUnits(unittest.TestCase):
@@ -213,12 +198,7 @@ class TestMultipleUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleConfigure(unittest.TestCase):
@@ -282,12 +262,7 @@ class TestMultipleConfigure(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleCommonA(unittest.TestCase):
@@ -343,12 +318,7 @@ class TestMultipleCommonA(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleCommonB(unittest.TestCase):
@@ -404,12 +374,7 @@ class TestMultipleCommonB(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleErrors(unittest.TestCase):

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -1959,11 +1959,7 @@ class TestExecCompParameterized(unittest.TestCase):
 
         if 'check_val' not in test_data:
             cpd = force_check_partials(prob, out_stream=None)
-
-            for comp in cpd:
-                for (var, wrt) in cpd[comp]:
-                    np.testing.assert_almost_equal(cpd[comp][var, wrt]['abs error'][0], 0, decimal=4,
-                                                   verbose=True, err_msg=f"{test_data['args']=}")
+            assert_check_partials(cpd, atol=3e-5, rtol=4e-6)
 
 
 if __name__ == "__main__":

--- a/openmdao/components/tests/test_ks_comp.py
+++ b/openmdao/components/tests/test_ks_comp.py
@@ -60,9 +60,7 @@ class TestKSFunction(unittest.TestCase):
         assert_near_equal(prob.get_val('ks.KS', indices=2), 51.0)
 
         partials = force_check_partials(prob, includes=['ks'], out_stream=None)
-
-        for (of, wrt) in partials['ks']:
-            assert_near_equal(partials['ks'][of, wrt]['abs error'][0], 0.0, 1e-6)
+        assert_check_partials(partials)
 
     def test_partials_no_compute(self):
         prob = om.Problem()

--- a/openmdao/components/tests/test_linear_system_comp.py
+++ b/openmdao/components/tests/test_linear_system_comp.py
@@ -5,7 +5,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -172,10 +172,7 @@ class TestLinearSystemComp(unittest.TestCase):
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
         data = force_check_partials(prob, out_stream=None)
-
-        abs_errors = data['lingrp.lin'][('x', 'x')]['abs error']
-        self.assertTrue(len(abs_errors) > 0)
-        self.assertTrue(abs_errors[0] < 1.e-6)
+        assert_check_partials(data)
 
     def test_solve_linear_vectorized(self):
         """Check against solve_linear."""
@@ -233,10 +230,7 @@ class TestLinearSystemComp(unittest.TestCase):
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
         data = force_check_partials(prob, out_stream=None)
-
-        abs_errors = data['lingrp.lin'][('x', 'x')]['abs error']
-        self.assertTrue(len(abs_errors) > 0)
-        self.assertTrue(abs_errors[0] < 1.e-6)
+        assert_check_partials(data)
 
     def test_solve_linear_vectorized_A(self):
         """Check against solve_linear."""
@@ -303,10 +297,7 @@ class TestLinearSystemComp(unittest.TestCase):
         assert_near_equal(J['lin.x', 'p2.b'], dx_db, .0001)
 
         data = force_check_partials(prob, out_stream=None)
-
-        abs_errors = data['lingrp.lin'][('x', 'x')]['abs error']
-        self.assertTrue(len(abs_errors) > 0)
-        self.assertTrue(abs_errors[0] < 1.e-6)
+        assert_check_partials(data)
 
     def test_feature_basic(self):
 

--- a/openmdao/components/tests/test_matrix_vector_product_comp.py
+++ b/openmdao/components/tests/test_matrix_vector_product_comp.py
@@ -4,7 +4,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.units import convert_units
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -49,12 +49,7 @@ class TestMatrixVectorProductComp3x3(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMatrixVectorProductComp6x4(unittest.TestCase):
@@ -98,12 +93,7 @@ class TestMatrixVectorProductComp6x4(unittest.TestCase):
 
     def test_partials(self):
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
@@ -144,12 +134,7 @@ class TestMatrixVectorProductCompNonVectorized(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                assert_near_equal(
-                                 actual=cpd[comp][var, wrt]['J_fwd'],
-                                 desired=cpd[comp][var, wrt]['J_fd'])
+        assert_check_partials(cpd)
 
 
 class TestUnits(unittest.TestCase):
@@ -195,12 +180,7 @@ class TestUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleUnits(unittest.TestCase):
@@ -268,13 +248,7 @@ class TestMultipleUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
-
+        assert_check_partials(cpd)
 
 class TestMultipleConfigure(unittest.TestCase):
 
@@ -340,12 +314,7 @@ class TestMultipleConfigure(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleCommonMatrix(unittest.TestCase):
@@ -409,12 +378,7 @@ class TestMultipleCommonMatrix(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleCommonVector(unittest.TestCase):
@@ -476,12 +440,7 @@ class TestMultipleCommonVector(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, out_stream=None, method='cs')
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleErrors(unittest.TestCase):

--- a/openmdao/components/tests/test_meta_model_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_structured_comp.py
@@ -573,7 +573,7 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         tol = 1e-5
         assert_near_equal(prob['f'], val0, tol)
         assert_near_equal(prob['g'], val1, tol)
-        self.run_and_check_derivs(prob)
+        self.run_and_check_derivs(prob, atol=3e-4)
 
     def test_dynamic_training(self):
         p1 = np.linspace(0, 100, 25)
@@ -681,21 +681,15 @@ class TestMetaModelStructuredScipy(unittest.TestCase):
         tol = 1e-5
         assert_near_equal(prob['f'], val0, tol)
         assert_near_equal(prob['g'], val1, tol)
-        self.run_and_check_derivs(prob)
+        self.run_and_check_derivs(prob, atol=5e-4, rtol=2e-5)
 
-    def run_and_check_derivs(self, prob, tol=1e-5, verbose=False):
+    def run_and_check_derivs(self, prob, atol=1e-5, rtol=2e-5):
         """Runs check_partials and compares to analytic derivatives."""
 
         prob.run_model()
 
         derivs = force_check_partials(prob, out_stream=None)
-
-        for i in derivs['comp'].keys():
-            if verbose:
-                print("Checking derivative pair:", i)
-            if derivs['comp'][i]['J_fwd'].sum() != 0.0:
-                rel_err = derivs['comp'][i]['rel error'][0]
-                self.assertLessEqual(rel_err, tol)
+        assert_check_partials(derivs, atol=atol, rtol=rtol)
 
     def test_error_msg_vectorized(self):
         # Tests bug in error message where it doesn't give the correct node value.
@@ -769,19 +763,13 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         self.prob['y'] = 0.75
         self.prob['z'] = -1.7
 
-    def run_and_check_derivs(self, prob, tol=1e-5, verbose=False):
+    def run_and_check_derivs(self, prob, atol=1e-5, rtol=1e-5, verbose=False):
         """Runs check_partials and compares to analytic derivatives."""
 
         prob.run_model()
 
         derivs = force_check_partials(prob, method='cs', out_stream=None)
-
-        for i in derivs['comp'].keys():
-            if verbose:
-                print("Checking derivative pair:", i)
-            if derivs['comp'][i]['J_fwd'].sum() != 0.0:
-                rel_err = derivs['comp'][i]['rel error'][0]
-                self.assertLessEqual(rel_err, tol)
+        assert_check_partials(derivs, atol=atol, rtol=rtol)
 
     def test_deriv1(self):
         # run at default pt
@@ -1086,7 +1074,7 @@ class TestMetaModelStructuredPython(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        self.run_and_check_derivs(prob)
+        self.run_and_check_derivs(prob, atol=1e-4)
 
     def test_training_gradient_akima(self):
         model = om.Group()

--- a/openmdao/components/tests/test_vector_magnitude_comp.py
+++ b/openmdao/components/tests/test_vector_magnitude_comp.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 from openmdao.utils.testing_utils import force_check_partials
 
 
@@ -44,12 +44,7 @@ class TestVectorMagnitudeCompNx3(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=False, method='fd', step=1.0E-9, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=5)
+        assert_check_partials(cpd)
 
 
 class TestVectorMagnitudeCompNx4(unittest.TestCase):
@@ -88,12 +83,7 @@ class TestVectorMagnitudeCompNx4(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=False, method='fd', step=1.0E-9, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestUnits(unittest.TestCase):
@@ -133,12 +123,7 @@ class TestUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleUnits(unittest.TestCase):
@@ -187,12 +172,7 @@ class TestMultipleUnits(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleConfigure(unittest.TestCase):
@@ -238,12 +218,7 @@ class TestMultipleConfigure(unittest.TestCase):
     def test_partials(self):
         np.set_printoptions(linewidth=1024)
         cpd = force_check_partials(self.p, compact_print=True, out_stream=None)
-
-        for comp in cpd:
-            for (var, wrt) in cpd[comp]:
-                np.testing.assert_almost_equal(actual=cpd[comp][var, wrt]['J_fwd'],
-                                               desired=cpd[comp][var, wrt]['J_fd'],
-                                               decimal=6)
+        assert_check_partials(cpd)
 
 
 class TestMultipleErrors(unittest.TestCase):

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2417,9 +2417,7 @@ class Component(System):
 
         # add pathname to the partials dict to make it compatible with the return value
         # from Problem.check_partials and passable to assert_check_partials.
-        data = {self.pathname: partials_data}, worst
-
-        return data
+        return {self.pathname: partials_data}, worst
 
 
 class _DictValues(object):

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2288,7 +2288,7 @@ class Component(System):
             self._inputs.set_val(input_cache)
             self._outputs.set_val(output_cache)
 
-            self.run_apply_nonlinear()
+            # self.run_apply_nonlinear()
 
         all_fd_options = {}
 
@@ -2306,6 +2306,7 @@ class Component(System):
         alloc_complex = self._outputs._alloc_complex
 
         for step in steps:
+            self.run_apply_nonlinear()
             approximations = {'fd': FiniteDifference(), 'cs': ComplexStep()}
 
             added_wrts = set()

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2401,7 +2401,7 @@ class Component(System):
                                                     all_fd_options, False, show_only_incorrect)
             else:
                 self._deriv_display(err_iter, partials_data, rel_err_tol, abs_err_tol, out_stream,
-                       all_fd_options, False, show_only_incorrect)
+                                    all_fd_options, False, show_only_incorrect)
 
         return partials_data, worst
 

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2068,6 +2068,9 @@ class Component(System):
             containing the max relative error, and header is the formatted table header.  'worst'
             is not None only if compact_print is True.
         """
+        if out_stream == _DEFAULT_OUT_STREAM:
+            out_stream = sys.stdout
+
         self._check_fds_differ(method, step, form, step_calc, minimum_step)
 
         # Make sure we're in a valid state

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -13,14 +13,15 @@ from scipy.sparse import issparse, coo_matrix
 
 from openmdao.core.system import System, _supported_methods, _DEFAULT_COLORING_META, \
     global_meta_names, collect_errors
-from openmdao.core.constants import INT_DTYPE
-from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian
+from openmdao.core.constants import INT_DTYPE, _DEFAULT_OUT_STREAM
+from openmdao.jacobians.dictionary_jacobian import DictionaryJacobian, _CheckingJacobian
 from openmdao.utils.array_utils import shape_to_len, submat_sparsity_iter
 from openmdao.utils.units import simplify_unit
-from openmdao.utils.name_maps import abs_key_iter, abs_key2rel_key
-from openmdao.utils.mpi import MPI
+from openmdao.utils.name_maps import abs_key_iter, abs_key2rel_key, rel_name2abs_name, \
+    rel_key2abs_key
+from openmdao.utils.mpi import MPI, multi_proc_exception_check
 from openmdao.utils.general_utils import format_as_float_or_array, ensure_compatible, \
-    find_matches, make_set, inconsistent_across_procs
+    find_matches, make_set, inconsistent_across_procs, LocalRangeIterable
 from openmdao.utils.indexer import Indexer, indexer
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.om_warnings import issue_warning, MPIWarning, DistributedComponentWarning, \
@@ -2005,6 +2006,404 @@ class Component(System):
 
                         issue_warning(msg, prefix=self.msginfo,
                                       category=OMInvalidCheckDerivativesOptionsWarning)
+
+    def check_partials(self, out_stream=_DEFAULT_OUT_STREAM, includes=None, excludes=None,
+                       compact_print=False, abs_err_tol=1e-6, rel_err_tol=1e-6,
+                       method='fd', step=None, form='forward', step_calc='abs',
+                       minimum_step=1e-12, force_dense=True, show_only_incorrect=False):
+        """
+        Check partial derivatives comprehensively for all components in your model.
+
+        Parameters
+        ----------
+        out_stream : file-like object
+            Where to send human readable output. By default it goes to stdout.
+            Set to None to suppress.
+        includes : None or list_like
+            List of glob patterns for pathnames to include in the check. Default is None, which
+            includes all components in the model.
+        excludes : None or list_like
+            List of glob patterns for pathnames to exclude from the check. Default is None, which
+            excludes nothing.
+        compact_print : bool
+            Set to True to just print the essentials, one line per input-output pair.
+        abs_err_tol : float
+            Threshold value for absolute error.  Errors about this value will have a '*' displayed
+            next to them in output, making them easy to search for. Default is 1.0E-6.
+        rel_err_tol : float
+            Threshold value for relative error.  Errors about this value will have a '*' displayed
+            next to them in output, making them easy to search for. Note at times there may be a
+            significant relative error due to a minor absolute error.  Default is 1.0E-6.
+        method : str
+            Method, 'fd' for finite difference or 'cs' for complex step. Default is 'fd'.
+        step : None, float, or list/tuple of float
+            Step size(s) for approximation. Default is None, which means 1e-6 for 'fd' and 1e-40 for
+            'cs'.
+        form : str
+            Form for finite difference, can be 'forward', 'backward', or 'central'. Default
+            'forward'.
+        step_calc : str
+            Step type for computing the size of the finite difference step. It can be 'abs' for
+            absolute, 'rel_avg' for a size relative to the absolute value of the vector input, or
+            'rel_element' for a size relative to each value in the vector input. In addition, it
+            can be 'rel_legacy' for a size relative to the norm of the vector.  For backwards
+            compatibilty, it can be 'rel', which is now equivalent to 'rel_avg'. Defaults to None,
+            in which case the approximation method provides its default value.
+        minimum_step : float
+            Minimum step size allowed when using one of the relative step_calc options.
+        force_dense : bool
+            If True, analytic derivatives will be coerced into arrays. Default is True.
+        show_only_incorrect : bool, optional
+            Set to True if output should print only the subjacs found to be incorrect.
+
+        Returns
+        -------
+        dict of dicts of dicts
+            First key is the component name.
+            Second key is the (output, input) tuple of strings.
+            Third key is one of ['rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev',
+            'rank_inconsistent'].
+            For 'rel error', 'abs error', and 'magnitude' the value is a tuple containing norms for
+            forward - fd, adjoint - fd, forward - adjoint.
+            For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
+            Jacobian for the three different methods of computation.
+            The boolean 'rank_inconsistent' indicates if the derivative wrt a serial variable is
+            inconsistent across MPI ranks.
+        """
+        self._check_fds_differ(method, step, form, step_calc, minimum_step)
+
+        # Make sure we're in a valid state
+        self.run_apply_nonlinear()
+
+        input_cache = self._inputs.asarray(copy=True)
+        output_cache = self._outputs.asarray(copy=True)
+
+        local_opts = self._get_check_partial_options()
+
+        if self.matrix_free:
+            directions = ('fwd', 'rev')
+        else:
+            directions = ('fwd',)  # rev same as fwd for analytic jacobians
+            self.run_linearize(sub_do_ln=False)
+
+        zero_derivs = set()
+        of_list = self._get_partials_ofs()
+        wrt_list = self._get_partials_wrts()
+        axis = {'fwd': 1, 'rev': 0}
+        mfree_directions = {}
+        abs2meta_in = self._var_allprocs_abs2meta['input']
+        abs2meta_out = self._var_allprocs_abs2meta['output']
+        partials_data = defaultdict(dict)
+        requested_method = method
+        probmeta = self._problem_meta
+
+        for mode in directions:
+            jac_key = 'J_' + mode
+
+            with self._unscaled_context():
+
+                # Matrix-free components need to calculate Jacobian by matrix-vector product.
+                if self.matrix_free:
+                    dstate = self._doutputs
+                    if mode == 'fwd':
+                        dinputs = self._dinputs
+                        doutputs = self._dresiduals
+                        in_list = wrt_list
+                        out_list = of_list
+                    else:
+                        dinputs = self._dresiduals
+                        doutputs = self._dinputs
+                        in_list = of_list
+                        out_list = wrt_list
+
+                    for inp in in_list:
+                        inp_abs = rel_name2abs_name(self, inp)
+                        if mode == 'fwd':
+                            directional = inp in local_opts and local_opts[inp]['directional']
+                        else:
+                            directional = len(mfree_directions) > 0
+
+                        try:
+                            flat_view = dinputs._abs_get_val(inp_abs)
+                        except KeyError:
+                            # Implicit state
+                            flat_view = dstate._abs_get_val(inp_abs)
+
+                        if directional:
+                            n_in = 1
+                            idxs = range(1)
+                            if inp in mfree_directions:
+                                perturb = mfree_directions[inp]
+                            else:
+                                perturb = 2.0 * np.random.random(len(flat_view)) - 1.0
+                                mfree_directions[inp] = perturb
+
+                        else:
+                            n_in = len(flat_view)
+                            idxs = LocalRangeIterable(self, inp_abs, use_vec_offset=False)
+                            perturb = 1.0
+
+                        for idx in idxs:
+
+                            dinputs.set_val(0.0)
+                            dstate.set_val(0.0)
+
+                            if directional:
+                                flat_view[:] = perturb
+                            elif idx is not None:
+                                flat_view[idx] = perturb
+
+                            # Matrix Vector Product
+                            probmeta['checking'] = True
+                            try:
+                                self.run_apply_linear(mode)
+                            finally:
+                                probmeta['checking'] = False
+
+                            for out in out_list:
+                                out_abs = rel_name2abs_name(self, out)
+
+                                try:
+                                    derivs = doutputs._abs_get_val(out_abs)
+                                except KeyError:
+                                    # Implicit state
+                                    derivs = dstate._abs_get_val(out_abs)
+
+                                if mode == 'fwd':
+                                    key = out, inp
+                                    deriv = partials_data[key]
+
+                                    # Allocate first time
+                                    if jac_key not in deriv:
+                                        shape = (len(derivs), n_in)
+                                        deriv[jac_key] = np.zeros(shape)
+
+                                    if idx is not None:
+                                        deriv[jac_key][:, idx] = derivs
+
+                                else:  # rev
+                                    key = inp, out
+                                    deriv = partials_data[key]
+
+                                    if directional:
+                                        # Dot product test for adjoint validity.
+                                        m = mfree_directions[out]
+                                        d = mfree_directions[inp]
+                                        mhat = derivs
+                                        dhat = deriv['J_fwd'][:, idx]
+
+                                        deriv['directional_fwd_rev'] = (mhat.dot(m),
+                                                                        dhat.dot(d))
+                                    else:
+                                        meta = abs2meta_in[out_abs] if out_abs in abs2meta_in \
+                                            else abs2meta_out[out_abs]
+                                        if not meta['distributed']:  # serial input or state
+                                            if inconsistent_across_procs(self.comm, derivs,
+                                                                         return_array=False):
+                                                deriv['rank_inconsistent'] = True
+
+                                    # Allocate first time
+                                    if jac_key not in deriv:
+                                        shape = (n_in, len(derivs))
+                                        deriv[jac_key] = np.zeros(shape)
+
+                                    if idx is not None:
+                                        deriv[jac_key][idx, :] = derivs
+
+                # These components already have a Jacobian with calculated derivatives.
+                else:
+
+                    subjacs = self._jacobian._subjacs_info
+
+                    for rel_key in product(of_list, wrt_list):
+                        abs_key = rel_key2abs_key(self, rel_key)
+                        of, wrt = abs_key
+
+                        if mode == 'fwd':
+                            inp = rel_key[1]
+                            directional = inp in local_opts and local_opts[inp]['directional']
+                        else:
+                            directional = len(mfree_directions) > 0
+
+                        if wrt in self._var_abs2meta['input']:
+                            wrt_meta = self._var_abs2meta['input'][wrt]
+                        else:
+                            wrt_meta = self._var_abs2meta['output'][wrt]
+
+                        copy = True
+
+                        # No need to calculate partials; they are already stored
+                        try:
+                            deriv_value = subjacs[abs_key]['val']
+                            rows = subjacs[abs_key]['rows']
+                        except KeyError:
+                            rows = None
+                            # Missing derivatives are assumed 0.
+                            in_size = 1 if directional else wrt_meta['size']
+                            out_size = self._var_abs2meta['output'][of]['size']
+                            deriv_value = np.zeros((out_size, in_size))
+                            copy = False
+
+                        # Testing for pairs that are not dependent so that we suppress printing
+                        # them unless the fd is non zero. Note: subjacs_info is empty for
+                        # undeclared partials, which is the default behavior now.
+                        try:
+                            if not subjacs[abs_key]['dependent']:
+                                zero_derivs.add(rel_key)
+                        except KeyError:
+                            zero_derivs.add(rel_key)
+
+                        if force_dense:
+                            if rows is not None:
+                                in_size = wrt_meta['size']
+                                out_size = self._var_abs2meta['output'][of]['size']
+                                # if a scalar value is provided (in declare_partials),
+                                # expand to the correct size array value for zipping
+                                if deriv_value.size == 1:
+                                    deriv_value *= np.ones(rows.size)
+                                deriv_value = \
+                                    coo_matrix((deriv_value, (rows, subjacs[abs_key]['cols'])),
+                                               shape=(out_size, in_size))
+                                if directional:
+                                    deriv_value = \
+                                        np.atleast_2d(deriv_value.sum(axis=axis[mode]))
+                                    if deriv_value.shape[0] < deriv_value.shape[1]:
+                                        deriv_value = deriv_value.T
+                                else:
+                                    deriv_value = deriv_value.toarray()
+                                copy = False
+
+                            elif issparse(deriv_value):
+                                if directional:
+                                    deriv_value = \
+                                        np.atleast_2d(deriv_value.sum(axis=axis[mode])).T
+                                    if deriv_value.shape[0] < deriv_value.shape[1]:
+                                        deriv_value = deriv_value.T
+                                else:
+                                    deriv_value = deriv_value.toarray()
+                                copy = False
+                            elif directional:
+                                deriv_value = \
+                                    np.atleast_2d(np.sum(deriv_value, axis=axis[mode])).T
+
+                        if copy:
+                            deriv_value = deriv_value.copy()
+
+                        partials_data[rel_key][jac_key] = deriv_value
+
+            self._inputs.set_val(input_cache)
+            self._outputs.set_val(output_cache)
+
+            self.run_apply_nonlinear()
+
+        all_fd_options = {}
+
+        of = self._get_partials_ofs()
+        wrt = self._get_partials_wrts()
+
+        if step is None or isinstance(step, (float, int)):
+            steps = [step]
+        else:
+            steps = step
+
+        # do_steps = len(steps) > 1
+
+        actual_steps = defaultdict(list)
+        alloc_complex = self._outputs._alloc_complex
+
+        for step in steps:
+            approximations = {'fd': FiniteDifference(), 'cs': ComplexStep()}
+
+            added_wrts = set()
+
+            # Load up approximation objects with the requested settings.
+
+            for rel_key in product(of, wrt):
+                abs_key = rel_key2abs_key(self, rel_key)
+                local_wrt = rel_key[1]
+
+                fd_options, could_not_cs = _get_fd_options(local_wrt, requested_method,
+                                                           local_opts, step, form, step_calc,
+                                                           alloc_complex, minimum_step)
+
+                actual_steps[rel_key].append(fd_options['step'])
+
+                # Determine if fd or cs.
+                method = requested_method
+
+                all_fd_options[local_wrt] = fd_options
+                if local_wrt in mfree_directions:
+                    vector = mfree_directions.get(local_wrt)
+                else:
+                    vector = None
+
+                # prevent adding multiple approxs with same wrt (and confusing users with
+                # warnings)
+                if abs_key[1] not in added_wrts:
+                    approximations[fd_options['method']].add_approximation(abs_key, self,
+                                                                           fd_options,
+                                                                           vector=vector)
+                    added_wrts.add(abs_key[1])
+
+            approx_jac = _CheckingJacobian(self)
+            for approximation in approximations.values():
+                # Perform the FD here.
+                approximation.compute_approximations(self, jac=approx_jac)
+
+            with multi_proc_exception_check(self.comm):
+                if approx_jac._errors:
+                    raise RuntimeError('\n'.join(approx_jac._errors))
+
+            for abs_key, partial in approx_jac.items():
+                rel_key = abs_key2rel_key(self, abs_key)
+                deriv = partials_data[rel_key]
+                _of, _wrt = rel_key
+
+                if 'J_fd' not in deriv:
+                    deriv['J_fd'] = []
+                    deriv['steps'] = []
+                deriv['J_fd'].append(partial)
+                deriv['steps'] = actual_steps[rel_key]
+
+                if _wrt in local_opts and local_opts[_wrt]['directional']:
+                    if self.matrix_free:
+                        # Dot product test for adjoint validity.
+                        m = mfree_directions[_of].flatten()
+                        d = mfree_directions[_wrt].flatten()
+                        mhat = partial.flatten()
+                        dhat = deriv['J_rev'].flatten()
+
+                        if 'directional_fd_rev' not in deriv:
+                            deriv['directional_fd_rev'] = []
+                        deriv['directional_fd_rev'].append((dhat.dot(d), mhat.dot(m)))
+
+        # if not do_steps:
+        #     _fix_check_data(partials_data)
+
+        # convert to regular dict from defaultdict
+        partials_data = {key: dict(d) for key, d in partials_data.items()}
+
+        return partials_data, zero_derivs, all_fd_options, could_not_cs
+
+
+# def _fix_check_data(data):
+#     """
+#     Modify the data dict to match the old format if there is only one fd step size.
+
+#     Parameters
+#     ----------
+#     data : dict
+#         Dictionary containing derivative information keyed by system name.
+#     """
+#     names = ['J_fd', 'abs error', 'rel error', 'magnitude', 'directional_fd_fwd',
+#              'directional_fd_rev']
+
+#     for dct in data.values():
+#         for name in names:
+#             if name in dct:
+#                 dct[name] = dct[name][0]
+#         if 'steps' in dct:
+#             del dct['steps']
 
 
 class _DictValues(object):

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1998,7 +1998,7 @@ class Component(System):
                                f"'{self.pathname}' using the same method and options as are used "
                                "to compute the component's derivatives will not provide any "
                                "relevant information on the accuracy.\n"
-                               "To correct this, change the options to do the\n"
+                               "To correct this, change the options to do the "
                                "check_partials using either:\n"
                                "     - arguments to Problem.check_partials.\n"
                                "     - arguments to Component.set_check_partial_options")

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -1937,7 +1937,7 @@ class Component(System):
                                   f"rows = {sjrows}\ncols = {sjcols}\n")
                 elif not np.all(np.asarray(meta['rows']) == sjrows):
                     issue_warning(f"Sparsity pattern for {of} wrt {wrt} was declared with "
-                                  f"rows={meta['rows']} and col={meta['cols']}, but a different "
+                                  f"rows={meta['rows']} and cols={meta['cols']}, but a different "
                                   "sparsity pattern has been computed:\n"
                                   f"rows = {sjrows}\ncols = {sjcols}\n")
             else:

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2247,7 +2247,7 @@ class Component(System):
                             # Missing derivatives are assumed 0.
                             in_size = 1 if directional else wrt_meta['size']
                             out_size = self._var_abs2meta['output'][of]['size']
-                            deriv_value = None  # np.zeros((out_size, in_size))
+                            deriv_value = None
                             copy = False
 
                         # If not compact printing, testing for pairs that are not dependent so
@@ -2415,6 +2415,8 @@ class Component(System):
                 self._deriv_display(err_iter, partials_data, rel_err_tol, abs_err_tol, out_stream,
                                     all_fd_options, False, show_only_incorrect)
 
+        # add pathname to the partials dict to make it compatible with the return value
+        # from Problem.check_partials and passable to assert_check_partials.
         data = {self.pathname: partials_data}, worst
 
         return data

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2238,14 +2238,16 @@ class Component(System):
                             deriv_value = np.zeros((out_size, in_size))
                             copy = False
 
-                        # Testing for pairs that are not dependent so that we suppress printing
-                        # them unless the fd is non zero. Note: subjacs_info is empty for
-                        # undeclared partials, which is the default behavior now.
-                        try:
-                            if not subjacs[abs_key]['dependent']:
+                        # If not compact printing, testing for pairs that are not dependent so
+                        # that we suppress printing them unless the fd is non zero.
+                        # Note: subjacs_info is empty for undeclared partials, which is the default
+                        # behavior now.
+                        if not compact_print:
+                            try:
+                                if not subjacs[abs_key]['dependent']:
+                                    nondep_derivs.add(rel_key)
+                            except KeyError:
                                 nondep_derivs.add(rel_key)
-                        except KeyError:
-                            nondep_derivs.add(rel_key)
 
                         if force_dense:
                             if rows is not None:

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -342,7 +342,7 @@ class ExplicitComponent(Component):
                 else:  # rev
                     d_inputs.set_val(new_vals)
         else:
-            dochk = mode == 'rev' and self._problem_meta['checking'] and self.comm.size > 1
+            dochk = self._problem_meta['checking'] and mode == 'rev' and self.comm.size > 1
 
             if dochk:
                 nzdresids = self._get_dist_nz_dresids()

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -230,7 +230,7 @@ class ImplicitComponent(Component):
                     d_inputs.set_val(new_ins)
                     d_outputs.set_val(new_outs)
         else:
-            if self.comm.size > 1 and mode == 'rev' and self._problem_meta['checking']:
+            if self._problem_meta['checking'] and self.comm.size > 1 and mode == 'rev':
                 nzdresids = self._get_dist_nz_dresids()
                 self.apply_linear(inputs, outputs, d_inputs, d_outputs, d_residuals, mode)
                 self._check_consistent_serial_dinputs(nzdresids)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1269,10 +1269,10 @@ class Problem(object, metaclass=ProblemMetaclass):
 
             if maxrelinfo is not None:
                 if worst is None or maxrelinfo[0] > worst[0]:
-                    worst = (maxrelinfo, type(comp).__name__, comp.pathname)
+                    worst = maxrelinfo + (type(comp).__name__, comp.pathname)
 
         if worst is not None:
-            (err, table_data, headers), ctype, cpath = worst
+            err, table_data, headers, ctype, cpath = worst
             print(file=out_stream)
             print(add_border(f"Sub Jacobian with Largest Relative Error: {ctype} '{cpath}'", '#'),
                   file=out_stream)
@@ -1560,6 +1560,7 @@ class Problem(object, metaclass=ProblemMetaclass):
                     data[''][key]['indices'] = resp[of]['indices'].indexed_src_size
 
         incon_keys = model._get_inconsistent_keys()
+
         # force iterator to run so that error info will be added to partials_data
         err_iter = list(_iter_derivs(data[''], show_only_incorrect, fd_args, True,
                                      set(), model.matrix_free, abs_err_tol, rel_err_tol,
@@ -1577,6 +1578,13 @@ class Problem(object, metaclass=ProblemMetaclass):
 
         if not do_steps:
             _fix_check_data(data)
+
+        if incon_keys:
+            # insert inconsistent key info into first (of, wrt) entry in data to avoid
+            # having to change the format of the data dict.
+            for key, meta in data[''].items():
+                meta['inconsistent_keys'] = incon_keys
+                break
 
         return data['']
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1258,21 +1258,24 @@ class Problem(object, metaclass=ProblemMetaclass):
             if not match_includes_excludes(comp.pathname, includes, excludes):
                 continue
 
-            data = comp.check_partials(out_stream=out_stream, compact_print=compact_print,
-                                       abs_err_tol=abs_err_tol, rel_err_tol=rel_err_tol,
-                                       method=method, step=step, form=form, step_calc=step_calc,
-                                       minimum_step=minimum_step, force_dense=force_dense,
-                                       show_only_incorrect=show_only_incorrect)
+            partials, wrst = comp.check_partials(out_stream=out_stream,
+                                                 compact_print=compact_print,
+                                                 abs_err_tol=abs_err_tol, rel_err_tol=rel_err_tol,
+                                                 method=method, step=step, form=form,
+                                                 step_calc=step_calc,
+                                                 minimum_step=minimum_step,
+                                                 force_dense=force_dense,
+                                                 show_only_incorrect=show_only_incorrect,
+                                                 show_worst=False)
 
-            partials = data['partials']
-            partials_data[comp.pathname] = partials
+            partials_data.update(partials)
 
-            if data['worst'] is not None:
-                if worst is None or data['worst'][0] > worst[0]:
-                    worst = data['worst'] + (type(comp).__name__, comp.pathname)
+            if wrst is not None:
+                if worst is None or wrst[0] > worst[0]:
+                    worst = wrst + (type(comp).__name__, comp.pathname)
 
         if worst is not None:
-            err, table_data, headers, ctype, cpath = worst
+            _, table_data, headers, ctype, cpath = worst
             print(file=out_stream)
             print(add_border(f"Sub Jacobian with Largest Relative Error: {ctype} '{cpath}'", '#'),
                   file=out_stream)
@@ -1569,8 +1572,7 @@ class Problem(object, metaclass=ProblemMetaclass):
         if out_stream is not None:
             if compact_print:
                 model._deriv_display_compact(err_iter, data[''], out_stream,
-                                             totals=True,
-                                             show_only_incorrect=show_only_incorrect)
+                                             totals=True, show_only_incorrect=show_only_incorrect)
             else:
                 model._deriv_display(err_iter, data[''], rel_err_tol, abs_err_tol, out_stream,
                                      fd_args, totals=True, lcons=lcons,

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1212,8 +1212,17 @@ class Problem(object, metaclass=ProblemMetaclass):
             inconsistent across MPI ranks.
         """
         model = self.model
-        if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP or model.iter_count < 1:
+
+        # on master, we were doing this:
+        # if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
+        #     self.final_setup()
+
+        # model.run_apply_nonlinear()
+
+        # but it seems more correct to run the model first if it hasn't been run yet, correct?
+        if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP or model.iter_count == 0:
             self.run_model()
+
 
         if not model._use_derivatives:
             raise RuntimeError(self.msginfo +

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1258,18 +1258,18 @@ class Problem(object, metaclass=ProblemMetaclass):
             if not match_includes_excludes(comp.pathname, includes, excludes):
                 continue
 
-            data, maxrelinfo = \
-                comp.check_partials(out_stream=out_stream, compact_print=compact_print,
-                                    abs_err_tol=abs_err_tol, rel_err_tol=rel_err_tol,
-                                    method=method, step=step, form=form, step_calc=step_calc,
-                                    minimum_step=minimum_step, force_dense=force_dense,
-                                    show_only_incorrect=show_only_incorrect)
+            data = comp.check_partials(out_stream=out_stream, compact_print=compact_print,
+                                       abs_err_tol=abs_err_tol, rel_err_tol=rel_err_tol,
+                                       method=method, step=step, form=form, step_calc=step_calc,
+                                       minimum_step=minimum_step, force_dense=force_dense,
+                                       show_only_incorrect=show_only_incorrect)
 
-            partials_data[comp.pathname] = data
+            partials = data['partials']
+            partials_data[comp.pathname] = partials
 
-            if maxrelinfo is not None:
-                if worst is None or maxrelinfo[0] > worst[0]:
-                    worst = maxrelinfo + (type(comp).__name__, comp.pathname)
+            if data['worst'] is not None:
+                if worst is None or data['worst'][0] > worst[0]:
+                    worst = data['worst'] + (type(comp).__name__, comp.pathname)
 
         if worst is not None:
             err, table_data, headers, ctype, cpath = worst
@@ -1286,7 +1286,7 @@ class Problem(object, metaclass=ProblemMetaclass):
     def check_totals(self, of=None, wrt=None, out_stream=_DEFAULT_OUT_STREAM, compact_print=False,
                      driver_scaling=False, abs_err_tol=1e-6, rel_err_tol=1e-6, method='fd',
                      step=None, form=None, step_calc='abs', show_progress=False,
-                     show_only_incorrect=False, directional=False, sort=False):
+                     show_only_incorrect=False, directional=False, sort=True):
         """
         Check total derivatives for the model vs. finite difference.
 
@@ -1564,17 +1564,17 @@ class Problem(object, metaclass=ProblemMetaclass):
         # force iterator to run so that error info will be added to partials_data
         err_iter = list(_iter_derivs(data[''], show_only_incorrect, fd_args, True,
                                      set(), model.matrix_free, abs_err_tol, rel_err_tol,
-                                     incon_keys))
+                                     incon_keys, sort=sort))
 
         if out_stream is not None:
             if compact_print:
-                model._deriv_display_compact(err_iter, data[''], rel_err_tol, abs_err_tol,
-                                             out_stream, fd_args, totals=True, lcons=lcons,
-                                             show_only_incorrect=show_only_incorrect, sort=sort)
+                model._deriv_display_compact(err_iter, data[''], out_stream,
+                                             totals=True,
+                                             show_only_incorrect=show_only_incorrect)
             else:
                 model._deriv_display(err_iter, data[''], rel_err_tol, abs_err_tol, out_stream,
                                      fd_args, totals=True, lcons=lcons,
-                                     show_only_incorrect=show_only_incorrect, sort=sort)
+                                     show_only_incorrect=show_only_incorrect)
 
         if not do_steps:
             _fix_check_data(data)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1272,10 +1272,14 @@ class Problem(object, metaclass=ProblemMetaclass):
                                                  show_worst=False)
 
             if out_stream is not None:
-                if show_only_incorrect and partials[comp.pathname] and incorrect_msg:
-                    print(incorrect_msg, file=out_stream)
-                    incorrect_msg = ''
-                print(comp_stream.getvalue(), file=out_stream, end='')
+                comp_content = comp_stream.getvalue()
+                if comp_content:
+                    if show_only_incorrect:
+                        if incorrect_msg:
+                            print(incorrect_msg, file=out_stream, end='')
+                            incorrect_msg = ''
+
+                    print(comp_content, file=out_stream)
 
             partials_data.update(partials)
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1519,23 +1519,6 @@ class Problem(object, metaclass=ProblemMetaclass):
 
                 comp.run_apply_nonlinear()
 
-        # model.run_apply_nonlinear()
-
-        # # Finite Difference to calculate Jacobian
-        # if step is None or isinstance(step, (float, int)):
-        #     steps = [step]
-        # else:
-        #     steps = step
-
-        # do_steps = len(steps) > 1
-
-        # alloc_complex = model._outputs._alloc_complex
-        # all_fd_options = {}
-        # comps_could_not_cs = set()
-        # requested_method = method
-        # for comp in comps:
-
-            # c_name = comp.pathname
             all_fd_options[c_name] = {}
 
             of = comp._get_partials_ofs()
@@ -1601,16 +1584,8 @@ class Problem(object, metaclass=ProblemMetaclass):
                     deriv['J_fd'].append(partial)
                     deriv['steps'] = actual_steps[rel_key]
 
-                    # If this is a directional derivative, convert the analytic to a directional
-                    # one.
                     if _wrt in local_opts and local_opts[_wrt]['directional']:
-                        # if i == 0:  # only do this on the first iteration
-                        #     deriv['J_fwd'] = np.atleast_2d(np.sum(deriv['J_fwd'], axis=1)).T
-
                         if comp.matrix_free:
-                            # if i == 0:  # only do this on the first iteration
-                            #     deriv['J_rev'] = np.atleast_2d(np.sum(deriv['J_rev'], axis=0)).T
-
                             # Dot product test for adjoint validity.
                             m = mfree_directions[c_name][_of].flatten()
                             d = mfree_directions[c_name][_wrt].flatten()

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -7035,7 +7035,7 @@ class System(object, metaclass=SystemMetaclass):
             out_stream.write(sys_buffer.getvalue())
 
     def _deriv_display_compact(self, err_iter, derivatives, out_stream, totals=False,
-                               show_only_incorrect=False):
+                               show_only_incorrect=False, show_worst=False):
         """
         Compute relative and absolute errors in the given derivatives and print to out_stream.
 
@@ -7055,6 +7055,8 @@ class System(object, metaclass=SystemMetaclass):
             True if derivatives are totals.
         show_only_incorrect : bool, optional
             Set to True if output should print only the subjacs found to be incorrect.
+        show_worst : bool
+            Set to True to show the worst subjac.
         """
         if out_stream is None:
             return
@@ -7200,6 +7202,10 @@ class System(object, metaclass=SystemMetaclass):
                                 'error desc'])
 
             _print_deriv_table(table_data, headers, sys_buffer)
+
+            if show_worst and worst_subjac is not None:
+                print(f"\nWorst Sub-Jacobian (rel. error): {worst_subjac[0]}\n", file=sys_buffer)
+                _print_deriv_table([worst_subjac[1]], headers, sys_buffer)
 
         if not show_only_incorrect or num_bad_jacs > 0:
             out_stream.write(sys_buffer.getvalue())

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6795,7 +6795,7 @@ class System(object, metaclass=SystemMetaclass):
     def _deriv_display(self, err_iter, derivatives, rel_error_tol, abs_error_tol, out_stream,
                        fd_opts, totals=False, show_only_incorrect=False, lcons=None):
         """
-        Compute the relative and absolute errors in the given derivatives and print to out_stream.
+        Print derivative error info to out_stream.
 
         Parameters
         ----------
@@ -7037,9 +7037,7 @@ class System(object, metaclass=SystemMetaclass):
     def _deriv_display_compact(self, err_iter, derivatives, out_stream, totals=False,
                                show_only_incorrect=False, show_worst=False):
         """
-        Compute relative and absolute errors in the given derivatives and print to out_stream.
-
-        Display is in a compact tabular format.
+        Print derivative error info to out_stream in a compact tabular format.
 
         Parameters
         ----------
@@ -7057,6 +7055,11 @@ class System(object, metaclass=SystemMetaclass):
             Set to True if output should print only the subjacs found to be incorrect.
         show_worst : bool
             Set to True to show the worst subjac.
+
+        Returns
+        -------
+        tuple or None
+            Tuple contains the worst relative error, corresponding table row, and table header.
         """
         if out_stream is None:
             return
@@ -7220,7 +7223,7 @@ _ErrorTuple = namedtuple('ErrorTuple', ['forward', 'reverse', 'forward_reverse']
 _MagnitudeTuple = namedtuple('MagnitudeTuple', ['forward', 'reverse', 'fd'])
 
 
-def _print_deriv_table(table_data, headers, out_stream):
+def _print_deriv_table(table_data, headers, out_stream, tablefmt='grid'):
     """
     Print a table of derivatives.
 
@@ -7232,13 +7235,16 @@ def _print_deriv_table(table_data, headers, out_stream):
         List of column headers.
     out_stream : file-like object
         Where to send human readable output.
+        Set to None to suppress.
+    tablefmt : str
+        The table format to use.
     """
-    if table_data:
+    if table_data and out_stream is not None:
         num_col_meta = {'format': '{: 1.4e}'}
         column_meta = [{}, {}]
         column_meta.extend([num_col_meta.copy() for _ in range(len(headers) - 3)])
         column_meta.append({})
-        print(generate_table(table_data, headers=headers, tablefmt='grid',
+        print(generate_table(table_data, headers=headers, tablefmt=tablefmt,
                              column_meta=column_meta, missing_val='n/a'), file=out_stream)
 
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -7233,12 +7233,13 @@ def _print_deriv_table(table_data, headers, out_stream):
     out_stream : file-like object
         Where to send human readable output.
     """
-    num_col_meta = {'format': '{: 1.4e}'}
-    column_meta = [{}, {}]
-    column_meta.extend([num_col_meta.copy() for _ in range(len(headers) - 3)])
-    column_meta.append({})
-    print(generate_table(table_data, headers=headers, tablefmt='grid',
-                         column_meta=column_meta, missing_val='n/a'), file=out_stream)
+    if table_data:
+        num_col_meta = {'format': '{: 1.4e}'}
+        column_meta = [{}, {}]
+        column_meta.extend([num_col_meta.copy() for _ in range(len(headers) - 3)])
+        column_meta.append({})
+        print(generate_table(table_data, headers=headers, tablefmt='grid',
+                             column_meta=column_meta, missing_val='n/a'), file=out_stream)
 
 
 def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5,14 +5,14 @@ import hashlib
 import pathlib
 import time
 import functools
+import textwrap
 
 from contextlib import contextmanager
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from itertools import chain
 from enum import IntEnum
-
+from io import StringIO
 from fnmatch import fnmatchcase
-
 from numbers import Integral
 
 import numpy as np
@@ -28,7 +28,7 @@ from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import create_local_meta, check_path, has_match
 from openmdao.utils.units import is_compatible, unit_conversion, simplify_unit
 from openmdao.utils.variable_table import write_var_table, NA
-from openmdao.utils.array_utils import evenly_distrib_idxs, shape_to_len
+from openmdao.utils.array_utils import evenly_distrib_idxs, shape_to_len, safe_norm
 from openmdao.utils.name_maps import name2abs_name, name2abs_names
 from openmdao.utils.coloring import _compute_coloring, Coloring, \
     _STD_COLORING_FNAME, _DEF_COMP_SPARSITY_ARGS, _ColSparsityJac
@@ -39,10 +39,11 @@ from openmdao.utils.om_warnings import issue_warning, \
 from openmdao.utils.general_utils import determine_adder_scaler, \
     format_as_float_or_array, all_ancestors, match_prom_or_abs, \
     ensure_compatible, env_truthy, make_traceback, _is_slicer_op, _wrap_comm, _unwrap_comm, \
-    _om_dump, SystemMetaclass
+    _om_dump, SystemMetaclass, add_border
 from openmdao.utils.file_utils import _get_outputs_dir
 from openmdao.approximation_schemes.complex_step import ComplexStep
 from openmdao.approximation_schemes.finite_difference import FiniteDifference
+from openmdao.visualization.tables.table_builder import generate_table
 
 _empty_frozen_set = frozenset()
 
@@ -6790,3 +6791,724 @@ class System(object, metaclass=SystemMetaclass):
             if path not in seen:
                 seen.add(path)
                 yield path
+
+    def _deriv_display(self, err_iter, derivatives, rel_error_tol, abs_error_tol, out_stream,
+                       fd_opts, totals=False, show_only_incorrect=False, lcons=None, sort=False):
+        """
+        Compute the relative and absolute errors in the given derivatives and print to the out_stream.
+
+        Parameters
+        ----------
+        err_iter : iterator
+            Iterator that yields tuples of the form (key, fd_norm, fd_opts, directional, above_abs,
+            above_rel, inconsistent) for each subjac.
+        derivatives : dict
+            Dictionary containing derivative information keyed by (of, wrt).
+        rel_error_tol : float
+            Relative error tolerance.
+        abs_error_tol : float
+            Absolute error tolerance.
+        out_stream : file-like object
+                Where to send human readable output.
+                Set to None to suppress.
+        totals : bool or _TotalJacInfo
+            Set to _TotalJacInfo if we are doing check_totals to skip a bunch of stuff.
+        show_only_incorrect : bool, optional
+            Set to True if output should print only the subjacs found to be incorrect.
+        lcons : list or None
+            For total derivatives only, list of outputs that are actually linear constraints.
+        sort : bool
+            If True, sort subjacobian keys alphabetically.
+        """
+        from openmdao.core.component import Component
+
+        # Match header to appropriate type.
+        if isinstance(self, Component):
+            sys_type = 'Component'
+        else:
+            sys_type = 'Group'
+
+        sys_name = self.pathname
+        sys_class_name = type(self).__name__
+
+        if totals:
+            sys_name = 'Full Model'
+
+        num_bad_jacs = 0  # Keep track of number of bad derivative values for each component
+
+        # Need to capture the output of a component's derivative
+        # info so that it can be used if that component is the
+        # worst subjac. That info is printed at the bottom of all the output
+        sys_buffer = StringIO()
+
+        if out_stream is not None:
+            if totals:
+                title = "Total Derivatives"
+            else:
+                title = f"{sys_type}: {sys_class_name} '{sys_name}'"
+
+            print(f"{add_border(title, '-')}\n", file=sys_buffer)
+
+        for key, fd_norm, fd_opts, directional, above_abs, above_rel, inconsistent in err_iter:
+
+            if above_abs or above_rel or inconsistent:
+                num_bad_jacs += 1
+
+            if out_stream is None:
+                continue
+
+            of, wrt = key
+            derivative_info = derivatives[key]
+
+            # Informative output for responses that were declared with an index.
+            indices = derivative_info.get('indices')
+            if indices is not None:
+                of = f'{of} (index size: {indices})'
+
+            # need this check because if directional may be list
+            if isinstance(wrt, str):
+                wrt = f"'{wrt}'"
+            if isinstance(of, str):
+                of = f"'{of}'"
+
+            if directional:
+                wrt = f"(d){wrt}"
+
+            abs_errs = derivative_info['abs error']
+            rel_errs = derivative_info['rel error']
+            magnitudes = derivative_info['magnitude']
+            steps = derivative_info['steps']
+
+            Jfor = derivative_info.get('J_fwd')
+            if Jfor is None:
+                Jrev = derivative_info['J_rev']
+
+            if len(steps) > 1:
+                stepstrs = [f", step={step}" for step in steps]
+            else:
+                stepstrs = [""]
+
+            if fd_norm == 0.:
+                if magnitudes[0].forward is None:
+                    divname = 'Jrev'
+                else:
+                    divname = 'Jfor'
+            else:
+                divname = 'Jfd'
+
+            if out_stream:
+                # Magnitudes
+                sys_buffer.write(f"  {sys_name}: {of} wrt {wrt}")
+                if not isinstance(of, tuple) and lcons and of.strip("'") in lcons:
+                    sys_buffer.write(" (Linear constraint)")
+
+                sys_buffer.write('\n')
+                if magnitudes[0].forward is not None:
+                    sys_buffer.write(f'     Forward Magnitude: {magnitudes[0].forward:.6e}\n')
+
+                if magnitudes[0].reverse is not None:
+                    sys_buffer.write(f'     Reverse Magnitude: {magnitudes[0].reverse:.6e}\n')
+
+                fd_desc = f"{fd_opts['method']}:{fd_opts['form']}"
+                for i in range(len(magnitudes)):
+                    sys_buffer.write(f'          Fd Magnitude: '
+                                        f'{magnitudes[i].fd:.6e} ({fd_desc}{stepstrs[i]})\n')
+                sys_buffer.write('\n')
+
+                for i in range(len(magnitudes)):
+                    # Absolute Errors
+                    if directional:
+                        if totals and abs_errs[i].forward is not None:
+                            err = _format_error(abs_errs[i].forward, abs_error_tol)
+                            sys_buffer.write(f'    Absolute Error (Jfor - Jfd){stepstrs[i]} : '
+                                                f'{err}\n')
+
+                        if abs_errs[i].reverse is not None:
+                            err = _format_error(abs_errs[i].reverse, abs_error_tol)
+                            sys_buffer.write(f'    Absolute Error ([rev, fd] Dot Product Test)'
+                                                f'{stepstrs[i]} : {err}\n')
+                    else:
+                        if abs_errs[i].forward is not None:
+                            err = _format_error(abs_errs[i].forward, abs_error_tol)
+                            sys_buffer.write(f'    Absolute Error (Jfor - Jfd){stepstrs[i]} : '
+                                                f'{err}\n')
+
+                        if abs_errs[i].reverse is not None:
+                            err = _format_error(abs_errs[i].reverse, abs_error_tol)
+                            sys_buffer.write(f'    Absolute Error (Jrev - Jfd){stepstrs[i]} : '
+                                                f'{err}\n')
+
+                if directional:
+                    if abs_errs[0].forward_reverse is not None:
+                        err = _format_error(abs_errs[0].forward_reverse, abs_error_tol)
+                        sys_buffer.write('    Absolute Error ([rev, for] Dot Product Test) : '
+                                            f'{err}\n')
+                else:
+                    if abs_errs[0].forward_reverse is not None:
+                        err = _format_error(abs_errs[0].forward_reverse, abs_error_tol)
+                        sys_buffer.write(f'    Absolute Error (Jrev - Jfor) : {err}\n')
+
+            sys_buffer.write('\n')
+
+            for i in range(len(magnitudes)):
+                # Relative Errors
+                if out_stream:
+                    if directional:
+                        if totals and rel_errs[i].forward is not None:
+                            err = _format_error(rel_errs[i].forward, rel_error_tol)
+                            sys_buffer.write(f'    Relative Error (Jfor - Jfd) / {divname}'
+                                                f'{stepstrs[i]} : {err}\n')
+
+                        if rel_errs[i].reverse is not None:
+                            err = _format_error(rel_errs[i].reverse, rel_error_tol)
+                            sys_buffer.write(f'    Relative Error ([rev, fd] Dot Product Test) '
+                                                f'/ {divname}{stepstrs[i]} : {err}\n')
+                    else:
+                        if rel_errs[i].forward is not None:
+                            err = _format_error(rel_errs[i].forward, rel_error_tol)
+                            sys_buffer.write(f'    Relative Error (Jfor - Jfd) / {divname}'
+                                                f'{stepstrs[i]} : {err}\n')
+
+                        if rel_errs[i].reverse is not None:
+                            err = _format_error(rel_errs[i].reverse, rel_error_tol)
+                            sys_buffer.write(f'    Relative Error (Jrev - Jfd) / {divname}'
+                                                f'{stepstrs[i]} : {err}\n')
+
+            if out_stream:
+                if directional:
+                    if rel_errs[0].forward_reverse is not None:
+                        err = _format_error(rel_errs[0].forward_reverse, rel_error_tol)
+                        sys_buffer.write(f'    Relative Error ([rev, for] Dot Product Test) / '
+                                            f'{divname} : {err}\n')
+                else:
+                    if rel_errs[0].forward_reverse is not None:
+                        err = _format_error(rel_errs[0].forward_reverse, rel_error_tol)
+                        sys_buffer.write(f'    Relative Error (Jrev - Jfor) / {divname} : '
+                                            f'{err}\n')
+
+            if inconsistent:
+                sys_buffer.write('\n    * Inconsistent value across ranks *\n')
+
+            comm = self._problem_meta['comm']
+            if MPI and comm.size > 1:
+                sys_buffer.write(f'\n    MPI Rank {comm.rank}\n')
+            sys_buffer.write('\n')
+
+            with np.printoptions(linewidth=240):
+                # Raw Derivatives
+                if magnitudes[0].forward is not None:
+                    if directional:
+                        sys_buffer.write('    Directional Derivative (Jfor)')
+                    else:
+                        sys_buffer.write('    Raw Forward Derivative (Jfor)')
+                    Jstr = textwrap.indent(str(Jfor), '    ')
+                    sys_buffer.write(f"\n{Jstr}\n\n")
+
+                fdtype = fd_opts['method'].upper()
+
+                if magnitudes[0].reverse is not None:
+                    if directional:
+                        if totals:
+                            sys_buffer.write('    Directional Derivative (Jrev) Dot Product')
+                        else:
+                            sys_buffer.write('    Directional Derivative (Jrev)')
+                    else:
+                        sys_buffer.write('    Raw Reverse Derivative (Jrev)')
+                    Jstr = textwrap.indent(str(Jrev), '    ')
+                    sys_buffer.write(f"\n{Jstr}\n\n")
+
+                try:
+                    fds = derivative_info['J_fd']
+                except KeyError:
+                    fds = [0.]
+
+                for i in range(len(magnitudes)):
+                    fd = fds[i]
+
+                    if directional:
+                        if totals and magnitudes[i].reverse is not None:
+                            sys_buffer.write(f'    Directional {fdtype} Derivative (Jfd) '
+                                                f'Dot Product{stepstrs[i]}\n    {fd}\n\n')
+                        else:
+                            sys_buffer.write(f"    Directional {fdtype} Derivative (Jfd)"
+                                                f"{stepstrs[i]}\n    {fd}\n\n")
+                    else:
+                        Jstr = textwrap.indent(str(fd), '    ')
+                        sys_buffer.write(f"    Raw {fdtype} Derivative (Jfd){stepstrs[i]}"
+                                            f"\n{Jstr}\n\n")
+
+            sys_buffer.write(' -' * 30 + '\n')
+
+        # End of for of, wrt in sorted_keys
+
+        if out_stream is not None and (not show_only_incorrect or num_bad_jacs > 0):
+            out_stream.write(sys_buffer.getvalue())
+
+    def _deriv_display_compact(self, err_iter, derivatives, rel_error_tol, abs_error_tol,
+                               out_stream, fd_opts, totals=False,
+                               show_only_incorrect=False, lcons=None, sort=False):
+        """
+        Compute relative and absolute errors in the given derivatives and print to out_stream.
+
+        Display is in a compact tabular format.
+
+        Parameters
+        ----------
+        err_iter : iterator
+            Iterator that yields tuples of the form (key, fd_norm, fd_opts, directional, above_abs,
+            above_rel, inconsistent) for each subjac.
+        derivatives : dict
+            Dictionary containing derivative information keyed by (of, wrt).
+        rel_error_tol : float
+            Relative error tolerance.
+        abs_error_tol : float
+            Absolute error tolerance.
+        out_stream : file-like object
+                Where to send human readable output.
+                Set to None to suppress.
+        fd_opts : dict
+            Dictionary containing the options for the approximation.
+        totals : bool or _TotalJacInfo
+            Set to _TotalJacInfo if we are doing check_totals to skip a bunch of stuff.
+        show_only_incorrect : bool, optional
+            Set to True if output should print only the subjacs found to be incorrect.
+        lcons : list or None
+            For total derivatives only, list of outputs that are actually linear constraints.
+        sort : bool
+            If True, sort subjacobian keys alphabetically.
+        """
+        from openmdao.core.component import Component
+
+        # Match header to appropriate type.
+        if isinstance(self, Component):
+            sys_type = 'Component'
+        else:
+            sys_type = 'Group'
+
+        sys_name = self.pathname
+        sys_class_name = type(self).__name__
+        matrix_free = self.matrix_free
+
+        if totals:
+            sys_name = 'Full Model'
+
+        num_bad_jacs = 0  # Keep track of number of bad derivative values for each component
+
+        # Need to capture the output of a component's derivative
+        # info so that it can be used if that component is the
+        # worst subjac. That info is printed at the bottom of all the output
+        sys_buffer = StringIO()
+
+        if out_stream is not None:
+            if totals:
+                title = "Total Derivatives"
+            else:
+                title = f"{sys_type}: {sys_class_name} '{sys_name}'"
+
+            print(f"{add_border(title, '-')}\n", file=sys_buffer)
+
+            table_data = []
+            worst_subjac = None
+
+        for key, fd_norm, fd_opts, directional, above_abs, above_rel, inconsistent in err_iter:
+
+            if above_abs or above_rel or inconsistent:
+                num_bad_jacs += 1
+
+            if out_stream is None:
+                continue
+
+            of, wrt = key
+            derivative_info = derivatives[key]
+
+            # Informative output for responses that were declared with an index.
+            indices = derivative_info.get('indices')
+            if indices is not None:
+                of = f'{of} (index size: {indices})'
+
+            # need this check because if directional may be list
+            if isinstance(wrt, str):
+                wrt = f"'{wrt}'"
+            if isinstance(of, str):
+                of = f"'{of}'"
+
+            if directional:
+                wrt = f"(d){wrt}"
+
+            err_desc = []
+            if above_abs:
+                err_desc.append('>ABS_TOL')
+            if above_rel:
+                err_desc.append('>REL_TOL')
+            if inconsistent:
+                err_desc.append('<RANK INCONSISTENT>')
+            err_desc = ' '.join(err_desc)
+
+            abs_errs = derivative_info['abs error']
+            rel_errs = derivative_info['rel error']
+            magnitudes = derivative_info['magnitude']
+            steps = derivative_info['steps']
+
+            for magnitude, abs_err, rel_err, step in zip(magnitudes, abs_errs, rel_errs, steps):
+                if magnitude.reverse is not None:
+                    calc_mag = magnitude.reverse
+                    calc_abs = abs_err.reverse
+                    calc_rel = rel_err.reverse
+
+                # use forward even if both fwd and rev are defined
+                if magnitude.forward is not None:
+                    calc_mag = magnitude.forward
+                    calc_abs = abs_err.forward
+                    calc_rel = rel_err.forward
+
+                if totals:
+                    if len(steps) > 1:
+                        table_data.append([of, wrt, step, calc_mag, magnitude.fd,
+                                            calc_abs, calc_rel, err_desc])
+                    else:
+                        table_data.append([of, wrt, calc_mag, magnitude.fd,
+                                            calc_abs, calc_rel, err_desc])
+                else:
+                    if matrix_free:
+                        if len(steps) > 1:
+                            table_data.append([of, wrt, step, magnitude.forward,
+                                                magnitude.reverse, magnitude.fd,
+                                                abs_err.forward, abs_err.reverse,
+                                                abs_err.forward_reverse, rel_err.forward,
+                                                rel_err.reverse, rel_err.forward_reverse,
+                                                err_desc])
+                        else:
+                            table_data.append([of, wrt, magnitude.forward,
+                                                magnitude.reverse, magnitude.fd,
+                                                abs_err.forward, abs_err.reverse,
+                                                abs_err.forward_reverse, rel_err.forward,
+                                                rel_err.reverse, rel_err.forward_reverse,
+                                                err_desc])
+                    else:
+                        if len(steps) > 1:
+                            table_data.append([of, wrt, step, magnitude.forward,
+                                                magnitude.fd, abs_err.forward,
+                                                rel_err.forward, err_desc])
+                        else:
+                            table_data.append([of, wrt, magnitude.forward, magnitude.fd,
+                                                abs_err.forward, rel_err.forward,
+                                                err_desc])
+                        assert abs_err.forward_reverse is None
+                        assert rel_err.forward_reverse is None
+                        assert abs_err.reverse is None
+                        assert rel_err.reverse is None
+
+                    # See if this component has the greater error in the derivative computation
+                    # compared to the other components so far
+                    for err in rel_err[:2]:
+                        if err is None or np.isnan(err):
+                            continue
+
+                        if worst_subjac is None or err > worst_subjac[0]:
+                            worst_subjac = (err, table_data[-1])
+
+        headers = []
+        if out_stream is not None:
+            if table_data:
+                headers = ["of '<variable>'", "wrt '<variable>'"]
+                if len(steps) > 1:
+                    headers.append('step')
+
+                if matrix_free:
+                    headers.extend(['fwd mag.', 'rev mag.', 'check mag.', 'a(fwd-chk)',
+                                    'a(rev-chk)', 'a(fwd-rev)', 'r(fwd-chk)', 'r(rev-chk)',
+                                    'r(fwd-rev)', 'error desc'])
+                else:
+                    headers.extend(['calc mag.', 'check mag.', 'a(cal-chk)', 'r(cal-chk)',
+                                    'error desc'])
+
+                _print_deriv_table(table_data, headers, sys_buffer)
+
+            if not show_only_incorrect or num_bad_jacs > 0:
+                out_stream.write(sys_buffer.getvalue())
+
+        if worst_subjac is None:
+            return None
+
+        return worst_subjac + (headers,) if out_stream is not None else None
+
+
+_ErrorTuple = namedtuple('ErrorTuple', ['forward', 'reverse', 'forward_reverse'])
+_MagnitudeTuple = namedtuple('MagnitudeTuple', ['forward', 'reverse', 'fd'])
+
+
+def _print_deriv_table(table_data, headers, out_stream):
+    """
+    Print a table of derivatives.
+
+    Parameters
+    ----------
+    table_data : list
+        List of lists containing the table data.
+    headers : list
+        List of column headers.
+    out_stream : file-like object
+        Where to send human readable output.
+    """
+    num_col_meta = {'format': '{: 1.4e}'}
+    column_meta = [{}, {}]
+    column_meta.extend([num_col_meta.copy() for _ in range(len(headers) - 3)])
+    column_meta.append({})
+    print(generate_table(table_data, headers=headers, tablefmt='grid',
+                         column_meta=column_meta, missing_val='n/a'), file=out_stream)
+
+
+def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):
+    """
+    Compute the errors between derivatives that were computed using different modes or methods.
+
+    Error information in the derivative_info dict is updated by this function.
+
+    Parameters
+    ----------
+    derivative_info : dict
+        Metadata dict corresponding to a particular (of, wrt) pair.
+    matrix_free : bool
+        True if the current dirivatives are computed in a matrix free manner.
+    directional : bool
+        True if the current dirivtives are directional.
+    totals : bool or _TotalJacInfo
+        _TotalJacInfo if the current derivatives are total derivatives.
+
+    Returns
+    -------
+    float
+        The norm of the FD jacobian.
+    """
+    nan = float('nan')
+
+    Jforward = derivative_info.get('J_fwd')
+    Jreverse = derivative_info.get('J_rev')
+    forward = Jforward is not None
+    reverse = Jreverse is not None
+
+    rev_norm = fwd_norm = fwd_rev_error = None
+    calc_norm = 0.
+    if reverse:
+        rev_norm = calc_norm = safe_norm(Jreverse)
+    if forward:
+        fwd_norm = calc_norm = safe_norm(Jforward)
+
+    try:
+        fdinfo = derivative_info['J_fd']
+        steps = derivative_info['steps']
+    except KeyError:
+        # this can happen when a partial is not declared, which means it should be zero
+        fdinfo = (np.zeros(1),)
+        steps = (None,)
+
+    if matrix_free:
+        derivative_info['matrix_free'] = True
+        if directional:
+            if forward and reverse:
+                mhatdotm, dhatdotd = derivative_info['directional_fwd_rev']
+                fwd_rev_error = safe_norm(mhatdotm - dhatdotd)
+            else:
+                fwd_rev_error = None
+        elif not totals:
+            fwd_rev_error = safe_norm(Jforward - Jreverse)
+
+    derivative_info['abs error'] = []
+    derivative_info['rel error'] = []
+    derivative_info['magnitude'] = []
+    derivative_info['steps'] = []
+    fdnorms = []
+
+    for i, fd in enumerate(fdinfo):
+        step = steps[i]
+        fd_norm = safe_norm(fd)
+        fdnorms.append(fd_norm)
+
+        fwd_error = rev_error = None
+
+        if reverse and not directional:
+            rev_error = safe_norm(Jreverse - fd)
+
+        if forward:
+            fwd_error = safe_norm(Jforward - fd)
+
+        if directional:
+            if reverse:
+                mhatdotm, dhatdotd = derivative_info['directional_fd_rev'][i]
+                rev_error = safe_norm(mhatdotm - dhatdotd)
+                if not totals:
+                    rev_norm = None
+            if forward and totals:
+                mhatdotm, dhatdotd = derivative_info['directional_fd_fwd'][i]
+                fwd_error = safe_norm(mhatdotm - dhatdotd)
+
+        derivative_info['abs error'].append(_ErrorTuple(fwd_error, rev_error, fwd_rev_error))
+        derivative_info['magnitude'].append(_MagnitudeTuple(fwd_norm, rev_norm, fd_norm))
+        derivative_info['steps'].append(step)
+
+        # If fd_norm is zero, let's use calc_norm as the divisor for the relative
+        # error check. That way we don't accidentally squelch a legitimate problem.
+        div_norm = fd_norm if fd_norm != 0. else calc_norm
+
+        if div_norm == 0.:
+            derivative_info['rel error'].append(_ErrorTuple(None if fwd_error is None else nan,
+                                                            None if rev_error is None else nan,
+                                                            None if fwd_rev_error is None else nan))
+        else:
+            if matrix_free and not totals:
+                derivative_info['rel error'].append(_ErrorTuple(fwd_error / div_norm,
+                                                                rev_error / div_norm,
+                                                                fwd_rev_error / div_norm))
+            else:
+                derivative_info['rel error'].append(_ErrorTuple(
+                    None if fwd_error is None else fwd_error / div_norm,
+                    None if rev_error is None else rev_error / div_norm,
+                    None if fwd_rev_error is None else fwd_rev_error / div_norm))
+
+    return np.max(fdnorms)
+
+
+def _errors_above_tol(deriv_info, abs_error_tol, rel_error_tol):
+    """
+    Return if either abs or rel tolerances are violated when comparing a group of derivatives.
+
+    Parameters
+    ----------
+    deriv_info : dict
+        Metadata dict corresponding to a particular (of, wrt) pair.
+    abs_error_tol : float
+        Absolute error tolerance.
+    rel_error_tol : float
+        Relative error tolerance.
+
+    Returns
+    -------
+    bool
+        True if absolute tolerance is violated.
+    bool
+        True if relative tolerance is violated.
+    """
+    abs_errs = deriv_info['abs error']
+    rel_errs = deriv_info['rel error']
+
+    above_abs = above_rel = False
+
+    for abs_err in abs_errs:
+        for error in abs_err:
+            if error is not None and not np.isnan(error) and error >= abs_error_tol:
+                above_abs = True
+                break
+        if above_abs:
+            break
+
+    for rel_err in rel_errs:
+        for error in rel_err:
+            if error is not None and not np.isnan(error) and error >= rel_error_tol:
+                above_rel = True
+                break
+        if above_rel:
+            break
+
+    return above_abs, above_rel
+
+
+def _iter_derivs(derivatives, show_only_incorrect, all_fd_opts, totals, nondep_derivs,
+                 matrix_free, abs_error_tol=1e-6, rel_error_tol=1e-6, incon_keys=()):
+    """
+    Iterate over all of the derivatives.
+
+    If show_only_incorrect is True, only the derivatives with abs or rel errors outside of
+    tolerance or derivatives wrt serial variables that are inconsistent across ranks will be
+    returned.
+
+    Parameters
+    ----------
+    derivatives : dict
+        Dict of metadata for derivative groups, keyed on (of, wrt) pairs.
+    show_only_incorrect : bool
+        If True, yield only derivatives with errors outside of tolerance.
+    all_fd_opts : dict
+        Dictionary containing the options for the approximation.
+    totals : bool or _TotalJacInfo
+        Set to _TotalJacInfo if we are doing check_totals to skip a bunch of stuff.
+    nondep_derivs : set
+        Contains the of/wrt keys that are declared not dependent or not declared at all.
+    matrix_free : bool
+        True if the system computes matrix free derivatives.
+    abs_error_tol : float
+        Absolute error tolerance.
+    rel_error_tol : float
+        Relative error tolerance.
+    incon_keys : set or tuple
+        Keys where there are serial d_inputs variables that are inconsistent across processes.
+
+    Yields
+    ------
+    tuple
+        The (of, wrt) pair for the current derivatives being compared.
+    float
+        The FD norm.
+    dict
+        The FD options.
+    bool
+        True if the current derivatives are directional.
+    bool
+        True if the differences for the current derivatives are above the absolute error tolerance.
+    bool
+        True if the differences for the current derivatives are above the relative error tolerance.
+    bool
+        True if the current derivative was computed where some serial d_inputs variables were not
+        consistent across processes.
+    """
+    # Sorted keys ensures deterministic ordering
+    sorted_keys = sorted(derivatives)
+
+    for key in sorted_keys:
+        _, wrt = key
+
+        inconsistent = False
+        derivative_info = derivatives[key]
+
+        if totals:
+            fd_opts = all_fd_opts
+        else:
+            fd_opts = all_fd_opts[wrt]
+            if key in incon_keys:
+                inconsistent = True
+
+        directional = bool(fd_opts) and fd_opts.get('directional')
+
+        fd_norm = _compute_deriv_errors(derivative_info, matrix_free, directional, totals)
+
+        # Skip printing the non-dependent keys if the derivatives are fine.
+        if key in nondep_derivs and fd_norm < abs_error_tol:
+            del derivatives[key]
+            continue
+
+        above_abs, above_rel = _errors_above_tol(derivative_info, abs_error_tol, rel_error_tol)
+
+        if show_only_incorrect and not (above_abs or above_rel or inconsistent):
+            continue
+
+        yield key, fd_norm, fd_opts, directional, above_abs, above_rel, inconsistent
+
+
+def _format_error(error, tol):
+    """
+    Format the error, flagging if necessary.
+
+    Parameters
+    ----------
+    error : float
+        The absolute or relative error.
+    tol : float
+        Tolerance above which errors are flagged
+
+    Returns
+    -------
+    str
+        Formatted and possibly flagged error.
+    """
+    if np.isnan(error) or error < tol:
+        return f'{error:.6e}'
+    return f'{error:.6e} *'

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -7480,6 +7480,10 @@ def _iter_derivs(derivatives, show_only_incorrect, all_fd_opts, totals, nondep_d
 
         fd_norm = _compute_deriv_errors(derivative_info, matrix_free, directional, totals)
 
+        print('abs error', derivative_info['abs error'])
+        print('rel error', derivative_info['rel error'])
+        print('magnitude', derivative_info['magnitude'])
+
         # Skip printing the non-dependent keys if the derivatives are fine.
         if key in nondep_derivs and fd_norm < abs_error_tol:
             del derivatives[key]

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6880,8 +6880,7 @@ class System(object, metaclass=SystemMetaclass):
             steps = derivative_info['steps']
 
             Jfor = derivative_info.get('J_fwd')
-            if Jfor is None:
-                Jrev = derivative_info['J_rev']
+            Jrev = derivative_info.get('J_rev')
 
             if len(steps) > 1:
                 stepstrs = [f", step={step}" for step in steps]

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -735,7 +735,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         p.run_model()
         # Formerly a KeyError
         derivs = p.check_totals(compact_print=True, out_stream=None)
-        assert_near_equal(0.0, derivs['y', 'x']['abs error'][1])
+        assert_check_totals(derivs)
 
         # Coverage
         derivs = p.driver._compute_totals(return_format='dict')
@@ -891,10 +891,7 @@ class TestGroupFiniteDifference(unittest.TestCase):
         totals = prob.driver._compute_totals(of=of, wrt=['p.x'], return_format='dict')
         assert_near_equal(totals['sub.ndp.g']['p.x'], np.diag([7.0, -2.0, 10.0]), 1e-6)
 
-        totals = prob.check_totals()
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
+        assert_check_totals(prob.check_totals())
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -1923,13 +1920,13 @@ class TestComponentComplexStep(unittest.TestCase):
 
         prob.run_model()
 
-        prob.check_totals(method='cs', out_stream=None)
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
-        prob.check_totals(method='cs', step=1e-12, out_stream=None)
+        assert_check_totals(prob.check_totals(method='cs', step=1e-12, out_stream=None))
 
-        prob.check_partials(method='cs', out_stream=None)
+        assert_check_partials(prob.check_partials(method='cs', out_stream=None))
 
-        prob.check_partials(method='cs', step=1e-14, out_stream=None)
+        assert_check_partials(prob.check_partials(method='cs', step=1e-14, out_stream=None))
 
     def test_partials_bad_sparse_explicit(self):
         class BadSparsityComp(om.ExplicitComponent):
@@ -2485,7 +2482,9 @@ class TestFDRelative(unittest.TestCase):
         # This derivative requires rel_element to be accurate.
         self.assertTrue(np.abs(partials['comp']['y', 'x_element']['J_fd'][2, 2]) < 1e-9)
 
-        totals = prob.check_totals(of='comp.y', wrt=['comp.x_element'], step_calc='rel_element', out_stream=None)
+        totals = prob.check_totals(of='comp.y', wrt=['comp.x_element'], step_calc='rel_element',
+                                   out_stream=None)
+        assert_check_totals(totals)
 
         # This derivative requires rel_element to be accurate.
         self.assertTrue(np.abs(totals['comp.y', 'comp.x_element']['J_fd'][2, 2]) < 1e-9)
@@ -2619,7 +2618,7 @@ class CheckTotalsIndices(unittest.TestCase):
         prob.setup()
 
         prob.run_model()
-        prob.check_totals(compact_print=True)
+        assert_check_totals(prob.check_totals(compact_print=True, out_stream=None))
 
 
 def _setup_1ivc_fdgroupwithpar_1sink(size=7):
@@ -2939,14 +2938,13 @@ class TestFDWithParallelSubGroups(unittest.TestCase):
         prob = _setup_1ivc_fdgroupwithpar_1sink(size=7)
         prob.setup(mode='fwd', force_alloc_complex=True)
         prob.run_model()
-        assert_check_totals(prob.check_totals(method='fd'), atol=3e-6)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
 
     def test_group_fd_inner_par_rev(self):
         prob = _setup_1ivc_fdgroupwithpar_1sink(size=7)
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()
-        # assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
-        assert_check_totals(prob.check_totals(method='fd', show_only_incorrect=True), atol=3e-6)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
 
     def test_group_fd_inner_par2_fwd(self):
         prob = _setup_2ivcs_fdgroupwithpar_2sinks(size=7)
@@ -3019,7 +3017,7 @@ class TestFDWithParallelSubGroups(unittest.TestCase):
         prob = _setup_2ivcs_fdgroupwithpar_1sink(size=7)
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()
-        assert_check_totals(prob.check_totals(method='fd'), atol=3e-6)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
 
     def test_group_fd_inner_par_indirect_fwd(self):
         prob = _setup_1ivc_dum_fdgroupwithpar_1sink(size=7)
@@ -3031,8 +3029,7 @@ class TestFDWithParallelSubGroups(unittest.TestCase):
         prob = _setup_1ivc_dum_fdgroupwithpar_1sink(size=7)
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()
-        # assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
-        assert_check_totals(prob.check_totals(method='fd', show_only_incorrect=True), atol=3e-6)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
 
     def test_group_fd_inner_par_indirect2_fwd(self):
         prob = _setup_1ivc_dum_fdgroupwithpar_1sink_c4(size=7)
@@ -3044,8 +3041,7 @@ class TestFDWithParallelSubGroups(unittest.TestCase):
         prob = _setup_1ivc_dum_fdgroupwithpar_1sink_c4(size=7)
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()
-        # assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
-        assert_check_totals(prob.check_totals(method='fd', show_only_incorrect=True), atol=3e-6)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None), atol=3e-6)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -5,6 +5,7 @@ import numpy as np
 
 import openmdao.api as om
 from openmdao.utils.mpi import MPI
+from openmdao.utils.assert_utils import assert_check_totals
 
 try:
     from parameterized import parameterized
@@ -241,9 +242,7 @@ class SerialTests(unittest.TestCase):
         p['indep.x'] = [9.9]
         p['indep.g'] = 9.80665
         p.run_model()
-        totals = p.check_totals(compact_print=True, method='cs', out_stream=None)
-        for key, meta in totals.items():
-            np.testing.assert_allclose(meta['abs error'][0], 0.)
+        assert_check_totals(p.check_totals(show_only_incorrect=True, method='cs', out_stream=None))
 
     def test_set_val_auto_ivc(self):
         p = om.Problem()

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1230,10 +1230,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.setup()
 
         stream = StringIO()
-        prob.check_partials(out_stream=stream, compact_print=True)
+        prob.check_partials(out_stream=stream, abs_err_tol=1.1e-6, compact_print=True)
 
-        self.assertEqual(stream.getvalue().count('n/a'), 25)
-        self.assertEqual(stream.getvalue().count('rev'), 15)
+        self.assertEqual(stream.getvalue().count('n/a'), 0)
+        self.assertEqual(stream.getvalue().count('rev'), 10)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 12) # counts rows (including headers)
 

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -16,7 +16,7 @@ from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.components.paraboloid_mat_vec import ParaboloidMatVec
 from openmdao.test_suite.components.array_comp import ArrayComp
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning, \
-     assert_check_partials, assert_check_partials_old
+     assert_check_partials
 from openmdao.utils.om_warnings import DerivativesWarning, OMInvalidCheckDerivativesOptionsWarning
 from openmdao.utils.testing_utils import set_env_vars_context
 from openmdao.utils.array_utils import safe_norm
@@ -783,10 +783,10 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        msg = "The following components requested complex step, but force_alloc_complex " + \
-              "has not been set to True, so finite difference was used: ['comp']\n" + \
+        msg = "Component 'comp' requested complex step, but force_alloc_complex " + \
+              "has not been set to True, so finite difference was used.\n" + \
               "To enable complex step, specify 'force_alloc_complex=True' when calling " + \
-              "setup on the problem, e.g. 'problem.setup(force_alloc_complex=True)'"
+              "setup on the problem, e.g. 'problem.setup(force_alloc_complex=True)'."
 
         with assert_warning(UserWarning, msg):
             data = prob.check_partials(out_stream=None)
@@ -1890,7 +1890,6 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.run_model()
         partials = prob.check_partials(method='cs', out_stream=None)
 
-        assert_check_partials_old(partials)
         assert_check_partials(partials)
 
     def test_no_linsolve_during_check(self):
@@ -2014,7 +2013,7 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         parab.declare_partials(of='*', wrt='*', method='fd')
         with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
             prob.check_partials(method='fd')
-            
+
         self.assertEqual(str(cm.exception),
                          expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -434,16 +434,16 @@ class TestProblemCheckPartials(unittest.TestCase):
         p.setup()
         data = p.check_partials(out_stream=None)
 
-        for comp_name, comp in data.items():
-            for partial_name, partial in comp.items():
+        for comp in data.values():
+            for partial in comp.values():
                 abs_error = partial['abs error']
                 self.assertAlmostEqual(abs_error.forward, 0.)
 
         # Make sure we only FD this twice.
-        # The count is 4 because in check_partials, there is one call to apply_nonlinear
+        # The count is 5 because in check_partials, there are two calls to apply_nonlinear
         # when compute the fwd and rev analytic derivatives, then one call to apply_nonlinear
         # to compute the reference point for FD, then two additional calls for the two inputs.
-        self.assertEqual(units.run_count, 4)
+        self.assertEqual(units.run_count, 5)
 
     def test_scalar_val(self):
         class PassThrough(om.ExplicitComponent):
@@ -1318,8 +1318,8 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
-        self.assertEqual(stream.getvalue().count('n/a'), 10)
-        self.assertEqual(stream.getvalue().count('rev'), 15)
+        self.assertEqual(stream.getvalue().count('n/a'), 0)
+        self.assertEqual(stream.getvalue().count('rev'), 10)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 8)
 
@@ -1444,7 +1444,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        data = prob.check_partials()#out_stream=None)
+        data = prob.check_partials(out_stream=None)
 
         # Note on why we run 9 times:
         # 1    - Initial execution

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1,7 +1,7 @@
 """ Testing for Problem.check_partials and check_totals."""
 
 from io import StringIO
-
+from itertools import zip_longest
 
 import unittest
 
@@ -18,7 +18,8 @@ from openmdao.test_suite.components.array_comp import ArrayComp
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning, \
      assert_check_partials, assert_check_totals
 from openmdao.utils.om_warnings import DerivativesWarning, OMInvalidCheckDerivativesOptionsWarning
-from openmdao.utils.testing_utils import set_env_vars_context, compare_prob_vs_comp_check_partials
+from openmdao.utils.testing_utils import set_env_vars_context, compare_prob_vs_comp_check_partials,\
+    snum_equal
 from openmdao.utils.array_utils import safe_norm
 
 from openmdao.utils.mpi import MPI
@@ -1945,7 +1946,8 @@ J_fd - J_analytic:
 [[2.]]
 """.strip()
 
-        self.assertEqual(ctx.exception.args[0].strip(), expected)
+        for line1, line2 in zip_longest(ctx.exception.args[0].strip().split('\n'), expected.split('\n'), fillvalue=''):
+            assert snum_equal(line1.strip(), line2.strip()), f"line1: {line1}, line2: {line2}"
 
         with self.assertRaises(ValueError) as ctx:
             assert_check_partials(data)
@@ -1964,7 +1966,8 @@ Component: comp
 y wrt x                     | abs         | fd-fwd | 2.000000000279556
 """.strip()
 
-        self.assertEqual(ctx.exception.args[0].strip(), expected)
+        for line1, line2 in zip_longest(ctx.exception.args[0].strip().split('\n'), expected.split('\n'), fillvalue=''):
+            assert snum_equal(line1.strip(), line2.strip()), f"line1: {line1}, line2: {line2}"
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1444,7 +1444,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.setup()
         prob.run_model()
 
-        data = prob.check_partials(out_stream=None)
+        data = prob.check_partials()#out_stream=None)
 
         # Note on why we run 9 times:
         # 1    - Initial execution
@@ -2842,9 +2842,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         contents = stream.getvalue()
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
-        self.assertEqual(contents.count("Sub Jacobian with Largest Relative Error: CompBadPartials 'bad'"), 1)
         self.assertEqual(contents.count(">ABS_TOL >REL_TOL"), 4)
         self.assertEqual(contents.count("step"), 3)
+        self.assertEqual(contents.count("Sub Jacobian with Largest Relative Error: CompBadPartials 'bad'"), 1)
         tables = self.get_tables(contents)
         self.assertEqual(len(tables), 3)
         self.assertEqual(len(tables[0]), 11)

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1988,7 +1988,7 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
             prob.setup(force_alloc_complex=force_alloc_complex)
             return prob, parab
 
-        expected_check_partials_error = "Problem {prob._name}: Checking partials " \
+        expected_check_partials_error = "'parab' <class Paraboloid>: Checking partials " \
               "with respect to variable '{var}' in component '{comp.pathname}' using the " \
               "same method and options as are used to compute the component's derivatives " \
               "will not provide any relevant information on the accuracy.\n" \

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1233,7 +1233,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.check_partials(out_stream=stream, abs_err_tol=1.1e-6, compact_print=True)
 
         self.assertEqual(stream.getvalue().count('n/a'), 0)
-        self.assertEqual(stream.getvalue().count('rev'), 10)
+        self.assertEqual(stream.getvalue().count('rev'), 5)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 12) # counts rows (including headers)
 

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -1425,7 +1425,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Relative Error (Jfor - Jfd) / Jfd : ' in content)
         self.assertTrue('Absolute Error (Jfor - Jfd) : ' in content)
-        assert_near_equal(data[(('comp.out',), 'comp.in')]['directional_fd_fwd'], 0., tolerance=2e-15)
+        mhatdotm, dhatdotd =  data[(('comp.out',), 'comp.in')]['directional_fd_fwd']
+        assert_near_equal(mhatdotm, dhatdotd, tolerance=2e-15)
 
     def test_directional_vectorized_matrix_free_rev_index_0(self):
 
@@ -1449,7 +1450,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Relative Error ([rev, fd] Dot Product Test) / Jfd : ' in content)
         self.assertTrue('Absolute Error ([rev, fd] Dot Product Test) : ' in content)
-        assert_near_equal(data[('comp.out', ('comp.in',))]['directional_fd_rev'], 0., tolerance=2e-15)
+        dJrev, dJfd =  data[('comp.out', ('comp.in',))]['directional_fd_rev']
+        assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
 
     def test_directional_vectorized_matrix_free_rev(self):
 
@@ -1473,7 +1475,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Relative Error ([rev, fd] Dot Product Test) / Jfd : ' in content)
         self.assertTrue('Absolute Error ([rev, fd] Dot Product Test) : ' in content)
-        assert_near_equal(data[('comp.out', ('comp.in',))]['directional_fd_rev'], 0., tolerance=2e-15)
+        dJrev, dJfd =  data[('comp.out', ('comp.in',))]['directional_fd_rev']
+        assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
 
     def test_directional_vectorized_matrix_free_rev_2in2out(self):
 
@@ -1500,8 +1503,10 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 2)
         self.assertTrue(content.count('Relative Error ([rev, fd] Dot Product Test) / Jfd :'), 2)
         self.assertTrue(content.count('Absolute Error ([rev, fd] Dot Product Test) :'), 2)
-        assert_near_equal(data[('comp.out1', ('comp.in1', 'comp.in2'))]['directional_fd_rev'], 0., tolerance=2e-15)
-        assert_near_equal(data[('comp.out2', ('comp.in1', 'comp.in2'))]['directional_fd_rev'], 0., tolerance=2e-15)
+        dJrev, dJfd = data[('comp.out1', ('comp.in1', 'comp.in2'))]['directional_fd_rev']
+        assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
+        dJrev, dJfd = data[('comp.out2', ('comp.in1', 'comp.in2'))]['directional_fd_rev']
+        assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
 
     def test_directional_vectorized_matrix_free_rev_2in2out_compact(self):
 
@@ -1519,8 +1524,10 @@ class TestProblemCheckTotals(unittest.TestCase):
         data = prob.check_totals(method='cs', out_stream=stream, compact_print=True, directional=True)
         content = stream.getvalue().strip()
         self.assertEqual(content.count("('comp.in1', 'comp.in2')"), 2)
-        assert_near_equal(data[('comp.out1', ('comp.in1', 'comp.in2'))]['directional_fd_rev'], 0., tolerance=2e-15)
-        assert_near_equal(data[('comp.out2', ('comp.in1', 'comp.in2'))]['directional_fd_rev'], 0., tolerance=2e-15)
+        dJrev, dJfd =  data[('comp.out1', ('comp.in1', 'comp.in2'))]['directional_fd_rev']
+        assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
+        dJrev, dJfd =  data[('comp.out2', ('comp.in1', 'comp.in2'))]['directional_fd_rev']
+        assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
 
     def test_directional_vectorized_matrix_free_fwd_2in2out(self):
 
@@ -1548,9 +1555,11 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 2)
         self.assertEqual(content.count('Relative Error ([rev, fd] Dot Product Test) / Jfd :'), 0)
         self.assertEqual(content.count('Absolute Error ([rev, fd] Dot Product Test) :'), 0)
-        assert_near_equal(np.linalg.norm(data[(('comp.out1', 'comp.out2'), 'comp.in1')]['directional_fd_fwd']), 0., tolerance=2e-15)
-        assert_near_equal(np.linalg.norm(data[(('comp.out1', 'comp.out2'), 'comp.in2')]['directional_fd_fwd']), 0., tolerance=2e-15)
-
+        dJfwd, dJfd =  data[(('comp.out1', 'comp.out2'), 'comp.in1')]['directional_fd_fwd']
+        assert_near_equal(np.linalg.norm(dJfwd - dJfd), 0., tolerance=2e-15)
+        dJfwd, dJfd =  data[(('comp.out1', 'comp.out2'), 'comp.in2')]['directional_fd_fwd']
+        assert_near_equal(np.linalg.norm(dJfwd - dJfd), 0., tolerance=2e-15)
+        
     def test_directional_vectorized_matrix_free_fwd_2in2out_compact(self):
 
         prob = om.Problem()
@@ -1567,8 +1576,10 @@ class TestProblemCheckTotals(unittest.TestCase):
         data = prob.check_totals(method='cs', out_stream=stream, compact_print=True, directional=True)
         content = stream.getvalue().strip()
         self.assertEqual(content.count("('comp.out1', 'comp.out2')"), 2)
-        assert_near_equal(np.linalg.norm(data[(('comp.out1', 'comp.out2'), 'comp.in1')]['directional_fd_fwd']), 0., tolerance=2e-15)
-        assert_near_equal(np.linalg.norm(data[(('comp.out1', 'comp.out2'), 'comp.in2')]['directional_fd_fwd']), 0., tolerance=2e-15)
+        dJfwd, dJfd =  data[(('comp.out1', 'comp.out2'), 'comp.in1')]['directional_fd_fwd']
+        assert_near_equal(np.linalg.norm(dJfwd - dJfd), 0., tolerance=2e-15)
+        dJfwd, dJfd =  data[(('comp.out1', 'comp.out2'), 'comp.in2')]['directional_fd_fwd']
+        assert_near_equal(np.linalg.norm(dJfwd - dJfd), 0., tolerance=2e-15)
 
     def test_directional_dymosish(self):
         class CollocationComp(om.ExplicitComponent):

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -412,6 +412,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         # check derivatives with complex step and a larger step size.
         stream = StringIO()
         totals = prob.check_totals(method='cs', out_stream=stream)
+        assert_check_totals(totals)
 
         lines = stream.getvalue().splitlines()
 
@@ -427,7 +428,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # Test compact_print output
         compact_stream = StringIO()
-        prob.check_totals(method='fd', out_stream=compact_stream, compact_print=True)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=compact_stream, compact_print=True))
 
         compact_lines = compact_stream.getvalue().splitlines()
 
@@ -567,6 +568,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(J['y1', 'x1'][1][1], Jbase[2, 3], 1e-8)
 
         totals = prob.check_totals()
+        assert_check_totals(totals)
+
         jac = totals[('y1', 'x1')]['J_fd']
         assert_near_equal(jac[0][0], Jbase[0, 1], 1e-8)
         assert_near_equal(jac[0][1], Jbase[0, 3], 1e-8)
@@ -602,6 +605,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(J['y1', 'x1'][0][1], Jbase[1, 3], 1e-8)
 
         totals = prob.check_totals()
+        assert_check_totals(totals)
         jac = totals[('y1', 'x1')]['J_fd']
         assert_near_equal(jac[0][0], Jbase[1, 1], 1e-8)
         assert_near_equal(jac[0][1], Jbase[1, 3], 1e-8)
@@ -656,15 +660,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
-
-        assert_near_equal(totals['x', 'x']['J_fwd'], [[1.0]], 1e-5)
-        assert_near_equal(totals['x', 'x']['J_fd'], [[1.0]], 1e-5)
-        assert_near_equal(totals['z', 'z']['J_fwd'], np.eye(2), 1e-5)
-        assert_near_equal(totals['z', 'z']['J_fd'], np.eye(2), 1e-5)
-        assert_near_equal(totals['x', 'z']['J_fwd'], [[0.0, 0.0]], 1e-5)
-        assert_near_equal(totals['x', 'z']['J_fd'], [[0.0, 0.0]], 1e-5)
-        assert_near_equal(totals['z', 'x']['J_fwd'], [[0.0], [0.0]], 1e-5)
-        assert_near_equal(totals['z', 'x']['J_fd'], [[0.0], [0.0]], 1e-5)
+        assert_check_totals(totals)
 
     def test_full_con_with_index_desvar(self):
         prob = om.Problem()
@@ -683,9 +679,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
-
-        assert_near_equal(totals['z', 'z']['J_fwd'], [[0.0], [1.0]], 1e-5)
-        assert_near_equal(totals['z', 'z']['J_fd'], [[0.0], [1.0]], 1e-5)
+        assert_check_totals(totals)
 
     def test_full_desvar_with_index_con(self):
         prob = om.Problem()
@@ -704,9 +698,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
-
-        assert_near_equal(totals['z', 'z']['J_rev'], [[0.0, 1.0]], 1e-5)
-        assert_near_equal(totals['z', 'z']['J_fd'], [[0.0, 1.0]], 1e-5)
+        assert_check_totals(totals)
 
     def test_full_desvar_with_index_obj(self):
         prob = om.Problem()
@@ -725,9 +717,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='fd', step=1.0e-1, out_stream=None)
-
-        assert_near_equal(totals['z', 'z']['J_rev'], [[0.0, 1.0]], 1e-5)
-        assert_near_equal(totals['z', 'z']['J_fd'], [[0.0, 1.0]], 1e-5)
+        assert_check_totals(totals)
 
     def test_bug_fd_with_sparse(self):
         # This bug was found via the x57 model in pointer.
@@ -813,10 +803,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         p.run_model()
 
         # Make sure we don't bomb out with an error.
-        J = p.check_totals(out_stream=None)
-
-        assert_near_equal(J[('time', 't_duration')]['J_fwd'][0], 17.0, 1e-5)
-        assert_near_equal(J[('time', 't_duration')]['J_fd'][0], 17.0, 1e-5)
+        totals = p.check_totals(out_stream=None)
+        assert_check_totals(totals)
 
         # Try again with a direct solver and sparse assembled hierarchy.
 
@@ -832,16 +820,12 @@ class TestProblemCheckTotals(unittest.TestCase):
         p.run_model()
 
         # Make sure we don't bomb out with an error.
-        J = p.check_totals(out_stream=None)
-
-        assert_near_equal(J[('sub.time', 'sub.t_duration')]['J_fwd'][0], 17.0, 1e-5)
-        assert_near_equal(J[('sub.time', 'sub.t_duration')]['J_fd'][0], 17.0, 1e-5)
+        totals = p.check_totals(out_stream=None)
+        assert_check_totals(totals)
 
         # Make sure check_totals cleans up after itself by running it a second time
-        J = p.check_totals(out_stream=None)
-
-        assert_near_equal(J[('sub.time', 'sub.t_duration')]['J_fwd'][0], 17.0, 1e-5)
-        assert_near_equal(J[('sub.time', 'sub.t_duration')]['J_fd'][0], 17.0, 1e-5)
+        totals = p.check_totals(out_stream=None)
+        assert_check_totals(totals)
 
     def test_vector_scaled_derivs(self):
 
@@ -879,7 +863,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(J, derivs['comp.y1']['px.x'], 1.0e-3)
 
         cderiv = prob.check_totals(driver_scaling=True, out_stream=None)
-        assert_near_equal(cderiv['comp.y1', 'px.x']['J_fwd'], J, 1.0e-3)
+        assert_check_totals(cderiv)
 
         # cleanup after FD
         prob.run_model()
@@ -892,7 +876,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(J, derivs['comp.y1']['px.x'], 1.0e-3)
 
         cderiv = prob.check_totals(out_stream=None)
-        assert_near_equal(cderiv['comp.y1', 'px.x']['J_fwd'], J, 1.0e-3)
+        assert_check_totals(cderiv)
 
     def test_cs_around_newton(self):
         # Basic sellar test.
@@ -932,9 +916,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-10)
+        assert_check_totals(totals)
 
     def test_cs_around_newton_new_method(self):
         # The old method of nudging the Newton and forcing it to reconverge could not achieve the
@@ -1066,9 +1048,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         prob.run_model()
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-12)
+        assert_check_totals(totals)
 
     def test_cs_around_broyden(self):
         # Basic sellar test.
@@ -1108,9 +1088,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
+        assert_check_totals(totals)
 
     def test_cs_around_newton_top_sparse(self):
         prob = om.Problem()
@@ -1198,9 +1176,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         # This test verifies fix of a TypeError (division by None)
-        J = prob.check_totals(out_stream=None)
-        assert_near_equal(J['comp.y', 'p.x']['J_fwd'], [[14.0]], 1e-6)
-        assert_near_equal(J['comp.y', 'p.x']['J_fd'], [[0.0]], 1e-6)
+        prob.check_totals(out_stream=None)
 
     def test_response_index(self):
         prob = om.Problem()
@@ -1217,7 +1193,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_model()
 
         stream = StringIO()
-        prob.check_totals(out_stream=stream)
+        assert_check_totals(prob.check_totals(out_stream=stream))
         lines = stream.getvalue().splitlines()
         self.assertTrue('index size: 1' in lines[4])
 
@@ -1239,15 +1215,12 @@ class TestProblemCheckTotals(unittest.TestCase):
         p.run_model()
 
         stream = StringIO()
-        J_driver = p.check_totals(out_stream=stream)
+        assert_check_totals(p.check_totals(out_stream=stream))
         lines = stream.getvalue().splitlines()
 
         self.assertTrue("Full Model: 'lcy' wrt 'x' (Linear constraint)" in lines[4])
         self.assertTrue("Absolute Error (Jfor - Jfd)" in lines[8])
         self.assertTrue("Relative Error (Jfor - Jfd) / Jfd" in lines[10])
-
-        assert_near_equal(J_driver['y', 'x']['J_fwd'][0, 0], 1.0)
-        assert_near_equal(J_driver['lcy', 'x']['J_fwd'][0, 0], 3.0)
 
     def test_alias_constraints(self):
         prob = om.Problem()
@@ -1273,11 +1246,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_driver()
 
         totals = prob.check_totals(out_stream=None)
-
-        assert_near_equal(totals['areas', 'widths']['abs error'][0], 0.0, 1e-6)
-        assert_near_equal(totals['a2', 'widths']['abs error'][0], 0.0, 1e-6)
-        assert_near_equal(totals['a3', 'widths']['abs error'][0], 0.0, 1e-6)
-        assert_near_equal(totals['a4', 'widths']['abs error'][0], 0.0, 1e-6)
+        assert_check_totals(totals)
 
         prob.list_driver_vars(show_promoted_name=True, print_arrays=False,
                               cons_opts=['indices', 'alias'])
@@ -1307,11 +1276,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.run_driver()
 
         totals = prob.check_totals(out_stream=None)
-
-        assert_near_equal(totals['areas', 'widths']['abs error'][1], 0.0, 1e-6)
-        assert_near_equal(totals['a2', 'widths']['abs error'][1], 0.0, 1e-6)
-        assert_near_equal(totals['a3', 'widths']['abs error'][1], 0.0, 1e-6)
-        assert_near_equal(totals['a4', 'widths']['abs error'][1], 0.0, 1e-6)
+        assert_check_totals(totals)
 
     def test_alias_constraints_nested(self):
         # Tests a bug where we need to lookup the constraint alias on a response that is from
@@ -1365,14 +1330,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         prob.compute_totals()
 
         stream = StringIO()
-        prob.check_totals(out_stream=stream, show_only_incorrect=True)
-
-        self.assertEqual(stream.getvalue().count("'C2.y' wrt 'badcomp.y1'"), 1)
-        self.assertEqual(stream.getvalue().count("'C2.y' wrt 'badcomp.y2'"), 1)
-        self.assertEqual(stream.getvalue().count("'C1.y' wrt 'goodcomp.y1'"), 0)
-        self.assertEqual(stream.getvalue().count("'C1.y' wrt 'goodcomp.y2'"), 0)
-        self.assertEqual(stream.getvalue().count("'C2.y' wrt 'goodcomp.y1'"), 0)
-        self.assertEqual(stream.getvalue().count("'C2.y' wrt 'goodcomp.y2'"), 0)
+        totals = prob.check_totals(out_stream=stream, show_only_incorrect=True)
+        assert_check_totals(totals)
 
     def test_compact_print_exceed_tol_show_only_incorrect(self):
 
@@ -1450,7 +1409,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Relative Error ([rev, fd] Dot Product Test) / Jfd : ' in content)
         self.assertTrue('Absolute Error ([rev, fd] Dot Product Test) : ' in content)
-        dJrev, dJfd =  data[('comp.out', ('comp.in',))]['directional_fd_rev']
+        dJrev, dJfd = data[('comp.out', ('comp.in',))]['directional_fd_rev']
         assert_near_equal(dJrev - dJfd, 0., tolerance=2e-15)
 
     def test_directional_vectorized_matrix_free_rev(self):
@@ -1559,7 +1518,7 @@ class TestProblemCheckTotals(unittest.TestCase):
         assert_near_equal(np.linalg.norm(dJfwd - dJfd), 0., tolerance=2e-15)
         dJfwd, dJfd =  data[(('comp.out1', 'comp.out2'), 'comp.in2')]['directional_fd_fwd']
         assert_near_equal(np.linalg.norm(dJfwd - dJfd), 0., tolerance=2e-15)
-        
+
     def test_directional_vectorized_matrix_free_fwd_2in2out_compact(self):
 
         prob = om.Problem()
@@ -2047,11 +2006,7 @@ class TestProblemCheckTotalsMPI(unittest.TestCase):
         prob.set_solver_print(level=0)
         prob.run_model()
 
-        J = prob.check_totals(out_stream=None)
-        assert_near_equal(J['sum.y', 'sub.sub1.p1.x']['J_rev'], [[2.0]], 1.0e-6)
-        assert_near_equal(J['sum.y', 'sub.sub2.p2.x']['J_rev'], [[4.0]], 1.0e-6)
-        assert_near_equal(J['sum.y', 'sub.sub1.p1.x']['J_fd'], [[2.0]], 1.0e-6)
-        assert_near_equal(J['sum.y', 'sub.sub2.p2.x']['J_fd'], [[4.0]], 1.0e-6)
+        assert_check_totals(prob.check_totals(out_stream=None))
 
 
 class TestCheckTotalsMultipleSteps(unittest.TestCase):

--- a/openmdao/core/tests/test_component.py
+++ b/openmdao/core/tests/test_component.py
@@ -1,6 +1,7 @@
 """Component unittests."""
-import numpy as np
 import unittest
+
+import numpy as np
 
 from openmdao.api import Problem, ExplicitComponent, IndepVarComp
 from openmdao.core.component import Component
@@ -302,7 +303,7 @@ class TestExplicitComponent(unittest.TestCase):
 
         with assert_warning(OMDeprecationWarning, msg):
             prob.setup()
-    
+
     def test_setup_residuals_error(self):
         class Comp(ExplicitComponent):
             def setup(self):
@@ -324,7 +325,7 @@ class TestExplicitComponent(unittest.TestCase):
 
         with self.assertRaises(RuntimeError) as e:
             prob.final_setup()
-        
+
         self.assertEqual(str(e.exception), msg)
 
     def test_add_residual_error(self):
@@ -342,7 +343,7 @@ class TestExplicitComponent(unittest.TestCase):
 
         with self.assertRaises(AttributeError) as e:
             prob.setup()
-        
+
         self.assertEqual(str(e.exception), msg)
 
 class TestImplicitComponent(unittest.TestCase):

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_totals
 from openmdao.utils.mpi import MPI
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1withDerivatives, \
      SellarDis2withDerivatives
@@ -1048,6 +1048,7 @@ class TestObjectiveOnModel(unittest.TestCase):
         p.run_model()
         # Formerly a KeyError
         derivs = p.check_totals(compact_print=True, out_stream=None)
+        assert_check_totals(derivs)
         assert_near_equal(0.0, derivs['y', 'x']['abs error'][1])
 
 

--- a/openmdao/core/tests/test_distrib_derivs.py
+++ b/openmdao/core/tests/test_distrib_derivs.py
@@ -617,17 +617,8 @@ class MPITests2(unittest.TestCase):
                           np.array([27.0, 24.96, 23.64, 23.04, 23.16, 24.0, 25.56]),
                           1e-6)
 
-        J = prob.check_totals(method='fd', out_stream=None)
-        assert_near_equal(J['f_xy', 'x']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_xy', 'y']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'x']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'y']['abs error'].forward, 0.0, 1e-5)
-
-        J = prob.check_totals(method='cs', out_stream=None)
-        assert_near_equal(J['f_xy', 'x']['abs error'].forward, 0.0, 1e-14)
-        assert_near_equal(J['f_xy', 'y']['abs error'].forward, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'x']['abs error'].forward, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'y']['abs error'].forward, 0.0, 1e-14)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None))
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
         # rev mode
 
@@ -643,17 +634,8 @@ class MPITests2(unittest.TestCase):
                           np.array([27.0, 24.96, 23.64, 23.04, 23.16, 24.0, 25.56]),
                           1e-6)
 
-        J = prob.check_totals(method='fd', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_xy', 'y']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'x']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'y']['abs error'].reverse, 0.0, 1e-5)
-
-        J = prob.check_totals(method='cs', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].reverse, 0.0, 1e-14)
-        assert_near_equal(J['f_xy', 'y']['abs error'].reverse, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'x']['abs error'].reverse, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'y']['abs error'].reverse, 0.0, 1e-14)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None))
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
     def test_distrib_voi_sparse(self):
         size = 7
@@ -692,17 +674,8 @@ class MPITests2(unittest.TestCase):
                           np.array([27.0, 24.96, 23.64, 23.04, 23.16, 24.0, 25.56]),
                           1e-6)
 
-        J = prob.check_totals(method='fd', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_xy', 'y']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'x']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'y']['abs error'].forward, 0.0, 1e-5)
-
-        J = prob.check_totals(method='cs', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].forward, 0.0, 1e-14)
-        assert_near_equal(J['f_xy', 'y']['abs error'].forward, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'x']['abs error'].forward, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'y']['abs error'].forward, 0.0, 1e-14)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None))
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
         # rev mode
 
@@ -718,17 +691,8 @@ class MPITests2(unittest.TestCase):
                           np.array([27.0, 24.96, 23.64, 23.04, 23.16, 24.0, 25.56]),
                           1e-6)
 
-        J = prob.check_totals(method='fd', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_xy', 'y']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'x']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'y']['abs error'].reverse, 0.0, 1e-5)
-
-        J = prob.check_totals(method='cs', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].reverse, 0.0, 1e-14)
-        assert_near_equal(J['f_xy', 'y']['abs error'].reverse, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'x']['abs error'].reverse, 0.0, 1e-14)
-        assert_near_equal(J['f_sum', 'y']['abs error'].reverse, 0.0, 1e-14)
+        assert_check_totals(prob.check_totals(method='fd', out_stream=None))
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
     def test_distrib_voi_fd(self):
         size = 7
@@ -767,11 +731,7 @@ class MPITests2(unittest.TestCase):
                           np.array([27.0, 24.96, 23.64, 23.04, 23.16, 24.0, 25.56]),
                           1e-6)
 
-        J = prob.check_totals(out_stream=None, method='cs')
-        assert_near_equal(J['f_xy', 'x']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_xy', 'y']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'x']['abs error'].forward, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'y']['abs error'].forward, 0.0, 1e-5)
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
         # rev mode
 
@@ -787,11 +747,7 @@ class MPITests2(unittest.TestCase):
                           np.array([27.0, 24.96, 23.64, 23.04, 23.16, 24.0, 25.56]),
                           1e-6)
 
-        J = prob.check_totals(method='cs', show_only_incorrect=True)
-        assert_near_equal(J['f_xy', 'x']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_xy', 'y']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'x']['abs error'].reverse, 0.0, 1e-5)
-        assert_near_equal(J['f_sum', 'y']['abs error'].reverse, 0.0, 1e-5)
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
     def _setup_distrib_voi_group_fd(self, mode, size=7):
         # Only supports groups where the inputs to the distributed component whose inputs are
@@ -2163,8 +2119,7 @@ class DeclarePartialsWithoutRowCol(unittest.TestCase):
         prob.run_model()
         assert_near_equal(prob['execcomp.z'], np.ones((size,))*-38.4450, 1e-9)
 
-        data = prob.check_totals(out_stream=None)
-        assert_near_equal(data[('execcomp.z', 'x')]['abs error'].forward, 0.0, 1e-6)
+        assert_check_totals(prob.check_totals(out_stream=None))
 
 
 class TestBugs(unittest.TestCase):
@@ -2194,8 +2149,7 @@ class TestBugs(unittest.TestCase):
 
         prob.setup()
         prob.run_model()
-        totals = prob.check_totals(wrt='dvs.state', show_only_incorrect=True)
-        assert_near_equal(totals['solver.func', 'dvs.state']['abs error'].reverse, 0.0, tolerance=1e-7)
+        assert_check_totals(prob.check_totals(wrt='dvs.state', show_only_incorrect=True))
 
 
 def f_out_dist(Id, Is):
@@ -2462,24 +2416,6 @@ class TestDistribBugs(unittest.TestCase):
 
         return prob
 
-    def _compare_totals(self, totals):
-        fails = []
-        for key, val in totals.items():
-            Jname = 'J_fwd' if 'J_fwd' in val else 'J_rev'
-            idx = 0 if 'J_fwd' in val else 1
-            try:
-                val[Jname]  # analytic
-                val['J_fd']  # FD
-            except Exception as err:
-                self.fail(f"For key {key}: {err}")
-            try:
-                assert_near_equal(val['rel error'][idx], 0.0, 1e-6)
-            except ValueError as err:
-                fails.append((key, val, err, Jname))
-        if fails:
-            msg = '\n\n'.join([f"Totals differ for {key}:\nAnalytic:\n{val[Jname]}\nFD:\n{val['J_fd']}\n{err}" for key, val, err, Jname in fails])
-            self.fail(msg)
-
     def test_get_val(self):
         prob = self.get_problem(Distrib_Derivs_Matfree, stacked=False)
         indep = prob.model.indep
@@ -2505,19 +2441,19 @@ class TestDistribBugs(unittest.TestCase):
         prob = self.get_problem(Distrib_Derivs_Matfree, mode='fwd')
         totals = prob.check_totals(method='cs', out_stream=None, of=['D1.out_nd', 'D1.out_dist'],
                                         wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_prod_fwd(self):
         prob = self.get_problem(Distrib_Derivs_Prod_Matfree, mode='fwd')
         totals = prob.check_totals(method='cs', out_stream=None, of=['D1.out_nd', 'D1.out_dist'],
                                         wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_rev(self):
         prob = self.get_problem(Distrib_Derivs_Matfree, mode='rev')
         totals = prob.check_totals(method='cs', out_stream=None, of=['D1.out_nd', 'D1.out_dist'],
                                                    wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_rev_old(self):
         prob = self.get_problem(Distrib_Derivs_Matfree_Old, mode='rev')
@@ -2543,31 +2479,31 @@ class TestDistribBugs(unittest.TestCase):
         prob = self.get_problem(Distrib_Derivs_Prod_Matfree, mode='rev')
         totals = prob.check_totals(method='cs', out_stream=None, of=['D1.out_nd', 'D1.out_dist'],
                                                    wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_fwd_stacked(self):
         prob = self.get_problem(Distrib_Derivs_Matfree, mode='fwd', stacked=True)
         totals = prob.check_totals(method='cs', out_stream=None, of=['D2.out_nd', 'D2.out_dist'],
                                         wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_prod_fwd_stacked(self):
         prob = self.get_problem(Distrib_Derivs_Prod_Matfree, mode='fwd', stacked=True)
         totals = prob.check_totals(method='cs', out_stream=None, of=['D2.out_nd', 'D2.out_dist'],
                                         wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_rev_stacked(self):
         prob = self.get_problem(Distrib_Derivs_Matfree, mode='rev', stacked=True)
         totals = prob.check_totals(method='cs', out_stream=None, of=['D2.out_nd', 'D2.out_dist'],
                                                    wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_totals_prod_rev_stacked(self):
         prob = self.get_problem(Distrib_Derivs_Prod_Matfree, mode='rev', stacked=True)
         totals = prob.check_totals(method='cs', out_stream=None, of=['D2.out_nd', 'D2.out_dist'],
                                                    wrt=['indep.x_serial', 'indep.x_dist'])
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_check_partials_cs(self):
         prob = self.get_problem(Distrib_Derivs_Matfree)
@@ -2634,7 +2570,7 @@ class TestDistribBugs(unittest.TestCase):
         assert_near_equal(con['a2'], 24.96)
 
         totals = prob.check_totals(method='cs', out_stream=None)
-        self._compare_totals(totals)
+        assert_check_totals(totals)
 
     def test_dist_desvar_dist_input(self):
         class SimpleSum(om.ExplicitComponent):

--- a/openmdao/core/tests/test_driver.py
+++ b/openmdao/core/tests/test_driver.py
@@ -804,11 +804,7 @@ class TestDriver(unittest.TestCase):
         prob.run_model()
 
         totals=prob.check_totals(out_stream=None)
-
-        assert_near_equal(totals['sub.f_xy', 'sub.x']['J_fwd'], [[1.44e2]], 1e-5)
-        assert_near_equal(totals['sub.f_xy', 'sub.y']['J_fwd'], [[1.58e2]], 1e-5)
-        assert_near_equal(totals['sub.f_xy', 'sub.x']['J_fd'], [[1.44e2]], 1e-5)
-        assert_near_equal(totals['sub.f_xy', 'sub.y']['J_fd'], [[1.58e2]], 1e-5)
+        assert_check_totals(totals)
 
     def test_get_vars_to_record(self):
         recorder = om.SqliteRecorder("cases.sql")

--- a/openmdao/core/tests/test_fd_color_chk_partials.py
+++ b/openmdao/core/tests/test_fd_color_chk_partials.py
@@ -96,4 +96,4 @@ class TestColoringChkPartials(unittest.TestCase):
         s = StringIO()
         p.check_partials(out_stream=s, method='cs', show_only_incorrect=True, step=1e-39)
         out = s.getvalue().strip()
-        self.assertEqual(out, '** Only writing information about components with incorrect Jacobians **')
+        self.assertEqual(out, '')

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -14,7 +14,8 @@ except ImportError:
 import openmdao.api as om
 from openmdao.test_suite.components.sellar import SellarDis2
 from openmdao.utils.mpi import MPI
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_no_warning, \
+    assert_check_totals
 from openmdao.utils.logger_utils import TestLogger
 from openmdao.utils.om_warnings import PromotionWarning
 from openmdao.utils.name_maps import name2abs_names
@@ -1384,9 +1385,7 @@ class TestGroup(unittest.TestCase):
         assert_near_equal(p['discipline.x'], 1.41421356, 1e-6)
 
         totals = p.check_totals(of=['discipline.comp1.z'], wrt=['parameters.input_value'], method='cs', out_stream=None)
-
-        for val in totals.values():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-15)
+        assert_check_totals(totals)
 
     def test_set_order_in_config_error(self):
 

--- a/openmdao/core/tests/test_impl_comp.py
+++ b/openmdao/core/tests/test_impl_comp.py
@@ -6,7 +6,7 @@ from io import StringIO
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_totals
 from openmdao.utils.general_utils import remove_whitespace
 from openmdao.test_suite.components.sellar import SellarImplicitDis1, SellarImplicitDis2
 
@@ -578,9 +578,7 @@ class ImplicitCompGuessTestCase(unittest.TestCase):
         assert_near_equal(prob['comp.x'], 3.)
 
         totals = prob.check_totals(of=['fn.y'], wrt=['p.a'], method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 3e-9)
+        assert_check_totals(totals)
 
     def test_guess_nonlinear_residuals(self):
 

--- a/openmdao/core/tests/test_parallel_derivatives.py
+++ b/openmdao/core/tests/test_parallel_derivatives.py
@@ -828,11 +828,7 @@ class CheckParallelDerivColoringEfficiency(unittest.TestCase):
 
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()
-        data = prob.check_totals(method='cs', out_stream=None)
-        assert_near_equal(data[('dc1.y', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
-        assert_near_equal(data[('dc2.y2', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
-        assert_near_equal(data[('dc2.y', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
-        assert_near_equal(data[('dc3.y', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
+        assert_check_totals(prob.check_totals(method='cs', out_stream=None))
 
         comm = model.comm
         # should only need one jacvec product per linear solve
@@ -859,10 +855,7 @@ class CheckParallelDerivColoringEfficiency(unittest.TestCase):
         prob.setup(mode='rev', force_alloc_complex=True)
         prob.run_model()
         data = prob.check_totals(method='cs', out_stream=None)
-        assert_near_equal(data[('dc1.y', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
-        assert_near_equal(data[('dc2.y2', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
-        assert_near_equal(data[('dc2.y', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
-        assert_near_equal(data[('dc3.y', 'iv.x')]['abs error'].reverse, 0.0, 1e-6)
+        assert_check_totals(data)
 
         # should only need one jacvec product per linear solve
         comm = model.comm

--- a/openmdao/core/tests/test_renamed_resids.py
+++ b/openmdao/core/tests/test_renamed_resids.py
@@ -3,7 +3,8 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, \
+    assert_check_totals
 
 
 class MyCompApprox(om.ImplicitComponent):
@@ -250,16 +251,14 @@ class ResidNamingTestCase(unittest.TestCase):
         assert_check_partials(prob.check_partials(method='cs', out_stream=None), atol=1e-5)
 
         totals = prob.check_totals(method='cs', out_stream=None)
-        for val in totals.values():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-10)
+        assert_check_totals(totals)
 
     def test_approx2(self):
         prob = self._build_model(MyCompApprox2)
         assert_check_partials(prob.check_partials(method='cs', out_stream=None), atol=1e-5)
 
         totals = prob.check_totals(method='cs', out_stream=None)
-        for val in totals.values():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-10)
+        assert_check_totals(totals)
 
     def test_size_mismatch(self):
         with self.assertRaises(Exception) as cm:
@@ -302,16 +301,14 @@ class ResidNamingTestCase(unittest.TestCase):
         assert_check_partials(prob.check_partials(method='cs', out_stream=None))
 
         totals = prob.check_totals(method='cs', out_stream=None)
-        for val in totals.values():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-12)
+        assert_check_totals(totals)
 
     def test_analytic2(self):
         prob = self._build_model(MyCompAnalytic2)
         assert_check_partials(prob.check_partials(method='cs', out_stream=None))
 
         totals = prob.check_totals(method='cs', out_stream=None)
-        for val in totals.values():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-12)
+        assert_check_totals(totals)
 
 
 class _InputResidComp(om.ImplicitComponent):

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -10,7 +10,9 @@ from openmdao.core.driver import Driver
 from openmdao.test_suite.components.expl_comp_array import TestExplCompArrayDense
 from openmdao.test_suite.components.impl_comp_array import TestImplCompArrayDense
 from openmdao.utils.testing_utils import force_check_partials
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, \
+    assert_check_totals
+
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompF
 
 
@@ -1076,8 +1078,7 @@ class TestScaling(unittest.TestCase):
         problem.run_model()
 
         totals = problem.check_totals(out_stream=None)
-        assert_near_equal(totals['c', 'a1']['abs error'].reverse, 0.0, tolerance=1e-7)
-        assert_near_equal(totals['c', 'a2']['abs error'].reverse, 0.0, tolerance=1e-7)
+        assert_check_totals(totals)
 
         # Now, include unit conversion
 
@@ -1104,8 +1105,7 @@ class TestScaling(unittest.TestCase):
         problem.run_model()
 
         totals = problem.check_totals(out_stream=None)
-        assert_near_equal(totals['c', 'a1']['abs error'].reverse, 0.0, tolerance=1e-7)
-        assert_near_equal(totals['c', 'a2']['abs error'].reverse, 0.0, tolerance=1e-7)
+        assert_check_totals(totals)
 
     def test_totals_with_solver_scaling_part2(self):
         # Covers the part that the previous test missed, namely when the ref is in a different
@@ -1202,8 +1202,7 @@ class TestScaling(unittest.TestCase):
         problem.run_model()
 
         totals = problem.check_totals(compact_print=True)
-        assert_near_equal(totals['c', 'a1']['abs error'].reverse, 0.0, tolerance=3e-7)
-        assert_near_equal(totals['c', 'a2']['abs error'].reverse, 0.0, tolerance=3e-7)
+        assert_check_totals(totals)
 
 
 class MyComp(om.ExplicitComponent):
@@ -1405,9 +1404,7 @@ class TestScalingOverhaul(unittest.TestCase):
         assert_near_equal(driver.sens_dict['comp.x3_s_s']['p.x1_s_s'][0][0], J[3, 3] / 17.0 * 7.0)
 
         totals = prob.check_totals(compact_print=True, out_stream=None)
-
-        for (of, wrt) in totals:
-            assert_near_equal(totals[of, wrt]['abs error'][0], 0.0, 1e-7)
+        assert_check_totals(totals)
 
     def test_iimplicit(self):
         # Testing that our scale/unscale contexts leave the output vector in the correct state when
@@ -1437,9 +1434,7 @@ class TestScalingOverhaul(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(compact_print=True, out_stream=None)
-
-        for (of, wrt) in totals:
-            assert_near_equal(totals[of, wrt]['abs error'][0], 0.0, 1e-7)
+        assert_check_totals(totals)
 
 
 class TestResidualScaling(unittest.TestCase):

--- a/openmdao/core/tests/test_serial_implicit_deriv_consist.py
+++ b/openmdao/core/tests/test_serial_implicit_deriv_consist.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.assert_utils import assert_check_totals
 from openmdao.utils.mpi import MPI  # MPI will be None here if MPI is not active
 
 try:
@@ -76,8 +76,7 @@ class SerialImplicitDerivConsist(unittest.TestCase):
         prob.setup(mode="rev")
         prob.run_model()
         totals = prob.check_totals(of="total", wrt="s0")
-        for var, err in totals.items():
-            assert_near_equal(err["rel error"].reverse, 0.0, 5e-3)
+        assert_check_totals(totals)
 
 
 if __name__ == "__main__":

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -3485,7 +3485,7 @@ class TestLinearOnlyDVs(unittest.TestCase):
         shape = (2, 5)
         # do first opt without coloring
         driver = om.pyOptSparseDriver(optimizer='IPOPT', print_results=False)
-        driver.opt_settings['print_level'] = 5
+        driver.opt_settings['print_level'] = 0
         driver.opt_settings['max_iter'] = 1000
         p = self.setup_lin_only_dv_problem(driver=driver, shape=shape)
         p.run_model()
@@ -3494,7 +3494,7 @@ class TestLinearOnlyDVs(unittest.TestCase):
         assert_check_totals(p.check_totals(method='cs', out_stream=None))
 
         driver = om.pyOptSparseDriver(optimizer='IPOPT', print_results=False)
-        driver.opt_settings['print_level'] = 5
+        driver.opt_settings['print_level'] = 0
         driver.opt_settings['max_iter'] = 1000
         driver.declare_coloring()
         p = self.setup_lin_only_dv_problem(driver=driver, shape=shape)

--- a/openmdao/jax/tests/test_jax_explicit.py
+++ b/openmdao/jax/tests/test_jax_explicit.py
@@ -185,7 +185,7 @@ class TestJaxComp(unittest.TestCase):
         p.run_model()
 
         assert_near_equal(p.get_val('comp.z'), np.dot(x, y))
-        p.check_totals(of=['comp.z'], wrt=['comp.x', 'comp.y'], method='cs', show_only_incorrect=True)
+        assert_check_totals(p.check_totals(of=['comp.z'], wrt=['comp.x', 'comp.y'], method='cs', show_only_incorrect=True))
         assert_check_partials(p.check_partials(method='cs', show_only_incorrect=True))
 
     @parameterized.expand(itertools.product(['fwd', 'rev'], [True, False]), name_func=parameterized_name)

--- a/openmdao/solvers/nonlinear/tests/test_broyden.py
+++ b/openmdao/solvers/nonlinear/tests/test_broyden.py
@@ -11,7 +11,7 @@ from openmdao.test_suite.components.implicit_newton_linesearch import ImplCompTw
 from openmdao.test_suite.components.sellar import SellarStateConnection, SellarDerivatives, \
      SellarDis1withDerivatives, SellarDis2withDerivatives
 from openmdao.test_suite.scripts.circuit_analysis import Circuit
-from openmdao.utils.assert_utils import assert_near_equal, assert_warning
+from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_check_totals
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -611,9 +611,7 @@ class TestBryoden(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
+        assert_check_totals(totals)
 
     def test_cs_around_broyden_compute_jac(self):
         # Basic sellar test.
@@ -653,9 +651,7 @@ class TestBryoden(unittest.TestCase):
         sub.nonlinear_solver.options['compute_jacobian'] = True
 
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
+        assert_check_totals(totals)
 
     def test_cs_around_broyden_compute_jac_dense(self):
         # Basic sellar test.
@@ -695,9 +691,7 @@ class TestBryoden(unittest.TestCase):
         sub.nonlinear_solver.options['compute_jacobian'] = True
 
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-6)
+        assert_check_totals(totals)
 
     def test_complex_step(self):
         prob = om.Problem()
@@ -735,9 +729,7 @@ class TestBryoden(unittest.TestCase):
         prob.run_model()
 
         totals = prob.check_totals(method='cs', out_stream=None)
-
-        for key, val in totals.items():
-            assert_near_equal(val['rel error'][0], 0.0, 1e-7)
+        assert_check_totals(totals)
 
 
 # Commented the following test out until we fix the broyden check

--- a/openmdao/test_suite/components/paraboloid_mat_vec.py
+++ b/openmdao/test_suite/components/paraboloid_mat_vec.py
@@ -7,9 +7,9 @@ class ParaboloidMatVec(Paraboloid):
     def setup_partials(self):
         pass
 
-    #def compute_partials(self, inputs, partials):
-        #"""Analytical derivatives."""
-        #pass
+    def compute_partials(self, inputs, partials):
+        """Analytical derivatives."""
+        pass
 
     def compute_jacvec_product(self, inputs, dinputs, doutputs, mode):
         """Returns the product of the incoming vector with the Jacobian."""
@@ -28,4 +28,3 @@ class ParaboloidMatVec(Paraboloid):
                 dinputs['x'] += (2.0*x - 6.0 + y)*doutputs['f_xy']
             if 'y' in dinputs:
                 dinputs['y'] += (2.0*y + 8.0 + x)*doutputs['f_xy']
- 

--- a/openmdao/test_suite/components/paraboloid_mat_vec.py
+++ b/openmdao/test_suite/components/paraboloid_mat_vec.py
@@ -7,9 +7,9 @@ class ParaboloidMatVec(Paraboloid):
     def setup_partials(self):
         pass
 
-    def compute_partials(self, inputs, partials):
-        """Analytical derivatives."""
-        pass
+    #def compute_partials(self, inputs, partials):
+        #"""Analytical derivatives."""
+        #pass
 
     def compute_jacvec_product(self, inputs, dinputs, doutputs, mode):
         """Returns the product of the incoming vector with the Jacobian."""
@@ -28,3 +28,4 @@ class ParaboloidMatVec(Paraboloid):
                 dinputs['x'] += (2.0*x - 6.0 + y)*doutputs['f_xy']
             if 'y' in dinputs:
                 dinputs['y'] += (2.0*y + 8.0 + x)*doutputs['f_xy']
+ 

--- a/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
+++ b/openmdao/test_suite/test_examples/beam_optimization/test_beam_optimization.py
@@ -3,7 +3,7 @@ import unittest
 import openmdao.api as om
 from openmdao.test_suite.test_examples.beam_optimization.beam_group import BeamGroup
 from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials, assert_check_totals
 from openmdao.utils.mpi import MPI
 
 try:
@@ -137,10 +137,7 @@ class TestCase(unittest.TestCase):
         prob.run_model()
 
         derivs = prob.check_totals(method='cs', out_stream=None)
-        assert_near_equal(derivs[('compliance_comp.compliance', 'h')]['rel error'].reverse,
-                         0.0, 1e-8)
-        assert_near_equal(derivs[('volume_comp.volume', 'h')]['rel error'].reverse,
-                         0.0, 1e-8)
+        assert_check_totals(derivs)
 
         derivs = prob.check_partials(method='cs', out_stream=None)
         assert_check_partials(derivs, rtol=1e-15)
@@ -171,10 +168,7 @@ class TestCase(unittest.TestCase):
         prob.run_model()
 
         derivs = prob.check_totals(method='cs', out_stream=None)
-        assert_near_equal(derivs[('obj_sum.obj', 'interp.h_cp')]['rel error'].reverse,
-                         0.0, 1e-8)
-        assert_near_equal(derivs[('volume_comp.volume', 'interp.h_cp')]['rel error'].reverse,
-                         0.0, 1e-8)
+        assert_check_totals(derivs)
 
         derivs = prob.check_partials(method='cs', out_stream=None)
         assert_check_partials(derivs, rtol=1e-15)

--- a/openmdao/test_suite/tests/test_quad_implicit.py
+++ b/openmdao/test_suite/tests/test_quad_implicit.py
@@ -25,6 +25,9 @@ class TestQuadImplicit(unittest.TestCase):
 
         p.setup()
 
+        # set starting value to avoid negative sqrt
+        p['quad.a'] = -1.
+
         check = p.check_partials(out_stream=None)
 
         for out_name, of in check.items():

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -994,3 +994,20 @@ def idxs2minmax_tuples(idxs):
         ranges.append((idxs[start], idxs[-1]))
 
     return ranges
+
+
+def safe_norm(arr):
+    """
+    Return the norm of the given array, or 0 if the array is None or empty.
+
+    Parameters
+    ----------
+    arr : ndarray or None
+        Array to be normed.
+
+    Returns
+    -------
+    float
+        Norm of the array or 0 if the array is None or empty.
+    """
+    return 0. if arr is None or arr.size == 0 else np.linalg.norm(arr)

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -325,6 +325,8 @@ def assert_check_totals(totals_data, atol=1e-6, rtol=1e-6, max_display_shape=(20
         if 'inconsistent_keys' in dct:
             incon_keys = dct['inconsistent_keys']
         J_fd = dct['J_fd']
+        if isinstance(J_fd, list):
+            J_fd = J_fd[0]
         try:
             nrows, ncols = J_fd.shape
         except ValueError:

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -213,6 +213,11 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, max_display_shape=(20, 20)
                 J_fds = [J_fds]
                 dir_fd_fwds = [dir_fd_fwds]
                 dir_fd_revs = [dir_fd_revs]
+            else:
+                if dir_fd_fwds is None:
+                    dir_fd_fwds = [dir_fd_fwds]
+                if dir_fd_revs is None:
+                    dir_fd_revs = [dir_fd_revs]
 
             dirstr = ' directional' if directional else ''
             jacs = [(f'J_fwd{dirstr}', J_fwd, f'Forward{dirstr}'),

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -330,6 +330,7 @@ def assert_check_totals(totals_data, atol=1e-6, rtol=1e-6, max_display_shape=(20
         except ValueError:
             nrows = J_fd.shape
             ncols = 1
+        break
 
     if isinstance(max_display_shape, int):
         maxrows = maxcols = max_display_shape

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -465,11 +465,9 @@ def pad_name(name, width=10, quotes=False):
         return f"{name}"
 
 
-def add_border(msg, borderstr='=', vpad=0):
+def add_border(msg, borderstr='=', vpad=0, above=True, below=True):
     """
-    Add border lines before and after a message.
-
-    The message is assumed not to span multiple lines.
+    Add border lines before and/or after a message.
 
     Parameters
     ----------
@@ -478,16 +476,21 @@ def add_border(msg, borderstr='=', vpad=0):
     borderstr : str
         The repeating string to be used in the border.
     vpad : int
-        The number of blank lines between the border and the message (before and after).
+        The number of blank lines between the border(s) and the message.
+    above : bool
+        If True, add a border above the message.
+    below : bool
+        If True, add a border below the message.
 
     Returns
     -------
     str
-        A string containing the original message enclosed in a border.
+        A string containing the original message and border(s) before and/or after.
     """
-    border = len(msg) * borderstr
+    width = max(len(line) for line in msg.split('\n'))
+    border = width * borderstr
     # handle borderstr of more than 1 char
-    border = border[:len(msg)]
+    border = border[:width]
     padding = '\n' * (vpad + 1)
     return f"{border}{padding}{msg}{padding}{border}"
 

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -465,6 +465,54 @@ def pad_name(name, width=10, quotes=False):
         return f"{name}"
 
 
+def get_max_widths(rows):
+    """
+    Determine the maximum width of each column.
+
+    Parameters
+    ----------
+    rows : list of list of str
+        List of rows, where each row is a list of strings.
+
+    Returns
+    -------
+    list of int
+        List of maximum widths for each column.
+    """
+    if not rows:
+        return []
+
+    for irow, row in enumerate(rows):
+        if irow == 0:
+            widths = [len(val) for val in row]
+        else:
+            for i, val in enumerate(row):
+                widths[i] = max(widths[i], len(val))
+    return widths
+
+
+def strs2row_iter(strs, colwidths, delim=' '):
+    """
+    Yield rows of strings formatted into columns.
+
+    Parameters
+    ----------
+    strs : list of str
+        List of strings to be formatted into columns.
+    colwidths : list of int
+        List of column widths.
+    delim : str
+        Delimiter to use between columns.
+
+    Yields
+    ------
+    str
+        Formatted row of strings.
+    """
+    for row in strs:
+        yield delim.join(f"{val:<{width}}" for val, width in zip(row, colwidths))
+
+
 def add_border(msg, borderstr='=', vpad=0, above=True, below=True):
     """
     Add border lines before and/or after a message.
@@ -491,8 +539,11 @@ def add_border(msg, borderstr='=', vpad=0, above=True, below=True):
     border = width * borderstr
     # handle borderstr of more than 1 char
     border = border[:width]
-    padding = '\n' * (vpad + 1)
-    return f"{border}{padding}{msg}{padding}{border}"
+    uborder = border if above else ''
+    lborder = border if below else ''
+    upadding = '\n' * (vpad + 1) if uborder else '\n' * vpad
+    lpadding = '\n' * vpad if vpad else '\n'
+    return f"{uborder}{upadding}{msg}{lpadding}{lborder}"
 
 
 def run_model(prob, ignore_exception=False):

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -57,7 +57,7 @@ class TestAssertUtils(unittest.TestCase):
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
-        
+
         expected = """
 ==============================================================
 assert_check_partials failed for the following Components
@@ -246,7 +246,7 @@ J_fd:
         prob.run_model()
 
         data = prob.check_partials(out_stream=None)
-        
+
         expected = """
 ==============================================================
 assert_check_partials failed for the following Components
@@ -263,7 +263,7 @@ J_fwd:
 [[nan]]
 J_fd:
 [[3.]]""".strip()
-        
+
 
         try:
             assert_check_partials(data, atol=1.e-6, rtol=1.e-6)

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -63,30 +63,27 @@ class TestAssertUtils(unittest.TestCase):
 assert_check_partials failed for the following Components
 with absolute tolerance = 1e-06 and relative tolerance = 1e-06
 ==============================================================
+
 ---------------
 Component: comp
 ---------------
-Forward derivatives of 'y' w.r.t 'x1' do not match finite difference.
+Forward derivatives of 'y' wrt 'x1' do not match finite difference.
 Mismatched elements: 1 / 1 (100%)
 Max absolute difference: 1.
 Max relative difference: 0.33333333
-J_fwd:
-[[4.]]
-J_fd:
-[[3.]]
+J_fd - J_fwd:
+[[-1.]]
 
-Forward derivatives of 'y' w.r.t 'x2' do not match finite difference.
+Forward derivatives of 'y' wrt 'x2' do not match finite difference.
 Mismatched elements: 1 / 1 (100%)
 Max absolute difference: 36.
 Max relative difference: 9.
-J_fwd:
-[[40.]]
-J_fd:
-[[4.]]
+J_fd - J_fwd:
+[[-36.]]
 """.strip()
 
         try:
-            assert_check_partials(data, atol=1.e-6, rtol=1.e-6)
+            assert_check_partials(data, atol=1.e-6, rtol=1.e-6, verbose=True)
         except Exception as err:
             if not snum_equal(err.args[0].strip(), expected):
                 # just show normal string diff
@@ -252,21 +249,21 @@ J_fd:
 assert_check_partials failed for the following Components
 with absolute tolerance = 1e-06 and relative tolerance = 1e-06
 ==============================================================
+
 ---------------
 Component: comp
 ---------------
-Forward derivatives of 'y' w.r.t 'x' do not match finite difference.
+Forward derivatives of 'y' wrt 'x' do not match finite difference.
 Mismatched elements: 1 / 1 (100%)
 Max absolute difference: nan
 Max relative difference: nan
-J_fwd:
+J_fd - J_fwd:
 [[nan]]
-J_fd:
-[[3.]]""".strip()
+""".strip()
 
 
         try:
-            assert_check_partials(data, atol=1.e-6, rtol=1.e-6)
+            assert_check_partials(data, atol=1.e-6, rtol=1.e-6, verbose=True)
         except ValueError as err:
             if not snum_equal(err.args[0].strip(), expected):
                 self.assertEqual(err.args[0].strip(), expected)

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -205,7 +205,7 @@ class TestReportsSystem(unittest.TestCase):
         driver.declare_coloring()
 
         driver.opt_settings['max_iter'] = 1000
-        driver.opt_settings['print_level'] = 5
+        driver.opt_settings['print_level'] = 0
         driver.opt_settings['mu_strategy'] = 'monotone'
         driver.opt_settings['alpha_for_y'] = 'safer-min-dual-infeas'
         driver.opt_settings['tol'] = 1.0E-4

--- a/openmdao/utils/tests/test_visualization.py
+++ b/openmdao/utils/tests/test_visualization.py
@@ -60,6 +60,9 @@ class TestVisualization(unittest.TestCase):
         # Instead of seeing if the images created by matplotlib match what we expect, which
         # is a fragile thing to do in testing, check a data structure inside matplotlib's
         # objects. We will assume matplotlib draws the correct thing.
+
+        # TODO: this test seems pretty fragile due to the small numbers involved. If it starts
+        # failing on other platforms we might want to consider reworking it.
         expected_array = np.array([[1., 0., 0., 1.],
                                    [0., 1., 0., 0.],
                                    [1., 0., 1., 0.],
@@ -72,10 +75,11 @@ class TestVisualization(unittest.TestCase):
                                    [ 0.,  1.,  0.,  1.]])
         actual_array = ax[1].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
-        expected_array = np.array([[  0.0,   0.0,   0.0, 1.0e-07],
-                                   [  0.0,   0.0,  -2.0e-07, 0.0],
-                                   [  0.0,   0.0,   0.0, 0.0],
-                                   [  0.0,   0.0,   0.0, 0.0]])
+        expected_array = np.array([[ 7.48400453e-10,  0.0,  0.0, 9.99097329e-08],
+                                   [ 0.0,  9.46442924e-11, -2.e-07, 0.0],
+                                   [ 1.39777967e-10,  0.0,  6.58133104e-10, 0.0],
+                                   [ 0.0, -5.59111868e-10,  0.0, 9.37689038e-10]])
+
         actual_array = ax[2].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
 
@@ -94,10 +98,10 @@ class TestVisualization(unittest.TestCase):
                                    [ 0.,  1.,  0.,  1.]])
         actual_array = ax[1].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
-        expected_array = np.array([[  0.0,   0.0,   0.0, 1.0e-07],
-                                   [  0.0,   0.0,  -2.0e-07, 0.0],
-                                   [  0.0,   0.0,   0.0, 0.0],
-                                   [  0.0,   0.0,   0.0, 0.0]])
+        expected_array = np.array([[ 7.48400453e-10,  0.0,  0.0, 9.99097329e-08],
+                                   [ 0.0,  9.46442924e-11, -2.e-07, 0.0],
+                                   [ 1.39777967e-10,  0.0,  6.58133104e-10, 0.0],
+                                   [ 0.0, -5.59111868e-10,  0.0, 9.37689038e-10]])
         actual_array = ax[2].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
 
@@ -116,10 +120,10 @@ class TestVisualization(unittest.TestCase):
                                    [  0.0,   4.0e+00,   0.0, 6.0e+00]])
         actual_array = ax[1].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
-        expected_array = np.array([[  0.0,   0.0,   0.0, 1.0e-07],
-                                   [  0.0,   0.0,  -2.0e-07, 0.0],
-                                   [  0.0,   0.0,   0.0, 0.0],
-                                   [  0.0,   0.0,   0.0, 0.0]])
+        expected_array = np.array([[ 7.48400453e-10,  0.0,  0.0, 9.99097329e-08],
+                                   [ 0.0,  9.46442924e-11, -2.e-07, 0.0],
+                                   [ 1.39777967e-10,  0.0,  6.58133104e-10, 0.0],
+                                   [ 0.0, -5.59111868e-10,  0.0, 9.37689038e-10]])
         actual_array = ax[2].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
 

--- a/openmdao/utils/tests/test_visualization.py
+++ b/openmdao/utils/tests/test_visualization.py
@@ -72,10 +72,10 @@ class TestVisualization(unittest.TestCase):
                                    [ 0.,  1.,  0.,  1.]])
         actual_array = ax[1].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
-        expected_array = np.array([[  9.31322575e-10,   0.0,   0.0, 1.0e-07],
+        expected_array = np.array([[  0.0,   0.0,   0.0, 1.0e-07],
                                    [  0.0,   0.0,  -2.0e-07, 0.0],
-                                   [  0.0,   0.0,   9.31322575e-10, 0.0],
-                                   [  0.0,   0.0,   0.0, 1.86264515e-09]])
+                                   [  0.0,   0.0,   0.0, 0.0],
+                                   [  0.0,   0.0,   0.0, 0.0]])
         actual_array = ax[2].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
 
@@ -94,10 +94,10 @@ class TestVisualization(unittest.TestCase):
                                    [ 0.,  1.,  0.,  1.]])
         actual_array = ax[1].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
-        expected_array = np.array([[  9.31322575e-10,   0.0,   0.0, 1.0e-07],
+        expected_array = np.array([[  0.0,   0.0,   0.0, 1.0e-07],
                                    [  0.0,   0.0,  -2.0e-07, 0.0],
-                                   [  0.0,   0.0,   9.31322575e-10, 0.0],
-                                   [  0.0,   0.0,   0.0, 1.86264515e-09]])
+                                   [  0.0,   0.0,   0.0, 0.0],
+                                   [  0.0,   0.0,   0.0, 0.0]])
         actual_array = ax[2].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
 
@@ -116,10 +116,10 @@ class TestVisualization(unittest.TestCase):
                                    [  0.0,   4.0e+00,   0.0, 6.0e+00]])
         actual_array = ax[1].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
-        expected_array = np.array([[  9.31322575e-10,   0.0,   0.0, 1.0e-07],
+        expected_array = np.array([[  0.0,   0.0,   0.0, 1.0e-07],
                                    [  0.0,   0.0,  -2.0e-07, 0.0],
-                                   [  0.0,   0.0,   9.31322575e-10, 0.0],
-                                   [  0.0,   0.0,   0.0, 1.86264515e-09]])
+                                   [  0.0,   0.0,   0.0, 0.0],
+                                   [  0.0,   0.0,   0.0, 0.0]])
         actual_array = ax[2].images[0]._A.data
         assert_near_equal(expected_array, actual_array, 1e-8)
 


### PR DESCRIPTION
### Summary

Also made `check_partials` callable directly on a Component.

### Related Issues

- Resolves #3413

### Backwards incompatibilities

Could see slightly different output from check_partials/assert_check_partials

### New Dependencies

None
