### PR TITLE
Updated Ubuntu images used by test workflows

### DIFF
--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -50,7 +50,7 @@ jobs:
           # test latest versions on ubuntu
           # Include pyOptSparse, which requires NumPy<2
           - NAME: Ubuntu Latest, NumPy<2
-            OS: ubuntu-latest
+            OS: ubuntu-22.04
             PY: '3.12'
             NUMPY: '<2'
             PETSc: true
@@ -63,7 +63,7 @@ jobs:
           # Exclude pyOptSparse, which requires NumPy<2
           # NumPy>=2.1 is required with Python 3.13
           - NAME: Ubuntu Latest, NumPy 2 (No pyOptSparse)
-            OS: ubuntu-latest
+            OS: ubuntu-22.04
             PY: '3.13'
             NUMPY: '>=2.1'
             PETSc: true

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -84,7 +84,7 @@ jobs:
         include:
           # test baseline versions on Ubuntu
           - NAME: Ubuntu Baseline
-            OS: ubuntu-latest
+            OS: ubuntu-22.04
             PY: '3.12'
             NUMPY: '1.26'
             SCIPY: '1.14'
@@ -138,7 +138,7 @@ jobs:
 
           # test oldest supported versions
           - NAME: Ubuntu Oldest
-            OS: ubuntu-latest
+            OS: ubuntu-22.04
             PY: '3.9'
             NUMPY: '1.24'
             SCIPY: '1.9'


### PR DESCRIPTION
### Summary

GitHub has recently updated their `ubuntu-latest` image to use Ubuntu 24.04.

This has resulted in some incompatibilities with system level libraries in the test workflows, e.g. 
```
symbol lookup error: /lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0: undefined symbol: atk_object_get_help_text
```

This PR reverts the tests and latest workflows to use the Ubuntu 22.04 image.


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
