### PR TITLE
Fixed a NumPy 2.x compatibility issue in FiniteDifference

### DIFF
--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -337,7 +337,7 @@ class FiniteDifference(ApproximationScheme):
             else:
                 results_array[:] = 0.
 
-        elif current_coeff:
+        elif not isinstance(current_coeff, np.ndarray) and current_coeff:
             current_vec = system._outputs if total else system._residuals
             # copy data from outputs (if doing total derivs) or residuals (if doing partials)
             results_array[:] = current_vec.asarray()


### PR DESCRIPTION
### Summary

Made change in FiniteDifference to handle zero length arrays in a NumPy 2.x compatible way

### Related Issues

- Resolves #3428

### Backwards incompatibilities

None

### New Dependencies

None
