### PR TITLE
Fix for computed sparsity when some subjacs are zero.

### DIFF
--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -954,7 +954,7 @@ def submat_sparsity_iter(row_var_size_iter, col_var_size_iter, nzrows, nzcols, s
             submat = csc[:, col_start:col_end].tocoo()
             col_start = col_end
 
-            if submat.row.size > 0:  # only yield if nonzero
+            if True:  # submat.row.size > 0:  # only yield if nonzero
                 yield (of, wrt, submat.row, submat.col, submat.shape)
 
 

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -954,8 +954,7 @@ def submat_sparsity_iter(row_var_size_iter, col_var_size_iter, nzrows, nzcols, s
             submat = csc[:, col_start:col_end].tocoo()
             col_start = col_end
 
-            if True:  # submat.row.size > 0:  # only yield if nonzero
-                yield (of, wrt, submat.row, submat.col, submat.shape)
+            yield (of, wrt, submat.row, submat.col, submat.shape)
 
 
 def idxs2minmax_tuples(idxs):

--- a/openmdao/utils/tests/test_array_utils.py
+++ b/openmdao/utils/tests/test_array_utils.py
@@ -128,6 +128,8 @@ class TestSubmatSparsityIter(unittest.TestCase):
         result = list(submat_sparsity_iter(row_var_size_iter, col_var_size_iter, nzrows, nzcols, shape))
         expected = [
             ('a', 'c', np.array([0, 1]), np.array([0, 1]), (2, 2)),
+            ('a', 'd', np.array([]), np.array([]), (2, 2)),
+            ('b', 'c', np.array([]), np.array([]), (2, 2)),
             ('b', 'd', np.array([0, 1]), np.array([0, 1]), (2, 2)),
         ]
         self._check_results(expected, result)
@@ -141,6 +143,8 @@ class TestSubmatSparsityIter(unittest.TestCase):
         result = list(submat_sparsity_iter(row_var_size_iter, col_var_size_iter, nzrows, nzcols, shape))
         expected = [
             ('a', 'c', np.array([0]), np.array([0]), (2, 2)),
+            ('a', 'd', np.array([]), np.array([]), (2, 2)),
+            ('b', 'c', np.array([]), np.array([]), (2, 2)),
             ('b', 'd', np.array([1]), np.array([1]), (2, 2))
         ]
         self._check_results(expected, result)


### PR DESCRIPTION
### Summary

A dymos cannon ball trajectory test was getting a very dense total jacobian sparsity without this fix.

I don't have an OpenMDAO test to reproduce the issue yet, but this is needed sooner rather than later to fix the failing dymos test.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
