### PR TITLE
Addressed change in `numpy.testing.allclose` error message in NumPy 2.x

### DIFF
--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -182,10 +182,29 @@ def _parse_assert_allclose_error(msg):
         if not line.startswith('Max'):
             continue
         parts = line.split()
+
+        # Note change in format of assert_allclose error message for NumPy 2.x
+
+        # Numpy 1.x format:
+        # ----------------
+        # Not equal to tolerance rtol=1e-06, atol=1e-06
+        #
+        # Mismatched elements: 15 / 15 (100%)
+        # Max absolute difference: 2.7
+        # Max relative difference: 1.
+
+        # Numpy 2.x format:
+        # ----------------
+        # Not equal to tolerance rtol=1e-06, atol=1e-06
+        #
+        # Mismatched elements: 15 / 15 (100%)
+        # Max absolute difference among violations: 2.7
+        # Max relative difference among violations: 1.
+
         if parts[1] == 'absolute':
-            abs_err = float(parts[3])
+            abs_err = float(parts[-1])
         elif parts[1] == 'relative':
-            rel_err = float(parts[3])
+            rel_err = float(parts[-1])
     return abs_err, rel_err
 
 

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -82,6 +82,9 @@ J_fd - J_fwd:
 [[-36.]]
 """.strip()
 
+        if np.__version__.split()[0] > '1':
+            expected = expected.replace('difference:', 'difference among violations:')
+
         try:
             assert_check_partials(data, atol=1.e-6, rtol=1.e-6, verbose=True)
         except Exception as err:
@@ -261,6 +264,8 @@ J_fd - J_fwd:
 [[nan]]
 """.strip()
 
+        if np.__version__.split()[0] > '1':
+            expected = expected.replace('difference:', 'difference among violations:')
 
         try:
             assert_check_partials(data, atol=1.e-6, rtol=1.e-6, verbose=True)

--- a/openmdao/utils/tests/test_assert_utils.py
+++ b/openmdao/utils/tests/test_assert_utils.py
@@ -82,7 +82,7 @@ J_fd - J_fwd:
 [[-36.]]
 """.strip()
 
-        if np.__version__.split()[0] > '1':
+        if np.__version__.split('.')[0] > '1':
             expected = expected.replace('difference:', 'difference among violations:')
 
         try:
@@ -264,7 +264,7 @@ J_fd - J_fwd:
 [[nan]]
 """.strip()
 
-        if np.__version__.split()[0] > '1':
+        if np.__version__.split('.')[0] > '1':
             expected = expected.replace('difference:', 'difference among violations:')
 
         try:


### PR DESCRIPTION
### Summary

The `assert_check_partials` function parses error messages from `numpy.testing.assert_allclose`.

With NumPy 2.x, the error message has changed slightly.

Logic has been changed/added to handle both variations.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
