### PR TITLE
Updated check_partials and check_totals to measure absolute and relative err in the same way that np.assert_allclose does

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2196,7 +2196,7 @@ class Component(System):
             For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
             Jacobian for the three different methods of computation.
             For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
-            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            tuple containing values for forward - fd, reverse - fd, forward - reverse. For
             'magnitude' the value is a tuple indicating the maximum magnitude of values found in
             Jfwd, Jrev, and Jfd.
             The boolean 'rank_inconsistent' indicates if the derivative wrt a serial variable is

--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2191,12 +2191,14 @@ class Component(System):
             Where derivs_dict is a dict, where the top key is the component pathname.
             Under the top key, the subkeys are the (of, wrt) keys of the subjacs.
             Within the (of, wrt) entries are the following keys:
-            'rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev', and
-            'rank_inconsistent'.
-            For 'rel error', 'abs error', and 'magnitude' the value is a tuple containing norms
-            for forward - fd, adjoint - fd, forward - adjoint.
+            'rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev', 'vals_at_max_abs',
+            'vals_at_max_rel', and 'rank_inconsistent'.
             For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
             Jacobian for the three different methods of computation.
+            For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
+            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            'magnitude' the value is a tuple indicating the maximum magnitude of values found in
+            Jfwd, Jrev, and Jfd.
             The boolean 'rank_inconsistent' indicates if the derivative wrt a serial variable is
             inconsistent across MPI ranks.
 
@@ -2335,9 +2337,7 @@ class Component(System):
                                         d = mfree_directions[inp]
                                         mhat = derivs
                                         dhat = deriv['J_fwd'][:, idx]
-
-                                        deriv['directional_fwd_rev'] = (mhat.dot(m),
-                                                                        dhat.dot(d))
+                                        deriv['directional_fwd_rev'] = (dhat.dot(d), mhat.dot(m))
                                     else:
                                         meta = abs2meta_in[out_abs] if out_abs in abs2meta_in \
                                             else abs2meta_out[out_abs]
@@ -2523,7 +2523,7 @@ class Component(System):
 
                         if 'directional_fd_rev' not in deriv:
                             deriv['directional_fd_rev'] = []
-                        deriv['directional_fd_rev'].append((dhat.dot(d), mhat.dot(m)))
+                        deriv['directional_fd_rev'].append((mhat.dot(m), dhat.dot(d)))
 
         # convert to regular dict from defaultdict
         partials_data = {key: dict(d) for key, d in partials_data.items()}

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -54,6 +54,7 @@ from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_d
     OMInvalidCheckDerivativesOptionsWarning
 import openmdao.utils.coloring as coloring_mod
 from openmdao.utils.file_utils import _get_outputs_dir, text2html, get_work_dir
+from openmdao.utils.testing_utils import _fix_comp_check_data
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -2539,13 +2540,6 @@ def _fix_check_data(data):
     data : dict
         Dictionary containing derivative information keyed by system name.
     """
-    names = ['J_fd', 'abs error', 'rel error', 'magnitude', 'directional_fd_fwd',
-             'directional_fd_rev']
-
     for sdata in data.values():
         for dct in sdata.values():
-            for name in names:
-                if name in dct:
-                    dct[name] = dct[name][0]
-            if 'steps' in dct:
-                del dct['steps']
+            _fix_comp_check_data(dct)

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1202,12 +1202,13 @@ class Problem(object, metaclass=ProblemMetaclass):
         dict of dicts of dicts
             First key is the component name.
             Second key is the (output, input) tuple of strings.
-            Third key is one of ['rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev',
-            'rank_inconsistent'].
-            For 'rel error', 'abs error', and 'magnitude' the value is a tuple containing norms for
-            forward - fd, adjoint - fd, forward - adjoint.
-            For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
-            Jacobian for the three different methods of computation.
+            The third key is one of:
+            'rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev', 'vals_at_max_abs',
+            'vals_at_max_rel', and 'rank_inconsistent'.
+            For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
+            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            'magnitude' the value is a tuple indicating the maximum magnitude of values found in
+            Jfwd, Jrev, and Jfd.
             The boolean 'rank_inconsistent' indicates if the derivative wrt a serial variable is
             inconsistent across MPI ranks.
         """
@@ -1354,10 +1355,12 @@ class Problem(object, metaclass=ProblemMetaclass):
             First key:
                 is the (output, input) tuple of strings;
             Second key:
-                is one of ['rel error', 'abs error', 'magnitude', 'fdstep'];
-
-            For 'rel error', 'abs error', 'magnitude' the value is: A tuple containing norms for
-                forward - fd, adjoint - fd, forward - adjoint.
+            'rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev', 'vals_at_max_abs',
+            'vals_at_max_rel', and 'rank_inconsistent'.
+            For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
+            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            'magnitude' the value is a tuple indicating the maximum magnitude of values found in
+            Jfwd, Jrev, and Jfd.
         """
         if out_stream == _DEFAULT_OUT_STREAM:
             out_stream = sys.stdout
@@ -1540,7 +1543,7 @@ class Problem(object, metaclass=ProblemMetaclass):
                         # check directional fwd against fd (one must have negative seed)
                         meta['J_fwd'] = total_info.J[:, Jcalc_slices['wrt'][wrt].start]
                         meta['J_fd'].append(Jfd[:, Jcalc_slices['wrt'][wrt].start])
-                        meta['directional_fd_fwd'].append((meta['J_fwd'], meta['J_fd'][-1]))
+                        meta['directional_fd_fwd'].append((meta['J_fd'][-1], meta['J_fwd']))
                     else:  # rev
                         if 'directional_fd_rev' not in meta:
                             meta['directional_fd_rev'] = []
@@ -1555,7 +1558,7 @@ class Problem(object, metaclass=ProblemMetaclass):
                         mhat_dot_m = mhat.dot(m)
 
                         # Dot product test for adjoint validity.
-                        meta['directional_fd_rev'].append((dhat_dot_d, mhat_dot_m))
+                        meta['directional_fd_rev'].append((mhat_dot_m, dhat_dot_d))
                         meta['J_rev'] = dhat_dot_d
                         meta['J_fd'].append(mhat_dot_m)
                 else:

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1212,14 +1212,6 @@ class Problem(object, metaclass=ProblemMetaclass):
             inconsistent across MPI ranks.
         """
         model = self.model
-
-        # on master, we were doing this:
-        # if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP:
-        #     self.final_setup()
-
-        # model.run_apply_nonlinear()
-
-        # but it seems more correct to run the model first if it hasn't been run yet, correct?
         if self._metadata['setup_status'] < _SetupStatus.POST_FINAL_SETUP or model.iter_count == 0:
             self.run_model()
 

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1351,12 +1351,12 @@ class Problem(object, metaclass=ProblemMetaclass):
         Returns
         -------
         Dict of Dicts of Tuples of Floats
-
             First key:
                 is the (output, input) tuple of strings;
             Second key:
-            'rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev', 'vals_at_max_abs',
-            'vals_at_max_rel', and 'rank_inconsistent'.
+                'rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev', 'vals_at_max_abs',
+                'vals_at_max_rel', and 'rank_inconsistent'.
+
             For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
             tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
             'magnitude' the value is a tuple indicating the maximum magnitude of values found in

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1358,7 +1358,7 @@ class Problem(object, metaclass=ProblemMetaclass):
                 'vals_at_max_rel', and 'rank_inconsistent'.
 
             For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
-            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            tuple containing values for forward - fd, reverse - fd, forward - reverse. For
             'magnitude' the value is a tuple indicating the maximum magnitude of values found in
             Jfwd, Jrev, and Jfd.
         """

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6939,7 +6939,7 @@ class System(object, metaclass=SystemMetaclass):
                 stepstrs = [""]
 
             fd_desc = f"{fd_opts['method']}:{fd_opts['form']}"
-            parts.append(f"  {sys_name.rpartition('.')[-1]}: {of} wrt {wrt}")
+            parts.append(f"  {sys_name}: {of} wrt {wrt}")
             if not isinstance(of, tuple) and lcons and of.strip("'") in lcons:
                 parts[-1] += " (Linear constraint)"
             parts.append('')

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -7184,8 +7184,6 @@ class System(object, metaclass=SystemMetaclass):
                                                err_desc])
                         assert abs_err.fwd_rev is None
                         assert rel_err.fwd_rev is None
-                        assert abs_err.rev is None
-                        assert rel_err.rev is None
 
                     # See if this subjacobian has the greater error in the derivative computation
                     # compared to the other subjacobians so far
@@ -7326,7 +7324,7 @@ def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):
         steps = derivative_info['steps']
     except KeyError:
         # this can happen when a partial is not declared, which means it should be zero
-        fdinfo = (np.zeros(1),)
+        fdinfo = (None,)
         steps = (None,)
 
     derivative_info['abs error'] = []
@@ -7378,6 +7376,10 @@ def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):
             if Jreverse is not None:
                 (abs_errs.rev, abs_mags.fd, abs_mags.rev,
                  rel_errs.rev, rel_mags.fd, rel_mags.rev) = get_errors_and_mags(fd, Jreverse)
+
+        if fd is not None and Jforward is None and Jreverse is None:
+            (abs_errs.rev, abs_mags.fd, abs_mags.rev,
+             rel_errs.rev, rel_mags.fd, rel_mags.rev) = get_errors_and_mags(fd, np.zeros_like(fd))
 
         derivative_info['abs error'].append(abs_errs)
         derivative_info['rel error'].append(rel_errs)

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6950,7 +6950,7 @@ class System(object, metaclass=SystemMetaclass):
 
             fd_desc = f"{fd_opts['method']}:{fd_opts['form']}"
             for i in range(len(magnitudes)):
-                sys_buffer.write(f'          Fd Magnitude: '
+                sys_buffer.write('          Fd Magnitude: '
                                  f'{magnitudes[i].fd:.6e} ({fd_desc}{stepstrs[i]})\n')
             sys_buffer.write('\n')
 
@@ -6963,7 +6963,7 @@ class System(object, metaclass=SystemMetaclass):
 
                     if abs_errs[i].rev is not None:
                         err = _format_error(abs_errs[i].rev, abs_error_tol)
-                        sys_buffer.write(f'    Absolute Error ([rev, fd] Dot Product Test)'
+                        sys_buffer.write('    Absolute Error ([rev, fd] Dot Product Test)'
                                          f'{stepstrs[i]} : {err}\n')
                 else:
                     if abs_errs[i].fwd is not None:
@@ -6977,7 +6977,7 @@ class System(object, metaclass=SystemMetaclass):
             if directional:
                 if abs_errs[0].fwd_rev is not None:
                     err = _format_error(abs_errs[0].fwd_rev, abs_error_tol)
-                    sys_buffer.write('    Absolute Error ([rev, for] Dot Product Test) : {err}\n')
+                    sys_buffer.write(f'    Absolute Error ([rev, for] Dot Product Test) : {err}\n')
             else:
                 if abs_errs[0].fwd_rev is not None:
                     err = _format_error(abs_errs[0].fwd_rev, abs_error_tol)
@@ -7065,15 +7065,15 @@ class System(object, metaclass=SystemMetaclass):
                 for i in range(len(magnitudes)):
                     fd = fds[i]
 
+                    Jstr = textwrap.indent(str(fd), '    ')
                     if directional:
                         if totals and magnitudes[i].rev is not None:
                             sys_buffer.write(f'    Directional {fdtype} Derivative (Jfd) '
-                                             f'Dot Product{stepstrs[i]}\n    {fd}\n\n')
+                                             f'Dot Product{stepstrs[i]}\n{Jstr}\n\n')
                         else:
                             sys_buffer.write(f"    Directional {fdtype} Derivative (Jfd)"
-                                             f"{stepstrs[i]}\n    {fd}\n\n")
+                                             f"{stepstrs[i]}\n{Jstr}\n\n")
                     else:
-                        Jstr = textwrap.indent(str(fd), '    ')
                         sys_buffer.write(f"    Raw {fdtype} Derivative (Jfd){stepstrs[i]}"
                                          f"\n{Jstr}\n\n")
 

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6859,7 +6859,7 @@ class System(object, metaclass=SystemMetaclass):
 
         print(f"{add_border(title, '-')}\n", file=sys_buffer)
 
-        for key, max_mag, fd_opts, directional, above_abs, above_rel, inconsistent in err_iter:
+        for key, _, fd_opts, directional, above_abs, above_rel, inconsistent in err_iter:
 
             if above_abs or above_rel or inconsistent:
                 num_bad_jacs += 1

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -28,7 +28,7 @@ from openmdao.utils.options_dictionary import OptionsDictionary
 from openmdao.utils.record_util import create_local_meta, check_path, has_match
 from openmdao.utils.units import is_compatible, unit_conversion, simplify_unit
 from openmdao.utils.variable_table import write_var_table, NA
-from openmdao.utils.array_utils import evenly_distrib_idxs, shape_to_len, get_errors_and_mags
+from openmdao.utils.array_utils import evenly_distrib_idxs, shape_to_len, get_errors
 from openmdao.utils.name_maps import name2abs_name, name2abs_names
 from openmdao.utils.coloring import _compute_coloring, Coloring, \
     _STD_COLORING_FNAME, _DEF_COMP_SPARSITY_ARGS, _ColSparsityJac
@@ -7384,11 +7384,11 @@ def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):
                 mhatdotm, dhatdotd = derivative_info['directional_fwd_rev']
                 (abs_errs.fwd_rev, abs_mags.reverse, abs_mags.forward,
                  rel_errs.fwd_rev, rel_mags.reverse, rel_mags.forward, didx) = \
-                    get_errors_and_mags(mhatdotm, dhatdotd)
+                    get_errors(mhatdotm, dhatdotd)
         elif not totals:
             (abs_errs.fwd_rev, abs_mags.forward, abs_mags.reverse,
              rel_errs.fwd_rev, rel_mags.forward, rel_mags.reverse, didx) = \
-                get_errors_and_mags(Jforward, Jreverse)
+                get_errors(Jforward, Jreverse)
 
     for i, fd in enumerate(fdinfo):
         step = steps[i]
@@ -7399,17 +7399,17 @@ def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):
                     mhatdotm, dhatdotd = derivative_info['directional_fd_fwd'][i]
                     (abs_errs.forward, abs_mags.forward, abs_mags.fd,
                      rel_errs.forward, rel_mags.forward, rel_mags.fd, didx) = \
-                        get_errors_and_mags(mhatdotm, dhatdotd)
+                        get_errors(mhatdotm, dhatdotd)
                 else:
                     (abs_errs.forward, abs_mags.fd, abs_mags.forward,
                      rel_errs.forward, rel_mags.fd, rel_mags.forward, didx) = \
-                        get_errors_and_mags(fd, Jforward)
+                        get_errors(fd, Jforward)
 
             if Jreverse is not None:
                 mhatdotm, dhatdotd = derivative_info['directional_fd_rev'][i]
                 (abs_errs.reverse, abs_mags.fd, abs_mags.reverse,
                  rel_errs.reverse, rel_mags.fd, rel_mags.reverse, didx) = \
-                    get_errors_and_mags(mhatdotm, dhatdotd)
+                    get_errors(mhatdotm, dhatdotd)
                 if not totals:
                     rel_mags.reverse = None
                     abs_mags.reverse = None
@@ -7417,17 +7417,17 @@ def _compute_deriv_errors(derivative_info, matrix_free, directional, totals):
             if Jforward is not None:
                 (abs_errs.forward, abs_mags.fd, abs_mags.forward,
                  rel_errs.forward, rel_mags.fd, rel_mags.forward, didx) = \
-                    get_errors_and_mags(fd, Jforward)
+                    get_errors(fd, Jforward)
 
             if Jreverse is not None:
                 (abs_errs.reverse, abs_mags.fd, abs_mags.reverse,
                  rel_errs.reverse, rel_mags.fd, rel_mags.reverse, didx) = \
-                    get_errors_and_mags(fd, Jreverse)
+                    get_errors(fd, Jreverse)
 
         if fd is not None and Jforward is None and Jreverse is None:
             (abs_errs.reverse, abs_mags.fd, abs_mags.reverse,
              rel_errs.reverse, rel_mags.fd, rel_mags.reverse, didx) = \
-                get_errors_and_mags(fd, np.zeros_like(fd))
+                get_errors(fd, np.zeros_like(fd))
 
         derivative_info['abs error'].append(abs_errs)
         derivative_info['rel error'].append(rel_errs)

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1971,35 +1971,36 @@ y wrt x                     | abs         | fd-fwd | 2.000000000279556
         for line1, line2 in zip_longest(ctx.exception.args[0].strip().split('\n'), expected.split('\n'), fillvalue=''):
             assert snum_equal(line1.strip(), line2.strip()), f"line1: {line1}, line2: {line2}"
 
-    # def test_zero_analytic_zero_fd(self):
-    #     # Test that we can check a component that has a zero analytic and fd derivative.
+    def test_zero_analytic_zero_fd(self):
+        # Test that we can check a component that has a zero analytic and fd derivative.
 
-    #     class ZeroAnalyticComp(om.ExplicitComponent):
+        class ZeroAnalyticComp(om.ExplicitComponent):
 
-    #         def setup(self):
-    #             self.add_input('x', val=3.0)
-    #             self.add_output('y', val=4.0)
+            def setup(self):
+                self.add_input('x', val=3.0)
+                self.add_output('y', val=4.0)
 
-    #             self.declare_partials('*', '*')
+                self.declare_partials('*', '*')
 
-    #         def compute(self, inputs, outputs):
-    #             pass
+            def compute(self, inputs, outputs):
+                pass
 
-    #         def compute_partials(self, inputs, partials):
-    #             pass
+            def compute_partials(self, inputs, partials):
+                pass
 
-    #     prob = om.Problem()
+        prob = om.Problem()
 
-    #     prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.5))
-    #     prob.model.add_subsystem('comp', ZeroAnalyticComp())
-    #     prob.model.connect('p1.x', 'comp.x')
+        prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.5))
+        prob.model.add_subsystem('comp', ZeroAnalyticComp())
+        prob.model.connect('p1.x', 'comp.x')
 
-    #     prob.setup()
+        prob.setup()
+        prob.run_model()
 
-    #     stream = StringIO()
-    #     data = prob.check_partials(out_stream=stream)
-    #     content = stream.getvalue()
-    #     raise RuntimeError("FOO")
+        msg = "Component 'comp' has zero derivatives for the following variable pairs that were declared as 'dependent': [('y', 'x')]."
+
+        with assert_warning(UserWarning, msg):
+            prob.check_partials(out_stream=None, compact_print=True)
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -345,15 +345,15 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         abs_error = data['comp']['y', 'x1']['abs error']
         rel_error = data['comp']['y', 'x1']['rel error']
-        self.assertAlmostEqual(abs_error.forward, 0.)
-        self.assertAlmostEqual(rel_error.forward, 0.)
+        self.assertAlmostEqual(abs_error.fwd, 0.)
+        self.assertAlmostEqual(rel_error.fwd, 0.)
         self.assertAlmostEqual(np.linalg.norm(data['comp']['y', 'x1']['J_fd'] - 3.), 0.,
                                delta=1e-6)
 
         abs_error = data['comp']['y', 'x2']['abs error']
         rel_error = data['comp']['y', 'x2']['rel error']
-        self.assertAlmostEqual(abs_error.forward, 4.)
-        self.assertAlmostEqual(rel_error.forward, 1.)
+        self.assertAlmostEqual(abs_error.fwd, 4.)
+        self.assertAlmostEqual(rel_error.fwd, 1.)
         self.assertAlmostEqual(np.linalg.norm(data['comp']['y', 'x2']['J_fd'] - 4.), 0.,
                                delta=1e-6)
 
@@ -2332,11 +2332,11 @@ class TestCheckPartialsFeature(unittest.TestCase):
 
         x1_error = data['comp']['y', 'x1']['abs error']
 
-        assert_near_equal(x1_error.forward, 1., 1e-8)
+        assert_near_equal(x1_error.fwd, 1., 1e-8)
 
         x2_error = data['comp']['y', 'x2']['rel error']
 
-        assert_near_equal(x2_error.forward, 9., 1e-8)
+        assert_near_equal(x2_error.fwd, 9., 1e-8)
 
     def test_feature_check_partials_suppress(self):
 

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -197,12 +197,12 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         y_wrt_x1_line = lines.index("  comp: 'y' wrt 'x1'")
 
-        self.assertTrue(lines[y_wrt_x1_line+4].endswith('*'),
+        self.assertTrue(lines[y_wrt_x1_line+2].endswith('*'),
                         msg='Error flag expected in output but not displayed')
         self.assertTrue(lines[y_wrt_x1_line+6].endswith('*'),
                         msg='Error flag expected in output but not displayed')
         y_wrt_x2_line = lines.index("  comp: 'y' wrt 'x2'")
-        self.assertTrue(lines[y_wrt_x2_line+4].endswith('*'),
+        self.assertTrue(lines[y_wrt_x2_line+2].endswith('*'),
                         msg='Error flag not expected in output but displayed')
         self.assertTrue(lines[y_wrt_x2_line+6].endswith('*'),
                         msg='Error flag not expected in output but displayed')
@@ -353,7 +353,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         abs_error = data['comp']['y', 'x2']['abs error']
         rel_error = data['comp']['y', 'x2']['rel error']
         self.assertAlmostEqual(abs_error.forward, 4.)
-        self.assertAlmostEqual(rel_error.forward, 1.)
+        self.assertAlmostEqual(rel_error.forward, 4.)
         self.assertAlmostEqual(np.linalg.norm(data['comp']['y', 'x2']['J_fd'] - 4.), 0.,
                                delta=1e-6)
 
@@ -972,9 +972,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.check_partials(out_stream=stream)
 
         lines = stream.getvalue().splitlines()
-        self.assertTrue('cs' in lines[6],
+        self.assertTrue('CS' in lines[17],
                         msg='Did you change the format for printing check derivs?')
-        self.assertTrue('fd' in lines[21],
+        self.assertTrue('FD' in lines[35],
                         msg='Did you change the format for printing check derivs?')
 
     def test_set_check_partial_options_invalid(self):
@@ -1203,13 +1203,13 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.check_partials(out_stream=stream, abs_err_tol=1.1e-6, compact_print=True)
 
         self.assertEqual(stream.getvalue().count('n/a'), 0)
-        self.assertEqual(stream.getvalue().count('rev'), 6)
+        self.assertEqual(stream.getvalue().count('rev'), 8)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 12) # counts rows (including headers)
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=False)
-        self.assertEqual(stream.getvalue().count('Reverse Magnitude'), 4)
+        self.assertEqual(stream.getvalue().count('rev value:'), 16)
         self.assertEqual(stream.getvalue().count('Raw Reverse Derivative'), 4)
         self.assertEqual(stream.getvalue().count('Jrev'), 20)
 
@@ -1242,8 +1242,8 @@ class TestProblemCheckPartials(unittest.TestCase):
         stream = StringIO()
         partials_data = prob.check_partials(out_stream=stream, compact_print=False)
         # So for this case, they do all provide them, so rev should not be shown
-        self.assertEqual(stream.getvalue().count('Forward Magnitude'), 2)
-        self.assertEqual(stream.getvalue().count('Reverse Magnitude'), 0)
+        self.assertEqual(stream.getvalue().count('fwd value'), 4)
+        self.assertEqual(stream.getvalue().count('rev value'), 0)
         self.assertEqual(stream.getvalue().count('Absolute Error'), 2)
         self.assertEqual(stream.getvalue().count('Relative Error'), 2)
         self.assertEqual(stream.getvalue().count('Raw Forward Derivative'), 2)
@@ -1264,11 +1264,11 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.run_model()
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
-        self.assertEqual(stream.getvalue().count('rev'), 12)
+        self.assertEqual(stream.getvalue().count('rev'), 16)
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=False)
-        self.assertEqual(stream.getvalue().count('Reverse'), 4)
+        self.assertEqual(stream.getvalue().count('Reverse'), 2)
         self.assertEqual(stream.getvalue().count('Jrev'), 10)
 
         # 4: Mixed comps. Some with jacobians. Some not
@@ -1289,14 +1289,14 @@ class TestProblemCheckPartials(unittest.TestCase):
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
         self.assertEqual(stream.getvalue().count('n/a'), 0)
-        self.assertEqual(stream.getvalue().count('rev'), 12)
+        self.assertEqual(stream.getvalue().count('rev'), 16)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 8)
 
         stream = StringIO()
         partials_data = prob.check_partials(out_stream=stream, compact_print=False)
-        self.assertEqual(stream.getvalue().count('Forward Magnitude'), 4)
-        self.assertEqual(stream.getvalue().count('Reverse Magnitude'), 2)
+        self.assertEqual(stream.getvalue().count('fwd value:'), 12)
+        self.assertEqual(stream.getvalue().count('rev value'), 8)
         self.assertEqual(stream.getvalue().count('Absolute Error'), 8)
         self.assertEqual(stream.getvalue().count('Relative Error'), 8)
         self.assertEqual(stream.getvalue().count('Raw Forward Derivative'), 4)
@@ -1486,9 +1486,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         lines = stream.getvalue().splitlines()
 
         entries = [s.strip() for s in lines[7].split('|') if s.strip()]
-        self.assertEqual(entries[3], 'n/a')
-        self.assertEqual(entries[9], 'n/a')
-        assert_near_equal(float(entries[11]), 0.0, 1e-15)
+        assert_near_equal(float(entries[19]), 0.0, 4e-15)
 
     def test_directional_mixed_matrix_free(self):
 
@@ -1815,7 +1813,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.check_partials(out_stream=stream)
         lines = stream.getvalue().splitlines()
 
-        self.assertTrue("Relative Error (Jfor - Jfd) / Jfor : 1." in lines[10])
+        self.assertTrue("Max Relative Error (Jfwd - Jfd) / Jfwd : 3." in lines[10])
 
     def test_directional_bug_implicit(self):
         # Test for bug in directional derivative direction for implicit var and matrix-free.
@@ -2825,10 +2823,10 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         nderivs = ncomps * 2
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
-        self.assertEqual(contents.count("Fd Magnitude:"), nderivs)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd), step="), 0)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd)"), nderivs)
-        self.assertEqual(contents.count("Relative Error (Jfor - Jfd) / Jf"), nderivs)
+        self.assertEqual(contents.count("fwd value:"), nderivs * 2)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd), step="), 0)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd)"), nderivs)
+        self.assertEqual(contents.count("Relative Error (Jfwd - Jfd) / Jf"), nderivs)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), 0)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd)"), nderivs)
 
@@ -2881,9 +2879,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         nderivs = ncomps * 2
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
-        self.assertEqual(contents.count("Fd Magnitude:"), nderivs * 2)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd), step="), nderivs * 2)
-        self.assertEqual(contents.count("Relative Error (Jfor - Jfd) / Jf"), nderivs * 2)
+        self.assertEqual(contents.count("fwd value:"), nderivs * 4)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd), step="), nderivs * 2)
+        self.assertEqual(contents.count("Relative Error (Jfwd - Jfd) / Jf"), nderivs * 2)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), nderivs * 2)
 
     def test_multi_fd_steps_compact(self):

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -713,7 +713,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # This will fail unless you set the check_step.
         x_error = data['comp']['f_xy', 'x']['rel error']
-        self.assertLess(x_error.forward, 1e-5)
+        self.assertLess(x_error.fwd, 1e-5)
 
     def test_set_step_global(self):
         prob = om.Problem()
@@ -734,7 +734,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # This will fail unless you set the global step.
         x_error = data['comp']['f_xy', 'x']['rel error']
-        self.assertLess(x_error.forward, 1e-5)
+        self.assertLess(x_error.fwd, 1e-5)
 
     def test_complex_step_not_allocated(self):
         prob = om.Problem()
@@ -829,7 +829,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # This will fail unless you set the check_step.
         x_error = data['comp']['f_xy', 'x']['rel error']
-        self.assertLess(x_error.forward, 1e-3)
+        self.assertLess(x_error.fwd, 1e-3)
 
     def test_set_form_global(self):
         prob = om.Problem()
@@ -850,7 +850,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # This will fail unless you set the check_step.
         x_error = data['comp']['f_xy', 'x']['rel error']
-        self.assertLess(x_error.forward, 1e-3)
+        self.assertLess(x_error.fwd, 1e-3)
 
     def test_set_step_calc_on_comp(self):
         prob = om.Problem()
@@ -873,7 +873,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # This will fail unless you set the check_step.
         x_error = data['comp']['f_xy', 'x']['rel error']
-        self.assertLess(x_error.forward, 3e-3)
+        self.assertLess(x_error.fwd, 3e-3)
 
     def test_set_step_calc_global(self):
         prob = om.Problem()
@@ -894,7 +894,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         # This will fail unless you set the global step.
         x_error = data['comp']['f_xy', 'x']['rel error']
-        self.assertLess(x_error.forward, 3e-3)
+        self.assertLess(x_error.fwd, 3e-3)
 
     def test_set_check_option_precedence(self):
         # Test that we omit derivs declared with dependent=False

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -649,9 +649,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         data = prob.check_partials(out_stream=stream, compact_print=True)
         txt = stream.getvalue()
 
-        self.assertTrue("'g'             | 'z'" in txt)
+        self.assertTrue("g             | z" in txt)
         self.assertTrue(('g', 'z') in data['comp'])
-        self.assertTrue("'g'             | 'x'" in txt)
+        self.assertTrue("g             | x" in txt)
         self.assertTrue(('g', 'x') in data['comp'])
 
     def test_dependent_false_show(self):
@@ -1203,7 +1203,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.check_partials(out_stream=stream, abs_err_tol=1.1e-6, compact_print=True)
 
         self.assertEqual(stream.getvalue().count('n/a'), 0)
-        self.assertEqual(stream.getvalue().count('rev'), 5)
+        self.assertEqual(stream.getvalue().count('rev'), 6)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 12) # counts rows (including headers)
 
@@ -1264,7 +1264,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.run_model()
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
-        self.assertEqual(stream.getvalue().count('rev'), 10)
+        self.assertEqual(stream.getvalue().count('rev'), 12)
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=False)
@@ -1289,7 +1289,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
         self.assertEqual(stream.getvalue().count('n/a'), 0)
-        self.assertEqual(stream.getvalue().count('rev'), 10)
+        self.assertEqual(stream.getvalue().count('rev'), 12)
         self.assertEqual(stream.getvalue().count('Component'), 2)
         self.assertEqual(len([ln for ln in stream.getvalue().splitlines() if ln.startswith('| ')]), 8)
 
@@ -1330,7 +1330,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
-        self.assertEqual(stream.getvalue().count("'z'             | 'y1'"), 2)
+        self.assertEqual(stream.getvalue().count("z             | y1"), 2)
 
     def test_check_partials_show_only_incorrect(self):
         # The second is adding an option to show only the incorrect subjacs
@@ -1356,7 +1356,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True, show_only_incorrect=True)
         self.assertEqual(stream.getvalue().count("MyCompBadPartials"), 2)
-        self.assertEqual(stream.getvalue().count("'z'             | 'y1'"), 2)
+        self.assertEqual(stream.getvalue().count("z             | y1"), 2)
         self.assertEqual(stream.getvalue().count("MyCompGoodPartials"), 0)
 
         stream = StringIO()
@@ -1430,8 +1430,8 @@ class TestProblemCheckPartials(unittest.TestCase):
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=True)
         output = stream.getvalue()
-        self.assertTrue("(d)'x1'" in output)
-        self.assertTrue("(d)'x2'" in output)
+        self.assertTrue("(d) x1" in output)
+        self.assertTrue("(d) x2" in output)
 
     def test_directional_derivative_option_complex_step(self):
 
@@ -1485,7 +1485,9 @@ class TestProblemCheckPartials(unittest.TestCase):
         J = prob.check_partials(method='cs', out_stream=stream, compact_print=True)
         lines = stream.getvalue().splitlines()
 
-        self.assertEqual(lines[7][53:56], 'n/a')
+        entries = [s.strip() for s in lines[7].split('|') if s.strip()]
+        self.assertEqual(entries[3], 'n/a')
+        self.assertEqual(entries[9], 'n/a')
         assert_near_equal(float(lines[7][121:131]), 0.0, 1e-15)
 
     def test_directional_mixed_matrix_free(self):
@@ -1968,6 +1970,36 @@ y wrt x                     | abs         | fd-fwd | 2.000000000279556
 
         for line1, line2 in zip_longest(ctx.exception.args[0].strip().split('\n'), expected.split('\n'), fillvalue=''):
             assert snum_equal(line1.strip(), line2.strip()), f"line1: {line1}, line2: {line2}"
+
+    # def test_zero_analytic_zero_fd(self):
+    #     # Test that we can check a component that has a zero analytic and fd derivative.
+
+    #     class ZeroAnalyticComp(om.ExplicitComponent):
+
+    #         def setup(self):
+    #             self.add_input('x', val=3.0)
+    #             self.add_output('y', val=4.0)
+
+    #             self.declare_partials('*', '*')
+
+    #         def compute(self, inputs, outputs):
+    #             pass
+
+    #         def compute_partials(self, inputs, partials):
+    #             pass
+
+    #     prob = om.Problem()
+
+    #     prob.model.add_subsystem('p1', om.IndepVarComp('x', 3.5))
+    #     prob.model.add_subsystem('comp', ZeroAnalyticComp())
+    #     prob.model.connect('p1.x', 'comp.x')
+
+    #     prob.setup()
+
+    #     stream = StringIO()
+    #     data = prob.check_partials(out_stream=stream)
+    #     content = stream.getvalue()
+    #     raise RuntimeError("FOO")
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
@@ -2815,9 +2847,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         self.assertEqual(len(tables[1]), 7)
         self.assertEqual(len(tables[2]), 5)
         # check cols
-        self.assertEqual(tables[0][0].count('+'), 8)
-        self.assertEqual(tables[1][0].count('+'), 8)
-        self.assertEqual(tables[2][0].count('+'), 7)
+        self.assertEqual(tables[0][0].count('+'), 10)
+        self.assertEqual(tables[1][0].count('+'), 10)
+        self.assertEqual(tables[2][0].count('+'), 9)
 
     def test_single_cs_step_compact(self):
         p = self.setup_model()
@@ -2835,9 +2867,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         self.assertEqual(len(tables[1]), 7)
         self.assertEqual(len(tables[2]), 5)
         # check cols
-        self.assertEqual(tables[0][0].count('+'), 8)
-        self.assertEqual(tables[1][0].count('+'), 8)
-        self.assertEqual(tables[2][0].count('+'), 7)
+        self.assertEqual(tables[0][0].count('+'), 10)
+        self.assertEqual(tables[1][0].count('+'), 10)
+        self.assertEqual(tables[2][0].count('+'), 9)
 
     def test_multi_fd_steps(self):
         p = self.setup_model()
@@ -2869,9 +2901,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         self.assertEqual(len(tables[1]), 11)
         self.assertEqual(len(tables[2]), 5)
         # check cols
-        self.assertEqual(tables[0][0].count('+'), 9)
-        self.assertEqual(tables[1][0].count('+'), 9)
-        self.assertEqual(tables[2][0].count('+'), 8)
+        self.assertEqual(tables[0][0].count('+'), 11)
+        self.assertEqual(tables[1][0].count('+'), 11)
+        self.assertEqual(tables[2][0].count('+'), 10)
 
     def test_multi_cs_steps_compact(self):
         p = self.setup_model()
@@ -2889,9 +2921,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         self.assertEqual(len(tables[1]), 11)
         self.assertEqual(len(tables[2]), 5)
         # check cols
-        self.assertEqual(tables[0][0].count('+'), 9)
-        self.assertEqual(tables[1][0].count('+'), 9)
-        self.assertEqual(tables[2][0].count('+'), 8)
+        self.assertEqual(tables[0][0].count('+'), 11)
+        self.assertEqual(tables[1][0].count('+'), 11)
+        self.assertEqual(tables[2][0].count('+'), 10)
 
     def test_multi_fd_steps_compact_directional(self):
         p = self.setup_model(directional=True)
@@ -2909,9 +2941,9 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         self.assertEqual(len(tables[1]), 11)
         self.assertEqual(len(tables[2]), 5)
         # check cols
-        self.assertEqual(tables[0][0].count('+'), 9)
-        self.assertEqual(tables[1][0].count('+'), 9)
-        self.assertEqual(tables[2][0].count('+'), 8)
+        self.assertEqual(tables[0][0].count('+'), 11)
+        self.assertEqual(tables[1][0].count('+'), 11)
+        self.assertEqual(tables[2][0].count('+'), 10)
 
 
 if __name__ == "__main__":

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -353,7 +353,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         abs_error = data['comp']['y', 'x2']['abs error']
         rel_error = data['comp']['y', 'x2']['rel error']
         self.assertAlmostEqual(abs_error.forward, 4.)
-        self.assertAlmostEqual(rel_error.forward, 4.)
+        self.assertTrue(np.isnan(rel_error.forward))
         self.assertAlmostEqual(np.linalg.norm(data['comp']['y', 'x2']['J_fd'] - 4.), 0.,
                                delta=1e-6)
 
@@ -1813,7 +1813,7 @@ class TestProblemCheckPartials(unittest.TestCase):
         prob.check_partials(out_stream=stream)
         lines = stream.getvalue().splitlines()
 
-        self.assertTrue("Max Relative Error (Jfwd - Jfd) / Jfwd : 3." in lines[10])
+        self.assertTrue("Max Relative Error (Jfwd - Jfd) / Jfwd : nan" in lines[10])
 
     def test_directional_bug_implicit(self):
         # Test for bug in directional derivative direction for implicit var and matrix-free.

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1995,7 +1995,7 @@ y wrt x                     | abs         | fd-fwd | 2.000000000279556
         prob.setup()
         prob.run_model()
 
-        msg = "Component 'comp' has zero derivatives for the following variable pairs that were declared as 'dependent': [('y', 'x')]."
+        msg = "\nComponent 'comp' has zero derivatives for the following variable pairs that were declared as 'dependent': [('y', 'x')].\n"
 
         with assert_warning(UserWarning, msg):
             prob.check_partials(out_stream=None, compact_print=True)

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -434,8 +434,8 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         self.assertTrue("of '<variable>'" in compact_lines[5],
             "of '<variable>' not found in '%s'" % compact_lines[5])
-        self.assertTrue('9.7743e+00' in compact_lines[-2],
-            "'9.7743e+00' not found in '%s'" % compact_lines[-2])
+        self.assertTrue('9.6100e+00' in compact_lines[-2],
+            "'9.6100e+00' not found in '%s'" % compact_lines[-2])
 
     def test_check_totals_show_progress(self):
         prob = om.Problem()

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -2136,7 +2136,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-------------------------------+------------------+-------------+-------------+-------------+-------------+-------------+--------------------+"), (nsubjacs*2) + 1)
+                self.assertEqual(contents.count("+-------------------------------+------------------+-------------+-------------+-------------+-------------+-------------+------------+"), (nsubjacs*2) + 1)
 
     def test_multi_cs_steps_compact(self):
         for mode in ('fwd', 'rev'):

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -419,9 +419,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         # Make sure auto-ivc sources are translated to promoted input names.
         self.assertTrue('x' in lines[4])
 
-        self.assertTrue('9.80614' in lines[5], "'9.80614' not found in '%s'" % lines[5])
-        self.assertTrue('9.80614' in lines[6], "'9.80614' not found in '%s'" % lines[6])
-        self.assertTrue('cs:None' in lines[6], "'cs:None not found in '%s'" % lines[6])
+        self.assertTrue('9.80614' in lines[7], "'9.80614' not found in '%s'" % lines[5])
+        self.assertTrue('9.80614' in lines[8], "'9.80614' not found in '%s'" % lines[6])
+        self.assertTrue('cs:None' in lines[8], "'cs:None not found in '%s'" % lines[6])
 
         assert_near_equal(totals['con2', 'x']['J_fwd'], [[0.09692762]], 1e-5)
         assert_near_equal(totals['con2', 'x']['J_fd'], [[0.09692762]], 1e-5)
@@ -501,9 +501,9 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         lines = stream.getvalue().splitlines()
 
-        self.assertTrue('1.000' in lines[5])
-        self.assertTrue('1.000' in lines[6])
-        self.assertTrue('0.000' in lines[8])
+        self.assertTrue('1.000' in lines[7])
+        self.assertTrue('1.000' in lines[8])
+        self.assertTrue('0.000' in lines[6])
         self.assertTrue('0.000' in lines[10])
 
         assert_near_equal(totals['x', 'x']['J_fwd'], [[1.0]], 1e-5)
@@ -1219,8 +1219,8 @@ class TestProblemCheckTotals(unittest.TestCase):
         lines = stream.getvalue().splitlines()
 
         self.assertTrue("Full Model: 'lcy' wrt 'x' (Linear constraint)" in lines[4])
-        self.assertTrue("Absolute Error (Jfor - Jfd)" in lines[8])
-        self.assertTrue("Relative Error (Jfor - Jfd) / Jfd" in lines[10])
+        self.assertTrue("Absolute Error (Jfwd - Jfd)" in lines[6])
+        self.assertTrue("Relative Error (Jfwd - Jfd) / Jfd" in lines[10])
 
     def test_alias_constraints(self):
         prob = om.Problem()
@@ -1377,13 +1377,13 @@ class TestProblemCheckTotals(unittest.TestCase):
         data = prob.check_totals(method='cs', out_stream=stream, directional=True)
         content = stream.getvalue()
 
-        self.assertEqual(content.count('Reverse Magnitude:'), 0)
-        self.assertEqual(content.count('Forward Magnitude:'), 1)
-        self.assertEqual(content.count('Fd Magnitude:'), 1)
-        self.assertEqual(content.count('Directional Derivative (Jfor)'), 1)
+        self.assertEqual(content.count('rev value:'), 0)
+        self.assertEqual(content.count('fwd value:'), 2)
+        self.assertEqual(content.count('fd value:'), 2)
+        self.assertEqual(content.count('Directional Derivative (Jfwd)'), 1)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
-        self.assertTrue('Relative Error (Jfor - Jfd) / Jfd : ' in content)
-        self.assertTrue('Absolute Error (Jfor - Jfd) : ' in content)
+        self.assertTrue('Max Relative Error (Jfwd - Jfd) / Jfd : ' in content)
+        self.assertTrue('Max Absolute Error (Jfwd - Jfd) : ' in content)
         mhatdotm, dhatdotd =  data[(('comp.out',), 'comp.in')]['directional_fd_fwd']
         assert_near_equal(mhatdotm, dhatdotd, tolerance=2e-15)
 
@@ -1402,9 +1402,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         content = stream.getvalue()
 
         self.assertEqual(content.count('comp.out (index size: 1)'), 1)
-        self.assertEqual(content.count('Reverse Magnitude:'), 1)
-        self.assertEqual(content.count('Forward Magnitude:'), 0)
-        self.assertEqual(content.count('Fd Magnitude:'), 1)
+        self.assertEqual(content.count('rev value:'), 2)
+        self.assertEqual(content.count('fwd value:'), 0)
+        self.assertEqual(content.count('fd value:'), 2)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 1)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Relative Error ([rev, fd] Dot Product Test) / Jfd : ' in content)
@@ -1427,9 +1427,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         content = stream.getvalue()
 
         self.assertEqual(content.count("'comp.out' wrt (d)('comp.in',)"), 1)
-        self.assertEqual(content.count('Reverse Magnitude:'), 1)
-        self.assertEqual(content.count('Forward Magnitude:'), 0)
-        self.assertEqual(content.count('Fd Magnitude:'), 1)
+        self.assertEqual(content.count('rev value:'), 2)
+        self.assertEqual(content.count('fwd value:'), 0)
+        self.assertEqual(content.count('fd value:'), 2)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 1)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Relative Error ([rev, fd] Dot Product Test) / Jfd : ' in content)
@@ -1455,9 +1455,9 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         self.assertEqual(content.count("'comp.out1' wrt (d)('comp.in1', 'comp.in2')"), 1)
         self.assertEqual(content.count("'comp.out2' wrt (d)('comp.in1', 'comp.in2')"), 1)
-        self.assertEqual(content.count('Reverse Magnitude:'), 2)
-        self.assertEqual(content.count('Forward Magnitude:'), 0)
-        self.assertEqual(content.count('Fd Magnitude:'), 2)
+        self.assertEqual(content.count('rev value:'), 4)
+        self.assertEqual(content.count('fwd value:'), 0)
+        self.assertEqual(content.count('fd value:'), 4)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 2)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 2)
         self.assertTrue(content.count('Relative Error ([rev, fd] Dot Product Test) / Jfd :'), 2)
@@ -1506,11 +1506,11 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         self.assertEqual(content.count("('comp.out1', 'comp.out2') wrt (d)'comp.in1'"), 1)
         self.assertEqual(content.count("('comp.out1', 'comp.out2') wrt (d)'comp.in2'"), 1)
-        self.assertEqual(content.count('Reverse Magnitude:'), 0)
-        self.assertEqual(content.count('Forward Magnitude:'), 2)
-        self.assertEqual(content.count('Fd Magnitude:'), 2)
+        self.assertEqual(content.count('rev value:'), 0)
+        self.assertEqual(content.count('fwd value:'), 4)
+        self.assertEqual(content.count('fd value:'), 4)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 0)
-        self.assertEqual(content.count('Directional Derivative (Jfor)'), 2)
+        self.assertEqual(content.count('Directional Derivative (Jfwd)'), 2)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 2)
         self.assertEqual(content.count('Relative Error ([rev, fd] Dot Product Test) / Jfd :'), 0)
         self.assertEqual(content.count('Absolute Error ([rev, fd] Dot Product Test) :'), 0)
@@ -2019,10 +2019,10 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("Fd Magnitude:"), nsubjacs)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd), step="), 0)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd)"), nsubjacs)
-        self.assertEqual(contents.count("Relative Error (Jfor - Jfd) / Jf"), nsubjacs)
+        self.assertEqual(contents.count("fd value:"), nsubjacs * 2)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd), step="), 0)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd)"), nsubjacs)
+        self.assertEqual(contents.count("Relative Error (Jfwd - Jfd) / Jf"), nsubjacs)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), 0)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd)"), nsubjacs)
 
@@ -2035,7 +2035,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("Fd Magnitude:"), nsubjacs)
+        self.assertEqual(contents.count("fd value:"), nsubjacs * 2)
         self.assertEqual(contents.count("Absolute Error (Jrev - Jfd), step="), 0)
         self.assertEqual(contents.count("Absolute Error (Jrev - Jfd)"), nsubjacs)
         self.assertEqual(contents.count("Relative Error (Jrev - Jfd) / J"), nsubjacs)
@@ -2054,7 +2054,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 0)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+--------------+-------------+-------------+--------------+-------------+--------------------+"), nsubjacs + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+-------------+-------------+-------------+-------------+-------------+--------------------+"), nsubjacs + 1)
 
     def test_single_cs_step_compact(self):
         for mode in ('fwd', 'rev'):
@@ -2068,7 +2068,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 0)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+--------------+-------------+-------------+--------------+-------------+------------+"), nsubjacs + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+-------------+-------------+-------------+-------------+-------------+------------+"), nsubjacs + 1)
 
     def test_multi_fd_steps_fwd(self):
         p = om.Problem(model=CircleOpt(), driver=om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False))
@@ -2079,9 +2079,9 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("Fd Magnitude:"), nsubjacs * 2)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd), step="), nsubjacs * 2)
-        self.assertEqual(contents.count("Relative Error (Jfor - Jfd) / Jf"), nsubjacs * 2)
+        self.assertEqual(contents.count("fd value:"), nsubjacs * 4)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd), step="), nsubjacs * 2)
+        self.assertEqual(contents.count("Relative Error (Jfwd - Jfd) / Jf"), nsubjacs * 2)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), nsubjacs * 2)
 
     def test_multi_fd_steps_fwd_directional(self):
@@ -2092,9 +2092,9 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Full Model:"), 3)
-        self.assertEqual(contents.count("Fd Magnitude:"), 6)
-        self.assertEqual(contents.count("Absolute Error (Jfor - Jfd), step="), 6)
-        self.assertEqual(contents.count("Relative Error (Jfor - Jfd) / Jf"), 6)
+        self.assertEqual(contents.count("fd value:"), 12)
+        self.assertEqual(contents.count("Absolute Error (Jfwd - Jfd), step="), 6)
+        self.assertEqual(contents.count("Relative Error (Jfwd - Jfd) / Jf"), 6)
         self.assertEqual(contents.count("Directional FD Derivative (Jfd), step="), 6)
 
     def test_multi_fd_steps_rev(self):
@@ -2106,7 +2106,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = stream.getvalue()
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("Fd Magnitude:"), nsubjacs * 2)
+        self.assertEqual(contents.count("fd value:"), nsubjacs * 4)
         self.assertEqual(contents.count("Absolute Error (Jrev - Jfd), step="), nsubjacs * 2)
         self.assertEqual(contents.count("Relative Error (Jrev - Jfd) / J"), nsubjacs * 2)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), nsubjacs * 2)
@@ -2119,7 +2119,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
         contents = stream.getvalue()
         self.assertEqual(contents.count("Full Model:"), 6)
-        self.assertEqual(contents.count("Fd Magnitude:"), 12)
+        self.assertEqual(contents.count("fd value:"), 24)
         self.assertEqual(contents.count("Absolute Error ([rev, fd] Dot Product Test), step="), 12)
         self.assertEqual(contents.count("Relative Error ([rev, fd] Dot Product Test) / Jfd, step="), 12)
         self.assertEqual(contents.count("Directional FD Derivative (Jfd) Dot Product, step="), 12)
@@ -2131,12 +2131,12 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 p.setup(mode=mode)
                 p.run_model()
                 stream = StringIO()
-                p.check_totals(step=[1e-6, 1e-7], compact_print=True, out_stream=stream)
+                p.check_totals(step=[1e-6, 1e-7], compact_print=True, out_stream=stream, abs_err_tol=2e-6, rel_err_tol=3e-6)
                 contents = stream.getvalue()
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+-------------+--------------+-------------+-------------+--------------+-------------+------------+"), (nsubjacs*2) + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+------------+"), (nsubjacs*2) + 1)
 
     def test_multi_cs_steps_compact(self):
         for mode in ('fwd', 'rev'):
@@ -2150,7 +2150,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+-------------+--------------+-------------+-------------+--------------+-------------+------------+"), (nsubjacs*2) + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+-------------+-------------+-------------+-------------+-------------+-------------+-------------+------------+"), (nsubjacs*2) + 1)
 
     def test_multi_fd_steps_compact_directional(self):
         expected_divs = {

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -2147,7 +2147,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 stream = StringIO()
                 p.check_totals(method='cs', step=[1e-20, 1e-30], compact_print=True, out_stream=stream)
                 contents = stream.getvalue()
-                nsubjacs = 18
+                nsubjacs = 10
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
                 self.assertEqual(contents.count("+-----------------------------+-------------------+-------------+-------------+--------------+-------------+-------------+--------------+-------------+------------+"), (nsubjacs*2) + 1)

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -2150,7 +2150,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-------------------------------+------------------+-------------+-------------+-------------+-------------+-------------+------------+"), (nsubjacs*2) + 1)
+                self.assertEqual(contents.count("+-----------------------------+-------------------+-------------+-------------+--------------+-------------+-------------+--------------+-------------+------------+"), (nsubjacs*2) + 1)
 
     def test_multi_fd_steps_compact_directional(self):
         expected_divs = {

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -428,7 +428,7 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         # Test compact_print output
         compact_stream = StringIO()
-        assert_check_totals(prob.check_totals(method='fd', out_stream=compact_stream, compact_print=True))
+        assert_check_totals(prob.check_totals(method='cs', out_stream=compact_stream, compact_print=True))
 
         compact_lines = compact_stream.getvalue().splitlines()
 

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1487,7 +1487,8 @@ class _TotalJacInfo(object):
 
                 # if some of the wrt vars are distributed in fwd mode, we bcast from the rank
                 # where each part of the distrib var exists
-                if self.get_remote and mode == 'fwd' and self.has_wrt_dist:
+                if self.get_remote and mode == 'fwd' and self.has_wrt_dist and \
+                        self.dist_input_range_map:
                     for start, stop, rank in self.dist_input_range_map[mode]:
                         contig = self.J[:, start:stop].copy()
                         model.comm.Bcast(contig, root=rank)

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/scipy_iter_solver.ipynb
@@ -486,8 +486,8 @@
    },
    "outputs": [],
    "source": [
-    "assert_near_equal(prob.get_val('sub1.q1.x'), 1.996, .0001)\n",
-    "assert_near_equal(prob.get_val('sub2.q2.x'), 1.996, .0001)"
+    "assert_near_equal(prob.get_val('sub1.q1.x'), 0.99857318, .0001)\n",
+    "assert_near_equal(prob.get_val('sub2.q2.x'), 0.99857318, .0001)"
    ]
   }
  ],

--- a/openmdao/test_suite/components/quad_implicit.py
+++ b/openmdao/test_suite/components/quad_implicit.py
@@ -13,9 +13,9 @@ class QuadraticComp(om.ImplicitComponent):
 
     def setup(self):
         self.add_input('a', val=1.)
-        self.add_input('b', val=1.)
+        self.add_input('b', val=5.)
         self.add_input('c', val=1.)
-        self.add_output('x', val=0.)
+        self.add_output('x', val=1.)
 
     def setup_partials(self):
         self.declare_partials(of='x', wrt='*')

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1011,3 +1011,61 @@ def safe_norm(arr):
         Norm of the array or 0 if the array is None or empty.
     """
     return 0. if arr is None or arr.size == 0 else np.linalg.norm(arr)
+
+
+def flat_to_2d_idx(flat_idx, shape):
+    """
+    Convert a flat index into a 2D index.
+
+    Parameters
+    ----------
+    flat_idx : int
+        Flat index to be converted.
+
+    Returns
+    -------
+    tuple
+        Index into a 2D array.
+    """
+    nrows, ncols = shape
+    return flat_idx // nrows, flat_idx % ncols
+
+
+def get_errors_and_mags(x, y):
+    """
+    Compute the max absolute and relative errors and the magnitudes of the difference in x and y.
+
+    Parameters
+    ----------
+    x : ndarray
+        The first array.
+    y : ndarray
+        The second array.
+
+    Returns
+    -------
+    tuple
+        Tuple of (max_abs_error, abs_mag_x, abs_mag_y, max_rel_error, rel_mag_x, rel_mag_y).
+    """
+    abs_error = abs(x - y)
+    max_abs_error_idx = np.argmax(abs_error)
+    max_abs_error = abs_error.flat[max_abs_error_idx]
+    abs_mag_x =np.abs(x.flat[max_abs_error_idx])
+    abs_mag_y = np.abs(y.flat[max_abs_error_idx])
+
+    # note: this definition of relative error matches that one
+    # used by assert_allclose (found in np.isclose)
+    # Filter values where the divisor would be zero
+    nonzero = y != 0
+    if not nonzero.any():
+        max_rel_error = float('nan')
+        rel_mag_x = 0.0
+        rel_mag_y = 0.0
+    else:
+        max_rel_error_nz = abs_error[nonzero] / np.abs(y[nonzero])
+        max_rel_error_idx = np.argmax(max_rel_error_nz)
+        max_rel_error = max_rel_error_nz.flat[max_rel_error_idx]
+        rel_mag_x = np.abs(x[nonzero].flat[max_rel_error_idx])
+        rel_mag_y = np.abs(y[nonzero].flat[max_rel_error_idx])
+
+    return max_abs_error, abs_mag_x, abs_mag_y, max_rel_error, rel_mag_x, rel_mag_y

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1151,9 +1151,9 @@ def get_errors(x, y):
     rel_max_x = x[nonzero].flat[max_rel_error_idx]
     rel_max_y = y[nonzero].flat[max_rel_error_idx]
 
-    # if one value is zero and the other is very small at the max relative error location,
-    # just use the absolute error.
+    # if one value is zero the relative error doesn't really make sense, so just defer to whatever
+    # the absolute error check says.
     if rel_max_x == 0.0 or rel_max_y == 0.0:
-        max_rel_error = np.abs(rel_max_x - rel_max_y)
+        max_rel_error = float('nan')
 
     return max_abs_error, (abs_max_x, abs_max_y), max_rel_error, (rel_max_x, rel_max_y), denom_idx

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1106,7 +1106,7 @@ def safe_norm(arr):
     return 0. if arr is None or arr.size == 0 else np.linalg.norm(arr)
 
 
-def get_errors_and_mags(x, y):
+def get_errors(x, y):
     """
     Compute the max absolute and relative errors and the magnitudes of the difference in x and y.
 
@@ -1120,19 +1120,20 @@ def get_errors_and_mags(x, y):
     Returns
     -------
     tuple
-        Tuple of (max_abs_error, abs_mag_x, abs_mag_y, max_rel_error, rel_mag_x, rel_mag_y,
-        denom_idx), where denom_idx is the index specifying which argument was used as the
-        denominator in the relative error.
+        Tuple of (max_abs_error, abs_max_x, abs_max_y, max_rel_error, rel_max_x, rel_max_y,
+        denom_idx, where ???_max_x and ???_max_y are the values of x and y at the locations where
+        absolute and relative errors are max, respectively, and denom_idx is the index specifying
+        which argument, 0 (x) or 1 (y), was used as the denominator in the relative error.
     """
     args = (x, y)
-    abs_error = abs(x - y)
+    abs_error = np.abs(x - y)
     if abs_error.size == 0:
-        return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0
+        return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0
 
     max_abs_error_idx = np.argmax(abs_error)
     max_abs_error = abs_error.flat[max_abs_error_idx]
-    abs_mag_x = np.abs(x.flat[max_abs_error_idx])
-    abs_mag_y = np.abs(y.flat[max_abs_error_idx])
+    abs_max_x = x.flat[max_abs_error_idx]
+    abs_max_y = y.flat[max_abs_error_idx]
 
     # Filter values where the divisor would be zero
     denom_idx = 0
@@ -1140,14 +1141,14 @@ def get_errors_and_mags(x, y):
     if not nonzero.any():
         nonzero = y != 0
         if not nonzero.any():
-            return max_abs_error, abs_mag_x, abs_mag_y, float('nan'), 0.0, 0.0, denom_idx
+            return max_abs_error, abs_max_x, abs_max_y, float('nan'), 0.0, 0.0, denom_idx
         else:
             denom_idx = 1
 
     max_rel_error_nz = abs_error[nonzero] / np.abs(args[denom_idx][nonzero])
     max_rel_error_idx = np.argmax(max_rel_error_nz)
     max_rel_error = max_rel_error_nz.flat[max_rel_error_idx]
-    rel_mag_x = np.abs(x[nonzero].flat[max_rel_error_idx])
-    rel_mag_y = np.abs(y[nonzero].flat[max_rel_error_idx])
+    rel_max_x = x[nonzero].flat[max_rel_error_idx]
+    rel_max_y = y[nonzero].flat[max_rel_error_idx]
 
-    return max_abs_error, abs_mag_x, abs_mag_y, max_rel_error, rel_mag_x, rel_mag_y, denom_idx
+    return max_abs_error, abs_max_x, abs_max_y, max_rel_error, rel_max_x, rel_max_y, denom_idx

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1056,13 +1056,13 @@ def get_errors_and_mags(x, y):
     # note: this definition of relative error matches that one
     # used by assert_allclose (found in np.isclose)
     # Filter values where the divisor would be zero
-    nonzero = y != 0
+    nonzero = x != 0
     if not nonzero.any():
         max_rel_error = float('nan')
         rel_mag_x = 0.0
         rel_mag_y = 0.0
     else:
-        max_rel_error_nz = abs_error[nonzero] / np.abs(y[nonzero])
+        max_rel_error_nz = abs_error[nonzero] / np.abs(x[nonzero])
         max_rel_error_idx = np.argmax(max_rel_error_nz)
         max_rel_error = max_rel_error_nz.flat[max_rel_error_idx]
         rel_mag_x = np.abs(x[nonzero].flat[max_rel_error_idx])

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1067,11 +1067,7 @@ def get_errors_and_mags(x, y):
     if not nonzero.any():
         nonzero = y != 0
         if not nonzero.any():
-            max_rel_error = float('nan')
-            rel_mag_x = 0.0
-            rel_mag_y = 0.0
-            return max_abs_error, abs_mag_x, abs_mag_y, max_rel_error, rel_mag_x, rel_mag_y, \
-                denom_idx
+            return max_abs_error, abs_mag_x, abs_mag_y, float('nan'), 0.0, 0.0, denom_idx
         else:
             denom_idx = 1
 

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -1108,7 +1108,7 @@ def safe_norm(arr):
 
 def get_errors(x, y):
     """
-    Compute the max absolute and relative errors and the magnitudes of the difference in x and y.
+    Compute the max absolute and relative errors of the difference in x and y.
 
     Parameters
     ----------
@@ -1120,15 +1120,15 @@ def get_errors(x, y):
     Returns
     -------
     tuple
-        Tuple of (max_abs_error, abs_max_x, abs_max_y, max_rel_error, rel_max_x, rel_max_y,
-        denom_idx, where ???_max_x and ???_max_y are the values of x and y at the locations where
+        Tuple of (max_abs_error, (abs_max_x, abs_max_y), max_rel_error, (rel_max_x, rel_max_y),
+        denom_idx), where ???_max_x and ???_max_y are the values of x and y at the locations where
         absolute and relative errors are max, respectively, and denom_idx is the index specifying
         which argument, 0 (x) or 1 (y), was used as the denominator in the relative error.
     """
     args = (x, y)
     abs_error = np.abs(x - y)
     if abs_error.size == 0:
-        return 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0, 0, 0
+        return 0.0, (0.0, 0.0), 0.0, (0.0, 0.0), 0
 
     max_abs_error_idx = np.argmax(abs_error)
     max_abs_error = abs_error.flat[max_abs_error_idx]
@@ -1136,14 +1136,14 @@ def get_errors(x, y):
     abs_max_y = y.flat[max_abs_error_idx]
 
     # Filter values where the divisor would be zero
-    denom_idx = 0
-    nonzero = x != 0
+    denom_idx = 1
+    nonzero = y != 0.
     if not nonzero.any():
-        nonzero = y != 0
+        nonzero = x != 0.
         if not nonzero.any():
-            return max_abs_error, abs_max_x, abs_max_y, float('nan'), 0.0, 0.0, denom_idx
+            return max_abs_error, (abs_max_x, abs_max_y), float('nan'), (0.0, 0.0), denom_idx
         else:
-            denom_idx = 1
+            denom_idx = 0
 
     max_rel_error_nz = abs_error[nonzero] / np.abs(args[denom_idx][nonzero])
     max_rel_error_idx = np.argmax(max_rel_error_nz)
@@ -1151,4 +1151,9 @@ def get_errors(x, y):
     rel_max_x = x[nonzero].flat[max_rel_error_idx]
     rel_max_y = y[nonzero].flat[max_rel_error_idx]
 
-    return max_abs_error, abs_max_x, abs_max_y, max_rel_error, rel_max_x, rel_max_y, denom_idx
+    # if one value is zero and the other is very small at the max relative error location,
+    # just use the absolute error.
+    if rel_max_x == 0.0 or rel_max_y == 0.0:
+        max_rel_error = np.abs(rel_max_x - rel_max_y)
+
+    return max_abs_error, (abs_max_x, abs_max_y), max_rel_error, (rel_max_x, rel_max_y), denom_idx

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -202,13 +202,16 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                 is the (output, input) tuple of strings;
             Third key:
                 is one of ['rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev',
-                           'directional_fd_fwd', 'directional_fd_rev', 'directional_fwd_rev',
-                           'rank_inconsistent', 'steps', 'matrix_free', 'directional']
+                           'vals_at_max_abs', 'vals_at_max_rel', 'directional_fd_fwd',
+                           'directional_fd_rev', 'directional_fwd_rev', 'rank_inconsistent',
+                           'matrix_free', 'directional', 'steps', and 'rank_inconsistent'].
 
-            For 'rel error', 'abs error', 'magnitude' the value is: A tuple containing norms for
-                forward - fd, adjoint - fd, forward - adjoint.
-            For 'J_fd', 'J_fwd', 'J_rev' the value is: A numpy array representing the computed
+                For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
                 Jacobian for the three different methods of computation.
+                For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
+                tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+                'magnitude' the value is a tuple indicating the maximum magnitude of values found in
+                Jfwd, Jrev, and Jfd.
     atol : float
         Absolute error. Default is 1e-6.
     rtol : float
@@ -306,7 +309,8 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
 
                 if not analytic_found:
                     # check if J_fd is all zeros.  If not, then we have a problem.
-                    if np.linalg.norm(J_fd) > 1e-15:
+                    abserr = np.max(np.abs(J_fd))
+                    if abserr > 1e-9:
                         if verbose:
                             bad_derivs.append(f"\nAnalytic deriv for '{key[0]}' wrt '{key[1]}' "
                                               f"is assumed zero, but finite difference{stepstr} "
@@ -378,10 +382,17 @@ def assert_check_totals(totals_data, atol=1e-6, rtol=1e-6, max_display_shape=(20
         First key:
             is the (output, input) tuple of strings;
         Second key:
-            is one of ['rel error', 'abs error', 'magnitude', 'fdstep'];
+            is one of ['rel error', 'abs error', 'magnitude', 'J_fd', 'J_fwd', 'J_rev',
+                       'vals_at_max_abs', 'vals_at_max_rel', 'directional_fd_fwd',
+                       'directional_fd_rev', 'directional_fwd_rev', 'rank_inconsistent',
+                       'matrix_free', 'directional', 'steps', and 'rank_inconsistent'].
 
-        For 'rel error', 'abs error', 'magnitude' the value is: A tuple containing norms for
-            forward - fd, adjoint - fd, forward - adjoint.
+            For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
+            Jacobian for the three different methods of computation.
+            For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
+            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            'magnitude' the value is a tuple indicating the maximum magnitude of values found in
+            Jfwd, Jrev, and Jfd.
     atol : float
         Absolute error. Default is 1e-6.
     rtol : float

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -280,17 +280,24 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                         analytic_found = True
                         try:
                             if fwd and dfwd is not None:
-                                dJfwd, dJfd = dfwd
-                                np.testing.assert_allclose(dJfwd, dJfd, atol=atol, rtol=rtol,
+                                J1, J2 = dfwd
+                                np.testing.assert_allclose(J1, J2, atol=atol, rtol=rtol,
                                                            verbose=False, equal_nan=False)
                             elif not fwd and drev is not None:
-                                dJrev, dJfd = drev
-                                np.testing.assert_allclose(dJrev, dJfd, atol=atol, rtol=rtol,
+                                J1, J2 = drev
+                                np.testing.assert_allclose(J1, J2, atol=atol, rtol=rtol,
                                                            verbose=False, equal_nan=False)
                             else:
-                                np.testing.assert_allclose(J, J_fd, atol=atol, rtol=rtol,
+                                J1, J2 = J, J_fd
+                                np.testing.assert_allclose(J1, J2, atol=atol, rtol=rtol,
                                                            verbose=False, equal_nan=False)
                         except Exception as err:
+                            abserr, relerr = _parse_assert_allclose_error(err.args[0])
+                            if abserr < atol and not (np.any(J1) or np.any(J2)):
+                                # if one array is all zeros and we don't violate the absolute
+                                # tolerance, then don't flag the relative error.
+                                continue
+
                             if verbose:
                                 bad_derivs.append(f"\n{direction} derivatives of '{key[0]}' wrt "
                                                   f"'{key[1]}' do not match finite "
@@ -301,7 +308,6 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                                         bad_derivs[-1] += f'\nJ_fd - {Jname}:\n' + \
                                             np.array2string(J_fd - J)
                             else:
-                                abserr, relerr = _parse_assert_allclose_error(err.args[0])
                                 bad_derivs.append([f"{key[0]} wrt {key[1]}", "abs",
                                                    f"fd-{Jname[2:]}", f"{abserr}"])
                                 bad_derivs.append([f"{key[0]} wrt {key[1]}", "rel",
@@ -310,7 +316,7 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                 if not analytic_found:
                     # check if J_fd is all zeros.  If not, then we have a problem.
                     abserr = np.max(np.abs(J_fd))
-                    if abserr > 1e-9:
+                    if abserr > atol:
                         if verbose:
                             bad_derivs.append(f"\nAnalytic deriv for '{key[0]}' wrt '{key[1]}' "
                                               f"is assumed zero, but finite difference{stepstr} "
@@ -328,12 +334,19 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                 try:
                     if dir_fwd_rev is not None:
                         dJfwd, dJrev = dir_fwd_rev
+                        either_zero = not (np.any(dJfwd) or np.any(dJrev))
                         np.testing.assert_allclose(dJfwd, dJrev, atol=atol, rtol=rtol,
                                                    verbose=False, equal_nan=False)
                     else:
+                        either_zero = not (np.any(J_fwd) or np.any(J_rev))
                         np.testing.assert_allclose(J_fwd, J_rev, atol=atol, rtol=rtol,
                                                    verbose=False, equal_nan=False)
                 except Exception as err:
+                    abserr, relerr = _parse_assert_allclose_error(err.args[0])
+                    if abserr < atol and either_zero:
+                        # if one array is all zeros and we don't violate the absolute
+                        # tolerance, then don't flag the relative error.
+                        continue
                     if verbose:
                         bad_derivs.append(f"\nForward and Reverse derivatives of '{key[0]}' wrt "
                                           f"'{key[1]}' do not match.\n")
@@ -343,7 +356,6 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                                 bad_derivs[-1] += '\nJ_fwd - J_rev:\n' + \
                                     np.array2string(J_fwd - J_rev)
                     else:
-                        abserr, relerr = _parse_assert_allclose_error(err.args[0])
                         bad_derivs.append([f"{key[0]} wrt {key[1]}", "abs", "fwd-rev", f"{abserr}"])
                         bad_derivs.append([f"{key[0]} wrt {key[1]}", "rel", "fwd-rev", f"{relerr}"])
 
@@ -433,6 +445,11 @@ def assert_check_totals(totals_data, atol=1e-6, rtol=1e-6, max_display_shape=(20
                     np.testing.assert_allclose(J, J_fd, atol=atol, rtol=rtol, verbose=False,
                                                equal_nan=False)
                 except Exception as err:
+                    abserr, relerr = _parse_assert_allclose_error(err.args[0])
+                    if abserr < atol and not (np.any(J) or np.any(J_fd)):
+                        # if one array is all zeros and we don't violate the absolute
+                        # tolerance, then don't flag the relative error.
+                        continue
                     fails.append(f"\n{direction} derivatives of '{key[0]}' w.r.t '{key[1]}' "
                                  "do not match finite difference.\n")
                     fails[-1] += _filter_np_err(err.args[0])

--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -209,7 +209,7 @@ def assert_check_partials(data, atol=1e-6, rtol=1e-6, verbose=False, max_display
                 For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
                 Jacobian for the three different methods of computation.
                 For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
-                tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+                tuple containing values for forward - fd, reverse - fd, forward - reverse. For
                 'magnitude' the value is a tuple indicating the maximum magnitude of values found in
                 Jfwd, Jrev, and Jfd.
     atol : float
@@ -402,7 +402,7 @@ def assert_check_totals(totals_data, atol=1e-6, rtol=1e-6, max_display_shape=(20
             For 'J_fd', 'J_fwd', 'J_rev' the value is a numpy array representing the computed
             Jacobian for the three different methods of computation.
             For 'rel error', 'abs error', 'vals_at_max_abs' and 'vals_at_max_rel' the value is a
-            tuple containing values for forward - fd, adjoint - fd, forward - adjoint. For
+            tuple containing values for forward - fd, reverse - fd, forward - reverse. For
             'magnitude' the value is a tuple indicating the maximum magnitude of values found in
             Jfwd, Jrev, and Jfd.
     atol : float

--- a/openmdao/utils/jax_utils.py
+++ b/openmdao/utils/jax_utils.py
@@ -15,7 +15,7 @@ import numpy as np
 
 from openmdao.visualization.tables.table_builder import generate_table
 from openmdao.utils.code_utils import _get_long_name, remove_src_blocks, replace_src_block, \
-    get_partials_deps
+    get_function_deps
 from openmdao.utils.file_utils import get_module_path, _load_and_exec
 
 
@@ -1183,7 +1183,7 @@ if __name__ == '__main__':
         zz = q + x * 1.5
         return z, zz
 
-    print('partials are:\n', list(get_partials_deps(func, ('z', 'zz'))))
+    print('partials are:\n', list(get_function_deps(func, ('z', 'zz'))))
 
     p = om.Problem()
     comp = p.model.add_subsystem('comp', om.ExecComp('y = 2.0*x', x=np.ones(3), y=np.ones(3)))

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -308,8 +308,8 @@ def _fix_comp_check_data(data):
     data : dict
         Dictionary containing derivative information keyed by subjac.
     """
-    names = ['J_fd', 'abs error', 'rel error', 'magnitude', 'directional_fd_fwd',
-             'directional_fd_rev']
+    names = ['J_fd', 'abs error', 'rel error', 'magnitude', 'magnitude_rel',
+             'directional_fd_fwd', 'directional_fd_rev']
 
     for name in names:
         if name in data:

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -309,7 +309,7 @@ def _fix_comp_check_data(data):
         Dictionary containing derivative information keyed by subjac.
     """
     names = ['J_fd', 'abs error', 'rel error', 'magnitude', 'magnitude_rel',
-             'directional_fd_fwd', 'directional_fd_rev']
+             'directional_fd_fwd', 'directional_fd_rev', 'denom_idx']
 
     for name in names:
         if name in data:
@@ -367,7 +367,7 @@ def compare_prob_vs_comp_check_partials(probdata, compdata, comp):
             probval2 = probval[key2]
             compval2 = compval[key2]
 
-            if key2 == 'J_fd' or key2 == 'J_fwd':
+            if key2 in ('J_fd', 'J_fwd', 'denom_idx'):
                 assert_near_equal(probval2, compval2, 1e-6, 1e-6)
             else:
                 for i in range(3):

--- a/openmdao/utils/testing_utils.py
+++ b/openmdao/utils/testing_utils.py
@@ -309,7 +309,8 @@ def _fix_comp_check_data(data):
         Dictionary containing derivative information keyed by subjac.
     """
     names = ['J_fd', 'abs error', 'rel error', 'magnitude', 'magnitude_rel',
-             'directional_fd_fwd', 'directional_fd_rev', 'denom_idx']
+             'directional_fd_fwd', 'directional_fd_rev', 'denom_idx',
+             'vals_at_max_abs', 'vals_at_max_rel']
 
     for name in names:
         if name in data:


### PR DESCRIPTION

### Backwards incompatibilities

Some test failures may occur in tests using check_partials/check_totals/assert_check_partials, assert_check_totals due to differences in computing errors.  Absolute errors are now just the maximum value of abs(J2 - J1)) and the relative errors are now the max value of abs(J2 - J1)/abs(J2) where J2 is nonzero, where before the errors were based on the norm of J2 - J1.

### New Dependencies

None
