### PR TITLE
Add image definition and workflow to publish image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,65 @@
+name: Publish Image
+
+on:
+  release:
+    types: [published]
+
+  # Run the workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Will use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+
+      - name: Get tags
+        run: |
+          git fetch --unshallow --tags
+          git describe --tags > tag.txt
+          echo "TAG=$(cat tag.txt)" >> $GITHUB_ENV
+
+      # Login against the registry
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels)
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.TAG }}
+
+      # Build and push image with Buildx
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: ${{ inputs.image_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -38,7 +38,6 @@ jobs:
           echo "TAG=$(cat tag.txt)" >> $GITHUB_ENV
 
       # Login against the registry
-      # https://github.com/docker/login-action
       - name: Log into registry ${{ env.REGISTRY }}
         uses: docker/login-action@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,65 @@
+# Define image with OpenMDAO and dependencies
+
+FROM ubuntu:24.04
+
+SHELL ["/bin/bash", "-c"]
+
+# Install updates
+RUN apt-get update -y && apt-get -y install sudo vim curl wget git g++ gfortran make cmake graphviz libblas-dev liblapack-dev
+
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb ;\
+    apt-get install -y ./google-chrome-stable_current_amd64.deb
+
+# Create user
+ENV USER=omdao
+RUN adduser --shell /bin/bash --disabled-password ${USER}
+RUN adduser ${USER} sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER ${USER}
+WORKDIR /home/${USER}
+
+# Install Miniforge
+RUN wget -q -O Miniforge3.sh "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh" ;\
+    bash Miniforge3.sh -b ;\
+    rm Miniforge3.sh ;\
+    export PATH=$HOME/miniforge3/bin:$PATH ;\
+    conda init bash
+
+# Create conda environment
+RUN source $HOME/miniforge3/etc/profile.d/conda.sh ;\
+    #
+    # Create conda environment
+    #
+    conda create -n mdaowork python=3.12 'numpy<2' scipy cython swig -y ;\
+    conda activate mdaowork ;\
+    conda install matplotlib graphviz -y ;\
+    conda install mpi4py petsc4py=3.20 -y ;\
+    python -m pip install pyparsing psutil objgraph plotly pyxdsm pydot ;\
+    #
+    # Install pyoptsparse
+    #
+    python -m pip install git+https://github.com/openmdao/build_pyoptsparse ;\
+    build_pyoptsparse -v ;\
+    #
+    # Install OpenMDAO
+    #
+    git clone https://github.com/OpenMDAO/OpenMDAO.git ;\
+    python -m pip install -e 'OpenMDAO[all]'
+
+# Modify .bashrc
+RUN echo "## Always activate mdaowork environment on startup ##" >> ~/.bashrc ;\
+    echo "conda activate mdaowork" >> ~/.bashrc ;\
+    echo "" >> ~/.bashrc ;\
+    echo "## OpenMPI settings" >> ~/.bashrc ;\
+    echo "export OMPI_MCA_rmaps_base_oversubscribe=1" >> ~/.bashrc ;\
+    echo "export OMPI_MCA_btl=^openib" >> ~/.bashrc ;\
+    echo "" >> ~/.bashrc ;\
+    echo "## Required for some newer MPI / libfabric instances" >> ~/.bashrc ;\
+    echo "export RDMAV_FORK_SAFE=true" >> ~/.bashrc ;\
+    echo "" >> ~/.bashrc
+
+# Set up a work directory that can be shared with the host operating system
+WORKDIR /home/${USER}/work
+
+ENTRYPOINT ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
### Summary

`Dockerfile` contains instructions to build a container image with a Python environment for working with OpenMDAO.

The GitHub workflow will build an image when triggered, either manually or by a `release` event.  The image will be tagged according to the current version tag/commit in the repository.

To make use of an image file, the end user would install either `docker` or `podman` and issue the following commands:
```
podman pull ghcr.io/OpenMDAO/openmdao:3.34.2-xxx
podman run --name openmdao -v ~/work:/home/omdao/work ghcr.io/OpenMDAO/openmdao:3.34.2-xxx &
podman exec -it openmdao /bin/bash
```
The `-v` option maps a work directory on the host to a work directory inside the container.

For further information see [podman.io](https://podman.io/) and/or [docker.com](https://www.docker.com/)

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None