### PR TITLE
Added work_dir as an option to problem,

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -54,7 +54,7 @@ from openmdao.utils.general_utils import pad_name, _find_dict_meta, env_truthy, 
 from openmdao.utils.om_warnings import issue_warning, DerivativesWarning, warn_deprecation, \
     OMInvalidCheckDerivativesOptionsWarning
 import openmdao.utils.coloring as coloring_mod
-from openmdao.utils.file_utils import _get_outputs_dir, text2html, get_work_dir
+from openmdao.utils.file_utils import _get_outputs_dir, text2html, _get_work_dir
 from openmdao.utils.testing_utils import _fix_comp_check_data
 
 try:
@@ -264,8 +264,11 @@ class Problem(object, metaclass=ProblemMetaclass):
 
         # General options
         self.options = OptionsDictionary(parent_name=type(self).__name__)
+        default_workdir = options['work_dir'] if 'work_dir' in options else _get_work_dir()
+        self.options.declare('work_dir', default=default_workdir,
+                             desc='Working directory for the problem.')
         self.options.declare('coloring_dir', types=str,
-                             default=os.path.join(get_work_dir(), 'coloring_files'),
+                             default=os.path.join(default_workdir, 'coloring_files'),
                              desc='Directory containing coloring files (if any) for this Problem.')
         self.options.declare('group_by_pre_opt_post', types=bool,
                              default=False,
@@ -962,6 +965,7 @@ class Problem(object, metaclass=ProblemMetaclass):
             'name': self._name,  # the name of this Problem
             'pathname': None,  # the pathname of this Problem in the current tree of Problems
             'comm': comm,
+            'work_dir': pathlib.Path(self.options['work_dir']),
             'coloring_dir': _DEFAULT_COLORING_DIR,  # directory for input coloring files
             'recording_iter': _RecIteration(comm.rank),  # manager of recorder iterations
             'local_vector_class': local_vector_class,

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -4,6 +4,7 @@ import pathlib
 import sys
 import unittest
 import itertools
+import tempfile
 
 from io import StringIO
 import numpy as np
@@ -19,7 +20,7 @@ import openmdao.utils.hooks as hooks
 from openmdao.utils.units import convert_units
 from openmdao.utils.om_warnings import DerivativesWarning, OMDeprecationWarning, OpenMDAOWarning
 from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
-from openmdao.utils.file_utils import get_work_dir
+from openmdao.utils.file_utils import _get_work_dir
 from openmdao.utils.tests.test_hooks import hooks_active
 
 try:
@@ -2231,6 +2232,28 @@ class TestProblem(unittest.TestCase):
         except RuntimeError:
             self.fail("'setup raised RuntimeError unexpectedly")
 
+    def test_set_work_dir(self):
+
+        with tempfile.TemporaryDirectory() as temp_dir_name:
+            prob = om.Problem(name='prob_name', work_dir=temp_dir_name)
+            model = prob.model
+
+            model.add_subsystem('comp', Paraboloid())
+
+            model.set_input_defaults('comp.x', 3.0)
+            model.set_input_defaults('comp.y', -4.0)
+
+            with self.assertRaises(RuntimeError) as e:
+                prob.get_outputs_dir()
+
+            self.assertEqual('The output directory cannot be accessed before setup.',
+                            str(e.exception))
+
+            prob.setup()
+
+            d = prob.get_outputs_dir('subdir')
+            self.assertEqual(str(pathlib.Path(temp_dir_name, 'prob_name_out', 'subdir')), str(d))
+
     def test_get_outputs_dir(self):
 
         prob = om.Problem(name='prob_name')
@@ -2250,7 +2273,7 @@ class TestProblem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path(get_work_dir(), 'prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(_get_work_dir(), 'prob_name_out', 'subdir')), str(d))
 
     def test_duplicate_prob_name(self):
 

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -7,7 +7,7 @@ import numpy as np
 from openmdao.api import Problem, Group, IndepVarComp, ExecComp, ExplicitComponent
 from openmdao.utils.assert_utils import assert_near_equal, assert_warning, assert_warnings
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.file_utils import get_work_dir
+from openmdao.utils.file_utils import _get_work_dir
 
 
 @use_tempdirs
@@ -694,7 +694,7 @@ class TestSystem(unittest.TestCase):
         prob.setup()
 
         d = prob.get_outputs_dir('subdir')
-        self.assertEqual(str(pathlib.Path(get_work_dir(), 'test_prob_name_out', 'subdir')), str(d))
+        self.assertEqual(str(pathlib.Path(_get_work_dir(), 'test_prob_name_out', 'subdir')), str(d))
 
 
 if __name__ == "__main__":

--- a/openmdao/devtools/iprofile.py
+++ b/openmdao/devtools/iprofile.py
@@ -9,7 +9,7 @@ from openmdao.utils.mpi import MPI
 
 from openmdao.devtools.iprof_utils import func_group, find_qualified_name, _collect_methods, \
      _setup_func_group, _get_methods, _Options
-from openmdao.utils.file_utils import get_work_dir
+from openmdao.utils.file_utils import _get_work_dir
 
 
 def _prof_node(fpath, parts):
@@ -44,7 +44,7 @@ def _setup(options, finalize=True):
     if _profile_setup:
         raise RuntimeError("profiling is already set up.")
 
-    _profile_prefix = os.path.join(get_work_dir(), 'iprof')
+    _profile_prefix = os.path.join(_get_work_dir(), 'iprof')
     _profile_setup = True
 
     methods = _get_methods(options, default='openmdao')

--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -105,7 +105,7 @@
     "\n",
     "2. The [openmdao clean](om-command-clean) or `openmdao.api.clean_outputs` function can be used to remove these directories.\n",
     "\n",
-    "In addition to setting `OPENMDAO_WORKDIR` to set the top level output directory for all problems, a user can set `work_dir` as an argument or option of Problem in order to set the top level output directory under which that problems `'{problem_name}_out'` directory will be placed.\n"
+    "As an alternative to setting `OPENMDAO_WORKDIR` to set the top level output directory for all problems, a user can set `work_dir` as an option of Problem in order to set the top level output directory under which that problem's `'{problem_name}_out'` directory will be placed. If provided, the value of the `work_dir` option takes precedence.\n"
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
+++ b/openmdao/docs/openmdao_book/features/reports/reports_system.ipynb
@@ -103,7 +103,9 @@
     "\n",
     "1. The user has the option of setting a common output directory for ALL problems using the `OPENMDAO_WORKDIR` environment variable. Thus there is a single directory that contains all OpenMDAO output data.\n",
     "\n",
-    "2. The [openmdao clean](om-command-clean) or `openmdao.api.clean_outputs` function can be used to remove these directories.\n"
+    "2. The [openmdao clean](om-command-clean) or `openmdao.api.clean_outputs` function can be used to remove these directories.\n",
+    "\n",
+    "In addition to setting `OPENMDAO_WORKDIR` to set the top level output directory for all problems, a user can set `work_dir` as an argument or option of Problem in order to set the top level output directory under which that problems `'{problem_name}_out'` directory will be placed.\n"
    ]
   },
   {
@@ -351,7 +353,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "py311",
    "language": "python",
    "name": "python3"
   },

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -12,7 +12,7 @@ from openmdao.utils.mpi import MPI
 import openmdao.api as om
 
 from openmdao.utils.array_utils import evenly_distrib_idxs
-from openmdao.utils.file_utils import get_work_dir
+from openmdao.utils.file_utils import _get_work_dir
 from openmdao.recorders.tests.sqlite_recorder_test_utils import \
     assertDriverIterDataRecorded, assertProblemDataRecorded
 from openmdao.recorders.tests.recorder_test_utils import run_driver
@@ -408,7 +408,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
         def run_parallel():
             # process cases.sql in parallel
-            cr = om.CaseReader(os.path.join(get_work_dir(), 'test_record_on_one_proc_out/cases.sql'))
+            cr = om.CaseReader(os.path.join(_get_work_dir(), 'test_record_on_one_proc_out/cases.sql'))
 
             cases = cr.list_cases()
             self.assertEqual(len(cases), 9)

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -433,7 +433,7 @@ def image2html(imagefile, title='', alt=''):
 """
 
 
-def get_work_dir():
+def _get_work_dir():
     """
     Return either os.getcwd() or the value of the OPENMDAO_WORKDIR environment variable.
 
@@ -494,7 +494,7 @@ def _get_outputs_dir(obj, *subdirs, mkdir=True):
 
     prob_pathname = prob_meta['pathname']
 
-    work_dir = pathlib.Path(get_work_dir())
+    work_dir = prob_meta['work_dir']
     if mkdir and not work_dir.exists():
         work_dir.mkdir(exist_ok=True)
 

--- a/openmdao/utils/tests/test_file_utils.py
+++ b/openmdao/utils/tests/test_file_utils.py
@@ -11,7 +11,7 @@ import sys
 
 import openmdao.api as om
 from openmdao.utils.testing_utils import use_tempdirs
-from openmdao.utils.file_utils import get_work_dir
+from openmdao.utils.file_utils import _get_work_dir
 from openmdao.core.problem import _clear_problem_names
 from openmdao.utils.reports_system import clear_reports
 
@@ -62,14 +62,14 @@ class TestCleanOutputs(unittest.TestCase):
         with redirect_stdout(ss):
             om.clean_outputs(p1)
 
-        self.assertEqual(len(os.listdir(get_work_dir())), 1)
+        self.assertEqual(len(os.listdir(_get_work_dir())), 1)
 
         # Now specify p2 with the output directory.
         ss = io.StringIO()
         with redirect_stdout(ss):
             om.clean_outputs(p2)
 
-        self.assertEqual(len(os.listdir(get_work_dir())), 0)
+        self.assertEqual(len(os.listdir(_get_work_dir())), 0)
 
     def test_specify_non_output_dir_no_prompt(self):
 
@@ -86,7 +86,7 @@ class TestCleanOutputs(unittest.TestCase):
         # First Test that a dryrun on '.' works as expected.
         ss = io.StringIO()
         cwd = os.getcwd()
-        os.chdir(get_work_dir())
+        os.chdir(_get_work_dir())
         try:
             with redirect_stdout(ss):
                 om.clean_outputs('.', dryrun=True)


### PR DESCRIPTION

### Summary

This PR allows the user to control the parent directory of the problem output folder without using an environment variable.

The file utility get_work_dir has been renamed _get_work_dir, since it should no longer be part of the user facing API.  Users should use `problem.options['work_dir']` to get the path of the working directory associated with a problem.

### Related Issues

- Resolves #3453 

### Backwards incompatibilities

openmdao.file_utils.get_work_dir is now `openmdao.file_utils._get_work_dir`. If necessary, users should obtain the top level working directory on a problem-by-problem basis from `problem.options['work_dir']`

### New Dependencies

None
