### PR TITLE
Updated the list of disallowed variable names for ExecComp.

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -28,7 +28,9 @@ _allowed_meta = {'value', 'val', 'shape', 'units', 'res_units', 'desc',
 
 # Names that are not allowed for input or output variables (keywords for options)
 _disallowed_names = {'has_diag_partials', 'units', 'shape', 'shape_by_conn', 'run_root_only',
-                     'constant', 'do_coloring'}
+                     'constant', 'do_coloring',
+                     'assembled_jac_type', 'derivs_method',
+                     'distributed', 'run_root_onoy', 'always_opt', 'use_jit'}
 
 
 def check_option(option, value):

--- a/openmdao/components/tests/test_exec_comp.py
+++ b/openmdao/components/tests/test_exec_comp.py
@@ -302,6 +302,21 @@ class TestExecComp(unittest.TestCase):
                          "'C1' <class ExecComp>: arg 'xx' in call to ExecComp() does not refer to any variable "
                          "in the expressions ['y=x+1.']")
 
+    def test_super_kwargs(self):
+        prob = om.Problem()
+        # Instantiate ExecComp with additional arguments that should be passed to
+        # the super class.
+        prob.model.add_subsystem('C1', om.ExecComp('y=x+1.',
+                                                   y={'copy_shape': 'x'}, x={'shape': (10,)},
+                                                   has_diag_partials=True,
+                                                   always_opt=True,
+                                                   use_jit=False))
+        prob.setup()
+        prob.set_val('C1.x', np.linspace(0, 1, 10))
+        prob.run_model()
+        assert_near_equal(prob.get_val('C1.y'), np.linspace(0, 1, 10) + 1)
+
+
     def test_bad_kwargs_meta(self):
         prob = om.Problem()
         prob.model.add_subsystem('C1', om.ExecComp('y=x+1.',


### PR DESCRIPTION
### Summary

Some recent component options names were still being confused for variable metadata in the initialization of ExecComp.  The missing options have been added to the list of disallowed variable names.

### Related Issues

- Resolves #3448 

### Backwards incompatibilities

Any code that was using one of the disallowed variable names will no longer work as expected.

### New Dependencies

None
