### PR TITLE
Fixed an issue where Case._get_units was not retrieving units of aliases

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -309,6 +309,10 @@ class Case(object):
             abs_name = prom2abs['input'][name][0]
             return meta[self._conns[abs_name]]['units']
 
+        elif name in self._var_info:
+            # This can happen if name is an alias.
+            return self._var_info[name]['units']
+
         raise KeyError('Variable name "{}" not found.'.format(name))
 
     def get_design_vars(self, scaled=True, use_indices=True):

--- a/openmdao/recorders/tests/test_sqlite_reader.py
+++ b/openmdao/recorders/tests/test_sqlite_reader.py
@@ -2831,6 +2831,34 @@ class TestSqliteCaseReader(unittest.TestCase):
         for i, line in enumerate(expected_cases):
             self.assertEqual(text[i], line)
 
+    def test_alias_units(self):
+        prob = SellarProblem()
+
+        if prob.model._static_mode and prob.model._static_responses:
+            responses = prob.model._static_responses
+        else:
+            responses = prob.model._responses
+        
+        responses.clear()
+
+        prob.model.add_objective('obj', alias='objective_alias')
+        prob.setup()
+
+        prob.add_recorder(self.recorder)
+        prob.driver.add_recorder(self.recorder)
+
+        prob.run_driver()
+
+        prob.cleanup()   
+
+        cr = om.CaseReader(prob.get_outputs_dir() / self.filename)     
+        cr.list_cases()
+        c = cr.get_case(0)
+        
+        units = c._get_units('obj')
+        units_alias = c._get_units('objective_alias')
+        self.assertEqual(units, units_alias)
+
     def test_list_sources_format(self):
         prob = SellarProblem()
         prob.setup()


### PR DESCRIPTION
### Summary

Units of aliased problem vars were not correctly returned by Case._get_units. This has been fixed and a test has been added.

### Related Issues

- Resolves #3460 

### Backwards incompatibilities

None

### New Dependencies

None
