### PR TITLE
When running under testflo, sets OPENMDAO_WORKDIR to a temp dir if it's not already set

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1492,13 +1492,13 @@ class Driver(object, metaclass=DriverMetaclass):
                 if isinstance(static, str):
                     fname = static
                 else:
-                    fname = self._get_total_coloring_fname(mode='input')
+                    fname = self.get_coloring_fname(mode='input')
 
                 print(f"loading total coloring from file {fname}")
                 coloring = info.coloring = coloring_mod.Coloring.load(fname)
                 info.update(coloring._meta)
 
-                ofname = self._get_total_coloring_fname(mode='output')
+                ofname = self.get_coloring_fname(mode='output')
                 if ((model._full_comm is not None and model._full_comm.rank == 0) or
                         (model._full_comm is None and model.comm.rank == 0)):
                     coloring.save(ofname)
@@ -1518,8 +1518,21 @@ class Driver(object, metaclass=DriverMetaclass):
 
         return coloring
 
-    def _get_total_coloring_fname(self, mode='output'):
-        return self._problem().get_coloring_dir(mode='output') / 'total_coloring.pkl'
+    def get_coloring_fname(self, mode='output'):
+        """
+        Get the filename for the coloring file.
+
+        Parameters
+        ----------
+        mode : str
+            'input' or 'output'.
+
+        Returns
+        -------
+        str
+            The filename for the coloring file.
+        """
+        return self._problem().model.get_coloring_fname(mode)
 
     def scaling_report(self, outfile='driver_scaling_report.html', title=None, show_browser=True,
                        jac=True):
@@ -1661,7 +1674,7 @@ class Driver(object, metaclass=DriverMetaclass):
                               "already been computed.")
 
             if self._coloring_info.dynamic and self._coloring_info.do_compute_coloring():
-                ofname = self._get_total_coloring_fname(mode='output')
+                ofname = self.get_coloring_fname(mode='output')
                 self._coloring_info.coloring = \
                     coloring_mod.dynamic_total_coloring(self,
                                                         run_model=run_model,

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5234,7 +5234,7 @@ class System(object, metaclass=SystemMetaclass):
         """
         return self._problem_meta['reports_dir']
 
-    def get_outputs_dir(self, *subdirs, mkdir=True):
+    def get_outputs_dir(self, *subdirs, mkdir=False):
         """
         Get the path under which all output files of this system are to be placed.
 

--- a/openmdao/core/tests/test_mpi_coloring_bug.py
+++ b/openmdao/core/tests/test_mpi_coloring_bug.py
@@ -482,7 +482,7 @@ class TestMPIColoringBug(unittest.TestCase):
                 if coloring_mod._use_total_sparsity:
                     if self._coloring_info.do_compute_coloring() and self._coloring_info['dynamic']:
                         coloring_mod.dynamic_total_coloring(self, run_model=True,
-                                                            fname=self._get_total_coloring_fname(mode='output'))
+                                                            fname=self.get_coloring_fname(mode='output'))
                         self._setup_tot_jac_sparsity()
 
         p = om.Problem()

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -660,7 +660,7 @@
  "metadata": {
   "celltoolbar": "Tags",
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py311forge",
    "language": "python",
    "name": "python3"
   },
@@ -674,7 +674,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.11.10"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/model_visualization/case_viewer_driver_cases.ipynb
+++ b/openmdao/docs/openmdao_book/features/model_visualization/case_viewer_driver_cases.ipynb
@@ -134,7 +134,7 @@
     "import matplotlib.pyplot as plt\n",
     "\n",
     "def plot_fence(p, idx=0, fig=None, axes=None):\n",
-    "    if axes is None:     \n",
+    "    if axes is None:\n",
     "        fig, axes = plt.subplots(3, 1, figsize=(12, 6), tight_layout=True, sharex=True)\n",
     "    axes[idx].plot(p.get_val('fence.x'), p.get_val('fence.y'), 'ko-')\n",
     "    axes[idx].fill_between(p.get_val('fence.x'), p.get_val('fence.y'), color='tab:green')\n",

--- a/openmdao/docs/openmdao_book/features/recording/case_recording_options.ipynb
+++ b/openmdao/docs/openmdao_book/features/recording/case_recording_options.ipynb
@@ -301,7 +301,7 @@
    "outputs": [],
    "source": [
     "assert '\\n'.join(driver_cases) == '\\n'.join([\n",
-    "    'Driver_Run1_rank0:Driver|0', \n",
+    "    'Driver_Run1_rank0:Driver|0',\n",
     "    'Driver_Run2_rank0:Driver|0'\n",
     "])\n",
     "\n",

--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -533,7 +533,7 @@ class pyOptSparseDriver(Driver):
 
         # Need to tell optimizer where to put its .out files
         if self.options['output_dir'] in (None, _DEFAULT_REPORTS_DIR):
-            output_dir = str(self._problem().get_outputs_dir())
+            output_dir = str(self._problem().get_outputs_dir(mkdir=True))
         else:
             output_dir = str(self.options['output_dir'])
 

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -176,7 +176,7 @@ class SqliteRecorder(CaseRecorder):
         self._pickle_version = pickle_version
         self._filepath = str(filepath)
 
-        self._use_outputs_dir = not (os.path.sep in str(filepath) or '/' in str(filepath))
+        self._use_outputs_dir = not (os.path.sep in self._filepath or '/' in self._filepath)
 
         self._database_initialized = False
         self._started = set()
@@ -193,6 +193,7 @@ class SqliteRecorder(CaseRecorder):
             The communicator for the recorder (should be the comm for the Problem).
         """
         filepath = None
+        self.connection = self.metadata_connection = None
 
         if MPI and comm and comm.size > 1:
             if self._record_on_proc:
@@ -351,7 +352,7 @@ class SqliteRecorder(CaseRecorder):
                              ': {0}'.format(recording_requester))
 
         if self._use_outputs_dir:
-            self._filepath = system.get_outputs_dir() / self._filepath
+            self._filepath = system.get_outputs_dir(mkdir=True) / self._filepath
 
         if not self._database_initialized:
             self._initialize_database(comm)

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -575,7 +575,7 @@ class Solver(object, metaclass=SolverMetaclass):
         """
         return True
 
-    def get_outputs_dir(self, *subdirs, mkdir=True):
+    def get_outputs_dir(self, *subdirs, mkdir=False):
         """
         Get the path under which all output files of this solver are to be placed.
 

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -10,8 +10,10 @@ from fnmatch import fnmatch
 from os.path import join, basename, dirname, isfile, split, splitext, abspath
 import pathlib
 import shutil
+import tempfile
 
 from openmdao.utils.om_warnings import issue_warning
+from openmdao.utils.general_utils import env_truthy
 
 
 def get_module_path(fpath):
@@ -443,6 +445,11 @@ def _get_work_dir():
         The working directory.
     """
     workdir = os.environ.get('OPENMDAO_WORKDIR', '')
+    if not workdir and env_truthy('TESTFLO_RUNNING'):
+        # if we're running under testflo, make a tempdir for all of the test related files
+        # so they don't pollute the user's directories
+        workdir = tempfile.mkdtemp()
+        os.environ['OPENMDAO_WORKDIR'] = workdir
 
     if workdir:
         return workdir

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -435,6 +435,10 @@ def image2html(imagefile, title='', alt=''):
 """
 
 
+if env_truthy('TESTFLO_RUNNING'):
+    os.environ['TESTFLO_WORKDIR'] = tempfile.mkdtemp()
+
+
 def _get_work_dir():
     """
     Return either os.getcwd() or the value of the OPENMDAO_WORKDIR environment variable.
@@ -446,15 +450,13 @@ def _get_work_dir():
     """
     workdir = os.environ.get('OPENMDAO_WORKDIR', '')
     if not workdir and env_truthy('TESTFLO_RUNNING'):
-        # if we're running under testflo, make a tempdir for all of the test related files
-        # so they don't pollute the user's directories
-        workdir = tempfile.mkdtemp()
-        os.environ['OPENMDAO_WORKDIR'] = workdir
+        # use testflo's temp dir for all of the test related files to avoid polluting the user's
+        # current directory
+        workdir = os.environ.get('TESTFLO_WORKDIR', '')
+        if workdir:
+            os.environ['OPENMDAO_WORKDIR'] = workdir
 
-    if workdir:
-        return workdir
-
-    return os.getcwd()
+    return workdir if workdir else os.getcwd()
 
 
 def _get_outputs_dir(obj, *subdirs, mkdir=True):

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -461,7 +461,7 @@ def _get_work_dir():
     return workdir if workdir else os.getcwd()
 
 
-def _get_outputs_dir(obj, *subdirs, mkdir=True):
+def _get_outputs_dir(obj, *subdirs, mkdir=False):
     """
     Return a pathlib.Path for the outputs directory related to the given problem or system.
 
@@ -640,7 +640,7 @@ def clean_outputs(obj='.', recurse=False, prompt=True, pattern='*_out', dryrun=F
         # Multiple paths given
         output_dirs.extend(_find_openmdao_output_dirs(obj, pattern, recurse))
     elif hasattr(obj, 'get_outputs_dir'):
-        output_dir = obj.get_outputs_dir(mkdir=False)
+        output_dir = obj.get_outputs_dir()
         prompt = False
         if output_dir and _is_openmdao_output_dir(output_dir):
             output_dirs.append(pathlib.Path(output_dir))

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -436,7 +436,9 @@ def image2html(imagefile, title='', alt=''):
 
 
 if env_truthy('TESTFLO_RUNNING'):
-    os.environ['TESTFLO_WORKDIR'] = tempfile.mkdtemp()
+    TESTFLO_WORKDIR = tempfile.mkdtemp()
+else:
+    TESTFLO_WORKDIR = ''
 
 
 def _get_work_dir():
@@ -452,7 +454,7 @@ def _get_work_dir():
     if not workdir and env_truthy('TESTFLO_RUNNING'):
         # use testflo's temp dir for all of the test related files to avoid polluting the user's
         # current directory
-        workdir = os.environ.get('TESTFLO_WORKDIR', '')
+        workdir = TESTFLO_WORKDIR
         if workdir:
             os.environ['OPENMDAO_WORKDIR'] = workdir
 

--- a/openmdao/utils/tests/test_cmdline.py
+++ b/openmdao/utils/tests/test_cmdline.py
@@ -142,8 +142,8 @@ class CmdlineTestCase(unittest.TestCase):
                 p2.setup()
                 p2.run_model()
 
-                p1_outdir = os.path.basename(str(p1.get_outputs_dir()))
-                p2_outdir = os.path.basename(str(p2.get_outputs_dir()))
+                p1_outdir = os.path.basename(str(p1.get_outputs_dir(mkdir=True)))
+                p2_outdir = os.path.basename(str(p2.get_outputs_dir(mkdir=True)))
 
                 subdirs = os.listdir(os.getcwd())
                 self.assertIn(p1_outdir, subdirs)

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -16,7 +16,7 @@ from openmdao.core.constants import _UNDEFINED
 from openmdao.utils.general_utils import set_pyoptsparse_opt
 from openmdao.utils.reports_system import register_report, \
     list_reports, clear_reports, activate_report, _reports_registry
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import use_tempdirs, set_env_vars
 from openmdao.utils.assert_utils import assert_no_warning
 from openmdao.utils.mpi import MPI
 from openmdao.utils.tests.test_hooks import hooks_active
@@ -512,10 +512,10 @@ class TestReportsSystem(unittest.TestCase):
                          f'The N2 report file, {str(path)} was found but should not exist.')
 
     @hooks_active
+    @set_env_vars(TESTFLO_RUNNING='true')
     def test_report_generation_test_TESTFLO_RUNNING(self):
         # need to do this here again even though it is done in setup, because otherwise
         # setup_reports won't see environment variable, TESTFLO_RUNNING
-        os.environ['TESTFLO_RUNNING'] = 'true'
         clear_reports()
 
         prob = self.setup_and_run_simple_problem()


### PR DESCRIPTION
### Summary

I've been seeing lots of *_out dirs cluttering up my current directory when running testflo lately, so this just puts those
in a temp directory when running under testflo.  Also adds a few tweaks to decrease the number of unnecessarily created directories.

### Backwards incompatibilities

The default value of mkdir in the various `get_outputs_dir` methods has been changed to False.  In most user-facing cases, for example the creation of a CaseReader, the outputs directory would need to be there prior to CaseReader creation anyway, so this shouldn't break any of those use cases.

### New Dependencies

None
