### PR TITLE
Fix issue for attempting to assign .shape attribute of np.generic objects during `get_val`.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5476,7 +5476,7 @@ class System(object, metaclass=SystemMetaclass):
                 if distrib:
                     self.comm.Allgatherv(loc_val, [val, sizes, offsets, MPI.DOUBLE])
                     if not flat:
-                        val =  np.reshape(val, meta['global_shape']) if get_remote \
+                        val = np.reshape(val, meta['global_shape']) if get_remote \
                             else np.reshape(val, meta['shape'])
                 else:
                     if owner != self.comm.rank:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -5476,7 +5476,8 @@ class System(object, metaclass=SystemMetaclass):
                 if distrib:
                     self.comm.Allgatherv(loc_val, [val, sizes, offsets, MPI.DOUBLE])
                     if not flat:
-                        val.shape = meta['global_shape'] if get_remote else meta['shape']
+                        val =  np.reshape(val, meta['global_shape']) if get_remote \
+                            else np.reshape(val, meta['shape'])
                 else:
                     if owner != self.comm.rank:
                         val = None
@@ -5487,7 +5488,8 @@ class System(object, metaclass=SystemMetaclass):
                 if distrib:
                     self.comm.Gatherv(loc_val, [val, sizes, offsets, MPI.DOUBLE], root=rank)
                     if not flat:
-                        val.shape = meta['global_shape'] if get_remote else meta['shape']
+                        val = np.reshape(val, meta['global_shape']) if get_remote \
+                            else np.reshape(val, meta['shape'])
                 else:
                     if rank != owner:
                         tag = self._var_allprocs_abs2idx[abs_name]
@@ -6015,13 +6017,13 @@ class System(object, metaclass=SystemMetaclass):
                         # if at component level, just keep shape of the target and don't flatten
                         if not flat and not is_prom:
                             shp = vmeta['shape']
-                            val.shape = shp
+                            val = np.reshape(val, shp)
                     else:
                         val = val[src_indices()]
                         if vshape is not None and val.shape != vshape:
-                            val.shape = vshape
+                            val = np.reshape(val, vshape)
                         elif not is_prom and vmeta is not None and val.shape != vmeta['shape']:
-                            val.shape = vmeta['shape']
+                            val = np.reshape(val, vmeta['shape'])
 
             if get_remote and self.comm.size > 1:
                 if distrib:
@@ -6043,9 +6045,9 @@ class System(object, metaclass=SystemMetaclass):
                         val = self.comm.bcast(None, root=self._owning_rank[abs_name])
 
             if distrib and get_remote:
-                val.shape = abs2meta_all_ins[abs_name]['global_shape']
+                val = np.reshape(val, abs2meta_all_ins[abs_name]['global_shape'])
             elif not flat and val.size > 0 and vshape is not None:
-                val.shape = vshape
+                val = np.reshape(val, vshape)
         elif vshape is not None:
             val = val.reshape(vshape)
 


### PR DESCRIPTION
### Summary

In certain situations assigning the shape attribute of a value fails when that val is extracted from a vector such that it is a scalar np.generic object. This PR replaces all `val.shape = vshape` assignments to `val = np.reshape(val, vshape)`

### Related Issues

- Resolves #3470 

### Backwards incompatibilities

None

### New Dependencies

None
