### PR TITLE
Fix for OpenMDAO jax related ordering bug found when running a dymos model.

### DIFF
--- a/openmdao/components/jax_explicit_comp.py
+++ b/openmdao/components/jax_explicit_comp.py
@@ -169,7 +169,7 @@ class JaxExplicitComponent(ExplicitComponent):
             if self.matrix_free:
                 if self._coloring_info.use_coloring():
                     issue_warning(f"{self.msginfo}: coloring has been set but matrix_free is True, "
-                                "so coloring will be ignored.")
+                                  "so coloring will be ignored.")
                 self._coloring_info.deactivate()
                 self.compute_jacvec_product = self._compute_jacvec_product
             else:
@@ -177,7 +177,7 @@ class JaxExplicitComponent(ExplicitComponent):
                     contvars = set(self._var_rel_names['input'])
                     contvars.update(self._var_rel_names['output'])
                     for of, wrt in get_function_deps(self._orig_compute_primal,
-                                                    self._var_rel_names['output']):
+                                                     self._var_rel_names['output']):
                         if of in contvars and wrt in contvars:
                             self.declare_partials(of, wrt)
 

--- a/openmdao/components/jax_explicit_comp.py
+++ b/openmdao/components/jax_explicit_comp.py
@@ -14,7 +14,8 @@ from openmdao.utils.jax_utils import jax, jit, \
     _update_subjac_sparsity, _jax_derivs2partials, _uncompress_jac, _jax2np, \
     _ensure_returns_tuple, _compute_output_shapes, _update_add_input_kwargs, \
     _update_add_output_kwargs
-from openmdao.utils.code_utils import get_return_names
+from openmdao.utils.code_utils import get_return_names, get_function_deps
+import openmdao.utils.coloring as coloring_mod
 
 
 class JaxExplicitComponent(ExplicitComponent):
@@ -91,6 +92,8 @@ class JaxExplicitComponent(ExplicitComponent):
         Variables will have default metadata for a jax component, so inputs will be shape_by_conn
         and outputs will use compute_shape.
         """
+        self._re_init()
+
         if not self._var_rel_names['input']:
             for argname in inspect.signature(self._orig_compute_primal).parameters:
                 self.add_input(argname)
@@ -143,30 +146,45 @@ class JaxExplicitComponent(ExplicitComponent):
         """
         _jax_register_pytree_class(self.__class__)
 
-        self._re_init()
-
-        self.compute = self._jax_compute
-
         if not self._discrete_inputs and not self.get_self_statics():
             # avoid unnecessary statics checks
             self._statics_changed = self._statics_noop
 
-        if self.matrix_free:
-            if self._coloring_info.use_coloring():
-                issue_warning(f"{self.msginfo}: coloring has been set but matrix_free is True, "
-                              "so coloring will be ignored.")
-                self._coloring_info.deactivate()
-            self.compute_jacvec_product = self._compute_jacvec_product
-        else:
-            if self._coloring_info.use_coloring():
-                # ensure coloring (and sparsity) is computed before partials
+    def _check_first_linearize(self):
+        if self._first_call_to_linearize:
+            self._first_call_to_linearize = False  # only do this once
+            if not self.matrix_free and self._coloring_info.use_coloring() and \
+                    coloring_mod._use_partial_sparsity:
                 self._get_coloring()
+                if self._jacobian is not None:
+                    self._jacobian._restore_approx_sparsity()
+            elif not self._declared_partials_patterns and self.options['derivs_method'] == 'jax':
+                self.compute_sparsity()
+
+    def _setup_partials(self):
+        """
+        Call setup_partials in components.
+        """
+        if self.options['derivs_method'] == 'jax':
+            if self.matrix_free:
+                if self._coloring_info.use_coloring():
+                    issue_warning(f"{self.msginfo}: coloring has been set but matrix_free is True, "
+                                "so coloring will be ignored.")
+                self._coloring_info.deactivate()
+                self.compute_jacvec_product = self._compute_jacvec_product
             else:
                 if not self._declared_partials_patterns:
-                    # auto determine subjac sparsities
-                    self.compute_sparsity()
-            self.compute_partials = self._compute_partials
-            self._has_compute_partials = True
+                    contvars = set(self._var_rel_names['input'])
+                    contvars.update(self._var_rel_names['output'])
+                    for of, wrt in get_function_deps(self._orig_compute_primal,
+                                                    self._var_rel_names['output']):
+                        if of in contvars and wrt in contvars:
+                            self.declare_partials(of, wrt)
+
+                self.compute_partials = self._compute_partials
+                self._has_compute_partials = True
+
+        super()._setup_partials()
 
     def _statics_changed(self, discrete_inputs):
         """
@@ -206,7 +224,7 @@ class JaxExplicitComponent(ExplicitComponent):
         """
         return False
 
-    def _jax_compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         """
         Compute outputs given inputs. The model is assumed to be in an unscaled state.
 
@@ -224,13 +242,12 @@ class JaxExplicitComponent(ExplicitComponent):
         discrete_outputs : dict-like or None
             If not None, dict-like object containing discrete output values.
         """
+        returns = self.compute_primal(*self._get_compute_primal_invals(inputs, discrete_inputs))
         if discrete_outputs:
-            returns = self.compute_primal(*self._get_compute_primal_invals(inputs, discrete_inputs))
             outputs.set_vals(returns[:outputs.nvars()])
             self._discrete_outputs.set_vals(returns[outputs.nvars():])
         else:
-            outputs.set_vals(self.compute_primal(*self._get_compute_primal_invals(inputs,
-                                                                                  discrete_inputs)))
+            outputs.set_vals(returns)
 
     def _get_differentiable_compute_primal(self, discrete_inputs):
         """

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -488,7 +488,7 @@ class Driver(object, metaclass=DriverMetaclass):
 
         # Now determine if later we'll need to allgather cons, objs, or desvars.
         if model.comm.size > 1:
-            loc_vars = set(model._outputs._abs_iter())
+            loc_vars = set(model._outputs)
             # some of these lists could have duplicate src names if aliases are used. We'll
             # fix that when we convert to sets after the allgather.
             remote_dvs = [n for n in _src_name_iter(self._designvars) if n not in loc_vars]
@@ -742,7 +742,7 @@ class Driver(object, metaclass=DriverMetaclass):
 
         if recording_options['record_residuals']:
             match_names.update(model._residuals)
-            myresiduals = [n for n in model._residuals._abs_iter()
+            myresiduals = [n for n in model._residuals
                            if check_path(abs2prom_output[n], incl, excl)]
 
         if recording_options['record_desvars']:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3044,7 +3044,7 @@ class Group(System):
                     if src_indices.indexed_src_size == 0:
                         continue
 
-                    if src_indices.indexed_src_size != meta_in['size']:
+                    if src_indices.indexed_src_size != shape_to_len(in_shape):
                         # initial dimensions of indices shape must be same shape as target
                         for idx_d, inp_d in zip(src_indices.indexed_src_shape, in_shape):
                             if idx_d != inp_d:

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -436,14 +436,9 @@ class Group(System):
         # This is a combined scale factor that includes the scaling of the connected source
         # and the unit conversion between the source output and each target input.
         if self._has_input_scaling:
-            abs2meta_in = self._var_abs2meta['input']
             allprocs_meta_out = self._var_allprocs_abs2meta['output']
-            for abs_in, abs_out in self._conn_global_abs_in2out.items():
-                if abs_in not in abs2meta_in:
-                    # we only perform scaling on local, non-discrete arrays, so skip
-                    continue
-
-                meta_in = abs2meta_in[abs_in]
+            for abs_in, meta_in in self._var_abs2meta['input'].items():
+                abs_out = self._conn_global_abs_in2out[abs_in]
 
                 meta_out = allprocs_meta_out[abs_out]
                 ref = meta_out['ref']
@@ -3049,7 +3044,7 @@ class Group(System):
                     if src_indices.indexed_src_size == 0:
                         continue
 
-                    if src_indices.indexed_src_size != shape_to_len(in_shape):
+                    if src_indices.indexed_src_size != meta_in['size']:
                         # initial dimensions of indices shape must be same shape as target
                         for idx_d, inp_d in zip(src_indices.indexed_src_shape, in_shape):
                             if idx_d != inp_d:

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -536,10 +536,10 @@ class ImplicitComponent(Component):
             # if we have renamed resids, remap them to use output naming
 
             plen = len(self.pathname) + 1
-            resid_mapper = RangeMapper.create([(n, shape_to_len(meta['shape']))
+            resid_mapper = RangeMapper.create([(n, meta['size'])
                                                for n, meta in self._declared_residuals.items()],
                                               max_flat_range_size=100)
-            out_mapper = RangeMapper.create([(n[plen:], shape_to_len(meta['shape']))
+            out_mapper = RangeMapper.create([(n[plen:], meta['size'])
                                              for n, meta in self._var_abs2meta['output'].items()],
                                             max_flat_range_size=100)
 
@@ -583,9 +583,9 @@ class ImplicitComponent(Component):
                 wrt_sizes = set()
                 for abs_wrt in abs_wrts:
                     if abs_wrt in self._var_abs2meta['input']:
-                        wrtsize = shape_to_len(self._var_abs2meta['input'][abs_wrt]['shape'])
+                        wrtsize = self._var_abs2meta['input'][abs_wrt]['size']
                     else:
-                        wrtsize = shape_to_len(self._var_abs2meta['output'][abs_wrt]['shape'])
+                        wrtsize = self._var_abs2meta['output'][abs_wrt]['size']
                     wrt_sizes.add(wrtsize)
 
                 if len(wrt_sizes) > 1:
@@ -659,8 +659,7 @@ class ImplicitComponent(Component):
                             meta['val'] = val
 
                 else:  # resid partials are all dense
-                    outsize = shape_to_len(self._var_abs2meta['output'][self.pathname + '.' +
-                                                                        oname]['shape'])
+                    outsize = self._var_abs2meta['output'][self.pathname + '.' + oname]['size']
                     for meta in existing_metas:
                         if pattern_val is not None:
                             val, r, c = _subjac_meta2value(meta)

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -536,10 +536,10 @@ class ImplicitComponent(Component):
             # if we have renamed resids, remap them to use output naming
 
             plen = len(self.pathname) + 1
-            resid_mapper = RangeMapper.create([(n, meta['size'])
+            resid_mapper = RangeMapper.create([(n, shape_to_len(meta['shape']))
                                                for n, meta in self._declared_residuals.items()],
                                               max_flat_range_size=100)
-            out_mapper = RangeMapper.create([(n[plen:], meta['size'])
+            out_mapper = RangeMapper.create([(n[plen:], shape_to_len(meta['shape']))
                                              for n, meta in self._var_abs2meta['output'].items()],
                                             max_flat_range_size=100)
 
@@ -583,9 +583,9 @@ class ImplicitComponent(Component):
                 wrt_sizes = set()
                 for abs_wrt in abs_wrts:
                     if abs_wrt in self._var_abs2meta['input']:
-                        wrtsize = self._var_abs2meta['input'][abs_wrt]['size']
+                        wrtsize = shape_to_len(self._var_abs2meta['input'][abs_wrt]['shape'])
                     else:
-                        wrtsize = self._var_abs2meta['output'][abs_wrt]['size']
+                        wrtsize = shape_to_len(self._var_abs2meta['output'][abs_wrt]['shape'])
                     wrt_sizes.add(wrtsize)
 
                 if len(wrt_sizes) > 1:
@@ -659,7 +659,8 @@ class ImplicitComponent(Component):
                             meta['val'] = val
 
                 else:  # resid partials are all dense
-                    outsize = self._var_abs2meta['output'][self.pathname + '.' + oname]['size']
+                    outsize = shape_to_len(self._var_abs2meta['output'][self.pathname + '.' +
+                                                                        oname]['shape'])
                     for meta in existing_metas:
                         if pattern_val is not None:
                             val, r, c = _subjac_meta2value(meta)

--- a/openmdao/core/implicitcomponent.py
+++ b/openmdao/core/implicitcomponent.py
@@ -16,7 +16,7 @@ from openmdao.utils.units import simplify_unit
 from openmdao.utils.rangemapper import RangeMapper
 from openmdao.utils.om_warnings import issue_warning
 from openmdao.utils.coloring import _ColSparsityJac
-
+from openmdao.utils.iter_utils import meta2range_iter
 
 _tuplist = (tuple, list)
 
@@ -981,46 +981,6 @@ class ImplicitComponent(Component):
             self._apply_nonlinear()
             self.compute_fd_jac(jac=jac, method=method)
         return jac.get_sparsity()
-
-
-def meta2range_iter(meta_dict, names=None, shp_name='shape'):
-    """
-    Iterate over variables and their ranges, based on shape metadata for each variable.
-
-    Parameters
-    ----------
-    meta_dict : dict
-        Mapping of variable name to metadata (which contains shape information).
-    names : iter of str or None
-        If not None, restrict the ranges to those variables contained in names.
-    shp_name : str
-        Name of the shape metadata entry.  Defaults to 'shape', but could also be 'global_shape'.
-
-    Yields
-    ------
-    str
-        Name of variable.
-    int
-        Starting index.
-    int
-        Ending index.
-    """
-    start = end = 0
-
-    if names is None:
-        for name in meta_dict:
-            end += shape_to_len(meta_dict[name][shp_name])
-            yield name, start, end
-            start = end
-    else:
-        if not isinstance(names, (set, dict)):
-            names = set(names)
-
-        for name in meta_dict:
-            end += shape_to_len(meta_dict[name][shp_name])
-            if name in names:
-                yield name, start, end
-            start = end
 
 
 def _overlap_range_iter(meta_dict1, meta_dict2, names1=None, names2=None):

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -6437,12 +6437,13 @@ class System(object, metaclass=SystemMetaclass):
             # to avoid a confusing KeyError
             return (0,)
         high_dims = shape[1:]
+        sz = shape_to_len(shape)
         with multi_proc_exception_check(self.comm):
             if high_dims:
                 high_size = shape_to_len(high_dims)
 
                 dim_size_match = bool(global_size % high_size == 0)
-                if not dim_size_match and meta['size'] > 0:
+                if dim_size_match is False and sz > 0:
                     raise RuntimeError(f"{self.msginfo}: All but the first dimension of the "
                                        "shape's local parts in a distributed variable must match "
                                        f"across processes. For output '{abs_name}', local shape "

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1880,14 +1880,14 @@ class System(object, metaclass=SystemMetaclass):
             if abs_key in self._subjacs_info:
                 self._subjacs_info[abs_key]['sparsity'] = (rows, cols, shape)
 
-    def subjac_sparsity_iter(self, sparsity=None, wrt_matches=None):
+    def subjac_sparsity_iter(self, sparsity, wrt_matches=None):
         """
         Iterate over sparsity for each subjac in the jacobian.
 
         Parameters
         ----------
-        sparsity : coo_matrix or None
-            Sparsity matrix to use. If None, compute_sparsity will be called to compute it.
+        sparsity : coo_matrix
+            Sparsity matrix to use.
         wrt_matches : set or None
             Only include row vars that are contained in this set.
 
@@ -1904,8 +1904,6 @@ class System(object, metaclass=SystemMetaclass):
         tuple
             Shape of the subjac.
         """
-        if sparsity is None:
-            sparsity, _ = self.compute_sparsity()
         rows = sparsity.row
         cols = sparsity.col
         plen = len(self.pathname) + 1 if self.pathname else 0
@@ -1941,19 +1939,12 @@ class System(object, metaclass=SystemMetaclass):
         bool
             True if they match, False otherwise.
         """
-        if self.pathname == '' or not ('derivs_method' in self.options and
-                                       self.options['derivs_method'] == 'jax'):
-            if outstream is not None:
-                print(f"{self.msginfo} already uses fd to compute sparsity so no comparison was "
-                      "performed.")
-            return True
-
         Jsys, _ = self.compute_sparsity(direction)
         Jfd, _ = self.compute_fd_sparsity()
 
         if outstream is not None:
             print(f"{self.msginfo} sparsity comparison with fd (direction={direction})")
-            print("0 or x = both agree, 1 = sys nonzero and fd zero, 2 = fd nonzero and sys zero")
+            print(". or x = both agree, 1 = sys nonzero and fd zero, 2 = fd nonzero and sys zero")
             ret = sparsity_diff_viz(Jsys, Jfd, stream=outstream)
         else:
             spdiff = get_sparsity_diff_array(Jsys, Jfd)
@@ -6446,13 +6437,12 @@ class System(object, metaclass=SystemMetaclass):
             # to avoid a confusing KeyError
             return (0,)
         high_dims = shape[1:]
-        sz = shape_to_len(shape)
         with multi_proc_exception_check(self.comm):
             if high_dims:
                 high_size = shape_to_len(high_dims)
 
                 dim_size_match = bool(global_size % high_size == 0)
-                if dim_size_match is False and sz > 0:
+                if not dim_size_match and meta['size'] > 0:
                     raise RuntimeError(f"{self.msginfo}: All but the first dimension of the "
                                        "shape's local parts in a distributed variable must match "
                                        f"across processes. For output '{abs_name}', local shape "

--- a/openmdao/jacobians/assembled_jacobian.py
+++ b/openmdao/jacobians/assembled_jacobian.py
@@ -10,7 +10,7 @@ from openmdao.matrices.coo_matrix import COOMatrix
 from openmdao.matrices.csr_matrix import CSRMatrix
 from openmdao.matrices.csc_matrix import CSCMatrix
 from openmdao.utils.units import unit_conversion
-from openmdao.utils.iter_utils import size2range_iter, meta2item_iter
+from openmdao.utils.iter_utils import meta2range_iter
 
 _empty_dict = {}
 
@@ -83,9 +83,9 @@ class AssembledJacobian(Jacobian):
             Tuples of the form (start, end) keyed on variable name.
         """
         return {
-            name: rng
-            for name, rng in size2range_iter(meta2item_iter(system._var_abs2meta[vtype].items(),
-                                                            'size'))
+            name: (start, end)
+            for name, start, end in meta2range_iter(system._var_abs2meta[vtype].items(),
+                                                    size_name='size')
         }
 
     def _initialize(self, system):

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -141,8 +141,13 @@ class DictionaryJacobian(Jacobian):
         is_explicit = system.is_explicit()
         do_randomize = self._randgen is not None and system._problem_meta['randomize_subjacs']
 
+        do_reset = False
         with system._unscaled_context(outputs=[d_outputs], residuals=[d_residuals]):
             for abs_key in self._iter_abs_keys(system):
+                if abs_key not in subjacs_info:
+                    do_reset = True
+                    continue
+
                 res_name, other_name = abs_key
 
                 if other_name in d_out_names:
@@ -216,6 +221,9 @@ class DictionaryJacobian(Jacobian):
                                     d_outputs._abs_set_val(other_name, left_vec)
                                 elif other_name in d_inp_names:
                                     d_inputs._abs_set_val(other_name, left_vec)
+
+            if do_reset:
+                self._iter_keys = None  # subjacs_info has been reduced, so update iter keys
 
 
 class _CheckingJacobian(DictionaryJacobian):

--- a/openmdao/jacobians/dictionary_jacobian.py
+++ b/openmdao/jacobians/dictionary_jacobian.py
@@ -145,6 +145,9 @@ class DictionaryJacobian(Jacobian):
         with system._unscaled_context(outputs=[d_outputs], residuals=[d_residuals]):
             for abs_key in self._iter_abs_keys(system):
                 if abs_key not in subjacs_info:
+                    # for components that compute sparsity at first linearization, some subjacs
+                    # will be determined to be zero and removed from subjacs_info., so we need to
+                    # update our iteration keys.
                     do_reset = True
                     continue
 

--- a/openmdao/jax/tests/test_jax_explicit.py
+++ b/openmdao/jax/tests/test_jax_explicit.py
@@ -436,6 +436,25 @@ class TestJaxComp(unittest.TestCase):
                                            method=method, show_only_incorrect=True))
         assert_sparsity_matches_fd(comp, outstream=None)
 
+    def test_jax_subjacs_info_entries(self):
+        p = om.Problem()
+        G = p.model.add_subsystem('G', om.Group())
+        G.add_subsystem('comp', DotProdMultPrimalNoDeclPartials())
+
+        p.setup()
+
+        p['G.comp.x'] = np.array([1, 2])
+        p['G.comp.y'] = np.array([3, 4])
+
+        p.run_model()
+
+        self.assertEqual(len(G._subjacs_info), 5)
+        self.assertEqual(set(G._subjacs_info.keys()),
+                         {('G.comp.z', 'G.comp.x'), ('G.comp.zz', 'G.comp.y'),
+                          ('G.comp.z', 'G.comp.y'), ('G.comp.zz', 'G.comp.zz'),
+                          ('G.comp.z', 'G.comp.z')})
+
+
 if sys.version_info >= (3, 9):
 
     class CompRetValue(om.JaxExplicitComponent):

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -951,7 +951,7 @@ else:
         The tolerance check is:
             abs(a - b) <= atol + rtol * abs(b)
 
-        Returns when the first non-close element is found.  a and b must have the same size.
+        Returns when the first non-close element is found.
 
         Parameters
         ----------
@@ -970,28 +970,21 @@ else:
             True if all elements of a and b are close within the given absolute and
             relative tolerance.
         """
-        for i in range(len(a)):
-            aval = a[i]
-            bval = b[i]
+        if a.size != b.size:
+            return False
 
-            absdiff = aval - bval
-            if absdiff < 0.:
-                absdiff = -absdiff
+        for aval, bval in zip(a, b):
+            abs_err = aval - bval
 
-            if aval < 0.:
-                aval = -aval
+            if abs_err < 0.:
+                abs_err = -abs_err
+
             if bval < 0.:
                 bval = -bval
 
-            if aval < bval:
-                vmax = rtol * bval
-            else:
-                vmax = rtol * aval
 
-            if atol > vmax:
-                vmax = atol
 
-            if absdiff > vmax:
+            if abs_err > atol + rtol * bval:
                 return False
 
         return True

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -979,10 +979,11 @@ else:
             if abs_err < 0.:
                 abs_err = -abs_err
 
+            if abs_err > atol:
+                return False
+
             if bval < 0.:
                 bval = -bval
-
-
 
             if abs_err > atol + rtol * bval:
                 return False

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -947,6 +947,7 @@ else:
     def allclose(a, b, rtol=3e-16, atol=3e-16):
         """
         Return True if all elements of a and b pass a tolerance check.
+
         The tolerance check is:
             abs(a - b) <= atol + rtol * abs(b)
 

--- a/openmdao/utils/array_utils.py
+++ b/openmdao/utils/array_utils.py
@@ -914,9 +914,7 @@ def convert_ndarray_to_support_nans_in_json(val):
     val = np.asarray(val)
 
     # do a quick check for any nans or infs and if not we can avoid the slow check
-    nans = np.where(np.isnan(val))
-    infs = np.where(np.isinf(val))
-    if nans[0].size == 0 and infs[0].size == 0:
+    if not (np.any(np.isnan(val)) or np.any(np.isinf(val))):
         return val.tolist()
 
     val_as_list = val.tolist()
@@ -948,7 +946,9 @@ else:
     @numba.jit(nopython=True, nogil=True)
     def allclose(a, b, rtol=3e-16, atol=3e-16):
         """
-        Return True if all elements of a and b are close within the given absolute tolerance.
+        Return True if all elements of a and b pass a tolerance check.
+        The tolerance check is:
+            abs(a - b) <= atol + rtol * abs(b)
 
         Returns when the first non-close element is found.  a and b must have the same size.
 

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -510,6 +510,7 @@ class _FuncGrapher(ast.NodeVisitor):
 
     def visit_FunctionDef(self, node):
         if self.fstack:
+            # TODO: support nested functions
             raise RuntimeError("Function contains nested functions, which are not supported.")
 
         for arg in node.args.args:

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -533,9 +533,9 @@ class _FuncGrapher(ast.NodeVisitor):
     def visit_Attribute(self, node):
         name = _get_long_name(node.value)
         if name is not None:
-            parts = name.split('.')
-            if parts[0] in self.graph:
-                self.names.append(parts[0])
+            base = name.partition('.')[0]
+            if base in self.graph:
+                self.names.append(base)
 
     def visit_Call(self, node):
         # only visit the args

--- a/openmdao/utils/code_utils.py
+++ b/openmdao/utils/code_utils.py
@@ -514,7 +514,7 @@ class _FuncGrapher(ast.NodeVisitor):
 
         for arg in node.args.args:
             self.graph.add_node(arg.arg)
-            
+
         self.fstack.append(node)
         for stmt in node.body:
             self.visit(stmt)

--- a/openmdao/utils/iter_utils.py
+++ b/openmdao/utils/iter_utils.py
@@ -3,47 +3,47 @@ Various utilities for working with iterators.
 """
 
 
-def meta2item_iter(metaiter, item):
+def meta2item_iter(meta_iter, item):
     """
     Convert a metadata iterator to an iterator over (name, <item>).
 
     Parameters
     ----------
-    metaiter : iter of (name, meta)
+    meta_iter : iter of (name, meta)
         Iterator over variable names and their metadata dicts.
     item : str
-        The item to extract from the metadata.
+        The name of the item to extract from the metadata.
 
     Yields
     ------
     tuple
         Tuple of (name, <item>) for each variable.
     """
-    for name, meta in metaiter:
+    for name, meta in meta_iter:
         yield name, meta[item]
 
 
-def meta2items_iter(metaiter, items):
+def meta2items_iter(meta_iter, items):
     """
     Convert a metadata iterator to an iterator over [name, meta[item0], meta[item1], ...].
 
     Parameters
     ----------
-    metaiter : iter of (name, meta)
+    meta_iter : iter of (name, meta)
         Iterator over variable names and their metadata dicts.
     items : list of str
-        The items to extract from the metadata.
+        The names of the items to extract from the metadata.
 
     Yields
     ------
     list
         [name, meta[item0], meta[item1], ...] for each variable.
     """
-    for name, meta in metaiter:
-        toyield = [name]
+    for name, meta in meta_iter:
+        to_yield = [name]
         for item in items:
-            toyield.append(meta[item])
-        yield toyield
+            to_yield.append(meta[item])
+        yield to_yield
 
 
 def size2range_iter(size_iter):
@@ -60,7 +60,53 @@ def size2range_iter(size_iter):
     tuple
         Tuple of (name, (start, end)) for each variable.
     """
-    start = 0
+    start = end = 0
     for name, size in size_iter:
-        yield name, (start, start + size)
-        start += size
+        end += size
+        yield name, (start, end)
+        start = end
+
+
+def meta2range_iter(meta_iter, size_name='size', subset=None):
+    """
+    Iterate over variables and their ranges, based on size metadata for each variable.
+
+    Parameters
+    ----------
+    meta_iter : iterator over (name, meta)
+        Iterator over variable name and metadata (which contains size information).
+    size_name : str
+        Name of the size metadata entry.  Defaults to 'size', but could also be 'global_size'.
+    subset : iter of str or None
+        If not None, restrict the ranges to those variables contained in subset.
+
+    Yields
+    ------
+    str
+        Name of variable.
+    int
+        Starting index.
+    int
+        Ending index.
+    """
+    start = end = 0
+
+    if subset is None:
+        for name, meta in meta_iter:
+            end += meta[size_name]
+            yield name, start, end
+            start = end
+    else:
+        if not isinstance(subset, (set, dict)):
+            subset = set(subset)
+
+        seen = set()
+        for name, meta in meta_iter:
+            end += meta[size_name]
+            if name in subset:
+                yield name, start, end
+            seen.add(name)
+            start = end
+
+        if subset - seen:
+            raise KeyError(f"In meta2range_iter, subset members {sorted(subset - seen)} not found.")

--- a/openmdao/utils/tests/test_code_utils.py
+++ b/openmdao/utils/tests/test_code_utils.py
@@ -218,7 +218,7 @@ class TestGraphFunction(unittest.TestCase):
                 return b + 1
             return nested(a)
 
-        msg = "Can't determine function graph for function 'func' due to: Function contains nested functions, which are not supported."
+        msg = "Can't determine function graph for function 'func' so assuming all outputs depend on all inputs.  Error was: Function contains nested functions, which are not supported."
         with assert_warning(UserWarning, msg):
             get_func_graph(func)
 

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -374,16 +374,14 @@ class DefaultVector(Vector):
         mode : str
             Derivative direction.
         """
-        if self._has_solver_ref and mode == 'fwd':
-            scaler = self._scaling_nl_vec[1]
-            adder = None
-        else:
-            adder, scaler = self._scaling
-
         if mode == 'rev':
-            self._scale_reverse(scaler, adder)
+            self._scale_reverse(self._scaling[1], self._scaling[0])
         else:
-            self._scale_forward(scaler, adder)
+            if self._has_solver_ref:
+                self._scale_forward(self._scaling_nl_vec[1], None)
+            else:
+                adder, scaler = self._scaling
+                self._scale_forward(scaler, adder)
 
     def scale_to_phys(self, mode='fwd'):
         """
@@ -394,16 +392,14 @@ class DefaultVector(Vector):
         mode : str
             Derivative direction.
         """
-        if self._has_solver_ref and mode == 'fwd':
-            scaler = self._scaling_nl_vec[1]
-            adder = None
-        else:
-            adder, scaler = self._scaling
-
         if mode == 'rev':
-            self._scale_forward(scaler, adder)
+            self._scale_forward(self._scaling[1], self._scaling[0])
         else:
-            self._scale_reverse(scaler, adder)
+            if self._has_solver_ref:
+                self._scale_reverse(self._scaling_nl_vec[1], None)
+            else:
+                adder, scaler = self._scaling
+                self._scale_reverse(scaler, adder)
 
     def _scale_forward(self, scaler, adder):
         """

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -13,7 +13,7 @@ _full_slice = slice(None)
 _flat_full_indexer = indexer(_full_slice, flat_src=True)
 _full_indexer = indexer(_full_slice, flat_src=False)
 
-_type_map = {
+_type_map = {  # map vector type to iotype
     'input': 'input',
     'output': 'output',
     'residual': 'output'
@@ -579,7 +579,7 @@ class Vector(object):
         """
         Set the data array of this vector using a value or iter of values, one for each variable.
 
-        The values must be in the same order as the variables appear in this Vector.
+        The values must be in the same order and size as the variables appear in this Vector.
 
         Parameters
         ----------
@@ -753,9 +753,7 @@ class Vector(object):
         start = end = 0
         for name, val in self._abs_item_iter(flat=False):
             end += val.size
-            view = arr[start:end]
-            view.shape = val.shape
-            dct[name[pathlen:]] = view
+            dct[name[pathlen:]] = arr[start:end].reshape(val.shape)
             start = end
 
         return dct


### PR DESCRIPTION
### Summary

The dict of declared sub-jacobians for a jax component was being populated after the parent Group had already updated its own sub-jacobians from its children.  The result was that the component's partials were correct but the model totals were wrong.

### Backwards incompatibilities

None

### New Dependencies

None
