### PR TITLE
Added numba as optional dependency

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -92,7 +92,7 @@ jobs:
             PYOPTSPARSE: 'v2.11.0'
             # PAROPT: true
             SNOPT: '7.7'
-            OPTIONAL: '[all]'
+            OPTIONAL: '[docs,doe,jax,notebooks,numba,test,visualization]'
             BANDIT: true
             PEP517: true
             TESTS: true
@@ -108,7 +108,7 @@ jobs:
             PYOPTSPARSE: 'v2.11.0'
             # PAROPT: true
             SNOPT: '7.7'
-            OPTIONAL: '[docs,doe,jax,notebooks,test]'
+            OPTIONAL: '[docs,doe,jax,notebooks,numba,test]'
             TESTS: true
             EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_Baseline }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ jax = [
     "jax>=0.4.0",
     "jaxlib>=0.4.0",
 ]
+numba = [
+    "numba",
+]
 notebooks = [
     "ipympl",
     "notebook",


### PR DESCRIPTION
### Summary

Added `numba` as optional dependency and added testing with `numba` to the baseline builds in the github test workflow.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
