### PR TITLE
Fixed an issue with check_partials reports not being generated correctly without rich.

### DIFF
--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -2805,10 +2805,10 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         return tables
 
     def test_report_generation(self):
-        for use_rich in ('1', '0'):
+        for disable_rich in ('1', '0'):
             for compact in (True, False):
-                with self.subTest(f'{use_rich=} {compact=}'):
-                    with set_env_vars_context(OPENMDAO_USE_RICH=use_rich,
+                with self.subTest(f'{disable_rich=} {compact=}'):
+                    with set_env_vars_context(OPENMDAO_DISABLE_RICH=disable_rich,
                                             TESTFLOW_RUNNING='0',
                                             OPENMDAO_REPORTS='1'):
                         p = self.setup_model()

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1,6 +1,7 @@
 """ Testing for Problem.check_partials and check_totals."""
 
 from io import StringIO
+import os
 from itertools import zip_longest
 
 import unittest
@@ -2802,6 +2803,19 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
                 tables.append(tlines)
                 tlines = []
         return tables
+
+    def test_report_generation(self):
+        for use_rich in ('1', '0'):
+            for compact in (True, False):
+                with self.subTest(f'{use_rich=} {compact=}'):
+                    with set_env_vars_context(OPENMDAO_USE_RICH=use_rich,
+                                            TESTFLOW_RUNNING='0',
+                                            OPENMDAO_REPORTS='1'):
+                        p = self.setup_model()
+                        stream = StringIO()
+                        p.check_partials(step=[1e-6], out_stream=stream, compact_print=compact)
+                        self.assertIn('check_partials-bad.html', os.listdir(p.get_reports_dir()))
+                        self.assertIn('check_partials-good.html', os.listdir(p.get_reports_dir()))
 
     def test_single_fd_step_fwd(self):
         p = self.setup_model()

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -20,7 +20,7 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_warning, asser
      assert_check_partials, assert_check_totals
 from openmdao.utils.om_warnings import DerivativesWarning, OMInvalidCheckDerivativesOptionsWarning
 from openmdao.utils.testing_utils import set_env_vars_context, compare_prob_vs_comp_check_partials,\
-    snum_equal
+    snum_equal, use_tempdirs
 from openmdao.utils.array_utils import safe_norm
 from openmdao.utils.rich_utils import strip_formatting
 
@@ -181,6 +181,7 @@ class DirectionalVectorizedMatFreeComp(om.ExplicitComponent):
                     self.n_rev += 1
 
 
+@use_tempdirs
 class TestProblemCheckPartials(unittest.TestCase):
 
     def test_incorrect_jacobian(self):
@@ -1995,6 +1996,7 @@ y wrt x                     | abs         | fd-fwd | 2.000000000279556
             prob.check_partials(out_stream=None, compact_print=True)
 
 
+@use_tempdirs
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestCheckPartialsDistribDirectional(unittest.TestCase):
 
@@ -2029,6 +2031,7 @@ class TestCheckPartialsDistribDirectional(unittest.TestCase):
         prob.check_partials(compact_print=True, method='cs')
 
 
+@use_tempdirs
 class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
     # Ensure check_partials options differs from the compute partials options
 
@@ -2322,6 +2325,7 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         assert_check_totals(prob.check_totals())
 
 
+@use_tempdirs
 class TestCheckPartialsFeature(unittest.TestCase):
 
     def test_feature_incorrect_jacobian(self):
@@ -2699,6 +2703,7 @@ class TestCheckPartialsFeature(unittest.TestCase):
         assert_check_partials(J, atol=1e-5, rtol=1e-5)
 
 
+@use_tempdirs
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestCheckPartialsDistrib(unittest.TestCase):
 
@@ -2736,6 +2741,7 @@ class TestCheckPartialsDistrib(unittest.TestCase):
         prob.check_partials(compact_print=True, method='cs')
 
 
+@use_tempdirs
 class TestCheckPartialsMultipleSteps(unittest.TestCase):
     def setup_model(self, directional=False):
         class CompGoodPartials(om.ExplicitComponent):
@@ -2809,8 +2815,8 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
             for compact in (True, False):
                 with self.subTest(f'{disable_rich=} {compact=}'):
                     with set_env_vars_context(OPENMDAO_DISABLE_RICH=disable_rich,
-                                            TESTFLOW_RUNNING='0',
-                                            OPENMDAO_REPORTS='1'):
+                                              TESTFLO_RUNNING='0',
+                                              OPENMDAO_REPORTS='1'):
                         p = self.setup_model()
                         stream = StringIO()
                         p.check_partials(step=[1e-6], out_stream=stream, compact_print=compact)

--- a/openmdao/utils/deriv_display.py
+++ b/openmdao/utils/deriv_display.py
@@ -506,7 +506,7 @@ def _deriv_display_compact(system, err_iter, derivatives, out_stream, totals=Fal
                 _print_deriv_table([worst_subjac[1]], headers, sys_buffer, col_meta=column_meta)
 
     if not show_only_incorrect or num_bad_jacs > 0:
-        if rich is not None:
+        if use_rich():
             c = Console(file=out_stream, force_terminal=True, record=True, soft_wrap=True)
             c.print(sys_buffer.getvalue(), highlight=False)
             if system.get_reports_dir().is_dir():
@@ -516,7 +516,7 @@ def _deriv_display_compact(system, err_iter, derivatives, out_stream, totals=Fal
             out_stream.write(sys_buffer.getvalue())
             if system.get_reports_dir().is_dir():
                 report = system.get_reports_dir() / f'check_partials-{system.pathname}.html'
-                with open(report, encoding="utf-8") as file:
+                with open(report, mode='w', encoding="utf-8") as file:
                     file.write(f'<html><body>\n{sys_buffer.getvalue()}\n</body></html>')
 
     if worst_subjac is None:
@@ -686,7 +686,7 @@ class _JacFormatter:
         # Default output, no format.
         s = f'{x: .12e}'
 
-        if self._shape is not None and rich is not None:
+        if self._shape is not None and use_rich():
             rich_fmt = set()
             if (Jref is not None and atol is not None and rtol is not None):
                 _, _, tol_viol, _, _ = get_tol_violation(x, Jref[i, j], atol, rtol)

--- a/openmdao/utils/deriv_display.py
+++ b/openmdao/utils/deriv_display.py
@@ -315,7 +315,9 @@ def _deriv_display(system, err_iter, derivatives, rel_error_tol, abs_error_tol, 
             if system.get_reports_dir().is_dir():
                 report = system.get_reports_dir() / report_name
                 with open(report, mode='w', encoding="utf-8") as file:
-                    file.write(f'<html><body>\n{sys_buffer.getvalue()}\n</body></html>')
+                    file.write('<html><body><pre>'
+                               f'\n{sys_buffer.getvalue()}'
+                               '\n</pre></body></html>')
 
 
 def _print_tv(tol_violation):
@@ -517,7 +519,9 @@ def _deriv_display_compact(system, err_iter, derivatives, out_stream, totals=Fal
             if system.get_reports_dir().is_dir():
                 report = system.get_reports_dir() / f'check_partials-{system.pathname}.html'
                 with open(report, mode='w', encoding="utf-8") as file:
-                    file.write(f'<html><body>\n{sys_buffer.getvalue()}\n</body></html>')
+                    file.write('<html><body><pre>'
+                               f'\n{sys_buffer.getvalue()}'
+                               '\n</pre></body></html>')
 
     if worst_subjac is None:
         return None


### PR DESCRIPTION
### Summary

When rich isn't available in the environment, the deriv_display_compact method tries to write to
 an html file but it is not opened with write access.

Added a test to verify that the reports are generated correctly with and without rich and with and without compact print.

### Related Issues

None

### Backwards incompatibilities

None

### New Dependencies

None
