### PR TITLE
Fixed a bug that caused openmdao to do output/residual scaling when not necessary.

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -875,10 +875,11 @@ class Component(System):
             self._has_output_scaling |= np.any(ref0)
             self._has_output_adder |= np.any(ref0)
 
-        if isscalar(res_ref):
-            self._has_resid_scaling |= res_ref != 1.0
-        else:
-            self._has_resid_scaling |= np.any(res_ref != 1.0)
+        if res_ref is not None:
+            if isscalar(res_ref):
+                self._has_resid_scaling |= res_ref != 1.0
+            else:
+                self._has_resid_scaling |= np.any(res_ref != 1.0)
 
         # until we get rid of component level distributed option, handle the case where
         # component distributed has been set to True but variable distributed has been set

--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -302,8 +302,8 @@ class ExplicitComponent(Component):
         Compute outputs. The model is assumed to be in a scaled state.
         """
         with Recording(self.pathname + '._solve_nonlinear', self.iter_count, self):
-            with self._unscaled_context(outputs=[self._outputs], residuals=[self._residuals]):
-                self._residuals.set_val(0.0)
+            self._residuals.set_val(0.0)
+            with self._unscaled_context(outputs=[self._outputs]):
                 self._compute_wrapper()
 
             # Iteration counter is incremented in the Recording context manager at exit.

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -422,15 +422,16 @@ class Group(System):
             'input': (0.0, 1.0),
         })
 
-        for abs_name, meta in self._var_allprocs_abs2meta['output'].items():
-            ref0 = meta['ref0']
-            res_ref = meta['res_ref']
-            a0 = ref0
-            a1 = meta['ref'] - ref0
-            scale_factors[abs_name] = {
-                'output': (a0, a1),
-                'residual': (0.0, 1.0 if res_ref is None else res_ref),
-            }
+        if self._has_output_scaling or self._has_resid_scaling:
+            for abs_name, meta in self._var_allprocs_abs2meta['output'].items():
+                ref0 = meta['ref0']
+                res_ref = meta['res_ref']
+                a0 = ref0
+                a1 = meta['ref'] - ref0
+                scale_factors[abs_name] = {
+                    'output': (a0, a1),
+                    'residual': (0.0, 1.0 if res_ref is None else res_ref),
+                }
 
         # Input scaling for connected inputs is added here.
         # This is a combined scale factor that includes the scaling of the connected source

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -135,6 +135,15 @@ class _PromotesInfo(object):
         return mismatches
 
 
+def _chk_scale_factor(factor):
+    try:
+        if factor == (0.0, 1.0):
+            return None
+    except ValueError:
+        pass
+    return factor
+
+
 class Group(System):
     """
     Class used to group systems together; instantiate or inherit.
@@ -417,21 +426,29 @@ class Group(System):
         dict
             Mapping of each absolute var name to its corresponding scaling factor tuple.
         """
-        # make this a defaultdict to handle the case of access using unconnected inputs
-        scale_factors = defaultdict(lambda: {
-            'input': (0.0, 1.0),
-        })
+        scale_factors = {}
 
         if self._has_output_scaling or self._has_resid_scaling:
             for abs_name, meta in self._var_allprocs_abs2meta['output'].items():
                 ref0 = meta['ref0']
-                res_ref = meta['res_ref']
                 a0 = ref0
                 a1 = meta['ref'] - ref0
-                scale_factors[abs_name] = {
-                    'output': (a0, a1),
-                    'residual': (0.0, 1.0 if res_ref is None else res_ref),
-                }
+                tup = _chk_scale_factor((a0, a1))
+                if tup is not None:
+                    scale_factors[abs_name] = {'output': tup}
+
+                res_ref = meta['res_ref']
+                try:
+                    if res_ref == 1.0:
+                        res_ref = None
+                except ValueError:
+                    pass
+
+                if res_ref is not None:
+                    if abs_name not in scale_factors:
+                        scale_factors[abs_name] = {'residual': (0.0, res_ref)}
+                    else:
+                        scale_factors[abs_name]['residual'] = (0.0, res_ref)
 
         # Input scaling for connected inputs is added here.
         # This is a combined scale factor that includes the scaling of the connected source
@@ -444,6 +461,9 @@ class Group(System):
                 meta_out = allprocs_meta_out[abs_out]
                 ref = meta_out['ref']
                 ref0 = meta_out['ref0']
+
+                units_in = meta_in['units']
+                units_out = meta_out['units']
 
                 src_indices = meta_in['src_indices']
 
@@ -484,28 +504,21 @@ class Group(System):
                 #   b1 = d0 + d1 a1 - d0
                 #   b1 = g(a1) - g(0)
 
-                units_in = meta_in['units']
-                units_out = meta_out['units']
+                a0 = ref0
+                a1 = ref - ref0
 
                 if units_in is None or units_out is None or units_in == units_out:
-                    a0 = ref0
-                    a1 = ref - ref0
-
+                    tup = _chk_scale_factor((a0, a1))
+                    if tup is None:
+                        continue
                     # No unit conversion, only scaling. Just send the scale factors.
-                    scale_factors[abs_in] = {
-                        'input': (a0, a1),
-                    }
-
+                    scale_factors[abs_in] = {'input': tup}
                 else:
                     factor, offset = unit_conversion(units_out, units_in)
-                    a0 = ref0
-                    a1 = ref - ref0
 
                     # Send both unit scaling and solver scaling. Linear input vectors need to
                     # treat them differently in reverse mode.
-                    scale_factors[abs_in] = {
-                        'input': (a0, a1, factor, offset),
-                    }
+                    scale_factors[abs_in] = {'input': (a0, a1, factor, offset)}
 
                     # For adder allocation check.
                     a0 = (ref0 + offset) * factor
@@ -3103,18 +3116,19 @@ class Group(System):
 
         if mode == 'fwd':
             if xfer is not None:
-                if self._has_input_scaling:
+                if xfer._has_input_scaling:
                     vec_inputs.scale_to_norm()
                     xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
                     vec_inputs.scale_to_phys()
                 else:
                     xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
+
             if self._conn_discrete_in2out and vec_name == 'nonlinear':
                 self._discrete_transfer(sub)
 
         else:  # rev
             if xfer is not None:
-                if self._has_input_scaling:
+                if xfer._has_input_scaling:
                     vec_inputs.scale_to_norm(mode='rev')
 
                 xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
@@ -3125,7 +3139,7 @@ class Group(System):
                         xfer = self._transfers['rev'][key]
                         xfer._transfer(vec_inputs, self._vectors['output'][vec_name], mode)
 
-                if self._has_input_scaling:
+                if xfer._has_input_scaling:
                     vec_inputs.scale_to_phys(mode='rev')
 
     def _discrete_transfer(self, sub):

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2950,7 +2950,7 @@ class Group(System):
 
                 # if units are defined and different, or if a connected output has any scaling,
                 # we need input scaling.
-                self._has_input_scaling = self._has_output_scaling or self._has_resid_scaling or \
+                self._has_input_scaling = self._has_output_scaling or \
                     (in_units and out_units and in_units != out_units)
 
         # check compatability for any discrete connections

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -952,10 +952,11 @@ class System(object, metaclass=SystemMetaclass):
                     subsys._has_output_adder |= np.any(ref0)
 
                 res_ref = metadata['res_ref']
-                if np.isscalar(res_ref):
-                    subsys._has_resid_scaling |= res_ref != 1.0
-                else:
-                    subsys._has_resid_scaling |= np.any(res_ref != 1.0)
+                if res_ref is not None:
+                    if np.isscalar(res_ref):
+                        subsys._has_resid_scaling |= res_ref != 1.0
+                    else:
+                        subsys._has_resid_scaling |= np.any(res_ref != 1.0)
 
                 if metadata['lower'] is not None or metadata['upper'] is not None:
                     subsys._has_bounds = True
@@ -2385,7 +2386,7 @@ class System(object, metaclass=SystemMetaclass):
                     raise RuntimeError(msg.format(self.msginfo, name, var_units, units))
 
                 # Derivation of the total scaler and total adder for design variables:
-                # Given based design variable value y
+                # Given base design variable value y
                 # First we apply the desired unit conversion
                 # y_in_desired_units = unit_scaler * (y + unit_adder)
                 # Then we apply the user-declared scaling

--- a/openmdao/core/tests/test_scaling.py
+++ b/openmdao/core/tests/test_scaling.py
@@ -15,6 +15,12 @@ from openmdao.utils.assert_utils import assert_near_equal, assert_check_partials
 
 from openmdao.test_suite.components.unit_conv import SrcComp, TgtCompF
 
+try:
+    from parameterized import parameterized
+except ImportError:
+    from openmdao.utils.assert_utils import SkipParameterized as parameterized
+from openmdao.utils.testing_utils import parameterized_name
+
 
 class PassThroughLength(om.ExplicitComponent):
     """Units/scaling test component taking length in cm and passing it through in km."""
@@ -604,7 +610,8 @@ class TestScaling(unittest.TestCase):
         prob.setup()
         prob.final_setup()
 
-    def test_scale_and_add_array_with_array(self):
+    @parameterized.expand(['fwd', 'rev'], name_func=parameterized_name)
+    def test_scale_and_add_array_with_array(self, mode):
 
         class ExpCompArrayScale(TestExplCompArrayDense):
 
@@ -635,7 +642,7 @@ class TestScaling(unittest.TestCase):
         model.add_subsystem('comp', ExpCompArrayScale())
         model.connect('p1.x', 'comp.lengths')
 
-        prob.setup()
+        prob.setup(mode=mode)
         prob['comp.widths'] = np.ones((2, 2))
         prob.run_model()
 

--- a/openmdao/vectors/default_vector.py
+++ b/openmdao/vectors/default_vector.py
@@ -231,30 +231,33 @@ class DefaultVector(Vector):
             if rel_lookup:
                 views_rel[abs_name[relstart:]] = (v, shape == ())
 
-            if do_scaling:
-                factor_tuple = factors[abs_name][kind]
+            if do_scaling and abs_name in factors:
+                factor = factors[abs_name]
+                if kind in factor:
+                    factor_tuple = factor[kind]
 
-                if len(factor_tuple) == 4:
-                    # Only input vectors can have 4 factors. Linear input vectors need to be able
-                    # to handle the unit and solver scaling in opposite directions in reverse mode.
-                    a0, a1, factor, offset = factor_tuple
+                    if len(factor_tuple) == 4:
+                        # Only input vectors can have 4 factors. Linear input vectors need to be
+                        # able to handle the unit and solver scaling in opposite directions in
+                        # reverse mode.
+                        a0, a1, factor, offset = factor_tuple
 
-                    if islinear:
-                        scale0 = None
-                        scale1 = factor / a1
+                        if islinear:
+                            scale0 = None
+                            scale1 = factor / a1
+                        else:
+                            scale0 = (a0 + offset) * factor
+                            scale1 = a1 * factor
                     else:
-                        scale0 = (a0 + offset) * factor
-                        scale1 = a1 * factor
-                else:
-                    if self._name == 'linear' and self._typ == 'input':
-                        scale0 = None
-                        scale1 = 1.0 / factor_tuple[1]
-                    else:
-                        scale0, scale1 = factor_tuple
+                        if self._name == 'linear' and self._typ == 'input':
+                            scale0 = None
+                            scale1 = 1.0 / factor_tuple[1]
+                        else:
+                            scale0, scale1 = factor_tuple
 
-                if scaling[0] is not None:
-                    scaling[0][start:end] = scale0
-                scaling[1][start:end] = scale1
+                    if scaling[0] is not None:
+                        scaling[0][start:end] = scale0
+                    scaling[1][start:end] = scale1
 
             start = end
 

--- a/openmdao/vectors/petsc_transfer.py
+++ b/openmdao/vectors/petsc_transfer.py
@@ -37,6 +37,8 @@ else:
             Input indices for the transfer.
         out_inds : int ndarray
             Output indices for the transfer.
+        has_input_scaling : bool
+            Whether any of the inputs has scaling.
         comm : MPI.Comm or <FakeComm>
             Communicator of the system that owns this transfer.
 
@@ -46,11 +48,11 @@ else:
             Method that performs a PETSc scatter.
         """
 
-        def __init__(self, in_vec, out_vec, in_inds, out_inds, comm):
+        def __init__(self, in_vec, out_vec, in_inds, out_inds, has_input_scaling, comm):
             """
             Initialize all attributes.
             """
-            super().__init__(in_vec, out_vec, in_inds, out_inds)
+            super().__init__(in_vec, out_vec, in_inds, out_inds, has_input_scaling)
             in_indexset = PETSc.IS().createGeneral(self._in_inds, comm=comm)
             out_indexset = PETSc.IS().createGeneral(self._out_inds, comm=comm)
 
@@ -97,6 +99,9 @@ else:
 
             total_len = 0
 
+            scaled_in_set = set()
+            scale_factors = group._problem_meta['model_ref']()._scale_factors
+
             # Loop through all connections owned by this system
             for abs_in, abs_out in group._conn_abs_in2out.items():
                 sub_in = abs_in[mypathlen:].partition('.')[0]
@@ -111,6 +116,11 @@ else:
 
                     total_len += len(input_inds)
 
+                    if scale_factors is not None and abs_in in scale_factors:
+                        factors = scale_factors[abs_in]
+                        if 'input' in factors:
+                            scaled_in_set.add(sub_in)
+
                     xfer_in[sub_in].append(input_inds)
                     xfer_out[sub_in].append(output_inds)
                 else:
@@ -124,13 +134,15 @@ else:
                 # full transfer (transfer to all subsystems at once)
                 transfers[None] = PETScTransfer(group._vectors['input']['nonlinear'],
                                                 group._vectors['output']['nonlinear'],
-                                                full_xfer_in, full_xfer_out, group._comm)
+                                                full_xfer_in, full_xfer_out, len(scaled_in_set) > 0,
+                                                group._comm)
 
                 # transfers to individual subsystems
                 for sname, inds in xfer_in.items():
                     transfers[sname] = PETScTransfer(group._vectors['input']['nonlinear'],
                                                      group._vectors['output']['nonlinear'],
-                                                     inds, xfer_out[sname], group._comm)
+                                                     inds, xfer_out[sname],
+                                                     sname in scaled_in_set, group._comm)
 
             return transfers
 
@@ -191,12 +203,20 @@ else:
 
             total_size = total_size_nocolor = 0
 
+            scaled_in_set = set()
+            scale_factors = group._problem_meta['model_ref']()._scale_factors
+
             # Loop through all connections owned by this system
             for abs_in, abs_out in group._conn_abs_in2out.items():
                 sub_out = abs_out[mypathlen:].partition('.')[0]
 
                 # Only continue if the input exists on this processor
                 if abs_in in abs2meta_in:
+                    if scale_factors is not None and abs_in in scale_factors:
+                        factors = scale_factors[abs_in]
+                        if 'input' in factors:
+                            scaled_in_set.add(sub_out)
+
                     meta_in = abs2meta_in[abs_in]
                     idx_in = allprocs_abs2idx[abs_in]
                     idx_out = allprocs_abs2idx[abs_out]
@@ -306,13 +326,15 @@ else:
             transfers = {
                 None: PETScTransfer(vectors['input']['nonlinear'],
                                     vectors['output']['nonlinear'],
-                                    full_xfer_in, full_xfer_out, group._comm)
+                                    full_xfer_in, full_xfer_out, len(scaled_in_set) > 0,
+                                    group._comm)
             }
 
             for sname, inds in xfer_out.items():
                 transfers[sname] = PETScTransfer(vectors['input']['nonlinear'],
                                                  vectors['output']['nonlinear'],
-                                                 xfer_in[sname], inds, group._comm)
+                                                 xfer_in[sname], inds, sname in scaled_in_set,
+                                                 group._comm)
 
             if has_par_coloring:
                 has_nocolor_xfers = group._comm.allreduce(has_nocolor_xfers)
@@ -324,13 +346,15 @@ else:
                     transfers[(None, '@nocolor')] = PETScTransfer(vectors['input']['nonlinear'],
                                                                   vectors['output']['nonlinear'],
                                                                   full_xfer_in, full_xfer_out,
+                                                                  len(scaled_in_set) > 0,
                                                                   group._comm)
 
                     for sname, inds in xfer_out_nocolor.items():
                         transfers[(sname, '@nocolor')] = \
                             PETScTransfer(vectors['input']['nonlinear'],
                                           vectors['output']['nonlinear'],
-                                          xfer_in_nocolor[sname], inds, group._comm)
+                                          xfer_in_nocolor[sname], inds,
+                                          sname in scaled_in_set, group._comm)
 
             return transfers
 

--- a/openmdao/vectors/transfer.py
+++ b/openmdao/vectors/transfer.py
@@ -15,6 +15,8 @@ class Transfer(object):
         Input indices for the transfer.
     out_inds : int ndarray
         Output indices for the transfer.
+    has_input_scaling : bool
+        Whether any of the inputs has scaling.
 
     Attributes
     ----------
@@ -22,14 +24,17 @@ class Transfer(object):
         input indices for the transfer.
     _out_inds : int ndarray
         output indices for the transfer.
+    _has_input_scaling : bool
+        Whether any of the inputs has scaling.
     """
 
-    def __init__(self, in_vec, out_vec, in_inds, out_inds):
+    def __init__(self, in_vec, out_vec, in_inds, out_inds, has_input_scaling):
         """
         Initialize all attributes.
         """
         self._in_inds = in_inds
         self._out_inds = out_inds
+        self._has_input_scaling = has_input_scaling
 
     def __str__(self):
         """


### PR DESCRIPTION
Also removed unnecessary input scaling during transfers, i.e., when transferring data to a particular subsystem of a group, the inputs are scaled now only if that is required for that particular transfer.  Before it was done if any inputs anywhere beneath that group required scaling.  

### Backwards incompatibilities

None

### New Dependencies

None
