### PR TITLE
Updated min version for bokeh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
 ]
 visualization = [
     "panel",
-    "bokeh>=2.4.0",
+    "bokeh>=3.4.0",
     "colorama",
     "matplotlib",
     "rich"


### PR DESCRIPTION
### Summary

Update the minimum version for the bokeh library to 3.4. 

Earlier versions result in this error when running the real-time optimization plot. 

```
ERROR:bokeh.util.tornado:Error thrown from periodic callback:
ERROR:bokeh.util.tornado:Traceback (most recent call last):
  File "/Users/hschilli/miniforge3/envs/openmdao/lib/python3.11/site-packages/tornado/gen.py", line 529, in callback
    result_list.append(f.result())
                       ^^^^^^^^^^
  File "/Users/hschilli/miniforge3/envs/openmdao/lib/python3.11/site-packages/bokeh/server/session.py", line 94, in _needs_document_lock_wrapper
    result = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hschilli/miniforge3/envs/openmdao/lib/python3.11/site-packages/bokeh/server/session.py", line 226, in with_document_locked
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hschilli/miniforge3/envs/openmdao/lib/python3.11/site-packages/bokeh/document/callbacks.py", line 485, in wrapper
    return invoke_with_curdoc(doc, invoke)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/hschilli/miniforge3/envs/openmdao/lib/python3.11/site-packages/bokeh/document/callbacks.py", line 443, in invoke_with_curdoc
    return f()
           ^^^
  File "/Users/hschilli/miniforge3/envs/openmdao/lib/python3.11/site-packages/bokeh/document/callbacks.py", line 484, in invoke
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/hschilli/Documents/OpenMDAO/dev/I3403-real-time-plotting/openmdao/visualization/realtime_opt_plot/realtime_opt_plot.py", line 678, in _update
    self._toggles[iline].label = f"{desvar_name} ({units}) {desvar_value.shape}"
    ~~~~~~~~~~~~~^^^^^^^
IndexError: list index out of range

```

### Related Issues

- Resolves #3507 

### Backwards incompatibilities

None

### New Dependencies

None
