### PR TITLE
`pyOptSparseDriver` will now raise an `ImportError` instead of a `RuntimeError` if `pyoptsparse` is not installed.

### DIFF
--- a/openmdao/drivers/pyoptsparse_driver.py
+++ b/openmdao/drivers/pyoptsparse_driver.py
@@ -191,7 +191,7 @@ class pyOptSparseDriver(Driver):
         """
         if pyoptsparse is None:
             # pyoptsparse is not installed
-            raise RuntimeError('pyOptSparseDriver is not available, pyOptsparse is not installed.')
+            raise ImportError('pyOptSparseDriver is not available, pyOptsparse is not installed.')
 
         if isinstance(pyoptsparse, Exception):
             # there is some other issue with the pyoptsparse installation

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -157,7 +157,7 @@ class TestNotInstalled(unittest.TestCase):
         from openmdao.drivers.pyoptsparse_driver import pyOptSparseDriver
 
         # but we get a RuntimeError if we try to instantiate
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaises(ImportError) as ctx:
             pyOptSparseDriver()
 
         self.assertEqual(str(ctx.exception),


### PR DESCRIPTION
### Summary

`pyOptSparseDriver` will now raise an `ImportError` instead of a `RuntimeError` if `pyoptsparse` is not installed.

### Related Issues

- Resolves #3510

### Backwards incompatibilities

`pyOptSparseDriver` will now raise an `ImportError` instead of a `RuntimeError` if `pyoptsparse` is not installed.

### New Dependencies

None
