### PR TITLE
Fixed a PEP issue

### DIFF
--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -612,7 +612,7 @@ def _new_unit(name, factor, powers):
 
 def add_offset_unit(name, baseunit, factor, offset, comment=''):
     """
-    Adding Offset Unit.
+    Add Offset Unit.
 
     Parameters
     ----------
@@ -646,7 +646,7 @@ def add_offset_unit(name, baseunit, factor, offset, comment=''):
 
 def add_unit(name, unit, comment=''):
     """
-    Adding Unit.
+    Add Unit.
 
     Parameters
     ----------


### PR DESCRIPTION
### Summary

```
/home/runner/miniconda3/envs/test/lib/python3.13/site-packages/openmdao/code_review/test_lint_peps.py:LintTestCase.test_pep257  ... FAIL (00:00:3.31, 50 MB)
Traceback (most recent call last):
  File "/home/runner/miniconda3/envs/test/lib/python3.13/site-packages/openmdao/code_review/test_lint_peps.py", line 121, in test_pep257
    self.fail('{} PEP 257 Failure(s):\n'.format(len(failures)) + '\n'.join(failures))
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: 2 PEP [25](https://github.com/swryan/OpenMDAO/actions/runs/14898629321/job/41878954844#step:15:26)7 Failure(s):
/home/runner/miniconda3/envs/test/lib/python3.13/site-packages/openmdao/utils/units.py:614 in public function `add_offset_unit`:
        D401: First line should be in imperative mood (perhaps 'Add', not 'Adding')
/home/runner/miniconda3/envs/test/lib/python3.13/site-packages/openmdao/utils/units.py:648 in public function `add_unit`:
        D401: First line should be in imperative mood (perhaps 'Add', not 'Adding')
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None

