### PR TITLE
replaced view[0] with view.item() in Vector to get true scalars instead of numpy scalar arrays

### DIFF
--- a/openmdao/components/exec_comp.py
+++ b/openmdao/components/exec_comp.py
@@ -1089,7 +1089,7 @@ class ExecComp(ExplicitComponent):
         inv_stepsize = 1.0 / self.complex_stepsize
         has_diag_partials = self.options['has_diag_partials']
         inarr = self._inarray
-        vdict = self._viewdict
+        vdict = self._viewdict.dct
 
         inarr[:] = self._inputs.asarray(copy=False)
 
@@ -1105,7 +1105,11 @@ class ExecComp(ExplicitComponent):
 
                 for u in out_names:
                     if (u, inp) in partials:
-                        partials[u, inp] = imag(vdict[u] * inv_stepsize).flat
+                        subval, subval_is_scalar = vdict[u]
+                        if subval_is_scalar:
+                            partials[u, inp] = imag(subval * inv_stepsize)
+                        else:
+                            partials[u, inp] = imag(subval * inv_stepsize).flat
 
                 # restore old input value
                 ival -= step
@@ -1120,7 +1124,11 @@ class ExecComp(ExplicitComponent):
                     for u in out_names:
                         if (u, inp) in partials:
                             # set the column in the Jacobian entry
-                            partials[u, inp][:, i] = imag(vdict[u] * inv_stepsize).flat
+                            subval, subval_is_scalar = vdict[u]
+                            if subval_is_scalar:
+                                partials[u, inp][:, i] = imag(subval * inv_stepsize)
+                            else:
+                                partials[u, inp][:, i] = imag(subval * inv_stepsize).flat
 
                     # restore old input value
                     ival[idx] -= step
@@ -1132,7 +1140,7 @@ class _ViewDict(object):
 
     def __getitem__(self, name):
         val, is_scalar = self.dct[name]
-        return val[0] if is_scalar else val
+        return val.item() if is_scalar else val
 
     def __setitem__(self, name, value):
         val, _ = self.dct[name]

--- a/openmdao/core/tests/test_expl_comp.py
+++ b/openmdao/core/tests/test_expl_comp.py
@@ -308,12 +308,12 @@ class ExplCompTestCase(unittest.TestCase):
                                           out_stream=stream)
 
         self.assertEqual([
-            ('comp.z', {'val': 24., 'resids': [0.], 'units': 'inch', 'shape': (), 'desc': '',
+            ('comp.z', {'val': 24., 'resids': 0., 'units': 'inch', 'shape': (), 'desc': '',
                         'lower': None, 'upper': None, 'ref': 1.0, 'ref0': 0.0, 'res_ref': 1.0}),
-            ('p1.x', {'val': 12., 'resids': [0.], 'units': 'inch', 'shape': (), 'desc': 'indep x',
-                      'lower': [1.], 'upper': [100.], 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1}),
-            ('p2.y', {'val': 1., 'resids': [0.], 'units': 'ft', 'shape': (), 'desc': 'indep y',
-                      'lower': [2.], 'upper': [200.], 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
+            ('p1.x', {'val': 12., 'resids': 0., 'units': 'inch', 'shape': (), 'desc': 'indep x',
+                      'lower': 1., 'upper': 100., 'ref': 1.1, 'ref0': 2.1, 'res_ref': 1.1}),
+            ('p2.y', {'val': 1., 'resids': 0., 'units': 'ft', 'shape': (), 'desc': 'indep y',
+                      'lower': 2., 'upper': 200., 'ref': 1.2, 'ref0': 0.0, 'res_ref': 2.2}),
         ], sorted(outputs))
 
         text = stream.getvalue().split('\n')

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -89,7 +89,10 @@ def ensure_compatible(name, value, shape=None, indices=None, default_shape=(1,))
     else:
         # shape is determined, if value is scalar assign it to array of shape
         # otherwise make sure value is an array of the determined shape
-        if np.ndim(value) == 0 or value.shape == (1,):
+        if np.ndim(value) == 0:
+            if shape != ():
+                value = np.full(shape, value)
+        elif value.shape == (1,):
             value = np.full(shape, value)
         else:
             value = np.atleast_1d(value).astype(np.float64)

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -170,7 +170,7 @@ class Vector(object):
         dict
             Dictionary containing the variable values.
         """
-        return {n: vinfo.view[0] if vinfo.is_scalar else vinfo.view.copy()
+        return {n: vinfo.view.item() if vinfo.is_scalar else vinfo.view.copy()
                 for n, vinfo in self._views.items()}
 
     def keys(self):
@@ -196,13 +196,13 @@ class Vector(object):
         if self._under_complex_step:
             for n, vinfo in self._views.items():
                 if n in self._names:
-                    yield vinfo.view[0] if vinfo.is_scalar else vinfo.view
+                    yield vinfo.view.item() if vinfo.is_scalar else vinfo.view
                 else:
                     yield 0.0j if vinfo.is_scalar else np.zeros_like(vinfo.view)
         else:
             for n, vinfo in self._views.items():
                 if n in self._names:
-                    yield vinfo.view[0].real if vinfo.is_scalar else vinfo.view.real
+                    yield vinfo.view.item().real if vinfo.is_scalar else vinfo.view.real
                 else:
                     yield 0.0 if vinfo.is_scalar else np.zeros_like(vinfo.view.real)
 
@@ -225,11 +225,11 @@ class Vector(object):
         if self._under_complex_step:
             for n, vinfo in self._views.items():
                 if n in self._names:
-                    yield n[plen:], vinfo.view[0] if vinfo.is_scalar else vinfo.view
+                    yield n[plen:], vinfo.view.item() if vinfo.is_scalar else vinfo.view
         else:
             for n, vinfo in self._views.items():
                 if n in self._names:
-                    yield n[plen:], vinfo.view[0].real if vinfo.is_scalar else vinfo.view.real
+                    yield n[plen:], vinfo.view.item().real if vinfo.is_scalar else vinfo.view.real
 
     def ranges(self):
         """
@@ -303,9 +303,9 @@ class Vector(object):
             for name, vinfo in self._views.items():
                 if vinfo.is_scalar:
                     if self._under_complex_step:
-                        yield name, vinfo.view[0]
+                        yield name, vinfo.view.item()
                     else:
-                        yield name, vinfo.view[0].real
+                        yield name, vinfo.view.item().real
                 else:
                     if self._under_complex_step:
                         yield name, vinfo.view
@@ -415,7 +415,7 @@ class Vector(object):
 
         vinfo = self._views[name]
         if vinfo.is_scalar:
-            return vinfo.view[0]
+            return vinfo.view.item() if self._under_complex_step else vinfo.view.item().real
 
         return vinfo.view if self._under_complex_step else vinfo.view.real
 


### PR DESCRIPTION
This should help a little with performance in cases where shape is declared as (). So now we'll get actual float scalars instead of numpy scalar arrays, which should be a little quicker inside of components for example.


### Backwards incompatibilities

None

### New Dependencies

None
