### PR TITLE
Updated some tests to use assert_warning

### DIFF
--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -2077,11 +2077,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         #    Expected result: Error
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
+        msg = expected_check_partials_error.format(prob=prob, var='x', comp=parab)
+        with assert_warning(OMInvalidCheckDerivativesOptionsWarning, msg):
             prob.check_partials(method='fd')
-
-        self.assertEqual(str(cm.exception),
-                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 3:
         #    Compute partials: fd, with default options
@@ -2123,10 +2121,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         #    Expected result: Error since using fd to check fd. All options the same
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
+        msg = expected_check_partials_error.format(prob=prob, var='x', comp=parab)
+        with assert_warning(OMInvalidCheckDerivativesOptionsWarning, msg):
             prob.check_partials(method='cs')
-        self.assertEqual(str(cm.exception),
-                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 7:
         #    Compute partials: fd, with default options
@@ -2146,10 +2143,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob, parab = create_problem()
         parab.declare_partials(of='*', wrt='*', method='fd')
         parab.set_check_partial_options('*')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
+        msg = expected_check_partials_error.format(prob=prob, var='x', comp=parab)
+        with assert_warning(OMInvalidCheckDerivativesOptionsWarning, msg):
             prob.check_partials()
-        self.assertEqual(str(cm.exception),
-                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 9:
         #    Compute partials: fd, with default options
@@ -2205,10 +2201,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob, parab = create_problem(force_alloc_complex=True)
         parab.declare_partials(of='*', wrt='*', method='cs')
         parab.set_check_partial_options('*', method='cs')
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
+        msg = expected_check_partials_error.format(prob=prob, var='x', comp=parab)
+        with assert_warning(OMInvalidCheckDerivativesOptionsWarning, msg):
             prob.check_partials()
-        self.assertEqual(str(cm.exception),
-                         expected_check_partials_error.format(prob=prob, var='x', comp=parab))
 
         # Scenario 15:
         #    Compute partials: cs, with default options
@@ -2245,10 +2240,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.model.approx_totals()
         prob.setup()
         prob.run_model()
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
+        msg = expected_check_totals_error_msg.format(prob=prob)
+        with assert_warning(OMInvalidCheckDerivativesOptionsWarning, msg):
             prob.check_totals()
-        self.assertEqual(str(cm.exception),
-                         expected_check_totals_error_msg.format(prob=prob))
 
         # Scenario 18:
         #    Compute totals: approx on totals using defaults
@@ -2299,10 +2293,9 @@ class TestCheckDerivativesOptionsDifferentFromComputeOptions(unittest.TestCase):
         prob.model.approx_totals(method='cs')
         prob.setup()
         prob.run_model()
-        with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
+        msg = expected_check_totals_error_msg.format(prob=prob)
+        with assert_warning(OMInvalidCheckDerivativesOptionsWarning, msg):
             prob.check_totals(method='cs')
-        self.assertEqual(str(cm.exception),
-                         expected_check_totals_error_msg.format(prob=prob))
 
         # Scenario 22:
         #    Compute totals: fd, the default


### PR DESCRIPTION
### Summary

We started getting test failures in `test_check_partials` on the `Latest` test workflow.  While I was not able to reproduce locally, the problem seems to be that the tests need to reset the warning registry as is done in the `assert_warning` utility function.

The tests have been updated to use `assert_warning` and all tests are now passing on the `Latest` workflow.

```
/home/runner/miniconda3/envs/test/lib/python3.13/site-packages/openmdao/core/tests/test_check_partials.py:TestCheckDerivativesOptionsDifferentFromComputeOptions.test_partials_check_same_as_derivative_compute  ... FAIL (00:00:0.01, 568 MB)
Traceback (most recent call last):
  File "/home/runner/miniconda3/envs/test/lib/python3.13/site-packages/openmdao/core/tests/test_check_partials.py", line 2080, in test_partials_check_same_as_derivative_compute
    with self.assertRaises(OMInvalidCheckDerivativesOptionsWarning) as cm:
         ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: OMInvalidCheckDerivativesOptionsWarning not raised
```

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
