### PR TITLE
Added MMBtu as a valid physical unit for our imperial-using HVAC users.

### DIFF
--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -274,6 +274,17 @@ class TestPhysicalUnit(unittest.TestCase):
             simplified_str = simplify_unit(test_str)
             self.assertEqual(simplified_str, correct_str)
 
+    def test_MMBtu(self):
+        fact = unit_conversion('MMBtu', 'Btu')
+        assert_near_equal(fact[0], 1000.)
+
+    def test_suggest_units(self):
+        with self.assertRaises(ValueError) as cm:
+            unit_conversion('lbm', 'kgg')
+        expected = ("The units 'kgg' are invalid. Perhaps "
+                    "you meant one of the following units?: ['kg', 'g']")
+        self.assertEqual(expected, str(cm.exception))
+
     def test_atto_seconds(self):
         # The unit 'as' was bugged because it is a python keyword.
 

--- a/openmdao/utils/tests/test_units.py
+++ b/openmdao/utils/tests/test_units.py
@@ -276,7 +276,7 @@ class TestPhysicalUnit(unittest.TestCase):
 
     def test_MMBtu(self):
         fact = unit_conversion('MMBtu', 'Btu')
-        assert_near_equal(fact[0], 1000.)
+        assert_near_equal(fact[0], 1.0E6)
 
     def test_suggest_units(self):
         with self.assertRaises(ValueError) as cm:

--- a/openmdao/utils/unit_library.ini
+++ b/openmdao/utils/unit_library.ini
@@ -196,6 +196,7 @@ rps: 2*pi*rad/s, RPS
 cal: 4.184*J, thermochemical calorie
 cali: 4.1868*J, international calorie
 Btu: 1055.05585262*J, British thermal unit
+MMBtu: 1055.05585262E3*J, one thousand Btu
 
 acre: mi**2/640, acre
 hp: 745.7*W, horsepower

--- a/openmdao/utils/unit_library.ini
+++ b/openmdao/utils/unit_library.ini
@@ -196,7 +196,7 @@ rps: 2*pi*rad/s, RPS
 cal: 4.184*J, thermochemical calorie
 cali: 4.1868*J, international calorie
 Btu: 1055.05585262*J, British thermal unit
-MMBtu: 1055.05585262E3*J, one thousand Btu
+MMBtu: 1055.05585262E6*J, one million Btu
 
 acre: mi**2/640, acre
 hp: 745.7*W, horsepower

--- a/openmdao/utils/units.py
+++ b/openmdao/utils/units.py
@@ -14,8 +14,8 @@ import sys
 import re
 import os.path
 from collections import OrderedDict
-
 from configparser import RawConfigParser as ConfigParser
+from difflib import get_close_matches
 
 # pylint: disable=E0611, F0401
 from math import floor, pi
@@ -915,7 +915,11 @@ def _find_unit(unit, error=False):
                         # no prefixes found, unknown unit
                         else:
                             if error:
-                                raise ValueError(f"The units '{name}' are invalid.")
+                                guesses = get_close_matches(name, list(unit_table.keys()),
+                                                            n=5, cutoff=0.5)
+                                raise ValueError(f"The units '{name}' are invalid. "
+                                                 "Perhaps you meant one of the "
+                                                 f"following units?: {guesses}")
                             return None
 
                 unit = eval(name, {'__builtins__': None}, unit_table)  # nosec: scope limited

--- a/roadmaps/2025roadmap.md
+++ b/roadmaps/2025roadmap.md
@@ -1,0 +1,47 @@
+# OpenMDAO Development Map 2023
+
+Author: Rob Falck
+Date: 2025-05-12
+
+## What is this roadmap for?
+As in previous years, this roadmap exists to provide general guidance for our development decisions in the coming year, and to provide a retrospective for our performance in the previous year.
+
+## Performance Assessment for 2024
+
+While we neglected to post an official roadmap for 2024, we made significant progress on reducing the activation energy for users.
+
+We made considerable strides into automatic differentiation by closely coupling the capability of the JAX framework with OpenMDAO's JAXExplicitComponent and JaxImplicitComponent. This is in addition to existing AD capability on the Julia side via `OpenMDAO.jl` and the work being developed on the Computational Systems Design Language (CSDL) at UCSD.
+
+AnalysisDriver is a generalization of capability regarding model analysis and visualization. DOEDriver's behavior was governed by the optimization problem as defined upon the system. Performing a simple parameter sweep across model inputs wasn't simple to do. The work on the AnalaysisDriver and related visualizations should improve the situation.
+
+While we made some good strides into developing instructional content on the web, changes in our team and our budget have put an end to those efforts in the short term.
+
+## 2025 Focus Areas
+
+1. Continued expansion of coupling with AD tools. Given what we can do with JAX, it makes sense to make similar efforts towards the portion of the community that relies upon PyTorch for similar capability. We will look at building components that wrap PyTorch models in much the same way that we can wrap JAX models today.
+
+2. Post-Optimality Sensitivity and Suboptimization
+
+We're finishing up some work that generalizes generation of lagrange multipliers following optimization. These multipliers provide the sensitivty of the objective function to the constraints and bounds imposed by the user, and we can use these to obtain sensitivities wrt other model inputs.
+
+In viewing the optimization problem as its own implicit process, we're also interested in obtaining sensitivities for the resulting design variable values with respect to the bounds/constraints and inputs. The math to accomplish this requires second derivatives, and at least initially, we'll be relying upon finite differences **across compute_totals** (not across the optmization) to obtain these.
+
+Ultimately the most robust way to do this would involve directly computing second total derivatives using the MAUD machinery in OpenMDAO. In the past this has always been hampered by the need for the user to compute their own second derivatives. Perhaps AD tools will open up a path to this.
+
+3. AnalysisDriver to Surrogate model tool
+
+One of the biggest use-cases for AnalysisDriver is to inform the creation of surrogate models. It mkes sense that OpenMDAO should provide some automation of this capability.
+
+4. Partial Derivative Relevance
+
+`compute_partials` currently has no way of knowing what partials are actually needed for the current optimization problem.  In many cases this is moot because the partial calculations are generally less expensive than conditionally checking for them.
+
+However, there are cases where individual partial calculations are not cheap. If we could use relevance to determine which ones need to be calculated, OpenMDAO would get considerably faster in some situations.
+
+This is also the case for using finite-difference or complex-step across big models, especially something like a file-wrapped external code. Using `declare_partials(of='*', wrt='*', method='fd')` will cause OpenMDAO to compute all of the partials, even those not needed. There should be room for some considerable performance gains here.
+
+5. Expand use of shape_by_conn and implement units_by_conn
+
+We have had a shape-by-connection capability for some time, but it hasn't gotten significant uptake because computing partials by hand when the shapes of inputs can be changing is too challenging. This is another scenario where AD should help.
+
+We also frequently find ourselves in situations where the units of outputs depend upon the units of inputs. This is often the case when "pass-thru" components are used, or with something like a simple matrix-vector product. Dymos is probably the best example of this.  Given a generic ODE model, it performs some significant introspection to determine the shapes and units of variables in the ODE. Having a units-by-conn capability would make life easier here as well.

--- a/roadmaps/2025roadmap.md
+++ b/roadmaps/2025roadmap.md
@@ -12,7 +12,7 @@ While we neglected to post an official roadmap for 2024, we made significant pro
 
 We made considerable strides into automatic differentiation by closely coupling the capability of the JAX framework with OpenMDAO's JAXExplicitComponent and JaxImplicitComponent. This is in addition to existing AD capability on the Julia side via `OpenMDAO.jl` and the work being developed on the Computational Systems Design Language (CSDL) at UCSD.
 
-AnalysisDriver is a generalization of capability regarding model analysis and visualization. DOEDriver's behavior was governed by the optimization problem as defined upon the system. Performing a simple parameter sweep across model inputs wasn't simple to do. The work on the AnalaysisDriver and related visualizations should improve the situation.
+AnalysisDriver is a generalization of DOEDriver capability regarding model analysis and visualization. DOEDriver's behavior was governed by the optimization problem as defined upon the system. Performing a simple parameter sweep across model inputs wasn't simple to do. The work on the AnalaysisDriver and related visualizations should improve the situation.
 
 While we made some good strides into developing instructional content on the web, changes in our team and our budget have put an end to those efforts in the short term.
 


### PR DESCRIPTION
### Summary

MMBtu is added as a valid physical unit, meaning "thousand-thousand Btu". 
This unit is common in HVAC use, but confusing because the M are not metric prefixes, but Roman numerals.
Previously, OpenMDAO would pick this up as "mega-mega Btu".

Added get_closest_matches logic to find units, so requesting an invalid unit give a somewhat more helpful message including close matches.

### Related Issues

- Resolves #3528 

### Backwards incompatibilities

None

### New Dependencies

None
