### PR TITLE
Added `compute_lagrange_multipliers` method to Driver.

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1703,7 +1703,8 @@ class Driver(object, metaclass=DriverMetaclass):
         assume_dvs_active : bool
             Override to force design variables to be treated as active.
 
-        Returns:
+        Returns
+        -------
         active_cons : dict[str: dict
             The names of the active constraints. For each active constraint,
             a dict of the active indices and the active bound (0='equals',

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1687,6 +1687,275 @@ class Driver(object, metaclass=DriverMetaclass):
         """
         pass
 
+    def _get_active_cons_and_dvs(self, feas_atol=1.e-6, feas_rtol=1.e-6, assume_dvs_active=False):
+        """
+        Obtain the constraints and design varaibles which are active.
+
+        Active means the constraint or design variable is on the bound (or close enough
+        that it satisfies np.isclose(val, bound, atol=feas_atol, rtol=feas_rtol))
+
+        Parameters
+        ----------
+        feas_atol : float
+            Feasibility absolute tolerance
+        feas_rtol : float
+            Feasibility relative tolerance
+        assume_dvs_active : bool
+            Override to force design variables to be treated as active.
+
+        Returns:
+        active_cons : dict[str: dict
+            The names of the active constraints. For each active constraint,
+            a dict of the active indices and the active bound (0='equals',
+            -1='lower', 1='upper') is provided.
+        active_dvs : list[str]
+            The names of the active design variables. For each active design
+            variable, a dict of the active indices and the active bound
+            (0='equals', -1='lower', 1='upper') is provided. An active
+            design variable bound of 'equal' is only possible when
+            assume_dvs_active is True, and the design variables are
+            returned as if they are on an active equality constraint.
+        """
+        active_cons = {}
+        active_dvs = {}
+        prob = self._problem()
+        des_vars = self._designvars
+        constraints = self._cons
+
+        for constraint, con_options in constraints.items():
+            constraint_value = np.copy(prob.get_val(constraint)).ravel()
+            con_size = con_options['size']
+            if con_options.get('equals', None) is not None:
+                active_cons[constraint] = {'indices': np.arange(con_size, dtype=int),
+                                           'active_bounds': np.zeros(con_size, dtype=int)}
+            else:
+                constraint_upper = con_options.get("upper", np.inf)
+                constraint_lower = con_options.get("lower", -np.inf)
+
+                upper_mask = np.logical_or(constraint_value > constraint_upper,
+                                           np.isclose(constraint_value, constraint_upper,
+                                                      atol=feas_atol, rtol=feas_rtol))
+                upper_idxs = np.where(upper_mask)[0]
+                lower_mask = np.logical_or(constraint_value < constraint_lower,
+                                           np.isclose(constraint_value, constraint_lower,
+                                                      atol=feas_atol, rtol=feas_rtol))
+                lower_idxs = np.where(lower_mask)[0]
+
+                active_idxs = sorted(np.concatenate((upper_idxs, lower_idxs)))
+                active_bounds = [1 if idx in upper_idxs else -1 for idx in active_idxs]
+                if active_idxs:
+                    active_cons[constraint] = {'indices': active_idxs,
+                                               'active_bounds': active_bounds}
+
+        for des_var, des_var_options in des_vars.items():
+            des_var_value = np.copy(prob.get_val(des_var)).ravel()
+            des_var_upper = np.ravel(des_var_options.get("upper", np.inf))
+            des_var_lower = np.ravel(des_var_options.get("lower", -np.inf))
+            des_var_size = des_var_options['size']
+            if assume_dvs_active:
+                active_dvs[des_var] = {'indices': np.arange(des_var_size, dtype=int),
+                                       'active_bounds': np.zeros(des_var_size, dtype=int)}
+            else:
+                upper_mask = np.logical_or(des_var_value > des_var_upper,
+                                           np.isclose(des_var_value, des_var_upper,
+                                                      atol=feas_atol, rtol=feas_rtol))
+                upper_idxs = np.where(upper_mask)[0]
+                lower_mask = np.logical_or(des_var_value < des_var_lower,
+                                           np.isclose(des_var_value, des_var_lower,
+                                                      atol=feas_atol, rtol=feas_rtol))
+                lower_idxs = np.where(lower_mask)[0]
+
+                active_idxs = sorted(np.concatenate((upper_idxs, lower_idxs)))
+                active_bounds = [1 if idx in upper_idxs else -1 for idx in active_idxs]
+                if active_idxs:
+                    active_dvs[des_var] = {'indices': np.asarray(active_idxs, dtype=int),
+                                           'active_bounds': np.asarray(active_bounds, dtype=int)}
+
+        return active_cons, active_dvs
+
+    def _unscale_lagrange_multipliers(self, multipliers):
+        """
+        Unscale the Lagrange multipliers from optimizer scaling to physical/model scaling.
+
+        This method assumes that the optimizer is in a converged state, satisfying both the
+        primal constraints as well as the optimality conditions.
+
+        Parameters
+        ----------
+        active_constraints : Sequence[str]
+            Active constraints/dvs in the optimization, determined using the
+            get_active_cons_and_dvs method.
+        multipliers : dict[str: ArrayLike]
+            The Lagrange multipliers, in Driver-scaled units.
+
+        Returns
+        -------
+        dict
+            The Lagrange multipliers in model/physical units.
+        """
+        if len(self._objs) != 1:
+            raise ValueError('Lagrange Multplier estimation requires that there '
+                             f'be a single objective, but there are {len(self._objs)}.')
+
+        obj_meta = list(self._objs.values())[0]
+        obj_ref = obj_meta['ref']
+        obj_ref0 = obj_meta['ref0']
+
+        if obj_ref is None:
+            obj_ref = 1.0
+        if obj_ref0 is None:
+            obj_ref0 = 0.0
+
+        unscaled_multipliers = {}
+
+        for name, val in multipliers.items():
+            if name in self._designvars:
+                ref = self._designvars[name]['ref']
+                ref0 = self._designvars[name]['ref0']
+            else:
+                for response in self._responses.values():
+                    if response['name'] == name:
+                        ref = response['ref']
+                        ref0 = response['ref0']
+
+            if ref is None:
+                ref = 1.0
+            if ref0 is None:
+                ref0 = 0.0
+
+            unscaled_multipliers[name] = val * (obj_ref - obj_ref0) / (ref - ref0)
+
+        return unscaled_multipliers
+
+    def compute_lagrange_multipliers(self, driver_scaling=False, feas_tol=1.0E-6):
+        """
+        Get the approximated Lagrange multipliers of one or more constraints.
+
+        This method assumes that the optimizer is in a converged state, satisfying both the
+        primal constraints as well as the optimality conditions.
+
+        The estimation of which constraints are active depends upon the feasibility tolerance
+        specified. This applies to the driver-scaled values of the constraints, and should be
+        the same as that used by the optimizer, if available.
+
+        Optimizers which provide their Lagrange multipliers may override this method.
+
+        Parameters
+        ----------
+        driver_scaling : bool
+            If False, return the Lagrange multipliers estimates in their physical units.
+            If True, return the Lagrange multiplier estimates in a driver-scaled state.
+        feas_tol : float or None
+            The feasibility tolerance under which the optimization was run. If None, attempt
+            to determine this automatically based on the specified optimizer settings.
+
+        Returns
+        -------
+        multipliers : dict[str: ArrayLike]
+            A dictionary with an entry for each active constraint and the
+            associated Lagrange multiplier value.
+        active_info : dict[str: dict
+            A dictionary with an entry for each active constraint and its
+            active indices and bounds.
+        """
+        if not self.supports['optimization']:
+            raise NotImplementedError('Lagrange multipliers are only available for '
+                                      'drivers which support optimization.')
+
+        prob = self._problem()
+
+        objective = list(self._objs.keys())[0]
+        constraints = self._cons
+        des_vars = self._designvars
+
+        of_totals = {objective, *constraints.keys()}
+        wrt_totals = {*des_vars.keys()}
+
+        active_cons, active_dvs = self._get_active_cons_and_dvs(feas_atol=feas_tol,
+                                                                feas_rtol=feas_tol)
+
+        totals = prob.compute_totals(list(of_totals),
+                                     list(wrt_totals),
+                                     driver_scaling=True)
+
+        grad_f = {inp: totals[objective, inp] for inp in des_vars.keys()}
+
+        n = 0
+        for inp in grad_f.keys():
+            n += grad_f[inp].size
+
+        grad_f_vec = np.zeros((n))
+        offset = 0
+        for inp in grad_f.keys():
+            inp_size = grad_f[inp].size
+            grad_f_vec[offset:offset + inp_size] = grad_f[inp]
+            offset += inp_size
+
+        actives = active_cons | active_dvs
+        n_active = np.sum(np.fromiter((len(c['indices']) for c in actives.values()), dtype=int))
+        active_cons_mat = np.zeros((n, n_active))
+        active_jac_blocks = []
+
+        if n_active > 0:
+            # TODO: Convert this to a sparse nonlinear least squares.
+            for i, (con_name, active_meta) in enumerate(actives.items()):
+                # If the constraint is a design variable, the constraint gradient
+                # wrt des vars is just an identity matrix sized by the number of
+                # active elements in the design variable.
+                active_idxs = active_meta['indices']
+                if con_name in des_vars.keys():
+                    size = des_vars[con_name]['size']
+                    con_grad = {(con_name, inp): np.eye(size)[active_idxs, ...] if inp == con_name
+                                else np.zeros((size, size))[active_idxs, ...]
+                                for inp in des_vars.keys()}
+                else:
+                    con_grad = {(con_name, inp): totals[con_name, inp][active_idxs, ...]
+                                for inp in des_vars.keys()}
+                active_jac_blocks.append(list(con_grad.values()))
+
+            active_cons_mat = np.block(active_jac_blocks)
+        else:
+            return {}, actives
+
+        multipliers_vec, optimality_squared, rank, singular_vals = \
+            np.linalg.lstsq(active_cons_mat.T, -grad_f_vec, rcond=None)
+
+        multipliers = dict()
+        offset = 0
+
+        opts = ['indices', 'ref0', 'ref', 'units']
+        driver_vars = prob.list_driver_vars(out_stream=None,
+                                            desvar_opts=opts + ['flat_indices'],
+                                            cons_opts=opts + ['flat_indices'],
+                                            objs_opts=opts,
+                                            return_format='dict')
+        driver_vars = driver_vars['design_vars'] | driver_vars['constraints']
+
+        for constraint, act_info in actives.items():
+            act_idxs = act_info['indices']
+            active_size = len(act_idxs)
+            mult_vals = multipliers_vec[offset:offset + active_size]
+
+            shape = prob.get_val(constraint).shape
+            opt_idxs = driver_vars[constraint]['indices']
+            opt_flat_idxs = driver_vars[constraint]['indices']
+            if opt_idxs is not None:
+                if opt_flat_idxs:
+                    flat_opt_idxs = opt_idxs
+                else:
+                    flat_opt_idxs = np.ravel_multi_index(opt_idxs)
+                unraveled_idxs = np.unravel_index(flat_opt_idxs[act_idxs], shape)
+            else:
+                unraveled_idxs = np.unravel_index(act_idxs, shape)
+            multipliers[constraint] = np.zeros(shape)
+            multipliers[constraint][unraveled_idxs] = mult_vals
+            offset += active_size
+
+        if not driver_scaling:
+            self._unscale_lagrange_multipliers(multipliers)
+
+        return multipliers, actives
+
 
 class SaveOptResult(object):
     """

--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -1737,16 +1737,16 @@ class Driver(object, metaclass=DriverMetaclass):
                     upper_idxs = np.empty()
                 else:
                     upper_mask = np.logical_or(constraint_value > constraint_upper,
-                                            np.isclose(constraint_value, constraint_upper,
-                                                        atol=feas_atol, rtol=feas_rtol))
+                                               np.isclose(constraint_value, constraint_upper,
+                                                          atol=feas_atol, rtol=feas_rtol))
                     upper_idxs = np.where(upper_mask)[0]
 
                 if np.all(np.isinf(constraint_lower)):
                     lower_idxs = np.empty()
                 else:
                     lower_mask = np.logical_or(constraint_value < constraint_lower,
-                                            np.isclose(constraint_value, constraint_lower,
-                                                        atol=feas_atol, rtol=feas_rtol))
+                                               np.isclose(constraint_value, constraint_lower,
+                                                          atol=feas_atol, rtol=feas_rtol))
                     lower_idxs = np.where(lower_mask)[0]
 
                 active_idxs = sorted(np.concatenate((upper_idxs, lower_idxs)))

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1770,7 +1770,8 @@ class Problem(object, metaclass=ProblemMetaclass):
                          desvar_opts=[],
                          cons_opts=[],
                          objs_opts=[],
-                         out_stream=_DEFAULT_OUT_STREAM
+                         out_stream=_DEFAULT_OUT_STREAM,
+                         return_format='list'
                          ):
         """
         Print all design variables and responses (objectives and constraints).
@@ -1807,6 +1808,10 @@ class Problem(object, metaclass=ProblemMetaclass):
         out_stream : file-like object
             Where to send human readable output. Default is sys.stdout.
             Set to None to suppress.
+        return_format : str
+            Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
+            If 'dict', the return value is a dictionary mapping {kind: {name: metadata}}.
+            If 'list', the return value is a dictionary mapping {kind: [(name, metadata), ...]}.
 
         Returns
         -------
@@ -1896,9 +1901,14 @@ class Problem(object, metaclass=ProblemMetaclass):
             o[1]['val'] = vals[o[0]]
         obj_vars = [tuple(o) for o in obj_vars]
 
-        prob_vars = {'design_vars': des_vars,
-                     'constraints': cons_vars,
-                     'objectives': obj_vars}
+        if return_format == 'dict':
+            prob_vars = {'design_vars': {k: v for k, v in des_vars},
+                         'constraints': {k: v for k, v in cons_vars},
+                         'objectives': {k: v for k, v in obj_vars}}
+        else:
+            prob_vars = {'design_vars': des_vars,
+                         'constraints': cons_vars,
+                         'objectives': obj_vars}
 
         return prob_vars
 

--- a/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
+++ b/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
@@ -66,10 +66,10 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
                 result =  prob.run_driver()
                 self.assertEqual(result.exit_status, 'SUCCESS',
                                  msg=f'Failed to converge optimization with {driver_name}.')
-                multipliers, active_info = prob.driver.compute_lagrange_multipliers()
-                assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
-                self.assertEqual(active_info['c']['indices'], [0])
-                self.assertEqual(active_info['c']['active_bounds'], [1])
+                _, active_cons = prob.driver.compute_lagrange_multipliers()
+                assert_near_equal(active_cons['c']['multipliers'], reference_multipliers['c'], tolerance=1.0E-5)
+                self.assertEqual(active_cons['c']['indices'], [0])
+                self.assertEqual(active_cons['c']['active_bounds'], [1])
 
     def test_simple_paraboloid_upper_inequality_constraint_scaled(self):
         """
@@ -87,8 +87,8 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
         self.assertEqual(result.exit_status, 'SUCCESS',
                          msg='Failed to converge baseline IPOPT optimization.')
         reference_multipliers = prob.driver.pyopt_solution.lambdaStar
-        multipliers, active_info = prob.driver.compute_lagrange_multipliers(driver_scaling=True)
-        assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
+        active_dvs, active_cons = prob.driver.compute_lagrange_multipliers(driver_scaling=True)
+        assert_near_equal(active_cons['c']['multipliers'], reference_multipliers['c'], tolerance=1.0E-5)
 
         for driver_name, driver in drivers.items():
             with self.subTest(f'{driver_name=}'):
@@ -96,13 +96,13 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
                 result =  prob.run_driver()
                 self.assertEqual(result.exit_status, 'SUCCESS',
                                  msg=f'Failed to converge optimization with {driver_name}.')
-                multipliers, active_info = prob.driver.compute_lagrange_multipliers(driver_scaling=True)
-                assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
-                self.assertEqual(active_info['c']['indices'], [0])
-                self.assertEqual(active_info['c']['active_bounds'], [1])
+                _, active_cons = prob.driver.compute_lagrange_multipliers(driver_scaling=True)
+                assert_near_equal(active_cons['c']['multipliers'], reference_multipliers['c'], tolerance=1.0E-5)
+                self.assertEqual(active_cons['c']['indices'], [0])
+                self.assertEqual(active_cons['c']['active_bounds'], [1])
                 # Now test the unscaled multipliers
-                unscaled_mults, active_info = prob.driver.compute_lagrange_multipliers(driver_scaling=False)
-                assert_near_equal(unscaled_mults['c'], 0.5, tolerance=1.0E-5)
+                _, unscaled_active_cons = prob.driver.compute_lagrange_multipliers(driver_scaling=False)
+                assert_near_equal(unscaled_active_cons['c']['multipliers'], 0.5, tolerance=1.0E-5)
 
     def test_simple_paraboloid_upper_inequality_constraint_lower_y_bound(self):
         """
@@ -127,18 +127,18 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
                 result =  prob.run_driver()
                 self.assertEqual(result.exit_status, 'SUCCESS',
                                  msg=f'Failed to converge optimization with {driver_name}.')
-                multipliers, active_info = prob.driver.compute_lagrange_multipliers()
-                assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
-                self.assertEqual(active_info['c']['indices'], [0])
-                self.assertEqual(active_info['c']['active_bounds'], [1])
+                active_dvs, active_cons = prob.driver.compute_lagrange_multipliers()
+                assert_near_equal(active_cons['c']['multipliers'], reference_multipliers['c'], tolerance=1.0E-5)
+                self.assertEqual(active_cons['c']['indices'], [0])
+                self.assertEqual(active_cons['c']['active_bounds'], [1])
 
                 # In this case, we also have a multiplier on the y lower bound
-                self.assertEqual(active_info['y']['indices'], [0])
-                self.assertEqual(active_info['y']['active_bounds'], [-1])
+                self.assertEqual(active_dvs['y']['indices'], [0])
+                self.assertEqual(active_dvs['y']['active_bounds'], [-1])
 
                 # if we decrease y bound by 0.01 units, we should see the objective increase by lambda[y] * 0.01 units.
                 # we use a loose tolerance when testing this due to FD across the optimization
-                lambda_y = multipliers['y']
+                lambda_y = active_dvs['y']['multipliers']
                 f_nom = prob.get_val('f_xy')
 
                 prob = self._make_problem(driver=driver, y_lower=-7.01)
@@ -167,34 +167,35 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
         reference_multipliers = prob.driver.pyopt_solution.lambdaStar
 
         for driver_name, driver in drivers.items():
-            with self.subTest(f'{driver_name=}'):
-                prob = self._make_problem(driver=driver, y_lower=-7.0, f_xy_ref=0.1,
-                                          c_ref=15, x_ref=10, y_ref=10)
-                result =  prob.run_driver()
-                self.assertEqual(result.exit_status, 'SUCCESS',
-                                 msg=f'Failed to converge optimization with {driver_name}.')
-                multipliers, active_info = prob.driver.compute_lagrange_multipliers(driver_scaling=True)
-                assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
-                self.assertEqual(active_info['c']['indices'], [0])
-                self.assertEqual(active_info['c']['active_bounds'], [1])
+            for use_sparse in [True, False]:
+                with self.subTest(f'{driver_name=} {use_sparse=}'):
+                    prob = self._make_problem(driver=driver, y_lower=-7.0, f_xy_ref=0.1,
+                                            c_ref=15, x_ref=10, y_ref=10)
+                    result =  prob.run_driver()
+                    self.assertEqual(result.exit_status, 'SUCCESS',
+                                    msg=f'Failed to converge optimization with {driver_name}.')
+                    active_dvs, active_cons = prob.driver.compute_lagrange_multipliers(driver_scaling=True)
+                    assert_near_equal(active_cons['c']['multipliers'], reference_multipliers['c'], tolerance=1.0E-5)
+                    self.assertEqual(active_cons['c']['indices'], [0])
+                    self.assertEqual(active_cons['c']['active_bounds'], [1])
 
-                # In this case, we also have a multiplier on the y lower bound
-                self.assertEqual(active_info['y']['indices'], [0])
-                self.assertEqual(active_info['y']['active_bounds'], [-1])
+                    # In this case, we also have a multiplier on the y lower bound
+                    self.assertEqual(active_dvs['y']['indices'], [0])
+                    self.assertEqual(active_dvs['y']['active_bounds'], [-1])
 
-                # if we decrease y bound by 0.01 units, we should see the objective increase by lambda[y] * 0.01 units.
-                # we use a loose tolerance when testing this due to FD across the optimization
-                multipliers, active_info = prob.driver.compute_lagrange_multipliers(driver_scaling=False)
-                lambda_y = multipliers['y']
-                f_nom = prob.get_val('f_xy')
+                    # if we decrease y bound by 0.01 units, we should see the objective increase by lambda[y] * 0.01 units.
+                    # we use a loose tolerance when testing this due to FD across the optimization
+                    active_dvs, active_cons = prob.driver.compute_lagrange_multipliers(driver_scaling=False,
+                                                                                       use_sparse_solve=use_sparse)
+                    lambda_y = active_dvs['y']['multipliers']
+                    f_nom = prob.get_val('f_xy')
 
-                prob = self._make_problem(driver=driver, y_lower=-7.01)
-                result =  prob.run_driver()
-                self.assertEqual(result.exit_status, 'SUCCESS',
-                                 msg=f'Failed to converge optimization with {driver_name}.')
-                f_perturbed = prob.get_val('f_xy')
-                assert_near_equal((f_perturbed - f_nom) / 0.01, lambda_y, tolerance=1.0E-1)
-
+                    prob = self._make_problem(driver=driver, y_lower=-7.01)
+                    result =  prob.run_driver()
+                    self.assertEqual(result.exit_status, 'SUCCESS',
+                                    msg=f'Failed to converge optimization with {driver_name}.')
+                    f_perturbed = prob.get_val('f_xy')
+                    assert_near_equal((f_perturbed - f_nom) / 0.01, lambda_y, tolerance=1.0E-1)
 
 
 if __name__ == "__main__":

--- a/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
+++ b/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
@@ -155,7 +155,7 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
         """
         drivers = {'pos_IPOPT': om.pyOptSparseDriver(optimizer='IPOPT', print_results=False),
                    'pos_SLSQP': om.pyOptSparseDriver(optimizer='SLSQP', print_results=False),
-                   'pos_SNOPT': om.pyOptSparseDriver(optimizer='snopt_opt', print_results=False),
+                   'pos_SNOPT': om.pyOptSparseDriver(optimizer=snopt_opt, print_results=False),
                    'scipy_SLSQP': om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False),
                    'scipy_COBYLA': om.ScipyOptimizeDriver(optimizer='COBYLA', disp=False)}
 

--- a/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
+++ b/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
@@ -111,7 +111,7 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
         """
         drivers = {'pos_IPOPT': om.pyOptSparseDriver(optimizer='IPOPT', print_results=False),
                    'pos_SLSQP': om.pyOptSparseDriver(optimizer='SLSQP', print_results=False),
-                   'pos_SNOPT': om.pyOptSparseDriver(optimizer='SNOPT', print_results=False),
+                   'pos_SNOPT': om.pyOptSparseDriver(optimizer=snopt_opt, print_results=False),
                    'scipy_SLSQP': om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False),
                    'scipy_COBYLA': om.ScipyOptimizeDriver(optimizer='COBYLA', disp=False)}
 
@@ -155,7 +155,7 @@ class TestComputeLagrangeMultipliers(unittest.TestCase):
         """
         drivers = {'pos_IPOPT': om.pyOptSparseDriver(optimizer='IPOPT', print_results=False),
                    'pos_SLSQP': om.pyOptSparseDriver(optimizer='SLSQP', print_results=False),
-                   'pos_SNOPT': om.pyOptSparseDriver(optimizer='SNOPT', print_results=False),
+                   'pos_SNOPT': om.pyOptSparseDriver(optimizer='snopt_opt', print_results=False),
                    'scipy_SLSQP': om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False),
                    'scipy_COBYLA': om.ScipyOptimizeDriver(optimizer='COBYLA', disp=False)}
 

--- a/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
+++ b/openmdao/drivers/tests/test_compute_lagrange_multipliers.py
@@ -1,0 +1,117 @@
+""" Unit tests for the Pyoptsparse Driver."""
+
+import unittest
+from packaging.version import Version
+
+import openmdao.api as om
+from openmdao.test_suite.components.paraboloid import Paraboloid
+from openmdao.utils.testing_utils import use_tempdirs, require_pyoptsparse
+from openmdao.drivers.pyoptsparse_driver import pyoptsparse_version
+from openmdao.utils.assert_utils import assert_near_equal
+
+
+@require_pyoptsparse('IPOPT')
+@unittest.skipIf(pyoptsparse_version is None or
+                 pyoptsparse_version < Version('2.13.0'),
+                 reason='Requires pyoptsparse 2.13.0 or later.')
+@use_tempdirs
+class TestComputeLagrangeMultipliers(unittest.TestCase):
+
+    def _make_problem(self, driver, y_lower=-50):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 50.0), promotes=['*'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 50.0), promotes=['*'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.add_subsystem('con', om.ExecComp('c = - x + y'), promotes=['*'])
+
+        prob.set_solver_print(level=0)
+
+        prob.driver = driver
+
+        model.add_design_var('x', lower=-50.0, upper=50.0)
+        model.add_design_var('y', lower=y_lower, upper=50.0)
+        model.add_objective('f_xy')
+        model.add_constraint('c', upper=-15)
+
+        prob.setup()
+
+        return prob
+
+    def test_simple_paraboloid_upper_inequality_constraint(self):
+        """
+        Test the computed Lagrange multipliers against IPOPT. Note IPOPT and
+        SNOPT use opposite sign conventions on Lagrange multipliers.
+        """
+        drivers = {'pos_IPOPT': om.pyOptSparseDriver(optimizer='IPOPT', print_results=False),
+                   'pos_SLSQP': om.pyOptSparseDriver(optimizer='SLSQP', print_results=False),
+                   'pos_SNOPT': om.pyOptSparseDriver(optimizer='SNOPT', print_results=False),
+                   'scipy_SLSQP': om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False),
+                   'scipy_COBYLA': om.ScipyOptimizeDriver(optimizer='COBYLA', disp=False)}
+
+        prob = self._make_problem(driver=drivers['pos_IPOPT'])
+        result = prob.run_driver()
+        self.assertEqual(result.exit_status, 'SUCCESS',
+                         msg='Failed to converge baseline IPOPT optimization.')
+        reference_multipliers = prob.driver.pyopt_solution.lambdaStar
+
+        for driver_name, driver in drivers.items():
+            with self.subTest(f'{driver_name=}'):
+                prob = self._make_problem(driver=driver)
+                result =  prob.run_driver()
+                self.assertEqual(result.exit_status, 'SUCCESS',
+                                 msg=f'Failed to converge optimization with {driver_name}.')
+                multipliers, active_info = prob.driver.compute_lagrange_multipliers()
+                assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
+                self.assertEqual(active_info['c']['indices'], [0])
+                self.assertEqual(active_info['c']['active_bounds'], [1])
+
+    def test_simple_paraboloid_upper_inequality_constraint_lower_y_bound(self):
+        """
+        Test the computed Lagrange multipliers against IPOPT. Note IPOPT and
+        SNOPT use opposite sign conventions on Lagrange multipliers.
+        """
+        drivers = {'pos_IPOPT': om.pyOptSparseDriver(optimizer='IPOPT', print_results=False),
+                   'pos_SLSQP': om.pyOptSparseDriver(optimizer='SLSQP', print_results=False),
+                   'pos_SNOPT': om.pyOptSparseDriver(optimizer='SNOPT', print_results=False),
+                   'scipy_SLSQP': om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False),
+                   'scipy_COBYLA': om.ScipyOptimizeDriver(optimizer='COBYLA', disp=False)}
+
+        prob = self._make_problem(driver=drivers['pos_IPOPT'], y_lower=-7.0)
+        result = prob.run_driver()
+        self.assertEqual(result.exit_status, 'SUCCESS',
+                         msg='Failed to converge baseline IPOPT optimization.')
+        reference_multipliers = prob.driver.pyopt_solution.lambdaStar
+
+        for driver_name, driver in drivers.items():
+            with self.subTest(f'{driver_name=}'):
+                prob = self._make_problem(driver=driver, y_lower=-7.0)
+                result =  prob.run_driver()
+                self.assertEqual(result.exit_status, 'SUCCESS',
+                                 msg=f'Failed to converge optimization with {driver_name}.')
+                multipliers, active_info = prob.driver.compute_lagrange_multipliers()
+                assert_near_equal(multipliers['c'], reference_multipliers['c'], tolerance=1.0E-5)
+                self.assertEqual(active_info['c']['indices'], [0])
+                self.assertEqual(active_info['c']['active_bounds'], [1])
+
+                # In this case, we also have a multiplier on the y lower bound
+                self.assertEqual(active_info['y']['indices'], [0])
+                self.assertEqual(active_info['y']['active_bounds'], [-1])
+
+                # if we decrease y bound by 0.01 units, we should see the objective increase by lambda[y] * 0.01 units.
+                # we use a loose tolerance when testing this due to FD across the optimization
+                lambda_y = multipliers['y']
+                f_nom = prob.get_val('f_xy')
+
+                prob = self._make_problem(driver=driver, y_lower=-7.01)
+                result =  prob.run_driver()
+                self.assertEqual(result.exit_status, 'SUCCESS',
+                                 msg=f'Failed to converge optimization with {driver_name}.')
+                f_perturbed = prob.get_val('f_xy')
+                assert_near_equal((f_perturbed - f_nom) / 0.01, lambda_y, tolerance=1.0E-1)
+
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Summary

This is an interim commit on the way to providing full post-optimality sensitivities.
Adds `compute_lagrange_multipliers` and some other related methods to Driver.
This method will solve for the Lagrange multipliers of the active constraints, where the user is responsible for setting the tolerance of what determines if a constraint is active.

Assuming that the KKT conditions have been satisfied by the optimizer, then the Lagrangian is

```math
\nabla_{\bar\theta} f(\bar\theta, \bar{p}) + \lambda \nabla_{\bar\theta} \bar{g}(\bar\theta, \bar{p}) = 0
```

where $\bar{\theta}$ are the design variables of the problem and $\bar{p}$ are any input parameters of the system.

We assume that $\bar{g}$ consists of all active equality and inequality constraints, and active bounds.

The returned values of `compute_lagrange_multipliers` are two dictionaries: one for active design variable bounds, and one for active constraints. These dictionaries contain the multipliers, the active indices of the dv/constraint, and the active bound of the dvs and constraints.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
