### PR TITLE
Fixed deprecated jax ArrayImpl references

### DIFF
--- a/openmdao/utils/assert_utils.py
+++ b/openmdao/utils/assert_utils.py
@@ -13,9 +13,12 @@ from itertools import chain
 import numpy as np
 
 try:
-    from jaxlib.xla_extension import ArrayImpl
+    from jax import Array as JaxArray
 except ImportError:
-    ArrayImpl = None
+    try:
+        from jaxlib.xla_extension import ArrayImpl as JaxArray
+    except ImportError:
+        JaxArray = None
 
 from openmdao.core.component import Component
 from openmdao.core.group import Group
@@ -602,10 +605,10 @@ def assert_near_equal(actual, desired, tolerance=1e-15, tol_type='rel'):
         desired = np.atleast_1d(desired)
 
     # Handle jax arrays, if available
-    if ArrayImpl is not None:
-        if isinstance(actual, ArrayImpl):
+    if JaxArray is not None:
+        if isinstance(actual, JaxArray):
             actual = np.atleast_1d(actual)
-        if isinstance(desired, ArrayImpl):
+        if isinstance(desired, JaxArray):
             desired = np.atleast_1d(desired)
 
     # if desired is numeric list or tuple, make ndarray out of it

--- a/openmdao/utils/tests/test_jax_utils.py
+++ b/openmdao/utils/tests/test_jax_utils.py
@@ -27,7 +27,10 @@ class TestJaxUtils(unittest.TestCase):
         try:
             import jax.numpy as np
             from jax import jit
-            import jaxlib
+            try:
+                from jax import Array as JaxArray
+            except ImportError:
+                from jaxlib.xla_extension import ArrayImpl as JaxArray
         except ImportError:
             self.skipTest('jax is not available but required for this test.')
 
@@ -40,7 +43,7 @@ class TestJaxUtils(unittest.TestCase):
         x = np.linspace(0, 10, 11)
         result = TestClass().f(x)
         assert_near_equal(result**2, x)
-        self.assertIsInstance(result, jaxlib.xla_extension.ArrayImpl)
+        self.assertIsInstance(result, JaxArray)
 
     def test_jax_component_option(self):
         """Test that the registration of jax-compatible components works."""


### PR DESCRIPTION
### Summary

ArrayImpl from jaxlib.xla_extension has been deprecated and removed as of jax 0.6.1 (released [today](https://github.com/jax-ml/jax/releases))

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
