### PR TITLE
Restored the get_source method on System.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -1453,6 +1453,27 @@ class System(object, metaclass=SystemMetaclass):
 
         return self._approx_subjac_keys
 
+    def get_source(self, name):
+        """
+        Return the source variable connected to the given named variable.
+
+        The name can be a promoted name or an absolute name.
+        If the given variable is an input, the absolute name of the connected source will
+        be returned.  If the given variable itself is a source, its own absolute name will
+        be returned.
+
+        Parameters
+        ----------
+        name : str
+            Absolute or promoted name of the variable.
+
+        Returns
+        -------
+        str
+            The absolute name of the source variable.
+        """
+        return self._resolver.source(name)
+
     def use_fixed_coloring(self, coloring=STD_COLORING_FNAME(), recurse=True):
         """
         Use a precomputed coloring for this System.

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -444,6 +444,12 @@ class TestGroup(unittest.TestCase):
         self.assertEqual(p['group2.comp1.b'], 20.0)
         self.assertEqual(p['group2.comp2.b'], 40.0)
 
+        src = p.model.group1.get_source('comp1.x')
+        self.assertEqual(src, 'group1.comp1.x')
+
+        src = p.model.get_source('group2.comp1.a')
+        self.assertEqual(src, 'group1.comp2.b')
+
     def test_reused_output_promoted_names(self):
         prob = om.Problem()
         prob.model.add_subsystem('px1', om.IndepVarComp('x1', 100.0))


### PR DESCRIPTION
### Summary

This public method was removed by mistake when the name resolver was added.

### Related Issues

- Resolves #3540

### Backwards incompatibilities

None

### New Dependencies

None
