### PR TITLE
Added print_mean to variable list methods

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -4243,6 +4243,7 @@ class System(object, metaclass=SystemMetaclass):
                   out_stream=_DEFAULT_OUT_STREAM,
                   print_min=False,
                   print_max=False,
+                  print_mean=False,
                   return_format='list'):
         """
         Write a list of inputs and outputs sorted by component in execution order.
@@ -4308,6 +4309,8 @@ class System(object, metaclass=SystemMetaclass):
             When true, if the output value is an array, print its smallest value.
         print_max : bool
             When true, if the output value is an array, print its largest value.
+        print_mean : bool
+            When true, if the output value is an array, print its mean value.
         return_format : str
             Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
             If 'list', the return value is a list of (name, metadata) tuples.
@@ -4384,6 +4387,9 @@ class System(object, metaclass=SystemMetaclass):
                         if print_max:
                             meta['max'] = np.round(np.max(meta['val']), np_precision)
 
+                        if print_mean:
+                            meta['mean'] = np.round(np.mean(meta['val']), np_precision)
+
                 if residuals or residuals_tol:
                     resids = self._abs_get_val(name, get_remote=True,
                                                rank=None if all_procs else 0,
@@ -4411,6 +4417,9 @@ class System(object, metaclass=SystemMetaclass):
 
                     if print_max:
                         meta['max'] = np.round(np.max(meta['val']), np_precision)
+
+                    if print_mean:
+                        meta['mean'] = np.round(np.mean(meta['val']), np_precision)
 
         # remove metadata we don't want to show/return
         to_remove = ['discrete']
@@ -4468,6 +4477,7 @@ class System(object, metaclass=SystemMetaclass):
                     out_stream=_DEFAULT_OUT_STREAM,
                     print_min=False,
                     print_max=False,
+                    print_mean=False,
                     return_format='list'):
         """
         Write a list of input names and other optional information to a specified stream.
@@ -4524,6 +4534,8 @@ class System(object, metaclass=SystemMetaclass):
             When true, if the input value is an array, print its smallest value.
         print_max : bool
             When true, if the input value is an array, print its largest value.
+        print_mean : bool
+            When true, if the input value is an array, print its mean value.
         return_format : str
             Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
             If 'list', the return value is a list of (name, metadata) tuples.
@@ -4570,6 +4582,9 @@ class System(object, metaclass=SystemMetaclass):
 
                     if print_max:
                         meta['max'] = np.round(np.max(meta['val']), np_precision)
+
+                    if print_mean:
+                        meta['mean'] = np.round(np.mean(meta['val']), np_precision)
 
         to_remove = ['discrete']
         if not print_tags:
@@ -4624,6 +4639,7 @@ class System(object, metaclass=SystemMetaclass):
                      out_stream=_DEFAULT_OUT_STREAM,
                      print_min=False,
                      print_max=False,
+                     print_mean=False,
                      return_format='list'):
         """
         Write a list of output names and other optional information to a specified stream.
@@ -4695,6 +4711,8 @@ class System(object, metaclass=SystemMetaclass):
             When true, if the output value is an array, print its smallest value.
         print_max : bool
             When true, if the output value is an array, print its largest value.
+        print_mean : bool
+            When true, if the output value is an array, print its mean value.
         return_format : str
             Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
             If 'list', the return value is a list of (name, metadata) tuples.
@@ -4748,6 +4766,9 @@ class System(object, metaclass=SystemMetaclass):
 
                         if print_max:
                             meta['max'] = np.round(np.max(meta['val']), np_precision)
+
+                        if print_mean:
+                            meta['mean'] = np.round(np.mean(meta['val']), np_precision)
 
                 if residuals or residuals_tol:
                     resids = self._abs_get_val(name, get_remote=True,

--- a/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
+++ b/openmdao/docs/openmdao_book/features/debugging/listing_variables.ipynb
@@ -891,9 +891,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### *Print Minimum or Maximum Array Values*\n",
+    "### *Print Minimum, Maximum or Mean Array Values*\n",
     "\n",
-    "When working with large arrays, it can be difficult to determine how the array is interacting with the upper and lower bounds by looking through the output of the entire contents. To provide a quick visual reference, the `list_inputs()` and `list_outputs()` methods have `print_min` and `print_max` options that output columns with the minimum and maximum values of the array."
+    "When working with large arrays, it can be difficult to determine how the array is interacting with the upper and lower bounds by looking through the output of the entire contents.\n",
+    "Additionally, seeing the mean value of the array can be useful.\n",
+    "To provide a quick visual reference, the `list_inputs()` and `list_outputs()` methods have `print_min`, `print_max`, `print_mean` options that output columns with the minimum and maximum values of the array."
    ]
   },
   {
@@ -906,7 +908,8 @@
     "                       units=True,\n",
     "                       hierarchical=True,\n",
     "                       print_min=True,\n",
-    "                       print_max=True);"
+    "                       print_max=True,\n",
+    "                       print_mean=True);"
    ]
   },
   {
@@ -924,7 +927,8 @@
     "                        scaling=True,\n",
     "                        hierarchical=True,\n",
     "                        print_min=True,\n",
-    "                        print_max=True);"
+    "                        print_max=True,\n",
+    "                        print_mean=True);"
    ]
   },
   {

--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -551,6 +551,7 @@ class Case(object):
                   out_stream=_DEFAULT_OUT_STREAM,
                   print_min=False,
                   print_max=False,
+                  print_mean=False,
                   return_format='list'):
         """
         Write a list of inputs and outputs sorted by component in execution order.
@@ -612,6 +613,8 @@ class Case(object):
             When true, if the output value is an array, print its smallest value.
         print_max : bool
             When true, if the output value is an array, print its largest value.
+        print_mean : bool
+            When true, if the output value is an array, print its mean value.
         return_format : str
             Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
             If 'list', the return value is a list of (name, metadata) tuples.
@@ -661,6 +664,9 @@ class Case(object):
                         if print_max:
                             meta['max'] = np.round(np.max(meta['val']), np_precision)
 
+                        if print_mean:
+                            meta['mean'] = np.round(np.mean(meta['val']), np_precision)
+
                 if residuals or residuals_tol:
                     if self.residuals is None:
                         meta['resids'] = 'Not Recorded'
@@ -700,6 +706,9 @@ class Case(object):
 
                     if print_max:
                         meta['max'] = np.round(np.max(meta['val']), np_precision)
+
+                    if print_mean:
+                        meta['mean'] = np.round(np.mean(meta['val']), np_precision)
 
         # combine inputs and outputs create return value
         var_dict = inputs
@@ -751,6 +760,7 @@ class Case(object):
                     out_stream=_DEFAULT_OUT_STREAM,
                     print_min=False,
                     print_max=False,
+                    print_mean=False,
                     return_format='list'):
         """
         Return and optionally log a list of input names and other optional information.
@@ -805,6 +815,8 @@ class Case(object):
             When true, if the input value is an array, print its smallest value.
         print_max : bool, optional
             When true, if the input value is an array, print its largest value.
+        print_mean : bool, optional
+            When true, if the input value is an array, print its mean value.
         return_format : str
             Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
             If 'list', the return value is a list of (name, metadata) tuples.
@@ -841,6 +853,8 @@ class Case(object):
                         meta['min'] = np.round(np.min(var_val), np_precision)
                     if print_max:
                         meta['max'] = np.round(np.max(var_val), np_precision)
+                    if print_mean:
+                        meta['mean'] = np.round(np.mean(var_val), np_precision)
 
         if out_stream:
             if self.inputs:
@@ -889,6 +903,7 @@ class Case(object):
                      out_stream=_DEFAULT_OUT_STREAM,
                      print_min=False,
                      print_max=False,
+                     print_mean=False,
                      return_format='list'):
         """
         Return and optionally log a list of output names and other optional information.
@@ -959,6 +974,8 @@ class Case(object):
             When true, if the output value is an array, print its smallest value.
         print_max : bool, optional
             When true, if the output value is an array, print its largest value.
+        print_mean : bool, optional
+            When true, if the output value is an array, print its mean value.
         return_format : str
             Indicates the desired format of the return value. Can have value of 'list' or 'dict'.
             If 'list', the return value is a list of (name, metadata) tuples.
@@ -1010,6 +1027,9 @@ class Case(object):
 
                         if print_max:
                             meta['max'] = np.round(np.max(meta['val']), np_precision)
+
+                        if print_mean:
+                            meta['mean'] = np.round(np.mean(meta['val']), np_precision)
 
                 if residuals or residuals_tol:
                     if self.residuals is None:

--- a/openmdao/recorders/tests/test_list_vars.py
+++ b/openmdao/recorders/tests/test_list_vars.py
@@ -108,6 +108,7 @@ class ListVarsTest(unittest.TestCase):
             list_autoivcs=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
         prob_case.list_inputs(
@@ -120,6 +121,7 @@ class ListVarsTest(unittest.TestCase):
             print_tags=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
         prob_case.list_outputs(
@@ -136,6 +138,7 @@ class ListVarsTest(unittest.TestCase):
             list_autoivcs=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
 
@@ -151,6 +154,7 @@ class ListVarsTest(unittest.TestCase):
             list_autoivcs=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
         drvr_case.list_inputs(
@@ -163,6 +167,7 @@ class ListVarsTest(unittest.TestCase):
             print_tags=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
         drvr_case.list_outputs(
@@ -179,6 +184,7 @@ class ListVarsTest(unittest.TestCase):
             list_autoivcs=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
 
@@ -194,6 +200,7 @@ class ListVarsTest(unittest.TestCase):
             list_autoivcs=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
         modl_case.list_inputs(
@@ -206,6 +213,7 @@ class ListVarsTest(unittest.TestCase):
             print_tags=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
         modl_case.list_outputs(
@@ -222,6 +230,7 @@ class ListVarsTest(unittest.TestCase):
             list_autoivcs=True,
             print_min=True,
             print_max=True,
+            print_mean=True,
             out_stream=None
         )
 

--- a/openmdao/utils/variable_table.py
+++ b/openmdao/utils/variable_table.py
@@ -93,13 +93,13 @@ def write_var_table(pathname, var_list, var_type, var_dict,
     #  so that we do the column output in the correct order
     if var_type == 'input':
         out_types = ('val', 'units', 'shape', 'global_shape', 'prom_name', 'desc', 'min', 'max',
-                     'tags')
+                     'mean', 'tags')
     elif var_type == 'all':
         out_types = ('val', 'io', 'resids', 'units', 'shape', 'global_shape', 'lower', 'upper',
-                     'ref', 'ref0', 'res_ref', 'prom_name', 'desc', 'min', 'max', 'tags')
+                     'ref', 'ref0', 'res_ref', 'prom_name', 'desc', 'min', 'max', 'mean', 'tags')
     else:
         out_types = ('val', 'resids', 'units', 'shape', 'global_shape', 'lower', 'upper',
-                     'ref', 'ref0', 'res_ref', 'prom_name', 'desc', 'min', 'max', 'tags')
+                     'ref', 'ref0', 'res_ref', 'prom_name', 'desc', 'min', 'max', 'mean', 'tags')
 
     # Figure out which columns will be displayed.
     for var_meta in var_dict.values():
@@ -259,7 +259,7 @@ def _write_variable(out_stream, row, column_names, var_dict, print_arrays):
         Set to None to suppress.
     row : str
         The string containing the contents of the beginning of this row output.
-        Contains the name of the System or varname, possibley indented to show hierarchy.
+        Contains the name of the System or varname, possibly indented to show hierarchy.
 
     column_names : list of str
         Indicates which columns will be written in this row.


### PR DESCRIPTION
### Summary

We use OpenMDAO's built-in `list_inputs` and `list_outputs` methods in our [H2Integrate tool](https://github.com/NREL/H2Integrate).
We often work with arrays of length 8760 (hours in a year) when modeling energy systems.
The norm of these arrays isn't necessarily useful, but seeing the mean would be helpful.
This PR adds the option to print the mean alongside the existing min and max printouts.

Originally suggested by @jmartin4nrel here: https://github.com/NREL/H2Integrate/issues/155
I first went to implement Jonathan's changes (optionally replace the norm with the mean), but saw that `print_min` and `print_max` already existed and liked the parallelism for the mean.

Feel free to suggest other related changes and let me know if I missed anywhere else in the codebase where we'd need to update accordingly.

### Related Issues


### Backwards incompatibilities

None

### New Dependencies

None
