### PR TITLE
Changed MacOS Baseline test to use Use Python3.12/Numpy1.26

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -102,7 +102,7 @@ jobs:
             OS: macos-13
             PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.15'
+            SCIPY: '1.13'
             PETSc: '3.20'
             PYOPTSPARSE_FROM: 'conda-forge'
             PYOPTSPARSE: '2.13.1'

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -102,7 +102,7 @@ jobs:
             OS: macos-13
             PY: '3.12'
             NUMPY: '1.26'
-            SCIPY: '1.13'
+            SCIPY: '1.14'
             PETSc: '3.20'
             PYOPTSPARSE_FROM: 'conda-forge'
             PYOPTSPARSE: '2.13.1'

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -100,8 +100,8 @@ jobs:
           # test baseline versions on MacOS
           - NAME: MacOS Baseline
             OS: macos-13
-            PY: '3.13'
-            NUMPY: '2.2'
+            PY: '3.12'
+            NUMPY: '1.26'
             SCIPY: '1.15'
             PETSc: '3'
             PYOPTSPARSE_FROM: 'conda-forge'

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -103,7 +103,7 @@ jobs:
             PY: '3.12'
             NUMPY: '1.26'
             SCIPY: '1.15'
-            PETSc: '3'
+            PETSc: '3.20'
             PYOPTSPARSE_FROM: 'conda-forge'
             PYOPTSPARSE: '2.13.1'
             SNOPT: '7.7'


### PR DESCRIPTION
### Summary

A previous change had configured the test workflow to use Python 3.13 and NumPy 2.2 for the MacOS 13 (Intel) job.

This has resulted in long build times, now frequently exceeding our 120 minute limit (mainly due to a much longer time to build/install PETSc in this configuration).

Rather than increase the time limit or implement caching of the PETSc wheel, I have reverted the MacOS Baseline build to the Pre-Numpy2 versions, taking into account that MacOS 13 is almost 3 years old and will be out of support later this year anyway.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
