### PR TITLE
Added PETScDirectSolver to available linear solver classes

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -42,6 +42,7 @@ from openmdao.components.jax_implicit_comp import JaxImplicitComponent
 from openmdao.solvers.linear.linear_block_gs import LinearBlockGS
 from openmdao.solvers.linear.linear_block_jac import LinearBlockJac
 from openmdao.solvers.linear.direct import DirectSolver
+from openmdao.solvers.linear.petsc_direct_solver import PETScDirectSolver
 from openmdao.solvers.linear.petsc_ksp import PETScKrylov
 from openmdao.solvers.linear.linear_runonce import LinearRunOnce
 from openmdao.solvers.linear.scipy_iter_solver import ScipyKrylov

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
@@ -35,29 +35,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "application/papermill.record/text/html": "<style>pre { line-height: 125%; }\ntd.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }\nspan.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }\ntd.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\nspan.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n.output_html .hll { background-color: #ffffcc }\n.output_html { background: #f8f8f8; }\n.output_html .c { color: #3D7B7B; font-style: italic } /* Comment */\n.output_html .err { border: 1px solid #F00 } /* Error */\n.output_html .k { color: #008000; font-weight: bold } /* Keyword */\n.output_html .o { color: #666 } /* Operator */\n.output_html .ch { color: #3D7B7B; font-style: italic } /* Comment.Hashbang */\n.output_html .cm { color: #3D7B7B; font-style: italic } /* Comment.Multiline */\n.output_html .cp { color: #9C6500 } /* Comment.Preproc */\n.output_html .cpf { color: #3D7B7B; font-style: italic } /* Comment.PreprocFile */\n.output_html .c1 { color: #3D7B7B; font-style: italic } /* Comment.Single */\n.output_html .cs { color: #3D7B7B; font-style: italic } /* Comment.Special */\n.output_html .gd { color: #A00000 } /* Generic.Deleted */\n.output_html .ge { font-style: italic } /* Generic.Emph */\n.output_html .ges { font-weight: bold; font-style: italic } /* Generic.EmphStrong */\n.output_html .gr { color: #E40000 } /* Generic.Error */\n.output_html .gh { color: #000080; font-weight: bold } /* Generic.Heading */\n.output_html .gi { color: #008400 } /* Generic.Inserted */\n.output_html .go { color: #717171 } /* Generic.Output */\n.output_html .gp { color: #000080; font-weight: bold } /* Generic.Prompt */\n.output_html .gs { font-weight: bold } /* Generic.Strong */\n.output_html .gu { color: #800080; font-weight: bold } /* Generic.Subheading */\n.output_html .gt { color: #04D } /* Generic.Traceback */\n.output_html .kc { color: #008000; font-weight: bold } /* Keyword.Constant */\n.output_html .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */\n.output_html .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */\n.output_html .kp { color: #008000 } /* Keyword.Pseudo */\n.output_html .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */\n.output_html .kt { color: #B00040 } /* Keyword.Type */\n.output_html .m { color: #666 } /* Literal.Number */\n.output_html .s { color: #BA2121 } /* Literal.String */\n.output_html .na { color: #687822 } /* Name.Attribute */\n.output_html .nb { color: #008000 } /* Name.Builtin */\n.output_html .nc { color: #00F; font-weight: bold } /* Name.Class */\n.output_html .no { color: #800 } /* Name.Constant */\n.output_html .nd { color: #A2F } /* Name.Decorator */\n.output_html .ni { color: #717171; font-weight: bold } /* Name.Entity */\n.output_html .ne { color: #CB3F38; font-weight: bold } /* Name.Exception */\n.output_html .nf { color: #00F } /* Name.Function */\n.output_html .nl { color: #767600 } /* Name.Label */\n.output_html .nn { color: #00F; font-weight: bold } /* Name.Namespace */\n.output_html .nt { color: #008000; font-weight: bold } /* Name.Tag */\n.output_html .nv { color: #19177C } /* Name.Variable */\n.output_html .ow { color: #A2F; font-weight: bold } /* Operator.Word */\n.output_html .w { color: #BBB } /* Text.Whitespace */\n.output_html .mb { color: #666 } /* Literal.Number.Bin */\n.output_html .mf { color: #666 } /* Literal.Number.Float */\n.output_html .mh { color: #666 } /* Literal.Number.Hex */\n.output_html .mi { color: #666 } /* Literal.Number.Integer */\n.output_html .mo { color: #666 } /* Literal.Number.Oct */\n.output_html .sa { color: #BA2121 } /* Literal.String.Affix */\n.output_html .sb { color: #BA2121 } /* Literal.String.Backtick */\n.output_html .sc { color: #BA2121 } /* Literal.String.Char */\n.output_html .dl { color: #BA2121 } /* Literal.String.Delimiter */\n.output_html .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */\n.output_html .s2 { color: #BA2121 } /* Literal.String.Double */\n.output_html .se { color: #AA5D1F; font-weight: bold } /* Literal.String.Escape */\n.output_html .sh { color: #BA2121 } /* Literal.String.Heredoc */\n.output_html .si { color: #A45A77; font-weight: bold } /* Literal.String.Interpol */\n.output_html .sx { color: #008000 } /* Literal.String.Other */\n.output_html .sr { color: #A45A77 } /* Literal.String.Regex */\n.output_html .s1 { color: #BA2121 } /* Literal.String.Single */\n.output_html .ss { color: #19177C } /* Literal.String.Symbol */\n.output_html .bp { color: #008000 } /* Name.Builtin.Pseudo */\n.output_html .fm { color: #00F } /* Name.Function.Magic */\n.output_html .vc { color: #19177C } /* Name.Variable.Class */\n.output_html .vg { color: #19177C } /* Name.Variable.Global */\n.output_html .vi { color: #19177C } /* Name.Variable.Instance */\n.output_html .vm { color: #19177C } /* Name.Variable.Magic */\n.output_html .il { color: #666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"k\">class</span><span class=\"w\"> </span><span class=\"nc\">SellarDerivatives</span><span class=\"p\">(</span><span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">Group</span><span class=\"p\">):</span>\n<span class=\"w\">    </span><span class=\"sd\">&quot;&quot;&quot;</span>\n<span class=\"sd\">    Group containing the Sellar MDA. This version uses the disciplines with derivatives.</span>\n<span class=\"sd\">    &quot;&quot;&quot;</span>\n\n    <span class=\"k\">def</span><span class=\"w\"> </span><span class=\"nf\">setup</span><span class=\"p\">(</span><span class=\"bp\">self</span><span class=\"p\">):</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;d1&#39;</span><span class=\"p\">,</span> <span class=\"n\">SellarDis1withDerivatives</span><span class=\"p\">(),</span> <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;x&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;d2&#39;</span><span class=\"p\">,</span> <span class=\"n\">SellarDis2withDerivatives</span><span class=\"p\">(),</span> <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;obj_cmp&#39;</span><span class=\"p\">,</span> <span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">ExecComp</span><span class=\"p\">(</span><span class=\"s1\">&#39;obj = x**2 + z[1] + y1 + exp(-y2)&#39;</span><span class=\"p\">,</span> <span class=\"n\">obj</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span>\n                                                  <span class=\"n\">x</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">z</span><span class=\"o\">=</span><span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">array</span><span class=\"p\">([</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"mf\">0.0</span><span class=\"p\">]),</span> <span class=\"n\">y1</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">y2</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">),</span>\n                           <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;obj&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;x&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;con_cmp1&#39;</span><span class=\"p\">,</span> <span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">ExecComp</span><span class=\"p\">(</span><span class=\"s1\">&#39;con1 = 3.16 - y1&#39;</span><span class=\"p\">,</span> <span class=\"n\">con1</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">y1</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">),</span>\n                           <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;con1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">])</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;con_cmp2&#39;</span><span class=\"p\">,</span> <span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">ExecComp</span><span class=\"p\">(</span><span class=\"s1\">&#39;con2 = y2 - 24.0&#39;</span><span class=\"p\">,</span> <span class=\"n\">con2</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">y2</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">),</span>\n                           <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;con2&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">set_input_defaults</span><span class=\"p\">(</span><span class=\"s1\">&#39;x&#39;</span><span class=\"p\">,</span> <span class=\"mf\">1.0</span><span class=\"p\">)</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">set_input_defaults</span><span class=\"p\">(</span><span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">array</span><span class=\"p\">([</span><span class=\"mf\">5.0</span><span class=\"p\">,</span> <span class=\"mf\">2.0</span><span class=\"p\">]))</span>\n</pre></div>\n",
-      "application/papermill.record/text/latex": "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n\\PY{k}{class}\\PY{+w}{ }\\PY{n+nc}{SellarDerivatives}\\PY{p}{(}\\PY{n}{om}\\PY{o}{.}\\PY{n}{Group}\\PY{p}{)}\\PY{p}{:}\n\\PY{+w}{    }\\PY{l+s+sd}{\\PYZdq{}\\PYZdq{}\\PYZdq{}}\n\\PY{l+s+sd}{    Group containing the Sellar MDA. This version uses the disciplines with derivatives.}\n\\PY{l+s+sd}{    \\PYZdq{}\\PYZdq{}\\PYZdq{}}\n\n    \\PY{k}{def}\\PY{+w}{ }\\PY{n+nf}{setup}\\PY{p}{(}\\PY{n+nb+bp}{self}\\PY{p}{)}\\PY{p}{:}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{d1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{SellarDis1withDerivatives}\\PY{p}{(}\\PY{p}{)}\\PY{p}{,} \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{x}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{d2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{SellarDis2withDerivatives}\\PY{p}{(}\\PY{p}{)}\\PY{p}{,} \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{obj\\PYZus{}cmp}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{om}\\PY{o}{.}\\PY{n}{ExecComp}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{obj = x**2 + z[1] + y1 + exp(\\PYZhy{}y2)}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{obj}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,}\n                                                  \\PY{n}{x}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{z}\\PY{o}{=}\\PY{n}{np}\\PY{o}{.}\\PY{n}{array}\\PY{p}{(}\\PY{p}{[}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{l+m+mf}{0.0}\\PY{p}{]}\\PY{p}{)}\\PY{p}{,} \\PY{n}{y1}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{y2}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{)}\\PY{p}{,}\n                           \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{obj}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{x}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con\\PYZus{}cmp1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{om}\\PY{o}{.}\\PY{n}{ExecComp}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con1 = 3.16 \\PYZhy{} y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{con1}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{y1}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{)}\\PY{p}{,}\n                           \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con\\PYZus{}cmp2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{om}\\PY{o}{.}\\PY{n}{ExecComp}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con2 = y2 \\PYZhy{} 24.0}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{con2}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{y2}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{)}\\PY{p}{,}\n                           \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{set\\PYZus{}input\\PYZus{}defaults}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{x}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+m+mf}{1.0}\\PY{p}{)}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{set\\PYZus{}input\\PYZus{}defaults}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{array}\\PY{p}{(}\\PY{p}{[}\\PY{l+m+mf}{5.0}\\PY{p}{,} \\PY{l+m+mf}{2.0}\\PY{p}{]}\\PY{p}{)}\\PY{p}{)}\n\\end{Verbatim}\n",
-      "application/papermill.record/text/plain": "class SellarDerivatives(om.Group):\n    \"\"\"\n    Group containing the Sellar MDA. This version uses the disciplines with derivatives.\n    \"\"\"\n\n    def setup(self):\n        self.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])\n        self.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])\n\n        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)', obj=0.0,\n                                                  x=0.0, z=np.array([0.0, 0.0]), y1=0.0, y2=0.0),\n                           promotes=['obj', 'x', 'z', 'y1', 'y2'])\n\n        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1', con1=0.0, y1=0.0),\n                           promotes=['con1', 'y1'])\n        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0', con2=0.0, y2=0.0),\n                           promotes=['con2', 'y2'])\n\n        self.set_input_defaults('x', 1.0)\n        self.set_input_defaults('z', np.array([5.0, 2.0]))"
-     },
-     "metadata": {
-      "scrapbook": {
-       "mime_prefix": "application/papermill.record/",
-       "name": "code_src23"
-      }
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.notebook_utils import get_code\n",
     "from myst_nb import glue\n",
@@ -79,17 +64,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "NL: NLBGS Converged in 8 iterations\n",
-      "9.610010556989947\n",
-      "1.7844853356313648\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import openmdao.api as om\n",
     "from openmdao.test_suite.components.sellar_feature import SellarDerivatives\n",
@@ -113,25 +88,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input",
      "remove-output"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "2.4481205496170354e-09"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "from openmdao.utils.assert_utils import assert_near_equal\n",
     "\n",
@@ -148,46 +112,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {
     "tags": [
      "remove-input"
     ]
    },
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "\n",
-       "<!DOCTYPE html>\n",
-       "<html lang=\"en\">\n",
-       "<head>\n",
-       "    <style>\n",
-       "        h2 {\n",
-       "            text-align: center;\n",
-       "        }\n",
-       "    </style>\n",
-       "</head>\n",
-       "<body>\n",
-       "    <h2></h2>\n",
-       "        <table style=\"border: 1px solid #999; border-collapse: collapse;\">\n",
-       "        <tr><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Option</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Default</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Acceptable Values</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Acceptable Types</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Description</th></tr>\n",
-       "       <tr style=\"background-color: ghostwhite;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">assemble_jac</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">True</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[True, False]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;bool&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">Activates use of assembled jacobian by this solver.</td></tr>\n",
-       "       <tr style=\"background-color: #F3F3F3;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">backend</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">superlu</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;superlu&#x27;, &#x27;klu&#x27;, &#x27;umfpack&#x27;, &#x27;petsc&#x27;, &#x27;mumps&#x27;, &#x27;superlu_dist&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">N/A</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\"></td></tr>\n",
-       "       <tr style=\"background-color: ghostwhite;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">iprint</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">1</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">N/A</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;int&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">whether to print output</td></tr>\n",
-       "       <tr style=\"background-color: #F3F3F3;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">rhs_checking</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">False</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">N/A</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;bool&#x27;, &#x27;dict&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">If True, check RHS vs. cache and/or zero to avoid some solves.Can also be set to a dict of options for the LinearRHSChecker to allow finer control over it. Allowed options are: (&#x27;check_zero&#x27;, &#x27;rtol&#x27;, &#x27;atol&#x27;, &#x27;max_cache_entries&#x27;, &#x27;collect_stats&#x27;, &#x27;auto&#x27;, &#x27;verbose&#x27;)</td></tr>\n",
-       "    </table>\n",
-       "</body>\n",
-       "</html>\n"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "om.show_options_table(\"openmdao.solvers.linear.petsc_direct_solver.PETScDirectSolver\")"
    ]

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
@@ -26,9 +26,11 @@
     "\n",
     "PETScDirectSolver is a linear solver that assembles the system Jacobian and solves the linear system with LU factorization and back substitution using the `petsc4py` library. It can handle any system topology. Since it assembles a global Jacobian for all of its subsystems, any linear solver that is assigned in any of its subsystems does not participate in this calculation (though they may be used in other ways such as in subsystem Newton solves). Unlike the standard DirectSolver which always uses SuperLU (for sparse) or LAPACK (dense) through scipy, the PETScDirectSolver has access to multiple DirectSolvers available in PETSc.\n",
     "\n",
-    "PETSc is more general and has more options than scipy for direct solvers, but due to the generality PETSc provides a thicker wrapper around its solvers. So when considering whether to use `DirectSolver` or `PETScDirectSolver`, one should consider the size of their problem and sparsity pattern. Typically PETSc will be more beneficial for larger matrices where the factorization / solving speedup is more than the slowdown due to overhead from the heavier wrapper. For more info about the solvers exposed by the PETScDirectSolver, see this summary table of direct solvers from the [PETSc documentation](https://petsc.org/release/overview/linear_solve_table/#direct-solvers).\n",
+    "PETSc is more general and has more options than scipy for direct solvers, but due to the generality PETSc provides a thicker wrapper around its solvers. So when considering whether to use `DirectSolver` or `PETScDirectSolver`, one should consider the size of their problem and sparsity pattern. Typically PETSc will be more beneficial for larger matrices where the factorization / solving speedup is larger than the slowdown due to overhead from the heavier wrapper. For more info about the solvers exposed by the PETScDirectSolver, see this summary table of direct solvers from the [PETSc documentation](https://petsc.org/release/overview/linear_solve_table/#direct-solvers).\n",
     "\n",
-    "As an example, here we calculate the total derivatives of the Sellar system objective with respect to the design variable 'z'."
+    "Of the available direct solvers, SuperLU, KLU, UMFPACK, and PETSc can only be used in serial. The MUMPS and SuperLU-Dist solver may also be used in parallel, though there is typically not much benefit in running the direct solver in parallel.\n",
+    "\n",
+    "As an example, here we calculate the total derivatives of the Sellar system objective with respect to the design variable 'z', using the \"klu\" direct solver in the PETScDirectSolver."
    ]
   },
   {

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
@@ -1,0 +1,231 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "active-ipynb",
+     "remove-output"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from openmdao.utils.notebook_utils import notebook_mode  # noqa: F401\n",
+    "except ImportError:\n",
+    "    !python -m pip install openmdao[notebooks]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PETScDirectSolver\n",
+    "\n",
+    "PETScDirectSolver is a linear solver that assembles the system Jacobian and solves the linear system with LU factorization and back substitution using the `petsc4py` library. It can handle any system topology. Since it assembles a global Jacobian for all of its subsystems, any linear solver that is assigned in any of its subsystems does not participate in this calculation (though they may be used in other ways such as in subsystem Newton solves). Unlike the standard DirectSolver which always uses SuperLU (for sparse) or LAPACK (dense) through scipy, the PETScDirectSolver has access to multiple DirectSolvers available in PETSc.\n",
+    "\n",
+    "PETSc is more general and has more options than scipy for direct solvers, but due to the generality PETSc provides a thicker wrapper around its solvers. So when considering whether to use `DirectSolver` or `PETScDirectSolver`, one should consider the size of their problem and sparsity pattern. Typically PETSc will be more beneficial for larger matrices where the factorization / solving speedup is more than the slowdown due to overhead from the heavier wrapper. For more info about the solvers exposed by the PETScDirectSolver, see this summary table of direct solvers from the [PETSc documentation](https://petsc.org/release/overview/linear_solve_table/#direct-solvers).\n",
+    "\n",
+    "As an example, here we calculate the total derivatives of the Sellar system objective with respect to the design variable 'z'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/papermill.record/text/html": "<style>pre { line-height: 125%; }\ntd.linenos .normal { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }\nspan.linenos { color: inherit; background-color: transparent; padding-left: 5px; padding-right: 5px; }\ntd.linenos .special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\nspan.linenos.special { color: #000000; background-color: #ffffc0; padding-left: 5px; padding-right: 5px; }\n.output_html .hll { background-color: #ffffcc }\n.output_html { background: #f8f8f8; }\n.output_html .c { color: #3D7B7B; font-style: italic } /* Comment */\n.output_html .err { border: 1px solid #F00 } /* Error */\n.output_html .k { color: #008000; font-weight: bold } /* Keyword */\n.output_html .o { color: #666 } /* Operator */\n.output_html .ch { color: #3D7B7B; font-style: italic } /* Comment.Hashbang */\n.output_html .cm { color: #3D7B7B; font-style: italic } /* Comment.Multiline */\n.output_html .cp { color: #9C6500 } /* Comment.Preproc */\n.output_html .cpf { color: #3D7B7B; font-style: italic } /* Comment.PreprocFile */\n.output_html .c1 { color: #3D7B7B; font-style: italic } /* Comment.Single */\n.output_html .cs { color: #3D7B7B; font-style: italic } /* Comment.Special */\n.output_html .gd { color: #A00000 } /* Generic.Deleted */\n.output_html .ge { font-style: italic } /* Generic.Emph */\n.output_html .ges { font-weight: bold; font-style: italic } /* Generic.EmphStrong */\n.output_html .gr { color: #E40000 } /* Generic.Error */\n.output_html .gh { color: #000080; font-weight: bold } /* Generic.Heading */\n.output_html .gi { color: #008400 } /* Generic.Inserted */\n.output_html .go { color: #717171 } /* Generic.Output */\n.output_html .gp { color: #000080; font-weight: bold } /* Generic.Prompt */\n.output_html .gs { font-weight: bold } /* Generic.Strong */\n.output_html .gu { color: #800080; font-weight: bold } /* Generic.Subheading */\n.output_html .gt { color: #04D } /* Generic.Traceback */\n.output_html .kc { color: #008000; font-weight: bold } /* Keyword.Constant */\n.output_html .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */\n.output_html .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */\n.output_html .kp { color: #008000 } /* Keyword.Pseudo */\n.output_html .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */\n.output_html .kt { color: #B00040 } /* Keyword.Type */\n.output_html .m { color: #666 } /* Literal.Number */\n.output_html .s { color: #BA2121 } /* Literal.String */\n.output_html .na { color: #687822 } /* Name.Attribute */\n.output_html .nb { color: #008000 } /* Name.Builtin */\n.output_html .nc { color: #00F; font-weight: bold } /* Name.Class */\n.output_html .no { color: #800 } /* Name.Constant */\n.output_html .nd { color: #A2F } /* Name.Decorator */\n.output_html .ni { color: #717171; font-weight: bold } /* Name.Entity */\n.output_html .ne { color: #CB3F38; font-weight: bold } /* Name.Exception */\n.output_html .nf { color: #00F } /* Name.Function */\n.output_html .nl { color: #767600 } /* Name.Label */\n.output_html .nn { color: #00F; font-weight: bold } /* Name.Namespace */\n.output_html .nt { color: #008000; font-weight: bold } /* Name.Tag */\n.output_html .nv { color: #19177C } /* Name.Variable */\n.output_html .ow { color: #A2F; font-weight: bold } /* Operator.Word */\n.output_html .w { color: #BBB } /* Text.Whitespace */\n.output_html .mb { color: #666 } /* Literal.Number.Bin */\n.output_html .mf { color: #666 } /* Literal.Number.Float */\n.output_html .mh { color: #666 } /* Literal.Number.Hex */\n.output_html .mi { color: #666 } /* Literal.Number.Integer */\n.output_html .mo { color: #666 } /* Literal.Number.Oct */\n.output_html .sa { color: #BA2121 } /* Literal.String.Affix */\n.output_html .sb { color: #BA2121 } /* Literal.String.Backtick */\n.output_html .sc { color: #BA2121 } /* Literal.String.Char */\n.output_html .dl { color: #BA2121 } /* Literal.String.Delimiter */\n.output_html .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */\n.output_html .s2 { color: #BA2121 } /* Literal.String.Double */\n.output_html .se { color: #AA5D1F; font-weight: bold } /* Literal.String.Escape */\n.output_html .sh { color: #BA2121 } /* Literal.String.Heredoc */\n.output_html .si { color: #A45A77; font-weight: bold } /* Literal.String.Interpol */\n.output_html .sx { color: #008000 } /* Literal.String.Other */\n.output_html .sr { color: #A45A77 } /* Literal.String.Regex */\n.output_html .s1 { color: #BA2121 } /* Literal.String.Single */\n.output_html .ss { color: #19177C } /* Literal.String.Symbol */\n.output_html .bp { color: #008000 } /* Name.Builtin.Pseudo */\n.output_html .fm { color: #00F } /* Name.Function.Magic */\n.output_html .vc { color: #19177C } /* Name.Variable.Class */\n.output_html .vg { color: #19177C } /* Name.Variable.Global */\n.output_html .vi { color: #19177C } /* Name.Variable.Instance */\n.output_html .vm { color: #19177C } /* Name.Variable.Magic */\n.output_html .il { color: #666 } /* Literal.Number.Integer.Long */</style><div class=\"highlight\"><pre><span></span><span class=\"k\">class</span><span class=\"w\"> </span><span class=\"nc\">SellarDerivatives</span><span class=\"p\">(</span><span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">Group</span><span class=\"p\">):</span>\n<span class=\"w\">    </span><span class=\"sd\">&quot;&quot;&quot;</span>\n<span class=\"sd\">    Group containing the Sellar MDA. This version uses the disciplines with derivatives.</span>\n<span class=\"sd\">    &quot;&quot;&quot;</span>\n\n    <span class=\"k\">def</span><span class=\"w\"> </span><span class=\"nf\">setup</span><span class=\"p\">(</span><span class=\"bp\">self</span><span class=\"p\">):</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;d1&#39;</span><span class=\"p\">,</span> <span class=\"n\">SellarDis1withDerivatives</span><span class=\"p\">(),</span> <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;x&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;d2&#39;</span><span class=\"p\">,</span> <span class=\"n\">SellarDis2withDerivatives</span><span class=\"p\">(),</span> <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;obj_cmp&#39;</span><span class=\"p\">,</span> <span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">ExecComp</span><span class=\"p\">(</span><span class=\"s1\">&#39;obj = x**2 + z[1] + y1 + exp(-y2)&#39;</span><span class=\"p\">,</span> <span class=\"n\">obj</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span>\n                                                  <span class=\"n\">x</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">z</span><span class=\"o\">=</span><span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">array</span><span class=\"p\">([</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"mf\">0.0</span><span class=\"p\">]),</span> <span class=\"n\">y1</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">y2</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">),</span>\n                           <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;obj&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;x&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;con_cmp1&#39;</span><span class=\"p\">,</span> <span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">ExecComp</span><span class=\"p\">(</span><span class=\"s1\">&#39;con1 = 3.16 - y1&#39;</span><span class=\"p\">,</span> <span class=\"n\">con1</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">y1</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">),</span>\n                           <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;con1&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y1&#39;</span><span class=\"p\">])</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">add_subsystem</span><span class=\"p\">(</span><span class=\"s1\">&#39;con_cmp2&#39;</span><span class=\"p\">,</span> <span class=\"n\">om</span><span class=\"o\">.</span><span class=\"n\">ExecComp</span><span class=\"p\">(</span><span class=\"s1\">&#39;con2 = y2 - 24.0&#39;</span><span class=\"p\">,</span> <span class=\"n\">con2</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">,</span> <span class=\"n\">y2</span><span class=\"o\">=</span><span class=\"mf\">0.0</span><span class=\"p\">),</span>\n                           <span class=\"n\">promotes</span><span class=\"o\">=</span><span class=\"p\">[</span><span class=\"s1\">&#39;con2&#39;</span><span class=\"p\">,</span> <span class=\"s1\">&#39;y2&#39;</span><span class=\"p\">])</span>\n\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">set_input_defaults</span><span class=\"p\">(</span><span class=\"s1\">&#39;x&#39;</span><span class=\"p\">,</span> <span class=\"mf\">1.0</span><span class=\"p\">)</span>\n        <span class=\"bp\">self</span><span class=\"o\">.</span><span class=\"n\">set_input_defaults</span><span class=\"p\">(</span><span class=\"s1\">&#39;z&#39;</span><span class=\"p\">,</span> <span class=\"n\">np</span><span class=\"o\">.</span><span class=\"n\">array</span><span class=\"p\">([</span><span class=\"mf\">5.0</span><span class=\"p\">,</span> <span class=\"mf\">2.0</span><span class=\"p\">]))</span>\n</pre></div>\n",
+      "application/papermill.record/text/latex": "\\begin{Verbatim}[commandchars=\\\\\\{\\}]\n\\PY{k}{class}\\PY{+w}{ }\\PY{n+nc}{SellarDerivatives}\\PY{p}{(}\\PY{n}{om}\\PY{o}{.}\\PY{n}{Group}\\PY{p}{)}\\PY{p}{:}\n\\PY{+w}{    }\\PY{l+s+sd}{\\PYZdq{}\\PYZdq{}\\PYZdq{}}\n\\PY{l+s+sd}{    Group containing the Sellar MDA. This version uses the disciplines with derivatives.}\n\\PY{l+s+sd}{    \\PYZdq{}\\PYZdq{}\\PYZdq{}}\n\n    \\PY{k}{def}\\PY{+w}{ }\\PY{n+nf}{setup}\\PY{p}{(}\\PY{n+nb+bp}{self}\\PY{p}{)}\\PY{p}{:}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{d1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{SellarDis1withDerivatives}\\PY{p}{(}\\PY{p}{)}\\PY{p}{,} \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{x}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{d2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{SellarDis2withDerivatives}\\PY{p}{(}\\PY{p}{)}\\PY{p}{,} \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{obj\\PYZus{}cmp}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{om}\\PY{o}{.}\\PY{n}{ExecComp}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{obj = x**2 + z[1] + y1 + exp(\\PYZhy{}y2)}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{obj}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,}\n                                                  \\PY{n}{x}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{z}\\PY{o}{=}\\PY{n}{np}\\PY{o}{.}\\PY{n}{array}\\PY{p}{(}\\PY{p}{[}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{l+m+mf}{0.0}\\PY{p}{]}\\PY{p}{)}\\PY{p}{,} \\PY{n}{y1}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{y2}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{)}\\PY{p}{,}\n                           \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{obj}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{x}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con\\PYZus{}cmp1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{om}\\PY{o}{.}\\PY{n}{ExecComp}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con1 = 3.16 \\PYZhy{} y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{con1}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{y1}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{)}\\PY{p}{,}\n                           \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y1}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{add\\PYZus{}subsystem}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con\\PYZus{}cmp2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{om}\\PY{o}{.}\\PY{n}{ExecComp}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con2 = y2 \\PYZhy{} 24.0}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{con2}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{,} \\PY{n}{y2}\\PY{o}{=}\\PY{l+m+mf}{0.0}\\PY{p}{)}\\PY{p}{,}\n                           \\PY{n}{promotes}\\PY{o}{=}\\PY{p}{[}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{con2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{y2}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{]}\\PY{p}{)}\n\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{set\\PYZus{}input\\PYZus{}defaults}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{x}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{l+m+mf}{1.0}\\PY{p}{)}\n        \\PY{n+nb+bp}{self}\\PY{o}{.}\\PY{n}{set\\PYZus{}input\\PYZus{}defaults}\\PY{p}{(}\\PY{l+s+s1}{\\PYZsq{}}\\PY{l+s+s1}{z}\\PY{l+s+s1}{\\PYZsq{}}\\PY{p}{,} \\PY{n}{np}\\PY{o}{.}\\PY{n}{array}\\PY{p}{(}\\PY{p}{[}\\PY{l+m+mf}{5.0}\\PY{p}{,} \\PY{l+m+mf}{2.0}\\PY{p}{]}\\PY{p}{)}\\PY{p}{)}\n\\end{Verbatim}\n",
+      "application/papermill.record/text/plain": "class SellarDerivatives(om.Group):\n    \"\"\"\n    Group containing the Sellar MDA. This version uses the disciplines with derivatives.\n    \"\"\"\n\n    def setup(self):\n        self.add_subsystem('d1', SellarDis1withDerivatives(), promotes=['x', 'z', 'y1', 'y2'])\n        self.add_subsystem('d2', SellarDis2withDerivatives(), promotes=['z', 'y1', 'y2'])\n\n        self.add_subsystem('obj_cmp', om.ExecComp('obj = x**2 + z[1] + y1 + exp(-y2)', obj=0.0,\n                                                  x=0.0, z=np.array([0.0, 0.0]), y1=0.0, y2=0.0),\n                           promotes=['obj', 'x', 'z', 'y1', 'y2'])\n\n        self.add_subsystem('con_cmp1', om.ExecComp('con1 = 3.16 - y1', con1=0.0, y1=0.0),\n                           promotes=['con1', 'y1'])\n        self.add_subsystem('con_cmp2', om.ExecComp('con2 = y2 - 24.0', con2=0.0, y2=0.0),\n                           promotes=['con2', 'y2'])\n\n        self.set_input_defaults('x', 1.0)\n        self.set_input_defaults('z', np.array([5.0, 2.0]))"
+     },
+     "metadata": {
+      "scrapbook": {
+       "mime_prefix": "application/papermill.record/",
+       "name": "code_src23"
+      }
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "from openmdao.utils.notebook_utils import get_code\n",
+    "from myst_nb import glue\n",
+    "glue(\"code_src23\", get_code(\"openmdao.test_suite.components.sellar_feature.SellarDerivatives\"), display=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    ":::{Admonition} `SellarDerivatives` class definition \n",
+    ":class: dropdown\n",
+    "\n",
+    "{glue:}`code_src23`\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NL: NLBGS Converged in 8 iterations\n",
+      "9.610010556989947\n",
+      "1.7844853356313648\n"
+     ]
+    }
+   ],
+   "source": [
+    "import openmdao.api as om\n",
+    "from openmdao.test_suite.components.sellar_feature import SellarDerivatives\n",
+    "\n",
+    "prob = om.Problem()\n",
+    "model = prob.model = SellarDerivatives()\n",
+    "\n",
+    "model.nonlinear_solver = om.NonlinearBlockGS()\n",
+    "model.linear_solver = om.PETScDirectSolver(backend='klu')\n",
+    "\n",
+    "prob.setup()\n",
+    "prob.run_model()\n",
+    "\n",
+    "wrt = ['z']\n",
+    "of = ['obj']\n",
+    "\n",
+    "J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')\n",
+    "print(J['obj', 'z'][0][0])\n",
+    "print(J['obj', 'z'][0][1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "tags": [
+     "remove-input",
+     "remove-output"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "2.4481205496170354e-09"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from openmdao.utils.assert_utils import assert_near_equal\n",
+    "\n",
+    "assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)\n",
+    "assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## PETScDirectSolver Options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "tags": [
+     "remove-input"
+    ]
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<!DOCTYPE html>\n",
+       "<html lang=\"en\">\n",
+       "<head>\n",
+       "    <style>\n",
+       "        h2 {\n",
+       "            text-align: center;\n",
+       "        }\n",
+       "    </style>\n",
+       "</head>\n",
+       "<body>\n",
+       "    <h2></h2>\n",
+       "        <table style=\"border: 1px solid #999; border-collapse: collapse;\">\n",
+       "        <tr><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Option</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Default</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Acceptable Values</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Acceptable Types</th><th style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; background-color: #E9E9E9; text-align: left;\">Description</th></tr>\n",
+       "       <tr style=\"background-color: ghostwhite;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">assemble_jac</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">True</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[True, False]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;bool&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">Activates use of assembled jacobian by this solver.</td></tr>\n",
+       "       <tr style=\"background-color: #F3F3F3;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">backend</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">superlu</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;superlu&#x27;, &#x27;klu&#x27;, &#x27;umfpack&#x27;, &#x27;petsc&#x27;, &#x27;mumps&#x27;, &#x27;superlu_dist&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">N/A</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\"></td></tr>\n",
+       "       <tr style=\"background-color: ghostwhite;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">iprint</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">1</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">N/A</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;int&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">whether to print output</td></tr>\n",
+       "       <tr style=\"background-color: #F3F3F3;\"><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">rhs_checking</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">False</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">N/A</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">[&#x27;bool&#x27;, &#x27;dict&#x27;]</td><td style=\"border: 1px solid #999; border-collapse: collapse; padding: 5px; text-align: left;\">If True, check RHS vs. cache and/or zero to avoid some solves.Can also be set to a dict of options for the LinearRHSChecker to allow finer control over it. Allowed options are: (&#x27;check_zero&#x27;, &#x27;rtol&#x27;, &#x27;atol&#x27;, &#x27;max_cache_entries&#x27;, &#x27;collect_stats&#x27;, &#x27;auto&#x27;, &#x27;verbose&#x27;)</td></tr>\n",
+       "    </table>\n",
+       "</body>\n",
+       "</html>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "om.show_options_table(\"openmdao.solvers.linear.petsc_direct_solver.PETScDirectSolver\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## DirectSolver Constructor\n",
+    "\n",
+    "The call signature for the `DirectSolver` constructor is:\n",
+    "\n",
+    "```{eval-rst}\n",
+    "    .. automethod:: openmdao.solvers.linear.direct.DirectSolver.__init__\n",
+    "        :noindex:\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "celltoolbar": "Tags",
+  "kernelspec": {
+   "display_name": "petsc-test",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  },
+  "orphan": true
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "PETSc is more general and has more options than scipy for direct solvers, but due to the generality PETSc provides a thicker wrapper around its solvers. So when considering whether to use `DirectSolver` or `PETScDirectSolver`, one should consider the size of their problem and sparsity pattern. Typically PETSc will be more beneficial for larger matrices where the factorization / solving speedup is larger than the slowdown due to overhead from the heavier wrapper. For more info about the solvers exposed by the PETScDirectSolver, see this summary table of direct solvers from the [PETSc documentation](https://petsc.org/release/overview/linear_solve_table/#direct-solvers).\n",
     "\n",
-    "Of the available direct solvers, SuperLU, KLU, UMFPACK, and PETSc can only be used in serial. The MUMPS and SuperLU-Dist solver may also be used in parallel, though there is typically not much benefit in running the direct solver in parallel.\n",
+    "Of the available direct solvers, SuperLU, KLU, UMFPACK, and PETSc can only be used in serial. The MUMPS and SuperLU-Dist solver can be used in serial, but will also be run distributed if the script is run with MPI.\n",
     "\n",
     "As an example, here we calculate the total derivatives of the Sellar system objective with respect to the design variable 'z', using the \"klu\" direct solver in the PETScDirectSolver."
    ]
@@ -127,12 +127,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## DirectSolver Constructor\n",
+    "## PETScDirectSolver Constructor\n",
     "\n",
-    "The call signature for the `DirectSolver` constructor is:\n",
+    "The call signature for the `PETScDirectSolver` constructor is:\n",
     "\n",
     "```{eval-rst}\n",
-    "    .. automethod:: openmdao.solvers.linear.direct.DirectSolver.__init__\n",
+    "    .. automethod:: openmdao.solvers.linear.petsc_direct_solver.PETScDirectSolver.__init__\n",
     "        :noindex:\n",
     "```"
    ]
@@ -155,7 +155,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.13"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
@@ -35,7 +35,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 18,
    "metadata": {
     "tags": [
      "remove-input",
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -98,7 +98,7 @@
     "model = prob.model = SellarDerivatives()\n",
     "\n",
     "model.nonlinear_solver = om.NonlinearBlockGS()\n",
-    "model.linear_solver = om.PETScDirectSolver(backend='klu')\n",
+    "model.linear_solver = om.PETScDirectSolver(sparse_solver_name='klu')\n",
     "\n",
     "prob.setup()\n",
     "prob.run_model()\n",
@@ -113,7 +113,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 20,
    "metadata": {
     "tags": [
      "remove-input",
@@ -148,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 21,
    "metadata": {
     "tags": [
      "remove-input"

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/petsc_direct_solver.ipynb
@@ -26,9 +26,9 @@
     "\n",
     "PETScDirectSolver is a linear solver that assembles the system Jacobian and solves the linear system with LU factorization and back substitution using the `petsc4py` library. It can handle any system topology. Since it assembles a global Jacobian for all of its subsystems, any linear solver that is assigned in any of its subsystems does not participate in this calculation (though they may be used in other ways such as in subsystem Newton solves). Unlike the standard DirectSolver which always uses SuperLU (for sparse) or LAPACK (dense) through scipy, the PETScDirectSolver has access to multiple DirectSolvers available in PETSc.\n",
     "\n",
-    "PETSc is more general and has more options than scipy for direct solvers, but due to the generality PETSc provides a thicker wrapper around its solvers. So when considering whether to use `DirectSolver` or `PETScDirectSolver`, one should consider the size of their problem and sparsity pattern. Typically PETSc will be more beneficial for larger matrices where the factorization / solving speedup is larger than the slowdown due to overhead from the heavier wrapper. For more info about the solvers exposed by the PETScDirectSolver, see this summary table of direct solvers from the [PETSc documentation](https://petsc.org/release/overview/linear_solve_table/#direct-solvers).\n",
+    "PETSc is more general and has more options than scipy for direct solvers, but due to the generality PETSc provides a thicker wrapper around its solvers. So when considering whether to use `DirectSolver` or `PETScDirectSolver`, one should consider the size of their problem and sparsity pattern. Typically PETSc will be more beneficial for larger matrices where the factorization / solving speedup from a different solver is larger than the slowdown due to overhead from the heavier wrapper. For more info about the solvers exposed by the PETScDirectSolver, see this summary table of direct solvers from the [PETSc documentation](https://petsc.org/release/overview/linear_solve_table/#direct-solvers).\n",
     "\n",
-    "Of the available direct solvers, SuperLU, KLU, UMFPACK, and PETSc can only be used in serial. The MUMPS and SuperLU-Dist solver can be used in serial, but will also be run distributed if the script is run with MPI.\n",
+    "Of the available sparse direct solvers, SuperLU, KLU, UMFPACK, and PETSc can only be used in serial. The MUMPS and SuperLU-Dist solvers can be used in serial, but will also be run distributed if the script is run with MPI. For dense matrices the solver will ignore the sparse algorithms and automatically use LAPACK, which only runs in serial.\n",
     "\n",
     "As an example, here we calculate the total derivatives of the Sellar system objective with respect to the design variable 'z', using the \"klu\" direct solver in the PETScDirectSolver."
    ]
@@ -155,7 +155,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.11.10"
   },
   "orphan": true
  },

--- a/openmdao/docs/openmdao_book/features/building_blocks/solvers/solvers.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/solvers/solvers.ipynb
@@ -42,6 +42,7 @@
     "- [PETScKrylov](petsc_krylov.ipynb)\n",
     "- [ScipyKrylov](scipy_iter_solver.ipynb)\n",
     "- [LinearUserDefined](linear_user_defined.ipynb)\n",
+    "- [PETScDirectSolver](petsc_direct_solver.ipynb)\n",
     "\n",
     "(linesearch-section)=\n",
     "## Linesearch/Backtracking\n",

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -185,7 +185,7 @@ class PETScLU:
 
         # OpenMDAO needs x to be a numpy array, so we need to take the distributed
         # x and "scatter" it (basically gather it to one rank). Once it's
-        # gathered into onen array, it can be converted to a numpy array and
+        # gathered into one array, it can be converted to a numpy array and
         # passed out.
         pc = self.ksp.getPC()
         if self.running_mpi and pc.getFactorSolverType() in PC_DISTRIBUTED_TYPES:
@@ -197,13 +197,13 @@ class PETScLU:
                 x_seq = PETSc.Vec().createSeq(0, comm=PETSc.COMM_SELF)
 
             # Have to call scatter on all ranks or MPI will error out (each
-            # rank is a processing being run in the MPI)
+            # rank is a process being run in the MPI)
             scatter, _ = PETSc.Scatter.toZero(self._x)
             scatter.scatter(self._x, x_seq, addv=PETSc.InsertMode.INSERT,
                             mode=PETSc.ScatterMode.FORWARD)
             scatter.destroy()
 
-            # Rank 0 owns x, broadcast (or send a copy) of it to the other ranks
+            # Rank 0 owns x, broadcast (or send a copy of) it to the other ranks
             # so that they don't break what OpenMDAO expects from the linear solver
             if self._x.comm.getRank() == 0:
                 x_array = x_seq.getArray().copy()

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -513,12 +513,13 @@ class PETScDirectSolver(LinearSolver):
             raise RuntimeError(format_singular_error(system, matrix)) from e
 
         elif "Could not locate solver type" in str(e):
-            raise RuntimeError(f"Specified PETSc sparse solver, "
-                                f"'{self.options['sparse_solver_name']}', "
-                                "is not installed.") from e
+            raise RuntimeError("Specified PETSc sparse solver, "
+                               f"'{self.options['sparse_solver_name']}', "
+                               "is not installed.") from e
 
         else:
-            raise(e)
+            # Just raise the original exception
+            raise
 
     def _build_mtx(self):
         """

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -225,11 +225,6 @@ class PETScDirectSolver(DirectSolver):
     ----------
     **kwargs : dict
         Options dictionary.
-
-    Attributes
-    ----------
-    _lin_rhs_checker : LinearRHSChecker or None
-        Object for checking the right-hand side of the linear solve.
     """
 
     SOLVER = 'LN: PETScDirect'

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -15,9 +15,12 @@ from openmdao.utils.om_warnings import issue_warning, SolverWarning
 
 try:
     from petsc4py import PETSc
-    DEFAULT_COMM = PETSc.COMM_WORLD
 except ImportError:
     PETSc = None
+try:
+    from mpi4py import MPI
+    DEFAULT_COMM = MPI.COMM_WORLD
+except ImportError:
     DEFAULT_COMM = None
 
 PC_SERIAL_TYPES = [

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -21,7 +21,7 @@ PC_SERIAL_TYPES = [
     "superlu",
     "klu",
     "umfpack",
-    "petsc"
+    "petsc",
 ]
 PC_DISTRIBUTED_TYPES = [
     "mumps",
@@ -29,6 +29,7 @@ PC_DISTRIBUTED_TYPES = [
 ]
 # Direct solvers that don't come installed with petsc4py or are not supported
 # for this problem
+# strumpack
 # pardiso
 # cholmod
 
@@ -116,6 +117,8 @@ class PETScLU:
         # iterative solve
         self.ksp.setType('preonly')
         pc = self.ksp.getPC()
+        # In practice, majority of OpenMDAO applications use general, unsymmetric
+        # Jacobians, so LU is usually the only practical choice.
         pc.setType('lu')
 
         # Backends are only for sparse matrices. For dense matrix should by
@@ -415,7 +418,11 @@ class PETScDirectSolver(LinearSolver):
         self.options.declare(
             'backend',
             values=PC_SERIAL_TYPES + PC_DISTRIBUTED_TYPES,
-            default='superlu'
+            default='superlu',
+            desc="Direct solver algorithm from PETSc that will be used for the "
+                 "LU factorization and solve if the matrix is sparse. For a "
+                 "dense matrix, this option will be ignored and LAPACK will "
+                 "be automatically used."
         )
 
         # this solver does not iterate

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -12,6 +12,7 @@ from openmdao.matrices.dense_matrix import DenseMatrix
 from openmdao.utils.array_utils import identity_column_iter
 from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
 from openmdao.utils.mpi import check_mpi_env
+from openmdao.utils.om_warnings import issue_warning, SolverWarning
 
 try:
     from petsc4py import PETSc
@@ -92,8 +93,13 @@ class PETScLU:
         # default use LAPACK
         if backend and not isinstance(A, np.ndarray):
             if backend in PC_DISTRIBUTED_TYPES and check_mpi_env() is False:
-                raise ImportError(f"OPENMDAO_USE_MPI is False, but using the "
-                                  f"PETSc direct solver {backend} which requires MPI.")
+                issue_warning(
+                    msg=('OPENMDAO_USE_MPI is False, but a linear solver which '
+                         'is meant to use MPI was selected. The solver will '
+                         'run sequentially.'),
+                    prefix='PETScDirectSolver',
+                    category=SolverWarning,
+                )
             pc.setFactorSolverType(backend)
 
         # Read and apply the user specified options to configure the solver,

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -230,7 +230,7 @@ def index_to_varname(system, loc):
         one) and index.
     """
     start = end = 0
-    varsizes = np.sum(system._owned_sizes, axis=0)
+    varsizes = np.sum(system._owned_output_sizes, axis=0)
     for i, name in enumerate(system._resolver.abs_iter('output')):
         end += varsizes[i]
         if loc < end:
@@ -356,7 +356,7 @@ def format_nan_error(system, matrix):
     """
     # Because of how we built the matrix, a NaN in a comp causes the whole row
     # to be NaN, so we need to associate each index with a variable.
-    varsizes = np.sum(system._owned_sizes, axis=0)
+    varsizes = np.sum(system._owned_output_sizes, axis=0)
 
     nanrows = np.zeros(matrix.shape[0], dtype=bool)
     nanrows[np.where(np.isnan(matrix))[0]] = True
@@ -606,7 +606,7 @@ class PETScDirectSolver(LinearSolver):
 
             if matrix is None:
                 # This happens if we're not rank 0 and owned_sizes are being used
-                sz = np.sum(system._owned_sizes)
+                sz = np.sum(system._owned_output_sizes)
                 inv_jac = np.zeros((sz, sz))
 
             # Dense and Sparse matrices have their own inverse method.

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -14,8 +14,10 @@ from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
 
 try:
     from petsc4py import PETSc
+    DEFAULT_COMM = PETSc.COMM_WORLD
 except ImportError:
     PETSc = None
+    DEFAULT_COMM = None
 
 PC_SERIAL_TYPES = [
     "superlu",
@@ -39,7 +41,7 @@ class PETScLU:
     Wrapper for PETSc LU decomposition, using petsc4py.
     """
     def __init__(self, A: scipy.sparse.spmatrix, sparse_solver_name: str = None,
-                 comm = PETSc.COMM_WORLD):
+                 comm = DEFAULT_COMM):
         """
         Initialize and setup the PETSc LU Direct Solver object.
 

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -112,10 +112,12 @@ class PETScLU:
                     self.A.setValues(i, cols, vals)
 
             else:
-                # Serial: build full CSR
+                # Serial: build full CSR (if you're running a serial solver
+                # while using MPI, then it will solve the full think on each rank)
                 self.A = PETSc.Mat().createAIJ(
                     size=A.shape,
-                    csr=(A.indptr, A.indices, A.data)
+                    csr=(A.indptr, A.indices, A.data),
+                    comm=PETSc.COMM_SELF,
                 )
 
             self.A.assemble()

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -39,31 +39,35 @@ PC_DISTRIBUTED_TYPES = [
 class PETScLU:
     """
     Wrapper for PETSc LU decomposition, using petsc4py.
+
+    Parameters
+    ----------
+    A : ndarray or <scipy.sparse.csc_matrix>
+        Matrix to use in solving x @ A == b
+    sparse_solver_name : str
+        Name of the direct solver from PETSc to use.
+    comm : <mpi4py.MPI.Intracomm>
+        The system MPI communicator
+
+    Attributes
+    ----------
+    orig_A : ndarray or <scipy.sparse.csc_matrix>
+        Originally provided matrx.
+    A : <petsc4py.PETSc.Mat>
+        Assembled PETSc AIJ (compressed sparse row format) matrix
+    ksp : <petsc4py.PETSc.KSP>
+        PETSc Krylov Subspace Solver context.
+    running_mpi : bool
+        Is the script currently being run under MPI (True) or not (False).
+    comm : <mpi4py.MPI.Intracomm>
+        The system MPI communicator.
+    _x : <petsc4py.PETSc.Vec>
+        Sequential (non-distributed) PETSc vector to store the solve solution.
     """
     def __init__(self, A: scipy.sparse.spmatrix, sparse_solver_name: str = None,
                  comm = DEFAULT_COMM):
         """
         Initialize and setup the PETSc LU Direct Solver object.
-
-        Parameters
-        ----------
-        A : ndarray or <scipy.sparse.csc_matrix>
-            Matrix to use in solving x @ A == b
-        sparse_solver_name : str
-            Name of the direct solver from PETSc to use.
-        comm : <mpi4py.MPI.Intracomm>
-            The system MPI communicator
-
-        Attributes
-        ----------
-        orig_A : ndarray or <scipy.sparse.csc_matrix>
-            Originally provided matrx.
-        A : <petsc4py.PETSc.Mat>
-            Assembled PETSc AIJ (compressed sparse row format) matrix
-        ksp : <petsc4py.PETSc.KSP>
-            PETSc Krylov Subspace Solver context.
-        _x : <petsc4py.PETSc.Vec>
-            Sequential (non-distributed) PETSc vector to store the solve solution.
         """
         self.comm = comm
         self.running_mpi = not comm.size == 1

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -621,7 +621,7 @@ class PETScDirectSolver(LinearSolver):
                     matrix = self._lup.orig_A
                 else:
                     sol_array = self._lu.solve(full_b, transpose=transpose)
-                    matrix = self._lu.orig_A.toarray()
+                    matrix = self._lu.orig_A
 
                 x_vec[:] = sol_array
 
@@ -632,9 +632,7 @@ class PETScDirectSolver(LinearSolver):
 
         # Detect singularities (PETSc linear solvers don't error out with NaN
         # and inf so need to check for them).
-        if np.isnan(x_vec).any():
-            raise RuntimeError(format_nan_error(system, matrix))
-        if np.isinf(x_vec).any():
+        if np.isinf(x_vec).any() or np.isnan(x_vec).any():
             raise RuntimeError(format_singular_error(system, matrix))
 
         if not system.under_complex_step and self._lin_rhs_checker is not None and mode == 'rev':

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -1,14 +1,12 @@
 """LinearSolver that uses PETSc for LU factor/solve."""
 
-import warnings
-
 import numpy as np
 import scipy.linalg
 import scipy.sparse.linalg
 import scipy.sparse
 
 from openmdao.solvers.linear.direct import DirectSolver
-from openmdao.solvers.linear.direct import format_singular_error, format_nan_error
+from openmdao.solvers.linear.direct import format_singular_error
 from openmdao.matrices.dense_matrix import DenseMatrix
 from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
 from openmdao.utils.om_warnings import issue_warning, SolverWarning

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -1,0 +1,655 @@
+"""LinearSolver that uses PETSc for LU factor/solve."""
+
+import warnings
+
+import numpy as np
+import scipy.linalg
+import scipy.sparse.linalg
+import scipy.sparse
+
+from openmdao.solvers.solver import LinearSolver
+from openmdao.matrices.dense_matrix import DenseMatrix
+from openmdao.utils.array_utils import identity_column_iter
+from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
+from openmdao.utils.mpi import check_mpi_env
+
+try:
+    from petsc4py import PETSc
+except ImportError:
+    PETSc = None
+
+PC_SERIAL_TYPES = [
+    "superlu",
+    "klu",
+    "umfpack",
+    "petsc"
+]
+PC_DISTRIBUTED_TYPES = [
+    "mumps",
+    "superlu_dist",
+]
+# Direct solvers that don't come installed with petsc4py or are not supported
+# for this problem
+# pardiso
+# cholmod
+
+
+class PETScLU:
+    """
+    Wrapper for PETSc LU decomposition, using petsc4py.
+    """
+    def __init__(self, A: scipy.sparse.spmatrix, backend: str = None):
+        """
+        Initialize and setup the PETSc LU Direct Solver object.
+
+        Parameters
+        ----------
+        A : spmatrix
+        backend : str
+            Name of the direct solver from PETSc to use.
+
+        Attributes
+        ----------
+        A : <petsc4py.PETSc.Mat>
+            Assembled PETSc AIJ (compressed sparse row format) matrix
+        ksp : <petsc4py.PETSc.KSP>
+            PETSc Krylov Subspace Solver context.
+        _x : <petsc4py.PETSc.Vec>
+            Sequential (non-distributed) PETSc vector to store the solve solution.
+        """
+        # Create PETSc matrix
+        # Dense
+        if isinstance(A, np.ndarray):
+            self.A = PETSc.Mat().createDense(A.shape, array=A)
+
+        # Sparse
+        else:
+            # PETSc wants to use CSR matrices, not CSC
+            if not scipy.sparse.isspmatrix_csr(A):
+                A = A.tocsr()
+            # TODO: Look at how to maybe provide a nnz argument for a rough
+            # estimate of number of nonzero rows so it hopefully doesn't have
+            # to do frequent reallocations
+            self.A = PETSc.Mat().createAIJ(size=A.shape, csr=(A.indptr,
+                                                              A.indices, A.data))
+            self.A.assemble()
+
+        # Create PETSc solver (KSP is the iterative linear solver [Krylov SPace
+        # solver] and PC is the preconditioner)
+        self.ksp = PETSc.KSP().create()
+        self.ksp.setOperators(self.A)
+        # Use only the preconditioner (e.g. direct LU solve) and skip the
+        # iterative solve
+        self.ksp.setType('preonly')
+        pc = self.ksp.getPC()
+        pc.setType('lu')
+
+        # Backends are only for sparse matrices. For dense matrix should by
+        # default use LAPACK
+        if backend and not isinstance(A, np.ndarray):
+            if backend in PC_DISTRIBUTED_TYPES and check_mpi_env() is False:
+                raise ImportError(f"OPENMDAO_USE_MPI is False, but using the "
+                                  f"PETSc direct solver {backend} which requires MPI.")
+            pc.setFactorSolverType(backend)
+
+        # Read and apply the user specified options to configure the solver,
+        # preconditioner, etc., then perform the internal setup and initialization
+        # (setUp can be called automatically by solve(), but we call it
+        # explicitly so we can prepare the solver beforehand)
+        self.ksp.setFromOptions()
+        self.ksp.setUp()
+
+        # Create a single process vector which will store the solve solution
+        # vector
+        self._x = PETSc.Vec().createSeq(A.shape[1])
+
+    def solve(self, b: np.ndarray, transpose: bool = False) -> np.ndarray:
+        """
+        Solve the linear system using only the preconditioner direct solver
+
+        Parameters
+        ----------
+        b : ndarray
+            Input data for the right hand side.
+        tranpose : bool
+            Is A.T @ x == b being solved (True) or A @ x == b (False).
+
+        Returns
+        -------
+        ndarray
+            The solution array.
+        """
+        b_petsc = PETSc.Vec().createWithArray(b)
+        if transpose:
+            self.ksp.solveTranspose(b_petsc, self._x)
+        else:
+            self.ksp.solve(b_petsc, self._x)
+        return self._x.getArray().copy()
+
+
+def index_to_varname(system, loc):
+    """
+    Given a matrix location, return the name of the variable associated with
+    that index.
+
+    Parameters
+    ----------
+    system : <System>
+        System containing the Directsolver.
+    loc : int
+        Index of row or column.
+
+    Returns
+    -------
+    str
+        String containing variable absolute name (and promoted name if there is
+        one) and index.
+    """
+    start = end = 0
+    varsizes = np.sum(system._owned_sizes, axis=0)
+    for i, name in enumerate(system._resolver.abs_iter('output')):
+        end += varsizes[i]
+        if loc < end:
+            varname = system._resolver.abs2prom(name, 'output')
+            break
+        start = end
+
+    if varname == name:
+        name_string = "'{}' index {}.".format(varname, loc - start)
+    else:
+        name_string = "'{}' ('{}') index {}.".format(varname, name, loc - start)
+
+    return name_string
+
+
+def loc_to_error_msg(system, loc_txt, loc):
+    """
+    Given a matrix location, format a coherent error message when matrix is singular.
+
+    Parameters
+    ----------
+    system : <System>
+        System containing the Directsolver.
+    loc_txt : str
+        Either 'row' or 'col'.
+    loc : int
+        Index of row or column.
+
+    Returns
+    -------
+    str
+        New error string.
+    """
+    names = index_to_varname(system, loc)
+    msg = "Singular entry found in {} for {} associated with state/residual " + names
+    return msg.format(system.msginfo, loc_txt)
+
+
+def format_singular_error(system, matrix):
+    """
+    Format a coherent error message for any ill-conditioned mmatrix.
+
+    Parameters
+    ----------
+    system : <System>
+        System containing the Directsolver.
+    matrix : ndarray
+        Matrix of interest.
+
+    Returns
+    -------
+    str
+        New error string.
+    """
+    if scipy.sparse.issparse(matrix):
+        matrix = matrix.toarray()
+
+    if np.any(np.isnan(matrix)):
+        # There is a nan in the matrix.
+        return format_nan_error(system, matrix)
+
+    zero_rows = np.where(~matrix.any(axis=1))[0]
+    zero_cols = np.where(~matrix.any(axis=0))[0]
+    if zero_cols.size <= zero_rows.size:
+
+        if zero_rows.size == 0:
+            # In this case, some row is a linear combination of the other rows.
+
+            # SVD gives us some information that may help locate the source of
+            # the problem.
+            try:
+                u, _, _ = np.linalg.svd(matrix)
+
+            except Exception:
+                msg = f"Jacobian in '{system.pathname}' is not full rank, but OpenMDAO was " + \
+                      "not able to determine which rows or columns."
+                return msg
+
+            # Nonzero elements in the left singular vector show the rows that
+            # contribute strongly to the singular subspace. Note that sometimes
+            # extra rows/cols are included in the set, currently don't have a
+            # good way to pare them down.
+            tol = 1e-15
+            u_sing = np.abs(u[:, -1])
+            left_idx = np.where(u_sing > tol)[0]
+
+            msg = "Jacobian in '{}' is not full rank. The following set of states/residuals " + \
+                  "contains one or more equations that is a linear combination of the others: \n"
+
+            for loc in left_idx:
+                name = index_to_varname(system, loc)
+                msg += ' ' + name + '\n'
+
+            if len(left_idx) > 2:
+                msg += "Note that the problem may be in a single Component."
+
+            return msg.format(system.pathname)
+
+        loc_txt = "row"
+        loc = zero_rows[0]
+    else:
+        loc_txt = "column"
+        loc = zero_cols[0]
+
+    return loc_to_error_msg(system, loc_txt, loc)
+
+
+def format_nan_error(system, matrix):
+    """
+    Format a coherent error message when the matrix contains NaN.
+
+    Parameters
+    ----------
+    system : <System>
+        System containing the Directsolver.
+    matrix : ndarray
+        Matrix of interest.
+
+    Returns
+    -------
+    str
+        New error string.
+    """
+    # Because of how we built the matrix, a NaN in a comp causes the whole row
+    # to be NaN, so we need to associate each index with a variable.
+    varsizes = np.sum(system._owned_sizes, axis=0)
+
+    nanrows = np.zeros(matrix.shape[0], dtype=bool)
+    nanrows[np.where(np.isnan(matrix))[0]] = True
+
+    varnames = []
+    start = end = 0
+    for i, name in enumerate(system._resolver.abs_iter('output')):
+        end += varsizes[i]
+        if np.any(nanrows[start:end]):
+            varnames.append("'%s'" % system._resolver.abs2prom(name, 'output'))
+        start = end
+
+    msg = "NaN entries found in {} for rows associated with states/residuals [{}]."
+    return msg.format(system.msginfo, ', '.join(varnames))
+
+
+class PETScDirectSolver(LinearSolver):
+    """
+    LinearSolver that uses PETSc for LU factor/solve.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Options dictionary.
+
+    Attributes
+    ----------
+    _lin_rhs_checker : LinearRHSChecker or None
+        Object for checking the right-hand side of the linear solve.
+    """
+
+    SOLVER = 'LN: PETScDirect'
+
+    def __init__(self, **kwargs):
+        """
+        Declare the solver options.
+        """
+        super().__init__(**kwargs)
+
+        if PETSc is None:
+            raise RuntimeError(f"{self.msginfo}: PETSc is not available. ")
+
+        self._lin_rhs_checker = None
+
+    def _declare_options(self):
+        """
+        Declare options before kwargs are processed in the init method.
+        """
+        super()._declare_options()
+
+        self.options.declare(
+            'err_on_singular',
+            types=bool,
+            default=True,
+            desc="Raise an error if LU decomposition is singular."
+        )
+
+        self.options.declare(
+            'rhs_checking',
+            types=(bool, dict),
+            default=False,
+            desc="If True, check RHS vs. cache and/or zero to avoid some solves."
+                 "Can also be set to a dict of options for the LinearRHSChecker to "
+                 "allow finer control over it. Allowed options are: "
+                 f"{LinearRHSChecker.options}"
+        )
+
+        self.options.declare(
+            'backend',
+            values=PC_SERIAL_TYPES + PC_DISTRIBUTED_TYPES,
+            default='superlu'
+        )
+
+        # this solver does not iterate
+        self.options.undeclare("maxiter")
+        self.options.undeclare("err_on_non_converge")
+
+        self.options.undeclare("atol")
+        self.options.undeclare("rtol")
+
+        # Use an assembled jacobian by default.
+        self.options['assemble_jac'] = True
+
+        self.supports['implicit_components'] = True
+
+    def _setup_solvers(self, system, depth):
+        """
+        Assign system instance, set depth, and optionally perform setup.
+
+        Parameters
+        ----------
+        system : <System>
+            pointer to the owning system.
+        depth : int
+            depth of the current system (already incremented).
+        """
+        super()._setup_solvers(system, depth)
+        self._disallow_distrib_solve()
+        self._lin_rhs_checker = LinearRHSChecker.create(self._system(),
+                                                        self.options['rhs_checking'])
+
+    def _linearize_children(self):
+        """
+        Return a flag that is True when we need to call linearize on our
+        subsystems' solvers.
+
+        Returns
+        -------
+        boolean
+            Flag for indicating child linearization.
+        """
+        return False
+
+    def can_solve_cycle(self):
+        """
+        Return True if this solver can solve groups with cycles.
+
+        Returns
+        -------
+        bool
+            True if this solver can solve groups with cycles.
+        """
+        return True
+
+    def use_relevance(self):
+        """
+        Return True if relevance should be active.
+
+        Returns
+        -------
+        bool
+            True if relevance should be active.
+        """
+        return False
+
+    def _build_mtx(self):
+        """
+        Assemble a Jacobian matrix by matrix-vector-product with columns of identity.
+
+        Returns
+        -------
+        ndarray
+            Jacobian matrix.
+        """
+        system = self._system()
+        bvec = system._dresiduals
+        xvec = system._doutputs
+
+        # First make a backup of the vectors
+        b_data = bvec.asarray(copy=True)
+        x_data = xvec.asarray(copy=True)
+
+        nmtx = x_data.size
+        seed = np.zeros(x_data.size)
+        mtx = np.empty((nmtx, nmtx), dtype=b_data.dtype)
+        scope_out, scope_in = system._get_matvec_scope()
+
+        # temporarily disable relevance to avoid creating a singular matrix
+        with system._relevance.active(False):
+            # Assemble the Jacobian by running the identity matrix through apply_linear
+            for i, seed in enumerate(identity_column_iter(seed)):
+                # set value of x vector to provided value
+                xvec.set_val(seed)
+
+                # apply linear
+                system._apply_linear(self._assembled_jac, 'fwd', scope_out, scope_in)
+
+                # put new value in out_vec
+                mtx[:, i] = bvec.asarray()
+
+        # Restore the backed-up vectors
+        bvec.set_val(b_data)
+        xvec.set_val(x_data)
+
+        return mtx
+
+    def _linearize(self):
+        """
+        Perform factorization.
+        """
+        system = self._system()
+        nproc = system.comm.size
+
+        if self._assembled_jac is not None:
+            matrix = self._assembled_jac._int_mtx._matrix
+
+            if matrix is None:
+                # this happens if we're not rank 0 when using owned_sizes
+                self._lu = self._lup = None
+
+            # Perform dense or sparse lu factorization.
+            # PETSc does not have an equivalent to scipy.linalg.lu_factor to use
+            # for dense matrices, so just use the same solver for either case
+            elif isinstance(matrix, scipy.sparse.csc_matrix):
+                try:
+                    self._lu = PETScLU(matrix, self.options['backend'])
+                except RuntimeError:
+                    raise RuntimeError(format_singular_error(system, matrix))
+
+            elif isinstance(matrix, np.ndarray):  # dense
+                # During LU decomposition, detect singularities and warn user.
+                with warnings.catch_warnings():
+                    if self.options['err_on_singular']:
+                        warnings.simplefilter('error', RuntimeWarning)
+                    try:
+                        self._lup = PETScLU(matrix)
+                    except RuntimeWarning:
+                        raise RuntimeError(format_singular_error(system, matrix))
+
+                    # NaN in matrix.
+                    except ValueError:
+                        raise RuntimeError(format_nan_error(system, matrix))
+
+            # Note: calling scipy.sparse.linalg.splu on a COO actually transposes
+            # the matrix during conversion to csc prior to LU decomp, so we can't use COO.
+            else:
+                raise RuntimeError("Direct solver not implemented for matrix type %s"
+                                   " in %s." % (type(self._assembled_jac._int_mtx),
+                                                system.msginfo))
+        else:
+            if nproc > 1:
+                raise RuntimeError("DirectSolvers without an assembled jacobian are not supported "
+                                   "when running under MPI if comm.size > 1.")
+
+            mtx = self._build_mtx()
+
+            # During LU decomposition, detect singularities and warn user.
+            with warnings.catch_warnings():
+
+                if self.options['err_on_singular']:
+                    warnings.simplefilter('error', RuntimeWarning)
+
+                try:
+                    self._lup = PETScLU(mtx)
+
+                except RuntimeWarning:
+                    raise RuntimeError(format_singular_error(system, mtx))
+
+                # NaN in matrix.
+                except ValueError:
+                    raise RuntimeError(format_nan_error(system, mtx))
+
+        if self._lin_rhs_checker is not None:
+            self._lin_rhs_checker.clear()
+
+    def _inverse(self):
+        """
+        Return the inverse Jacobian.
+
+        This is only used by the Broyden solver when calculating a full model
+        Jacobian. Since it is only done for a single RHS, no need for LU.
+
+        Returns
+        -------
+        ndarray
+            Inverse Jacobian.
+        """
+        system = self._system()
+        nproc = system.comm.size
+
+        if self._assembled_jac is not None:
+
+            matrix = self._assembled_jac._int_mtx._matrix
+
+            if matrix is None:
+                # This happens if we're not rank 0 and owned_sizes are being used
+                sz = np.sum(system._owned_sizes)
+                inv_jac = np.zeros((sz, sz))
+
+            # Dense and Sparse matrices have their own inverse method.
+            elif isinstance(matrix, np.ndarray):
+                # Detect singularities and warn user.
+                with warnings.catch_warnings():
+                    if self.options['err_on_singular']:
+                        warnings.simplefilter('error', RuntimeWarning)
+                    try:
+                        inv_jac = scipy.linalg.inv(matrix)
+                    except RuntimeWarning:
+                        raise RuntimeError(format_singular_error(system, matrix))
+
+                    # NaN in matrix.
+                    except ValueError:
+                        raise RuntimeError(format_nan_error(system, matrix))
+
+            elif isinstance(matrix, scipy.sparse.csc_matrix):
+                try:
+                    inv_jac = scipy.sparse.linalg.inv(matrix)
+                except RuntimeError:
+                    raise RuntimeError(format_singular_error(system, matrix))
+
+                # to prevent broadcasting errors later, make sure inv_jac is 2D
+                # scipy.sparse.linalg.inv returns a shape (1,) array if matrix
+                # is shape (1,1)
+                if inv_jac.size == 1:
+                    inv_jac = inv_jac.reshape((1, 1))
+            else:
+                raise RuntimeError("Direct solver not implemented for matrix type %s"
+                                   " in %s." % (type(matrix), system.msginfo))
+
+        else:
+            if nproc > 1:
+                raise RuntimeError("BroydenSolvers without an assembled jacobian "
+                                   "are not supported when running under MPI if "
+                                   "comm.size > 1.")
+            mtx = self._build_mtx()
+
+            # During inversion detect singularities and warn user.
+            with warnings.catch_warnings():
+
+                if self.options['err_on_singular']:
+                    warnings.simplefilter('error', RuntimeWarning)
+
+                try:
+                    inv_jac = scipy.linalg.inv(mtx)
+
+                except RuntimeWarning:
+                    raise RuntimeError(format_singular_error(system, mtx))
+
+                # NaN in matrix.
+                except ValueError:
+                    raise RuntimeError(format_nan_error(system, mtx))
+
+        return inv_jac
+
+    def solve(self, mode, rel_systems=None): ###
+        """
+        Run the solver.
+
+        Parameters
+        ----------
+        mode : str
+            'fwd' or 'rev'.
+        rel_systems : set of str
+            Names of systems relevant to the current solve.  Deprecated.
+        """
+        system = self._system()
+        d_residuals = system._dresiduals
+        d_outputs = system._doutputs
+
+        if system.under_complex_step:
+            raise RuntimeError('{}: PETScDirectSolver is not supported under '
+                               'complex step.'.format(self.msginfo))
+
+        # assign x and b vectors based on mode
+        if mode == 'fwd':
+            x_vec = d_outputs.asarray()
+            b_vec = d_residuals.asarray()
+            transpose = False
+        else:  # rev
+            x_vec = d_residuals.asarray()
+            b_vec = d_outputs.asarray()
+            transpose = True
+
+            if self._lin_rhs_checker is not None:
+                sol_array, is_zero = self._lin_rhs_checker.get_solution(b_vec, system)
+                if is_zero:
+                    x_vec[:] = 0.0
+                    return
+                if sol_array is not None:
+                    x_vec[:] = sol_array
+                    return
+
+        # AssembledJacobians are unscaled.
+        if self._assembled_jac is not None:
+            full_b = b_vec
+
+            with system._unscaled_context(outputs=[d_outputs], residuals=[d_residuals]):
+                if isinstance(self._assembled_jac._int_mtx, DenseMatrix):
+                    sol_array = self._lup.solve(full_b, transpose=transpose)
+                else:
+                    sol_array = self._lu.solve(full_b, transpose=transpose)
+
+                x_vec[:] = sol_array
+
+        # matrix-vector-product generated jacobians are scaled.
+        else:
+            x_vec[:] = sol_array = self._lup.solve(full_b, transpose=transpose)
+
+        if not system.under_complex_step and self._lin_rhs_checker is not None and mode == 'rev':
+            self._lin_rhs_checker.add_solution(b_vec, sol_array, copy=True)

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -65,8 +65,9 @@ class PETScLU:
     _x : <petsc4py.PETSc.Vec>
         Sequential (non-distributed) PETSc vector to store the solve solution.
     """
+
     def __init__(self, A: scipy.sparse.spmatrix, sparse_solver_name: str = None,
-                 comm = DEFAULT_COMM):
+                 comm=DEFAULT_COMM):
         """
         Initialize and setup the PETSc LU Direct Solver object.
         """
@@ -103,8 +104,8 @@ class PETScLU:
                 for i in range(rstart, rend):
                     row_start = indptr[i]
                     row_end = indptr[i + 1]
-                    cols = indices[row_start : row_end]
-                    vals = data[row_start : row_end]
+                    cols = indices[row_start: row_end]
+                    vals = data[row_start: row_end]
                     self.A.setValues(i, cols, vals)
 
             else:
@@ -169,7 +170,7 @@ class PETScLU:
         """
         b_petsc = self.A.createVecRight()
         rstart, rend = b_petsc.getOwnershipRange()
-        b_petsc.setValues(range(rstart, rend), b[rstart : rend])
+        b_petsc.setValues(range(rstart, rend), b[rstart: rend])
         b_petsc.assemble()
 
         if transpose:
@@ -193,7 +194,8 @@ class PETScLU:
             # Have to call scatter on all ranks or MPI will error out (each
             # rank is a processing being run in the MPI)
             scatter, _ = PETSc.Scatter.toZero(self._x)
-            scatter.scatter(self._x, x_seq, addv=PETSc.InsertMode.INSERT, mode=PETSc.ScatterMode.FORWARD)
+            scatter.scatter(self._x, x_seq, addv=PETSc.InsertMode.INSERT,
+                            mode=PETSc.ScatterMode.FORWARD)
             scatter.destroy()
 
             # Rank 0 owns x, broadcast (or send a copy) of it to the other ranks
@@ -456,8 +458,7 @@ class PETScDirectSolver(LinearSolver):
 
     def _linearize_children(self):
         """
-        Return a flag that is True when we need to call linearize on our
-        subsystems' solvers.
+        Return a flag that is True when we need to call linearize on our subsystems' solvers.
 
         Returns
         -------
@@ -657,7 +658,7 @@ class PETScDirectSolver(LinearSolver):
 
         return inv_jac
 
-    def solve(self, mode, rel_systems=None): ###
+    def solve(self, mode, rel_systems=None):
         """
         Run the solver.
 

--- a/openmdao/solvers/linear/tests/linear_test_base.py
+++ b/openmdao/solvers/linear/tests/linear_test_base.py
@@ -6,6 +6,7 @@ import numpy as np
 from openmdao.api import Group, IndepVarComp, Problem
 from openmdao.solvers.nonlinear.nonlinear_block_gs import NonlinearBlockGS
 from openmdao.solvers.linear.direct import DirectSolver
+from openmdao.solvers.linear.petsc_direct_solver import PETScDirectSolver
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
@@ -53,7 +54,7 @@ class LinearSolverTests(object):
 
         def test_simple_matvec(self):
             # Tests derivatives on a simple comp that defines compute_jacvec.
-            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
+            # Note, For direct solvers, assemble_jac must be False for mat-vec.
             prob = Problem()
             model = prob.model
             model.add_subsystem('x_param', IndepVarComp('length', 3.0),
@@ -66,8 +67,9 @@ class LinearSolverTests(object):
 
             prob.setup(check=False, mode='fwd')
 
-            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
-            if isinstance(model.linear_solver, DirectSolver):
+            # Note, For direct solvers, assemble_jac must be False for mat-vec.
+            if (isinstance(model.linear_solver, DirectSolver) or
+                    isinstance(model.linear_solver, PETScDirectSolver)):
                 model.linear_solver.options['assemble_jac'] = False
 
             prob['width'] = 2.0
@@ -104,8 +106,9 @@ class LinearSolverTests(object):
             prob.setup(check=False, mode='fwd')
             prob['width'] = 2.0
 
-            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
-            if isinstance(model.linear_solver, DirectSolver):
+            # Note, For direct solvers, assemble_jac must be False for mat-vec.
+            if (isinstance(model.linear_solver, DirectSolver) or
+                    isinstance(model.linear_solver, PETScDirectSolver)):
                 model.linear_solver.options['assemble_jac'] = False
 
             prob.run_model()
@@ -142,8 +145,9 @@ class LinearSolverTests(object):
             prob.setup(check=False, mode='fwd')
             prob['width'] = 2.0
 
-            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
-            if isinstance(model.linear_solver, DirectSolver):
+            # Note, For direct solvers, assemble_jac must be False for mat-vec.
+            if (isinstance(model.linear_solver, DirectSolver) or
+                    isinstance(model.linear_solver, PETScDirectSolver)):
                 model.linear_solver.options['assemble_jac'] = False
 
             prob.run_model()

--- a/openmdao/solvers/linear/tests/linear_test_base.py
+++ b/openmdao/solvers/linear/tests/linear_test_base.py
@@ -6,7 +6,6 @@ import numpy as np
 from openmdao.api import Group, IndepVarComp, Problem
 from openmdao.solvers.nonlinear.nonlinear_block_gs import NonlinearBlockGS
 from openmdao.solvers.linear.direct import DirectSolver
-from openmdao.solvers.linear.petsc_direct_solver import PETScDirectSolver
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
 from openmdao.test_suite.components.sellar import SellarDerivativesGrouped, \
@@ -54,7 +53,7 @@ class LinearSolverTests(object):
 
         def test_simple_matvec(self):
             # Tests derivatives on a simple comp that defines compute_jacvec.
-            # Note, For direct solvers, assemble_jac must be False for mat-vec.
+            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
             prob = Problem()
             model = prob.model
             model.add_subsystem('x_param', IndepVarComp('length', 3.0),
@@ -67,9 +66,8 @@ class LinearSolverTests(object):
 
             prob.setup(check=False, mode='fwd')
 
-            # Note, For direct solvers, assemble_jac must be False for mat-vec.
-            if (isinstance(model.linear_solver, DirectSolver) or
-                    isinstance(model.linear_solver, PETScDirectSolver)):
+            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
+            if isinstance(model.linear_solver, DirectSolver):
                 model.linear_solver.options['assemble_jac'] = False
 
             prob['width'] = 2.0
@@ -106,9 +104,8 @@ class LinearSolverTests(object):
             prob.setup(check=False, mode='fwd')
             prob['width'] = 2.0
 
-            # Note, For direct solvers, assemble_jac must be False for mat-vec.
-            if (isinstance(model.linear_solver, DirectSolver) or
-                    isinstance(model.linear_solver, PETScDirectSolver)):
+            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
+            if isinstance(model.linear_solver, DirectSolver):
                 model.linear_solver.options['assemble_jac'] = False
 
             prob.run_model()
@@ -145,9 +142,8 @@ class LinearSolverTests(object):
             prob.setup(check=False, mode='fwd')
             prob['width'] = 2.0
 
-            # Note, For direct solvers, assemble_jac must be False for mat-vec.
-            if (isinstance(model.linear_solver, DirectSolver) or
-                    isinstance(model.linear_solver, PETScDirectSolver)):
+            # Note, For DirectSolver, assemble_jac must be False for mat-vec.
+            if isinstance(model.linear_solver, DirectSolver):
                 model.linear_solver.options['assemble_jac'] = False
 
             prob.run_model()

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -420,6 +420,25 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
         self.assertEqual(expected_msg, str(cm.exception))
 
+    def test_raise_error_on_not_installed_solver(self):
+        prob = om.Problem()
+        model = prob.model
+
+        class TestSolver(om.PETScDirectSolver):
+            def _declare_options(self):
+                super()._declare_options()
+                self.options.declare('sparse_solver_name')
+
+        model.add_subsystem('comp', om.ExecComp('y = x * 2.'))
+        model.linear_solver = TestSolver(sparse_solver_name='hello')
+        prob.setup()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.compute_totals('comp.y', 'comp.x')
+
+        expected_msg = "Specified PETSc sparse solver, 'hello', is not installed."
+        self.assertEqual(expected_msg, str(cm.exception))
+
     def test_raise_error_on_dup_partials(self):
         prob = om.Problem()
         model = prob.model

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -3,6 +3,7 @@
 import unittest
 import numpy as np
 from scipy import sparse
+from sys import platform
 import openmdao.api as om
 
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
@@ -110,7 +111,9 @@ class DistribComp(om.ExplicitComponent):
             outputs['y'] = 3.0 * inputs['x']
 
 # Test the class used to setup and interact with the PETSc solver
-@unittest.skipUnless(PETSc, "only run with PETSc.")
+# OSX doesn't install any of the solvers with PETSc (they have to be manually
+# built, so skip all tests for OSX)
+@unittest.skipUnless(PETSc and platform != "darwin", "only run with PETSc and not on Mac.")
 class TestPETScClass(unittest.TestCase):
 
     def test_instantiate_dense(self):
@@ -217,7 +220,7 @@ class TestPETScClass(unittest.TestCase):
 
 # Test the class used to setup and interact with the PETSc solver when it is
 # being run under MPI
-@unittest.skipUnless(MPI and PETSc, "only run with MPI and PETSc.")
+@unittest.skipUnless(MPI and PETSc and platform != "darwin", "only run with MPI and PETSc and not on Mac.")
 class TestPETScClassMPI(unittest.TestCase):
 
     N_PROCS = 2
@@ -251,7 +254,7 @@ class TestPETScClassMPI(unittest.TestCase):
 # Run the same test suite as the DirectSolver since the functionality is very
 # close to the same (except skip "test_raise_no_error_on_singular" PETSc
 # direct solver doesn't do that)
-@unittest.skipUnless(PETSc, "only run with PETSc.")
+@unittest.skipUnless(PETSc and platform != "darwin", "only run with PETSc.")
 class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     linear_solver_class = om.PETScDirectSolver
@@ -416,7 +419,10 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.run_model()
 
-        expected_msg = "Singular entry found in 'thrust_equilibrium_group' <class Group> for row associated with state/residual 'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') index 0."
+        expected_msg = ("Singular entry found in 'thrust_equilibrium_group' "
+                        "<class Group> for row associated with state/residual "
+                        "'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') "
+                        "index 0.")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -452,7 +458,10 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
             with self.assertRaises(Exception) as cm:
                 prob.setup()
 
-        expected_msg = "'dupcomp' <class DupPartialsComp>: d(x)/d(c): declare_partials has been called with rows and cols that specify the following duplicate subjacobian entries: [(4, 11), (10, 2)]."
+        expected_msg = ("'dupcomp' <class DupPartialsComp>: d(x)/d(c): "
+                        "declare_partials has been called with rows and cols "
+                        "that specify the following duplicate subjacobian "
+                        "entries: [(4, 11), (10, 2)].")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -490,7 +499,10 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.run_model()
 
-        expected_msg = "Singular entry found in 'thrust_equilibrium_group' <class Group> for row associated with state/residual 'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') index 0."
+        expected_msg = ("Singular entry found in 'thrust_equilibrium_group' "
+                        "<class Group> for row associated with state/residual "
+                        "'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') "
+                        "index 0.")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -527,7 +539,10 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.run_model()
 
-        expected_msg = "Singular entry found in 'thrust_equilibrium_group' <class Group> for row associated with state/residual 'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') index 0."
+        expected_msg = ("Singular entry found in 'thrust_equilibrium_group' "
+                        "<class Group> for row associated with state/residual "
+                        "'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') "
+                        "index 0.")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -560,7 +575,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             print(prob.compute_totals(of=['c5.y'], wrt=['p.x']))
 
-        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['sub.c2.y', 'c4.y']."
+        expected_msg = ("NaN entries found in <model> <class Group> for rows "
+                        "associated with states/residuals ['sub.c2.y', 'c4.y'].")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -593,7 +609,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             print(prob.compute_totals(of=['c5.y'], wrt=['p.x']))
 
-        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['sub.c2.y', 'c4.y']."
+        expected_msg = ("NaN entries found in <model> <class Group> for rows "
+                        "associated with states/residuals ['sub.c2.y', 'c4.y'].")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -626,7 +643,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.compute_totals(of=['c5.y'], wrt=['p.x'])
 
-        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['sub.c2.y', 'c4.y']."
+        expected_msg = ("NaN entries found in <model> <class Group> for rows "
+                        "associated with states/residuals ['sub.c2.y', 'c4.y'].")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -655,7 +673,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.compute_totals(of=['c5.y'], wrt=['p.x'])
 
-        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['c5.y']."
+        expected_msg = ("NaN entries found in <model> <class Group> for rows "
+                        "associated with states/residuals ['c5.y'].")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -684,7 +703,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.compute_totals(of=['c5.y'], wrt=['p.x'])
 
-        expected_msg = "Singular entry found in <model> <class Group> for row associated with state/residual 'c5.y' index 0."
+        expected_msg = ("Singular entry found in <model> <class Group> for row "
+                        "associated with state/residual 'c5.y' index 0.")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -714,7 +734,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.compute_totals(of=['c5.y'], wrt=['p.x'])
 
-        expected_msg = "Singular entry found in <model> <class Group> for row associated with state/residual 'c5.y' index 0."
+        expected_msg = ("Singular entry found in <model> <class Group> for row "
+                        "associated with state/residual 'c5.y' index 0.")
 
         self.assertEqual(expected_msg, str(cm.exception))
 
@@ -781,7 +802,9 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob.run_model()
 
-        expected = "Jacobian in 'sub' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected = ("Jacobian in 'sub' is not full rank. The following set of "
+                    "states/residuals contains one or more equations that is a "
+                    "linear combination of the others: \n")
         expected += " 'gen.I_out' ('sub.gen.I_out') index 0.\n"
         expected += " 'Vm_dc' ('sub.calcs.V_out') index 0.\n"
 
@@ -840,7 +863,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
                 self.declare_partials('z', 'aa', val=-1.0)
 
             def apply_nonlinear(self, inputs, outputs, residuals):
-                residuals['z'] = 2.0 * inputs['x'] + inputs['y'] - 4.0 * outputs['z'] - inputs['a'] - inputs['aa']
+                residuals['z'] = (2.0 * inputs['x'] + inputs['y'] - 4.0
+                                  * outputs['z'] - inputs['a'] - inputs['aa'])
 
 
         class E3bad(om.ImplicitComponent):
@@ -859,7 +883,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
                 self.declare_partials('z', 'aa', val=-1.0)
 
             def apply_nonlinear(self, inputs, outputs, residuals):
-                residuals['z'] = 2.0 * inputs['x'] + inputs['y'] - 4.0 * outputs['z'] - inputs['a'] - inputs['aa']
+                residuals['z'] = (2.0 * inputs['x'] + inputs['y'] - 4.0
+                                  * outputs['z'] - inputs['a'] - inputs['aa'])
 
         # Configuration 1
         p = om.Problem()
@@ -895,7 +920,9 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             p.run_model()
 
-        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected = ("Jacobian in '' is not full rank. The following set of "
+                    "states/residuals contains one or more equations that is a "
+                    "linear combination of the others: \n")
         expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
         expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
 
@@ -936,7 +963,9 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             p.run_model()
 
-        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected = ("Jacobian in '' is not full rank. The following set of "
+                    "states/residuals contains one or more equations that is a "
+                    "linear combination of the others: \n")
         expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
         expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
 
@@ -975,7 +1004,9 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
         with self.assertRaises(RuntimeError) as cm:
             p.run_model()
 
-        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected = ("Jacobian in '' is not full rank. The following set of "
+                    "states/residuals contains one or more equations that is a "
+                    "linear combination of the others: \n")
         expected += " 'sub1.a' ('_auto_ivc.v0') index 0.\n"
         expected += " 'sub1.aa' ('_auto_ivc.v1') index 0.\n"
         expected += " 'sub1.e3.a' ('_auto_ivc.v2') index 0.\n"
@@ -1015,7 +1046,8 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
                 self.declare_partials('z', 'y', val=-1.0)
                 self.declare_partials('z', 'z', val=-2.0)
 
-            def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs=None, discrete_outputs=None):
+            def apply_nonlinear(self, inputs, outputs, residuals,
+                                discrete_inputs=None, discrete_outputs=None):
                 a = inputs['a']
                 x, y, z = outputs.values()
 
@@ -1062,7 +1094,7 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
             prob.run_model()
 
 
-@unittest.skipUnless(MPI and PETSc, "only run with MPI and PETSc.")
+@unittest.skipUnless(MPI and PETSc and platform != "darwin", "only run with MPI and PETSc and not on Mac.")
 class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
 
     N_PROCS = 2
@@ -1088,8 +1120,9 @@ class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
-            "distributed component."
+        msg = ("PETScDirectSolver linear solver in <model> <class Group> "
+               "cannot be used in or above a ParallelGroup or a distributed "
+               "component.")
         self.assertEqual(str(cm.exception), msg)
 
     def test_distrib_direct_subbed(self):
@@ -1113,8 +1146,9 @@ class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
-            "distributed component."
+        msg = ("PETScDirectSolver linear solver in <model> <class Group> "
+               "cannot be used in or above a ParallelGroup or a distributed "
+               "component.")
         self.assertEqual(str(cm.exception), msg)
 
     def test_par_direct_subbed(self):
@@ -1142,8 +1176,9 @@ class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
-            "distributed component."
+        msg = ("PETScDirectSolver linear solver in <model> <class Group> "
+               "cannot be used in or above a ParallelGroup or a distributed "
+               "component.")
         self.assertEqual(str(cm.exception), msg)
 
     def test_par_direct(self):
@@ -1163,12 +1198,13 @@ class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
         with self.assertRaises(Exception) as cm:
             prob.run_model()
 
-        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
-            "distributed component."
+        msg = ("PETScDirectSolver linear solver in <model> <class Group> "
+               "cannot be used in or above a ParallelGroup or a distributed "
+               "component.")
         self.assertEqual(str(cm.exception), msg)
 
 
-@unittest.skipUnless(PETSc, "only run with PETSc.")
+@unittest.skipUnless(PETSc and platform != "darwin", "only run with PETSc and not on Mac.")
 class TestPETScDirectSolverMPI(unittest.TestCase):
 
     N_PROCS = 2

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -287,6 +287,15 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
             self.assertEqual(str(context.exception), msg % option)
 
+    def test_err_on_singular_option(self):
+        # Test that "err_on_singular" option will raise an error if not True
+        msg = ('The PETScDirectSolver must always have its "err_on_singular" '
+               'option set to True. This option is only maintained for '
+               'compatibility with parent solver methods.')
+        with self.assertRaises(ValueError) as context:
+            om.PETScDirectSolver(err_on_singular=False)
+        self.assertEqual(str(context.exception), msg)
+
     def test_solve_on_subsystem(self):
         """solve an implicit system with PETScDirectSolver attached to a subsystem"""
 

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -242,7 +242,7 @@ class TestPETScClassMPI(unittest.TestCase):
         lu = PETScLU(
             A=sparse.csc_matrix(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 3]])),
             sparse_solver_name='mumps',
-            comm=PETSc.COMM_WORLD,
+            comm=MPI.COMM_WORLD,
         )
         x = lu.solve(b=np.array([1, 2, 3]), transpose=False)
         assert_near_equal(x, np.array([0.0, 1.0, 1.0]))

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -16,9 +16,9 @@ from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.mpi import MPI
 try:
-    from openmdao.vectors.petsc_vector import PETScVector
+    from petsc4py import PETSc
 except ImportError:
-    PETScVector = None
+    PETSc = None
 
 # TODO: ADD TESTS FOR EACH SOLVER TYPE
 # TODO: ADD TESTS FOR THE PETSC OBJECT
@@ -113,6 +113,7 @@ class DistribComp(om.ExplicitComponent):
 # Run the same test suite as the DirectSolver since the functionality is very
 # close to the same (except skip "test_raise_no_error_on_singular" PETSc
 # direct solver doesn't do that)
+@unittest.skipUnless(PETSc, "only run with PETSc.")
 class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     linear_solver_class = om.PETScDirectSolver
@@ -904,7 +905,7 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
             prob.run_model()
 
 
-@unittest.skipUnless(MPI and PETScVector, "only run with MPI and PETSc.")
+@unittest.skipUnless(MPI and PETSc, "only run with MPI and PETSc.")
 class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
 
     N_PROCS = 2

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -1,0 +1,1054 @@
+"""Test the PETScDirectSolver linear solver class."""
+
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+
+from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
+from openmdao.test_suite.components.double_sellar import DoubleSellar
+from openmdao.test_suite.components.expl_comp_simple import TestExplCompSimpleJacVec
+from openmdao.test_suite.components.sellar import SellarDerivatives
+from openmdao.test_suite.groups.implicit_group import TestImplicitGroup
+from openmdao.utils.array_utils import evenly_distrib_idxs
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.general_utils import printoptions
+from openmdao.utils.mpi import MPI
+try:
+    from openmdao.vectors.petsc_vector import PETScVector
+except ImportError:
+    PETScVector = None
+
+# TODO: ADD TESTS FOR EACH SOLVER TYPE
+# TODO: ADD TESTS FOR THE PETSC OBJECT
+
+class NanComp(om.ExplicitComponent):
+    def setup(self):
+        self.add_input('x', 1.0)
+        self.add_output('y', 1.0)
+
+        self.declare_partials(of='*', wrt='*')
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = 3.0*inputs['x']
+
+    def compute_partials(self, inputs, partials):
+        """Intentionally incorrect derivative."""
+        J = partials
+        J['y', 'x'] = np.nan
+
+
+class SingularComp(om.ImplicitComponent):
+    def setup(self):
+        self.add_input('x', 1.0)
+        self.add_output('y', 1.0)
+
+        self.declare_partials(of='*', wrt='*')
+
+    def compute_partials(self, inputs, partials):
+        """Intentionally incorrect derivative."""
+        J = partials
+        J['y', 'x'] = 0.0
+        J['y', 'y'] = 0.0
+
+
+class NanComp2(om.ExplicitComponent):
+    def setup(self):
+        self.add_input('x', 1.0)
+        self.add_output('y', 1.0)
+        self.add_output('y2', 1.0)
+
+        self.declare_partials(of='*', wrt='*')
+
+    def compute(self, inputs, outputs):
+        outputs['y'] = 3.0*inputs['x']
+        outputs['y2'] = 2.0*inputs['x']
+
+    def compute_partials(self, inputs, partials):
+        """Intentionally incorrect derivative."""
+        J = partials
+        J['y', 'x'] = np.nan
+        J['y2', 'x'] = 2.0
+
+class DupPartialsComp(om.ExplicitComponent):
+    def setup(self):
+        self.add_input('c', np.zeros(19))
+        self.add_output('x', np.zeros(11))
+
+        rows = [0,  1,  4, 10, 7, 9, 10, 4]
+        cols = [0, 18, 11,  2, 5, 9,  2, 11]
+        self.declare_partials(of='x', wrt='c', rows=rows, cols=cols)
+
+    def compute(self, inputs, outputs):
+        pass
+
+    def compute_partials(self, inputs, partials):
+        pass
+
+
+class DistribComp(om.ExplicitComponent):
+    def __init__(self, arr_size=11, **kwargs):
+        super().__init__(**kwargs)
+        self.arr_size = arr_size
+        self.options['distributed'] = True
+
+    def setup(self):
+        comm = self.comm
+        rank = comm.rank
+
+        sizes, _ = evenly_distrib_idxs(comm.size, self.arr_size)
+
+        self.add_input('x', np.ones(sizes[rank]))
+        self.add_output('y', np.ones(sizes[rank]))
+
+        self.declare_partials(of='y', wrt='x', method='cs')
+
+    def compute(self, inputs, outputs):
+        if self.comm.rank == 0:
+            outputs['y'] = 2.0 * inputs['x']
+        else:
+            outputs['y'] = 3.0 * inputs['x']
+
+# Run the same test suite as the DirectSolver since the functionality is very
+# close to the same (except skip "test_raise_no_error_on_singular" PETSc
+# direct solver doesn't do that)
+class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
+
+    linear_solver_class = om.PETScDirectSolver
+
+    def test_specify_solver(self):
+
+        prob = om.Problem()
+        model = prob.model = SellarDerivatives()
+
+        model.nonlinear_solver = om.NonlinearBlockGS()
+        model.linear_solver = om.PETScDirectSolver()
+
+        prob.setup()
+        prob.run_model()
+
+        wrt = ['z']
+        of = ['obj']
+
+        J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+        assert_near_equal(J['obj', 'z'][0][0], 9.61001056, .00001)
+        assert_near_equal(J['obj', 'z'][0][1], 1.78448534, .00001)
+
+    # PETScDirectSolver doesn't iterate.
+    def test_solve_linear_maxiter(self):
+        # Test that using options that should not exist in class cause an error
+        solver = om.PETScDirectSolver()
+
+        msg = "\"PETScDirectSolver: Option '%s' cannot be set because it has not been declared.\""
+
+        for option in ['atol', 'rtol', 'maxiter', 'err_on_non_converge']:
+            with self.assertRaises(KeyError) as context:
+                solver.options[option] = 1
+
+            self.assertEqual(str(context.exception), msg % option)
+
+    def test_solve_on_subsystem(self):
+        """solve an implicit system with PETScDirectSolver attached to a subsystem"""
+
+        p = om.Problem()
+        model = p.model
+        dv = model.add_subsystem('des_vars', om.IndepVarComp())
+        # just need a dummy variable so the sizes don't match between root and g1
+        dv.add_output('dummy', val=1.0, shape=10)
+
+        g1 = model.add_subsystem('g1', TestImplicitGroup(lnSolverClass=om.PETScDirectSolver))
+
+        p.setup()
+
+        g1.linear_solver.options['assemble_jac'] = False
+
+        p.set_solver_print(level=0)
+
+        # Conclude setup but don't run model.
+        p.final_setup()
+
+        # forward
+        d_inputs, d_outputs, d_residuals = g1.get_linear_vectors()
+
+        d_residuals.set_val(1.0)
+        d_outputs.set_val(0.0)
+        g1._linearize(g1._assembled_jac)
+        g1.linear_solver._linearize()
+        g1.run_solve_linear('fwd')
+
+        output = d_outputs.asarray()
+        assert_near_equal(output, g1.expected_solution, 1e-15)
+
+        # reverse
+        d_inputs, d_outputs, d_residuals = g1.get_linear_vectors()
+
+        d_outputs.set_val(1.0)
+        d_residuals.set_val(0.0)
+        g1.linear_solver._linearize()
+        g1.run_solve_linear('rev')
+
+        output = d_residuals.asarray()
+        assert_near_equal(output, g1.expected_solution, 3e-15)
+
+    def test_rev_mode_bug(self):
+
+        prob = om.Problem()
+        prob.model = SellarDerivatives(nonlinear_solver=om.NewtonSolver(solve_subsystems=False),
+                                       linear_solver=om.PETScDirectSolver())
+
+        prob.setup(check=False, mode='rev')
+        prob.set_solver_print(level=0)
+        prob.run_model()
+
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
+
+        wrt = ['x', 'z']
+        of = ['obj', 'con1', 'con2']
+
+        Jbase = {}
+        Jbase['con1', 'x'] = [[-0.98061433]]
+        Jbase['con1', 'z'] = np.array([[-9.61002285, -0.78449158]])
+        Jbase['con2', 'x'] = [[0.09692762]]
+        Jbase['con2', 'z'] = np.array([[1.94989079, 1.0775421]])
+        Jbase['obj', 'x'] = [[2.98061392]]
+        Jbase['obj', 'z'] = np.array([[9.61001155, 1.78448534]])
+
+        J = prob.compute_totals(of=of, wrt=wrt, return_format='flat_dict')
+        for key, val in Jbase.items():
+            assert_near_equal(J[key], val, .00001)
+
+        # In the bug, the solver mode got switched from fwd to rev when it shouldn't
+        # have been, causing a singular matrix and NaNs in the output.
+        prob.run_model()
+
+        assert_near_equal(prob['y1'], 25.58830273, .00001)
+        assert_near_equal(prob['y2'], 12.05848819, .00001)
+
+    def test_multi_dim_src_indices(self):
+        prob = om.Problem()
+        model = prob.model
+        size = 5
+
+        model.add_subsystem('indeps', om.IndepVarComp('x', np.arange(5).reshape((1,size,1))))
+        model.add_subsystem('comp', om.ExecComp('y = x * 2.', x=np.zeros((size,)), y=np.zeros((size,))))
+        src_indices = [[0]*size, np.arange(size, dtype=int), [0]*size]
+        model.connect('indeps.x', 'comp.x', src_indices=src_indices)
+
+        model.linear_solver = om.PETScDirectSolver()
+        prob.setup()
+        prob.run_model()
+
+        J = prob.compute_totals(wrt=['indeps.x'], of=['comp.y'], return_format='array')
+        np.testing.assert_almost_equal(J, np.eye(size) * 2.)
+
+    def test_raise_error_on_singular(self):
+        prob = om.Problem()
+        model = prob.model
+
+        comp = om.IndepVarComp()
+        comp.add_output('dXdt:TAS', val=1.0)
+        comp.add_output('accel_target', val=2.0)
+        model.add_subsystem('des_vars', comp, promotes=['*'])
+
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
+
+        thrust_bal = om.BalanceComp()
+        thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
+                               rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
+
+        teg.add_subsystem(name='thrust_bal', subsys=thrust_bal,
+                          promotes_inputs=['dXdt:TAS', 'accel_target'],
+                          promotes_outputs=['thrust'])
+
+        teg.linear_solver = om.PETScDirectSolver(assemble_jac=False)
+
+        teg.nonlinear_solver = om.NewtonSolver()
+        teg.nonlinear_solver.options['solve_subsystems'] = True
+        teg.nonlinear_solver.options['max_sub_solves'] = 1
+        teg.nonlinear_solver.options['atol'] = 1e-4
+
+        prob.setup()
+        prob.set_solver_print(level=0)
+        prob.final_setup()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.run_model()
+
+        expected_msg = "Singular entry found in 'thrust_equilibrium_group' <class Group> for row associated with state/residual 'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') index 0."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_raise_error_on_dup_partials(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('des_vars', om.IndepVarComp('x', 1.0), promotes=['*'])
+        model.add_subsystem('dupcomp', DupPartialsComp())
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+
+        with printoptions(legacy='1.21'):
+            with self.assertRaises(Exception) as cm:
+                prob.setup()
+
+        expected_msg = "'dupcomp' <class DupPartialsComp>: d(x)/d(c): declare_partials has been called with rows and cols that specify the following duplicate subjacobian entries: [(4, 11), (10, 2)]."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_raise_error_on_singular_with_densejac(self):
+        prob = om.Problem()
+        model = prob.model
+
+        comp = om.IndepVarComp()
+        comp.add_output('dXdt:TAS', val=1.0)
+        comp.add_output('accel_target', val=2.0)
+        model.add_subsystem('des_vars', comp, promotes=['*'])
+
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
+
+        thrust_bal = om.BalanceComp()
+        thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
+                               rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
+
+        teg.add_subsystem(name='thrust_bal', subsys=thrust_bal,
+                          promotes_inputs=['dXdt:TAS', 'accel_target'],
+                          promotes_outputs=['thrust'])
+
+        teg.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+        teg.options['assembled_jac_type'] = 'dense'
+
+        teg.nonlinear_solver = om.NewtonSolver()
+        teg.nonlinear_solver.options['solve_subsystems'] = True
+        teg.nonlinear_solver.options['max_sub_solves'] = 1
+        teg.nonlinear_solver.options['atol'] = 1e-4
+
+        prob.setup()
+        prob.set_solver_print(level=0)
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.run_model()
+
+        expected_msg = "Singular entry found in 'thrust_equilibrium_group' <class Group> for row associated with state/residual 'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') index 0."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_raise_error_on_singular_with_sparsejac(self):
+        prob = om.Problem()
+        model = prob.model
+
+        comp = om.IndepVarComp()
+        comp.add_output('dXdt:TAS', val=1.0)
+        comp.add_output('accel_target', val=2.0)
+        model.add_subsystem('des_vars', comp, promotes=['*'])
+
+        teg = model.add_subsystem('thrust_equilibrium_group', subsys=om.Group())
+        teg.add_subsystem('dynamics', om.ExecComp('z = 2.0*thrust'), promotes=['*'])
+
+        thrust_bal = om.BalanceComp()
+        thrust_bal.add_balance(name='thrust', val=1207.1, lhs_name='dXdt:TAS',
+                               rhs_name='accel_target', eq_units='m/s**2', lower=-10.0, upper=10000.0)
+
+        teg.add_subsystem(name='thrust_bal', subsys=thrust_bal,
+                          promotes_inputs=['dXdt:TAS', 'accel_target'],
+                          promotes_outputs=['thrust'])
+
+        teg.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+
+        teg.nonlinear_solver = om.NewtonSolver()
+        teg.nonlinear_solver.options['solve_subsystems'] = True
+        teg.nonlinear_solver.options['max_sub_solves'] = 1
+        teg.nonlinear_solver.options['atol'] = 1e-4
+
+        prob.setup()
+        prob.set_solver_print(level=0)
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.run_model()
+
+        expected_msg = "Singular entry found in 'thrust_equilibrium_group' <class Group> for row associated with state/residual 'thrust' ('thrust_equilibrium_group.thrust_bal.thrust') index 0."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_raise_error_on_nan(self):
+
+        prob = om.Problem(allow_post_setup_reorder=False)
+        model = prob.model
+
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x'))
+        sub = model.add_subsystem('sub', om.Group())
+        sub.add_subsystem('c2', NanComp())
+        model.add_subsystem('c3', om.ExecComp('y = 4.0*x'))
+        model.add_subsystem('c4', NanComp2())
+        model.add_subsystem('c5', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('c6', om.ExecComp('y = 2.0*x'))
+
+        model.connect('p.x', 'c1.x')
+        model.connect('c1.y', 'sub.c2.x')
+        model.connect('sub.c2.y', 'c3.x')
+        model.connect('c3.y', 'c4.x')
+        model.connect('c4.y', 'c5.x')
+        model.connect('c4.y2', 'c6.x')
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=False)
+
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            print(prob.compute_totals(of=['c5.y'], wrt=['p.x']))
+
+        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['sub.c2.y', 'c4.y']."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_raise_error_on_nan_sparse(self):
+
+        prob = om.Problem(allow_post_setup_reorder=False)
+        model = prob.model
+
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x'))
+        sub = model.add_subsystem('sub', om.Group())
+        sub.add_subsystem('c2', NanComp())
+        model.add_subsystem('c3', om.ExecComp('y = 4.0*x'))
+        model.add_subsystem('c4', NanComp2())
+        model.add_subsystem('c5', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('c6', om.ExecComp('y = 2.0*x'))
+
+        model.connect('p.x', 'c1.x')
+        model.connect('c1.y', 'sub.c2.x')
+        model.connect('sub.c2.y', 'c3.x')
+        model.connect('c3.y', 'c4.x')
+        model.connect('c4.y', 'c5.x')
+        model.connect('c4.y2', 'c6.x')
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            print(prob.compute_totals(of=['c5.y'], wrt=['p.x']))
+
+        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['sub.c2.y', 'c4.y']."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_raise_error_on_nan_dense(self):
+
+        prob = om.Problem(model=om.Group(assembled_jac_type='dense'), allow_post_setup_reorder=False)
+        model = prob.model
+
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x'))
+        sub = model.add_subsystem('sub', om.Group())
+        sub.add_subsystem('c2', NanComp())
+        model.add_subsystem('c3', om.ExecComp('y = 4.0*x'))
+        model.add_subsystem('c4', NanComp2())
+        model.add_subsystem('c5', om.ExecComp('y = 3.0*x'))
+        model.add_subsystem('c6', om.ExecComp('y = 2.0*x'))
+
+        model.connect('p.x', 'c1.x')
+        model.connect('c1.y', 'sub.c2.x')
+        model.connect('sub.c2.y', 'c3.x')
+        model.connect('c3.y', 'c4.x')
+        model.connect('c4.y', 'c5.x')
+        model.connect('c4.y2', 'c6.x')
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.compute_totals(of=['c5.y'], wrt=['p.x'])
+
+        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['sub.c2.y', 'c4.y']."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_error_on_NaN_bug(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0*np.ones((2, 2))))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c2', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c3', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c4', om.ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c5', NanComp())
+
+        model.connect('p.x', 'c1.x')
+        model.connect('c1.y', 'c2.x')
+        model.connect('c2.y', 'c3.x')
+        model.connect('c3.y', 'c4.x')
+        model.connect('c4.y', 'c5.x', src_indices=[0], flat_src_indices=True)
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.compute_totals(of=['c5.y'], wrt=['p.x'])
+
+        expected_msg = "NaN entries found in <model> <class Group> for rows associated with states/residuals ['c5.y']."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_error_on_singular_with_sparsejac_bug(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0*np.ones((2, 2))))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c2', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c3', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c4', om.ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c5', SingularComp())
+
+        model.connect('p.x', 'c1.x')
+        model.connect('c1.y', 'c2.x')
+        model.connect('c2.y', 'c3.x')
+        model.connect('c3.y', 'c4.x')
+        model.connect('c4.y', 'c5.x', src_indices=([0]), flat_src_indices=True)
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.compute_totals(of=['c5.y'], wrt=['p.x'])
+
+        expected_msg = "Singular entry found in <model> <class Group> for row associated with state/residual 'c5.y' index 0."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_error_on_singular_with_densejac_bug(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p', om.IndepVarComp('x', 2.0*np.ones((2, 2))))
+        model.add_subsystem('c1', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c2', om.ExecComp('y = 4.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c3', om.ExecComp('y = 3.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c4', om.ExecComp('y = 2.0*x', x=np.zeros((2, 2)), y=np.zeros((2, 2))))
+        model.add_subsystem('c5', SingularComp())
+
+        model.connect('p.x', 'c1.x')
+        model.connect('c1.y', 'c2.x')
+        model.connect('c2.y', 'c3.x')
+        model.connect('c3.y', 'c4.x')
+        model.connect('c4.y', 'c5.x', src_indices=[0], flat_src_indices=True)
+
+        model.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+        model.options['assembled_jac_type'] = 'dense'
+
+        prob.setup()
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.compute_totals(of=['c5.y'], wrt=['p.x'])
+
+        expected_msg = "Singular entry found in <model> <class Group> for row associated with state/residual 'c5.y' index 0."
+
+        self.assertEqual(expected_msg, str(cm.exception))
+
+    def test_error_msg_underdetermined_1(self):
+
+        class DCgenerator(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('V_bus', val=1.0)
+                self.add_input('V_out', val=1.0)
+
+                self.add_output('I_out', val=-2.0)
+                self.add_output('P_out', val=-2.0)
+
+                self.declare_partials('I_out', 'V_bus', val=1.0)
+                self.declare_partials('I_out', 'V_out', val=-1.0)
+                self.declare_partials('P_out', ['V_out', 'I_out'])
+                self.declare_partials('P_out', 'P_out', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, resids):
+                resids['I_out'] = inputs['V_bus'] - inputs['V_out']
+                resids['P_out'] = inputs['V_out'] * outputs['I_out'] - outputs['P_out']
+
+            def linearize(self, inputs, outputs, J):
+                J['P_out', 'V_out'] = outputs['I_out']
+                J['P_out', 'I_out'] = inputs['V_out']
+
+        class RectifierCalcs(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('P_out', val=1.0)
+
+                self.add_output('P_in', val=1.0)
+                self.add_output('V_out', val=1.0)
+                self.add_output('Q_in', val=1.0)
+
+                self.declare_partials('P_in', 'P_out', val=1.0)
+                self.declare_partials('P_in', 'P_in', val=-1.0)
+                self.declare_partials('V_out', 'V_out', val=-1.0)
+                self.declare_partials('Q_in', 'P_in', val=1.0)
+                self.declare_partials('Q_in', 'Q_in', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, resids):
+                resids['P_in'] = inputs['P_out'] - outputs['P_in']
+                resids['V_out'] = 1.0 - outputs['V_out']
+                resids['Q_in'] = outputs['P_in'] - outputs['Q_in']
+
+        class Rectifier(om.Group):
+
+            def setup(self):
+                self.add_subsystem('gen', DCgenerator(), promotes=[('V_bus', 'Vm_dc'), 'P_out'])
+
+                self.add_subsystem('calcs', RectifierCalcs(), promotes=['P_out', ('V_out', 'Vm_dc')])
+
+                self.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+                self.linear_solver = om.PETScDirectSolver()
+
+        prob = om.Problem(allow_post_setup_reorder=False)
+        prob.model.add_subsystem('sub', Rectifier())
+
+        prob.setup()
+        prob.set_solver_print(level=0)
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.run_model()
+
+        expected = "Jacobian in 'sub' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'gen.I_out' ('sub.gen.I_out') index 0.\n"
+        expected += " 'Vm_dc' ('sub.calcs.V_out') index 0.\n"
+
+        self.assertEqual(expected, str(cm.exception))
+
+    def test_error_msg_underdetermined_2(self):
+
+        class E1(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('a', 1.0)
+                self.add_input('aa', 1.0)
+                self.add_input('y', 1.0)
+                self.add_input('z', 1.0)
+                self.add_output('x', 1.0)
+
+                self.declare_partials('x', 'x', val=1.0)
+                self.declare_partials('x', 'y', val=1.0)
+                self.declare_partials('x', 'z', val=1.0)
+                self.declare_partials('x', 'a', val=-1.0)
+                self.declare_partials('x', 'aa', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['x'] = outputs['x'] + inputs['y'] + inputs['z'] - inputs['a'] - inputs['aa']
+
+
+        class E2(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('x', 1.0)
+                self.add_output('y', 1.0)
+
+                self.declare_partials('y', 'x', val=2.063e-4)
+                self.declare_partials('y', 'y')
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['y'] = 2.063e-4 * inputs['x'] - outputs['y'] ** 2
+
+            def linearize(self, inputs, outputs, jacobian):
+                jacobian['y', 'y'] = -2.0 * outputs['y']
+
+
+        class E3(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('a', 1.0)
+                self.add_input('aa', 1.0)
+                self.add_input('x', 1.0)
+                self.add_input('y', 1.0)
+                self.add_output('z', 1.0)
+
+                self.declare_partials('z', 'x', val=2.0)
+                self.declare_partials('z', 'y', val=1.0)
+                self.declare_partials('z', 'z', val=-4.0)
+                self.declare_partials('z', 'a', val=-1.0)
+                self.declare_partials('z', 'aa', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['z'] = 2.0 * inputs['x'] + inputs['y'] - 4.0 * outputs['z'] - inputs['a'] - inputs['aa']
+
+
+        class E3bad(om.ImplicitComponent):
+
+            def setup(self):
+                self.add_input('a', 1.0)
+                self.add_input('aa', 1.0)
+                self.add_input('x', 1.0)
+                self.add_input('y', 1.0)
+                self.add_output('z', 1.0)
+
+                self.declare_partials('z', 'x', val=1.0)
+                self.declare_partials('z', 'y', val=1.0)
+                self.declare_partials('z', 'z', val=1.0)
+                self.declare_partials('z', 'a', val=-1.0)
+                self.declare_partials('z', 'aa', val=-1.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals):
+                residuals['z'] = 2.0 * inputs['x'] + inputs['y'] - 4.0 * outputs['z'] - inputs['a'] - inputs['aa']
+
+        # Configuration 1
+        p = om.Problem()
+        model = p.model
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('aa', 1.0)
+        model.add_subsystem('p', ivc, promotes=['aa'])
+
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = model.add_subsystem('sub2', om.Group())
+        sub3 = model.add_subsystem('sub3', om.Group())
+
+        sub1.add_subsystem('e1', E1(), promotes=['*'])
+        sub1.add_subsystem('e2', E2(), promotes=['*'])
+        sub1.add_subsystem('e3', E3(), promotes=['*'])
+
+        sub2.add_subsystem('e1', E1(), promotes=['*'])
+        sub2.add_subsystem('e2', E2(), promotes=['*'])
+        sub2.add_subsystem('e3', E3bad(), promotes=['*'])
+
+        sub3.add_subsystem('e1', E1(), promotes=['*'])
+        sub3.add_subsystem('e2', E2(), promotes=['*'])
+        sub3.add_subsystem('e3', E3(), promotes=['*'])
+
+        model.connect('sub1.z', 'sub2.a')
+        model.connect('sub2.z', 'sub3.a')
+        model.connect('sub3.z', 'sub1.a')
+        model.linear_solver = om.PETScDirectSolver()
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+        p.setup()
+        with self.assertRaises(RuntimeError) as cm:
+            p.run_model()
+
+        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
+        expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
+
+        self.assertEqual(expected, str(cm.exception))
+
+        # Configuration 1 Dense
+        p = om.Problem()
+        model = p.model
+        model.options['assembled_jac_type'] = 'dense'
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('aa', 1.0)
+        model.add_subsystem('p', ivc, promotes=['aa'])
+
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = model.add_subsystem('sub2', om.Group())
+        sub3 = model.add_subsystem('sub3', om.Group())
+
+        sub1.add_subsystem('e1', E1(), promotes=['*'])
+        sub1.add_subsystem('e2', E2(), promotes=['*'])
+        sub1.add_subsystem('e3', E3(), promotes=['*'])
+
+        sub2.add_subsystem('e1', E1(), promotes=['*'])
+        sub2.add_subsystem('e2', E2(), promotes=['*'])
+        sub2.add_subsystem('e3', E3bad(), promotes=['*'])
+
+        sub3.add_subsystem('e1', E1(), promotes=['*'])
+        sub3.add_subsystem('e2', E2(), promotes=['*'])
+        sub3.add_subsystem('e3', E3(), promotes=['*'])
+
+        model.connect('sub1.z', 'sub2.a')
+        model.connect('sub2.z', 'sub3.a')
+        model.connect('sub3.z', 'sub1.a')
+        model.linear_solver = om.PETScDirectSolver()
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+        p.setup()
+        with self.assertRaises(RuntimeError) as cm:
+            p.run_model()
+
+        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
+        expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
+
+        self.assertEqual(expected, str(cm.exception))
+
+        # Configuration 2
+        p = om.Problem()
+        model = p.model
+
+        ivc = om.IndepVarComp()
+        ivc.add_output('aa', 1.0)
+        model.add_subsystem('p', ivc, promotes=['aa'])
+
+        sub1 = model.add_subsystem('sub1', om.Group())
+        sub2 = model.add_subsystem('sub2', om.Group())
+        sub3 = model.add_subsystem('sub3', om.Group())
+
+        sub1.add_subsystem('e1', E1(), promotes=['*'])
+        sub1.add_subsystem('e2', E2(), promotes=['*'])
+        sub1.add_subsystem('e3', E3(), promotes=['aa', 'x', 'y', 'z'])
+
+        sub2.add_subsystem('e1', E1(), promotes=['*'])
+        sub2.add_subsystem('e2', E2(), promotes=['*'])
+        sub2.add_subsystem('e3', E3bad(), promotes=['aa', 'x', 'y', 'z'])
+
+        sub3.add_subsystem('e1', E1(), promotes=['*'])
+        sub3.add_subsystem('e2', E2(), promotes=['*'])
+        sub3.add_subsystem('e3', E3(), promotes=['aa', 'x', 'y', 'z'])
+
+        model.connect('sub1.z', 'sub2.a')
+        model.connect('sub2.z', 'sub3.a')
+        model.linear_solver = om.PETScDirectSolver()
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+        p.setup()
+        with self.assertRaises(RuntimeError) as cm:
+            p.run_model()
+
+        expected = "Jacobian in '' is not full rank. The following set of states/residuals contains one or more equations that is a linear combination of the others: \n"
+        expected += " 'sub1.a' ('_auto_ivc.v0') index 0.\n"
+        expected += " 'sub1.aa' ('_auto_ivc.v1') index 0.\n"
+        expected += " 'sub1.e3.a' ('_auto_ivc.v2') index 0.\n"
+        expected += " 'sub2.e3.a' ('_auto_ivc.v4') index 0.\n"
+        expected += " 'sub1.x' ('sub1.e1.x') index 0.\n"
+        expected += " 'sub1.y' ('sub1.e2.y') index 0.\n"
+        expected += " 'sub1.z' ('sub1.e3.z') index 0.\n"
+        expected += " 'sub2.x' ('sub2.e1.x') index 0.\n"
+        expected += " 'sub2.z' ('sub2.e3.z') index 0.\n"
+        expected += "Note that the problem may be in a single Component."
+
+        self.assertEqual(expected, str(cm.exception))
+
+    def test_error_msg_bad_svd(self):
+
+        class BadComp(om.ImplicitComponent):
+
+            def setup(self):
+
+                self.add_input('a', 3.0)
+
+                self.add_output('x', 1.0)
+                self.add_output('y', 1.0)
+                self.add_output('z', 1.0)
+
+                self.declare_partials('x', 'a', val=1.0)
+                self.declare_partials('x', 'a', val=1.0)
+                self.declare_partials('x', 'a', val=1.0)
+
+                self.declare_partials('x', 'x', val=-2.0)
+                self.declare_partials('x', 'y', val=-1.0e331)
+                self.declare_partials('x', 'z', val=-1.0e331)
+                self.declare_partials('y', 'x', val=-1.0)
+                self.declare_partials('y', 'y', val=-2.0)
+                self.declare_partials('y', 'z', val=-1.0e331)
+                self.declare_partials('z', 'x', val=-1.0e331)
+                self.declare_partials('z', 'y', val=-1.0)
+                self.declare_partials('z', 'z', val=-2.0)
+
+            def apply_nonlinear(self, inputs, outputs, residuals, discrete_inputs=None, discrete_outputs=None):
+                a = inputs['a']
+                x, y, z = outputs.values()
+
+                residuals['x'] = a - 2.0 * x - y - z
+                residuals['y'] = a - x - 2.0 * y - z
+                residuals['z'] = a - x - y - 2.0 * z
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('comp', BadComp(), promotes=['*'])
+
+        model.linear_solver = om.PETScDirectSolver()
+
+        prob.setup()
+
+        prob.run_model()
+
+        with self.assertRaises(RuntimeError) as cm:
+            prob.compute_totals(of=['x', 'y', 'z'], wrt=['a'])
+
+        expected = "Jacobian in '' is not full rank, but OpenMDAO was not " + \
+                   "able to determine which rows or columns."
+
+        self.assertEqual(expected, str(cm.exception))
+
+    def test_matvec_error_raised(self):
+        prob = om.Problem()
+        model = prob.model
+        model.add_subsystem('x_param', om.IndepVarComp('length', 3.0),
+                            promotes=['length'])
+        model.add_subsystem('mycomp', TestExplCompSimpleJacVec(),
+                            promotes=['length', 'width', 'area'])
+
+        model.linear_solver = self.linear_solver_class()
+        prob.set_solver_print(level=0)
+
+        prob.setup(check=False, mode='fwd')
+
+        prob['width'] = 2.0
+
+        msg = "AssembledJacobian not supported for matrix-free subcomponent."
+        with self.assertRaisesRegex(Exception, msg):
+            prob.run_model()
+
+
+@unittest.skipUnless(MPI and PETScVector, "only run with MPI and PETSc.")
+class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
+
+    N_PROCS = 2
+
+    def test_distrib_direct(self):
+        size = 3
+        group = om.Group()
+
+        group.add_subsystem('P', om.IndepVarComp('x', np.arange(size)))
+        group.add_subsystem('C1', DistribComp(arr_size=size))
+        group.add_subsystem('C2', om.ExecComp(['z=3.0*y'],
+                                              y=np.zeros(size),
+                                              z=np.zeros(size)))
+
+        prob = om.Problem()
+        prob.model = group
+        prob.model.linear_solver = om.PETScDirectSolver()
+        prob.model.connect('P.x', 'C1.x')
+        prob.model.connect('C1.y', 'C2.y', src_indices=om.slicer[:])
+
+
+        prob.setup(check=False, mode='fwd')
+        with self.assertRaises(Exception) as cm:
+            prob.run_model()
+
+        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_distrib_direct_subbed(self):
+        size = 3
+        prob = om.Problem()
+        group = prob.model = om.Group()
+
+        group.add_subsystem('P', om.IndepVarComp('x', np.arange(size)))
+        sub = group.add_subsystem('sub', om.Group())
+
+        sub.add_subsystem('C1', DistribComp(arr_size=size))
+        sub.add_subsystem('C2', om.ExecComp(['z=3.0*y'],
+                                            y=np.zeros(size),
+                                            z=np.zeros(size)))
+
+        prob.model.linear_solver = om.PETScDirectSolver()
+        group.connect('P.x', 'sub.C1.x')
+        group.connect('sub.C1.y', 'sub.C2.y', src_indices=om.slicer[:])
+
+        prob.setup(check=False, mode='fwd')
+        with self.assertRaises(Exception) as cm:
+            prob.run_model()
+
+        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_par_direct_subbed(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 1.0))
+        model.add_subsystem('p2', om.IndepVarComp('x', 1.0))
+
+        parallel = model.add_subsystem('parallel', om.ParallelGroup())
+        parallel.add_subsystem('c1', om.ExecComp(['y=-2.0*x']))
+        parallel.add_subsystem('c2', om.ExecComp(['y=5.0*x']))
+
+        model.add_subsystem('c3', om.ExecComp(['y=3.0*x1+7.0*x2']))
+
+        model.connect("parallel.c1.y", "c3.x1")
+        model.connect("parallel.c2.y", "c3.x2")
+
+        model.connect("p1.x", "parallel.c1.x")
+        model.connect("p2.x", "parallel.c2.x")
+
+        model.linear_solver = om.PETScDirectSolver()
+
+        prob.setup(check=False, mode='fwd')
+        with self.assertRaises(Exception) as cm:
+            prob.run_model()
+
+        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
+
+    def test_par_direct(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('P', om.IndepVarComp('x', 1.0))
+        par = model.add_subsystem('par', om.ParallelGroup())
+        par.add_subsystem('C1', om.ExecComp(['y=2.0*x']))
+        par.add_subsystem('C2', om.ExecComp(['z=3.0*y']))
+
+        model.linear_solver = om.PETScDirectSolver()
+        model.connect('P.x', 'par.C1.x')
+        model.connect('P.x', 'par.C2.y')
+
+        prob.setup()
+        with self.assertRaises(Exception) as cm:
+            prob.run_model()
+
+        msg = "PETScDirectSolver linear solver in <model> <class Group> cannot be used in or above a ParallelGroup or a " + \
+            "distributed component."
+        self.assertEqual(str(cm.exception), msg)
+
+
+class TestPETScDirectSolverMPI(unittest.TestCase):
+
+    N_PROCS = 2
+
+    def test_serial_in_mpi(self):
+        # Tests that we can take an MPI model with a PETScDirectSolver and run it in mpi with more
+        # procs. This verifies fix of a bug.
+
+        prob = om.Problem(model=DoubleSellar())
+        model = prob.model
+
+        g1 = model.g1
+        g1.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        g1.nonlinear_solver.options['rtol'] = 1.0e-5
+        g1.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+        g1.options['assembled_jac_type'] = 'dense'
+
+        g2 = model.g2
+        g2.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+        g2.nonlinear_solver.options['rtol'] = 1.0e-5
+        g2.linear_solver = om.PETScDirectSolver(assemble_jac=True)
+        g2.options['assembled_jac_type'] = 'dense'
+
+        model.nonlinear_solver = om.NewtonSolver()
+        model.linear_solver = om.ScipyKrylov(assemble_jac=True)
+        model.options['assembled_jac_type'] = 'dense'
+
+        model.nonlinear_solver.options['solve_subsystems'] = True
+
+        prob.set_solver_print(level=0)
+
+        prob.setup()
+        prob.run_model()
+
+        assert_near_equal(prob['g1.y1'], 0.64, 1.0e-5)
+        assert_near_equal(prob['g1.y2'], 0.80, 1.0e-5)
+        assert_near_equal(prob['g2.y1'], 0.64, 1.0e-5)
+        assert_near_equal(prob['g2.y2'], 0.80, 1.0e-5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -1,10 +1,8 @@
 """Test the PETScDirectSolver linear solver class."""
 
 import unittest
-from unittest.mock import patch
 import numpy as np
 from scipy import sparse
-import os
 import openmdao.api as om
 
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
@@ -16,7 +14,6 @@ from openmdao.utils.array_utils import evenly_distrib_idxs
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.general_utils import printoptions
 from openmdao.utils.mpi import MPI
-from openmdao.utils.om_warnings import SolverWarning
 try:
     from petsc4py import PETSc
     from openmdao.solvers.linear.petsc_direct_solver import PETScLU

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -3,7 +3,6 @@
 import unittest
 import numpy as np
 from scipy import sparse
-from sys import platform
 import openmdao.api as om
 
 from openmdao.solvers.linear.tests.linear_test_base import LinearSolverTests
@@ -111,9 +110,7 @@ class DistribComp(om.ExplicitComponent):
             outputs['y'] = 3.0 * inputs['x']
 
 # Test the class used to setup and interact with the PETSc solver
-# OSX doesn't install any of the solvers with PETSc (they have to be manually
-# built, so skip all tests for OSX)
-@unittest.skipUnless(PETSc and platform != "darwin", "only run with PETSc and not on Mac.")
+@unittest.skipUnless(PETSc, "only run with PETSc.")
 class TestPETScClass(unittest.TestCase):
 
     def test_instantiate_dense(self):
@@ -220,7 +217,7 @@ class TestPETScClass(unittest.TestCase):
 
 # Test the class used to setup and interact with the PETSc solver when it is
 # being run under MPI
-@unittest.skipUnless(MPI and PETSc and platform != "darwin", "only run with MPI and PETSc and not on Mac.")
+@unittest.skipUnless(MPI and PETSc, "only run with MPI and PETSc.")
 class TestPETScClassMPI(unittest.TestCase):
 
     N_PROCS = 2
@@ -254,7 +251,7 @@ class TestPETScClassMPI(unittest.TestCase):
 # Run the same test suite as the DirectSolver since the functionality is very
 # close to the same (except skip "test_raise_no_error_on_singular" PETSc
 # direct solver doesn't do that)
-@unittest.skipUnless(PETSc and platform != "darwin", "only run with PETSc.")
+@unittest.skipUnless(PETSc, "only run with PETSc.")
 class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
 
     linear_solver_class = om.PETScDirectSolver
@@ -1094,7 +1091,7 @@ class TestPETScDirectSolver(LinearSolverTests.LinearSolverTestCase):
             prob.run_model()
 
 
-@unittest.skipUnless(MPI and PETSc and platform != "darwin", "only run with MPI and PETSc and not on Mac.")
+@unittest.skipUnless(MPI and PETSc, "only run with MPI and PETSc.")
 class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
 
     N_PROCS = 2
@@ -1204,7 +1201,7 @@ class TestPETScDirectSolverRemoteErrors(unittest.TestCase):
         self.assertEqual(str(cm.exception), msg)
 
 
-@unittest.skipUnless(PETSc and platform != "darwin", "only run with PETSc and not on Mac.")
+@unittest.skipUnless(PETSc, "only run with PETSc.")
 class TestPETScDirectSolverMPI(unittest.TestCase):
 
     N_PROCS = 2

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -171,7 +171,7 @@ class TestPETScClass(unittest.TestCase):
         Test that each allowable solver type can be used without raising an
         error by PETSc
         """
-        for backend in ["superlu", "klu", "umfpack", "petsc", "pardiso"]:
+        for backend in ["superlu", "klu", "umfpack", "petsc", "mumps", "superlu_dist"]:
             with self.subTest(backend=backend):
                 PETScLU(
                     A=sparse.csr_matrix(np.array([[1, 0], [0, 1]])),

--- a/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_petsc_direct_solver.py
@@ -131,7 +131,7 @@ class TestPETScClass(unittest.TestCase):
         """
         lup = PETScLU(
             A=np.array([[1, 2], [3, 4]]),
-            backend='umfpack',
+            sparse_solver_name='umfpack',
         )
         self.assertEqual(lup.A.getType(), 'seqdense')
         self.assertEqual(lup.A.getSize(), (2, 2))
@@ -144,7 +144,7 @@ class TestPETScClass(unittest.TestCase):
         """
         lu = PETScLU(
             A=sparse.csr_matrix(np.array([[1, 0, 0], [0, 2, 0], [0, 0, 3]])),
-            backend='umfpack',
+            sparse_solver_name='umfpack',
         )
         self.assertEqual(lu.A.getType(), 'seqaij')
         self.assertEqual(lu.A.getSize(), (3, 3))
@@ -157,7 +157,7 @@ class TestPETScClass(unittest.TestCase):
         """
         lu = PETScLU(
             A=sparse.csc_matrix(np.array([[1, 0, 0], [0, 2, 0], [0, 0, 3]])),
-            backend='umfpack',
+            sparse_solver_name='umfpack',
         )
         self.assertEqual(lu.A.getType(), 'seqaij')
         self.assertEqual(lu.A.getSize(), (3, 3))
@@ -168,11 +168,12 @@ class TestPETScClass(unittest.TestCase):
         Test that each allowable solver type can be used without raising an
         error by PETSc
         """
-        for backend in ["superlu", "klu", "umfpack", "petsc", "mumps", "superlu_dist"]:
-            with self.subTest(backend=backend):
+        for sparse_solver_name in ["superlu", "klu", "umfpack", "petsc",
+                                   "mumps", "superlu_dist"]:
+            with self.subTest(sparse_solver_name=sparse_solver_name):
                 PETScLU(
                     A=sparse.csr_matrix(np.array([[1, 0], [0, 1]])),
-                    backend=backend,
+                    sparse_solver_name=sparse_solver_name,
                 )
 
     def test_serial_solve(self):
@@ -182,7 +183,7 @@ class TestPETScClass(unittest.TestCase):
         """
         lu = PETScLU(
             A=sparse.csc_matrix(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 3]])),
-            backend='umfpack',
+            sparse_solver_name='umfpack',
         )
         x = lu.solve(b=np.array([1, 2, 3]), transpose=False)
         assert_near_equal(x, np.array([0.0, 1.0, 1.0]))
@@ -194,7 +195,7 @@ class TestPETScClass(unittest.TestCase):
         """
         lu = PETScLU(
             A=sparse.csc_matrix(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 3]])),
-            backend='umfpack',
+            sparse_solver_name='umfpack',
         )
         x = lu.solve(b=np.array([1, 2, 3]), transpose=True)
         assert_near_equal(x, np.array([1.0, 1.0, 2.0 / 3.0]))
@@ -215,10 +216,10 @@ class TestPETScClassMPI(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             PETScLU(
                 A=sparse.csr_matrix(np.array([[1, 0, 0], [0, 2, 0], [0, 0, 3]])),
-                backend='klu',
+                sparse_solver_name='klu',
                 comm=PETSc.COMM_WORLD
             )
-        expected_msg = 'backend cannot be used when running the PETScDirectSolver with MPI.'
+        expected_msg = 'cannot be used when running the PETScDirectSolver with MPI.'
         self.assertIn(expected_msg, str(cm.exception))
 
     def test_dense_mpi_error(self):
@@ -231,7 +232,7 @@ class TestPETScClassMPI(unittest.TestCase):
                 A=np.array([[1, 2], [3, 4]]),
                 comm=PETSc.COMM_WORLD,
             )
-        expected_msg = 'backend cannot be used when running the PETScDirectSolver with MPI.'
+        expected_msg = 'cannot be used when running the PETScDirectSolver with MPI.'
         self.assertIn(expected_msg, str(cm.exception))
 
     def test_mpi_solve(self):
@@ -241,7 +242,7 @@ class TestPETScClassMPI(unittest.TestCase):
         """
         lu = PETScLU(
             A=sparse.csc_matrix(np.array([[1, 0, 1], [0, 2, 0], [0, 0, 3]])),
-            backend='mumps',
+            sparse_solver_name='mumps',
             comm=PETSc.COMM_WORLD,
         )
         x = lu.solve(b=np.array([1, 2, 3]), transpose=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ linearrunoncec = "openmdao.solvers.linear.linear_runonce:LinearRunOnce"
 petsckrylov = "openmdao.solvers.linear.petsc_ksp:PETScKrylov"
 scipykrylov = "openmdao.solvers.linear.scipy_iter_solver:ScipyKrylov"
 userdefined = "openmdao.solvers.linear.user_defined:LinearUserDefined"
+petscdirectsolver = "openmdao.solvers.linear.petsc_direct_solver:PETScDirectSolver"
 
 [project.entry-points.openmdao_nl_solver]
 armijogoldsteinls = "openmdao.solvers.linesearch.backtracking:ArmijoGoldsteinLS"


### PR DESCRIPTION
### Summary

Added a new linear solver class called PETScDirectSolver, along with associated tests and documentation. This new linear solver works similarly to the existing DirectSolver, but leverages `petsc4py` instead of scipy for the LU factorization and solve. This new solver has an option called `sparse_solver_name` which can be used to specify the sparse direct solver from PETSc you would like to use. The available solvers to use are `superlu`, `umfpack`, `klu`, `petsc`, `mumps`, and `superlu_dist`. The `mumps` and `superlu_dist` solvers may be used with MPI while the others may only be used serially.

### Related Issues

- [POEM 104](https://github.com/OpenMDAO/POEMs/pull/207)

### Backwards incompatibilities

None

### New Dependencies

None
