### PR TITLE
Updated GitHub workflows

### DIFF
--- a/.github/workflows/openmdao_docs_workflow.yml
+++ b/.github/workflows/openmdao_docs_workflow.yml
@@ -74,6 +74,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Fetch tags
+        run: |
+          git fetch --prune --unshallow --tags
+
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3
         with:
@@ -194,11 +198,6 @@ jobs:
 
           cd openmdao/docs
 
-          echo "============================================================="
-          echo "Fetch tags to get docs version"
-          echo "============================================================="
-          git fetch --prune --unshallow --tags
-
           if [[ "${{ secrets.SNOPT_LOCATION_72 }}" || "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
             echo "============================================================="
             echo "Building docs with SNOPT examples."
@@ -242,11 +241,6 @@ jobs:
             echo "============================================================="
             conda create -n upload python=3.11 packaging openssl=3
             conda activate upload
-
-            echo "============================================================="
-            echo "Fetch tags to get docs version"
-            echo "============================================================="
-            git fetch --prune --unshallow --tags
 
             echo "============================================================="
             echo "Publish docs"

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -70,8 +70,7 @@ jobs:
 
   tests:
 
-    # bump this up to 180 temporarily to address a build issue on MacOS
-    timeout-minutes: 180
+    timeout-minutes: 120
 
     strategy:
       fail-fast: false

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -31,12 +31,6 @@ on:
         required: false
         default: true
 
-      MacOS_ARM_Baseline:
-        type: boolean
-        description: 'Include MacOS ARM Baseline in test matrix'
-        required: false
-        default: true
-
       Windows_Baseline:
         type: boolean
         description: 'Include Windows Baseline in test matrix'
@@ -86,11 +80,11 @@ jobs:
           # test baseline versions on Ubuntu
           - NAME: Ubuntu Baseline
             OS: ubuntu-24.04
-            PY: '3.12'
-            NUMPY: '1.26'
+            PY: '3.13'
+            NUMPY: '2.2'
             SCIPY: '1.15'
-            PETSc: '3.20'
-            PYOPTSPARSE_FROM: 'build_pyoptsparse'
+            PETSc: '3.21'
+            PYOPTSPARSE_FROM: 'conda-forge'
             PYOPTSPARSE: '2.13.1'
             SNOPT: '7.7'
             OPTIONAL: '[all,numba]'
@@ -100,29 +94,16 @@ jobs:
 
           # test baseline versions on MacOS
           - NAME: MacOS Baseline
-            OS: macos-13
-            PY: '3.13'
-            NUMPY: '2.2'
-            SCIPY: '1.15'
-            PETSc: '3'
-            PYOPTSPARSE_FROM: 'conda-forge'
-            PYOPTSPARSE: '2.13.1'
-            SNOPT: '7.7'
-            OPTIONAL: '[all,numba]'
-            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_Baseline }}
-
-          # test baseline versions on MacOS/ARM
-          - NAME: MacOS ARM Baseline
             OS: macos-15
             PY: '3.13'
             NUMPY: '2.2'
             SCIPY: '1.15'
-            PETSc: '3.23'
+            PETSc: '3.21'
             PYOPTSPARSE_FROM: 'build_pyoptsparse'
             PYOPTSPARSE: '2.13.1'
             SNOPT: '7.7'
             OPTIONAL: '[all]'
-            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_ARM_Baseline }}
+            EXCLUDE: ${{ github.event_name == 'workflow_dispatch'  && ! inputs.MacOS_Baseline }}
 
           # test minimal install
           - NAME: Ubuntu Minimal
@@ -243,14 +224,10 @@ jobs:
             conda install openmpi-mpicc -q -y
           fi
 
-          if [[ "${{ matrix.PETSc }}" == "3" ]]; then
-            python -m pip install mpi4py petsc petsc4py
+          if [[ "${{ matrix.MPI4PY }}" ]]; then
+            conda install mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
           else
-            if [[ "${{ matrix.MPI4PY }}" ]]; then
-              conda install mpi4py=${{ matrix.MPI4PY }} petsc4py=${{ matrix.PETSc }} -q -y
-            else
-              conda install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
-            fi
+            conda install mpi4py petsc4py=${{ matrix.PETSc }} -q -y
           fi
 
           echo "============================================================="

--- a/openmdao/utils/om.py
+++ b/openmdao/utils/om.py
@@ -307,7 +307,7 @@ def _clean_setup_parser(parser):
 
 def _clean_cmd(options, user_args):
     """
-    Return the post_setup hook function for 'openmdao summary'.
+    Return the post_setup hook function for 'openmdao clean'.
 
     Parameters
     ----------


### PR DESCRIPTION
### Summary

- streamlined the GitHub test workflow by removing the MacOS 13 build 
  - that version of the OS will be out of support in a few months and the ARM platform is now the common architecture for Macs
  - reverted the temporary bump of the timeout that got around the MacOS 13 `PETSc` install issue

- synced the Ubuntu and MacOS dependency versions to a common baseline of `Python 3.13`, `NumPy 2.2` and `PETSc 3.21`

- changed the `Ubuntu Baseline` job to install `pyoptsparse` from `conda-forge` and build SNOPT separately to make sure we are still verifying this alternative to using the `build_pyoptsparse` script 
  - this was previously demonstrated by the deleted MacOS 13 job

- moved the fetch to the beginning of the docs workflow so all subsequent steps have access to tags and and an unshallow clone
  - Bret had a doc build fail because `jupyter-book` wanted an unshallow clone

- Fixed a typo in a docstring

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
