### PR TITLE
Added require_pyoptsparse to MPISetvalBug test case

### DIFF
--- a/openmdao/core/tests/test_set_val_bug.py
+++ b/openmdao/core/tests/test_set_val_bug.py
@@ -4,7 +4,7 @@ import unittest
 import openmdao.api as om
 from openmdao.utils.assert_utils import assert_near_equal
 from openmdao.utils.mpi import MPI
-from openmdao.utils.testing_utils import use_tempdirs
+from openmdao.utils.testing_utils import require_pyoptsparse, use_tempdirs
 
 try:
     from openmdao.vectors.petsc_vector import PETScVector
@@ -13,6 +13,7 @@ except ImportError:
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
+@require_pyoptsparse(optimizer='SLSQP')
 @use_tempdirs
 class MPISetvalBug(unittest.TestCase):
     N_PROCS = 2
@@ -99,5 +100,3 @@ class MPISetvalBug(unittest.TestCase):
 
         assert_near_equal(p.model.get_val(p.model.get_source('x1')), 2.5)
         assert_near_equal(p.model.get_val(p.model.get_source('x2')), 2.6)
-
-


### PR DESCRIPTION
### Summary

`MPISetvalBug` in `test_set_val_bug.py` requires pyoptsparse, condition was added to the TestCase

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
