### PR TITLE
Updated test workflow to use PETSc 3.21 for oldest job

### DIFF
--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -119,7 +119,7 @@ jobs:
             PY: '3.10'
             NUMPY: '1.26'
             SCIPY: '1.12'
-            PETSc: '3.16'
+            PETSc: '3'
             PYOPTSPARSE_FROM: 'build_pyoptsparse'
             PYOPTSPARSE: '2.10.2'
             SNOPT: '7.7'

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -119,7 +119,7 @@ jobs:
             PY: '3.10'
             NUMPY: '1.26'
             SCIPY: '1.12'
-            PETSc: '3'
+            PETSc: '3.21'
             PYOPTSPARSE_FROM: 'build_pyoptsparse'
             PYOPTSPARSE: '2.10.2'
             SNOPT: '7.7'


### PR DESCRIPTION
### Summary

The `oldest` job in the test workflow was pinned to use PETsc 3.16.

The time to install this version from conda-forge has been increasing.  It was taking 20-30 minutes last week, today it's taking 60-90 minutes.   This may be partially attributable to this [incident](https://anaconda.statuspage.io/incidents/nn13j2zn849s), but bumping the version to 3.21 allows the installation to take less than a minute.  I don't think there's a good reason to leave it pinned to the old version.


### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
