### PR TITLE
Added a `--format` option to the `openmdao find_repos` command

### DIFF
--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -769,7 +769,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "openmdao find_repos command\n",
+    "openmdao find_repos command --format text\n",
     "```"
    ]
   },
@@ -783,7 +783,7 @@
    },
    "outputs": [],
    "source": [
-    "!openmdao find_repos driver --format text"
+    "!openmdao find_repos command --format text"
    ]
   },
   {
@@ -913,7 +913,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.3"
+   "version": "3.13.3"
   }
  },
  "nbformat": 4,

--- a/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
+++ b/openmdao/docs/openmdao_book/other_useful_docs/om_command.ipynb
@@ -783,7 +783,7 @@
    },
    "outputs": [],
    "source": [
-    "!openmdao find_repos command"
+    "!openmdao find_repos driver --format text"
    ]
   },
   {

--- a/openmdao/utils/entry_points.py
+++ b/openmdao/utils/entry_points.py
@@ -12,6 +12,7 @@ from inspect import getmembers, isclass
 import textwrap
 
 from openmdao.utils.file_utils import package_iter, get_module_path, _iter_entry_points
+from openmdao.utils.notebook_utils import notebook_mode
 
 from openmdao.core.component import Component
 from openmdao.core.explicitcomponent import ExplicitComponent
@@ -360,7 +361,7 @@ def _list_installed_cmd(options, user_args):
     list_installed(options.types, options.includes, options.excludes, options.show_docs)
 
 
-def find_repos(types=None, tablefmt='tabulator'):
+def find_repos(types=None, tablefmt='tabulator' if not notebook_mode() else 'text'):
     """
     Search github for repositories containing OpenMDAO plugins.
 

--- a/openmdao/utils/entry_points.py
+++ b/openmdao/utils/entry_points.py
@@ -361,7 +361,10 @@ def _list_installed_cmd(options, user_args):
     list_installed(options.types, options.includes, options.excludes, options.show_docs)
 
 
-def find_repos(types=None, tablefmt='tabulator' if not notebook_mode() else 'text'):
+default_tablefmt = 'tabulator' if not notebook_mode() else 'text'
+
+
+def find_repos(types=None, tablefmt=default_tablefmt):
     """
     Search github for repositories containing OpenMDAO plugins.
 

--- a/openmdao/utils/entry_points.py
+++ b/openmdao/utils/entry_points.py
@@ -12,7 +12,6 @@ from inspect import getmembers, isclass
 import textwrap
 
 from openmdao.utils.file_utils import package_iter, get_module_path, _iter_entry_points
-from openmdao.utils.notebook_utils import notebook_mode
 
 from openmdao.core.component import Component
 from openmdao.core.explicitcomponent import ExplicitComponent
@@ -361,10 +360,7 @@ def _list_installed_cmd(options, user_args):
     list_installed(options.types, options.includes, options.excludes, options.show_docs)
 
 
-default_tablefmt = 'tabulator' if not notebook_mode() else 'text'
-
-
-def find_repos(types=None, tablefmt=default_tablefmt):
+def find_repos(types=None, tablefmt='tabulator'):
     """
     Search github for repositories containing OpenMDAO plugins.
 
@@ -463,6 +459,10 @@ def _find_repos_setup_parser(parser):
     """
     parser.add_argument('topics', nargs='*', help='Find github repos with these topics. '
                         'Allowed topics are {}.'.format(sorted(_github_topics)))
+    parser.add_argument('--format', action='store', dest='tablefmt', default='tabulator',
+                        help="Format for generated table. Defaults to 'tabulator' which "
+                             "generates a sortable, filterable web-based table. "
+                             "Other options include 'html', 'text', 'rst' and 'grid'.")
 
 
 def _find_repos_exec(options, user_args):
@@ -481,4 +481,5 @@ def _find_repos_exec(options, user_args):
     function
         The hook function.
     """
-    find_repos(options.topics)
+    find_repos(options.topics, options.tablefmt)
+

--- a/openmdao/utils/entry_points.py
+++ b/openmdao/utils/entry_points.py
@@ -482,4 +482,3 @@ def _find_repos_exec(options, user_args):
         The hook function.
     """
     find_repos(options.topics, options.tablefmt)
-


### PR DESCRIPTION
### Summary

Added a `--format` option to the `openmdao find_repos` command.

The `--format text` option is used in the jupyter-book documentation since it does not require opening a separate browser window.

### Related Issues

- Resolves #3562

### Backwards incompatibilities

None

### New Dependencies

None
