### PR TITLE
fix for bug in check_totals for directional derivs - Issue #3565

### DIFF
--- a/openmdao/core/component.py
+++ b/openmdao/core/component.py
@@ -2489,7 +2489,7 @@ class Component(System):
                 # Perform the FD here.
                 approximation.compute_approximations(self, jac=approx_jac)
 
-            for abs_key, partial in approx_jac.items():
+            for abs_key, fd_partial in approx_jac.items():
                 rel_key = abs_key2rel_key(self, abs_key)
                 deriv = partials_data[rel_key]
                 subjacs_info = approx_jac._subjacs_info[abs_key]
@@ -2498,7 +2498,7 @@ class Component(System):
                 if 'J_fd' not in deriv:
                     deriv['J_fd'] = []
                     deriv['steps'] = []
-                deriv['J_fd'].append(partial)
+                deriv['J_fd'].append(fd_partial)
                 deriv['steps'] = actual_steps[rel_key]
                 deriv['rows'] = subjacs_info['rows']
                 deriv['cols'] = subjacs_info['cols']
@@ -2512,12 +2512,12 @@ class Component(System):
                         # Dot product test for adjoint validity.
                         m = mfree_directions[_of].flatten()
                         d = mfree_directions[_wrt].flatten()
-                        mhat = partial.flatten()
+                        mhat = fd_partial.flatten()
                         dhat = deriv['J_rev'].flatten()
 
                         if 'directional_fd_rev' not in deriv:
                             deriv['directional_fd_rev'] = []
-                        deriv['directional_fd_rev'].append((mhat.dot(m), dhat.dot(d)))
+                        deriv['directional_fd_rev'].append((dhat.dot(d), mhat.dot(m)))
 
         # convert to regular dict from defaultdict
         partials_data = {key: dict(d) for key, d in partials_data.items()}

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1597,7 +1597,7 @@ class Problem(object, metaclass=ProblemMetaclass):
                         mhat_dot_m = mhat.dot(m)
 
                         # Dot product test for adjoint validity.
-                        meta['directional_fd_rev'].append((mhat_dot_m, dhat_dot_d))
+                        meta['directional_fd_rev'].append((dhat_dot_d, mhat_dot_m))
                         meta['J_rev'] = dhat_dot_d
                         meta['J_fd'].append(mhat_dot_m)
                 else:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -7249,16 +7249,16 @@ def _compute_deriv_errors(derivative_info, matrix_free, directional, totals, ato
                 if totals:
                     mhatdotm, dhatdotd = derivative_info['directional_fd_fwd'][i]
                     errs.forward, err_vals.forward, above, abs_errs.forward, rel_errs.forward = \
-                        get_tol_violation(mhatdotm, dhatdotd, atol, rtol)
+                        get_tol_violation(dhatdotd, mhatdotm, atol, rtol)
                 else:
                     errs.forward, err_vals.forward, above, abs_errs.forward, rel_errs.forward = \
                         get_tol_violation(Jforward, Jfd, atol, rtol)
                 above_tol |= above
 
             if Jreverse is not None and 'directional_fd_rev' in derivative_info:
-                mhatdotm, dhatdotd = derivative_info['directional_fd_rev'][i]
+                dhatdotd, mhatdotm = derivative_info['directional_fd_rev'][i]
                 errs.reverse, err_vals.reverse, above, abs_errs.reverse, rel_errs.reverse = \
-                    get_tol_violation(mhatdotm, dhatdotd, atol, rtol)
+                    get_tol_violation(dhatdotd, mhatdotm, atol, rtol)
                 above_tol |= above
         else:
             if Jforward is not None:

--- a/openmdao/core/tests/test_check_partials.py
+++ b/openmdao/core/tests/test_check_partials.py
@@ -1202,7 +1202,7 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         stream = StringIO()
         prob.check_partials(out_stream=stream, compact_print=False)
-        self.assertEqual(stream.getvalue().count('rev value:'), 8)
+        self.assertEqual(stream.getvalue().count('rev value @ max viol:'), 8)
         self.assertEqual(stream.getvalue().count('Raw Reverse Derivative'), 4)
         self.assertEqual(stream.getvalue().count('Jrev'), 12)
 
@@ -1238,8 +1238,8 @@ class TestProblemCheckPartials(unittest.TestCase):
         dz_dx2_fd = partials_data['comp'][('z', 'x2')]['J_fd']
 
         # So for this case, they do all provide them, so rev should not be shown
-        self.assertEqual(stream.getvalue().count('fwd value'), 2)
-        self.assertEqual(stream.getvalue().count('rev value'), 0)
+        self.assertEqual(stream.getvalue().count('fwd value @ max viol'), 2)
+        self.assertEqual(stream.getvalue().count('rev value @ max viol'), 0)
         self.assertEqual(stream.getvalue().count('Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd)'), 2)
         self.assertEqual(stream.getvalue().count('Relative Error'), 0)
         self.assertEqual(stream.getvalue().count('Raw Forward Derivative'), 2)
@@ -1291,8 +1291,8 @@ class TestProblemCheckPartials(unittest.TestCase):
 
         stream = StringIO()
         partials_data = prob.check_partials(out_stream=stream, compact_print=False)
-        self.assertEqual(stream.getvalue().count('fwd value:'), 6)
-        self.assertEqual(stream.getvalue().count('rev value'), 4)
+        self.assertEqual(stream.getvalue().count('fwd value @ max viol:'), 6)
+        self.assertEqual(stream.getvalue().count('rev value @ max viol'), 4)
         self.assertEqual(stream.getvalue().count('Max Tolerance Violation'), 8)
         self.assertEqual(stream.getvalue().count('Raw Forward Derivative'), 4)
         self.assertEqual(stream.getvalue().count('Raw Reverse Derivative'), 2)
@@ -2825,7 +2825,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         nderivs = ncomps * 2
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
-        self.assertEqual(contents.count("fwd value:"), nderivs)
+        self.assertEqual(contents.count("fwd value @ max viol:"), nderivs)
         self.assertEqual(contents.count("Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd), step="), 0)
         self.assertEqual(contents.count("Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd)"), nderivs)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), 0)
@@ -2880,7 +2880,7 @@ class TestCheckPartialsMultipleSteps(unittest.TestCase):
         nderivs = ncomps * 2
         self.assertEqual(contents.count("Component: CompGoodPartials 'good'"), 1)
         self.assertEqual(contents.count("Component: CompBadPartials 'bad'"), 1)
-        self.assertEqual(contents.count("fwd value:"), nderivs * 2)
+        self.assertEqual(contents.count("fwd value @ max viol:"), nderivs * 2)
         self.assertEqual(contents.count("Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd), step="), nderivs * 2)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), nderivs * 2)
 

--- a/openmdao/core/tests/test_check_totals.py
+++ b/openmdao/core/tests/test_check_totals.py
@@ -1374,9 +1374,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         data = prob.check_totals(method='cs', out_stream=stream, directional=True)
         content = strip_formatting(stream.getvalue())
 
-        self.assertEqual(content.count('rev value:'), 0)
-        self.assertEqual(content.count('fwd value:'), 1)
-        self.assertEqual(content.count('fd value:'), 1)
+        self.assertEqual(content.count('rev value @ max viol:'), 0)
+        self.assertEqual(content.count('fwd value @ max viol:'), 1)
+        self.assertEqual(content.count('fd value @ max viol:'), 1)
         self.assertEqual(content.count('Directional Derivative (Jfwd)'), 1)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Max Tolerance Violation ([fwd, fd] Dot Product Test) : ' in content)
@@ -1398,9 +1398,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         content = stream.getvalue()
 
         self.assertEqual(content.count('comp.out (index size: 1)'), 1)
-        self.assertEqual(content.count('rev value:'), 1)
-        self.assertEqual(content.count('fwd value:'), 0)
-        self.assertEqual(content.count('fd value:'), 1)
+        self.assertEqual(content.count('rev value @ max viol:'), 1)
+        self.assertEqual(content.count('fwd value @ max viol:'), 0)
+        self.assertEqual(content.count('fd value @ max viol:'), 1)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 1)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Max Tolerance Violation ([rev, fd] Dot Product Test) : ' in content)
@@ -1422,9 +1422,9 @@ class TestProblemCheckTotals(unittest.TestCase):
         content = strip_formatting(stream.getvalue())
 
         self.assertEqual(content.count("'comp.out' wrt (d)('comp.in',)"), 1)
-        self.assertEqual(content.count('rev value:'), 1)
-        self.assertEqual(content.count('fwd value:'), 0)
-        self.assertEqual(content.count('fd value:'), 1)
+        self.assertEqual(content.count('rev value @ max viol:'), 1)
+        self.assertEqual(content.count('fwd value @ max viol:'), 0)
+        self.assertEqual(content.count('fd value @ max viol:'), 1)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 1)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 1)
         self.assertTrue('Max Tolerance Violation ([rev, fd] Dot Product Test) : ' in content)
@@ -1449,9 +1449,9 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         self.assertEqual(content.count("'comp.out1' wrt (d)('comp.in1', 'comp.in2')"), 1)
         self.assertEqual(content.count("'comp.out2' wrt (d)('comp.in1', 'comp.in2')"), 1)
-        self.assertEqual(content.count('rev value:'), 2)
-        self.assertEqual(content.count('fwd value:'), 0)
-        self.assertEqual(content.count('fd value:'), 2)
+        self.assertEqual(content.count('rev value @ max viol:'), 2)
+        self.assertEqual(content.count('fwd value @ max viol:'), 0)
+        self.assertEqual(content.count('fd value @ max viol:'), 2)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 2)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 2)
         self.assertTrue(content.count('Max Tolerance Violation ([rev, fd] Dot Product Test) :'), 2)
@@ -1500,9 +1500,9 @@ class TestProblemCheckTotals(unittest.TestCase):
 
         self.assertEqual(content.count("('comp.out1', 'comp.out2') wrt (d)'comp.in1'"), 1)
         self.assertEqual(content.count("('comp.out1', 'comp.out2') wrt (d)'comp.in2'"), 1)
-        self.assertEqual(content.count('rev value:'), 0)
-        self.assertEqual(content.count('fwd value:'), 2)
-        self.assertEqual(content.count('fd value:'), 2)
+        self.assertEqual(content.count('rev value @ max viol:'), 0)
+        self.assertEqual(content.count('fwd value @ max viol:'), 2)
+        self.assertEqual(content.count('fd value @ max viol:'), 2)
         self.assertEqual(content.count('Directional Derivative (Jrev)'), 0)
         self.assertEqual(content.count('Directional Derivative (Jfwd)'), 2)
         self.assertEqual(content.count('Directional CS Derivative (Jfd)'), 2)
@@ -2012,7 +2012,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = strip_formatting(stream.getvalue())
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("fd value:"), nsubjacs)
+        self.assertEqual(contents.count("fd value @ max viol:"), nsubjacs)
         self.assertEqual(contents.count("Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd), step="), 0)
         self.assertEqual(contents.count("Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd)"), nsubjacs)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), 0)
@@ -2027,7 +2027,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = strip_formatting(stream.getvalue())
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("fd value:"), nsubjacs)
+        self.assertEqual(contents.count("fd value @ max viol:"), nsubjacs)
         self.assertEqual(contents.count("Max Tolerance Violation (Jrev - Jfd) - (atol + rtol * Jfd), step="), 0)
         self.assertEqual(contents.count("Max Tolerance Violation (Jrev - Jfd) - (atol + rtol * Jfd)"), nsubjacs)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), 0)
@@ -2045,7 +2045,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 0)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+---------------+---------------+------------------------+-------------------+"), nsubjacs + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+---------------------+-------------------+------------------------+-------------------+"), nsubjacs + 1)
 
     def test_single_cs_step_compact(self):
         for mode in ('fwd', 'rev'):
@@ -2059,7 +2059,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 0)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+---------------+---------------+------------------------+------------+"), nsubjacs + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+---------------------+-------------------+------------------------+------------+"), nsubjacs + 1)
 
     def test_multi_fd_steps_fwd(self):
         p = om.Problem(model=CircleOpt(), driver=om.ScipyOptimizeDriver(optimizer='SLSQP', disp=False))
@@ -2070,7 +2070,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = strip_formatting(stream.getvalue())
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("fd value:"), nsubjacs * 2)
+        self.assertEqual(contents.count("fd value @ max viol:"), nsubjacs * 2)
         self.assertEqual(contents.count("Max Tolerance Violation (Jfwd - Jfd) - (atol + rtol * Jfd), step="), nsubjacs * 2)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), nsubjacs * 2)
 
@@ -2082,7 +2082,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
         contents = strip_formatting(stream.getvalue())
         self.assertEqual(contents.count("Full Model:"), 3)
-        self.assertEqual(contents.count("fd value:"), 6)
+        self.assertEqual(contents.count("fd value @ max viol:"), 6)
         self.assertEqual(contents.count("Max Tolerance Violation ([fwd, fd] Dot Product Test), step="), 6)
         self.assertEqual(contents.count("Directional FD Derivative (Jfd), step="), 6)
 
@@ -2095,7 +2095,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         contents = strip_formatting(stream.getvalue())
         nsubjacs = 18
         self.assertEqual(contents.count("Full Model:"), nsubjacs)
-        self.assertEqual(contents.count("fd value:"), nsubjacs * 2)
+        self.assertEqual(contents.count("fd value @ max viol:"), nsubjacs * 2)
         self.assertEqual(contents.count("Max Tolerance Violation (Jrev - Jfd) - (atol + rtol * Jfd), step="), nsubjacs * 2)
         self.assertEqual(contents.count("Raw FD Derivative (Jfd), step="), nsubjacs * 2)
 
@@ -2107,7 +2107,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         p.check_totals(step=[1e-6, 1e-7], directional=True, out_stream=stream)
         contents = strip_formatting(stream.getvalue())
         self.assertEqual(contents.count("Full Model:"), 6)
-        self.assertEqual(contents.count("fd value:"), 12)
+        self.assertEqual(contents.count("fd value @ max viol:"), 12)
         self.assertEqual(contents.count("Max Tolerance Violation ([rev, fd] Dot Product Test), step="), 12)
         self.assertEqual(contents.count("Directional FD Derivative (Jfd) Dot Product, step="), 12)
 
@@ -2123,7 +2123,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+---------------+---------------+---------------+------------------------+------------+"), (nsubjacs*2) + 1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+---------------+---------------------+-------------------+------------------------+------------+"), (nsubjacs*2) + 1)
 
     def test_multi_cs_steps_compact(self):
         for mode in ('fwd', 'rev'):
@@ -2137,7 +2137,7 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
                 nsubjacs = 18
                 self.assertEqual(contents.count("step"), 1)
                 # check number of rows/cols
-                self.assertEqual(contents.count("+-----------------------------+----------------+---------------+---------------+---------------+------------------------+------------+"), (nsubjacs*2)+1)
+                self.assertEqual(contents.count("+-----------------------------+----------------+---------------+---------------------+-------------------+------------------------+------------+"), (nsubjacs*2)+1)
 
     def test_multi_fd_steps_compact_directional(self):
         expected_divs = {
@@ -2162,6 +2162,114 @@ class TestCheckTotalsMultipleSteps(unittest.TestCase):
         finally:
             tot_jac_mod._directional_rng = rand_save
 
+    def test_check_fdvsrev_matfree_values(self):
+        class Comp(om.ExplicitComponent):
+            def setup(self):
+                self.add_input("in1", val=1.)
+                self.add_output("out1", val=1.)
+            def compute(self, inputs, outputs):
+                outputs['out1'] = inputs['in1']**2.
+            def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
+                if mode=='rev':
+                    if 'out1' in d_outputs:
+                        d_inputs['in1'] += 2*inputs['in1']*d_outputs['out1']
+
+        class Top(om.Group):
+            def setup(self):
+                self.add_subsystem("ivc", om.IndepVarComp(), promotes=["*"])
+                self.ivc.add_output("in1", [1.])
+                self.add_subsystem("comp1", Comp(), promotes=['*'])
+
+        prob = om.Problem()
+        prob.model = Top()
+        prob.setup(mode='rev')
+        prob.run_model()
+        stream = StringIO()
+        res = prob.check_totals(of=['out1'], wrt=['in1'], step=[1e-6, 1e-4, 1e-2, 1e0],
+                                compact_print=True, directional=True, out_stream=stream)
+        vals_at_max =  res['out1', ('in1', )]['vals_at_max_error']
+        revs = [v.reverse[0] for v in vals_at_max]
+        fds = [v.reverse[1] for v in vals_at_max]
+
+        # verify that the analytic 'rev' value is the same at all steps
+        self.assertEqual(len(set(revs)), 1)
+
+        # verify that fd values differ across steps
+        self.assertNotEqual(len(set(fds)), 1)
+        output = stream.getvalue()
+
+        fdouts = []
+        anouts = []
+        for line in output.split('\n'):
+            if line.startswith('| ') and not line.startswith("| '"):
+                parts = line.strip().split('|')
+                anouts.append(float(parts[4]))
+                fdouts.append(float(parts[5]))
+
+        assert_near_equal(fds, fdouts, tolerance=1e-6)
+        assert_near_equal(revs, anouts, tolerance=1e-6)
+
+    def check_fd_values(self, mode):
+        class Comp(om.ExplicitComponent):
+            def setup(self):
+                self.add_input("in1", val=1.)
+                self.add_output("out1", val=1.)
+                self.declare_partials("out1", "in1")
+
+            def compute(self, inputs, outputs):
+                outputs['out1'] = inputs['in1']**2.
+
+            def compute_partials(self, inputs, partials):
+                partials['out1', 'in1'] = 2*inputs['in1']
+
+        class Top(om.Group):
+            def setup(self):
+                self.add_subsystem("ivc", om.IndepVarComp(), promotes=["*"])
+                self.ivc.add_output("in1", [1.])
+                self.add_subsystem("comp1", Comp(), promotes=['*'])
+
+        prob = om.Problem()
+        prob.model = Top()
+        prob.setup(mode=mode)
+        prob.run_model()
+        stream = StringIO()
+        res = prob.check_totals(of=['out1'], wrt=['in1'], step=[1e-6, 1e-4, 1e-2, 1e0],
+                                compact_print=True, directional=True, out_stream=stream)
+
+        if mode == 'rev':
+            key =  ('out1', ('in1', ))
+            vals_at_max =  res[key]['vals_at_max_error']
+            analytic = [v.reverse[0] for v in vals_at_max]
+            fds = [v.reverse[1] for v in vals_at_max]
+        else:
+            key = (('out1', ), 'in1')
+            vals_at_max =  res[key]['vals_at_max_error']
+            analytic = [v.forward[0] for v in vals_at_max]
+            fds = [v.forward[1] for v in vals_at_max]
+
+        # verify that the analytic 'rev' value is the same at all steps
+        self.assertEqual(len(set(analytic)), 1)
+
+        # verify that fd values differ across steps
+        self.assertNotEqual(len(set(fds)), 1)
+        output = stream.getvalue()
+
+        fdouts = []
+        anouts = []
+        for line in output.split('\n'):
+            if line.startswith('| ') and not line.startswith("| '"):
+                parts = line.strip().split('|')
+                anouts.append(float(parts[4]))
+                fdouts.append(float(parts[5]))
+
+        assert_near_equal(fds, fdouts, tolerance=1e-6)
+        assert_near_equal(analytic, anouts, tolerance=1e-6)
+
+    def test_check_fd_values_fwd(self):
+        self.check_fd_values('fwd')
+
+    def test_check_fd_values_rev(self):
+        self.check_fd_values('rev')
 
 
 if __name__ == "__main__":

--- a/openmdao/utils/deriv_display.py
+++ b/openmdao/utils/deriv_display.py
@@ -149,8 +149,8 @@ def _deriv_display(system, err_iter, derivatives, rel_error_tol, abs_error_tol, 
                                  f'{stepstrs[i]} : {err}')
                     parts.append(f'      abs error: {abs_errs[i].forward:.6e}')
                     parts.append(f'      rel error: {rel_errs[i].forward:.6e}')
-                    parts.append(f'      fwd value: {vals_at_max_err[i].forward[0]:.6e}')
-                    parts.append(f'      fd value: {vals_at_max_err[i].forward[1]:.6e} '
+                    parts.append(f'      fwd value @ max viol: {vals_at_max_err[i].forward[0]:.6e}')
+                    parts.append(f'      fd value @ max viol: {vals_at_max_err[i].forward[1]:.6e} '
                                  f'({fd_desc}{stepstrs[i]})\n')
 
                 if ('directional_fd_rev' in derivative_info and
@@ -161,9 +161,9 @@ def _deriv_display(system, err_iter, derivatives, rel_error_tol, abs_error_tol, 
                                  f'{stepstrs[i]} : {err}')
                     parts.append(f'      abs error: {abs_errs[i].reverse:.6e}')
                     parts.append(f'      rel error: {rel_errs[i].reverse:.6e}')
-                    fd, rev = derivative_info['directional_fd_rev'][i]
-                    parts.append(f'      rev value: {rev:.6e}')
-                    parts.append(f'      fd value: {fd:.6e} ({fd_desc}{stepstrs[i]})\n')
+                    rev, fd = derivative_info['directional_fd_rev'][i]
+                    parts.append(f'      rev value @ max viol: {rev:.6e}')
+                    parts.append(f'      fd value @ max viol: {fd:.6e} ({fd_desc}{stepstrs[i]})\n')
             else:
                 if tol_violations[i].forward is not None:
                     err = _format_error(tol_violations[i].forward, 0.0)
@@ -171,8 +171,8 @@ def _deriv_display(system, err_iter, derivatives, rel_error_tol, abs_error_tol, 
                                  f'{stepstrs[i]} : {err}')
                     parts.append(f'      abs error: {abs_errs[i].forward:.6e}')
                     parts.append(f'      rel error: {rel_errs[i].forward:.6e}')
-                    parts.append(f'      fwd value: {vals_at_max_err[i].forward[0]:.6e}')
-                    parts.append(f'      fd value: {vals_at_max_err[i].forward[1]:.6e} '
+                    parts.append(f'      fwd value @ max viol: {vals_at_max_err[i].forward[0]:.6e}')
+                    parts.append(f'      fd value @ max viol: {vals_at_max_err[i].forward[1]:.6e} '
                                  f'({fd_desc}{stepstrs[i]})\n')
 
                 if tol_violations[i].reverse is not None:
@@ -181,8 +181,8 @@ def _deriv_display(system, err_iter, derivatives, rel_error_tol, abs_error_tol, 
                                  f'{stepstrs[i]} : {err}')
                     parts.append(f'      abs error: {abs_errs[i].reverse:.6e}')
                     parts.append(f'      rel error: {rel_errs[i].reverse:.6e}')
-                    parts.append(f'      rev value: {vals_at_max_err[i].reverse[0]:.6e}')
-                    parts.append(f'      fd value: {vals_at_max_err[i].reverse[1]:.6e} '
+                    parts.append(f'      rev value @ max viol: {vals_at_max_err[i].reverse[0]:.6e}')
+                    parts.append(f'      fd value @ max viol: {vals_at_max_err[i].reverse[1]:.6e} '
                                  f'({fd_desc}{stepstrs[i]})\n')
 
         if directional:
@@ -194,16 +194,16 @@ def _deriv_display(system, err_iter, derivatives, rel_error_tol, abs_error_tol, 
                 parts.append(f'      abs error: {abs_errs[0].fwd_rev:.6e}')
                 parts.append(f'      rel error: {rel_errs[0].fwd_rev:.6e}')
                 fwd, rev = derivative_info['directional_fwd_rev']
-                parts.append(f'      rev value: {rev:.6e}')
-                parts.append(f'      fwd value: {fwd:.6e}\n')
+                parts.append(f'      rev value @ max viol: {rev:.6e}')
+                parts.append(f'      fwd value @ max viol: {fwd:.6e}\n')
         elif tol_violations[0].fwd_rev is not None:
             err = _format_error(tol_violations[0].fwd_rev, 0.0)
             parts.append(f'    Max Tolerance Violation {tol_violation_str("Jrev", "Jfwd")}'
                          f' : {err}')
             parts.append(f'      abs error: {abs_errs[0].fwd_rev:.6e}')
             parts.append(f'      rel error: {rel_errs[0].fwd_rev:.6e}')
-            parts.append(f'      rev value: {vals_at_max_err[0].fwd_rev[0]:.6e}')
-            parts.append(f'      fwd value: {vals_at_max_err[0].fwd_rev[1]:.6e}\n')
+            parts.append(f'      rev value @ max viol: {vals_at_max_err[0].fwd_rev[0]:.6e}')
+            parts.append(f'      fwd value @ max viol: {vals_at_max_err[0].fwd_rev[1]:.6e}\n')
 
         if inconsistent:
             parts.append('\n    * Inconsistent value across ranks *\n')
@@ -487,13 +487,13 @@ def _deriv_display_compact(system, err_iter, derivatives, out_stream, totals=Fal
             column_meta[4] = {'align': 'right'}
             column_meta[7] = {'align': 'right'}
             column_meta[10] = {'align': 'right'}
-            headers.extend(['fwd val', 'fd val', '(fwd-fd) - (a + r*fd)',
-                            'rev val', 'fd val', '(rev-fd) - (a + r*fd)',
-                            'fwd val', 'rev val', '(fwd-rev) - (a + r*rev)',
+            headers.extend(['fwd val @ max viol', 'fd val @ max viol', '(fwd-fd) - (a + r*fd)',
+                            'rev val @ max viol', 'fd val @ max viol', '(rev-fd) - (a + r*fd)',
+                            'fwd val @ max viol', 'rev val @ max viol', '(fwd-rev) - (a + r*rev)',
                             'error desc'])
         else:
             column_meta[4] = {'align': 'right'}
-            headers.extend(['calc val', 'fd val', '(calc-fd) - (a + r*fd)',
+            headers.extend(['calc val @ max viol', 'fd val @ max viol', '(calc-fd) - (a + r*fd)',
                             'error desc'])
 
         _print_deriv_table(table_data, headers, sys_buffer, col_meta=column_meta)


### PR DESCRIPTION
### Summary

FD and analytic values were swapped in the compact_print output.

Also updated 'calc val' and 'fd val' headers by adding '@ max viol' to them to emphasize that the value given is at the location where the maximum violation is found.

### Related Issues

- Resolves #3565

### Backwards incompatibilities

None

### New Dependencies

None
