### PR TITLE
Allow MetaModelSemiStructuredComp to accept "val" as argument to "add_output"

### DIFF
--- a/openmdao/components/meta_model_semi_structured_comp.py
+++ b/openmdao/components/meta_model_semi_structured_comp.py
@@ -101,7 +101,7 @@ class MetaModelSemiStructuredComp(ExplicitComponent):
 
         self.pnames.append(name)
 
-    def add_output(self, name, training_data=None, **kwargs):
+    def add_output(self, name, training_data=None, val=1.0, **kwargs):
         """
         Add an output to this component and a corresponding training output.
 
@@ -112,11 +112,21 @@ class MetaModelSemiStructuredComp(ExplicitComponent):
         training_data : ndarray
             Training data sample points for this output variable. Must be of length m, where m is
             the total number of points in the table.
+        val : float or ndarray
+            Initial value for the output.
         **kwargs : dict
             Additional agruments for add_output.
         """
         n = self.options['vec_size']
-        super().add_output(name, np.ones(n), **kwargs)
+
+        # Currently no support for vector outputs, apart from vec_size
+        if not np.isscalar(val):
+
+            if len(val) not in [1, n] or len(val.shape) > 1:
+                msg = "{}: Output {} must either be scalar, or of length equal to vec_size."
+                raise ValueError(msg.format(self.msginfo, name))
+
+        super().add_output(name, val * np.ones(n), **kwargs)
 
         if self.options['training_data_gradients']:
             if training_data is None:

--- a/openmdao/components/tests/test_meta_model_semi_structured_comp.py
+++ b/openmdao/components/tests/test_meta_model_semi_structured_comp.py
@@ -443,6 +443,37 @@ class TestMetaModelSemiStructured(unittest.TestCase):
         assert_near_equal(prob.get_val('interp.f'), 3.39415716, 1e-7)
         assert_near_equal(prob.get_val('interp.g'), 2.0 * 3.39415716, 1e-7)
 
+    def test_simple_initial_input_and_output(self):
+
+        prob = om.Problem()
+        model = prob.model
+
+        interp = om.MetaModelSemiStructuredComp(method='lagrange2', training_data_gradients=True)
+        interp.add_input('x', data_x, 10.0)
+        interp.add_input('y', data_y)
+        interp.add_output('f', training_data=data_values, val=5.0)
+
+        model.add_subsystem('interp', interp)
+
+        prob.setup(force_alloc_complex=True)
+
+        assert_near_equal(prob.get_val('interp.x'), 10.0)
+        assert_near_equal(prob.get_val('interp.f'), 5.0)
+
+    def test_simple_invalid_initial_input_and_output(self):
+
+        interp = om.MetaModelSemiStructuredComp(method='lagrange2', training_data_gradients=True)
+
+        msg = ('<class MetaModelSemiStructuredComp>: Input x must either be '
+               'scalar, or of length equal to vec_size.')
+        with self.assertRaisesRegex(ValueError, msg):
+            interp.add_input('x', data_x, np.array([10.0, 3.0]))
+
+        msg = ('<class MetaModelSemiStructuredComp>: Output f must either be '
+               'scalar, or of length equal to vec_size.')
+        with self.assertRaisesRegex(ValueError, msg):
+            interp.add_output('f', training_data=data_values, val=np.array([5.0, 1.0]))
+
     def test_simple_training_inputs(self):
         prob = om.Problem()
         model = prob.model


### PR DESCRIPTION
### Summary

Added a "val" argument to the "add_output" method of "MetaModelSemiStructuredComp" for initializing the value of an output (as well as corresponding tests). The "add_input" accepts a "val" argument and the "add_input" / "add_output" for the "MetaModelStructuredComp" both also accept a "val" argument, so just updated the "add_output" of "MetaModelSemiStructuredComp" to match those.

### Related Issues

- Resolves #3347

### Backwards incompatibilities

None

### New Dependencies

None
