### PR TITLE
Added DOE analysis generators for use with AnalysisDriver

### DIFF
--- a/openmdao/api.py
+++ b/openmdao/api.py
@@ -90,6 +90,14 @@ from openmdao.drivers.doe_generators import ListGenerator, CSVGenerator, Uniform
 from openmdao.drivers.analysis_driver import AnalysisDriver
 from openmdao.drivers.analysis_generator import ProductGenerator, ZipGenerator, SequenceGenerator, \
     CSVGenerator as CSVAnalysisGenerator
+from openmdao.drivers.sampling.uniform_generator import \
+    UniformGenerator as UniformAnalysisGenerator
+from openmdao.drivers.sampling.pyDOE_generators import \
+    LatinHypercubeGenerator as LatinHypercubeAnalysisGenerator, \
+    BoxBehnkenGenerator as BoxBehnkenAnalysisGenerator, \
+    PlackettBurmanGenerator as PlackettBurmanAnalysisGenerator, \
+    FullFactorialGenerator as FullFactorialAnalysisGenerator, \
+    GeneralizedSubsetGenerator as GeneralizedSubsetAnalysisGenerator
 
 # System-Building Tools
 from openmdao.utils.options_dictionary import OptionsDictionary

--- a/openmdao/drivers/analysis_driver.py
+++ b/openmdao/drivers/analysis_driver.py
@@ -63,7 +63,7 @@ class AnalysisDriver(Driver):
             self._generator = samples
         elif samples is not None:
             raise ValueError('If given, samples must be a list, tuple, '
-                             f'or derived from AnalysisDriver but got {type(samples)}')
+                             f'or derived from AnalysisGenerator but got {type(samples)}')
 
         super().__init__(**kwargs)
 

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -414,7 +414,7 @@ class _pyDOE_Generator(DOEGenerator):
         Parameters
         ----------
         size : int
-            The number of factors for the design.
+            The total size (sum of sizes) of all factors for the design.
 
         Returns
         -------

--- a/openmdao/drivers/sampling/pyDOE_generators.py
+++ b/openmdao/drivers/sampling/pyDOE_generators.py
@@ -1,0 +1,468 @@
+"""
+pyDOE3 sample generators for Analysis Driver.
+"""
+import numpy as np
+
+from openmdao.drivers.analysis_generator import AnalysisGenerator
+from openmdao.drivers.sampling.sampling_util import _get_size
+
+try:
+    import pyDOE3
+except ImportError:
+    pyDOE3 = None
+
+
+_LEVELS = 2  # default number of levels for pyDOE generators
+
+
+class _pyDOE_AnalysisGenerator(AnalysisGenerator):
+    """
+    Base class for DOE generators implementing methods from pyDOE3.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary whose keys are promoted paths of variables to be set, and whose
+        values are the arguments to `set_val` and may include additional metadata such
+        as size, global_size, val, lower, and upper.  Both 'lower' and 'upper' keys
+        are required to define the range of each factor.
+    levels : int or dict, optional
+        The number of evenly spaced levels between each factor
+        lower and upper bound.  Dictionary input is supported by Full Factorial or
+        Generalized Subset Design.
+        Defaults to 2.
+
+    Attributes
+    ----------
+    _levels : int or dict(str, int)
+        The number of evenly spaced levels between each factor
+        lower and upper bound. Dictionary input is supported by Full Factorial or
+        Generalized Subset Design.
+    """
+
+    def __init__(self, var_dict, levels=_LEVELS):
+        """
+        Initialize the _pyDOE_AnalysisGenerator.
+        """
+        if pyDOE3 is None:
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+                               "which can be installed with one of the following commands:\n"
+                               "    pip install openmdao[doe]\n"
+                               "    pip install pyDOE3")
+
+        self._levels = levels
+        self._sizes = sizes = {}
+
+        for name, meta in var_dict.items():
+            sizes[name] = _get_size(name, meta)
+
+        super().__init__(var_dict)
+
+    def _get_levels(self, name):
+        """
+        Get the number of levels of a factor.
+
+        If the name is not given, it looks for a "default" key in the dictionary. If this is also
+        missing, it uses the default number of levels (2).
+
+        Parameters
+        ----------
+        name : str
+            Name of factor for which to get the number of levels.
+
+        Returns
+        -------
+            int
+        """
+        levels = self._levels
+        if isinstance(levels, int):
+            return levels
+        else:
+            return levels.get(name, levels.get("default", _LEVELS))
+
+    def _get_all_levels(self):
+        """
+        Return the levels of all factors.
+        """
+        sizes = self._sizes
+        if isinstance(self._levels, int):  # All have the same number of levels
+            return [self._levels] * sum(self._sizes.values())
+        elif isinstance(self._levels, dict):  # Different DVs have different number of levels
+            return sum([v * [self._get_levels(k)] for k, v in sizes.items()], [])
+        else:
+            raise ValueError(f"Levels should be an int or dictionary, not '{type(self._levels)}'")
+
+    def _setup(self):
+        """
+        Generate the DOE and instantiate the internal Iterator.
+        """
+        super()._setup()
+
+        factors = self._var_dict
+
+        self._sizes = dict([(name, _get_size(name, meta)) for name, meta in factors.items()])
+        size = sum(self._sizes.values())
+        doe = self._generate_design(size).astype('int')
+
+        # Maximum number of levels, or the default if the maximum is smaller than the default.
+        # This is to ensure that the array will be big enough even if some keys are missing
+        # from levels (defaulted).
+        levels_max = self._levels if isinstance(self._levels, int) else \
+            max(max(self._levels.values()), _LEVELS)
+
+        # Generate values for each level for each factor
+        # over the range of that variable's lower to upper bound
+
+        # rows = vars (# rows/var = var size), cols = levels
+        values = np.empty((size, levels_max))  # Initialize array for the largest number of levels
+        values[:] = np.nan  # and fill with NaNs.
+
+        row = 0
+        for name, meta in factors.items():
+            size = self._sizes[name]
+
+            try:
+                for k in range(size):
+                    lower = meta['lower']
+                    if isinstance(lower, np.ndarray):
+                        lower = lower[k]
+
+                    upper = meta['upper']
+                    if isinstance(upper, np.ndarray):
+                        upper = upper[k]
+
+                    levels = self._get_levels(name)
+                    values[row, 0:levels] = np.linspace(lower, upper, num=levels)
+
+                    row += 1
+            except KeyError:
+                raise RuntimeError(f"Unable to determine levels for factor '{name}'. "
+                                   "Factors dictionary must contain both 'lower' and 'upper' keys.")
+
+        # construct iterator for doe values
+        retvals = []
+        for idxs in doe:
+            retval = []
+            row = 0
+            for name, meta in factors.items():
+                size_i = _get_size(name, meta)
+                val = np.empty(size_i)
+                for k in range(size_i):
+                    idx = idxs[row + k]
+                    val[k] = values[row + k][idx]
+                retval.append(val)
+                row += size_i
+
+            retvals.append(retval)
+
+        self._iter = iter(retvals)
+
+    def _generate_design(self, size):
+        """
+        Generate DOE design.
+
+        Parameters
+        ----------
+        size : int
+            The number of factors for the design.
+
+        Returns
+        -------
+        ndarray
+            The design matrix as a size x levels array of indices.
+        """
+        pass
+
+
+class FullFactorialGenerator(_pyDOE_AnalysisGenerator):
+    """
+    DOE case generator implementing the Full Factorial method.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary whose keys are promoted paths of variables to be set, and whose
+        values are the arguments to `set_val` and may include additional metadata such
+        as size, global_size, val, lower, and upper.  Both 'lower' and 'upper' keys
+        are required to define the range of each factor.
+    levels : int or dict, optional
+        The number of evenly spaced levels between each factor
+        lower and upper bound.  Dictionary input is supported by Full Factorial or
+        Generalized Subset Design.
+        Defaults to 2.
+    """
+
+    def _generate_design(self, size):
+        """
+        Generate a full factorial DOE design.
+
+        Parameters
+        ----------
+        size : int
+            The number of factors for the design.
+
+        Returns
+        -------
+        ndarray
+            The design matrix as a size x levels array of indices.
+        """
+        return pyDOE3.fullfact(self._get_all_levels())
+
+
+class GeneralizedSubsetGenerator(_pyDOE_AnalysisGenerator):
+    """
+    DOE case generator implementing the General Subset Design Factorial method.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary whose keys are promoted paths of variables to be set, and whose
+        values are the arguments to `set_val` and may include additional metadata such
+        as size, global_size, val, lower, and upper.  Both 'lower' and 'upper' keys
+        are required to define the range of each factor.
+    levels : int or dict
+        The number of evenly spaced levels between each factor
+        lower and upper bound. Defaults to 2.
+    reduction : int
+        Reduction factor (bigger than 1). Larger `reduction` means fewer
+        experiments in the design and more possible complementary designs.
+    n : int, optional
+        Number of complementary GSD-designs. The complementary
+        designs are balanced analogous to fold-over in two-level fractional
+        factorial designs.
+        Defaults to 1.
+
+    Attributes
+    ----------
+    _reduction : int
+        Reduction factor (bigger than 1). Larger `reduction` means fewer
+        experiments in the design and more possible complementary designs.
+    _n : int, optional
+        Number of complementary GSD-designs. The complementary
+        designs are balanced analogous to fold-over in two-level fractional
+        factorial designs.
+        Defaults to 1.
+    """
+
+    def __init__(self, var_dict, levels, reduction, n=1):
+        """
+        Initialize the GeneralizedSubsetGenerator.
+        """
+        self._reduction = reduction
+        self._n = n
+        super().__init__(var_dict, levels=levels)
+
+    def _generate_design(self, size):
+        """
+        Generate a general subset DOE design.
+
+        Parameters
+        ----------
+        size : int
+            The total size (sum of sizes) of all factors for the design.
+
+        Returns
+        -------
+        ndarray
+            The design matrix as a size x levels array of indices.
+        """
+        return pyDOE3.gsd(levels=self._get_all_levels(), reduction=self._reduction, n=self._n)
+
+
+class PlackettBurmanGenerator(_pyDOE_AnalysisGenerator):
+    """
+    DOE case generator implementing the Plackett-Burman method.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary whose keys are promoted paths of variables to be set, and whose
+        values are the arguments to `set_val` and may include additional metadata such
+        as size, global_size, val, lower, and upper.  Both 'lower' and 'upper' keys
+        are required to define the range of each factor.
+    """
+
+    def __init__(self, var_dict):
+        """
+        Initialize the PlackettBurmanGenerator.
+        """
+        super().__init__(var_dict, levels=2)
+
+    def _generate_design(self, size):
+        """
+        Generate a Plackett-Burman DOE design.
+
+        Parameters
+        ----------
+        size : int
+            The total size (sum of sizes) of all factors for the design.
+
+        Returns
+        -------
+        ndarray
+            The design matrix as a size x levels array of indices.
+        """
+        doe = pyDOE3.pbdesign(size)
+
+        doe[doe < 0] = 0  # replace -1 with zero
+
+        return doe
+
+
+class BoxBehnkenGenerator(_pyDOE_AnalysisGenerator):
+    """
+    DOE case generator implementing the Box-Behnken method.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary whose keys are promoted paths of variables to be set, and whose
+        values are the arguments to `set_val`.
+    center : int, optional
+        The number of center points to include (default = None).
+
+    Attributes
+    ----------
+    _center : int
+        The number of center points to include.
+    """
+
+    def __init__(self, var_dict, center=None):
+        """
+        Initialize the BoxBehnkenGenerator.
+        """
+        self._center = center
+        super().__init__(var_dict, levels=3)
+
+    def _generate_design(self, size):
+        """
+        Generate a Box-Behnken DOE design.
+
+        Parameters
+        ----------
+        size : int
+            The number of factors for the design.
+
+        Returns
+        -------
+        ndarray
+            The design matrix as a size x levels array of indices.
+        """
+        if size < 3:
+            raise RuntimeError("Total size of factors is %d,"
+                               "but must be at least 3 when using %s. " %
+                               (size, self.__class__.__name__))
+
+        doe = pyDOE3.bbdesign(size, center=self._center)
+
+        return doe + 1  # replace [-1, 0, 1] with [0, 1, 2]
+
+
+class LatinHypercubeGenerator(AnalysisGenerator):
+    """
+    DOE case generator implementing Latin hypercube method via pyDOE3.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary whose keys are promoted paths of variables to be set, and whose
+        values are the arguments to `set_val`.
+    samples : int, optional
+        The number of samples to generate for each factor (Defaults to n).
+    criterion : str, optional
+        Allowable values are "center" or "c", "maximin" or "m",
+        "centermaximin" or "cm", and "correlation" or "corr". If no value
+        given, the design is simply randomized.
+    iterations : int, optional
+        The number of iterations in the maximin and correlations algorithms
+        (Defaults to 5).
+    seed : int, optional
+        Random seed to use if design is randomized. Defaults to None.
+
+    Attributes
+    ----------
+    _samples : int
+        The number of evenly spaced levels between each factor
+        lower and upper bound.
+    _criterion : str
+        the pyDOE criterion to use.
+    _iterations : int
+        The number of iterations to use for maximin and correlations algorithms.
+    _seed : int or None
+        Random seed.
+    """
+
+    # supported pyDOE criterion names.
+    _supported_criterion = [
+        "center", "c",
+        "maximin", "m",
+        "centermaximin", "cm",
+        "correlation", "corr",
+        None
+    ]
+
+    def __init__(self, var_dict, samples=None, criterion=None, iterations=5, seed=None):
+        """
+        Initialize the LatinHypercubeGenerator.
+
+        See : https://pythonhosted.org/pyDOE/randomized.html
+        """
+        if criterion not in self._supported_criterion:
+            raise ValueError("Invalid criterion '%s' specified for %s. "
+                             "Must be one of %s." %
+                             (criterion, self.__class__.__name__,
+                              self._supported_criterion))
+
+        self._samples = samples
+        self._criterion = criterion
+        self._iterations = iterations
+        self._seed = seed
+
+        super().__init__(var_dict)
+
+    def _setup(self):
+        """
+        Generate the DOE and instantiate the internal Iterator.
+        """
+        if self._seed is not None:
+            np.random.seed(self._seed)
+
+        factors = self._var_dict
+
+        size = sum([_get_size(name, meta) for name, meta in factors.items()])
+
+        if self._samples is None:
+            self._samples = size
+
+        # generate design
+        doe = pyDOE3.lhs(size, samples=self._samples,
+                         criterion=self._criterion,
+                         iterations=self._iterations,
+                         random_state=self._seed)
+
+        # construct iterator for doe values
+        # rows = vars (# rows/var = var size), cols = levels
+        def generator():
+            for row in doe:
+                retval = []
+                col = 0
+                for name, meta in factors.items():
+                    size = _get_size(name, meta)
+                    sample = row[col:col + size]
+
+                    lower = meta['lower']
+                    if not isinstance(lower, np.ndarray):
+                        lower = lower * np.ones(size)
+
+                    upper = meta['upper']
+                    if not isinstance(upper, np.ndarray):
+                        upper = upper * np.ones(size)
+
+                    val = lower + sample * (upper - lower)
+
+                    retval.append(val)
+                    col += size
+
+                yield retval
+
+        self._iter = iter(generator())

--- a/openmdao/drivers/sampling/sampling_util.py
+++ b/openmdao/drivers/sampling/sampling_util.py
@@ -1,0 +1,48 @@
+"""
+Utility functions for sampling generators.
+"""
+
+import numpy as np
+
+
+def _get_size(name, dct):
+    """
+    Get the size of a variable from its metadata dictionary.
+
+    This relies on the presence of 'lower' and 'upper' keys in the metadata dictionary.
+    Both 'lower' and 'upper' must be present anyway to compute the levels for a DOE.
+    If either 'lower' or 'upper' is not found, a RuntimeError is raised.
+    If they are both present but do not have the same size, a ValueError is raised.
+
+    Parameters
+    ----------
+    name : str
+        The name of the variable for which to determine the size.
+    dct : dict
+        Dictionary containing metadata for the variable, must include 'upper', and 'lower' keys.
+
+    Returns
+    -------
+    int
+        The size of the variable as determined from the lower and upper bounds of the range.
+        Note that both 'lower' and 'upper' must be present in the dictionary and have the same size.
+
+    Raises
+    ------
+    ValueError
+        The size of the specified lower bound does not match the size of the upper bound.
+    RuntimeError
+        The required metadata was not found in the dictionary to determine the size of the
+        variable. Both the lower and upper bounds must be specified in order to compute the
+        levels for a DOE.
+    """
+    try:
+        lower_size = np.size(dct['lower'])
+        upper_size = np.size(dct['upper'])
+        if lower_size != upper_size:
+            raise ValueError(f"Size mismatch for factor '{name}': 'lower' bound size "
+                             f"({lower_size}) does not match 'upper' bound size ({upper_size}).")
+        return lower_size
+    except KeyError:
+        raise RuntimeError(f"Unable to determine levels for factor '{name}'. "
+                           "Factors dictionary must contain both 'lower' and 'upper' keys.")

--- a/openmdao/drivers/sampling/tests/test_pyDOE_sampling.py
+++ b/openmdao/drivers/sampling/tests/test_pyDOE_sampling.py
@@ -1,0 +1,763 @@
+"""
+Test Sampling Generators.
+"""
+import unittest
+
+import numpy as np
+
+from packaging.version import Version
+
+import openmdao.api as om
+
+from openmdao.test_suite.components.paraboloid import Paraboloid
+
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
+
+from openmdao.drivers.sampling.pyDOE_generators import FullFactorialGenerator, \
+    GeneralizedSubsetGenerator, PlackettBurmanGenerator, \
+    BoxBehnkenGenerator, LatinHypercubeGenerator
+
+
+try:
+    import pyDOE3
+except ImportError:
+    pyDOE3 = None
+
+
+class ParaboloidArray(om.ExplicitComponent):
+    """
+    Evaluates the equation f(x,y) = (x-3)^2 + x*y + (y+4)^2 - 3.
+
+    Where x and y are xy[0] and xy[1] respectively.
+    """
+
+    def setup(self):
+        self.add_input('xy', val=np.array([0., 0.]))
+        self.add_output('f_xy', val=0.0)
+
+    def compute(self, inputs, outputs):
+        """
+        f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+        """
+        x = inputs['xy'][0]
+        y = inputs['xy'][1]
+        outputs['f_xy'] = (x - 3.0)**2 + x * y + (y + 4.0)**2 - 3.0
+
+
+class TestPyDOEErrors(unittest.TestCase):
+
+    @unittest.skipIf(pyDOE3, "only runs if 'pyDOE3' is not installed")
+    def test_no_pyDOE3(self):
+        with self.assertRaises(RuntimeError) as err:
+            FullFactorialGenerator(var_dict={}, levels=3)
+
+        self.assertEqual(str(err.exception),
+                         "FullFactorialGenerator requires the 'pyDOE3' package, "
+                         "which can be installed with one of the following commands:\n"
+                         "    pip install openmdao[doe]\n"
+                         "    pip install pyDOE3")
+
+        with self.assertRaises(RuntimeError) as err:
+            om.AnalysisDriver(samples=FullFactorialGenerator(var_dict={}, levels=3))
+
+        self.assertEqual(str(err.exception),
+                         "FullFactorialGenerator requires the 'pyDOE3' package, "
+                         "which can be installed with one of the following commands:\n"
+                         "    pip install openmdao[doe]\n"
+                         "    pip install pyDOE3")
+
+    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    def test_lhc_criterion(self):
+        with self.assertRaises(ValueError) as err:
+            LatinHypercubeGenerator(var_dict={}, criterion='foo')
+
+        self.assertEqual(str(err.exception),
+                         "Invalid criterion 'foo' specified for LatinHypercubeGenerator. "
+                         "Must be one of ['center', 'c', 'maximin', 'm', 'centermaximin', "
+                         "'cm', 'correlation', 'corr', None].")
+
+    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    def test_missing_bounds(self):
+        with self.assertRaises(RuntimeError) as err:
+            factors = {
+                'x': {'upper': 1.0},
+            }
+            FullFactorialGenerator(factors, levels=3)
+
+        self.assertEqual(str(err.exception),
+                         "Unable to determine levels for factor 'x'. Factors dictionary must "
+                         "contain both 'lower' and 'upper' keys.")
+
+    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    def test_mismatched_bounds(self):
+        with self.assertRaises(ValueError) as err:
+            factors = {
+                'x': {'lower': 0.0, 'upper': np.array([1.0, 2.0, 3.0])},
+            }
+            FullFactorialGenerator(factors, levels=3)
+
+        self.assertEqual(str(err.exception),
+                         "Size mismatch for factor 'x': "
+                         "'lower' bound size (1) does not match 'upper' bound size (3).")
+
+
+@use_tempdirs
+@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+class TestPyDOEGenerators(unittest.TestCase):
+
+    def setUp(self):
+        self.NOfullfact3 = [
+            [('x', 0.), ('y', 0.)],
+            [('x', .5), ('y', 0.)],
+            [('x', 1.), ('y', 0.)],
+
+            [('x', 0.), ('y', .5)],
+            [('x', .5), ('y', .5)],
+            [('x', 1.), ('y', .5)],
+
+            [('x', 0.), ('y', 1.)],
+            [('x', .5), ('y', 1.)],
+            [('x', 1.), ('y', 1.)],
+        ]
+
+        self.expected_fullfact3 = [
+            {'x': np.array([0.]), 'y': np.array([0.]), 'f_xy': np.array([22.00])},
+            {'x': np.array([.5]), 'y': np.array([0.]), 'f_xy': np.array([19.25])},
+            {'x': np.array([1.]), 'y': np.array([0.]), 'f_xy': np.array([17.00])},
+
+            {'x': np.array([0.]), 'y': np.array([.5]), 'f_xy': np.array([26.25])},
+            {'x': np.array([.5]), 'y': np.array([.5]), 'f_xy': np.array([23.75])},
+            {'x': np.array([1.]), 'y': np.array([.5]), 'f_xy': np.array([21.75])},
+
+            {'x': np.array([0.]), 'y': np.array([1.]), 'f_xy': np.array([31.00])},
+            {'x': np.array([.5]), 'y': np.array([1.]), 'f_xy': np.array([28.75])},
+            {'x': np.array([1.]), 'y': np.array([1.]), 'f_xy': np.array([27.00])},
+        ]
+
+    def test_full_factorial(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+        model.set_input_defaults('x', 0.0)
+        model.set_input_defaults('y', 0.0)
+
+        factors = {
+            'x': {'lower': 0.0, 'upper': 1.0},
+            'y': {'lower': 0.0, 'upper': 1.0}
+        }
+
+        prob.driver = om.AnalysisDriver(samples=FullFactorialGenerator(factors, levels=3))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        expected = self.expected_fullfact3
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 9)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y', 'f_xy'):
+                self.assertEqual(outputs[name], expected_case[name])
+
+    def test_full_factorial_factoring(self):
+
+        class Digits2Num(om.ExplicitComponent):
+            """
+            Makes from two vectors with 2 elements a 4 digit number.
+            For singe digit integers always gives a unique output number.
+            """
+
+            def setup(self):
+                self.add_input('x', val=np.array([0., 0.]))
+                self.add_input('y', val=np.array([0., 0.]))
+                self.add_output('f', val=0.0)
+
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                y = inputs['y']
+                outputs['f'] = x[0] * 1000 + x[1] * 100 + y[0] * 10 + y[1]
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('x', np.array([0.0, 0.0]))
+        model.set_input_defaults('y', np.array([0.0, 0.0]))
+        model.add_subsystem('comp', Digits2Num(), promotes=['*'])
+
+        factors = {
+            'x': {'lower': np.array([0., 0.]), 'upper': np.array([1.0, 2.0])},
+            'y': {'lower': np.array([0., 0.]), 'upper': np.array([3.0, 4.0])}
+        }
+
+        prob.driver = om.AnalysisDriver(samples=FullFactorialGenerator(factors, levels=2))
+        prob.driver.add_response('f')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        objs = [cr.get_case(case).outputs['f'].item() for case in cases]
+
+        self.assertEqual(len(objs), 16)
+        # Testing uniqueness. If all elements are unique, it should be the same length as the
+        # number of cases
+        self.assertEqual(len(set(objs)), 16)
+
+    def test_full_factorial_array(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('xy', np.array([0., 0.]))
+        model.add_subsystem('comp', ParaboloidArray(), promotes=['*'])
+
+        model.add_design_var('xy', lower=np.array([-10., -50.]), upper=np.array([10., 50.]))
+
+        factors = {
+            'xy': {'lower': np.array([-10., -50.]), 'upper': np.array([10., 50.])},
+        }
+
+        prob.driver = om.AnalysisDriver(FullFactorialGenerator(factors, levels=3))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        expected = [
+            {'xy': np.array([-10., -50.])},
+            {'xy': np.array([0., -50.])},
+            {'xy': np.array([10., -50.])},
+
+            {'xy': np.array([-10.,   0.])},
+            {'xy': np.array([0.,   0.])},
+            {'xy': np.array([10.,   0.])},
+
+            {'xy': np.array([-10.,  50.])},
+            {'xy': np.array([0.,  50.])},
+            {'xy': np.array([10.,  50.])},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 9)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            self.assertEqual(outputs['xy'][0], expected_case['xy'][0])
+            self.assertEqual(outputs['xy'][1], expected_case['xy'][1])
+
+    def test_full_fact_dict_levels(self):
+        # Specifying levels only for one factor, the other is defaulted
+        prob = om.Problem()
+        model = prob.model
+
+        expected = [
+            {'x': np.array([0.]), 'y': np.array([0.]), 'f_xy': np.array([22.00])},
+            {'x': np.array([1.]), 'y': np.array([0.]), 'f_xy': np.array([17.00])},
+
+            {'x': np.array([0.]), 'y': np.array([.5]), 'f_xy': np.array([26.25])},
+            {'x': np.array([1.]), 'y': np.array([.5]), 'f_xy': np.array([21.75])},
+
+            {'x': np.array([0.]), 'y': np.array([1.]), 'f_xy': np.array([31.00])},
+            {'x': np.array([1.]), 'y': np.array([1.]), 'f_xy': np.array([27.00])},
+        ]
+
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+        model.set_input_defaults('x', 0.0)
+        model.set_input_defaults('y', 0.0)
+
+        factors = {
+            'x': {'lower': 0.0, 'upper': 1.0},
+            'y': {'lower': 0.0, 'upper': 1.0}
+        }
+
+        prob.driver = om.AnalysisDriver(samples=FullFactorialGenerator(factors, levels={"y": 3}))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 6)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            self.assertEqual(outputs['x'], expected_case['x'])
+            self.assertEqual(outputs['y'], expected_case['y'])
+            self.assertEqual(outputs['f_xy'], expected_case['f_xy'])
+
+    def test_generalized_subset(self):
+        # All factors have the same number of levels
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('x', 0.0)
+        model.set_input_defaults('y', 0.0)
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+
+        factors = {
+            'x': {'lower': 0.0, 'upper': 1.0},
+            'y': {'lower': 0.0, 'upper': 1.0}
+        }
+
+        prob.driver = om.AnalysisDriver(GeneralizedSubsetGenerator(factors, levels=2, reduction=2))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        expected = [
+            {'x': np.array([0.0]), 'y': np.array([0.0]), 'f_xy': np.array([22.0])},
+            {'x': np.array([1.0]), 'y': np.array([1.0]), 'f_xy': np.array([27.0])},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 2)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y', 'f_xy'):
+                self.assertEqual(outputs[name], expected_case[name])
+
+    def test_generalized_subset_dict_levels(self):
+        # Number of levels specified individually for all factors (scalars).
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('x', 0.0)
+        model.set_input_defaults('y', 0.0)
+        model.add_subsystem('comp', Paraboloid(default_shape=()), promotes=['x', 'y', 'f_xy'])
+
+        factors = {
+            'x': {'lower': 0.0, 'upper': 1.0},
+            'y': {'lower': 0.0, 'upper': 1.0}
+        }
+
+        prob.driver = om.AnalysisDriver(GeneralizedSubsetGenerator(factors, levels={'x': 3, 'y': 6}, reduction=2))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        expected = [
+            {'x': np.array([0.]), 'y': np.array([0.]), 'f_xy': 22.},
+            {'x': np.array([0.]), 'y': np.array([0.4]), 'f_xy': 25.36},
+            {'x': np.array([0.]), 'y': np.array([0.8]), 'f_xy': 29.04},
+            {'x': np.array([1.]), 'y': np.array([0.]), 'f_xy': 17.},
+            {'x': np.array([1.]), 'y': np.array([0.4]), 'f_xy': 20.76},
+            {'x': np.array([1.]), 'y': np.array([0.8]), 'f_xy': 24.84},
+            {'x': np.array([0.5]), 'y': np.array([0.2]), 'f_xy': 20.99},
+            {'x': np.array([0.5]), 'y': np.array([0.6]), 'f_xy': 24.71},
+            {'x': np.array([0.5]), 'y': np.array([1.]), 'f_xy': 28.75},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 9)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y'):
+                self.assertAlmostEqual(outputs[name][0], expected_case[name][0])
+            self.assertAlmostEqual(outputs['f_xy'], expected_case['f_xy'])
+
+    def test_generalized_subset_array(self):
+        # Number of levels specified individually for all factors (arrays).
+
+        class Digits2Num(om.ExplicitComponent):
+            """
+            Makes from two vectors with 2 elements a 4 digit number.
+            For singe digit integers always gives a unique output number.
+            """
+
+            def setup(self):
+                self.add_input('x', val=np.array([0., 0.]))
+                self.add_input('y', val=np.array([0., 0.]))
+                self.add_output('f', val=0.0)
+
+            def compute(self, inputs, outputs):
+                x = inputs['x']
+                y = inputs['y']
+                outputs['f'] = x[0] * 1000 + x[1] * 100 + y[0] * 10 + y[1]
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.set_input_defaults('x', np.array([0.0, 0.0]))
+        model.set_input_defaults('y', np.array([0.0, 0.0]))
+        model.add_subsystem('comp', Digits2Num(), promotes=['*'])
+
+        factors = {
+            'x': {'lower': np.array([0., 0.]), 'upper': np.array([1.0, 2.0])},
+            'y': {'lower': np.array([0., 0.]), 'upper': np.array([3.0, 4.0])}
+        }
+
+        prob.driver = om.AnalysisDriver(GeneralizedSubsetGenerator(factors, levels={'x': 5, 'y': 8}, reduction=14))
+        prob.driver.add_response('f')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        objs = [cr.get_case(case).outputs['f'].item() for case in cases]
+
+        self.assertEqual(len(objs), 104)  # The number can be verified with standalone pyDOE3
+        # Testing uniqueness. If all elements are unique, it should be the same length as the number of cases
+        self.assertEqual(len(set(objs)), 104)
+
+    def test_plackett_burman(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+
+        factors = {
+            'x': {'lower': 0.0, 'upper': 1.0},
+            'y': {'lower': 0.0, 'upper': 1.0}
+        }
+
+        prob.driver = om.AnalysisDriver(PlackettBurmanGenerator(factors))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        expected = [
+            {'x': np.array([0.]), 'y': np.array([0.]), 'f_xy': np.array([22.00])},
+            {'x': np.array([1.]), 'y': np.array([0.]), 'f_xy': np.array([17.00])},
+            {'x': np.array([0.]), 'y': np.array([1.]), 'f_xy': np.array([31.00])},
+            {'x': np.array([1.]), 'y': np.array([1.]), 'f_xy': np.array([27.00])},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 4)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y', 'f_xy'):
+                self.assertEqual(outputs[name], expected_case[name])
+
+    def test_box_behnken(self):
+        upper = 10.
+        center = 1
+
+        prob = om.Problem()
+        model = prob.model
+
+        indep = model.add_subsystem('indep', om.IndepVarComp(), promotes=['*'])
+        indep.add_output('x', 0.0)
+        indep.add_output('y', 0.0)
+        indep.add_output('z', 0.0)
+
+        model.add_subsystem('comp', om.ExecComp('a = x**2 + y - z'), promotes=['*'])
+
+        factors = {
+            'x': {'lower': 0.0, 'upper': upper},
+            'y': {'lower': 0.0, 'upper': upper},
+            'z': {'lower': 0.0, 'upper': upper}
+        }
+        prob.driver = om.AnalysisDriver(BoxBehnkenGenerator(factors, center=center))
+        prob.driver.add_response('a')
+
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        # The Box-Behnken design for 3 factors involves three blocks, in each of
+        # which 2 factors are varied thru the 4 possible combinations of high & low.
+        # It also includes centre points (all factors at their central values).
+        # ref: https://en.wikipedia.org/wiki/Box-Behnken_design
+        self.assertEqual(len(cases), (3*4)+center)
+
+        # slight change in order from refactor in pyDOE3 v1.0.4 (PR #15)
+        if Version(pyDOE3.__version__) >= Version("1.0.4"):
+            expected = [
+                {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
+                {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
+                {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
+                {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
+
+                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
+                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
+                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
+                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
+
+                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
+                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
+                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
+                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
+
+                {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])}
+            ]
+        else:
+            expected = [
+                {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
+                {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
+                {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
+                {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
+
+                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
+                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
+                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
+                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
+
+                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
+                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
+                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
+                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
+
+                {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])},
+            ]
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y', 'z'):
+                self.assertEqual(outputs[name], expected_case[name])
+
+    def test_latin_hypercube(self):
+        samples = 4
+
+        bounds = np.array([
+            [-1, -10],  # lower bounds for x and y
+            [1,  10]   # upper bounds for x and y
+        ])
+        xlb, xub = bounds[0][0], bounds[1][0]
+        ylb, yub = bounds[0][1], bounds[1][1]
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('x', 0.0), promotes=['x'])
+        model.add_subsystem('p2', om.IndepVarComp('y', 0.0), promotes=['y'])
+        model.add_subsystem('comp', Paraboloid(), promotes=['x', 'y', 'f_xy'])
+
+        factors = {
+            'x': {'lower': xlb, 'upper': xub},
+            'y': {'lower': ylb, 'upper': yub}
+        }
+
+        prob.driver = om.AnalysisDriver(LatinHypercubeGenerator(factors, samples=4, seed=0))
+        prob.driver.add_response('f_xy')
+
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        # the sample space for each variable should be divided into equal
+        # size buckets and each variable should have a value in each bucket
+        all_buckets = set(range(samples))
+
+        x_offset = - xlb
+        x_bucket_size = xub - xlb
+        x_buckets_filled = set()
+
+        y_offset = - ylb
+        y_bucket_size = yub - ylb
+        y_buckets_filled = set()
+
+        # expected values for seed = 0
+        expected = [
+            {'x': np.array([-0.19861831]), 'y': np.array([-6.42405317])},
+            {'x': np.array([0.2118274]),  'y': np.array([9.458865])},
+            {'x': np.array([0.71879361]), 'y': np.array([3.22947057])},
+            {'x': np.array([-0.72559325]), 'y': np.array([-2.27558409])},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 4)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            x = outputs['x'].item()
+            y = outputs['y'].item()
+
+            bucket = int((x + x_offset) / (x_bucket_size / samples))
+            x_buckets_filled.add(bucket)
+
+            bucket = int((y + y_offset) / (y_bucket_size / samples))
+            y_buckets_filled.add(bucket)
+
+            assert_near_equal(x, expected_case['x'], 1e-4)
+            assert_near_equal(y, expected_case['y'], 1e-4)
+
+        self.assertEqual(x_buckets_filled, all_buckets)
+        self.assertEqual(y_buckets_filled, all_buckets)
+
+    def test_latin_hypercube_array(self):
+        samples = 4
+
+        bounds = np.array([
+            [-10, -50],  # lower bounds for x and y
+            [10,  50]   # upper bounds for x and y
+        ])
+
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('p1', om.IndepVarComp('xy', np.array([50., 50.])), promotes=['*'])
+        model.add_subsystem('comp', ParaboloidArray(), promotes=['*'])
+
+        factors = {
+            'xy': {'lower': bounds[0], 'upper': bounds[1]},
+        }
+
+        prob.driver = om.AnalysisDriver(LatinHypercubeGenerator(factors, samples=4, seed=0))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        # the sample space for each variable should be divided into equal
+        # size buckets and each variable should have a value in each bucket
+        all_buckets = set(range(samples))
+
+        xlb, xub = bounds[0][0], bounds[1][0]
+        x_offset = - xlb
+        x_bucket_size = xub - xlb
+        x_buckets_filled = set()
+
+        ylb, yub = bounds[0][1], bounds[1][1]
+        y_offset = - ylb
+        y_bucket_size = yub - ylb
+        y_buckets_filled = set()
+
+        # expected values for seed = 0
+        expected = [
+            {'xy': np.array([-1.98618312, -32.12026584])},
+            {'xy': np.array([2.118274,    47.29432502])},
+            {'xy': np.array([7.18793606,  16.14735283])},
+            {'xy': np.array([-7.25593248, -11.37792043])},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 4)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            x = outputs['xy'][0]
+            y = outputs['xy'][1]
+
+            bucket = int((x + x_offset) / (x_bucket_size / samples))
+            x_buckets_filled.add(bucket)
+
+            bucket = int((y + y_offset) / (y_bucket_size / samples))
+            y_buckets_filled.add(bucket)
+
+            assert_near_equal(x, expected_case['xy'][0], 1e-4)
+            assert_near_equal(y, expected_case['xy'][1], 1e-4)
+
+        self.assertEqual(x_buckets_filled, all_buckets)
+        self.assertEqual(y_buckets_filled, all_buckets)
+
+    def test_latin_hypercube_center(self):
+        samples = 4
+        upper = 10.
+
+        prob = om.Problem()
+        model = prob.model
+
+        indep = model.add_subsystem('indep', om.IndepVarComp())
+        indep.add_output('x', 0.0)
+        indep.add_output('y', 0.0)
+
+        model.add_subsystem('comp', Paraboloid())
+
+        model.connect('indep.x', 'comp.x')
+        model.connect('indep.y', 'comp.y')
+
+        factors = {
+            'indep.x': {'lower': 0.0, 'upper': upper},
+            'indep.y': {'lower': 0.0, 'upper': upper}
+        }
+
+        prob.driver = om.AnalysisDriver(LatinHypercubeGenerator(factors, samples=samples, criterion='c'))
+        prob.driver.add_response('comp.f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+        prob.driver.recording_options['includes'] = ['indep.x', 'indep.y']
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), samples)
+
+        # the sample space for each variable (0 to upper) should be divided into
+        # equal size buckets and each variable should have a value in each bucket
+        bucket_size = upper / samples
+        all_buckets = set(range(samples))
+
+        x_buckets_filled = set()
+        y_buckets_filled = set()
+
+        # with criterion of 'center', each value should be in the center of it's bucket
+        valid_values = [round(bucket_size * (bucket + 1 / 2), 3) for bucket in all_buckets]
+
+        for case in cases:
+            outputs = cr.get_case(case).outputs
+            x = outputs['indep.x'].item()
+            y = outputs['indep.y'].item()
+
+            x_buckets_filled.add(int(x/bucket_size))
+            y_buckets_filled.add(int(y/bucket_size))
+
+            self.assertTrue(round(x, 3) in valid_values, '%f not in %s' % (x, valid_values))
+            self.assertTrue(round(y, 3) in valid_values, '%f not in %s' % (y, valid_values))
+
+        self.assertEqual(x_buckets_filled, all_buckets)
+        self.assertEqual(y_buckets_filled, all_buckets)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/drivers/sampling/tests/test_sampling.py
+++ b/openmdao/drivers/sampling/tests/test_sampling.py
@@ -1,0 +1,83 @@
+"""
+Test Sampling Generators.
+"""
+import unittest
+
+import numpy as np
+
+import openmdao.api as om
+
+from openmdao.test_suite.components.paraboloid import Paraboloid
+
+from openmdao.utils.assert_utils import assert_near_equal
+from openmdao.utils.testing_utils import use_tempdirs
+
+from openmdao.drivers.sampling.uniform_generator import UniformGenerator
+
+
+class ParaboloidArray(om.ExplicitComponent):
+    """
+    Evaluates the equation f(x,y) = (x-3)^2 + x*y + (y+4)^2 - 3.
+
+    Where x and y are xy[0] and xy[1] respectively.
+    """
+
+    def setup(self):
+        self.add_input('xy', val=np.array([0., 0.]))
+        self.add_output('f_xy', val=0.0)
+
+    def compute(self, inputs, outputs):
+        """
+        f(x,y) = (x-3)^2 + xy + (y+4)^2 - 3
+        """
+        x = inputs['xy'][0]
+        y = inputs['xy'][1]
+        outputs['f_xy'] = (x - 3.0)**2 + x * y + (y + 4.0)**2 - 3.0
+
+
+@use_tempdirs
+class TestUniformGenerator(unittest.TestCase):
+
+    def test_uniform(self):
+        prob = om.Problem()
+        model = prob.model
+
+        model.add_subsystem('comp', Paraboloid(), promotes=['*'])
+        model.set_input_defaults('x', 0.0)
+        model.set_input_defaults('y', 0.0)
+
+        factors = {
+            'x': {'lower': -10, 'upper': 10},
+            'y': {'lower': -10, 'upper': 10},
+        }
+
+        prob.driver = om.AnalysisDriver(UniformGenerator(factors, num_samples=5, seed=0))
+        prob.driver.add_response('f_xy')
+        prob.driver.add_recorder(om.SqliteRecorder("cases.sql"))
+
+        prob.setup()
+        prob.run_driver()
+        prob.cleanup()
+
+        # all values should be between -10 and 10, check expected values for seed = 0
+        expected = [
+            {'x': np.array([0.97627008]), 'y': np.array([4.30378733])},
+            {'x': np.array([2.05526752]), 'y': np.array([0.89766366])},
+            {'x': np.array([-1.52690401]), 'y': np.array([2.91788226])},
+            {'x': np.array([-1.24825577]), 'y': np.array([7.83546002])},
+            {'x': np.array([9.27325521]), 'y': np.array([-2.33116962])},
+        ]
+
+        cr = om.CaseReader(prob.get_outputs_dir() / "cases.sql")
+        cases = cr.list_cases('driver', out_stream=None)
+
+        self.assertEqual(len(cases), 5)
+
+        for case, expected_case in zip(cases, expected):
+            outputs = cr.get_case(case).outputs
+            for name in ('x', 'y'):
+                assert_near_equal(outputs[name], expected_case[name], 1e-4)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openmdao/drivers/sampling/uniform_generator.py
+++ b/openmdao/drivers/sampling/uniform_generator.py
@@ -1,0 +1,95 @@
+"""
+Uniform generator for Analysis Driver.
+"""
+import numpy as np
+
+from openmdao.drivers.analysis_generator import AnalysisGenerator
+from openmdao.drivers.sampling.sampling_util import _get_size
+
+
+class UniformGenerator(AnalysisGenerator):
+    """
+    DOE case generator implementing the Uniform method.
+
+    Parameters
+    ----------
+    var_dict : dict
+        A dictionary mapping a variable name to 'upper' and 'lower' values to be assumed,
+        as well as optional units and indices specifications.
+    num_samples : int, optional
+        The number of samples to run. Defaults to 1.
+    seed : int or None, optional
+        Seed for random number generator.
+
+    Attributes
+    ----------
+    _num_samples : int
+        The number of samples in the DOE.
+    _seed : int or None
+        Random seed.
+    _sizes : dict
+        A dictionary mapping variable names to their sizes, determined from the 'lower' and 'upper'
+        bounds in the var_dict.
+    """
+
+    def __init__(self, var_dict, num_samples=1, seed=None):
+        """
+        Initialize the UniformGenerator.
+        """
+        self._num_samples = num_samples
+        self._seed = seed
+        self._sizes = sizes = {}
+
+        for name, meta in var_dict.items():
+            sizes[name] = _get_size(name, meta)
+
+        super().__init__(var_dict)
+
+    def _setup(self):
+        """
+        Set up the iterator which provides each case.
+
+        Raises
+        ------
+        ValueError
+            Raised if the length of var_dict for each case are not all the same size.
+        """
+        if self._seed is not None:
+            np.random.seed(self._seed)
+
+        self._iter = iter(range(self._num_samples))
+
+        super()._setup()
+
+    def __next__(self):
+        """
+        Provide a dictionary of the next point to be analyzed.
+
+        The key of each entry is the promoted path of var whose values are to be set.
+        The associated value is the values to set (required), units (options),
+        and indices (optional).
+
+        Raises
+        ------
+        StopIteration
+            When all analysis var_dict have been exhausted.
+
+        Returns
+        -------
+        dict
+            A dictionary containing the promoted paths of variables to
+            be set by the AnalysisDriver
+        """
+        next(self._iter)
+
+        sizes = self._sizes
+
+        d = {}
+        for name, meta in self._var_dict.items():
+            d[name] = {
+                'val': np.random.uniform(meta['lower'], meta['upper'], sizes[name]),
+                'units': meta.get('units', None),
+                'indices': meta.get('indices', None)
+            }
+        self._run_count += 1
+        return d

--- a/openmdao/drivers/tests/test_analysis_driver.py
+++ b/openmdao/drivers/tests/test_analysis_driver.py
@@ -12,7 +12,6 @@ from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.utils.assert_utils import assert_warning, assert_warnings, assert_near_equal
 from openmdao.utils.testing_utils import use_tempdirs
 from openmdao.utils.mpi import MPI
-# from openmdao.test_suite.test_examples.beam_optimization.multipoint_beam_group import MultipointBeamGroup
 
 
 try:
@@ -219,7 +218,7 @@ class TestAnalysisDriverParallel(unittest.TestCase):
         """
         samples = {'x': {'val': [0.0, 0.5, 1.0]},
                    'y': {'val': [0.0, 0.5, 1.0]}}
-        
+
         generator = om.ProductGenerator(samples)
 
         samples_list = [s for s in generator]
@@ -340,7 +339,7 @@ class TestAnalysisDriverParallel(unittest.TestCase):
         prob = om.Problem(FanInGrouped())
 
         # Note the absense of adding design varaibles here, compared to DOEGenerator
-       
+
         # the FanInGrouped model uses 2 processes, so we can run
         # two instances of the model at a time, each using 2 of our 4 procs
         procs_per_model = 2
@@ -460,9 +459,9 @@ class TestAnalysisDriver(unittest.TestCase):
             self.assertEqual(num_recorded_cases, 1)
 
     def test_csv(self):
-        
+
         ### Part 1 - Create a CSV file of the cases we want to run
-        
+
         var_dict = {'x': {'val': [0.0, 0.5, 1.0], 'units': None, 'indices': [0]},
                     'y': {'val': [0.0, 0.5, 1.0], 'units': None, 'indices': [0]}}
 
@@ -484,9 +483,9 @@ class TestAnalysisDriver(unittest.TestCase):
             writer = csv.DictWriter(f, fieldnames=var_dict.keys())
             writer.writeheader()
             writer.writerows(cases_csv_data)
-        
+
         ### Part 2 - Run the CSVGenerator on the file we just created
-        
+
         prob = om.Problem()
         model = prob.model
 
@@ -537,6 +536,19 @@ class TestAnalysisDriver(unittest.TestCase):
                    "{'x': 5, 'y': 4}")
 
         self.assertEqual(expected, str(e.exception))
+
+
+class TestErrors(unittest.TestCase):
+
+    def test_generator_check(self):
+        prob = om.Problem()
+
+        with self.assertRaises(ValueError) as err:
+            prob.driver = om.AnalysisDriver(om.Problem())
+
+        self.assertEqual(str(err.exception),
+                         "If given, samples must be a list, tuple, or derived from AnalysisGenerator "
+                         "but got <class 'openmdao.core.problem.Problem'>")
 
 
 if __name__ == "__main__":

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -13,7 +13,7 @@ import shutil
 import tempfile
 
 from openmdao.utils.om_warnings import issue_warning
-from openmdao.utils.testing_utils import set_env_vars_context, env_truthy
+from openmdao.utils.testing_utils import set_env_vars_context, env_truthy, get_tempdir
 
 
 def get_module_path(fpath):
@@ -437,7 +437,7 @@ def image2html(imagefile, title='', alt=''):
 
 
 if env_truthy('TESTFLO_RUNNING'):
-    TESTFLO_WORKDIR = tempfile.mkdtemp()
+    TESTFLO_WORKDIR = get_tempdir()
 else:
     TESTFLO_WORKDIR = ''
 

--- a/openmdao/utils/file_utils.py
+++ b/openmdao/utils/file_utils.py
@@ -10,7 +10,6 @@ from fnmatch import fnmatch
 from os.path import join, basename, dirname, isfile, split, splitext, abspath
 import pathlib
 import shutil
-import tempfile
 
 from openmdao.utils.om_warnings import issue_warning
 from openmdao.utils.testing_utils import set_env_vars_context, env_truthy, get_tempdir


### PR DESCRIPTION
### Summary

- ported the pyDOE3 DOEGenerator classes for use with AnalysisDriver
- ported the UniformGenerator class for use with AnalysisDriver
- renamed the classes in `openmdao.api` per the precedent set for CSVGenerator
- created a new `sampling` namespace under `drivers` for these and future sampling methods
- duplicated the DOEGenerator tests for the new AnalysisGenerator classes

Also:
- incorporated Bret's fix for the test working directory under MPI (the same commit as on PR#3567)

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
