### PR TITLE
Removed numpy type information from output of singular jac check.

### DIFF
--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -1658,9 +1658,12 @@ class _TotalJacInfo(object):
                         zero_rows.append((n, list(zip(*zero_idxs))))
 
             if zero_rows:
-                zero_rows = [f"('{n}', inds={idxs})" for n, idxs in zero_rows]
-                msg = (f"Constraints or objectives [{', '.join(zero_rows)}] cannot be impacted by "
-                       "the design variables of the problem.")
+                # zero_rows = [f"('{n}', inds={idxs})" for n, idxs in zero_rows]
+                msg = ('The following constraints or objectives cannot be impacted by '
+                       'the design variables of the problem at the current design point:\n')
+                for name, idxs in zero_rows:
+                    with np.printoptions(legacy='1.21'):
+                        msg += f'  {name}, inds={idxs}\n'
                 if raise_error:
                     raise RuntimeError(msg)
                 else:
@@ -1684,9 +1687,11 @@ class _TotalJacInfo(object):
                         zero_cols.append((n, list(zip(*zero_idxs))))
 
             if zero_cols:
-                zero_cols = [f"('{n}', inds={idxs})" for n, idxs in zero_cols]
-                msg = (f"Design variables [{', '.join(zero_cols)}] have no impact on the "
-                       "constraints or objective.")
+                msg = ('The following design variables have no impact on the '
+                       'constraints or objective at the current design point:\n')
+                for name, idxs in zero_cols:
+                    with np.printoptions(legacy='1.21'):
+                        msg += f'  {name}, inds={idxs}\n'
                 if raise_error:
                     raise RuntimeError(msg)
                 else:

--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2204,7 +2204,8 @@ class TestPyoptSparse(unittest.TestCase):
             prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         'Constraints or objectives [parab.z] cannot be impacted by the design variables of the problem because no partials were defined for them in their parent component(s).')
+                         'Constraints or objectives [parab.z] cannot be impacted by the design variables'
+                         ' of the problem because no partials were defined for them in their parent component(s).')
 
     def test_singular_jac_error_desvars(self):
         prob = om.Problem()
@@ -2292,7 +2293,8 @@ class TestPyoptSparse(unittest.TestCase):
 
         prob.setup()
 
-        msg = 'Constraints or objectives [parab.z] cannot be impacted by the design variables of the problem because no partials were defined for them in their parent component(s).'
+        msg = ('Constraints or objectives [parab.z] cannot be impacted by the design variables of'
+               ' the problem because no partials were defined for them in their parent component(s).')
 
         with assert_warning(UserWarning, msg):
             prob.run_driver()

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -2100,7 +2100,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
             prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         'Constraints or objectives [parab.z] cannot be impacted by the design variables of the problem because no partials were defined for them in their parent component(s).')
+                         'Constraints or objectives [parab.z] cannot be impacted by the design'
+                         ' variables of the problem because no partials were defined for them in their parent component(s).')
 
     def test_singular_jac_error_desvars(self):
         prob = om.Problem()
@@ -2130,12 +2131,12 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        with printoptions(legacy='1.21'):
-            with self.assertRaises(RuntimeError) as msg:
-                prob.run_driver()
+        with self.assertRaises(RuntimeError) as msg:
+            prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         "Design variables [('z', inds=[0])] have no impact on the constraints or objective.")
+                         'The following design variables have no impact on the constraints or '
+                         'objective at the current design point:\n  z, inds=[0]\n')
 
     def test_singular_jac_ignore(self):
         prob = om.Problem()
@@ -2187,15 +2188,15 @@ class TestScipyOptimizeDriver(unittest.TestCase):
 
         prob.setup()
 
-        msg = "Constraints or objectives [('parab.z', inds=[0])] cannot be impacted by the design variables of the problem."
+        expected_msg = ('The following constraints or objectives cannot be impacted by'
+                        ' the design variables of the problem at the current design point:\n  parab.z, inds=[0]\n')
 
-        with printoptions(legacy='1.21'):
-            with assert_warning(UserWarning, msg):
-                prob.run_driver()
+        with assert_warning(DerivativesWarning, expected_msg):
+            prob.run_driver()
 
     def test_singular_jac_desvars_multidim_indices_dv(self):
-        expected_msg = "Design variables [('z', inds=[(0, 1, 0), (1, 0, 1), (1, 1, 0)])] " \
-                       "have no impact on the constraints or objective."
+        expected_msg = "The following design variables " \
+                       "have no impact on the constraints or objective at the current design point:\n  z, inds=[(0, 1, 0), (1, 0, 1), (1, 1, 0)]\n"
 
         for option in ['error', 'warn', 'ignore']:
             with self.subTest(f'singular_jac_behavior = {option}'):
@@ -2268,7 +2269,8 @@ class TestScipyOptimizeDriver(unittest.TestCase):
                 prob.run_driver()
 
         self.assertEqual(str(msg.exception),
-                         "Constraints or objectives [('parab.f_z', inds=[(1, 1, 0)])] cannot be impacted by the design variables of the problem.")
+                         'The following constraints or objectives cannot be impacted by the design'
+                         ' variables of the problem at the current design point:\n  parab.f_z, inds=[(1, 1, 0)]\n')
 
     @unittest.skipUnless(ScipyVersion >= Version("1.2"),
                          "scipy >= 1.2 is required.")


### PR DESCRIPTION
### Summary

Numpy 2.x output for the singular jac check was excessively verbose, including the `np.int64(...)` type information around each integer in the indices.

This change sets the legacy print mode within the singularity checking logic to `1.21` so that numpy only prints the literal integer indices.

### Related Issues

- Resolves #3579 

### Backwards incompatibilities

None

### New Dependencies

None
