### PR TITLE
Fix N2 Diagram HTML Failing for Custom Solvers

### DIFF
--- a/openmdao/visualization/n2_viewer/src/OmLegend.js
+++ b/openmdao/visualization/n2_viewer/src/OmLegend.js
@@ -44,11 +44,13 @@ class OmLegend extends Legend {
             { 'name': "Collapsed", 'color': OmStyle.color.collapsed },
             { 'name': "Declared Partial", 'color': OmStyle.color.declaredPartial }
         ];
-                
+
         const rootLinearSolver =
-            OmStyle.solverStyleObject.find(x => x.ln === modelData.tree.linear_solver);
+            OmStyle.solverStyleObject.find(x => x.ln === modelData.tree.linear_solver)
+            || OmStyle.solverStyleObject.find(x => x.ln === "other");
         const rootNonLinearSolver =
-            OmStyle.solverStyleObject.find(x => x.nl === modelData.tree.nonlinear_solver);
+            OmStyle.solverStyleObject.find(x => x.nl === modelData.tree.nonlinear_solver)
+            || OmStyle.solverStyleObject.find(x => x.nl === "other");
         this.linearSolvers = [
             { 'name': modelData.tree.linear_solver, 'color': rootLinearSolver.color }
         ];

--- a/openmdao/visualization/n2_viewer/src/OmStyle.js
+++ b/openmdao/visualization/n2_viewer/src/OmStyle.js
@@ -49,6 +49,7 @@ class OmStyle extends Style {
         ['LN: USER',        null,              '#fccde5'],
         [null,              'NL: Newton',      '#d9d9d9'],
         [null,              'NL: BROYDEN',     '#bc80bd'],
+        ['LN: PETScDirect', null,              '#636b2f'],
         ['solve_linear',    'solve_nonlinear', '#ccebc5'],
         ['other',           'other',           '#ffed6f'],
     ];


### PR DESCRIPTION
### Summary

N2 diagram has the corresponding color for each NL / LN solver hardcoded, but does not have a default value when a solver being used in the model is not in that hardcoded list. As a result, the generated html fails to open with an error about the solver color attribute if the solver used is not in the hardcoded list. To address this, the "other" solver category was made the default and is used if the used NL / NL solver does not exist in the list of hardcoded solvers.

Also, when the PETScDirectSolver was added it was not added to the list of NL / LN solvers for the N2 diagram. The PETScDirectSolver has been added with its own custom color.

### Related Issues

- Resolves #3573 

### Backwards incompatibilities

None

### New Dependencies

None
