### PR TITLE
Changed default behavior of `list_driver_vars` to be verbose 

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1799,17 +1799,20 @@ class Problem(object, metaclass=ProblemMetaclass):
             the ref and ref0 values that were specified when add_design_var, add_objective, and
             add_constraint were called on the model. Default is True.
         desvar_opts : list of str
-            List of optional columns to be displayed in the desvars table.
+            List of optional columns to be displayed in the desvars table. All are displayed by
+            defualt.
             Allowed values are:
             ['lower', 'upper', 'ref', 'ref0', 'indices', 'adder', 'scaler', 'parallel_deriv_color',
             'cache_linear_solution', 'units', 'min', 'max'].
         cons_opts : list of str
-            List of optional columns to be displayed in the cons table.
+            List of optional columns to be displayed in the cons table. All are displayed by
+            defualt.
             Allowed values are:
             ['lower', 'upper', 'equals', 'ref', 'ref0', 'indices', 'adder', 'scaler',
             'linear', 'parallel_deriv_color', 'cache_linear_solution', 'units', 'min', 'max'].
         objs_opts : list of str
-            List of optional columns to be displayed in the objs table.
+            List of optional columns to be displayed in the objs table. All are displayed by
+            defualt.
             Allowed values are:
             ['ref', 'ref0', 'indices', 'adder', 'scaler', 'units',
             'parallel_deriv_color', 'cache_linear_solution'].

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1852,9 +1852,10 @@ class Problem(object, metaclass=ProblemMetaclass):
         header = "Design Variables"
         if desvar_opts is None:
             desvar_opts = ['lower', 'upper', 'ref', 'ref0', 'indices', 'adder', 'scaler',
-                           'parallel_deriv_color','cache_linear_solution', 'units', 'min', 'max']
+                           'parallel_deriv_color', 'cache_linear_solution', 'units', 'min', 'max']
         def_desvar_opts = [opt for opt in ('indices',) if opt not in desvar_opts and
                            _find_dict_meta(desvars, opt)]
+        desvar_opts = [opt for opt in desvar_opts if _find_dict_meta(desvars, opt)]
         col_names = default_col_names + def_desvar_opts + desvar_opts
         if out_stream:
             self._write_var_info_table(header, col_names, desvars, vals,
@@ -1883,11 +1884,12 @@ class Problem(object, metaclass=ProblemMetaclass):
         header = "Constraints"
         if cons_opts is None:
             cons_opts = ['lower', 'upper', 'equals', 'ref', 'ref0', 'indices', 'adder', 'scaler',
-                        'linear', 'parallel_deriv_color', 'cache_linear_solution', 'units', 'min',
-                        'max']
+                         'linear', 'parallel_deriv_color', 'cache_linear_solution', 'units', 'min',
+                         'max']
         # detect any cons that use aliases
         def_cons_opts = [opt for opt in ('indices', 'alias') if opt not in cons_opts and
                          _find_dict_meta(cons, opt)]
+        cons_opts = [opt for opt in cons_opts if _find_dict_meta(cons, opt)]
         col_names = default_col_names + def_cons_opts + cons_opts
         if out_stream:
             self._write_var_info_table(header, col_names, cons, vals,

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1775,9 +1775,9 @@ class Problem(object, metaclass=ProblemMetaclass):
                          show_promoted_name=True,
                          print_arrays=False,
                          driver_scaling=True,
-                         desvar_opts=[],
-                         cons_opts=[],
-                         objs_opts=[],
+                         desvar_opts=None,
+                         cons_opts=None,
+                         objs_opts=None,
                          out_stream=_DEFAULT_OUT_STREAM,
                          return_format='list'
                          ):
@@ -1847,6 +1847,10 @@ class Problem(object, metaclass=ProblemMetaclass):
                 if 'upper' in meta:
                     meta['upper'] = meta['upper'] / scaler - adder
         header = "Design Variables"
+
+        if desvar_opts is None:
+            desvar_opts = ['lower', 'upper', 'ref', 'ref0', 'indices', 'adder', 'scaler',
+                           'parallel_deriv_color','cache_linear_solution', 'units', 'min', 'max']
         def_desvar_opts = [opt for opt in ('indices',) if opt not in desvar_opts and
                            _find_dict_meta(desvars, opt)]
         col_names = default_col_names + def_desvar_opts + desvar_opts
@@ -1875,6 +1879,10 @@ class Problem(object, metaclass=ProblemMetaclass):
                 if 'upper' in meta:
                     meta['upper'] = meta['upper'] / scaler - adder
         header = "Constraints"
+        if cons_opts is None:
+            cons_opts = ['lower', 'upper', 'equals', 'ref', 'ref0', 'indices', 'adder', 'scaler',
+                        'linear', 'parallel_deriv_color', 'cache_linear_solution', 'units', 'min',
+                        'max']
         # detect any cons that use aliases
         def_cons_opts = [opt for opt in ('indices', 'alias') if opt not in cons_opts and
                          _find_dict_meta(cons, opt)]
@@ -1894,6 +1902,9 @@ class Problem(object, metaclass=ProblemMetaclass):
         objs = self.driver._objs
         vals = self.driver.get_objective_values(driver_scaling=driver_scaling)
         header = "Objectives"
+        if objs_opts is None:
+            objs_opts = ['ref', 'ref0', 'indices', 'adder', 'scaler', 'units',
+                         'parallel_deriv_color', 'cache_linear_solution']
         def_obj_opts = [opt for opt in ('indices',) if opt not in objs_opts and
                         _find_dict_meta(objs, opt)]
         col_names = default_col_names + def_obj_opts + objs_opts

--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1847,7 +1847,6 @@ class Problem(object, metaclass=ProblemMetaclass):
                 if 'upper' in meta:
                     meta['upper'] = meta['upper'] / scaler - adder
         header = "Design Variables"
-
         if desvar_opts is None:
             desvar_opts = ['lower', 'upper', 'ref', 'ref0', 'indices', 'adder', 'scaler',
                            'parallel_deriv_color','cache_linear_solution', 'units', 'min', 'max']

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1800,6 +1800,23 @@ class TestProblem(unittest.TestCase):
         self.assertEqual(output[17], r'Objectives')
         self.assertRegex(output[21], r'^obj +\[[0-9. e+-]+\] +1')
 
+        # General make sure that the default settings print all columns.
+        self.assertTrue('parallel_deriv_color' in output[3])
+        self.assertTrue('units' in output[3])
+        self.assertTrue('upper' in output[3])
+        self.assertTrue('lower' in output[3])
+        self.assertTrue('ref0' in output[3])
+        self.assertTrue('parallel_deriv_color' in output[11])
+        self.assertTrue('units' in output[11])
+        self.assertTrue('upper' in output[11])
+        self.assertTrue('lower' in output[11])
+        self.assertTrue('ref0' in output[11])
+        self.assertTrue('units' in output[19])
+        self.assertTrue('ref' in output[19])
+        self.assertTrue('adder' in output[19])
+        self.assertTrue('parallel_deriv_color' in output[19])
+        self.assertTrue('cache_linear_solution' in output[19])
+
         # With show_promoted_name=False
         stdout = sys.stdout
         strout = StringIO()

--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -455,7 +455,7 @@ def _find_dict_meta(dct, key):
         True if non-None metadata at the given key was found.
     """
     for meta in dct.values():
-        if key in meta and meta[key] is not None:
+        if key in meta:
             return True
     return False
 


### PR DESCRIPTION
### Summary

Changed default behavior of `list_driver_vars` to be verbose (i.e., print all available columns). This also fixes some default kwargs that were lists.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
