### PR TITLE
Made auto_ivc connection ambiguity message simpler.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -25,9 +25,8 @@ from openmdao.solvers.linear.linear_runonce import LinearRunOnce
 from openmdao.solvers.linear.direct import DirectSolver
 from openmdao.utils.array_utils import array_connection_compatible, _flatten_src_indices, \
     shape_to_len, ValueRepeater
-from openmdao.utils.general_utils import common_subpath, \
-    convert_src_inds, shape2tuple, get_connection_owner, ensure_compatible, \
-    meta2src_iter, get_rev_conns, is_undefined
+from openmdao.utils.general_utils import convert_src_inds, shape2tuple, get_connection_owner, \
+    ensure_compatible, meta2src_iter, get_rev_conns, is_undefined
 from openmdao.utils.units import is_compatible, unit_conversion, _has_val_mismatch, _find_unit, \
     _is_unitless, simplify_unit
 from openmdao.utils.graph_utils import get_out_of_order_nodes, get_sccs_topo, are_connected
@@ -1901,23 +1900,13 @@ class Group(System):
                                         prm = f"('{origin_prom}' / '{submeta['prom']}')"
                                     else:
                                         prm = f"'{origin_prom}'"
-                                    common = common_subpath((origin, submeta['path']))
-                                    if common:
-                                        sub = self._get_subsystem(common)
-                                        if sub is not None:
-                                            for a in resolver.absnames(prom, 'input'):
-                                                if sub._resolver.is_local(a, 'input'):
-                                                    prom = sub._resolver.abs2prom(a, 'input')
-                                                    break
-
-                                    gname = f"Group named '{common}'" if common else 'model'
                                     self._collect_error(f"{self.msginfo}: The subsystems {origin} "
                                                         f"and {submeta['path']} called "
                                                         f"set_input_defaults for promoted input "
                                                         f"{prm} with conflicting values for "
-                                                        f"'{key}'. Call <group>.set_input_defaults("
-                                                        f"'{prom}', {key}=?), where <group> is the "
-                                                        f"{gname} to remove the ambiguity.")
+                                                        f"'{key}'. Call model.set_input_defaults("
+                                                        f"'{prom}', {key}=?) to remove the "
+                                                        "ambiguity.")
 
             # update all metadata dicts with any missing metadata that was filled in elsewhere
             # and update src_shape and use_tgt in abs_in2prom_info
@@ -4407,6 +4396,7 @@ class Group(System):
         found_dup = False
         abs2meta_in = self._var_abs2meta['input']
         abs_in2prom_info = self._problem_meta['abs_in2prom_info']
+        abs2prom = self._resolver.abs2prom
         start_val = val = None
         val_shape = None
         chosen_tgt = None
@@ -4552,11 +4542,13 @@ class Group(System):
             info = (tgt, val, False)
 
         if src_idx_found:  # auto_ivc connected to local vars with src_indices
+            prom = abs2prom(src_idx_found[0], 'input')
             self._collect_error("Attaching src_indices to inputs requires that the shape of the "
-                                "source variable is known, but the source shape for inputs "
-                                f"{src_idx_found} is unknown. You can specify the src shape for "
-                                "these inputs by setting 'val' or 'src_shape' in a call to "
-                                "set_input_defaults, or by adding an IndepVarComp as the source.",
+                                "source variable is known, but the source shape for input "
+                                f"{prom} is unknown. You can specify the src shape "
+                                "for this input by setting 'val' or 'src_shape' in a call to "
+                                "set_input_defaults. For example: model.set_input_defaults"
+                                f"('{prom}', src_shape=?)",
                                 ident=(self.pathname, tuple(src_idx_found)))
             return None
 
@@ -4814,35 +4806,15 @@ class Group(System):
         else:
             meta = sorted(metadata)
         inputs = sorted(tgts)
-        gpath = common_subpath(tgts)
-        if gpath == self.pathname:
-            g = self
-        else:
-            g = self._get_subsystem(gpath)
-        gprom = None
 
-        # get promoted name relative to g
-        if MPI and self.comm.size > 1:
-            if g is not None and not g._is_local:
-                g = None
-            if self.comm.allreduce(int(g is not None)) < self.comm.size:
-                # some procs have remote g
-                if g is not None:
-                    gprom = g._resolver.abs2prom(inputs[0], 'input')
-                proms = self.comm.allgather(gprom)
-                for p in proms:
-                    if p is not None:
-                        gprom = p
-                        break
-        if gprom is None:
-            gprom = g._resolver.abs2prom(inputs[0], 'input')
+        model = self._problem_meta['model_ref']()
+        gprom = model._resolver.abs2prom(tgts[0], 'input')
 
-        gname = f"Group named '{gpath}'" if gpath else 'model'
         args = ', '.join([f'{n}=?' for n in errs])
         self._collect_error(f"{self.msginfo}: The following inputs, {inputs}, promoted "
-                            f"to '{prom}', are connected but their metadata entries {meta}"
-                            f" differ. Call <group>.set_input_defaults('{gprom}', {args}), "
-                            f"where <group> is the {gname} to remove the ambiguity.")
+                            f"to '{gprom}', are connected but their metadata entries {meta}"
+                            f" differ. Call model.set_input_defaults('{gprom}', {args}) "
+                            "to remove the ambiguity.")
 
     def _ordered_comp_name_iter(self):
         """

--- a/openmdao/core/tests/test_auto_ivc.py
+++ b/openmdao/core/tests/test_auto_ivc.py
@@ -209,8 +209,7 @@ class SerialTests(unittest.TestCase):
               "\nCollected errors for problem 'discrete_fan_out2':"
               "\n   <model> <class Group>: The following inputs, ['par.C1.x', 'par.C2.x'], promoted "
               "to 'x', are connected but their metadata entries ['val'] differ. Call "
-              "<group>.set_input_defaults('x', val=?), where <group> is the Group named 'par' to "
-              "remove the ambiguity." in str(err))
+              "model.set_input_defaults('x', val=?) to remove the ambiguity." in str(err))
         else:
             self.fail("Exception expected.")
 

--- a/openmdao/core/tests/test_getset_vars.py
+++ b/openmdao/core/tests/test_getset_vars.py
@@ -373,7 +373,7 @@ class TestGetSetVariables(unittest.TestCase):
            "\nCollected errors for problem 'serial_multi_src_inds_units_promoted_no_src':"
            "\n   <model> <class Group>: The following inputs, ['C1.x', 'C2.x', 'C3.x'], promoted "
            "to 'x', are connected but their metadata entries ['units'] differ. Call "
-           "<group>.set_input_defaults('x', units=?), where <group> is the model to remove the ambiguity.")
+           "model.set_input_defaults('x', units=?) to remove the ambiguity.")
 
     def test_serial_multi_src_inds_units_setval_promoted(self):
         p = Problem()

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1503,8 +1503,8 @@ class TestGroup(unittest.TestCase):
                          "\nCollected errors for problem 'promote_units_and_none':\n   "
                          "<model> <class Group>: The following inputs, ['c1.x', 'c2.x'], promoted to 'x', "
                          "are connected but their metadata entries ['units', 'val'] differ. "
-                         "Call <group>.set_input_defaults('x', units=?, val=?), "
-                         "where <group> is the model to remove the ambiguity.")
+                         "Call model.set_input_defaults('x', units=?, val=?) "
+                         "to remove the ambiguity.")
 
     def test_double_set_input_defaults(self):
         problem = om.Problem()
@@ -2971,8 +2971,7 @@ class TestGroupAddInput(unittest.TestCase):
             "\nCollected errors for problem 'missing_diff_units':"
             "\n   <model> <class Group>: The following inputs, ['par.C1.x', 'par.C2.x'], promoted "
             "to 'x', are connected but their metadata entries ['units', 'val'] differ. "
-            "Call <group>.set_input_defaults('x', units=?, val=?), where <group> is the Group named "
-            "'par' to remove the ambiguity.")
+            "Call model.set_input_defaults('x', units=?, val=?) to remove the ambiguity.")
 
     def test_missing_diff_vals(self):
         p = om.Problem(name="missing_diff_vals")
@@ -2990,8 +2989,7 @@ class TestGroupAddInput(unittest.TestCase):
             "\nCollected errors for problem 'missing_diff_vals':"
             "\n   <model> <class Group>: The following inputs, ['par.C1.x', 'par.C2.x'], promoted "
             "to 'x', are connected but their metadata entries ['val'] differ. "
-            "Call <group>.set_input_defaults('x', val=?), where <group> is the Group named 'par' "
-            "to remove the ambiguity.")
+            "Call model.set_input_defaults('x', val=?) to remove the ambiguity.")
 
     def test_conflicting_units(self):
         # multiple Group.set_input_defaults calls at same tree level with conflicting units args
@@ -3017,8 +3015,7 @@ class TestGroupAddInput(unittest.TestCase):
             "\nCollected errors for problem 'conflicting_units':"
             "\n   <model> <class Group>: The subsystems G1.G2 and par.G4 called set_input_defaults "
             "for promoted input 'x' with conflicting values for 'units'. "
-            "Call <group>.set_input_defaults('x', units=?), where <group> is the model to remove "
-            "the ambiguity.")
+            "Call model.set_input_defaults('x', units=?) to remove the ambiguity.")
 
     def test_conflicting_units_multi_level(self):
         # multiple Group.set_input_defaults calls at different tree levels with conflicting units args
@@ -3047,14 +3044,14 @@ class TestGroupAddInput(unittest.TestCase):
            "\nCollected errors for problem 'conflicting_units_multi_level':"
            "\n   <model> <class Group>: The subsystems G1 and par.G4 called set_input_defaults "
            "for promoted input 'x' with conflicting values for 'units'. "
-           "Call <group>.set_input_defaults('x', units=?), where <group> is the model to remove the ambiguity."
+           "Call model.set_input_defaults('x', units=?) to remove the ambiguity."
            "\n   <model> <class Group>: The subsystems G1 and par.G5 called set_input_defaults for "
            "promoted input 'x' with conflicting values for 'units'. "
-           "Call <group>.set_input_defaults('x', units=?), where <group> is the model to remove the ambiguity."
+           "Call model.set_input_defaults('x', units=?) to remove the ambiguity."
            "\n   <model> <class Group>: The following inputs, ['G1.G2.C1.x', 'G1.G2.C2.x', "
            "'G1.G3.C3.x', 'G1.G3.C4.x', 'par.G4.C5.x', 'par.G4.C6.x', 'par.G5.C7.x', 'par.G5.C8.x'], "
            "promoted to 'x', are connected but their metadata entries ['val'] differ. "
-           "Call <group>.set_input_defaults('x', val=?), where <group> is the model to remove the ambiguity.")
+           "Call model.set_input_defaults('x', val=?) to remove the ambiguity.")
 
     def test_override_units(self):
         # multiple Group.set_input_defaults calls at different tree levels with conflicting units args
@@ -3177,12 +3174,12 @@ class TestGroupAddInput(unittest.TestCase):
             "\nCollected errors for problem 'conflicting_units_multi_level_par':"
             "\n   <model> <class Group>: The subsystems G1.G2 and par called set_input_defaults "
             "for promoted input 'x' with conflicting values for 'units'. "
-            "Call <group>.set_input_defaults('x', units=?), where <group> is the model to remove "
+            "Call model.set_input_defaults('x', units=?) to remove "
             "the ambiguity."
             "\n   <model> <class Group>: The following inputs, ['G1.G2.C1.x', 'G1.G2.C2.x', "
             "'G1.G3.C3.x', 'G1.G3.C4.x', 'par.G4.C5.x', 'par.G4.C6.x', 'par.G5.C7.x', 'par.G5.C8.x'], "
             "promoted to 'x', are connected but their metadata entries ['val'] differ. "
-            "Call <group>.set_input_defaults('x', val=?), where <group> is the model to remove the "
+            "Call model.set_input_defaults('x', val=?) to remove the "
             "ambiguity.")
 
     def test_group_input_not_found(self):
@@ -3214,7 +3211,7 @@ class TestGroupAddInput(unittest.TestCase):
            "\n   <model> <class Group>: The following inputs, ['G1.G2.C1.x', 'G1.G2.C2.x', "
            "'G1.G3.C3.x', 'G1.G3.C4.x', 'par.G4.C5.x', 'par.G4.C6.x', 'par.G5.C7.x', 'par.G5.C8.x'],"
            " promoted to 'x', are connected but their metadata entries ['val'] differ. "
-           "Call <group>.set_input_defaults('x', val=?), where <group> is the model to remove the "
+           "Call model.set_input_defaults('x', val=?) to remove the "
            "ambiguity.")
 
     def test_conflicting_val(self):
@@ -3243,10 +3240,9 @@ class TestGroupAddInput(unittest.TestCase):
            "\nCollected errors for problem 'conflicting_val':"
            "\n   <model> <class Group>: The subsystems G1 and par.G4 called set_input_defaults for "
            "promoted input 'x' with conflicting values for 'val'. Call "
-           "<group>.set_input_defaults('x', val=?), where <group> is the model to remove the ambiguity."
+           "model.set_input_defaults('x', val=?) to remove the ambiguity."
            "\n   <model> <class Group>: The subsystems G1 and par.G5 called set_input_defaults for "
-           "promoted input 'x' with conflicting values for 'val'. Call <group>.set_input_defaults('x', val=?), "
-           "where <group> is the model to remove the ambiguity.")
+           "promoted input 'x' with conflicting values for 'val'. Call model.set_input_defaults('x', val=?) to remove the ambiguity.")
 
     def test_set_input_defaults_discrete(self):
         import math

--- a/openmdao/core/tests/test_problem.py
+++ b/openmdao/core/tests/test_problem.py
@@ -1059,8 +1059,7 @@ class TestProblem(unittest.TestCase):
                "\nCollected errors for problem 'get_set_with_units_diff_err':"
                "\n   <model> <class Group>: The following inputs, ['C1.x', 'C2.x'], promoted to "
                "'x', are connected but their metadata entries ['units', 'val'] differ. "
-               "Call <group>.set_input_defaults('x', units=?, val=?), where <group> is the model "
-               "to remove the ambiguity.")
+               "Call model.set_input_defaults('x', units=?, val=?) to remove the ambiguity.")
         else:
             self.fail("Exception expected.")
 
@@ -1173,7 +1172,7 @@ class TestProblem(unittest.TestCase):
         with self.assertRaises(RuntimeError) as cm:
             prob['G1.x']
 
-        msg = "<model> <class Group>: The following inputs, ['G1.C1.x', 'G1.C2.x'], promoted to 'G1.x', are connected but their metadata entries ['units'] differ. Call <group>.set_input_defaults('x', units=?), where <group> is the Group named 'G1' to remove the ambiguity."
+        msg = "<model> <class Group>: The following inputs, ['G1.C1.x', 'G1.C2.x'], promoted to 'G1.x', are connected but their metadata entries ['units'] differ. Call model.set_input_defaults('G1.x', units=?) to remove the ambiguity."
         self.assertEqual(cm.exception.args[0], msg)
 
     def test_get_set_with_units_error_messages(self):

--- a/openmdao/core/tests/test_units.py
+++ b/openmdao/core/tests/test_units.py
@@ -918,8 +918,7 @@ class TestUnitConversion(unittest.TestCase):
            "\nCollected errors for problem 'promotes_non_equivalent_units':"
            "\n   <model> <class Group>: The following inputs, ['G1.C1.x', 'G1.C2.x'], promoted "
            "to 'x', are connected but their metadata entries ['units', 'val'] differ. "
-           "Call <group>.set_input_defaults('x', units=?, val=?), where <group> is the Group "
-           "named 'G1' to remove the ambiguity."
+           "Call model.set_input_defaults('x', units=?, val=?) to remove the ambiguity."
            "\n   <model> <class Group>: Output units of 'J/s**2' for '_auto_ivc.v0' are "
            "incompatible with input units of 'm/s**2' for 'G1.C2.x'.")
 

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_get.ipynb
@@ -690,7 +690,7 @@
     "    prob.final_setup()\n",
     "except RuntimeError as err:\n",
     "    print(str(err))\n",
-    "    assert(str(err) == \"\\nCollected errors for problem 'no_set_input_defaults':\\n   <model> <class Group>: The following inputs, ['C1.x', 'C2.x'], promoted to 'x', are connected but their metadata entries ['units', 'val'] differ. Call <group>.set_input_defaults('x', units=?, val=?), where <group> is the model to remove the ambiguity.\")\n",
+    "    assert(str(err) == \"\\nCollected errors for problem 'no_set_input_defaults':\\n   <model> <class Group>: The following inputs, ['C1.x', 'C2.x'], promoted to 'x', are connected but their metadata entries ['units', 'val'] differ. Call model.set_input_defaults('x', units=?, val=?) to remove the ambiguity.\")\n",
     "else:\n",
     "    raise RuntimeError(\"Exception expected.\")"
    ]

--- a/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_input_defaults.ipynb
+++ b/openmdao/docs/openmdao_book/features/core_features/running_your_models/set_input_defaults.ipynb
@@ -82,7 +82,7 @@
     "try:\n",
     "    p1.final_setup()\n",
     "except Exception as err:\n",
-    "    assert(\"<model> <class Group>: The following inputs, ['C1.x', 'C2.x'], promoted to 'x', are connected but their metadata entries ['units', 'val'] differ. Call <group>.set_input_defaults('x', units=?, val=?), where <group> is the model to remove the ambiguity.\" in str(err))\n",
+    "    assert(\"<model> <class Group>: The following inputs, ['C1.x', 'C2.x'], promoted to 'x', are connected but their metadata entries ['units', 'val'] differ. Call model.set_input_defaults('x', units=?, val=?) to remove the ambiguity.\" in str(err))\n",
     "else:\n",
     "    raise RuntimeError(\"Exception expected.\")"
    ]


### PR DESCRIPTION
### Summary

The message now contains a call to set_input_defaults that can be made at the model level to fix the ambiguity.

### Related Issues

- Resolves #3584

### Backwards incompatibilities

None

### New Dependencies

None
