### PR TITLE
Fix for an earlier change to ExplicitComponent.add_output that caused a regression in pyCycle

### DIFF
--- a/openmdao/core/explicitcomponent.py
+++ b/openmdao/core/explicitcomponent.py
@@ -181,7 +181,7 @@ class ExplicitComponent(Component):
     def add_output(self, name, val=1.0, shape=None, units=None, res_units=None, desc='',
                    lower=None, upper=None, ref=1.0, ref0=0.0, res_ref=None, tags=None,
                    shape_by_conn=False, copy_shape=None, compute_shape=None,
-                   units_by_conn=None, compute_units=None, copy_units=None,
+                   units_by_conn=False, compute_units=None, copy_units=None,
                    distributed=None, primal_name=None):
         """
         Add an output variable to the component.

--- a/openmdao/solvers/linear/petsc_direct_solver.py
+++ b/openmdao/solvers/linear/petsc_direct_solver.py
@@ -10,6 +10,7 @@ from openmdao.solvers.linear.direct import format_singular_error
 from openmdao.matrices.dense_matrix import DenseMatrix
 from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
 from openmdao.utils.om_warnings import issue_warning, SolverWarning
+from openmdao.utils.mpi import FakeComm
 
 try:
     from petsc4py import PETSc
@@ -19,7 +20,7 @@ try:
     from mpi4py import MPI
     DEFAULT_COMM = MPI.COMM_WORLD
 except ImportError:
-    DEFAULT_COMM = None
+    DEFAULT_COMM = FakeComm()
 
 PC_SERIAL_TYPES = [
     "superlu",


### PR DESCRIPTION
### Summary

Also fixed a minor issue with PETScDirectSolver when MPI was not active.

### Backwards incompatibilities

None

### New Dependencies

None
