### PR TITLE
Turn on pre-opt-post default. Move warning about redundant adjoint solves into optional checks. Remove warning about overwriting recorder files.

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -273,7 +273,7 @@ class Problem(object, metaclass=ProblemMetaclass):
                              default=os.path.join(default_workdir, 'coloring_files'),
                              desc='Directory containing coloring files (if any) for this Problem.')
         self.options.declare('group_by_pre_opt_post', types=bool,
-                             default=False,
+                             default=True,
                              desc="If True, group subsystems of the top level model into "
                              "pre-optimization, optimization, and post-optimization, and only "
                              "iterate over the optimization subsystems during optimization.  This "

--- a/openmdao/error_checking/check_config.py
+++ b/openmdao/error_checking/check_config.py
@@ -437,6 +437,13 @@ def _check_solvers(problem, logger):
         final.extend(lines)
         logger.warning('\n'.join(final))
 
+    # Report any additional solver warnings.
+    for system in problem.model.system_iter(include_self=True, recurse=True):
+        if system._nonlinear_solver is not None:
+            system._nonlinear_solver.check_config(logger)
+        if system._linear_solver is not None:
+            system._linear_solver.check_config(logger)
+
 
 def _check_missing_recorders(problem, logger):
     """

--- a/openmdao/recorders/sqlite_recorder.py
+++ b/openmdao/recorders/sqlite_recorder.py
@@ -123,7 +123,7 @@ class SqliteRecorder(CaseRecorder):
     filepath : str or Path
         Path to the recorder file.
     append : bool, optional
-        Optional. If True, append to an existing case recorder file.
+        Optional. If True, append to an existing case recorder file. Default is False.
     pickle_version : int, optional
         The pickle protocol version to use when pickling metadata.
     record_viewer_data : bool, optional
@@ -210,9 +210,6 @@ class SqliteRecorder(CaseRecorder):
                               f"{metadata_filepath}.")
                         try:
                             os.remove(metadata_filepath)
-                            issue_warning("The existing case recorder metadata file, "
-                                          f"{metadata_filepath}, is being overwritten.",
-                                          category=UserWarning)
                         except OSError:
                             pass
                         self.metadata_connection = sqlite3.connect(metadata_filepath)
@@ -228,8 +225,6 @@ class SqliteRecorder(CaseRecorder):
         if filepath:
             try:
                 os.remove(filepath)
-                issue_warning(f'The existing case recorder file, {filepath},'
-                              ' is being overwritten.', category=UserWarning)
             except OSError:
                 pass
 

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -359,23 +359,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
         outputs_dir = prob.get_outputs_dir()
 
-        if prob.comm.rank == 0:
-            expected_warnings = [
-                (UserWarning,
-                f'The existing case recorder metadata file, {outputs_dir}/cases.sql_meta, '
-                'is being overwritten.'),
-                (UserWarning,
-                f'The existing case recorder file, {outputs_dir}/cases.sql_0, is being '
-                'overwritten.'),
-            ]
-        else:
-            expected_warnings = [
-                (UserWarning,
-                    f'The existing case recorder file, {outputs_dir}/cases.sql_1, is being '
-                    'overwritten.'),
-            ]
-        with assert_warnings(expected_warnings):
-            prob.run_driver()
+        prob.run_driver()
 
         prob.cleanup()
 

--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -223,6 +223,26 @@ class DirectSolver(LinearSolver):
 
         self.supports['implicit_components'] = True
 
+    def check_config(self, logger):
+        """
+        Perform optional error checks.
+
+        Parameters
+        ----------
+        logger : object
+            The object that manages logging output.
+        """
+        if self.options['rhs_checking'] is False:
+            system = self._system()
+            redundant_adj = system.pathname in system._relevance.get_redundant_adjoint_systems()
+            if redundant_adj:
+                logger.info(
+                    f"\n'rhs_checking' is disabled for '{system.linear_solver.msginfo}'"
+                    ", but that solver has redundant adjoint solves. If it is "
+                    "expensive to compute derivatives for this solver, turning on "
+                    "'rhs_checking' may improve performance.\n"
+                )
+
     def _setup_solvers(self, system, depth):
         """
         Assign system instance, set depth, and optionally perform setup.
@@ -236,8 +256,7 @@ class DirectSolver(LinearSolver):
         """
         super()._setup_solvers(system, depth)
         self._disallow_distrib_solve()
-        self._lin_rhs_checker = LinearRHSChecker.create(self._system(),
-                                                        self.options['rhs_checking'])
+        self._lin_rhs_checker = LinearRHSChecker.create(system, self.options['rhs_checking'])
 
     def _linearize_children(self):
         """

--- a/openmdao/solvers/linear/linear_rhs_checker.py
+++ b/openmdao/solvers/linear/linear_rhs_checker.py
@@ -147,6 +147,10 @@ class LinearRHSChecker(object):
         LinearRHSChecker or None
             A LinearRHSChecker instance if it was created, None otherwise.
         """
+        if opts is False:
+            # User did not request RHS checking.
+            return None
+
         redundant_adj = system.pathname in system._relevance.get_redundant_adjoint_systems()
         if isinstance(opts, dict):
             LinearRHSChecker.check_options(system, opts)
@@ -159,13 +163,6 @@ class LinearRHSChecker(object):
                           "'rhs_checking' options.")
                 else:
                     return None
-        elif not opts:
-            if redundant_adj:
-                print(f"\n'rhs_checking' is disabled for '{system.linear_solver.msginfo}'"
-                      " but that solver has redundant adjoint solves. If it is "
-                      "expensive to compute derivatives for this solver, turning on "
-                      "'rhs_checking' may improve performance.\n")
-            return None
         else:
             opts = dict(max_cache_entries=3, check_zero=False, rtol=3e-16, atol=3e-16,
                         collect_stats=False, verbose=False)

--- a/openmdao/solvers/solver.py
+++ b/openmdao/solvers/solver.py
@@ -594,6 +594,17 @@ class Solver(object, metaclass=SolverMetaclass):
         """
         return _get_outputs_dir(self, *subdirs, mkdir=mkdir)
 
+    def check_config(self, logger):
+        """
+        Perform optional error checks.
+
+        Parameters
+        ----------
+        logger : object
+            The object that manages logging output.
+        """
+        pass
+
 
 class NonlinearSolver(Solver):
     """


### PR DESCRIPTION
### Summary

1. Turned on the `group_by_pre_opt_post` option. We have been using it for a while, and it is the way we should run.
2. Moved a warning about redundant adjoint solves with DirectSolver into the check_config section, so that they only run when requested (i.e., check=True).
3. Removed the warning about overwriting case files. By now, everyone expects case files to be overwritten.

### Related Issues

- Resolves #

### Backwards incompatibilities

It is possible that `group_by_pre_opt_post` might cause some unexpected behavior in some complicated models, including those with Mphys running in MPI. We need to check on these.

### New Dependencies

None
