### PR TITLE
Fixed a bug that prevented CaseReader from handling array constraints with indices.

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -1187,7 +1187,7 @@ class Case(object):
                 if isinstance(val, np.ndarray):
                     val = val.copy()
                 if use_indices and meta['indices'] is not None:
-                    val = val[meta['indices']]
+                    val = val.ravel()[meta['indices']]
                 if scaled:
                     if meta['total_adder'] is not None:
                         val += meta['total_adder']


### PR DESCRIPTION
### Summary

The method that handles the constraints in CaseReader was applying meta['indices'] as if they were shaped, but by that point they've been processed to be flat indices.

### Related Issues

- Resolves #3603

### Backwards incompatibilities

None

### New Dependencies

None
