### PR TITLE
Fix AttributeError in AnalysisError when using location parameter

### DIFF
--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -30,6 +30,6 @@ class AnalysisError(Exception):
         if location is not None:
             with reset_warning_registry():
                 warnings.formatwarning = _warn_simple_format
-                msg = (f"Analysis Error: {msginfo} Line {location.lineno} of file "
-                       f"{location.filename}")
+                msg = (f"Analysis Error: {msginfo} Line {location.f_lineno} of file "
+                       f"{location.f_code.co_filename}")
                 warnings.warn(msg, UserWarning, 2)


### PR DESCRIPTION
### Summary

Fixes an `AttributeError` that occurs when `AnalysisError` is instantiated with the location parameter set to `inspect.currentframe()` The error occurs because Python frame objects use different attribute names than what the code expects.

## Problem

When raising an `AnalysisError` with location tracking:

`raise om.AnalysisError("Error message", location=inspect.currentframe())`

will return an `AttributeError`


## Solution

Update the attribute names to use the correct frame object properties:

`location.lineno` → `location.f_lineno`
`location.filename` → `location.f_code.co_filename`

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
