### PR TITLE
Allow AnalysisError to be specified with `inspect.currentframe()` per the documentation.

### DIFF
--- a/openmdao/components/meta_model_semi_structured_comp.py
+++ b/openmdao/components/meta_model_semi_structured_comp.py
@@ -217,8 +217,7 @@ class MetaModelSemiStructuredComp(ExplicitComponent):
                           f"because input '{varname_causing_error}' required extrapolation while "
                           f"interpolating dimension {err.idx + 1}, where its value '{err.value}'"
                           f" exceeded the range ('{err.lower}', '{err.upper}')")
-                raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()),
-                                    self.msginfo)
+                raise AnalysisError(errmsg, inspect.currentframe(), self.msginfo)
 
             except ValueError as err:
                 raise ValueError(f"{self.msginfo}: Error interpolating output '{out_name}':\n"

--- a/openmdao/components/meta_model_structured_comp.py
+++ b/openmdao/components/meta_model_structured_comp.py
@@ -209,8 +209,7 @@ class MetaModelStructuredComp(ExplicitComponent):
                 errmsg = (f"{self.msginfo}: Error interpolating output '{out_name}' "
                           f"because input '{varname_causing_error}' was out of bounds "
                           f"('{err.lower}', '{err.upper}') with value '{err.value}'")
-                raise AnalysisError(errmsg, inspect.getframeinfo(inspect.currentframe()),
-                                    self.msginfo)
+                raise AnalysisError(errmsg, inspect.currentframe(), self.msginfo)
 
             except ValueError as err:
                 raise ValueError(f"{self.msginfo}: Error interpolating output '{out_name}':\n"

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -28,8 +28,15 @@ class AnalysisError(Exception):
         """
         super().__init__(error)
         if location is not None:
+            if hasattr(location, 'f_lineno'):
+                # from inspect.currentframe()
+                line_num = location.f_lineno
+                file_name = location.f_code.co_filename
+            else:
+                # from inspect.getframeinfo(inspect.currentframe())
+                line_num = location.lineno
+                file_name = location.filename
             with reset_warning_registry():
                 warnings.formatwarning = _warn_simple_format
-                msg = (f"Analysis Error: {msginfo} Line {location.f_lineno} of file "
-                       f"{location.f_code.co_filename}")
+                msg = (f"Analysis Error: {msginfo} Line {line_num} of file {file_name}")
                 warnings.warn(msg, UserWarning, 2)

--- a/openmdao/core/analysis_error.py
+++ b/openmdao/core/analysis_error.py
@@ -30,6 +30,6 @@ class AnalysisError(Exception):
         if location is not None:
             with reset_warning_registry():
                 warnings.formatwarning = _warn_simple_format
-                msg = (f"Analysis Error: {msginfo} Line {location.lineno} of file "
-                       f"{location.filename}")
+                msg = (f"Analysis Error: {msginfo} Line {location.f_lineno} of file "
+                       f"{location.f_code.co_filename}")
                 warnings.warn(msg, UserWarning, 2)

--- a/openmdao/drivers/tests/test_scipy_optimizer.py
+++ b/openmdao/drivers/tests/test_scipy_optimizer.py
@@ -2466,7 +2466,7 @@ class TestScipyOptimizeDriverCOBYQA(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-9, disp=False)
+        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-6, disp=False)
 
         # note: want x to have no bounds, but COBYQA won't converge with bounds
         # of +/- 1e30 due to how the algorithm works. So set big bounds, but still
@@ -2498,7 +2498,7 @@ class TestScipyOptimizeDriverCOBYQA(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-9, disp=False)
+        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-6, disp=False)
 
         model.add_design_var('x', lower=-50.0, upper=50.0)
         model.add_design_var('y', lower=-50.0, upper=50.0)
@@ -2535,7 +2535,7 @@ class TestScipyOptimizeDriverCOBYQA(unittest.TestCase):
 
         prob.set_solver_print(level=0)
 
-        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-9, disp=False)
+        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-6, disp=False)
         prob.setup()
 
         failed = not prob.run_driver().success
@@ -2552,7 +2552,7 @@ class TestScipyOptimizeDriverCOBYQA(unittest.TestCase):
         model = prob.model = SellarDerivativesGrouped(nonlinear_solver=om.NonlinearBlockGS,
                                                       linear_solver=om.ScipyKrylov)
 
-        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-9, disp=False)
+        prob.driver = om.ScipyOptimizeDriver(optimizer='COBYQA', tol=1e-6, disp=False)
 
         model.add_design_var('z', lower=np.array([-10.0, 0.0]), upper=np.array([10.0, 10.0]))
         model.add_design_var('x', lower=0.0, upper=10.0)


### PR DESCRIPTION
### Summary

The documentation of AnalysisError claims that the location argument should be from `inspect.currentframe()`.
However, internally to OpenMDAO it is used with `inspect.getframeinfo(inspect.currentframe())`.

This pull request allows it to accept either so that it is backward compatible but adheres to the documentation.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
