### PR TITLE
Fix `Vector.items()`

### DIFF
--- a/openmdao/vectors/tests/test_vector.py
+++ b/openmdao/vectors/tests/test_vector.py
@@ -80,6 +80,21 @@ class TestVector(unittest.TestCase):
 
         self.assertEqual(hash1, hash3)
 
+    def test_items(self):
+        d_expected = {"v1": 1.0, "v2": 2.0, "v3": [3.0, 4.0]}
+
+        p = om.Problem()
+        comp = om.IndepVarComp()
+        comp.add_output('v1', val=d_expected["v1"], shape=tuple())
+        comp.add_output('v2', val=d_expected["v2"], shape=tuple())
+        comp.add_output('v3', val=d_expected["v3"])
+        p.model.add_subsystem('des_vars', comp, promotes=['*'])
+        p.setup()
+        p.final_setup()
+
+        for k, v in p.model._outputs.items(relative_to="des_vars"):
+            assert_near_equal(v, d_expected[k])
+
 
 A = np.array([[1.0, 8.0, 0.0], [-1.0, 10.0, 2.0], [3.0, 100.5, 1.0]])
 

--- a/openmdao/vectors/vector.py
+++ b/openmdao/vectors/vector.py
@@ -239,13 +239,13 @@ class Vector(object):
         if self._under_complex_step:
             for n, vinfo in self._views.items():
                 if n in self._names:
-                    yield n[plen:], vinfo.item() if vinfo.is_scalar else vinfo.view
+                    yield n[plen:], vinfo.view.item() if vinfo.is_scalar else vinfo.view
                 else:
                     yield n[plen:], 0.0j if vinfo.is_scalar else np.zeros_like(vinfo.view)
         else:
             for n, vinfo in self._views.items():
                 if n in self._names:
-                    yield n[plen:], vinfo.item().real if vinfo.is_scalar else vinfo.view.real
+                    yield n[plen:], vinfo.view.item().real if vinfo.is_scalar else vinfo.view.real
                 else:
                     yield n[plen:], 0.0 if vinfo.is_scalar else np.zeros_like(vinfo.view.real)
 


### PR DESCRIPTION
### Summary

Summary of PR.

`Vector.items()` appears to be broken when used with `Vector`s containing scalar vectors (which are created when setting `shape=tuple()`). Appears to be a regression with OpenMDAO `3.40.0`.

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
