### PR TITLE
Simple fix for scalar vars in Group/AutoIVC(?)

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -5022,7 +5022,9 @@ class Group(System):
                             errs.add('units')
 
                     if 'val' not in gmeta:
-                        if tval.shape == sval.shape:
+                        tval_shape = () if np.isscalar(tval) else tval.shape
+                        sval_shape = () if np.isscalar(sval) else sval.shape
+                        if tval_shape == sval_shape:
                             if _has_val_mismatch(tunits, tval, sunits, sval):
                                 errs.add('val')
                         else:

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1704,16 +1704,14 @@ class TestGroup(unittest.TestCase):
         p = om.Problem()
 
         p.model.add_subsystem('circle', CircleAreaComp(), promotes_inputs=['r'])
-        p.model.add_subsystem('circle2', CircleAreaComp(), promotes_inputs=[('r', 'r2')])
+        p.model.add_subsystem('circle2', CircleAreaComp(), promotes_inputs=['r'])
 
         p.setup()
 
         p.set_val("r", 1.0)
-        p.set_val("r2", 1.0)
         p.run_model()
         assert_near_equal(p.get_val('circle.area'), np.pi)
         assert_near_equal(p.get_val('circle2.area'), np.pi)
-
 
 
 @unittest.skipUnless(MPI, "MPI is required.")

--- a/openmdao/core/tests/test_group.py
+++ b/openmdao/core/tests/test_group.py
@@ -1685,6 +1685,36 @@ class TestGroup(unittest.TestCase):
         comp.set_val('x', 3.5, units='m')
         assert_near_equal(comp.get_val('x'), 3.5)
 
+    def test_scalar_vars(self):
+
+        class CircleAreaComp(om.ExplicitComponent):
+
+            def setup(self):
+                self.add_input("r", shape=tuple())
+                self.add_output("area", shape=tuple())
+
+                self.declare_partials("*", "*")
+
+            def compute(self, inputs, outputs):
+                outputs["area"] = np.pi*inputs["r"]**2
+
+            def compute_partials(self, inputs, partials):
+                partials["area", "r"] = 2*np.pi*inputs["r"]
+
+        p = om.Problem()
+
+        p.model.add_subsystem('circle', CircleAreaComp(), promotes_inputs=['r'])
+        p.model.add_subsystem('circle2', CircleAreaComp(), promotes_inputs=[('r', 'r2')])
+
+        p.setup()
+
+        p.set_val("r", 1.0)
+        p.set_val("r2", 1.0)
+        p.run_model()
+        assert_near_equal(p.get_val('circle.area'), np.pi)
+        assert_near_equal(p.get_val('circle2.area'), np.pi)
+
+
 
 @unittest.skipUnless(MPI, "MPI is required.")
 class TestGroupMPISlice(unittest.TestCase):


### PR DESCRIPTION
### Summary

Small change to check for scalar variables in `Group._resolve_ambiguous_input_meta`.

### Related Issues

- Resolves [#3625](https://github.com/OpenMDAO/OpenMDAO/issues/3625)

### Backwards incompatibilities

None

### New Dependencies

None
