### PR TITLE
Remove SNOPT from docs build

### DIFF
--- a/.github/workflows/openmdao_docs_workflow.yml
+++ b/.github/workflows/openmdao_docs_workflow.yml
@@ -69,7 +69,6 @@ jobs:
             PETSc: '3.21'
             PYOPTSPARSE: '2.13.1'
             PYOPTSPARSE_FROM: 'build_pyoptsparse'
-            SNOPT: '7.7'
             OPTIONAL: '[all,numba]'
             PEP517: true
             PUBLISH: true


### PR DESCRIPTION
### Summary

Currently unable to download SNOPT which is preventing the OpenMDAO docs workflow from completing.
This temporarily disables SNOPT in the build process.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
