### PR TITLE
Updated GitHub workflows to properly download SNOPT 

### DIFF
--- a/.github/actions/install_pyoptsparse/action.yml
+++ b/.github/actions/install_pyoptsparse/action.yml
@@ -97,7 +97,7 @@ runs:
           echo "-------------------------------------------------------------"
           echo "Getting SNOPT source"
           echo "-------------------------------------------------------------"
-          scp -qr "$SNOPT_LOCATION" .
+          .github/actions/install_pyoptsparse/download_snopt.sh
         elif [[ "${{ inputs.snopt_version }}" ]]; then
           echo "SNOPT version ${{ inputs.snopt_version }} was requested but source is not available"
         fi
@@ -185,16 +185,13 @@ runs:
           BRANCH="-b v${{ inputs.pyoptsparse_version }}"
         fi
 
-        if [[ "$SNOPT_VERSION" == "7.7" && -n "$SNOPT_LOCATION_77" ]]; then
+        if [[ "$SNOPT_VERSION" == "7.7" ]]; then
           echo "  > Secure copying SNOPT 7.7 over SSH"
-          mkdir SNOPT
-          scp -qr "$SNOPT_LOCATION_77" SNOPT
+          .github/actions/install_pyoptsparse/download_snopt.sh
           SNOPT="-s SNOPT/src"
-        elif [[ "$SNOPT_VERSION" == "7.2" && -n "$SNOPT_LOCATION_72" ]]; then
+        elif [[ "$SNOPT_VERSION" == "7.2" ]]; then
           echo "  > Secure copying SNOPT 7.2 over SSH"
-          mkdir SNOPT
-          scp -qr "$SNOPT_LOCATION_72" SNOPT
-          ls -lR SNOPT
+          .github/actions/install_pyoptsparse/download_snopt.sh
           SNOPT="-s SNOPT/source"
         elif [[ "$SNOPT_VERSION" ]]; then
           echo "SNOPT version $SNOPT_VERSION was requested but source is not available"

--- a/.github/actions/install_pyoptsparse/action.yml
+++ b/.github/actions/install_pyoptsparse/action.yml
@@ -188,11 +188,15 @@ runs:
         if [[ "$SNOPT_VERSION" == "7.7" ]]; then
           echo "  > Secure copying SNOPT 7.7 over SSH"
           .github/actions/install_pyoptsparse/download_snopt.sh
-          SNOPT="-s SNOPT/src"
+          if [ -d "SNOPT" ] ; then
+            SNOPT="-s SNOPT/src"
+          fi
         elif [[ "$SNOPT_VERSION" == "7.2" ]]; then
           echo "  > Secure copying SNOPT 7.2 over SSH"
           .github/actions/install_pyoptsparse/download_snopt.sh
-          SNOPT="-s SNOPT/source"
+          if [ -d "SNOPT" ] ; then
+            SNOPT="-s SNOPT/source"
+          fi
         elif [[ "$SNOPT_VERSION" ]]; then
           echo "SNOPT version $SNOPT_VERSION was requested but source is not available"
         fi
@@ -204,4 +208,3 @@ runs:
       shell: bash -l {0}
       run: |
         python -c "import pyoptsparse; from pyoptsparse import SLSQP; SLSQP()" && echo "pyOptSparse OK" || echo "pyOptSparse FAILED"
-

--- a/.github/actions/install_pyoptsparse/download_snopt.sh
+++ b/.github/actions/install_pyoptsparse/download_snopt.sh
@@ -1,4 +1,4 @@
-# this script will create a SNOPT firectory and populate it
+# this script will create a SNOPT directory and populate it
 # with the specified version of the SNOPT source code
 # via secure copy over SSH
 

--- a/.github/actions/install_pyoptsparse/download_snopt.sh
+++ b/.github/actions/install_pyoptsparse/download_snopt.sh
@@ -1,0 +1,39 @@
+# this script will create a SNOPT firectory and populate it
+# with the specified version of the SNOPT source code
+# via secure copy over SSH
+
+# The version of SNOPT is specified via the SNOPT_VERSION environment variable:
+#     SNOPT_VERSION=7.7   (for SNOPT 7.7) (default)
+#     SNOPT_VERSION=7.2   (for SNOPT 7.2)
+
+# The location of the SNOPT source code must be specified via one of
+# the following environment variables:
+#     SNOPT_LOCATION_72 (for SNOPT 7.2, 'source' directory only)
+#     SNOPT_LOCATION_77 (for SNOPT 7.7, 'src' directory only)
+#     SNOPT_LOCATION    (for SNOPT 7.7, 'SNOPT' directory with build files and 'src' subdirectory)
+
+if [[ -z "$SNOPT_VERSION" ]]; then
+    echo "SNOPT version (7.2 or 7.7) has not been specified, skipping download."
+    exit 0
+fi
+
+if [[ "$SNOPT_VERSION" == "7.2" ]]; then
+    if [[ -n "$SNOPT_LOCATION_72" ]]; then
+        echo "Downloading SNOPT version $SNOPT_VERSION from SNOPT_LOCATION_72 ..."
+        mkdir SNOPT
+        scp -qr $SNOPT_LOCATION_72 SNOPT
+    else
+        echo "SNOPT location not found for SNOPT version $SNOPT_VERSION, skipping download."
+    fi
+else
+    if [[ -n "$SNOPT_LOCATION_77" ]]; then
+        echo "Downloading SNOPT version $SNOPT_VERSION from SNOPT_LOCATION_77 ..."
+        mkdir SNOPT
+        scp -qr $SNOPT_LOCATION_77 SNOPT
+    elif [[ -n "$SNOPT_LOCATION" ]]; then
+        echo "Downloading SNOPT version $SNOPT_VERSION from SNOPT_LOCATION ..."
+        scp -qr $SNOPT_LOCATION .
+    else
+        echo "SNOPT location not found for SNOPT version $SNOPT_VERSION, skipping download."
+    fi
+fi

--- a/.github/workflows/openmdao_docs_workflow.yml
+++ b/.github/workflows/openmdao_docs_workflow.yml
@@ -144,7 +144,7 @@ jobs:
         uses: ./.github/actions/build_docs
         with:
           matrix_name: ${{ matrix.NAME }}
-          use_snopt: ${{ format('{0}', matrix.SNOPT_LOCATION_72 != '' || matrix.SNOPT_LOCATION_77 != '') }}
+          use_snopt: true
           SECRET_docs_location: ${{ secrets.DOCS_LOCATION }}
           SECRET_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           publish: ${{ matrix.PUBLISH }}

--- a/.github/workflows/openmdao_docs_workflow.yml
+++ b/.github/workflows/openmdao_docs_workflow.yml
@@ -144,7 +144,7 @@ jobs:
         uses: ./.github/actions/build_docs
         with:
           matrix_name: ${{ matrix.NAME }}
-          use_snopt: true
+          use_snopt: ${{ format('{0}', matrix.SNOPT_LOCATION != '' || matrix.SNOPT_LOCATION_77 != '') }}
           SECRET_docs_location: ${{ secrets.DOCS_LOCATION }}
           SECRET_slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
           publish: ${{ matrix.PUBLISH }}

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -50,6 +50,7 @@ jobs:
             OS: ubuntu-latest
             PY: 3
             NUMPY: 2
+            SNOPT: 7.7
             PETSc: true
 
           # test latest versions on macos
@@ -57,6 +58,7 @@ jobs:
             OS: macos-latest
             PY: 3
             NUMPY: 2
+            SNOPT: 7.7
             PETSc: true
 
     runs-on: ${{ matrix.OS }}
@@ -162,6 +164,9 @@ jobs:
 
       - name: Install pyOptSparse
         if: ${{ matrix.PYOPTSPARSE }}
+        env:
+          SNOPT_LOCATION: ${{ secrets.SNOPT_LOCATION }}
+          SNOPT_VERSION: ${{ matrix.SNOPT }}
         run: |
           echo "============================================================="
           echo "Define useful functions"
@@ -183,10 +188,7 @@ jobs:
           python -m pip install git+https://github.com/OpenMDAO/build_pyoptsparse
           BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
           if [[ "${{ matrix.SNOPT }}" ]]; then
-            if [[ "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
-              echo "  > Secure copying SNOPT 7.7 over SSH"
-              mkdir SNOPT
-              scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT
+              .github/actions/install_pyoptsparse/download_snopt.sh
               SNOPT="-s SNOPT/src"
             else
               echo "SNOPT source is not available"
@@ -269,7 +271,7 @@ jobs:
           export PYDEVD_DISABLE_FILE_VALIDATION=1
 
           cd openmdao/docs
-          if [[ "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
+          if [[ "${{ matrix.SNOPT }}" ]]; then
             echo "============================================================="
             echo "Building docs with SNOPT examples."
             echo "============================================================="

--- a/.github/workflows/openmdao_latest_workflow.yml
+++ b/.github/workflows/openmdao_latest_workflow.yml
@@ -189,7 +189,9 @@ jobs:
           BRANCH="-b $(latest_version https://github.com/mdolab/pyoptsparse)"
           if [[ "${{ matrix.SNOPT }}" ]]; then
               .github/actions/install_pyoptsparse/download_snopt.sh
-              SNOPT="-s SNOPT/src"
+              if [ -d "SNOPT" ] ; then
+                SNOPT="-s SNOPT/src"
+              fi
             else
               echo "SNOPT source is not available"
             fi

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -360,11 +360,15 @@ jobs:
           if [[ "${{ matrix.SNOPT }}" == "7.7" ]]; then
             echo "  > Secure copying SNOPT 7.7 over SSH"
             .github/actions/install_pyoptsparse/download_snopt.sh
-            SNOPT="-s SNOPT/src"
+            if [ -d "SNOPT" ] ; then
+              SNOPT="-s SNOPT/src"
+            fi
           elif [[ "${{ matrix.SNOPT }}" == "7.2" ]]; then
             echo "  > Secure copying SNOPT 7.2 over SSH"
             .github/actions/install_pyoptsparse/download_snopt.sh
-            SNOPT="-s SNOPT/source"
+            if [ -d "SNOPT" ] ; then
+              SNOPT="-s SNOPT/source"
+            fi
           elif [[ "${{ matrix.SNOPT }}" ]]; then
             echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
           fi

--- a/.github/workflows/openmdao_test_workflow.yml
+++ b/.github/workflows/openmdao_test_workflow.yml
@@ -262,6 +262,9 @@ jobs:
       - name: Build SNOPT
         if: matrix.PYOPTSPARSE_FROM != 'build_pyoptsparse' && matrix.SNOPT
         continue-on-error: false
+        env:
+          SNOPT_LOCATION: ${{ secrets.SNOPT_LOCATION }}
+          SNOPT_VERSION: ${{ matrix.SNOPT }}
         run: |
           echo "============================================================="
           echo "Build SNOPT library"
@@ -270,9 +273,7 @@ jobs:
             echo "-------------------------------------------------------------"
             echo "Getting SNOPT source"
             echo "-------------------------------------------------------------"
-            scp -qr ${{ secrets.SNOPT_LOCATION }} .
-          elif [[ "${{ matrix.SNOPT }}" ]]; then
-            echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"
+            .github/actions/install_pyoptsparse/download_snopt.sh
           fi
 
           if [ -d "SNOPT" ] ; then
@@ -332,6 +333,9 @@ jobs:
       - name: Install pyOptSparse using build_pyoptsparse
         if: matrix.PYOPTSPARSE && matrix.PYOPTSPARSE_FROM == 'build_pyoptsparse'
         continue-on-error: false
+        env:
+          SNOPT_LOCATION: ${{ secrets.SNOPT_LOCATION }}
+          SNOPT_VERSION: ${{ matrix.SNOPT }}
         run: |
           conda install -c conda-forge swig -q -y
 
@@ -353,16 +357,13 @@ jobs:
             PAROPT="-a"
           fi
 
-          if [[ "${{ matrix.SNOPT }}" == "7.7" && "${{ secrets.SNOPT_LOCATION_77 }}" ]]; then
+          if [[ "${{ matrix.SNOPT }}" == "7.7" ]]; then
             echo "  > Secure copying SNOPT 7.7 over SSH"
-            mkdir SNOPT
-            scp -qr ${{ secrets.SNOPT_LOCATION_77 }} SNOPT
+            .github/actions/install_pyoptsparse/download_snopt.sh
             SNOPT="-s SNOPT/src"
-          elif [[ "${{ matrix.SNOPT }}" == "7.2" && "${{ secrets.SNOPT_LOCATION_72 }}" ]]; then
+          elif [[ "${{ matrix.SNOPT }}" == "7.2" ]]; then
             echo "  > Secure copying SNOPT 7.2 over SSH"
-            mkdir SNOPT
-            scp -qr ${{ secrets.SNOPT_LOCATION_72 }} SNOPT
-            ls -lR SNOPT
+            .github/actions/install_pyoptsparse/download_snopt.sh
             SNOPT="-s SNOPT/source"
           elif [[ "${{ matrix.SNOPT }}" ]]; then
             echo "SNOPT version ${{ matrix.SNOPT }} was requested but source is not available"


### PR DESCRIPTION
### Summary

Updated workflows to properly download SNOPT 

- moved SNOPT download logic into a bash script
- updated `install_pyoptsparse` action to use the new script
- updated the `docs` workflow to build the docs with SNOPT support
- updated the `latest` workflow to use the new script
- updated the `test` workflow to use the new script

> [!NOTE]  
> Since SNOPT 7.2 is no longer used in CI testing, this could all be cleaned up to just use SNOPT 7.7 from SNOPT_LOCATION. This is left as future work (as part of assumed further refactoring).

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
