### PR TITLE
bump version to 3.41.1 for next dev cycle

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.41.0
+current_version = 3.41.1-dev
 commit = False
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: OpenMDAO Version
       description: What version of OpenMDAO is being used.
-      placeholder: "3.41.0"
+      placeholder: "3.41.1-dev"
     validations:
       required: true
   - type: textarea

--- a/openmdao/__init__.py
+++ b/openmdao/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '3.41.0'
+__version__ = '3.41.1-dev'
 
 INF_BOUND = 1.0E30


### PR DESCRIPTION
### Summary

bump version to 3.41.1 for next dev cycle

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
