### PR TITLE
#3649 fix: Handle Jacobians of type dict in addition to BLOBs

### DIFF
--- a/openmdao/recorders/case.py
+++ b/openmdao/recorders/case.py
@@ -174,7 +174,10 @@ class Case(object):
 
         if 'jacobian' in data.keys():
             if data_format >= 2:
-                jacobian = blob_to_array(data['jacobian'])
+                if isinstance(data['jacobian'], dict):
+                    jacobian = data['jacobian']
+                else:
+                    jacobian = blob_to_array(data['jacobian'])
                 if type(jacobian) is np.ndarray and not jacobian.shape:
                     jacobian = None
             else:


### PR DESCRIPTION
### Summary

Handle loading Jacobians of type dict in addition to BLOBs in Case Reader

### Related Issues

- Resolves #3649 

### Backwards incompatibilities

None; no breaking changes 

### New Dependencies

None; no changes
