### PR TITLE
Fixed error message when shape_by_conn is unresolved and compute_shape is set.

### DIFF
--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2926,10 +2926,9 @@ class Group(System):
 
             if name in all_abs2meta_out:
                 io = 'input'
-                abs2meta = my_abs2meta_out if name in my_abs2meta_out else all_abs2meta_out
             else:
                 io = 'output'
-                abs2meta = my_abs2meta_in if name in my_abs2meta_in else all_abs2meta_in
+            abs2meta = self._var_allprocs_abs2meta[io]
 
             for abs_name in component_io[comp_name, io]:
                 if abs_name not in graph:

--- a/openmdao/core/tests/test_dyn_sizing.py
+++ b/openmdao/core/tests/test_dyn_sizing.py
@@ -195,6 +195,34 @@ class TestPassSize(unittest.TestCase):
             "['B.in', 'B.out', 'C.in', 'C.out']. To see the dynamic shapes dependency graph, do "
             "'openmdao view_dyn_shapes <your_py_file>'.")
 
+    def test_err_msg_with_other_input(self):
+        class CGInertia(om.ExplicitComponent):
+
+            def setup(self):
+
+                # This shape_by_conn is missing a source shape. An error is correctly
+                # raised for this.
+                self.add_input('Mission:FUEL_MASS', shape_by_conn=True, units="lbm")
+                self.add_output('aircraft:CG', compute_shape=lambda shapes: (
+                    shapes['Mission:FUEL_MASS'][0], 3))
+
+                # However, when you have one more normal input, the error is short-circuited,
+                # and setup2 bombs out while building a graph.
+                # You can try with this line commented to see the correct error.
+                self.add_input('aircraft:air_conditioning:mass', val=0.0, units="lbm")
+
+
+        prob = om.Problem(name='dyn_err_check')
+        prob.model.add_subsystem("cg", CGInertia(), promotes=["*"])
+        prob.setup()
+        with self.assertRaises(Exception) as cm:
+            prob.final_setup()
+
+        self.assertEqual(cm.exception.args[0],
+                         "\nCollected errors for problem 'dyn_err_check':"
+                         "\n   <model> <class Group>: Failed to resolve shapes for ['cg.Mission:FUEL_MASS', 'cg.aircraft:CG']. To see the dynamic shapes dependency graph, do 'openmdao view_dyn_shapes <your_py_file>'."
+                         "\n   <model> <class Group>: The source and target shapes do not match or are ambiguous for the connection '_auto_ivc.v0' to 'cg.Mission:FUEL_MASS'. The source shape is (1,) but the target shape is None.")
+
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
 class TestPassSizeDistributed(unittest.TestCase):


### PR DESCRIPTION
### Summary

The wrong io type was being used to look up variables of the opposite io type of a 'compute_shape' variable.

### Related Issues

- Resolves #3655

### Backwards incompatibilities

None

### New Dependencies

None
