### PR TITLE
added inHg60 and inHg32 to unit conversion. 

### DIFF
--- a/openmdao/utils/unit_library.ini
+++ b/openmdao/utils/unit_library.ini
@@ -1,6 +1,7 @@
 # Default unit library definitions.  Much of this is based on
 # http://www.bipm.org/utils/common/pdf/si_brochure_8_en.pdf
-
+# Look up other standards here:
+# https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
 
 # ------------------------------------------------------------------------
 [prefixes]
@@ -205,6 +206,8 @@ atm: 101325.*Pa, standard atmosphere
 torr: atm/760, Torr (1 mm of mercury)
 psi: 6894.75729317*Pa, pounds per square inch
 psf: psi/144, pounds per square foot
+inHg32: Pa*3386.389, inches of mercury at 32degF
+inHg60: Pa*3376.85, inches of mercury at 60degF
 
 mu0: 4.e-7*pi*N/A**2, permeability of vacuum
 eps0: 1/mu0/c0**2, permittivity of vacuum


### PR DESCRIPTION
### Summary
Added lesser used pressure units to unit conversion tables. This is useful for referencing the older atmospheric data i.e. from MIL_SPEC_210A and USatm1976.

inHg (inches of mercury) has two standard reference temperatures, 32degF and 60degF. Both of those conversions were added (`inHg32` and `inHg60` respectively). Because there are two standard reference temperatures, a generic `inHg` was not used because it could lead to confusion and errors.

Source data from these comes from NIST 
https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors/nist-guide-si-appendix-b8
and inHg32 matches the U.S. Standard Atmosphere 1976 source publication as well
https://www.ngdc.noaa.gov/stp/space-weather/online-publications/miscellaneous/us-standard-atmosphere-1976/us-standard-atmosphere_st76-1562_noaa.pdf

### Related Issues

N/A

### Backwards incompatibilities

None

### New Dependencies

None
