### PR TITLE
Fix typo in Pixi environment documentation

### DIFF
--- a/openmdao/docs/openmdao_book/getting_started/pixi_environment.ipynb
+++ b/openmdao/docs/openmdao_book/getting_started/pixi_environment.ipynb
@@ -10,7 +10,7 @@
     "\n",
     "OpenMDAO uses [Pixi](https://pixi.sh) for dependency management. Pixi is especially useful because some OpenMDAO dependencies (like MPI, PETSc) are not available on PyPI but are needed for parallel computing features.\n",
     "\n",
-    "Using Pixi allows users and developers to get consistent, reproducable environments.\n",
+    "Using Pixi allows users and developers to get consistent, reproducible environments.\n",
     "\n",
     "## Installing Pixi\n",
     "\n",


### PR DESCRIPTION
Minor typo in the word "reproducible."
