### PR TITLE
Add reference to Julia docs in features/experimental/main

### DIFF
--- a/openmdao/docs/openmdao_book/features/experimental/main.ipynb
+++ b/openmdao/docs/openmdao_book/features/experimental/main.ipynb
@@ -12,7 +12,8 @@
     "- [Working with Plugins](plugins)\n",
     "- [Running Some Systems only Before or After an Optimization](pre_opt_post)\n",
     "- [Automatic Setting of Execution Order](auto_order)\n",
-    "- [Components that use Jax to Compute Partial Derivatives](jax_partial_derivs)"
+    "- [Components that use Jax to Compute Partial Derivatives](jax_partial_derivs)\n",
+    "- [Implementing and Differentiating Explicit Components with Julia](julia_explicit_ad)"
    ]
   }
  ],


### PR DESCRIPTION
Add reference to the Julia docs to the `main.ipynb` file so users can actually find it.
