### PR TITLE
docs: fix typo in ks_max docstring

### DIFF
--- a/openmdao/jax_funcs/ks.py
+++ b/openmdao/jax_funcs/ks.py
@@ -42,7 +42,7 @@ def ks_max(x, rho=100.0):
     Returns
     -------
     float
-        A conservative approximation to the minimum value in x.
+        A conservative approximation to the maximum value in x.
     """
     x = jnp.asarray(x)
     x_max = jnp.max(x)


### PR DESCRIPTION
## Description
Fixes a typo in the docstring of `ks_max` function.

## Changes
In `openmdao/jax_funcs/ks.py`, the docstring for `ks_max` incorrectly stated:
```
A conservative approximation to the minimum value in x.
```

This should be `maximum` since the function computes a differentiable maximum, not minimum.

Fixes #3713