### PR TITLE
Add missing return to `get_subjac_sparsity`

### DIFF
--- a/openmdao/drivers/tests/test_pyoptsparse_driver.py
+++ b/openmdao/drivers/tests/test_pyoptsparse_driver.py
@@ -2758,6 +2758,80 @@ class TestPyoptSparse(unittest.TestCase):
         assert_near_equal(J[('exec.z', 'exec.a')].flatten(), np.array([1.]))
         assert_near_equal(J[('ALIAS_TEST', 'exec.a')].flatten(), np.array([1.]))
 
+    @require_pyoptsparse('IPOPT')
+    def test_driver_sparsity(self):
+        prob = om.Problem()
+        prob.driver = driver = om.pyOptSparseDriver(optimizer='IPOPT', print_results=False)
+        driver.opt_settings['print_level'] = 0
+        driver.opt_settings['max_iter'] = 1000
+        driver.declare_coloring()
+        model = prob.model
+
+        shape = (1, 5)
+        ivc = model.add_subsystem('ivc', om.IndepVarComp())
+        ivc.add_output('x', np.ones(shape))
+        ivc.add_output('y', np.ones(shape))
+
+        model.add_subsystem(
+            'obj',
+            om.ExecComp(
+                'obj = sum(x + y)',
+                obj=1.,
+                x=np.ones(shape),
+                y=np.ones(shape),
+            )
+        )
+        model.add_subsystem(
+            'con',
+            om.ExecComp(
+                'w = x',
+                x=np.ones(shape),
+                w=np.ones(shape)
+            )
+        )
+
+        model.connect('ivc.x', 'obj.x')
+        model.connect('ivc.x', 'con.x')
+        model.connect('ivc.y', 'obj.y')
+
+        model.add_design_var('ivc.x', lower=0.0, upper=1.0)
+        model.add_design_var('ivc.y', lower=0.0, upper=1.0)
+
+        model.add_objective('obj.obj')
+        model.add_constraint('con.w', lower=0.0)
+
+        prob.setup()
+        prob.run_model()
+        prob.run_driver()
+
+        sparsity_truth = {
+            'con.w': {
+                'ivc.x': {
+                    'coo': [np.array([0, 1, 2, 3, 4]),
+                            np.array([0, 1, 2, 3, 4]),
+                            np.array([1., 1., 1., 1., 1.])],
+                    'shape': (5, 5)
+                },
+                'ivc.y': {
+                    'coo': [np.array([]), np.array([]), np.array([])],
+                    'shape': (5, 5)
+                }
+            }
+        }
+
+        # Check _con_subjacs, but it's a nested dict so check it in parts
+        subjacs = prob.driver._con_subjacs
+        self.assertListEqual(list(sparsity_truth.keys()), ['con.w'])
+        self.assertListEqual(list(sparsity_truth['con.w'].keys()), ['ivc.x', 'ivc.y'])
+        np.testing.assert_equal(
+            sparsity_truth['con.w']['ivc.x']['coo'],
+            subjacs['con.w']['ivc.x']['coo']
+        )
+        np.testing.assert_equal(
+            sparsity_truth['con.w']['ivc.y']['coo'],
+            subjacs['con.w']['ivc.y']['coo']
+        )
+
     def test_dynamic_coloring_w_multi_constraints(self):
 
         OPT, OPTIMIZER = set_pyoptsparse_opt('SNOPT', fallback=False)

--- a/openmdao/utils/coloring.py
+++ b/openmdao/utils/coloring.py
@@ -1926,6 +1926,7 @@ class Coloring(object):
                 if of not in sparsity:
                     sparsity[of] = {}
                 sparsity[of][wrt] = (nzrows, nzcols, shape)
+            return sparsity
 
     def _subjac_sparsity_iter(self):
         if self._row_vars and self._col_vars and self._row_var_sizes and self._col_var_sizes:


### PR DESCRIPTION
### Summary

The `get_subjac_sparsity` method on the `Coloring` class was missing a return which caused it to always return None. This means that that the `pyOptSparseDriver` always thought that there was no sparsity in the optimization problem.

### Related Issues

- Resolves #3717 

### Backwards incompatibilities

None

### New Dependencies

None
