### PR TITLE
fixed bad import in vscode launch file generator

### DIFF
--- a/openmdao/utils/general_utils.py
+++ b/openmdao/utils/general_utils.py
@@ -1235,7 +1235,7 @@ def _remove_old_configs(vscode_dir):
 
 
 def _generate_launch_json_file(vscode_dir, base_port, ranks):
-    from libopenmdao.utils.mpi import MPI
+    from openmdao.utils.mpi import MPI
 
     launch_path = os.path.join(vscode_dir, 'launch.json')
 


### PR DESCRIPTION
### Summary

I fixed the VSCode launcher file generator in another repo and forgot to update an import statement.  This has no effect on anyone unless they use VSCODE_DBG=1 to attach to and debug an OpenMDAO process in VSCode or Cursor.

### Backwards incompatibilities

None

### New Dependencies

None
