### PR TITLE
OpenMDAO now issues a warning if a constraint is added without a lower, upper, or equals.

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -3664,6 +3664,10 @@ class System(object, metaclass=SystemMetaclass):
         The arguments (:code:`lower`, :code:`upper`, :code:`equals`) can not be strings or variable
         names.
         """
+        if lower is None and upper is None and equals is None:
+            issue_warning(f"{self.msginfo}: Constraint '{name}' requires one of arguments"
+                          " 'lower', 'upper', or 'equals' to be specified.")
+        
         self.add_response(name=name, type_='con', lower=lower, upper=upper,
                           equals=equals, scaler=scaler, adder=adder, ref=ref,
                           ref0=ref0, indices=indices, linear=linear, units=units,

--- a/openmdao/core/tests/test_des_vars_responses.py
+++ b/openmdao/core/tests/test_des_vars_responses.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 import openmdao.api as om
-from openmdao.utils.assert_utils import assert_near_equal, assert_check_totals
+from openmdao.utils.assert_utils import assert_near_equal, assert_check_totals, assert_warning
 from openmdao.utils.mpi import MPI
 from openmdao.test_suite.components.sellar import SellarDerivatives, SellarDis1withDerivatives, \
      SellarDis2withDerivatives
@@ -729,6 +729,18 @@ class TestConstraintOnModel(unittest.TestCase):
 
         msg = "<class SellarDerivatives>: Constraint 'con1' cannot be both equality and inequality."
         self.assertEqual(str(context.exception), msg)
+
+    def test_error_con_no_type(self):
+        prob = om.Problem()
+
+        prob.model = SellarDerivatives()
+        prob.model.nonlinear_solver = om.NonlinearBlockGS()
+
+        expected_msg = ("<class SellarDerivatives>: Constraint 'con1' requires one of arguments "
+                        "'lower', 'upper', or 'equals' to be specified.")
+
+        with assert_warning(om.OpenMDAOWarning, expected_msg):
+            prob.model.add_constraint('con1', ref=1.0)
 
 
 class exampleComp(om.ExplicitComponent):


### PR DESCRIPTION

### Summary

This is not an error because a lot of tests call without that information, and in some cases users may be adding constraints just to make them automatically show up in compute_totals.

### Related Issues

- Resolves #3738

### Backwards incompatibilities

None

### New Dependencies

None
