### PR TITLE
Fixed a bug where the "rel_element" calc_step didn't work correctly in the presence of other inputs.

### DIFF
--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -439,7 +439,7 @@ class ApproximationScheme(object):
         Yields
         ------
         list
-            [[Vector, inds]]
+            [[Vector, inds, loc_idx]]
         """
         if self._totals_directions:
             yield vec_ind_list, vec_ind_list[0][1], 0

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -449,10 +449,10 @@ class ApproximationScheme(object):
             for vec, vec_idxs in vec_ind_list:
                 if vec_idxs is None:
                     continue
-                for vinds in vec_idxs:
+                for loc_idx, vinds in enumerate(vec_idxs):
                     ent0[0] = vec
                     ent0[1] = vinds
-                    yield entry, vinds
+                    yield entry, vinds, loc_idx
 
     def _uncolored_column_iter(self, system, approx_groups):
         """
@@ -515,7 +515,7 @@ class ApproximationScheme(object):
             mult = self._get_multiplier(data)
 
             jidx_iter = iter(range(len(jcol_idxs)))
-            for vec_ind_info, vecidxs in self._vec_ind_iter(vec_ind_list):
+            for vec_ind_info, vecidxs, loc_idx in self._vec_ind_iter(vec_ind_list):
 
                 if fd_count % num_par_fd == system._par_fd_id:
                     # run the finite difference
@@ -524,11 +524,11 @@ class ApproximationScheme(object):
                         with system._relevance.seeds_active(fwd_seeds=seeds):
                             result = self._run_point(system, vec_ind_info,
                                                      app_data, results_array, total_or_semi,
-                                                     jcol_idxs)
+                                                     loc_idx)
                     else:
                         result = self._run_point(system, vec_ind_info,
                                                  app_data, results_array, total_or_semi,
-                                                 jcol_idxs)
+                                                 loc_idx)
 
                     result = self._transform_result(result)
 

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -442,7 +442,7 @@ class ApproximationScheme(object):
             [[Vector, inds]]
         """
         if self._totals_directions:
-            yield vec_ind_list, vec_ind_list[0][1]
+            yield vec_ind_list, vec_ind_list[0][1], 0
         else:
             entry = [[None, None]]
             ent0 = entry[0]

--- a/openmdao/approximation_schemes/approximation_scheme.py
+++ b/openmdao/approximation_schemes/approximation_scheme.py
@@ -439,7 +439,7 @@ class ApproximationScheme(object):
         Yields
         ------
         list
-            [[Vector, inds, loc_idx]]
+            [[Vector, inds, int]]
         """
         if self._totals_directions:
             yield vec_ind_list, vec_ind_list[0][1], 0

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -363,9 +363,9 @@ class FiniteDifference(ApproximationScheme):
             Perturbation amount.
         total : bool
             If True total derivatives are being approximated, else partials.
-        loc_idx : range
+        loc_idx : int
             Current index of variable being stepped: only used when step_calc is rel_element.
-        rel_element : int
+        rel_element : bool
             If True, then each element has a different delta.
 
         Returns

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -318,16 +318,17 @@ class FiniteDifference(ApproximationScheme):
         rel_element = isinstance(current_coeff, np.ndarray) and current_coeff.size > 1
 
         if rel_element:
-            if current_coeff[0]:
+            if current_coeff[loc_idx]:
                 current_vec = system._outputs if total else system._residuals
                 # copy data from outputs (if doing total derivs) or residuals (if doing partials)
                 results_array[:] = current_vec.asarray()
+                print('results_array', loc_idx, current_coeff, results_array)
                 results_array *= current_coeff[loc_idx]
 
             else:
                 results_array[:] = 0.
 
-        elif not isinstance(current_coeff, np.ndarray) and current_coeff:
+        elif current_coeff:
             current_vec = system._outputs if total else system._residuals
             # copy data from outputs (if doing total derivs) or residuals (if doing partials)
             results_array[:] = current_vec.asarray()
@@ -337,8 +338,16 @@ class FiniteDifference(ApproximationScheme):
 
         # Run the Finite Difference
         for delta, coeff in zip(deltas, coeffs):
-            results = self._run_sub_point(system, idx_info, delta, total, loc_idx=loc_idx,
-                                          rel_element=rel_element)
+
+            # Support rel_element stepsizing
+            if rel_element:
+                local_delta = delta[loc_idx].item()
+            elif isinstance(delta, np.ndarray) and len(delta) > 0:
+                local_delta = delta[0]
+            else:
+                local_delta = delta
+
+            results = self._run_sub_point(system, idx_info, local_delta, total)
 
             if rel_element:
                 results *= coeff[loc_idx]
@@ -349,7 +358,7 @@ class FiniteDifference(ApproximationScheme):
 
         return results_array
 
-    def _run_sub_point(self, system, idx_info, delta, total, loc_idx, rel_element=False):
+    def _run_sub_point(self, system, idx_info, delta, total):
         """
         Alter the specified inputs by the given delta, run the system, and return the results.
 
@@ -363,10 +372,6 @@ class FiniteDifference(ApproximationScheme):
             Perturbation amount.
         total : bool
             If True total derivatives are being approximated, else partials.
-        loc_idx : int
-            Current index of variable being stepped: only used when step_calc is rel_element.
-        rel_element : bool
-            If True, then each element has a different delta.
 
         Returns
         -------
@@ -375,14 +380,7 @@ class FiniteDifference(ApproximationScheme):
         """
         for vec, idxs in idx_info:
             if vec is not None and idxs is not None:
-
-                # Support rel_element stepsizing
-                if rel_element:
-                    local_delta = delta[loc_idx]
-                else:
-                    local_delta = delta
-
-                vec.iadd(local_delta, idxs)
+                vec.iadd(delta, idxs)
 
         if total:
             system.run_solve_nonlinear()

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -315,7 +315,8 @@ class FiniteDifference(ApproximationScheme):
             Copy of the outputs or residuals array after running the perturbed system.
         """
         deltas, coeffs, current_coeff = data
-        rel_element = isinstance(current_coeff, np.ndarray) and current_coeff.size > 1
+        vec_curr = isinstance(current_coeff, np.ndarray)
+        rel_element = vec_curr and current_coeff.size > 1
 
         if rel_element:
             if current_coeff[loc_idx]:
@@ -327,7 +328,7 @@ class FiniteDifference(ApproximationScheme):
             else:
                 results_array[:] = 0.
 
-        elif current_coeff:
+        elif np.any(current_coeff != 0.0):
             current_vec = system._outputs if total else system._residuals
             # copy data from outputs (if doing total derivs) or residuals (if doing partials)
             results_array[:] = current_vec.asarray()
@@ -341,7 +342,7 @@ class FiniteDifference(ApproximationScheme):
             # Support rel_element stepsizing
             if rel_element:
                 local_delta = delta[loc_idx].item()
-            elif isinstance(delta, np.ndarray) and len(delta) > 0:
+            elif vec_curr and isinstance(delta, np.ndarray) and len(delta) > 0:
                 local_delta = delta[0]
             else:
                 local_delta = delta

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -290,7 +290,7 @@ class FiniteDifference(ApproximationScheme):
         """
         return array.real
 
-    def _run_point(self, system, idx_info, data, results_array, total, idx_range=range(1)):
+    def _run_point(self, system, idx_info, data, results_array, total, loc_idx=0):
         """
         Alter the specified inputs by the given deltas, run the system, and return the results.
 
@@ -306,7 +306,7 @@ class FiniteDifference(ApproximationScheme):
             Where the results will be stored.
         total : bool
             If True total derivatives are being approximated, else partials.
-        idx_range : range
+        loc_idx : range
             Range of vector indices for this wrt variable.
 
         Returns
@@ -316,8 +316,9 @@ class FiniteDifference(ApproximationScheme):
         """
         deltas, coeffs, current_coeff = data
         rel_element = False
+        print(loc_idx, idx_info)
 
-        if isinstance(current_coeff, np.ndarray) and current_coeff.size > 0:
+        if isinstance(current_coeff, np.ndarray) and current_coeff.size > 1:
             # rel_element - each element has its own relative step.
             rel_element = True
 
@@ -329,7 +330,7 @@ class FiniteDifference(ApproximationScheme):
                 for vec, idxs in idx_info:
                     if vec is not None and idxs is not None:
 
-                        results_array *= current_coeff[idxs - idx_range[0]]
+                        results_array *= current_coeff[loc_idx]
                         # We don't allow mixed fd forms, so first one is all we need.
                         break
 
@@ -346,13 +347,13 @@ class FiniteDifference(ApproximationScheme):
 
         # Run the Finite Difference
         for delta, coeff in zip(deltas, coeffs):
-            results = self._run_sub_point(system, idx_info, delta, total, idx_range=idx_range,
+            results = self._run_sub_point(system, idx_info, delta, total, loc_idx=loc_idx,
                                           rel_element=rel_element)
 
             if rel_element:
                 for vec, idxs in idx_info:
                     if vec is not None and idxs is not None:
-                        results *= coeff[idxs - idx_range[0]]
+                        results *= coeff[loc_idx]
                         break
             else:
                 results *= coeff
@@ -361,7 +362,7 @@ class FiniteDifference(ApproximationScheme):
 
         return results_array
 
-    def _run_sub_point(self, system, idx_info, delta, total, idx_range, rel_element=False):
+    def _run_sub_point(self, system, idx_info, delta, total, loc_idx, rel_element=False):
         """
         Alter the specified inputs by the given delta, run the system, and return the results.
 
@@ -375,7 +376,7 @@ class FiniteDifference(ApproximationScheme):
             Perturbation amount.
         total : bool
             If True total derivatives are being approximated, else partials.
-        idx_range : range
+        loc_idx : range
             Range of vector indices for this wrt variable.
         rel_element : bool
             If True, then each element has a different delta.
@@ -390,7 +391,7 @@ class FiniteDifference(ApproximationScheme):
 
                 # Support rel_element stepsizing
                 if rel_element:
-                    local_delta = delta[idxs - idx_range[0]]
+                    local_delta = delta[loc_idx]
                 else:
                     local_delta = delta
 

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -322,7 +322,6 @@ class FiniteDifference(ApproximationScheme):
                 current_vec = system._outputs if total else system._residuals
                 # copy data from outputs (if doing total derivs) or residuals (if doing partials)
                 results_array[:] = current_vec.asarray()
-                print('results_array', loc_idx, current_coeff, results_array)
                 results_array *= current_coeff[loc_idx]
 
             else:

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -307,7 +307,7 @@ class FiniteDifference(ApproximationScheme):
         total : bool
             If True total derivatives are being approximated, else partials.
         loc_idx : int
-            Current index of variable being stepped: only used when calc_type is rel_element.
+            Current index of variable being stepped: only used when step_calc is rel_element.
 
         Returns
         -------
@@ -364,9 +364,9 @@ class FiniteDifference(ApproximationScheme):
         total : bool
             If True total derivatives are being approximated, else partials.
         loc_idx : range
-            Range of vector indices for this wrt variable.
+            Current index of variable being stepped: only used when step_calc is rel_element.
         rel_element : int
-            Current index of variable being stepped: only used when calc_type is rel_element.
+            If True, then each element has a different delta.
 
         Returns
         -------

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -322,13 +322,7 @@ class FiniteDifference(ApproximationScheme):
                 current_vec = system._outputs if total else system._residuals
                 # copy data from outputs (if doing total derivs) or residuals (if doing partials)
                 results_array[:] = current_vec.asarray()
-
-                for vec, idxs in idx_info:
-                    if vec is not None and idxs is not None:
-
-                        results_array *= current_coeff[loc_idx]
-                        # We don't allow mixed fd forms, so first one is all we need.
-                        break
+                results_array *= current_coeff[loc_idx]
 
             else:
                 results_array[:] = 0.
@@ -347,10 +341,7 @@ class FiniteDifference(ApproximationScheme):
                                           rel_element=rel_element)
 
             if rel_element:
-                for vec, idxs in idx_info:
-                    if vec is not None and idxs is not None:
-                        results *= coeff[loc_idx]
-                        break
+                results *= coeff[loc_idx]
             else:
                 results *= coeff
 

--- a/openmdao/approximation_schemes/finite_difference.py
+++ b/openmdao/approximation_schemes/finite_difference.py
@@ -306,8 +306,8 @@ class FiniteDifference(ApproximationScheme):
             Where the results will be stored.
         total : bool
             If True total derivatives are being approximated, else partials.
-        loc_idx : range
-            Range of vector indices for this wrt variable.
+        loc_idx : int
+            Current index of variable being stepped: only used when calc_type is rel_element.
 
         Returns
         -------
@@ -315,13 +315,9 @@ class FiniteDifference(ApproximationScheme):
             Copy of the outputs or residuals array after running the perturbed system.
         """
         deltas, coeffs, current_coeff = data
-        rel_element = False
-        print(loc_idx, idx_info)
+        rel_element = isinstance(current_coeff, np.ndarray) and current_coeff.size > 1
 
-        if isinstance(current_coeff, np.ndarray) and current_coeff.size > 1:
-            # rel_element - each element has its own relative step.
-            rel_element = True
-
+        if rel_element:
             if current_coeff[0]:
                 current_vec = system._outputs if total else system._residuals
                 # copy data from outputs (if doing total derivs) or residuals (if doing partials)
@@ -378,8 +374,8 @@ class FiniteDifference(ApproximationScheme):
             If True total derivatives are being approximated, else partials.
         loc_idx : range
             Range of vector indices for this wrt variable.
-        rel_element : bool
-            If True, then each element has a different delta.
+        rel_element : int
+            Current index of variable being stepped: only used when calc_type is rel_element.
 
         Returns
         -------

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2999,6 +2999,12 @@ class Group(System):
         wrt = []
         for name, m in self._owns_approx_wrt.items():
             src = m['source']
+            if src in ivc:
+                wrt.append(src)
+            else:
+                raise RuntimeError("When computing total derivatives for the model, the "
+                                   f"wrt variable '{name}' is not an independent variable "
+                                   "or does not have an independant variable as a source.")
             wrt.append(src)
 
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -2999,12 +2999,8 @@ class Group(System):
         wrt = []
         for name, m in self._owns_approx_wrt.items():
             src = m['source']
-            if src in ivc:
-                wrt.append(src)
-            else:
-                raise RuntimeError("When computing total derivatives for the model, the "
-                                   f"wrt variable '{name}' is not an independent variable "
-                                   "or does not have an independant variable as a source.")
+            wrt.append(src)
+
 
         of = [m['source'] for m in self._owns_approx_of.values()]
 

--- a/openmdao/core/group.py
+++ b/openmdao/core/group.py
@@ -3005,8 +3005,6 @@ class Group(System):
                 raise RuntimeError("When computing total derivatives for the model, the "
                                    f"wrt variable '{name}' is not an independent variable "
                                    "or does not have an independant variable as a source.")
-            wrt.append(src)
-
 
         of = [m['source'] for m in self._owns_approx_of.values()]
 

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2331,6 +2331,48 @@ class TestFDRelative(unittest.TestCase):
         # Central diff is super accurate on this.
         assert_near_equal(deriv, x, 1e-6)
 
+    def test_rel_element_steps(self):
+        # This test explicitly checks that the steps are the correct size.
+
+        class MatMultComp(om.ExplicitComponent):
+
+            def setup(self):
+                self.add_input('x', val=np.ones(3))
+                self.add_output('y', val=np.zeros(3))
+                self.cache = []
+
+            def setup_partials(self):
+                self.declare_partials('*', '*', method='fd', step=0.1, step_calc='rel_element', form='central')
+
+            def compute(self, inputs, outputs):
+                outputs['y'] = 2 * inputs['x']
+                self.cache.append(inputs['x'].copy())
+
+        p = om.Problem()
+        model = p.model
+        comp = model.add_subsystem('comp', MatMultComp())
+
+        p.setup(mode='fwd')
+
+        # Make it obvious that we are stepping correctly.
+        model.set_val('comp.x', np.array([3.0, 40.0, 500.0]))
+
+        p.run_model()
+
+        J = p.compute_totals(of=['comp.y'], wrt=['comp.x'], return_format='array')
+        x_vals = comp.cache
+
+        # All steps are 10%, forward then back.
+
+        assert_near_equal(x_vals[1], np.array([3.3, 40.0, 500.0]))
+        assert_near_equal(x_vals[2], np.array([2.7, 40.0, 500.0]))
+
+        assert_near_equal(x_vals[3], np.array([3.0, 44.0, 500.0]))
+        assert_near_equal(x_vals[4], np.array([3.0, 36.0, 500.0]))
+
+        assert_near_equal(x_vals[5], np.array([3.0, 40.0, 550.0]))
+        assert_near_equal(x_vals[6], np.array([3.0, 40.0, 450.0]))
+
     def test_minimum_step(self):
         # Test that minimum_step prevents us from taking a zero step.
 

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2337,8 +2337,8 @@ class TestFDRelative(unittest.TestCase):
         class MatMultComp(om.ExplicitComponent):
 
             def setup(self):
-                self.add_input('z', val=np.ones(2))
                 self.add_input('x', val=np.ones(3))
+                self.add_input('z', val=np.ones(2))
                 self.add_output('y', val=np.zeros(3))
                 self.cache_x = []
                 self.cache_z = []

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2336,6 +2336,9 @@ class TestFDRelative(unittest.TestCase):
 
         class MatMultComp(om.ExplicitComponent):
 
+            def initialize(self):
+                self.options.declare('form')
+
             def setup(self):
                 self.add_input('x', val=np.ones(3))
                 self.add_input('z', val=np.ones(2))
@@ -2344,16 +2347,18 @@ class TestFDRelative(unittest.TestCase):
                 self.cache_z = []
 
             def setup_partials(self):
-                self.declare_partials('*', '*', method='fd', step=0.1, step_calc='rel_element', form='central')
+                self.declare_partials('*', '*', method='fd', step=0.1, step_calc='rel_element', form=self.options['form'])
 
             def compute(self, inputs, outputs):
                 outputs['y'] = 2 * inputs['x'] + np.sum(inputs['z'])
                 self.cache_x.append(inputs['x'].copy())
                 self.cache_z.append(inputs['z'].copy())
 
+        # Do central
+
         p = om.Problem()
         model = p.model
-        comp = model.add_subsystem('comp', MatMultComp())
+        comp = model.add_subsystem('comp', MatMultComp(form='central'))
 
         p.setup(mode='fwd')
 
@@ -2383,6 +2388,33 @@ class TestFDRelative(unittest.TestCase):
 
         assert_near_equal(z_vals[9], np.array([13.0, 24.2]))
         assert_near_equal(z_vals[10], np.array([13.0, 19.8]))
+
+        # Do forward
+
+        p = om.Problem()
+        model = p.model
+        comp = model.add_subsystem('comp', MatMultComp(form='forward'))
+
+        p.setup(mode='fwd')
+
+        # Make it obvious that we are stepping correctly.
+        model.set_val('comp.x', np.array([3.0, 40.0, 500.0]))
+        model.set_val('comp.z', np.array([13.0, 22.0]))
+
+        p.run_model()
+
+        J = p.compute_totals(of=['comp.y'], wrt=['comp.x', 'comp.z'], return_format='array')
+        x_vals = comp.cache_x
+        z_vals = comp.cache_z
+
+        # All steps are 10%, forward then back.
+
+        assert_near_equal(x_vals[1], np.array([3.3, 40.0, 500.0]))
+        assert_near_equal(x_vals[2], np.array([3.0, 44.0, 500.0]))
+        assert_near_equal(x_vals[3], np.array([3.0, 40.0, 550.0]))
+
+        assert_near_equal(z_vals[4], np.array([14.3, 22.0]))
+        assert_near_equal(z_vals[5], np.array([13.0, 24.2]))
 
     def test_minimum_step(self):
         # Test that minimum_step prevents us from taking a zero step.

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2337,8 +2337,8 @@ class TestFDRelative(unittest.TestCase):
         class MatMultComp(om.ExplicitComponent):
 
             def setup(self):
-                self.add_input('x', val=np.ones(3))
                 self.add_input('z', val=np.ones(2))
+                self.add_input('x', val=np.ones(3))
                 self.add_output('y', val=np.zeros(3))
                 self.cache_x = []
                 self.cache_z = []

--- a/openmdao/core/tests/test_approx_derivs.py
+++ b/openmdao/core/tests/test_approx_derivs.py
@@ -2338,15 +2338,18 @@ class TestFDRelative(unittest.TestCase):
 
             def setup(self):
                 self.add_input('x', val=np.ones(3))
+                self.add_input('z', val=np.ones(2))
                 self.add_output('y', val=np.zeros(3))
-                self.cache = []
+                self.cache_x = []
+                self.cache_z = []
 
             def setup_partials(self):
                 self.declare_partials('*', '*', method='fd', step=0.1, step_calc='rel_element', form='central')
 
             def compute(self, inputs, outputs):
-                outputs['y'] = 2 * inputs['x']
-                self.cache.append(inputs['x'].copy())
+                outputs['y'] = 2 * inputs['x'] + np.sum(inputs['z'])
+                self.cache_x.append(inputs['x'].copy())
+                self.cache_z.append(inputs['z'].copy())
 
         p = om.Problem()
         model = p.model
@@ -2356,11 +2359,13 @@ class TestFDRelative(unittest.TestCase):
 
         # Make it obvious that we are stepping correctly.
         model.set_val('comp.x', np.array([3.0, 40.0, 500.0]))
+        model.set_val('comp.z', np.array([13.0, 22.0]))
 
         p.run_model()
 
-        J = p.compute_totals(of=['comp.y'], wrt=['comp.x'], return_format='array')
-        x_vals = comp.cache
+        J = p.compute_totals(of=['comp.y'], wrt=['comp.x', 'comp.z'], return_format='array')
+        x_vals = comp.cache_x
+        z_vals = comp.cache_z
 
         # All steps are 10%, forward then back.
 
@@ -2372,6 +2377,12 @@ class TestFDRelative(unittest.TestCase):
 
         assert_near_equal(x_vals[5], np.array([3.0, 40.0, 550.0]))
         assert_near_equal(x_vals[6], np.array([3.0, 40.0, 450.0]))
+
+        assert_near_equal(z_vals[7], np.array([14.3, 22.0]))
+        assert_near_equal(z_vals[8], np.array([11.7, 22.0]))
+
+        assert_near_equal(z_vals[9], np.array([13.0, 24.2]))
+        assert_near_equal(z_vals[10], np.array([13.0, 19.8]))
 
     def test_minimum_step(self):
         # Test that minimum_step prevents us from taking a zero step.


### PR DESCRIPTION
### Summary

Fixed a bug where the "rel_element" calc_step didn't work correctly in the presence of other inputs.
Essentially, we weren't properly figuring out the correct index to apply each relative step. Sometimes this lead to indexerrors, other times it just led to using the wrong stepsize at a particular index.

Added a test that directly checks the inputs that were stepped.

### Related Issues

- Resolves #3708 

### Backwards incompatibilities

None

### New Dependencies

None
