### PR TITLE
Fix bug where n2 wasn't correctly running setup part II

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1282,7 +1282,14 @@ class Problem(object, metaclass=ProblemMetaclass):
 
         if status >= _SetupStatus.POST_SETUP2:
             if self._metadata['setup_status'] < _SetupStatus.POST_SETUP2:
-                self.model._setup_part2()
+                self._metadata['static_mode'] = False
+                try:
+                    self.model._setup_part2()
+                    self._check_collected_errors()
+                finally:
+                    # whenever we're outside of model._setup, static mode should be True so that
+                    # anything added outside of _setup will persist.
+                    self._metadata['static_mode'] = True
                 self._metadata['setup_status'] = _SetupStatus.POST_SETUP2
 
         if status >= _SetupStatus.POST_FINAL_SETUP:


### PR DESCRIPTION
### Summary

When you call om.n2(prob) before setup, it runs "setup part 2" to assemble the remainder of what it needs for building the n2. However, it wasn't running it correctly, and notably the "static_mode" flag needed to be turned off while running the part 2 setup method.

### Related Issues

- Resolves #3743

### Backwards incompatibilities

None

### New Dependencies

None
