### PR TITLE
Fixed System._call_user_function to handle OutOfBoundsError

### DIFF
--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2954,8 +2954,9 @@ class System(object, metaclass=SystemMetaclass):
             if str(err).startswith(self.msginfo):
                 raise
             else:
-                err.add_note(f'{self.msginfo}: Encountered error calling {fname}')
-                raise
+                msg = err.args[0] if err.args else ''
+                err.args = (f"{self.msginfo}: Error calling {fname}(), " + msg,) + err.args[1:]
+                raise 
         finally:
             self._inputs.read_only = False
             self._outputs.read_only = False

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2950,19 +2950,13 @@ class System(object, metaclass=SystemMetaclass):
 
         try:
             yield
-        except Exception:
-            err_type, err, trace = sys.exc_info()
+        except Exception as err:
+            # err_type, err, trace = sys.exc_info()
             if str(err).startswith(self.msginfo):
                 raise
             else:
-                new_msg = f"{self.msginfo}: Error calling {fname}(), {err}"
-                try:
-                    new_err = err_type(new_msg)
-                except TypeError:
-                    # OutOfBoundsError requires idx, value, lower, upper).
-                    # Fall back to RuntimeError so the diagnostic message is not lost.
-                    raise RuntimeError(new_msg).with_traceback(trace) from None
-                raise new_err.with_traceback(trace)
+                err.add_note(f'{self.msginfo}: Encountered error calling {fname}')
+                raise
         finally:
             self._inputs.read_only = False
             self._outputs.read_only = False

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2951,7 +2951,6 @@ class System(object, metaclass=SystemMetaclass):
         try:
             yield
         except Exception as err:
-            # err_type, err, trace = sys.exc_info()
             if str(err).startswith(self.msginfo):
                 raise
             else:

--- a/openmdao/core/system.py
+++ b/openmdao/core/system.py
@@ -2955,8 +2955,14 @@ class System(object, metaclass=SystemMetaclass):
             if str(err).startswith(self.msginfo):
                 raise
             else:
-                raise err_type(
-                    f"{self.msginfo}: Error calling {fname}(), {err}").with_traceback(trace)
+                new_msg = f"{self.msginfo}: Error calling {fname}(), {err}"
+                try:
+                    new_err = err_type(new_msg)
+                except TypeError:
+                    # OutOfBoundsError requires idx, value, lower, upper).
+                    # Fall back to RuntimeError so the diagnostic message is not lost.
+                    raise RuntimeError(new_msg).with_traceback(trace) from None
+                raise new_err.with_traceback(trace)
         finally:
             self._inputs.read_only = False
             self._outputs.read_only = False

--- a/openmdao/core/tests/test_call_user_function_outofbounds.py
+++ b/openmdao/core/tests/test_call_user_function_outofbounds.py
@@ -24,7 +24,6 @@ import unittest
 
 import openmdao.api as om
 from openmdao.components.interp_util.outofbounds_error import OutOfBoundsError
-from openmdao.utils.assert_utils import assert_warning
 from openmdao.utils.testing_utils import use_tempdirs
 
 
@@ -78,12 +77,13 @@ class TestCallUserFunctionOutOfBounds(unittest.TestCase):
         #
         # After the fix it should raise RuntimeError (or OutOfBoundsError) with
         # a message that mentions both the component and the original error.
-        with self.assertRaises((RuntimeError, OutOfBoundsError)) as ctx:
+        with self.assertRaises((OutOfBoundsError)) as ctx:
             p.run_model()
 
         # The error message must contain the component path so the user can
-        # identify which component is out of bounds.
-        self.assertIn('comp', str(ctx.exception))
+        # identify which component is out of bounds. This is stored in the
+        # notes of the exception by the call_user_function wrapper.
+        self.assertIn('comp', '\n'.join(ctx.exception.__notes__))
 
         # The error message must also carry the original out-of-bounds description.
         self.assertIn('outside the interpolation range', str(ctx.exception))

--- a/openmdao/core/tests/test_call_user_function_outofbounds.py
+++ b/openmdao/core/tests/test_call_user_function_outofbounds.py
@@ -1,0 +1,93 @@
+"""
+Test that OutOfBoundsError raised inside a user compute() function is reported
+clearly rather than being masked by a secondary TypeError.
+
+Background
+----------
+`System._call_user_function` (openmdao/core/system.py) wraps user-defined
+callbacks (compute, apply_nonlinear, etc.) and re-raises any exception as::
+
+    raise err_type(f"{msginfo}: Error calling {fname}(), {err}")
+
+For most exception types this is fine because they accept a single string
+argument.  `OutOfBoundsError`, however, requires five positional arguments::
+
+    OutOfBoundsError(message, idx, value, lower, upper)
+
+Attempting to construct it with only a formatted message string raises a
+secondary ``TypeError: OutOfBoundsError.__init__() missing 4 required
+positional arguments``.  This TypeError then masks the original
+OutOfBoundsError and provides no useful diagnostic information to the user.
+"""
+
+import unittest
+
+import openmdao.api as om
+from openmdao.components.interp_util.outofbounds_error import OutOfBoundsError
+from openmdao.utils.assert_utils import assert_warning
+from openmdao.utils.testing_utils import use_tempdirs
+
+
+class RaisesOutOfBoundsComp(om.ExplicitComponent):
+    """
+    Minimal component that intentionally raises OutOfBoundsError in compute().
+
+    This simulates what an interpolation component does when an input value
+    falls outside the tabulated domain.
+    """
+
+    def setup(self):
+        self.add_input('x', val=0.5)
+        self.add_output('y', val=1.0)
+
+    def compute(self, inputs, outputs):
+        x = float(inputs['x'].flat[0])
+        lower, upper = 0.0, 1.0
+        if x < lower or x > upper:
+            raise OutOfBoundsError(
+                f"Input x={x} is outside the interpolation range [{lower}, {upper}].",
+                idx=0,
+                value=x,
+                lower=lower,
+                upper=upper,
+            )
+        outputs['y'] = x ** 2
+
+
+@use_tempdirs
+class TestCallUserFunctionOutOfBounds(unittest.TestCase):
+    """
+    Verify that OutOfBoundsError raised in a component compute() surfaces as a
+    clear RuntimeError (or OutOfBoundsError) rather than a secondary TypeError.
+
+    In OpenMDAO <= 3.43.0, this was raising the following:
+
+        TypeError: OutOfBoundsError.__init__() missing 4 required positional
+        arguments: 'idx', 'value', 'lower', and 'upper'
+    """
+
+    def test_outofbounds_not_masked_by_typeerror(self):
+        """OutOfBoundsError in compute() must not be hidden by a secondary TypeError."""
+        p = om.Problem()
+        p.model.add_subsystem('comp', RaisesOutOfBoundsComp())
+        p.setup()
+        p.set_val('comp.x', 2.0)  # outside [0, 1] — will trigger OutOfBoundsError
+
+        # Before the fix this raises:
+        #   TypeError: OutOfBoundsError.__init__() missing 4 required positional arguments
+        #
+        # After the fix it should raise RuntimeError (or OutOfBoundsError) with
+        # a message that mentions both the component and the original error.
+        with self.assertRaises((RuntimeError, OutOfBoundsError)) as ctx:
+            p.run_model()
+
+        # The error message must contain the component path so the user can
+        # identify which component is out of bounds.
+        self.assertIn('comp', str(ctx.exception))
+
+        # The error message must also carry the original out-of-bounds description.
+        self.assertIn('outside the interpolation range', str(ctx.exception))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openmdao/core/tests/test_call_user_function_outofbounds.py
+++ b/openmdao/core/tests/test_call_user_function_outofbounds.py
@@ -80,14 +80,9 @@ class TestCallUserFunctionOutOfBounds(unittest.TestCase):
         with self.assertRaises((OutOfBoundsError)) as ctx:
             p.run_model()
 
-        # The error message must contain the component path so the user can
-        # identify which component is out of bounds. This is stored in the
-        # notes of the exception by the call_user_function wrapper.
-        self.assertIn('comp', '\n'.join(ctx.exception.__notes__))
-
-        # The error message must also carry the original out-of-bounds description.
-        self.assertIn('outside the interpolation range', str(ctx.exception))
-
+        self.assertEqual("'comp' <class RaisesOutOfBoundsComp>: Error calling compute(), "
+                         "Input x=2.0 is outside the interpolation range [0.0, 1.0].",
+                         str(ctx.exception))
 
 if __name__ == '__main__':
     unittest.main()

--- a/openmdao/jacobians/tests/test_jacobian.py
+++ b/openmdao/jacobians/tests/test_jacobian.py
@@ -777,7 +777,7 @@ class TestJacobian(unittest.TestCase):
         with self.assertRaises(KeyError) as ctx:
             prob.compute_totals(of=['comp.y'], wrt=['p1.x'])
 
-        self.assertEqual(ctx.exception.args[0], '\'comp\' <class Undeclared>: Error calling compute_partials(), "Variable name pair (\'y\', \'x\') must first be declared."')
+        self.assertEqual(ctx.exception.args[0], '\'comp\' <class Undeclared>: Error calling compute_partials(), Variable name pair (\'y\', \'x\') must first be declared.')
 
     def test_one_src_2_tgts_with_src_indices_densejac(self):
         size = 4


### PR DESCRIPTION
### Summary

When `System._call_user_function` encounters an error, it attempts to reraise it, wrapping the message string.  However, OutOfBoundsError was not able to be instantiated with a single string argument. To make this robust since other errors may also be instantiated in non-standard ways, `System._call_user_function` now reraises the same exception after modifying the string message.

### Related Issues

- Resolves #3750 

### Backwards incompatibilities

None

### New Dependencies

None
