### PR TITLE
Added a lockfile update workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Basic `dependabot.yml` file with
+# minimum configuration for three package managers
+
+version: 2
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`
+    # You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -42,7 +42,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup conda
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/update_pixi_lockfile.yml
+++ b/.github/workflows/update_pixi_lockfile.yml
@@ -1,0 +1,46 @@
+name: Update pixi lockfile
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      cooldown_days:
+        description: 'Exclude packages uploaded within this many days (supply chain cooldown)'
+        required: false
+        default: '7'
+        type: string
+  schedule:
+    - cron: '0 5 15 * *'  # Runs at 05:00 UTC on the 15th of every month
+
+jobs:
+  pixi-update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up pixi
+        uses: prefix-dev/setup-pixi@v0.8.3
+        with:
+          run-install: false
+      - name: Apply cooldown period
+        run: |
+          COOLDOWN="${{ inputs.cooldown_days || '7' }}"
+          sed -i "s/exclude-newer = \"[0-9]*d\"/exclude-newer = \"${COOLDOWN}d\"/" pixi.toml
+      - name: Update lockfile
+        run: |
+          set -o pipefail
+          pixi update --json --no-install | pixi exec pixi-diff-to-markdown >> diff.md
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: 'Update pixi lockfile'
+          title: 'Update pixi lockfile'
+          body-path: diff.md
+          branch: update-pixi-lockfile
+          base: master
+          labels: pixi
+          delete-branch: true
+          add-paths: pixi.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,12 @@ repos:
       # For now, only run on the pixi workflows
       files: ^\.github/workflows/.*_pixi\.ya?ml$
       # files: ^\.github/workflows/.*\.ya?ml$
+
+- repo: local
+  hooks:
+    - id: check-pixi-lock-changes
+      name: Check pixi.lock without pixi.toml changes
+      entry: python openmdao/devtools/check_pixi_lock.py
+      language: system
+      files: pixi.lock
+      stages: [commit]

--- a/openmdao/devtools/check_pixi_lock.py
+++ b/openmdao/devtools/check_pixi_lock.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+"""Pre-commit hook to prevent accidental pixi.lock commits without pixi.toml changes.
+
+Lockfile updates should only occur when dependencies in pixi.toml change.
+This prevents committing pixi.lock alone, which usually indicates
+an accidental commit rather than an intentional dependency update.
+
+To bypass this check for intentional standalone lockfile commits:
+    git commit --no-verify
+"""
+
+import subprocess
+import sys
+
+
+def get_staged_files():
+    """Get list of staged files."""
+    result = subprocess.run(
+        ['git', 'diff', '--cached', '--name-only'],
+        capture_output=True,
+        text=True
+    )
+    return result.stdout.strip().split('\n') if result.stdout.strip() else []
+
+
+def main():
+    """Check if pixi.lock is staged without pixi.toml."""
+    staged_files = get_staged_files()
+
+    has_pixi_lock = 'pixi.lock' in staged_files
+    has_pixi_toml = 'pixi.toml' in staged_files
+
+    if has_pixi_lock and not has_pixi_toml:
+        print('ERROR: pixi.lock is staged but pixi.toml is not.')
+        print()
+        print('Lockfile updates should only happen when updating dependencies in pixi.toml.')
+        print('The lockfile is typically updated via the automated workflow on the 15th of each month.')
+        print()
+        print('If this is an intentional standalone lockfile update, you can bypass this check with:')
+        print('  git commit --no-verify')
+        print()
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/pixi.toml
+++ b/pixi.toml
@@ -43,6 +43,7 @@ description = "OpenMDAO workspace"
 authors = ["OpenMDAO Team <https://github.com/OpenMDAO>"]
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64", "win-64"]
+exclude-newer = "7d"  # Cooldown to mitigate supply chain attacks
 
 ###############################################
 # Base Dependencies


### PR DESCRIPTION
### Summary

- Adds a dependency cooldown period so that pixi will not update packages that were updated in the last 7 days.  This will help to mitigate supply chain attack issues.

- Added a github action that attempts to update the lockfile on the 15th of every month, and automatically submits a PR with the updated lockfile if it was successful. This will then trigger the normal workflow that will catch any issues with packages that updated in a way that break OpenMDAO.

- The lockfile update workflow may also be triggered manually with workflow dispatch, and the cooldown period modified. If we discover urgent changes we can update the lockfile with a smaller cooldown period.

- Added a pre-commit hook that rejects the commit if the lockfile is updated without corresponding changes to the pixi.toml file. This serves as a check against accidental updates that shouldn't be committed.  If necessary, it can be overridden with the `--no-verify` flag.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
