### PR TITLE
MacOS CI Stability

### DIFF
--- a/.github/actions/build_docs/action.yml
+++ b/.github/actions/build_docs/action.yml
@@ -134,7 +134,7 @@ runs:
 
     - name: Slack doc build failure
       if: steps.build_docs.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.SECRET_slack_webhook_url }}
         status: ${{ steps.build_docs.outcome }}

--- a/.github/actions/display_environment_info/action.yml
+++ b/.github/actions/display_environment_info/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Slack env change
       if: steps.env_info.outputs.errors != ''
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.SECRET_slack_webhook_url }}
         status: 'warning'

--- a/.github/actions/run_openmdao_tests_pixi/action.yml
+++ b/.github/actions/run_openmdao_tests_pixi/action.yml
@@ -199,10 +199,6 @@ runs:
           # shellcheck disable=SC2129
           echo "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe" >> "$GITHUB_ENV"
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> "$GITHUB_ENV"
-          echo "OMPI_MCA_btl=^openib" >> "$GITHUB_ENV"
-
-          echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
-          echo "TMPDIR=/tmp" >> "$GITHUB_ENV"
         else
           echo "mpi4py or petsc4py not installed in this environment, skipping MPI checks"
         fi
@@ -228,12 +224,8 @@ runs:
       shell: bash -l {0}
       env:
         OPENMDAO_CHECK_ALL_PARTIALS: true
-        # MPI settings for CI (all platforms)
-        PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
-        OMPI_MCA_rmaps_base_oversubscribe: "1"
         COVERAGE_RUN: "true"
       run: |
-        eval "$(pixi shell-hook -e ${{ inputs.PIXI_ENVIRONMENT }})"
         echo "============================================================="
         echo "Run tests with coverage (from directory other than repo root)"
         echo "============================================================="
@@ -243,20 +235,25 @@ runs:
         cp .coveragerc $HOME
         cd $HOME
 
-        # Build testflo command
-        TESTFLO_CMD="testflo openmdao --skip_dir=.pixi --timeout=240 --durations=20"
+        # Build pixi run test command
+        TESTFLO_ARGS="--timeout=240 --durations=20"
+
+        # Run serially on macOS CI to avoid resource contention on shared runners
+        if [[ "${{ runner.os }}" == "macOS" ]]; then
+          TESTFLO_ARGS="-n 1 $TESTFLO_ARGS"
+        fi
 
         # Only perform coverage on specified OS + Python version combinations
         if [[ "${{ inputs.COVERAGE }}" == "true" ]]; then
-          TESTFLO_CMD="$TESTFLO_CMD --coverage --coverpkg openmdao"
+          TESTFLO_ARGS="$TESTFLO_ARGS --coverage --coverpkg openmdao"
         fi
 
         # Add --show_skipped unless we're in minimal environment
         if [[ "${{ inputs.PIXI_ENVIRONMENT }}" != "minimal" ]]; then
-          TESTFLO_CMD="$TESTFLO_CMD --show_skipped"
+          TESTFLO_ARGS="$TESTFLO_ARGS --show_skipped"
         fi
 
-        $TESTFLO_CMD
+        pixi run --manifest-path $GITHUB_WORKSPACE/pixi.toml -e ${{ inputs.PIXI_ENVIRONMENT }} test $TESTFLO_ARGS
 
     - name: Display test report on failure (bash)
       if: steps.run_tests_bash.outcome == 'failure'
@@ -321,7 +318,7 @@ runs:
 
     - name: Slack failure to upload to coveralls.io
       if: inputs.COVERAGE == 'true' && steps.coveralls.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.slack_webhook_url }}
         status: 'warning'
@@ -355,7 +352,7 @@ runs:
 
     - name: Slack unit test failure
       if: failure() && steps.run_tests_bash.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.slack_webhook_url }}
         status: ${{ steps.run_tests_bash.outcome }}
@@ -365,7 +362,7 @@ runs:
 
     - name: Slack security issue
       if: steps.bandit.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.slack_webhook_url }}
         status: ${{ steps.bandit.outcome }}

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -122,7 +122,7 @@ jobs:
           python -m pip_audit -s osv --ignore-vuln GHSA-g4r7-86gm-pgqc
 
       - name: Notify slack
-        uses: act10ns/slack@v2.0.0
+        uses: act10ns/slack@v2.2.0
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}

--- a/.github/workflows/openmdao_update_poem.yml
+++ b/.github/workflows/openmdao_update_poem.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Slack POEM message
         if: (github.event.action == 'opened' || github.event.action == 'reopened') && steps.check_for_poem.outputs.POEM_ID != ''
-        uses: act10ns/slack@v2.0.0
+        uses: act10ns/slack@v2.2.0
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: 'warning'

--- a/pixi.toml
+++ b/pixi.toml
@@ -223,7 +223,7 @@ py314 = { features = ["py314", "doe", "opt", "jax", "numba", "notebooks", "visua
 # Development workflow helpers
 clean = "rm -rf packaging dist *.egg-info .pixi"
 
-test = "testflo --skip_dir=.pixi"
+test = { cmd = "testflo openmdao --skip_dir=.pixi" }
 
 # Install OpenMDAO in development mode and set up pre-commit hooks
 install-openmdao-dev = { cmd = "pip install --no-deps -e . && pre-commit install", description = "Install OpenMDAO in development mode and set up pre-commit hooks" }
@@ -244,3 +244,8 @@ description = "Build SNOPT module. Usage: pixi run build-snopt <path_to_snopt_so
 args = ["snopt_src"]
 cmd = "python -m build_pyoptsparse.snopt_module {{snopt_src}}"
 
+[target.osx-64.tasks]
+test = { cmd = "testflo openmdao --skip_dir=.pixi", env = { OMPI_MCA_rmaps_base_oversubscribe = "1", OMPI_MCA_hwloc_base_binding_policy = "none", TMPDIR = "/tmp" } }
+
+[target.osx-arm64.tasks]
+test = { cmd = "testflo openmdao --skip_dir=.pixi", env = { OMPI_MCA_rmaps_base_oversubscribe = "1", OMPI_MCA_hwloc_base_binding_policy = "none", TMPDIR = "/tmp" } }


### PR DESCRIPTION
### Summary

Update some environment variables and switch OS X runners to use 1 process under testflo.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
