### PR TITLE
Fix intermittent MPI test timeouts on macOS runners

### DIFF
--- a/.github/actions/build_docs/action.yml
+++ b/.github/actions/build_docs/action.yml
@@ -134,7 +134,7 @@ runs:
 
     - name: Slack doc build failure
       if: steps.build_docs.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.SECRET_slack_webhook_url }}
         status: ${{ steps.build_docs.outcome }}

--- a/.github/actions/display_environment_info/action.yml
+++ b/.github/actions/display_environment_info/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Slack env change
       if: steps.env_info.outputs.errors != ''
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.SECRET_slack_webhook_url }}
         status: 'warning'

--- a/.github/actions/run_openmdao_tests_pixi/action.yml
+++ b/.github/actions/run_openmdao_tests_pixi/action.yml
@@ -184,6 +184,7 @@ runs:
           echo "============================================================="
           export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe
           export OMPI_MCA_rmaps_base_oversubscribe=1
+          export OMPI_MCA_mpi_yield_when_idle=1
           export OMPI_MCA_btl=^openib
           echo "-----------------------"
           echo "Quick test of mpi4py:"
@@ -199,6 +200,7 @@ runs:
           # shellcheck disable=SC2129
           echo "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe" >> "$GITHUB_ENV"
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> "$GITHUB_ENV"
+          echo "OMPI_MCA_mpi_yield_when_idle=1" >> "$GITHUB_ENV"
           echo "OMPI_MCA_btl=^openib" >> "$GITHUB_ENV"
 
           echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
@@ -231,6 +233,9 @@ runs:
         # MPI settings for CI (all platforms)
         PRTE_MCA_rmaps_default_mapping_policy: ":oversubscribe"
         OMPI_MCA_rmaps_base_oversubscribe: "1"
+        # Make oversubscribed MPI ranks yield the CPU while idle instead of
+        # busy-polling, which starves working ranks on the small CI runners
+        OMPI_MCA_mpi_yield_when_idle: "1"
         COVERAGE_RUN: "true"
       run: |
         eval "$(pixi shell-hook -e ${{ inputs.PIXI_ENVIRONMENT }})"
@@ -245,6 +250,12 @@ runs:
 
         # Build testflo command
         TESTFLO_CMD="testflo openmdao --skip_dir=.pixi --timeout=240 --durations=20"
+
+        # Limit concurrency on macOS runners, which have only 3-4 cores and
+        # bog down when N_PROCS=8 MPI tests run alongside other test workers
+        if [[ "$RUNNER_OS" == "macOS" ]]; then
+          TESTFLO_CMD="$TESTFLO_CMD -n 2"
+        fi
 
         # Only perform coverage on specified OS + Python version combinations
         if [[ "${{ inputs.COVERAGE }}" == "true" ]]; then

--- a/.github/actions/run_openmdao_tests_pixi/action.yml
+++ b/.github/actions/run_openmdao_tests_pixi/action.yml
@@ -332,7 +332,7 @@ runs:
 
     - name: Slack failure to upload to coveralls.io
       if: inputs.COVERAGE == 'true' && steps.coveralls.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.slack_webhook_url }}
         status: 'warning'
@@ -366,7 +366,7 @@ runs:
 
     - name: Slack unit test failure
       if: failure() && steps.run_tests_bash.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.slack_webhook_url }}
         status: ${{ steps.run_tests_bash.outcome }}
@@ -376,7 +376,7 @@ runs:
 
     - name: Slack security issue
       if: steps.bandit.outcome == 'failure'
-      uses: act10ns/slack@v2.0.0
+      uses: act10ns/slack@v2.2.0
       with:
         webhook-url: ${{ inputs.slack_webhook_url }}
         status: ${{ steps.bandit.outcome }}

--- a/.github/actions/run_openmdao_tests_pixi/action.yml
+++ b/.github/actions/run_openmdao_tests_pixi/action.yml
@@ -200,11 +200,9 @@ runs:
           # shellcheck disable=SC2129
           echo "PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe" >> "$GITHUB_ENV"
           echo "OMPI_MCA_rmaps_base_oversubscribe=1" >> "$GITHUB_ENV"
-          echo "OMPI_MCA_mpi_yield_when_idle=1" >> "$GITHUB_ENV"
-          echo "OMPI_MCA_btl=^openib" >> "$GITHUB_ENV"
+          echo "OMPI_MCA_btl=tcp,self" >> "$GITHUB_ENV"
+          echo "OMPI_MCA_orte_tmpdir_base=$RUNNER_TEMP/ompi" >> "$GITHUB_ENV"
 
-          echo "Workaround for intermittent failures with OMPI https://github.com/open-mpi/ompi/issues/7393"
-          echo "TMPDIR=/tmp" >> "$GITHUB_ENV"
         else
           echo "mpi4py or petsc4py not installed in this environment, skipping MPI checks"
         fi

--- a/.github/actions/setup_openmdao_pixi/action.yml
+++ b/.github/actions/setup_openmdao_pixi/action.yml
@@ -101,9 +101,9 @@ runs:
               exit 1
             fi
             echo "Building wheel"
-            cd ${{ github.workspace }}
+            cd "$GITHUB_WORKSPACE"
             python -m pip install build
-            python -m build --wheel
+            python -m build --wheel --no-isolation
             WHEEL=$(find dist/openmdao-*.whl)
             echo "Installing from wheel: $WHEEL"
             python -m pip install "${WHEEL}" --no-deps

--- a/.github/actions/setup_openmdao_pixi/action.yml
+++ b/.github/actions/setup_openmdao_pixi/action.yml
@@ -102,7 +102,9 @@ runs:
             fi
             echo "Building wheel"
             cd "$GITHUB_WORKSPACE"
-            python -m pip install build
+            # Manually install package requirements for the isolated build environment.
+            python -m pip install build hatchling "numpy>=2.0"
+
             python -m build --wheel --no-isolation
             WHEEL=$(find dist/openmdao-*.whl)
             echo "Installing from wheel: $WHEEL"

--- a/.github/workflows/openmdao_audit.yml
+++ b/.github/workflows/openmdao_audit.yml
@@ -122,7 +122,7 @@ jobs:
           python -m pip_audit -s osv --ignore-vuln GHSA-g4r7-86gm-pgqc
 
       - name: Notify slack
-        uses: act10ns/slack@v2.0.0
+        uses: act10ns/slack@v2.2.0
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: ${{ job.status }}

--- a/.github/workflows/openmdao_update_poem.yml
+++ b/.github/workflows/openmdao_update_poem.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Slack POEM message
         if: (github.event.action == 'opened' || github.event.action == 'reopened') && steps.check_for_poem.outputs.POEM_ID != ''
-        uses: act10ns/slack@v2.0.0
+        uses: act10ns/slack@v2.2.0
         with:
           webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           status: 'warning'


### PR DESCRIPTION
### Summary

The N_PROCS=8 tests (e.g., in test_parallel_fd.py) were swamping the available cores on MacOS, which do not yield to other ranks by default. This bogged the tests down and led to timeouts.

This is fixed in two ways:
- Sets OMPI_MCA_mpi_yield_when_idle=1 in the test step so waiting ranks yield the CPU instead of spinning at 100%.
- Caps testflo concurrency at `-n 2` on macOS to prevent stacking too many additional test workers on top of 8-rank MPI jobs.

### Related Issues

- Resolves #

### Backwards incompatibilities

None

### New Dependencies

None
