### PR TITLE
Turn off driver scaling in the optimizer report

### DIFF
--- a/openmdao/utils/tests/test_rangemapper.py
+++ b/openmdao/utils/tests/test_rangemapper.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import patch
 
 from openmdao.utils.rangemapper import RangeMapper, RangeTree, FlatRangeMapper
 
@@ -105,7 +106,7 @@ class TestRangeMapper(unittest.TestCase):
                 self.assertEqual(list(mapper.overlap_iter('z', other_mapper)), [('z', 0, 6, 'z', 1, 7)])
 
     def test_dump(self):
-        with unittest.mock.patch('builtins.print') as mock_print:
+        with patch('builtins.print') as mock_print:
             for mclass in (RangeTree, FlatRangeMapper):
                 with self.subTest(msg=f'{mclass.__name__} test'):
                     mapper = mclass(_data.items())

--- a/openmdao/visualization/opt_report/opt_report.py
+++ b/openmdao/visualization/opt_report/opt_report.py
@@ -122,7 +122,7 @@ def opt_report(prob, outfile=None):
     if not outfile:
         outfile = _default_optimizer_report_filename
 
-    driver_scaling = True
+    driver_scaling = False
 
     # Collect the entire array of array valued desvars and constraints (ignore indices)
     objs_vals = {}


### PR DESCRIPTION
### Summary

Turned off driver scaling in the opt report. Never should have been on. The report should all be in physical units

### Related Issues

- Resolves #3794 

### Backwards incompatibilities

None

### New Dependencies

None
