### PR TITLE
Migrate optional DOE dependency from pyDOE3 to pydoe

### DIFF
--- a/.github/scripts/install_latest_deps.sh
+++ b/.github/scripts/install_latest_deps.sh
@@ -27,7 +27,7 @@ python -m pip install --upgrade --pre ipyparallel
 echo "============================================================="
 echo "Install latest versions of 'doe' dependencies"
 echo "============================================================="
-python -m pip install --upgrade --pre pyDOE3
+python -m pip install --upgrade --pre pydoe
 
 echo "============================================================="
 echo "Install latest versions of 'jax' dependencies"

--- a/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
+++ b/openmdao/docs/openmdao_book/features/building_blocks/drivers/doe_driver.ipynb
@@ -25,29 +25,7 @@
    "cell_type": "markdown",
    "id": "0425ab73",
    "metadata": {},
-   "source": [
-    "# DOEDriver\n",
-    "\n",
-    "DOEDriver facilitates performing a design of experiments (DOE) with your OpenMDAO model. It will run your model multiple times with different values for the design variables depending on the selected input generator. A number of generators are available, each with its own parameters that can be specified when it is instantiated:\n",
-    "\n",
-    "  - UniformGenerator\n",
-    "  - FullFactorialGenerator\n",
-    "  - PlackettBurmanGenerator\n",
-    "  - BoxBehnkenGenerator\n",
-    "  - LatinHypercubeGenerator\n",
-    "  - CSVGenerator\n",
-    "  - ListGenerator\n",
-    "\n",
-    "See the [source documentation](../../../_srcdocs/packages/drivers/doe_generators) of these generators for details.\n",
-    "\n",
-    "```{Note}\n",
-    "`FullFactorialGenerator`, `PlackettBurmanGenerator`, `BoxBehnkenGenerator` and `LatinHypercubeGenerator` are provided via the [pyDOE3](https://pypi.org/project/pyDOE3/) package, which is an updated version of [pyDOE](https://pythonhosted.org/pyDOE/). See the original [pyDOE](https://pythonhosted.org/pyDOE/) page for information on those algorithms.\n",
-    "```\n",
-    "\n",
-    "The generator instance may be supplied as an argument to the `DOEDriver` or as an option.\n",
-    "\n",
-    "## DOEDriver Options"
-   ]
+   "source": "# DOEDriver\n\nDOEDriver facilitates performing a design of experiments (DOE) with your OpenMDAO model. It will run your model multiple times with different values for the design variables depending on the selected input generator. A number of generators are available, each with its own parameters that can be specified when it is instantiated:\n\n  - UniformGenerator\n  - FullFactorialGenerator\n  - PlackettBurmanGenerator\n  - BoxBehnkenGenerator\n  - LatinHypercubeGenerator\n  - CSVGenerator\n  - ListGenerator\n\nSee the [source documentation](../../../_srcdocs/packages/drivers/doe_generators) of these generators for details.\n\n```{Note}\n`FullFactorialGenerator`, `PlackettBurmanGenerator`, `BoxBehnkenGenerator` and `LatinHypercubeGenerator` are provided via the [pydoe](https://pypi.org/project/pydoe/) package, the actively maintained continuation of pyDOE2 and pyDOE3. See the [PyDOE documentation](https://pydoe.github.io/pydoe/) for information on those algorithms.\n```\n\nThe generator instance may be supplied as an argument to the `DOEDriver` or as an option.\n\n## DOEDriver Options"
   },
   {
    "cell_type": "code",

--- a/openmdao/drivers/differential_evolution_driver.py
+++ b/openmdao/drivers/differential_evolution_driver.py
@@ -61,11 +61,11 @@ class DifferentialEvolutionDriver(Driver):
         """
         Initialize the DifferentialEvolutionDriver driver.
         """
-        if find_spec('pyDOE3') is None:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+        if find_spec('pydoe') is None:
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(**kwargs)
 
@@ -508,7 +508,7 @@ class DifferentialEvolution(object):
     objfun : function
         Objective function callback.
     _lhs : function
-        The lazily-imported pyDOE3 latin hypercube sampling function.
+        The lazily-imported pydoe latin hypercube sampling function.
     """
 
     def __init__(self, objfun, comm=None, model_mpi=None):
@@ -516,13 +516,13 @@ class DifferentialEvolution(object):
         Initialize genetic algorithm object.
         """
         try:
-            from pyDOE3 import lhs
+            from pydoe import lhs
             self._lhs = lhs
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         self.objfun = objfun
         self.comm = comm

--- a/openmdao/drivers/doe_generators.py
+++ b/openmdao/drivers/doe_generators.py
@@ -271,7 +271,7 @@ class UniformGenerator(DOEGenerator):
 
 class _pyDOE_Generator(DOEGenerator):
     """
-    Base class for DOE case generators implementing methods from pyDOE3.
+    Base class for DOE case generators implementing methods from pydoe.
 
     Parameters
     ----------
@@ -428,20 +428,20 @@ class FullFactorialGenerator(_pyDOE_Generator):
     Attributes
     ----------
     _fullfact : function
-        The pyDOE3 full factorial function, lazily imported.
+        The pydoe full factorial function, lazily imported.
     """
 
     def __init__(self, levels=_LEVELS):
         """Initialize the FullFactorialGenerator."""
         super().__init__(levels=levels)
         try:
-            from pyDOE3 import fullfact
+            from pydoe import fullfact
             self._fullfact = fullfact
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
     def _generate_design(self, size):
         """
@@ -489,7 +489,7 @@ class GeneralizedSubsetGenerator(_pyDOE_Generator):
         factorial designs.
         Defaults to 1.
     _gsd : function
-        The pyDOE3 General Subset Design function, lazily imported.
+        The pydoe General Subset Design function, lazily imported.
     """
 
     def __init__(self, levels, reduction, n=1):
@@ -501,13 +501,13 @@ class GeneralizedSubsetGenerator(_pyDOE_Generator):
         self._n = n
 
         try:
-            from pyDOE3 import gsd
+            from pydoe import gsd
             self._gsd = gsd
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
     def _generate_design(self, size):
         """
@@ -533,7 +533,7 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
     Attributes
     ----------
     _pbdesign : function
-        The pyDOE3 Plackett-Burman function, lazily imported.
+        The pydoe Plackett-Burman function, lazily imported.
     """
 
     def __init__(self):
@@ -543,13 +543,13 @@ class PlackettBurmanGenerator(_pyDOE_Generator):
         super().__init__(levels=2)
 
         try:
-            from pyDOE3 import pbdesign
+            from pydoe import pbdesign
             self._pbdesign = pbdesign
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
     def _generate_design(self, size):
         """
@@ -586,7 +586,7 @@ class BoxBehnkenGenerator(_pyDOE_Generator):
     _center : int
         The number of center points to include.
     _bbdesign : function
-        The pyDOE3 BoxBehnken function, lazily imported.
+        The pydoe BoxBehnken function, lazily imported.
     """
 
     def __init__(self, center=None):
@@ -597,13 +597,13 @@ class BoxBehnkenGenerator(_pyDOE_Generator):
         self._center = center
 
         try:
-            from pyDOE3 import bbdesign
+            from pydoe import bbdesign
             self._bbdesign = bbdesign
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
     def _generate_design(self, size):
         """
@@ -631,7 +631,7 @@ class BoxBehnkenGenerator(_pyDOE_Generator):
 
 class LatinHypercubeGenerator(DOEGenerator):
     """
-    DOE case generator implementing Latin hypercube method via pyDOE3.
+    DOE case generator implementing Latin hypercube method via pydoe.
 
     Parameters
     ----------
@@ -659,7 +659,7 @@ class LatinHypercubeGenerator(DOEGenerator):
     _seed : int or None
         Random seed.
     _lhs : function
-        The pyDOE3 latin hypercube sampling function, lazily imported.
+        The pydoe latin hypercube sampling function, lazily imported.
     """
 
     # supported pyDOE criterion names.
@@ -675,18 +675,18 @@ class LatinHypercubeGenerator(DOEGenerator):
         """
         Initialize the LatinHypercubeGenerator.
 
-        See : https://pythonhosted.org/pyDOE/randomized.html
+        See : https://pydoe.github.io/pydoe/
         """
         super().__init__()
 
         try:
-            from pyDOE3 import lhs
+            from pydoe import lhs
             self._lhs = lhs
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         if criterion not in self._supported_criterion:
             raise ValueError("Invalid criterion '%s' specified for %s. "

--- a/openmdao/drivers/genetic_algorithm_driver.py
+++ b/openmdao/drivers/genetic_algorithm_driver.py
@@ -66,11 +66,11 @@ class SimpleGADriver(Driver):
         """
         Initialize the SimpleGADriver driver.
         """
-        if find_spec('pyDOE3') is None:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+        if find_spec('pydoe') is None:
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(**kwargs)
 
@@ -619,7 +619,7 @@ class GeneticAlgorithm:
     objfun : function
         Objective function callback.
     _lhs : function
-        A lazily imported instance of the pyDOE3 latin hypercube sampling function.
+        A lazily imported instance of the pydoe latin hypercube sampling function.
     """
 
     def __init__(self, objfun, comm=None, model_mpi=None):
@@ -627,13 +627,13 @@ class GeneticAlgorithm:
         Initialize genetic algorithm object.
         """
         try:
-            from pyDOE3 import lhs
+            from pydoe import lhs
             self._lhs = lhs
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         self.objfun = objfun
         self.comm = comm

--- a/openmdao/drivers/sampling/pyDOE_generators.py
+++ b/openmdao/drivers/sampling/pyDOE_generators.py
@@ -1,5 +1,5 @@
 """
-pyDOE3 sample generators for Analysis Driver.
+pydoe sample generators for Analysis Driver.
 """
 import numpy as np
 
@@ -12,7 +12,7 @@ _LEVELS = 2  # default number of levels for pyDOE generators
 
 class _pyDOE_AnalysisGenerator(AnalysisGenerator):
     """
-    Base class for Analysis generators implementing methods from pyDOE3.
+    Base class for Analysis generators implementing methods from pydoe.
 
     Parameters
     ----------
@@ -191,13 +191,13 @@ class FullFactorialGenerator(_pyDOE_AnalysisGenerator):
         Initialize the FullFactorialGenerator.
         """
         try:
-            from pyDOE3 import fullfact
+            from pydoe import fullfact
             self._fullfact = fullfact
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(var_dict=var_dict, levels=levels)
 
@@ -252,7 +252,7 @@ class GeneralizedSubsetGenerator(_pyDOE_AnalysisGenerator):
         factorial designs.
         Defaults to 1.
     _gsd : function
-        The pyDOE3 generalized subset function, lazily imported.
+        The pydoe generalized subset function, lazily imported.
     """
 
     def __init__(self, var_dict, levels, reduction, n=1):
@@ -263,13 +263,13 @@ class GeneralizedSubsetGenerator(_pyDOE_AnalysisGenerator):
         self._n = n
 
         try:
-            from pyDOE3 import gsd
+            from pydoe import gsd
             self._gsd = gsd
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(var_dict, levels=levels)
 
@@ -305,7 +305,7 @@ class PlackettBurmanGenerator(_pyDOE_AnalysisGenerator):
     Attributes
     ----------
     _pbdesign : function
-        The pyDOE3 Plackett-Burman function, lazily imported.
+        The pydoe Plackett-Burman function, lazily imported.
     """
 
     def __init__(self, var_dict):
@@ -313,13 +313,13 @@ class PlackettBurmanGenerator(_pyDOE_AnalysisGenerator):
         Initialize the PlackettBurmanGenerator.
         """
         try:
-            from pyDOE3 import pbdesign
+            from pydoe import pbdesign
             self._pbdesign = pbdesign
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(var_dict, levels=2)
 
@@ -361,7 +361,7 @@ class BoxBehnkenGenerator(_pyDOE_AnalysisGenerator):
     _center : int
         The number of center points to include.
     _bbdesign : function
-        The pyDOE3 Box-Behnken function, lazily imported.
+        The pydoe Box-Behnken function, lazily imported.
     """
 
     def __init__(self, var_dict, center=None):
@@ -370,13 +370,13 @@ class BoxBehnkenGenerator(_pyDOE_AnalysisGenerator):
         """
         self._center = center
         try:
-            from pyDOE3 import bbdesign
+            from pydoe import bbdesign
             self._bbdesign = bbdesign
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(var_dict, levels=3)
 
@@ -406,7 +406,7 @@ class BoxBehnkenGenerator(_pyDOE_AnalysisGenerator):
 
 class LatinHypercubeGenerator(AnalysisGenerator):
     """
-    DOE case generator implementing Latin hypercube method via pyDOE3.
+    DOE case generator implementing Latin hypercube method via pydoe.
 
     Parameters
     ----------
@@ -437,7 +437,7 @@ class LatinHypercubeGenerator(AnalysisGenerator):
     _seed : int or None
         Random seed.
     _lhs : function
-        The pyDOE3 latin hypercube sampling function, lazily imported.
+        The pydoe latin hypercube sampling function, lazily imported.
     """
 
     # supported pyDOE criterion names.
@@ -453,7 +453,7 @@ class LatinHypercubeGenerator(AnalysisGenerator):
         """
         Initialize the LatinHypercubeGenerator.
 
-        See : https://pythonhosted.org/pyDOE/randomized.html
+        See : https://pydoe.github.io/pydoe/
         """
         if criterion not in self._supported_criterion:
             raise ValueError("Invalid criterion '%s' specified for %s. "
@@ -467,13 +467,13 @@ class LatinHypercubeGenerator(AnalysisGenerator):
         self._seed = seed
 
         try:
-            from pyDOE3 import lhs
+            from pydoe import lhs
             self._lhs = lhs
         except ImportError:
-            raise RuntimeError(f"{self.__class__.__name__} requires the 'pyDOE3' package, "
+            raise RuntimeError(f"{self.__class__.__name__} requires the 'pydoe' package, "
                                "which can be installed with one of the following commands:\n"
                                "    pip install openmdao[doe]\n"
-                               "    pip install pyDOE3")
+                               "    pip install pydoe")
 
         super().__init__(var_dict)
 

--- a/openmdao/drivers/sampling/tests/test_pyDOE_sampling.py
+++ b/openmdao/drivers/sampling/tests/test_pyDOE_sampling.py
@@ -5,7 +5,6 @@ import unittest
 
 import numpy as np
 
-from packaging.version import Version
 
 import openmdao.api as om
 
@@ -20,9 +19,9 @@ from openmdao.drivers.sampling.pyDOE_generators import FullFactorialGenerator, \
 
 
 try:
-    import pyDOE3
+    import pydoe
 except ImportError:
-    pyDOE3 = None
+    pydoe = None
 
 
 class ParaboloidArray(om.ExplicitComponent):
@@ -47,27 +46,27 @@ class ParaboloidArray(om.ExplicitComponent):
 
 class TestPyDOEErrors(unittest.TestCase):
 
-    @unittest.skipIf(pyDOE3, "only runs if 'pyDOE3' is not installed")
-    def test_no_pyDOE3(self):
+    @unittest.skipIf(pydoe, "only runs if 'pydoe' is not installed")
+    def test_no_pydoe(self):
         with self.assertRaises(RuntimeError) as err:
             FullFactorialGenerator(var_dict={}, levels=3)
 
         self.assertEqual(str(err.exception),
-                         "FullFactorialGenerator requires the 'pyDOE3' package, "
+                         "FullFactorialGenerator requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
         with self.assertRaises(RuntimeError) as err:
             om.AnalysisDriver(samples=FullFactorialGenerator(var_dict={}, levels=3))
 
         self.assertEqual(str(err.exception),
-                         "FullFactorialGenerator requires the 'pyDOE3' package, "
+                         "FullFactorialGenerator requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_lhc_criterion(self):
         with self.assertRaises(ValueError) as err:
             LatinHypercubeGenerator(var_dict={}, criterion='foo')
@@ -77,7 +76,7 @@ class TestPyDOEErrors(unittest.TestCase):
                          "Must be one of ['center', 'c', 'maximin', 'm', 'centermaximin', "
                          "'cm', 'correlation', 'corr', None].")
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_missing_bounds(self):
         with self.assertRaises(RuntimeError) as err:
             factors = {
@@ -89,7 +88,7 @@ class TestPyDOEErrors(unittest.TestCase):
                          "Unable to determine levels for factor 'x'. Factors dictionary must "
                          "contain both 'lower' and 'upper' keys.")
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_mismatched_bounds(self):
         with self.assertRaises(ValueError) as err:
             factors = {
@@ -103,7 +102,7 @@ class TestPyDOEErrors(unittest.TestCase):
 
 
 @use_tempdirs
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
 class TestPyDOEGenerators(unittest.TestCase):
 
     def setUp(self):
@@ -431,7 +430,7 @@ class TestPyDOEGenerators(unittest.TestCase):
 
         objs = [cr.get_case(case).outputs['f'].item() for case in cases]
 
-        self.assertEqual(len(objs), 104)  # The number can be verified with standalone pyDOE3
+        self.assertEqual(len(objs), 104)  # The number can be verified with standalone pydoe
         # Testing uniqueness. If all elements are unique, it should be the same length as the number of cases
         self.assertEqual(len(set(objs)), 104)
 
@@ -510,45 +509,24 @@ class TestPyDOEGenerators(unittest.TestCase):
         # ref: https://en.wikipedia.org/wiki/Box-Behnken_design
         self.assertEqual(len(cases), (3*4)+center)
 
-        # slight change in order from refactor in pyDOE3 v1.0.4 (PR #15)
-        if Version(pyDOE3.__version__) >= Version("1.0.4"):
-            expected = [
-                {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
+        expected = [
+            {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
+            {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
+            {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
+            {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
 
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
+            {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
+            {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
+            {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
+            {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
 
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
+            {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
+            {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
+            {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
+            {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
 
-                {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])}
-            ]
-        else:
-            expected = [
-                {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
-
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
-
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
-
-                {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])},
-            ]
+            {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])}
+        ]
 
         for case, expected_case in zip(cases, expected):
             outputs = cr.get_case(case).outputs

--- a/openmdao/drivers/tests/test_differential_evolution_driver.py
+++ b/openmdao/drivers/tests/test_differential_evolution_driver.py
@@ -32,9 +32,9 @@ except ImportError:
     PETScVector = None
 
 try:
-    import pyDOE3
+    import pydoe
 except ImportError:
-    pyDOE3 = None
+    pydoe = None
 
 extra_prints = False  # enable printing results
 
@@ -53,28 +53,28 @@ def _test_func_name(func, num, param):
 
 class TestErrors(unittest.TestCase):
 
-    @unittest.skipIf(pyDOE3, "only runs if 'pyDOE3' is not installed")
-    def test_no_pyDOE3(self):
+    @unittest.skipIf(pydoe, "only runs if 'pydoe' is not installed")
+    def test_no_pydoe(self):
         with self.assertRaises(RuntimeError) as err:
             DifferentialEvolution(lambda: 0)
 
         self.assertEqual(str(err.exception),
-                         "DifferentialEvolution requires the 'pyDOE3' package, "
+                         "DifferentialEvolution requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
         with self.assertRaises(RuntimeError) as err:
             om.DifferentialEvolutionDriver()
 
         self.assertEqual(str(err.exception),
-                         "DifferentialEvolutionDriver requires the 'pyDOE3' package, "
+                         "DifferentialEvolutionDriver requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
     def test_deprecation_warning(self):
         """Test that DifferentialEvolutionDriver raises a deprecation warning on instantiation."""
         msg = ('The `DifferentialEvolutionDriver` is deprecated. Please use '
@@ -83,7 +83,7 @@ class TestErrors(unittest.TestCase):
             om.DifferentialEvolutionDriver()
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestDifferentialEvolution(unittest.TestCase):
 
     def setUp(self):
@@ -443,7 +443,7 @@ class TestDifferentialEvolution(unittest.TestCase):
             self.assertLessEqual(1.0 - 1e-6, prob["x"][i])
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestDriverOptionsDifferentialEvolution(unittest.TestCase):
 
     def setUp(self):
@@ -476,7 +476,7 @@ class TestDriverOptionsDifferentialEvolution(unittest.TestCase):
         self.assertEqual(prob.driver.options['Pc'], 0.0123)
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestMultiObjectiveDifferentialEvolution(unittest.TestCase):
 
     def setUp(self):
@@ -589,7 +589,7 @@ class TestMultiObjectiveDifferentialEvolution(unittest.TestCase):
         self.assertGreater(h2, h1)  # top area does not depend on height
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestConstrainedDifferentialEvolution(unittest.TestCase):
 
     def setUp(self):
@@ -871,7 +871,7 @@ class TestConstrainedDifferentialEvolution(unittest.TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class MPITestDifferentialEvolution(unittest.TestCase):
     N_PROCS = 2
 
@@ -921,7 +921,7 @@ class MPITestDifferentialEvolution(unittest.TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class MPITestDifferentialEvolutionNoSetSeed(unittest.TestCase):
     N_PROCS = 2
 
@@ -1005,7 +1005,7 @@ class Summer(om.ExplicitComponent):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 @use_tempdirs
 class MPITestDifferentialEvolution4Procs(unittest.TestCase):
     N_PROCS = 4

--- a/openmdao/drivers/tests/test_doe_driver.py
+++ b/openmdao/drivers/tests/test_doe_driver.py
@@ -11,7 +11,6 @@ import csv
 
 import numpy as np
 
-from packaging.version import Version
 
 import openmdao.api as om
 
@@ -31,9 +30,9 @@ except ImportError:
     PETScVector = None
 
 try:
-    import pyDOE3
+    import pydoe
 except ImportError:
-    pyDOE3 = None
+    pydoe = None
 
 
 class ParaboloidArray(om.ExplicitComponent):
@@ -103,27 +102,27 @@ class TestErrors(unittest.TestCase):
                          "DOEDriver requires an instance of DOEGenerator, "
                          "but an instance of Problem was found.")
 
-    @unittest.skipIf(pyDOE3, "only runs if 'pyDOE3' is not installed")
-    def test_no_pyDOE3(self):
+    @unittest.skipIf(pydoe, "only runs if 'pydoe' is not installed")
+    def test_no_pydoe(self):
         with self.assertRaises(RuntimeError) as err:
             om.FullFactorialGenerator(levels=3)
 
         self.assertEqual(str(err.exception),
-                         "FullFactorialGenerator requires the 'pyDOE3' package, "
+                         "FullFactorialGenerator requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
         with self.assertRaises(RuntimeError) as err:
             om.DOEDriver(generator=om.FullFactorialGenerator(levels=3))
 
         self.assertEqual(str(err.exception),
-                         "FullFactorialGenerator requires the 'pyDOE3' package, "
+                         "FullFactorialGenerator requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_lhc_criterion(self):
         with self.assertRaises(ValueError) as err:
             om.LatinHypercubeGenerator(criterion='foo')
@@ -351,7 +350,7 @@ class TestDOEDriver(unittest.TestCase):
             for name in ('x', 'y', 'f_xy'):
                 self.assertEqual(outputs[name], expected_case[name])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_csv_array(self):
         prob = om.Problem()
         model = prob.model
@@ -532,7 +531,7 @@ class TestDOEDriver(unittest.TestCase):
             for name in ('x', 'y'):
                 assert_near_equal(outputs[name], expected_case[name], 1e-4)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_full_factorial(self):
         prob = om.Problem()
         model = prob.model
@@ -563,7 +562,7 @@ class TestDOEDriver(unittest.TestCase):
             for name in ('x', 'y', 'f_xy'):
                 self.assertEqual(outputs[name], expected_case[name])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_full_factorial_factoring(self):
 
         class Digits2Num(om.ExplicitComponent):
@@ -610,7 +609,7 @@ class TestDOEDriver(unittest.TestCase):
         # number of cases
         self.assertEqual(len(set(objs)), 16)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_full_factorial_array(self):
         prob = om.Problem()
         model = prob.model
@@ -652,7 +651,7 @@ class TestDOEDriver(unittest.TestCase):
             self.assertEqual(outputs['xy'][0], expected_case['xy'][0])
             self.assertEqual(outputs['xy'][1], expected_case['xy'][1])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_full_fact_dict_levels(self):
         # Specifying levels only for one DV, the other is defaulted
         prob = om.Problem()
@@ -694,7 +693,7 @@ class TestDOEDriver(unittest.TestCase):
             self.assertEqual(outputs['y'], expected_case['y'])
             self.assertEqual(outputs['f_xy'], expected_case['f_xy'])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_generalized_subset(self):
         # All DVs have the same number of levels
         prob = om.Problem()
@@ -730,7 +729,7 @@ class TestDOEDriver(unittest.TestCase):
             for name in ('x', 'y', 'f_xy'):
                 self.assertEqual(outputs[name], expected_case[name])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_generalized_subset_dict_levels(self):
         # Number of variables specified individually for all DVs (scalars).
         prob = om.Problem()
@@ -774,7 +773,7 @@ class TestDOEDriver(unittest.TestCase):
                 self.assertAlmostEqual(outputs[name][0], expected_case[name][0])
             self.assertAlmostEqual(outputs['f_xy'], expected_case['f_xy'])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_generalized_subset_array(self):
         # Number of levels specified individually for all DVs (arrays).
 
@@ -817,11 +816,11 @@ class TestDOEDriver(unittest.TestCase):
 
         objs = [cr.get_case(case).outputs['f'].item() for case in cases]
 
-        self.assertEqual(len(objs), 104)  # The number can be verified with standalone pyDOE3
+        self.assertEqual(len(objs), 104)  # The number can be verified with standalone pydoe
         # Testing uniqueness. If all elements are unique, it should be the same length as the number of cases
         self.assertEqual(len(set(objs)), 104)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_plackett_burman(self):
         prob = om.Problem()
         model = prob.model
@@ -858,7 +857,7 @@ class TestDOEDriver(unittest.TestCase):
             for name in ('x', 'y', 'f_xy'):
                 self.assertEqual(outputs[name], expected_case[name])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_box_behnken(self):
         upper = 10.
         center = 1
@@ -895,52 +894,31 @@ class TestDOEDriver(unittest.TestCase):
         # ref: https://en.wikipedia.org/wiki/Box-Behnken_design
         self.assertEqual(len(cases), (3*4)+center)
 
-        # slight change in order from refactor in pyDOE3 v1.0.4 (PR #15)
-        if Version(pyDOE3.__version__) >= Version("1.0.4"):
-            expected = [
-                {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
+        expected = [
+            {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
+            {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
+            {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
+            {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
 
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
+            {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
+            {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
+            {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
+            {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
 
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
+            {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
+            {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
+            {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
+            {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
 
-                {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])}
-            ]
-        else:
-            expected = [
-                {'x': np.array([0.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([0.]), 'z': np.array([5.])},
-                {'x': np.array([0.]), 'y': np.array([10.]), 'z': np.array([5.])},
-                {'x': np.array([10.]), 'y': np.array([10.]), 'z': np.array([5.])},
-
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([0.])},
-                {'x': np.array([0.]), 'y': np.array([5.]), 'z': np.array([10.])},
-                {'x': np.array([10.]), 'y': np.array([5.]), 'z': np.array([10.])},
-
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([0.])},
-                {'x': np.array([5.]), 'y': np.array([0.]), 'z': np.array([10.])},
-                {'x': np.array([5.]), 'y': np.array([10.]), 'z': np.array([10.])},
-
-                {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])},
-            ]
+            {'x': np.array([5.]), 'y': np.array([5.]), 'z': np.array([5.])}
+        ]
 
         for case, expected_case in zip(cases, expected):
             outputs = cr.get_case(case).outputs
             for name in ('x', 'y', 'z'):
                 self.assertEqual(outputs[name], expected_case[name])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_latin_hypercube(self):
         samples = 4
 
@@ -1013,7 +991,7 @@ class TestDOEDriver(unittest.TestCase):
         self.assertEqual(x_buckets_filled, all_buckets)
         self.assertEqual(y_buckets_filled, all_buckets)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_latin_hypercube_array(self):
         samples = 4
 
@@ -1082,7 +1060,7 @@ class TestDOEDriver(unittest.TestCase):
         self.assertEqual(x_buckets_filled, all_buckets)
         self.assertEqual(y_buckets_filled, all_buckets)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_latin_hypercube_center(self):
         samples = 4
         upper = 10.
@@ -1141,7 +1119,7 @@ class TestDOEDriver(unittest.TestCase):
         self.assertEqual(x_buckets_filled, all_buckets)
         self.assertEqual(y_buckets_filled, all_buckets)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_record_bug(self):
         # There was a bug that caused values to be recorded in driver_scaled form.
 
@@ -1399,7 +1377,7 @@ class TestDOEDriver(unittest.TestCase):
                 self.assertEqual(outputs[name], expected_case[name])
                 self.assertTrue(isinstance(outputs[name], int))
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_desvar_indices(self):
         prob = om.Problem()
         prob.model.add_subsystem('comp', om.ExecComp('y=x**2',
@@ -1455,7 +1433,7 @@ class TestDOEDriver(unittest.TestCase):
         for name in ('x', 'y', 'z'):
             assert_near_equal(outputs[name], prob[name])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_multi_constraint_doe(self):
         prob = om.Problem()
         prob.model.add_subsystem('comp', om.ExecComp('y=x**2 + b',
@@ -1517,7 +1495,7 @@ class TestDOEDriver(unittest.TestCase):
             for dv in ('x', 'y'):
                 self.assertEqual(derivs['f_xy', dv], expected_deriv['f_xy', dv])
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
     def test_derivative_scaled_recording(self):
         prob = om.Problem()
         model = prob.model
@@ -2170,7 +2148,7 @@ class TestParallelDOE2proc(unittest.TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', pip install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', pip install openmdao[doe]")
 @use_tempdirs
 class TestParallelDistribDOE(unittest.TestCase):
 

--- a/openmdao/drivers/tests/test_genetic_algorithm_driver.py
+++ b/openmdao/drivers/tests/test_genetic_algorithm_driver.py
@@ -34,9 +34,9 @@ except ImportError:
     PETScVector = None
 
 try:
-    import pyDOE3
+    import pydoe
 except ImportError:
-    pyDOE3 = None
+    pydoe = None
 
 extra_prints = False  # enable printing results
 
@@ -55,28 +55,28 @@ def _test_func_name(func, num, param):
 
 class TestErrors(unittest.TestCase):
 
-    @unittest.skipIf(pyDOE3, "only runs if 'pyDOE3' is not installed")
-    def test_no_pyDOE3(self):
+    @unittest.skipIf(pydoe, "only runs if 'pydoe' is not installed")
+    def test_no_pydoe(self):
         with self.assertRaises(RuntimeError) as err:
             GeneticAlgorithm(lambda: 0)
 
         self.assertEqual(str(err.exception),
-                         "GeneticAlgorithm requires the 'pyDOE3' package, "
+                         "GeneticAlgorithm requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
         with self.assertRaises(RuntimeError) as err:
             om.SimpleGADriver()
 
         self.assertEqual(str(err.exception),
-                         "SimpleGADriver requires the 'pyDOE3' package, "
+                         "SimpleGADriver requires the 'pydoe' package, "
                          "which can be installed with one of the following commands:\n"
                          "    pip install openmdao[doe]\n"
-                         "    pip install pyDOE3")
+                         "    pip install pydoe")
 
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
     def test_deprecation_warning(self):
         """Test that SimpleGADriver raises a deprecation warning on instantiation."""
         msg = ('The `SimpleGADriver` is deprecated. Please use '
@@ -85,7 +85,7 @@ class TestErrors(unittest.TestCase):
             om.SimpleGADriver()
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestSimpleGA(unittest.TestCase):
 
     def setUp(self):
@@ -590,7 +590,7 @@ class TestSimpleGA(unittest.TestCase):
             self.assertLessEqual(1.0, prob["x"][i])
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestDriverOptionsSimpleGA(unittest.TestCase):
 
     def setUp(self):
@@ -640,7 +640,7 @@ class Box(om.ExplicitComponent):
         outputs['volume'] = length*height*width
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestMultiObjectiveSimpleGA(unittest.TestCase):
 
     def setUp(self):
@@ -772,7 +772,7 @@ class TestMultiObjectiveSimpleGA(unittest.TestCase):
         self.assertTrue(np.all(sorted_obj[:-1, 1] >= sorted_obj[1:, 1]))
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestConstrainedSimpleGA(unittest.TestCase):
 
     def setUp(self):
@@ -1091,7 +1091,7 @@ class TestConstrainedSimpleGA(unittest.TestCase):
         assert_near_equal(prob['parab.f'], f_opt, 1e-4)
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class MPITestSimpleGA(unittest.TestCase):
 
     N_PROCS = 2
@@ -1330,7 +1330,7 @@ class Summer(om.ExplicitComponent):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 @use_tempdirs
 class MPITestSimpleGA4Procs(unittest.TestCase):
 
@@ -1555,7 +1555,7 @@ class MPITestSimpleGA4Procs(unittest.TestCase):
         assert_near_equal(np.sum(prob.get_val('f_xy', get_remote=True))/3, -23.1333, 0.15)
 
 
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class TestFeatureSimpleGA(unittest.TestCase):
 
     def setUp(self):
@@ -1789,7 +1789,7 @@ class TestFeatureSimpleGA(unittest.TestCase):
 
 
 @unittest.skipUnless(MPI and PETScVector, "MPI and PETSc are required.")
-@unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+@unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
 class MPIFeatureTests(unittest.TestCase):
     N_PROCS = 2
 

--- a/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
+++ b/openmdao/recorders/tests/test_distrib_sqlite_recorder.py
@@ -23,9 +23,9 @@ else:
     PETScVector = None
 
 try:
-    import pyDOE3
+    import pydoe
 except ImportError:
-    pyDOE3 = None
+    pydoe = None
 
 from openmdao.test_suite.components.paraboloid import Paraboloid
 
@@ -316,7 +316,7 @@ class DistributedRecorderTest(unittest.TestCase):
         prob.run_model()
         prob.record('final')
 
-    @unittest.skipUnless(pyDOE3, "This test uses full factorial from pyDOE3.")
+    @unittest.skipUnless(pydoe, "This test uses full factorial from pydoe.")
     def test_sql_meta_file_exists(self):
         # Check that an existing sql_meta file will be deleted/overwritten
         # if it already exists before a run. (see Issue #2062)
@@ -362,7 +362,7 @@ class DistributedRecorderTest(unittest.TestCase):
 
         prob.cleanup()
 
-    @unittest.skipUnless(pyDOE3, "This test uses full factorial from pyDOE3.")
+    @unittest.skipUnless(pydoe, "This test uses full factorial from pydoe.")
     def test_record_on_one_proc(self):
         # This test verifies that cases can be recorded on a single process in an MPI environment
         # with more than one process, and the recorded cases can then be processed in parallel

--- a/openmdao/visualization/opt_report/tests/test_opt_report.py
+++ b/openmdao/visualization/opt_report/tests/test_opt_report.py
@@ -21,9 +21,9 @@ from openmdao.visualization.opt_report.opt_report import opt_report, \
     _default_optimizer_report_filename
 
 try:
-    import pyDOE3
+    import pydoe
 except ImportError:
-    pyDOE3 = None
+    pydoe = None
 
 
 @use_tempdirs
@@ -251,7 +251,7 @@ class TestOptimizationReport(unittest.TestCase):
         outfilepath = prob.get_reports_dir() / _default_optimizer_report_filename
         self.assertFalse(os.path.exists(outfilepath))
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
     def test_opt_report_genetic_algorithm(self):
         self.setup_problem_and_run_driver(om.SimpleGADriver,
                                           vars_lower=-50, vars_upper=50.,
@@ -262,7 +262,7 @@ class TestOptimizationReport(unittest.TestCase):
         opt_report(self.prob)
         self.check_opt_report(expected=expect)
 
-    @unittest.skipUnless(pyDOE3, "requires 'pyDOE3', install openmdao[doe]")
+    @unittest.skipUnless(pydoe, "requires 'pydoe', install openmdao[doe]")
     def test_opt_report_differential_evolution(self):
         prob = om.Problem()
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -1,9 +1,25 @@
 version: 7
 platforms:
 - name: linux-64
+  virtual-packages:
+  - __unix=0=0
+  - __linux=4.18
+  - __glibc=2.28
+  - __archspec=0=x86_64
 - name: osx-64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=x86_64
 - name: osx-arm64
+  virtual-packages:
+  - __unix=0=0
+  - __osx=13.0
+  - __archspec=0=m1
 - name: win-64
+  virtual-packages:
+  - __win=10.0
+  - __archspec=0=x86_64
 environments:
   default:
     channels:
@@ -363,7 +379,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -561,7 +577,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -936,7 +952,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -1304,7 +1320,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -1887,7 +1903,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -2111,7 +2127,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -2519,7 +2535,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -2920,7 +2936,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydata-sphinx-theme-0.15.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -4299,7 +4315,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -4500,7 +4515,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -4878,7 +4892,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -5249,7 +5262,6 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -5812,7 +5824,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -6012,7 +6024,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -6389,7 +6401,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -6759,7 +6771,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -7321,7 +7333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -7521,7 +7533,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -7898,7 +7910,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -8268,7 +8280,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -8829,7 +8841,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -9027,7 +9039,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -9402,7 +9414,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -9770,7 +9782,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -10322,7 +10334,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -10522,7 +10534,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -10865,7 +10877,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
@@ -11202,7 +11214,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycodestyle-2.14.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydocstyle-6.3.0-pyhd8ed1ab_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pyparsing-3.3.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
@@ -11450,7 +11462,7 @@ packages:
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/aiohttp?source=compressed-mapping
+  - pkg:pypi/aiohttp?source=hash-mapping
   run_exports: {}
   size: 1083744
   timestamp: 1780914191006
@@ -11574,7 +11586,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 239892
   timestamp: 1781450817988
@@ -11589,7 +11601,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 242845
   timestamp: 1781450812380
@@ -12239,7 +12251,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/debugpy?source=compressed-mapping
+  - pkg:pypi/debugpy?source=hash-mapping
   run_exports: {}
   size: 2730876
   timestamp: 1780390154098
@@ -12409,7 +12421,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   run_exports: {}
   size: 2995315
   timestamp: 1778770432258
@@ -12588,7 +12600,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 267125
   timestamp: 1782524630615
@@ -14760,8 +14772,7 @@ packages:
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 14874
   timestamp: 1782829561867
@@ -14776,8 +14787,7 @@ packages:
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 14887
   timestamp: 1782829550796
@@ -14855,7 +14865,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8889973
   timestamp: 1782829541508
@@ -14887,7 +14897,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8877024
   timestamp: 1782829532714
@@ -14919,7 +14929,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8974852
   timestamp: 1782829528425
@@ -15118,7 +15128,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/nh3?source=compressed-mapping
+  - pkg:pypi/nh3?source=hash-mapping
   run_exports: {}
   size: 672346
   timestamp: 1782129862714
@@ -15315,7 +15325,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -15688,7 +15698,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 14872605
   timestamp: 1778602625175
@@ -15746,7 +15756,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 15001668
   timestamp: 1778602610159
@@ -15804,7 +15814,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 15303815
   timestamp: 1778602611222
@@ -16058,7 +16068,7 @@ packages:
   - zlib-ng >=2.3.3,<2.4.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1081155
   timestamp: 1782912080163
@@ -16082,7 +16092,7 @@ packages:
   - libwebp-base >=1.6.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1064129
   timestamp: 1782912080163
@@ -16106,7 +16116,7 @@ packages:
   - openjpeg >=2.5.4,<3.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1077037
   timestamp: 1782912080163
@@ -16130,7 +16140,7 @@ packages:
   - tk >=8.6.13,<8.7.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1108174
   timestamp: 1782912080163
@@ -17018,7 +17028,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 299898
   timestamp: 1782831307838
@@ -17035,7 +17045,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 300259
   timestamp: 1782831325201
@@ -17052,7 +17062,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 299711
   timestamp: 1782831281126
@@ -17086,7 +17096,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=compressed-mapping
+  - pkg:pypi/ruff?source=hash-mapping
   run_exports: {}
   size: 9342178
   timestamp: 1782428525856
@@ -17328,7 +17338,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 864705
   timestamp: 1781006801632
@@ -17343,7 +17353,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 885824
   timestamp: 1781006802459
@@ -17661,7 +17671,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115842
   timestamp: 1782133640094
@@ -17691,7 +17701,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 118096
   timestamp: 1782133651496
@@ -18073,7 +18083,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/yarl?source=compressed-mapping
+  - pkg:pypi/yarl?source=hash-mapping
   run_exports: {}
   size: 155105
   timestamp: 1779246217985
@@ -18186,7 +18196,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/aiohappyeyeballs?source=compressed-mapping
+  - pkg:pypi/aiohappyeyeballs?source=hash-mapping
   run_exports: {}
   size: 24690
   timestamp: 1782986823268
@@ -18272,7 +18282,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/anyio?source=compressed-mapping
+  - pkg:pypi/anyio?source=hash-mapping
   run_exports: {}
   size: 161308
   timestamp: 1782357087265
@@ -18396,8 +18406,7 @@ packages:
   depends:
   - python >=3.14
   license: BSD-3-Clause AND MIT AND EPL-2.0
-  purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 7526
   timestamp: 1781450817767
@@ -18426,7 +18435,7 @@ packages:
   - tinycss2 >=1.1.0,<1.5
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/bleach?source=compressed-mapping
+  - pkg:pypi/bleach?source=hash-mapping
   run_exports: {}
   size: 142246
   timestamp: 1780675823953
@@ -18460,7 +18469,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/bokeh?source=compressed-mapping
+  - pkg:pypi/bokeh?source=hash-mapping
   run_exports: {}
   size: 4526315
   timestamp: 1781002115296
@@ -18515,7 +18524,7 @@ packages:
   - python >=3.10
   license: ISC
   purls:
-  - pkg:pypi/certifi?source=compressed-mapping
+  - pkg:pypi/certifi?source=hash-mapping
   run_exports: {}
   size: 133877
   timestamp: 1781719949728
@@ -18568,7 +18577,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/click?source=compressed-mapping
+  - pkg:pypi/click?source=hash-mapping
   run_exports: {}
   size: 104999
   timestamp: 1779900548735
@@ -18745,7 +18754,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/decorator?source=compressed-mapping
+  - pkg:pypi/decorator?source=hash-mapping
   run_exports: {}
   size: 16102
   timestamp: 1779115228886
@@ -18890,7 +18899,7 @@ packages:
   - python >=3.10
   license: Unlicense
   purls:
-  - pkg:pypi/filelock?source=compressed-mapping
+  - pkg:pypi/filelock?source=hash-mapping
   run_exports: {}
   size: 36989
   timestamp: 1781381078337
@@ -19069,7 +19078,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/hatchling?source=compressed-mapping
+  - pkg:pypi/hatchling?source=hash-mapping
   run_exports: {}
   size: 61807
   timestamp: 1780403469805
@@ -19081,7 +19090,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/hpack?source=compressed-mapping
+  - pkg:pypi/hpack?source=hash-mapping
   run_exports: {}
   size: 32884
   timestamp: 1782283986153
@@ -19153,7 +19162,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/idna?source=compressed-mapping
+  - pkg:pypi/idna?source=hash-mapping
   run_exports: {}
   size: 163869
   timestamp: 1781620148226
@@ -19179,7 +19188,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/importlib-metadata?source=compressed-mapping
+  - pkg:pypi/importlib-metadata?source=hash-mapping
   run_exports: {}
   size: 34766
   timestamp: 1779714582554
@@ -19236,7 +19245,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipykernel?source=compressed-mapping
+  - pkg:pypi/ipykernel?source=hash-mapping
   run_exports: {}
   size: 138046
   timestamp: 1781101760172
@@ -19264,7 +19273,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipykernel?source=compressed-mapping
+  - pkg:pypi/ipykernel?source=hash-mapping
   run_exports: {}
   size: 138635
   timestamp: 1781101665847
@@ -19308,7 +19317,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/ipython?source=compressed-mapping
+  - pkg:pypi/ipython?source=hash-mapping
   run_exports: {}
   size: 658801
   timestamp: 1782482716877
@@ -19389,7 +19398,7 @@ packages:
   - python
   license: Apache-2.0 AND MIT
   purls:
-  - pkg:pypi/jedi?source=compressed-mapping
+  - pkg:pypi/jedi?source=hash-mapping
   run_exports: {}
   size: 2715215
   timestamp: 1782251948616
@@ -19415,7 +19424,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/json5?source=compressed-mapping
+  - pkg:pypi/json5?source=hash-mapping
   run_exports: {}
   size: 39373
   timestamp: 1781926894833
@@ -19550,7 +19559,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-client?source=compressed-mapping
+  - pkg:pypi/jupyter-client?source=hash-mapping
   run_exports: {}
   size: 117954
   timestamp: 1781019994076
@@ -19640,7 +19649,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/jupyter-server?source=compressed-mapping
+  - pkg:pypi/jupyter-server?source=hash-mapping
   run_exports: {}
   size: 363068
   timestamp: 1781713810089
@@ -19885,7 +19894,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/matplotlib-inline?source=compressed-mapping
+  - pkg:pypi/matplotlib-inline?source=hash-mapping
   run_exports: {}
   size: 15725
   timestamp: 1778264403247
@@ -19938,7 +19947,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/mistune?source=compressed-mapping
+  - pkg:pypi/mistune?source=hash-mapping
   run_exports: {}
   size: 86960
   timestamp: 1782218255079
@@ -20013,7 +20022,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/narwhals?source=compressed-mapping
+  - pkg:pypi/narwhals?source=hash-mapping
   run_exports: {}
   size: 288381
   timestamp: 1782924928916
@@ -20029,7 +20038,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/nbclient?source=compressed-mapping
+  - pkg:pypi/nbclient?source=hash-mapping
   run_exports: {}
   size: 29138
   timestamp: 1780661039538
@@ -20179,7 +20188,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/notebook?source=compressed-mapping
+  - pkg:pypi/notebook?source=hash-mapping
   run_exports: {}
   size: 4629848
   timestamp: 1781800954960
@@ -20299,7 +20308,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/panel?source=compressed-mapping
+  - pkg:pypi/panel?source=hash-mapping
   run_exports: {}
   size: 23014831
   timestamp: 1780383113204
@@ -20408,7 +20417,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pip?source=compressed-mapping
+  - pkg:pypi/pip?source=hash-mapping
   run_exports: {}
   size: 1202377
   timestamp: 1780262809860
@@ -20422,7 +20431,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pip?source=compressed-mapping
+  - pkg:pypi/pip?source=hash-mapping
   run_exports: {}
   size: 1203173
   timestamp: 1780262795392
@@ -20435,7 +20444,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/platformdirs?source=compressed-mapping
+  - pkg:pypi/platformdirs?source=hash-mapping
   run_exports: {}
   size: 26308
   timestamp: 1779972894916
@@ -20572,7 +20581,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pycparser?source=compressed-mapping
+  - pkg:pypi/pycparser?source=hash-mapping
   run_exports: {}
   size: 55886
   timestamp: 1779293633166
@@ -20610,20 +20619,20 @@ packages:
   run_exports: {}
   size: 40236
   timestamp: 1733261742916
-- conda: https://conda.anaconda.org/conda-forge/noarch/pydoe3-1.6.2-pyhd8ed1ab_0.conda
-  sha256: b78ae083c7b0fb664ba2ba1769676ca3351a56a3e0faadca7642c63085631db5
-  md5: dfa729b3aab301fe51e558f5cd17731f
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydoe-1.0.1-pyhd8ed1ab_0.conda
+  sha256: 5a39509d954c81f55d7052068f03b39112d981c8a096bd486d5b76c117664156
+  md5: d25292fc5a1fb3b46b1f20edc9f095f5
   depends:
-  - numpy
+  - numpy >=2.2.6
   - python >=3.10
-  - scipy
+  - scipy >=1.15.2
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pydoe3?source=hash-mapping
+  - pkg:pypi/pydoe?source=hash-mapping
   run_exports: {}
-  size: 54869
-  timestamp: 1768308709740
+  size: 58954
+  timestamp: 1780003608619
 - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.20.0-pyhd8ed1ab_0.conda
   sha256: cf70b2f5ad9ae472b71235e5c8a736c9316df3705746de419b59d442e8348e86
   md5: 16c18772b340887160c79a6acc022db0
@@ -20701,7 +20710,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/python-discovery?source=compressed-mapping
+  - pkg:pypi/python-discovery?source=hash-mapping
   run_exports: {}
   size: 35514
   timestamp: 1781257630962
@@ -20894,7 +20903,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/requests?source=compressed-mapping
+  - pkg:pypi/requests?source=hash-mapping
   run_exports: {}
   size: 68709
   timestamp: 1778851103479
@@ -21060,7 +21069,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/smmap?source=compressed-mapping
+  - pkg:pypi/smmap?source=hash-mapping
   run_exports: {}
   size: 27262
   timestamp: 1781021238494
@@ -21096,7 +21105,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/soupsieve?source=compressed-mapping
+  - pkg:pypi/soupsieve?source=hash-mapping
   run_exports: {}
   size: 38802
   timestamp: 1779635534390
@@ -21359,7 +21368,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/sphinxcontrib-serializinghtml?source=compressed-mapping
+  - pkg:pypi/sphinxcontrib-serializinghtml?source=hash-mapping
   run_exports: {}
   size: 30640
   timestamp: 1781260357443
@@ -21501,7 +21510,7 @@ packages:
   - ipywidgets >=6.0
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=compressed-mapping
+  - pkg:pypi/tqdm?source=hash-mapping
   run_exports: {}
   size: 94965
   timestamp: 1781741268338
@@ -21518,7 +21527,7 @@ packages:
   - ipywidgets >=6.0
   license: MPL-2.0 and MIT
   purls:
-  - pkg:pypi/tqdm?source=compressed-mapping
+  - pkg:pypi/tqdm?source=hash-mapping
   run_exports: {}
   size: 94630
   timestamp: 1781741323148
@@ -21531,7 +21540,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/traitlets?source=compressed-mapping
+  - pkg:pypi/traitlets?source=hash-mapping
   run_exports: {}
   size: 115158
   timestamp: 1780507822178
@@ -21544,7 +21553,7 @@ packages:
   license: Apache-2.0
   license_family: APACHE
   purls:
-  - pkg:pypi/trove-classifiers?source=compressed-mapping
+  - pkg:pypi/trove-classifiers?source=hash-mapping
   run_exports: {}
   size: 24210
   timestamp: 1780385194431
@@ -21670,7 +21679,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/wcwidth?source=compressed-mapping
+  - pkg:pypi/wcwidth?source=hash-mapping
   run_exports: {}
   size: 132415
   timestamp: 1782771807703
@@ -21768,7 +21777,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/zipp?source=compressed-mapping
+  - pkg:pypi/zipp?source=hash-mapping
   run_exports: {}
   size: 24190
   timestamp: 1779159948016
@@ -21920,7 +21929,7 @@ packages:
   - python_abi 3.12.* *_cp312
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 240505
   timestamp: 1781450862223
@@ -22602,7 +22611,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/debugpy?source=compressed-mapping
+  - pkg:pypi/debugpy?source=hash-mapping
   run_exports: {}
   size: 2768469
   timestamp: 1780390318296
@@ -22689,7 +22698,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   run_exports: {}
   size: 2914614
   timestamp: 1778770861388
@@ -22860,7 +22869,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 261350
   timestamp: 1782524782743
@@ -24397,7 +24406,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8702375
   timestamp: 1782829893189
@@ -24427,7 +24436,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8988367
   timestamp: 1782829965885
@@ -24653,7 +24662,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/nh3?source=compressed-mapping
+  - pkg:pypi/nh3?source=hash-mapping
   run_exports: {}
   size: 652268
   timestamp: 1782129922275
@@ -24848,7 +24857,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -25409,7 +25418,7 @@ packages:
   - libtiff >=4.7.1,<4.8.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 987687
   timestamp: 1782912253167
@@ -25432,7 +25441,7 @@ packages:
   - libjpeg-turbo >=3.1.4.1,<4.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1000472
   timestamp: 1782912253167
@@ -25455,7 +25464,7 @@ packages:
   - openjpeg >=2.5.4,<3.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1029929
   timestamp: 1782912253167
@@ -25774,7 +25783,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=compressed-mapping
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   run_exports: {}
   size: 382873
   timestamp: 1782265579173
@@ -26109,7 +26118,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=compressed-mapping
+  - pkg:pypi/pyzmq?source=hash-mapping
   run_exports: {}
   size: 192531
   timestamp: 1779484028794
@@ -26168,7 +26177,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 301356
   timestamp: 1782831427136
@@ -26184,7 +26193,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 300879
   timestamp: 1782831643076
@@ -26499,7 +26508,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 915832
   timestamp: 1781007541495
@@ -26703,7 +26712,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 113519
   timestamp: 1782134186680
@@ -26879,7 +26888,7 @@ packages:
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/aiohttp?source=compressed-mapping
+  - pkg:pypi/aiohttp?source=hash-mapping
   run_exports: {}
   size: 1059799
   timestamp: 1780913969743
@@ -27691,7 +27700,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/debugpy?source=compressed-mapping
+  - pkg:pypi/debugpy?source=hash-mapping
   run_exports: {}
   size: 2754468
   timestamp: 1780390249891
@@ -27955,7 +27964,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 263371
   timestamp: 1782524773735
@@ -29366,8 +29375,7 @@ packages:
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 14839
   timestamp: 1782829652227
@@ -29425,7 +29433,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8643964
   timestamp: 1782829547608
@@ -29455,7 +29463,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8650165
   timestamp: 1782829632549
@@ -29485,7 +29493,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8837817
   timestamp: 1782829619432
@@ -29515,7 +29523,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8826632
   timestamp: 1782829663874
@@ -30330,7 +30338,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 14368928
   timestamp: 1778602917992
@@ -30490,7 +30498,7 @@ packages:
   - libwebp-base >=1.6.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 993213
   timestamp: 1782912213683
@@ -30514,7 +30522,7 @@ packages:
   - python_abi 3.12.* *_cp312
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 977597
   timestamp: 1782912213683
@@ -30538,7 +30546,7 @@ packages:
   - libjpeg-turbo >=3.1.4.1,<4.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 990406
   timestamp: 1782912213683
@@ -30562,7 +30570,7 @@ packages:
   - lcms2 >=2.19.1,<3.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 1019767
   timestamp: 1782912213683
@@ -30873,7 +30881,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=compressed-mapping
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   run_exports: {}
   size: 383474
   timestamp: 1782265775966
@@ -30889,7 +30897,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=compressed-mapping
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   run_exports: {}
   size: 383688
   timestamp: 1782266005999
@@ -30905,7 +30913,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyobjc-framework-cocoa?source=compressed-mapping
+  - pkg:pypi/pyobjc-framework-cocoa?source=hash-mapping
   run_exports: {}
   size: 383812
   timestamp: 1782265953125
@@ -31276,7 +31284,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 286691
   timestamp: 1782831311985
@@ -31308,7 +31316,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 285490
   timestamp: 1782831312575
@@ -31324,7 +31332,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 285627
   timestamp: 1782831308617
@@ -31340,7 +31348,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/ruff?source=compressed-mapping
+  - pkg:pypi/ruff?source=hash-mapping
   run_exports: {}
   size: 8539333
   timestamp: 1782428897543
@@ -31603,7 +31611,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 863360
   timestamp: 1781007464047
@@ -31836,7 +31844,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 112459
   timestamp: 1782134073014
@@ -31851,7 +31859,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 113551
   timestamp: 1782133966372
@@ -32036,7 +32044,7 @@ packages:
   license: MIT AND Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/aiohttp?source=compressed-mapping
+  - pkg:pypi/aiohttp?source=hash-mapping
   run_exports: {}
   size: 1033618
   timestamp: 1780913488229
@@ -32136,7 +32144,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 245115
   timestamp: 1781450835602
@@ -32152,7 +32160,7 @@ packages:
   - zstd >=1.5.7,<1.6.0a0
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 238542
   timestamp: 1781450836106
@@ -32168,7 +32176,7 @@ packages:
   - python_abi 3.13.* *_cp313
   license: BSD-3-Clause AND MIT AND EPL-2.0
   purls:
-  - pkg:pypi/backports-zstd?source=compressed-mapping
+  - pkg:pypi/backports-zstd?source=hash-mapping
   run_exports: {}
   size: 241936
   timestamp: 1781450845361
@@ -32739,7 +32747,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/debugpy?source=compressed-mapping
+  - pkg:pypi/debugpy?source=hash-mapping
   run_exports: {}
   size: 4005806
   timestamp: 1780390185602
@@ -32876,7 +32884,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   run_exports: {}
   size: 2533681
   timestamp: 1778770493020
@@ -32894,7 +32902,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/fonttools?source=compressed-mapping
+  - pkg:pypi/fonttools?source=hash-mapping
   run_exports: {}
   size: 2563148
   timestamp: 1778770478353
@@ -33016,7 +33024,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/greenlet?source=compressed-mapping
+  - pkg:pypi/greenlet?source=hash-mapping
   run_exports: {}
   size: 249080
   timestamp: 1782524683597
@@ -34064,8 +34072,7 @@ packages:
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 15163
   timestamp: 1782829753413
@@ -34080,8 +34087,7 @@ packages:
   - tornado >=5
   license: PSF-2.0
   license_family: PSF
-  purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  purls: []
   run_exports: {}
   size: 15252
   timestamp: 1782829784214
@@ -34158,7 +34164,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8621787
   timestamp: 1782829733178
@@ -34189,7 +34195,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/matplotlib?source=compressed-mapping
+  - pkg:pypi/matplotlib?source=hash-mapping
   run_exports: {}
   size: 8570719
   timestamp: 1782829763444
@@ -34273,7 +34279,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/nh3?source=compressed-mapping
+  - pkg:pypi/nh3?source=hash-mapping
   run_exports: {}
   size: 600627
   timestamp: 1782129887550
@@ -34432,7 +34438,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -34455,7 +34461,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -34478,7 +34484,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/numpy?source=compressed-mapping
+  - pkg:pypi/numpy?source=hash-mapping
   run_exports:
     weak:
     - numpy >=1.23,<3
@@ -34708,7 +34714,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 13644207
   timestamp: 1778602674307
@@ -34826,7 +34832,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pandas?source=compressed-mapping
+  - pkg:pypi/pandas?source=hash-mapping
   run_exports: {}
   size: 14062915
   timestamp: 1778602665890
@@ -34868,7 +34874,7 @@ packages:
   - libxcb >=1.17.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 965494
   timestamp: 1782912129930
@@ -34893,7 +34899,7 @@ packages:
   - libwebp-base >=1.6.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 949403
   timestamp: 1782912129930
@@ -34918,7 +34924,7 @@ packages:
   - libwebp-base >=1.6.0,<2.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 962591
   timestamp: 1782912129930
@@ -34943,7 +34949,7 @@ packages:
   - zlib-ng >=2.3.3,<2.4.0a0
   license: HPND
   purls:
-  - pkg:pypi/pillow?source=compressed-mapping
+  - pkg:pypi/pillow?source=hash-mapping
   run_exports: {}
   size: 989058
   timestamp: 1782912129930
@@ -35524,7 +35530,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32?source=compressed-mapping
+  - pkg:pypi/pywin32?source=hash-mapping
   run_exports: {}
   size: 4459779
   timestamp: 1781362887119
@@ -35556,7 +35562,7 @@ packages:
   license: PSF-2.0
   license_family: PSF
   purls:
-  - pkg:pypi/pywin32?source=compressed-mapping
+  - pkg:pypi/pywin32?source=hash-mapping
   run_exports: {}
   size: 4472831
   timestamp: 1781362876741
@@ -35728,7 +35734,7 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/pyzmq?source=compressed-mapping
+  - pkg:pypi/pyzmq?source=hash-mapping
   run_exports: {}
   size: 182831
   timestamp: 1779483925948
@@ -35811,7 +35817,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/rpds-py?source=compressed-mapping
+  - pkg:pypi/rpds-py?source=hash-mapping
   run_exports: {}
   size: 217956
   timestamp: 1782831653430
@@ -36017,7 +36023,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 885527
   timestamp: 1781006887264
@@ -36033,7 +36039,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 865801
   timestamp: 1781006895319
@@ -36049,7 +36055,7 @@ packages:
   license: Apache-2.0
   license_family: Apache
   purls:
-  - pkg:pypi/tornado?source=compressed-mapping
+  - pkg:pypi/tornado?source=hash-mapping
   run_exports: {}
   size: 888693
   timestamp: 1781006912014
@@ -36341,7 +36347,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115115
   timestamp: 1782133736690
@@ -36357,7 +36363,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 113162
   timestamp: 1782133745435
@@ -36373,7 +36379,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 114396
   timestamp: 1782133745518
@@ -36389,7 +36395,7 @@ packages:
   license: BSD-2-Clause
   license_family: BSD
   purls:
-  - pkg:pypi/wrapt?source=compressed-mapping
+  - pkg:pypi/wrapt?source=hash-mapping
   run_exports: {}
   size: 115544
   timestamp: 1782133735742

--- a/pixi.toml
+++ b/pixi.toml
@@ -97,7 +97,7 @@ jinja2 = "*"
 tqdm = "*"
 
 [feature.doe.dependencies]
-pydoe3 = "*"
+pydoe = ">=1.0.0"
 
 [feature.opt.dependencies]
 pyoptsparse = ">=2.14.0"
@@ -205,7 +205,11 @@ dev = { features = ["py313", "doe", "opt", "jax", "numba", "notebooks", "visuali
 minimal = { features = ["py313", "test", "openblas-explicit"], solve-group = "default" }
 
 # Oldest supported versions
-oldest = { features = ["deps-oldest", "doe", "opt", "jax", "numba", "notebooks", "visualization", "test", "mpi", "openblas-explicit"], solve-group = "oldest" }
+# Note: "doe" is intentionally omitted here. Every pydoe release requires
+# numpy>=2.2.6 / scipy>=1.15.3, which cannot co-exist with the numpy 2.0.* and
+# scipy 1.13.* pins in deps-oldest. The DOE tests are all guarded by
+# skipUnless(pydoe, ...) so they skip cleanly in this environment.
+oldest = { features = ["deps-oldest", "opt", "jax", "numba", "notebooks", "visualization", "test", "mpi", "openblas-explicit"], solve-group = "oldest" }
 
 # Python version matrix
 py311 = { features = ["py311", "doe", "opt", "jax", "numba", "notebooks", "visualization", "test", "mpi", "openblas-explicit"], solve-group = "py311" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ docs = [
     "tqdm>=4.66.3"
 ]
 doe = [
-    "pyDOE3",
+    "pydoe",
 ]
 jax = [
     "jax>=0.4.0",


### PR DESCRIPTION
### Summary

Replaces the optional DOE dependency `pyDOE3` with `pydoe`, the upstream PyDOE project into which pyDOE3 development has been consolidated. pyDOE3's README now carries an explicit deprecation notice directing users to PyDOE, and PyDOE is co-maintained by the pyDOE3 maintainer (Rémi Lafage), so this is a maintainer-endorsed handoff rather than a fork. License is unchanged (BSD-3-Clause).

Verified that `fullfact`, `gsd`, `pbdesign`, `bbdesign` and `lhs` produce **bit-identical** output between pyDOE3 1.6.2 and pydoe 1.3.0 across all 40 seeded call patterns OpenMDAO uses — no DOE results change. Ordering was additionally confirmed identical on pydoe 1.0.1 (the current conda-forge build), so the result holds across every version either packaging path can resolve.

Removes the now-dead `pyDOE3 v1.0.4` sample-ordering version gate in `test_doe_driver.py` and `test_pyDOE_sampling.py`. Every pydoe release uses the newer ordering, so the `else` branch was unreachable — and comparing a different package's version number against `1.0.4` would have been meaningless. The now-unused `packaging.version.Version` imports are dropped with it.

Drops the `doe` feature from the pixi `oldest` environment: every pydoe release requires `numpy>=2.2.6`, which cannot co-exist with that environment's `numpy=2.0.*` pin. DOE tests skip cleanly there via their existing `skipUnless` guards.

Also updates the `doe_driver` docs note and replaces the dead `pythonhosted.org/pyDOE` link with the current PyDOE documentation. Historical `release_notes.md` references to pyDOE2/pyDOE3 are intentionally left untouched.

**Testing:** 114 passed / 0 failed / 31 skipped across `test_doe_driver`, `test_pyDOE_sampling`, `test_genetic_algorithm_driver`, `test_differential_evolution_driver`. All four `test_no_pydoe` error paths verified in a pydoe-free environment. `ruff check` clean repo-wide; `openmdao.code_review` passes.

### Related Issues

- Resolves #3793

### Backwards incompatibilities

**Not none** — there are three, all minor but user-visible:

1. **`openmdao[doe]` now installs `pydoe` instead of `pyDOE3`.** Existing environments that have only pyDOE3 installed will raise `RuntimeError` from the DOE generators and `SimpleGADriver`/`DifferentialEvolutionDriver` until `pydoe` is installed. No transition shim is provided; the packages are not import-compatible (`pyDOE3` vs `pydoe`).
2. **`RuntimeError` message text changed** from `requires the 'pyDOE3' package … pip install pyDOE3` to the `pydoe` equivalent. Affects anyone string-matching on it.
3. **Effective floors for the `doe` extra rise**: pydoe requires `numpy>=2.2.6` and `scipy>=1.15.3`, above OpenMDAO's own `numpy>=2.0` / `scipy>=1.13`. Installing `openmdao[doe]` will now upgrade numpy/scipy for users below those versions. This is also why the pixi `oldest` environment can no longer include `doe`.

Generated DOE values are unchanged, so no user results shift.

### New Dependencies

**Not none** — one swapped, none added:

- `openmdao[doe]`: `pyDOE3` → `pydoe`
- pixi `doe` feature: `pydoe3` → `pydoe >=1.0.0` (conda-forge currently serves 1.0.1)
- `pixi.lock` regenerated; `.github/scripts/install_latest_deps.sh` updated