### PR TITLE
Fix reports directory race during Problem.setup

### DIFF
--- a/openmdao/core/problem.py
+++ b/openmdao/core/problem.py
@@ -1,6 +1,7 @@
 """Define the Problem class and a FakeComm class for non-MPI users."""
 
 import __main__
+import errno
 import shutil
 
 import sys
@@ -127,6 +128,38 @@ def _default_prob_name():
         return 'problem'
 
     return name.stem
+
+
+def _clear_reports_dir(reports_dirpath):
+    """
+    Remove the contents of the given reports directory without removing the directory itself.
+
+    The directory itself is intentionally left in place because other MPI ranks or processes
+    sharing the same output tree may be concurrently creating it, and deleting it out from under
+    them can cause a spurious FileExistsError from Path.mkdir(exist_ok=True) if the directory
+    vanishes between mkdir's EEXIST and its internal is_dir() check.  See issue #3746 and
+    python/cpython#142916.
+
+    Parameters
+    ----------
+    reports_dirpath : str or pathlib.Path
+        Path of the reports directory to be cleared.
+    """
+    try:
+        entries = list(os.scandir(reports_dirpath))
+    except FileNotFoundError:
+        # another process sharing this output tree already removed the directory
+        return
+
+    for entry in entries:
+        try:
+            if entry.is_dir(follow_symlinks=False):
+                shutil.rmtree(entry.path)
+            else:
+                os.unlink(entry.path)
+        except FileNotFoundError:
+            # another process already removed this entry. Removal is the goal, so not an error.
+            pass
 
 
 class Problem(object, metaclass=ProblemMetaclass):
@@ -1124,19 +1157,30 @@ class Problem(object, metaclass=ProblemMetaclass):
 
         # We don't want to delete the outputs directory because we may be using the coloring files
         # from a previous run.
-        # Start setup by deleting any existing reports so that the files
-        # that are in that directory are all from this run and not a previous run
-        # However, skip this deletion if we're in list_pre_post mode to preserve previously
+        # Start setup by removing any stale reports so that the files in the reports directory
+        # are all from this run and not a previous run.  When reports are active, remove only the
+        # contents of the reports directory, not the directory itself.  Removing the directory
+        # would race with its creation by other ranks/processes sharing this output tree, and
+        # Path.mkdir(exist_ok=True) on another rank can raise a spurious FileExistsError if the
+        # directory vanishes between mkdir's EEXIST and its internal is_dir() check (see
+        # issue #3746 and python/cpython#142916).  When reports are inactive, no rank creates
+        # the directory, so a stale directory can be safely removed entirely.
+        # However, skip this removal if we're in list_pre_post mode to preserve previously
         # generated reports (since list_pre_post exits before report generation hooks run).
         if os.environ.get('OPENMDAO_CLI_LIST_PRE_POST_MODE') != 'true':
-            reports_dirpath = self.get_reports_dir()
+            reports_dirpath = self.get_outputs_dir('reports', mkdir=False)
             if not MPI or (self.comm is not None and self.comm.rank == 0):
                 if os.path.isdir(reports_dirpath):
-                    try:
-                        shutil.rmtree(reports_dirpath)
-                    except FileNotFoundError:
-                        # Folder already removed by another proccess
-                        pass
+                    _clear_reports_dir(reports_dirpath)
+                    if not self._reports:
+                        try:
+                            os.rmdir(reports_dirpath)
+                        except OSError as err:
+                            # ENOENT: another process sharing this output tree already removed
+                            # it.  ENOTEMPTY: another process re-populated it after we cleared
+                            # it, so it is no longer stale and should be left alone.
+                            if err.errno not in (errno.ENOENT, errno.ENOTEMPTY):
+                                raise
         self._metadata['reports_dir'] = self.get_reports_dir()
 
         try:

--- a/openmdao/utils/tests/test_reports_system.py
+++ b/openmdao/utils/tests/test_reports_system.py
@@ -1,9 +1,13 @@
 """Unit Tests for the code that does automatic report generation"""
 from importlib.util import find_spec
 import unittest
+import unittest.mock as mock
 import pathlib
+import shutil
 import sys
 import os
+import threading
+import time
 from io import StringIO
 
 import numpy as np
@@ -11,7 +15,7 @@ import numpy as np
 import openmdao.api as om
 from openmdao.test_suite.components.paraboloid import Paraboloid
 from openmdao.test_suite.groups.parallel_groups import Diamond
-from openmdao.core.problem import _default_prob_name
+from openmdao.core.problem import _default_prob_name, _clear_reports_dir
 import openmdao.core.problem as probmod
 from openmdao.core.constants import _UNDEFINED
 from openmdao.utils.general_utils import set_pyoptsparse_opt
@@ -699,6 +703,260 @@ class TestReportsSystemMPI(unittest.TestCase):
             self.assertTrue(path.is_file(), f'The scaling report file, {str(path)}, was not found')
             path = pathlib.Path(problem_reports_dir).joinpath(self.optimizer_filename)
             self.assertTrue(path.is_file(), f'The optimizer report file, {str(path)}, was not found')
+
+
+@use_tempdirs
+class TestSetupReportsDirRace(unittest.TestCase):
+    """
+    Tests for the reports directory handling in Problem.setup (issue #3746).
+
+    During setup, stale reports must be removed, but the reports directory itself must not be
+    deleted while other ranks/processes sharing the output tree may be concurrently creating it,
+    because Path.mkdir(exist_ok=True) can raise a spurious FileExistsError if the directory
+    vanishes between mkdir's EEXIST and its internal is_dir() check (python/cpython#142916).
+    """
+
+    # generous timeout for the orchestration events below.  The events fire microseconds apart
+    # in a normal run; the timeout only bounds a hang if orchestration is broken.
+    TIMEOUT = 30.0
+
+    def setUp(self):
+        probmod._clear_problem_names()  # need to reset these to simulate separate runs
+        os.environ.pop('OPENMDAO_REPORTS', None)
+        # The reports code does nothing if TESTFLO_RUNNING is set, so remove it for these tests
+        # and remember its value so it can be restored.
+        self.testflo_running = os.environ.pop('TESTFLO_RUNNING', None)
+        clear_reports()
+
+    def tearDown(self):
+        if self.testflo_running is not None:
+            os.environ['TESTFLO_RUNNING'] = self.testflo_running
+
+    def _make_problem(self, name, reports='n2'):
+        prob = om.Problem(name=name, reports=reports)
+        prob.model.add_subsystem('comp', om.ExecComp('y = 2.0*x'))
+        return prob
+
+    def test_setup_no_spurious_fileexists_from_concurrent_mkdir(self):
+        # Deterministic regression test for issue #3746.
+        #
+        # Interleaving exercised (all filesystem operations and exceptions are real; the
+        # events below only fix the order in which the two actors reach them):
+        #
+        #   "rank 1" (worker thread): calls prob.get_reports_dir(force=True), the same
+        #       production call every rank makes during Problem.setup.  Its exists() check
+        #       sees no reports dir, so it proceeds into Path.mkdir(parents=True,
+        #       exist_ok=True).
+        #   "rank 0" (main thread): calls prob.setup() with active reports.
+        #
+        #   1. rank 1 reaches os.mkdir for the reports dir and waits for rank 0 to create it.
+        #   2. rank 0's setup creates the reports dir.
+        #   3. rank 1's os.mkdir now raises a genuine FileExistsError from the kernel.
+        #   4. if rank 0's setup deletes the reports directory itself (the pre-fix behavior),
+        #      that deletion is allowed to complete here, inside pathlib's window between
+        #      os.mkdir raising EEXIST and its is_dir() verification.
+        #   5. rank 1's pathlib mkdir then runs its real is_dir() check.
+        #
+        # On code that deletes the reports directory during setup, step 5 finds no directory
+        # and mkdir(exist_ok=True) raises FileExistsError for a path that does not exist.
+        # With setup only clearing the directory's contents, no deletion ever occurs, the
+        # is_dir() check sees the directory, and the mkdir call succeeds.
+        prob = self._make_problem('race_prob')
+        self.assertTrue(len(prob._reports) > 0)  # active reports required for this scenario
+        prob.setup()
+
+        leaf = prob.get_outputs_dir() / 'reports'
+        if leaf.is_dir():
+            os.rmdir(leaf)  # start with no reports dir, as on a first run
+        leaf_str = os.fspath(leaf)
+
+        rank1_entered = threading.Event()   # rank 1 is inside os.mkdir for the reports dir
+        created = threading.Event()         # rank 0's setup has created the reports dir
+        eexist = threading.Event()          # rank 1 has its genuine EEXIST in hand
+        deleted = threading.Event()         # rank 0's setup has deleted the reports dir
+        rank1_done = threading.Event()      # rank 1's mkdir call has fully completed
+        setup_done = threading.Event()      # rank 0's setup() has returned
+
+        real_mkdir = os.mkdir
+        real_rmtree = shutil.rmtree
+        result = {}
+
+        def instrumented_mkdir(path, mode=0o777, *args, **kwargs):
+            if os.fspath(path) != leaf_str:
+                return real_mkdir(path, mode, *args, **kwargs)
+            if threading.current_thread().name == 'rank1':
+                rank1_entered.set()
+                if not created.wait(self.TIMEOUT):
+                    raise RuntimeError('orchestration timeout waiting for creation')
+                try:
+                    real_mkdir(path, mode, *args, **kwargs)
+                except OSError:
+                    eexist.set()
+                    # give the setup-side deletion (if the implementation performs one) time
+                    # to land inside pathlib's EEXIST -> is_dir() window
+                    t0 = time.perf_counter()
+                    while not (deleted.is_set() or setup_done.is_set()):
+                        if time.perf_counter() - t0 > self.TIMEOUT:
+                            raise RuntimeError('orchestration timeout in EEXIST window')
+                        time.sleep(0.001)
+                    raise
+            else:
+                # rank 0 re-creating the dir after a deletion must not beat rank 1's
+                # is_dir() check, else the race window closes by luck
+                if deleted.is_set() and not rank1_done.is_set():
+                    if not rank1_done.wait(self.TIMEOUT):
+                        raise RuntimeError('orchestration timeout waiting for rank 1')
+                real_mkdir(path, mode, *args, **kwargs)
+                created.set()
+
+        def instrumented_rmtree(path, *args, **kwargs):
+            if os.fspath(path) == leaf_str:
+                if not eexist.wait(self.TIMEOUT):
+                    raise RuntimeError('orchestration timeout waiting for EEXIST')
+                real_rmtree(path, *args, **kwargs)
+                deleted.set()
+            else:
+                real_rmtree(path, *args, **kwargs)
+
+        def rank1():
+            try:
+                result['dir'] = prob.get_reports_dir(force=True)
+            except BaseException as exc:
+                result['exc'] = exc
+            finally:
+                rank1_done.set()
+
+        with mock.patch('os.mkdir', instrumented_mkdir), \
+                mock.patch('shutil.rmtree', instrumented_rmtree):
+            t = threading.Thread(target=rank1, name='rank1')
+            t.start()
+            self.assertTrue(rank1_entered.wait(self.TIMEOUT), 'rank 1 never reached mkdir')
+            try:
+                prob.setup()
+            finally:
+                setup_done.set()
+                t.join(self.TIMEOUT)
+
+        self.assertFalse(t.is_alive(), 'rank 1 thread did not finish')
+        if 'exc' in result:
+            raise result['exc']
+        self.assertTrue(pathlib.Path(result['dir']).is_dir())
+
+    def test_setup_clears_stale_report_files(self):
+        # stale files in an existing reports dir must be gone after setup, and the reports
+        # dir must exist afterward when reports are active
+        prob = self._make_problem('stale_prob')
+        prob.setup()
+
+        reports_dir = prob.get_outputs_dir() / 'reports'
+        self.assertTrue(reports_dir.is_dir())
+        stale = reports_dir / 'stale_report.html'
+        stale.write_text('from a previous run')
+        stale_sub = reports_dir / 'stale_subdir'
+        stale_sub.mkdir()
+        (stale_sub / 'nested.html').write_text('nested stale content')
+
+        prob.setup()
+
+        self.assertTrue(reports_dir.is_dir())
+        self.assertFalse(stale.exists())
+        self.assertFalse(stale_sub.exists())
+
+    def test_setup_removes_stale_reports_dir_when_reports_inactive(self):
+        # when no reports are active, nothing will create the reports dir, so a stale one
+        # from a previous run must be removed entirely, as before
+        prob = self._make_problem('inactive_prob')
+        prob.setup()
+
+        reports_dir = prob.get_outputs_dir() / 'reports'
+        self.assertTrue(reports_dir.is_dir())
+        (reports_dir / 'stale_report.html').write_text('from a previous run')
+
+        probmod._clear_problem_names()
+        prob2 = self._make_problem('inactive_prob', reports=False)
+        self.assertEqual(len(prob2._reports), 0)
+        prob2.setup()
+
+        self.assertFalse(reports_dir.exists())
+
+    def test_clear_reports_dir_tolerates_concurrent_removal(self):
+        # a peer process removing an entry (or the whole dir) first is a benign outcome
+        workdir = pathlib.Path('clear_tol')
+        workdir.mkdir()
+        for fname in ('a.html', 'b.html'):
+            (workdir / fname).write_text('x')
+
+        real_unlink = os.unlink
+        calls = {'n': 0}
+
+        def racing_unlink(path, *args, **kwargs):
+            calls['n'] += 1
+            if calls['n'] == 1:
+                real_unlink(path, *args, **kwargs)  # a peer removed this entry first
+                raise FileNotFoundError(2, 'No such file or directory', os.fspath(path))
+            real_unlink(path, *args, **kwargs)
+
+        with mock.patch('os.unlink', racing_unlink):
+            _clear_reports_dir(workdir)
+
+        self.assertTrue(workdir.is_dir())
+        self.assertEqual(list(workdir.iterdir()), [])
+
+        # the whole directory having been removed by a peer is also benign
+        _clear_reports_dir(workdir / 'no_such_dir')
+
+    def test_clear_reports_dir_propagates_real_errors(self):
+        # only the benign concurrent-removal outcome is tolerated; real filesystem errors
+        # must propagate
+        workdir = pathlib.Path('clear_err')
+        workdir.mkdir()
+        (workdir / 'a.html').write_text('x')
+
+        def denied_unlink(path, *args, **kwargs):
+            raise PermissionError(13, 'Permission denied', os.fspath(path))
+
+        with mock.patch('os.unlink', denied_unlink):
+            with self.assertRaises(PermissionError):
+                _clear_reports_dir(workdir)
+
+    @unittest.skipIf(sys.platform == 'win32', 'symlink creation requires privileges on Windows')
+    def test_clear_reports_dir_unlinks_symlinks_without_following(self):
+        workdir = pathlib.Path('clear_sym')
+        workdir.mkdir()
+        target_dir = pathlib.Path('sym_target')
+        target_dir.mkdir()
+        keep = target_dir / 'keep.txt'
+        keep.write_text('do not delete')
+
+        os.symlink(target_dir.resolve(), workdir / 'link_to_dir')
+        os.symlink('no_such_file', workdir / 'dangling')
+
+        _clear_reports_dir(workdir)
+
+        self.assertEqual(list(workdir.iterdir()), [])
+        self.assertTrue(keep.is_file())  # symlinked-to contents must be untouched
+
+    @unittest.skipIf(sys.platform == 'win32',
+                     'directory file descriptors are not supported on Windows')
+    def test_setup_preserves_reports_dir_identity(self):
+        # supplementary architecture coverage: with active reports, setup must not replace
+        # the reports directory with a new one.  A deleted-and-recreated directory can reuse
+        # the same inode number, so instead of comparing st_ino, watch the original
+        # directory's link count through an open descriptor: it drops to 0 if the directory
+        # is unlinked.
+        prob = self._make_problem('ident_prob')
+        prob.setup()
+
+        reports_dir = prob.get_outputs_dir() / 'reports'
+        fd = os.open(reports_dir, os.O_RDONLY)
+        try:
+            prob.setup()
+
+            self.assertTrue(reports_dir.is_dir())
+            self.assertGreater(os.fstat(fd).st_nlink, 0,
+                               'the original reports directory was deleted during setup')
+        finally:
+            os.close(fd)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

During `Problem.setup`, every rank could create `<prob>_out/reports`, rank 0 then deleted that
directory with `shutil.rmtree`, and every rank then re-created it.

`pathlib.Path.mkdir(exist_ok=True)` suppresses `FileExistsError` only if its follow-up
`is_dir()` check still sees the directory. If setup's deletion lands between another rank's
`EEXIST` and that verification, `FileExistsError` escapes from the
`mkdir(parents=True, exist_ok=True)` call in `_get_outputs_dir`, which matches the failure
reported in #3746. This is the pathlib TOCTOU window tracked by python/cpython#142916 (a
retry-based fix there was rejected as not actually closing the window, which is why this PR
removes the deletion instead of hardening the mkdir).

The mechanism was reproduced both under synchronized multi-process timing on a local
filesystem and deterministically through the production call path. The issue report doesn't
include enough environment detail to prove this exact interleaving caused the reporter's
incidents, so no such claim is made; it is the only deletion of an output directory in the
OpenMDAO runtime, and removing it eliminates the only in-tree way to hit the window.

## Change

Setup now computes the reports path without creating it first (the old code created the
directory solely so it could be deleted).

When reports are active, rank 0 removes stale contents but preserves the reports directory
itself, so other ranks can create or observe the directory without setup deleting it
underneath them. When reports are inactive, nothing will re-create the directory, so stale
contents are cleared and the empty directory is removed, preserving the previous
no-reports-directory-left-behind behavior.

Only narrowly-defined benign outcomes are tolerated during cleanup (an entry or the directory
already removed by a peer process, and `ENOENT`/`ENOTEMPTY` on the inactive-path `rmdir`);
`PermissionError` and all other filesystem errors still propagate. Symlinks are unlinked
without being followed. No MPI barrier or mkdir retry is introduced, and `_get_outputs_dir`
is unchanged.

## Ordering

Report hooks run after setup, and the writers that can run earliest are gated to the clearing
rank itself. For non-rank-0 writers the ordering argument passes through `final_setup`; the
relevant collective there (`sync_auto_ivcs`) is over `model.comm`, not `self.comm`.
Split-communicator driver paths were reviewed separately: no supported report writer creates a
new clearing race in that configuration, so this is a clarification of the ordering argument
rather than a limitation of the patch.

## Tests

`TestSetupReportsDirRace` in `test_reports_system.py`:

- A deterministic regression test forces setup's own deletion into pathlib's
  `EEXIST -> is_dir()` window using only real filesystem operations and the genuine kernel
  exception. On unpatched master it fails every run with
  `FileExistsError: [Errno 17] File exists: '.../race_prob_out/reports'`; on this branch it
  passes every run (independently re-verified: 3/3 pre-fix failures, 50/50 post-fix passes).
- Companion tests pin the preserved semantics: stale report files are still removed at setup,
  a stale reports directory is still removed entirely when reports are inactive, benign
  concurrent removal by a peer is tolerated while `PermissionError` propagates, symlinked
  targets are never followed or deleted, and the reports directory itself survives repeated
  setups (verified via link count through an open descriptor, since a deleted-and-recreated
  directory can reuse its inode number).

Existing reports tests pass serially and under MPI (including `TestReportsSystemMPI`), and
repeated-`setup()` stress runs at 2/4/8 ranks with an active report show no failures and
consistent report output. The full suite was checked; the only failures in the test
environment were unrelated environment/optional-dependency issues (MPI slot limits on a
4-core host and a missing optional optimizer), classified separately.

## References

Fixes #3746

python/cpython#142916
