### PR TITLE
Raise when approximated subgroup totals target internal source variables

### DIFF
--- a/openmdao/core/tests/test_semitotals.py
+++ b/openmdao/core/tests/test_semitotals.py
@@ -107,6 +107,25 @@ class TestSemiTotals(unittest.TestCase):
 
         assert_check_totals(data, atol=1e-6, rtol=1e-6)
 
+    def test_approx_totals_internal_wrt_raises(self):
+        prob = om.Problem()
+
+        group = prob.model.add_subsystem('G', om.Group())
+        group.add_subsystem('ivc', om.IndepVarComp('x', 1.0))
+        group.add_subsystem('comp', om.ExecComp('y = 2.0 * x'))
+        group.connect('ivc.x', 'comp.x')
+        group.approx_totals(method='fd')
+
+        prob.setup(mode='fwd')
+        prob.run_model()
+
+        msg = r"'G.ivc.x'.*approx_totals.*internal"
+        with self.assertRaisesRegex(RuntimeError, msg):
+            prob.compute_totals(of=['G.comp.y'], wrt=['G.ivc.x'])
+
+        with self.assertRaisesRegex(RuntimeError, msg):
+            prob.check_totals(of=['G.comp.y'], wrt=['G.ivc.x'], out_stream=None)
+
     def test_multi_conn_inputs_manual_connect(self):
 
         prob = om.Problem()

--- a/openmdao/core/total_jac.py
+++ b/openmdao/core/total_jac.py
@@ -25,6 +25,46 @@ from openmdao.utils.units import unit_conversion
 _directional_rng = np.random.default_rng(99)
 
 
+def _check_approx_totals_internal_wrt(model, wrt_metadata):
+    """
+    Raise if totals are requested with respect to an internal variable of an approximated group.
+
+    Parameters
+    ----------
+    model : Group
+        The top-level model.
+    wrt_metadata : dict
+        Metadata for variables with respect to which totals are being computed.
+    """
+    if not wrt_metadata:
+        return
+
+    wrt_sources = [(name, meta['source']) for name, meta in wrt_metadata.items()]
+
+    for group in model.system_iter(include_self=False, recurse=True):
+        if not group._owns_approx_jac:
+            continue
+
+        prefix = group.pathname + '.'
+        offenders = []
+        for name, src in wrt_sources:
+            if src.startswith(prefix) and src not in group._var_allprocs_abs2meta['input']:
+                offenders.append((name, src))
+
+        if offenders:
+            parts = [f"'{name}'" if name == src else f"'{name}' (source '{src}')"
+                     for name, src in offenders]
+            variables = ', '.join(parts)
+            source_text = 'source variable is' if len(offenders) == 1 else 'source variables are'
+
+            raise RuntimeError(
+                f"{group.msginfo}: Total derivatives were requested with respect to {variables}, "
+                f"but this group uses approx_totals and the {source_text} internal to that group. "
+                "Subgroup approximations are computed only with respect to the group's inputs, so "
+                "these derivatives cannot be computed by the model's linear derivative solve."
+            )
+
+
 class _TotalJacInfo(object):
     """
     Object to manage computation of total derivatives.
@@ -210,6 +250,9 @@ class _TotalJacInfo(object):
         else:
             of_metadata, wrt_metadata, has_custom_derivs = model._get_totals_metadata(driver, of,
                                                                                       wrt)
+
+        if not approx:
+            _check_approx_totals_internal_wrt(model, wrt_metadata)
 
         if (of_indices is not None) and (orig_of is not None):
             conn_graph = model.get_conn_graph()


### PR DESCRIPTION
### Summary

A subgroup using `approx_totals` builds its approximated Jacobian with respect to group inputs only. If totals are requested with respect to an internal source variable, that variable has no column in the subgroup's approximated Jacobian. OpenMDAO previously allowed that request and returned zero. This is misleading, as there may be a correct, nonzero, gradient.

This PR detects that unsupported case before the total derivative solve and raises a clear `RuntimeError` instead. It also adds a semitotals regression test covering both `compute_totals` and `check_totals`.

### Related Issues

- Addresses #3230

### Backwards incompatibilities

Calls to `compute_totals` or `check_totals` that request totals with respect to an internal source variable of a subgroup using `approx_totals` now raise `RuntimeError` instead of returning zero.

### New Dependencies

None
