### PR TITLE
fixed bug where val metadata wasn't being copied during dynamic shape resolution

### DIFF
--- a/openmdao/core/conn_graph.py
+++ b/openmdao/core/conn_graph.py
@@ -444,6 +444,7 @@ class NodeAttrs():
                         self._val = np.ones(shape)
                     self._locmeta['shape'] = shape
                     self._locmeta['size'] = size
+                    self._locmeta['val'] = self._val
 
     @property
     def size(self):

--- a/openmdao/core/tests/test_distrib_list_vars.py
+++ b/openmdao/core/tests/test_distrib_list_vars.py
@@ -598,6 +598,46 @@ class DistributedListVarsTest(unittest.TestCase):
 
         assert_near_equal(prob['C3.sum'], -5.)
 
+    def test_distrib_list_vars_dyn_shapes(self):
+        class SourceComp(om.ExplicitComponent):
+
+            def setup(self):
+                # Distributed input with known local shape
+                self.add_output( "x", val=np.ones(10), distributed=True )
+
+            def compute(self, inputs, outputs):
+                pass
+
+
+        class CopyComp(om.ExplicitComponent):
+
+            def setup(self):
+
+                # The input shape is determined by the connection
+                self.add_input( "x", distributed=True, shape_by_conn=True )
+
+                # Output shape is copied from input
+                self.add_output( "y", distributed=True, copy_shape="x" )
+
+            def compute(self, inputs, outputs):
+                outputs["y"] = inputs["x"]
+
+
+        prob = om.Problem()
+
+        prob.model.add_subsystem( "src", SourceComp() )
+
+        prob.model.add_subsystem( "copy", CopyComp() )
+
+        prob.model.connect( "src.x", "copy.x" )
+
+        prob.setup()
+        prob.final_setup()
+
+        # before the bug fix, this raised an AtrributeError
+        prob.model.list_outputs(out_stream=None)
+
+
 
 @use_tempdirs
 @unittest.skipUnless(PETScVector, "PETSc is required.")


### PR DESCRIPTION

### Related Issues

- Resolves #3812

### Backwards incompatibilities

None

### New Dependencies

None
