### PR TITLE
Preserve DirectSolver factorization path when computing approximated totals

### DIFF
--- a/openmdao/solvers/linear/direct.py
+++ b/openmdao/solvers/linear/direct.py
@@ -8,7 +8,6 @@ import scipy.sparse.linalg
 from scipy.sparse import csc_matrix
 
 from openmdao.solvers.solver import LinearSolver
-from openmdao.matrices.dense_matrix import DenseMatrix
 from openmdao.utils.array_utils import identity_column_iter
 from openmdao.solvers.linear.linear_rhs_checker import LinearRHSChecker
 
@@ -184,6 +183,16 @@ class DirectSolver(LinearSolver):
     ----------
     _lin_rhs_checker : LinearRHSChecker or None
         Object for checking the right-hand side of the linear solve.
+    _lu : SuperLU or None
+        Sparse factorization, set when the assembled jacobian is sparse.
+    _lup : tuple or None
+        Dense factorization, set when the jacobian is dense or built from matrix-vector
+        products.
+    _factored_assembled_jac : bool
+        True if the factorization currently held came from an assembled jacobian. The
+        system's jacobian can change identity between linearize and solve, for instance
+        when a group begins approximating its own derivatives, so the solve is driven by
+        what was factorized rather than by what the system reports at solve time.
     """
 
     SOLVER = 'LN: Direct'
@@ -194,6 +203,9 @@ class DirectSolver(LinearSolver):
         """
         super().__init__(**kwargs)
         self._lin_rhs_checker = None
+        self._lu = None
+        self._lup = None
+        self._factored_assembled_jac = False
 
     def _declare_options(self):
         """
@@ -341,6 +353,8 @@ class DirectSolver(LinearSolver):
 
         if system._get_assembled_jac() is not None:
             matrix = system._assembled_jac.get_dr_do_matrix()
+            self._lu = self._lup = None
+            self._factored_assembled_jac = True
 
             if matrix is None:
                 # this happens if we're not rank 0 when using owned_sizes
@@ -378,6 +392,8 @@ class DirectSolver(LinearSolver):
                                    "when running under MPI if comm.size > 1.")
 
             mtx = self._build_mtx()
+            self._lu = self._lup = None
+            self._factored_assembled_jac = False
 
             # During LU decomposition, detect singularities and warn user.
             with warnings.catch_warnings():
@@ -511,12 +527,17 @@ class DirectSolver(LinearSolver):
                     x_vec[:] = sol_array
                     return
 
+        if self._lu is None and self._lup is None:
+            raise RuntimeError(f"{system.msginfo}: DirectSolver has no factorization to "
+                               "solve with. Its linearize step either did not run or ran "
+                               "while the system was using a different jacobian.")
+
         # AssembledJacobians are unscaled.
-        if system._get_assembled_jac() is not None:
+        if self._factored_assembled_jac:
             full_b = b_vec
 
             with system._unscaled_context(outputs=[d_outputs], residuals=[d_residuals]):
-                if isinstance(system._assembled_jac._dr_do_mtx, DenseMatrix):
+                if self._lu is None:
                     sol_array = scipy.linalg.lu_solve(self._lup, full_b, trans=trans_lu)
                 else:
                     sol_array = self._lu.solve(full_b, trans_splu)

--- a/openmdao/solvers/linear/tests/test_direct_solver.py
+++ b/openmdao/solvers/linear/tests/test_direct_solver.py
@@ -1079,5 +1079,138 @@ class TestDirectSolverMPI(unittest.TestCase):
         assert_near_equal(prob['g2.y2'], 0.80, 1.0e-5)
 
 
+class SqrtState(om.ImplicitComponent):
+    """
+    R(y, x) = y**2 - x, so y = sqrt(x) and dy/dx = 1 / (2*sqrt(x)).
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Component options.
+    """
+
+    def setup(self):
+        """
+        Declare inputs, outputs and partials.
+        """
+        self.add_input('x', 3.0)
+        self.add_output('y', 2.0)
+        self.declare_partials('y', ['x', 'y'])
+
+    def apply_nonlinear(self, inputs, outputs, residuals):
+        """
+        Compute the residual.
+
+        Parameters
+        ----------
+        inputs : Vector
+            Unscaled, dimensional input variables.
+        outputs : Vector
+            Unscaled, dimensional output variables.
+        residuals : Vector
+            Unscaled, dimensional residuals.
+        """
+        residuals['y'] = outputs['y'] ** 2 - inputs['x']
+
+    def linearize(self, inputs, outputs, partials):
+        """
+        Compute the partials.
+
+        Parameters
+        ----------
+        inputs : Vector
+            Unscaled, dimensional input variables.
+        outputs : Vector
+            Unscaled, dimensional output variables.
+        partials : Jacobian
+            Sub-jac components written to partials[output_name, input_name].
+        """
+        partials['y', 'y'] = 2.0 * outputs['y']
+        partials['y', 'x'] = -1.0
+
+
+class ScaledSqrtState(SqrtState):
+    """
+    The same state, declared with output and residual scaling.
+
+    Parameters
+    ----------
+    **kwargs : dict
+        Component options.
+    """
+
+    def setup(self):
+        """
+        Declare inputs, outputs and partials with non-unit scaling.
+        """
+        self.add_input('x', 3.0)
+        self.add_output('y', 2.0, ref=100.0, res_ref=0.01)
+        self.declare_partials('y', ['x', 'y'])
+
+
+class TestDirectSolverUnderApproximation(unittest.TestCase):
+    """
+    A group may approximate its own derivatives while containing a DirectSolver.
+
+    The system's jacobian changes identity when the group starts approximating, so a
+    DirectSolver that factorized before the switch must still solve with the factorization
+    it holds rather than with the one the system reports at solve time.
+    """
+
+    def _build(self, method, comp_class=None):
+        p = om.Problem(reports=False)
+        g = p.model.add_subsystem('g', om.Group(), promotes=['*'])
+        g.add_subsystem('comp', (comp_class or SqrtState)(), promotes=['*'])
+        g.nonlinear_solver = om.NewtonSolver(solve_subsystems=False, iprint=-1)
+        g.linear_solver = om.DirectSolver()
+        g.approx_totals(method=method)
+        p.setup(force_alloc_complex=(method == 'cs'))
+        p.set_val('x', 3.0)
+        p.run_model()
+        return p
+
+    def test_approx_totals_fd_on_group_with_direct_solver(self):
+        p = self._build('fd')
+        assert_near_equal(p.get_val('y')[0], np.sqrt(3.0), 1e-10)
+        J = p.compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        assert_near_equal(J['y', 'x'][0][0], 1.0 / (2.0 * np.sqrt(3.0)), 1e-5)
+
+    def test_approx_totals_cs_on_group_with_direct_solver(self):
+        p = self._build('cs')
+        J = p.compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        assert_near_equal(J['y', 'x'][0][0], 1.0 / (2.0 * np.sqrt(3.0)), 1e-10)
+
+    def test_approx_totals_with_scaling(self):
+        # the assembled and matrix-free solve paths differ by the unscaled context, so a
+        # scaled model is what tells them apart
+        for method in ('fd', 'cs'):
+            with self.subTest(method=method):
+                p = self._build(method, ScaledSqrtState)
+                assert_near_equal(p.get_val('y')[0], np.sqrt(3.0), 1e-8)
+                J = p.compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+                assert_near_equal(J['y', 'x'][0][0], 1.0 / (2.0 * np.sqrt(3.0)), 1e-5)
+
+    def test_scaled_model_without_approximation(self):
+        # the same scaled model, solved analytically, must be unaffected
+        p = om.Problem(reports=False)
+        g = p.model.add_subsystem('g', om.Group(), promotes=['*'])
+        g.add_subsystem('comp', ScaledSqrtState(), promotes=['*'])
+        g.nonlinear_solver = om.NewtonSolver(solve_subsystems=False, iprint=-1)
+        g.linear_solver = om.DirectSolver()
+        p.setup()
+        p.set_val('x', 3.0)
+        p.run_model()
+        J = p.compute_totals(of=['y'], wrt=['x'], return_format='flat_dict')
+        assert_near_equal(J['y', 'x'][0][0], 1.0 / (2.0 * np.sqrt(3.0)), 1e-10)
+
+    def test_solve_without_factorization_gives_a_clear_error(self):
+        p = self._build('fd')
+        solver = p.model.g.linear_solver
+        solver._lu = solver._lup = None
+        with self.assertRaises(RuntimeError) as cm:
+            solver.solve('fwd')
+        self.assertIn('no factorization', str(cm.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

A `Group` that owns an approximation via `approx_totals()` and also uses a `DirectSolver`
solves the model correctly but crashes during total derivative computation:

```
AttributeError: 'DirectSolver' object has no attribute '_lu'
```

Root cause:

* `DirectSolver._linearize()` decides which factorization path to take based on the system
  state at that moment, and creates either the assembled factorization (`_lu`) or the
  matrix-free one (`_lup`).
* `DirectSolver.solve()` previously re-queried `system._get_assembled_jac()` to make the same
  decision later.
* Those two answers can differ. `Group._get_jacobian()` selects between a `DictionaryJacobian`
  and the assembled jacobian based on `_owns_approx_jac`, `_get_assembled_jac()` creates the
  assembled jacobian lazily on first request, `_relevance_changed()` can reset the choice, and
  `NewtonSolver._single_iteration` temporarily sets `_owns_approx_jac = False` before
  linearizing.
* As a result `_linearize()` could take the matrix-free path and create only `_lup`, while
  `solve()` later took the assembled path and reached for `_lu`, which was never created.

## Change

`DirectSolver` now records the factorization path actually produced during `_linearize()`, and
`solve()` dispatches from that recorded state instead of re-querying mutable system state.
Within the assembled branch, the sparse or dense solve is likewise chosen by which
factorization exists rather than by inspecting the matrix object.

If `solve()` is reached with no valid factorization at all, it now raises a clear `RuntimeError`
naming the system, instead of failing with an incidental `AttributeError`.

## Validation

Reproducer, a group holding `NewtonSolver` and a default `DirectSolver` with
`approx_totals()`, exact derivative `dy/dx = 1 / (2*sqrt(3)) = 0.2886751345948129`:

* on master: `AttributeError: 'DirectSolver' object has no attribute '_lu'`
* with this change: `0.2886751345948129`

Trigger matrix of 108 configurations (`fd`/`cs`, approximation on the solver's own group, on an
outer group, or absent, three nonlinear solvers, six linear solvers), each gated on whether the
model actually converged so that invalid setups are discarded rather than counted: four cells
change, each from `AttributeError` to the exact analytic value, and 92 cells are bit-identical.
No cell that was correct on master becomes incorrect.

Regression tests added to `openmdao/solvers/linear/tests/test_direct_solver.py`: the `fd` case,
the `cs` case, a scaled model in both modes, an analytic control on the same scaled model, and
the missing-factorization error contract. Three of these fail on master with the
`AttributeError`. With this change the file passes 41/41 in serial and 45/45 with MPI enabled.

The scaled-model test exists because mutation testing required it. Six mutations were applied to
the changed logic and run against `openmdao/solvers/linear`, and five were caught. The two that
reverted the dispatch were not caught until a scaled model was added, since the assembled and
matrix-free paths differ only by the unscaled context and an unscaled model cannot distinguish
them. The one surviving mutation, retaining a stale factorization across successive
linearizations, is only observable if a solver's assembled matrix changes sparsity format
between two factorizations.

Targeted suites all pass with no failures and match the baseline: `openmdao/solvers/linear`
(216 passed, 0 failed, 2 skipped with MPI enabled), `openmdao/solvers`, `test_approx_derivs`
and `test_check_totals`.

Full suite, run on this branch and on the unmodified baseline with identical settings:

| | passed | failed | skipped | total |
|---|---|---|---|---|
| this branch | 4527 | 2 | 210 | 4739 |
| baseline | 4522 | 2 | 210 | 4734 |

The two failures are `test_pyoptsparse_driver.py:TestPyoptSparse.test_error_gradfun_reraise_1_Uno`
and `test_error_objfun_reraise_1_Uno`. They fail identically on the unmodified baseline in this
environment and are unrelated to this change. The difference in totals is the five added tests.
No new failure is attributable to this patch.

`ruff` and `git diff --check` are clean.

## Scope

* `DirectSolver` only.
* Addresses the configuration where a group owns both an approximation and a `DirectSolver`.
* No change to other linear or nonlinear solvers. `DirectSolver(assemble_jac=False)` and
  `ScipyKrylov` were already correct in this configuration and are unaffected.
* Does not address a neighbouring failure observed during this work, where
  `approx_totals(method='cs')` on a group one level above the solvers raises
  `UFuncTypeError: Cannot cast ufunc 'add' output from dtype('complex128') to dtype('float64')`.
  That looks like a different problem.
* Contains no work related to issue #2929.

Fixes #3816
